### PR TITLE
style: add rustfmt.toml, set group_imports = StdExternalCrate

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+
+


### PR DESCRIPTION
Use `StdExternalCrate` style to group imports, see [group_imports](https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#group_imports)