### PR TITLE
feat: implement log related macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,7 @@ name = "common-telemetry"
 version = "0.1.0"
 dependencies = [
  "backtrace",
+ "common-error",
  "console-subscriber",
  "metrics",
  "metrics-exporter-prometheus",

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -7,11 +7,11 @@ async fn datanode_main(_opts: &GrepTimeOpts) {
     match DataNode::new() {
         Ok(data_node) => {
             if let Err(e) = data_node.start().await {
-                error!("Fail to start data node, error: {:?}", e);
+                error!(e; "Fail to start data node");
             }
         }
 
-        Err(e) => error!("Fail to new data node, error: {:?}", e),
+        Err(e) => error!(e; "Fail to new data node"),
     }
 }
 

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -87,8 +87,6 @@ macro_rules! define_opaque_error {
 mod tests {
     use std::error::Error as StdError;
 
-    use snafu::{prelude::*, Backtrace, ErrorCompat};
-
     use super::*;
     use crate::prelude::*;
 

--- a/src/common/error/src/format.rs
+++ b/src/common/error/src/format.rs
@@ -5,7 +5,7 @@ use crate::ext::ErrorExt;
 /// Pretty debug format for error, also prints source and backtrace.
 pub struct DebugFormat<'a, E: ?Sized>(&'a E);
 
-impl<'a, E: ErrorExt + ?Sized> DebugFormat<'a, E> {
+impl<'a, E: ?Sized> DebugFormat<'a, E> {
     /// Create a new format struct from `err`.
     pub fn new(err: &'a E) -> Self {
         Self(err)

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -11,6 +11,7 @@ deadlock_detection=["parking_lot"]
 
 [dependencies]
 backtrace = "0.3"
+common-error = { path = "../error" }
 console-subscriber = { version = "0.1", optional = true }
 metrics = "0.18"
 metrics-exporter-prometheus = { version = "0.9", default-features = false }

--- a/src/common/telemetry/src/lib.rs
+++ b/src/common/telemetry/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod logging;
+mod macros;
 pub mod metric;
 mod panic_hook;
 
+pub use common_error;
 pub use logging::init_default_ut_logging;
 pub use logging::init_global_logging;
 pub use metric::init_default_metrics_recorder;

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -7,7 +7,7 @@ use std::sync::Once;
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry::sdk::propagation::TraceContextPropagator;
-pub use tracing::{debug, error, info, span, warn, Level};
+pub use tracing::{event, span, Level};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_appender::rolling::Rotation;
@@ -19,6 +19,8 @@ use tracing_subscriber::fmt::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
+
+pub use crate::{debug, error, info, log, trace, warn};
 
 /// Init tracing for unittest.
 /// Write logs to file `unittest`.

--- a/src/common/telemetry/src/macros.rs
+++ b/src/common/telemetry/src/macros.rs
@@ -1,0 +1,258 @@
+/// The standard logging macro.
+#[macro_export]
+macro_rules! log {
+    // log!(target: "my_target", Level::INFO, "a {} event", "log");
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => {
+        $crate::logging::event!(target: $target, $lvl, $($arg)+)
+    };
+
+    // log!(Level::INFO, "a log event")
+    ($lvl:expr, $($arg:tt)+) => {
+        $crate::logging::event!($lvl, $($arg)+)
+    };
+}
+
+/// Logs a message at the error level.
+#[macro_export]
+macro_rules! error {
+    // error!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => ({
+        $crate::log!(target: $target, $crate::logging::Level::ERROR, $($arg)+)
+    });
+
+    // error!(e; target: "my_target", "a {} event", "log")
+    ($e:expr; target: $target:expr, $($arg:tt)+) => ({
+        use $crate::common_error::ext::ErrorExt;
+        use std::error::Error;
+        match ($e.source(), $e.backtrace_opt()) {
+            (Some(source), Some(backtrace)) => {
+                $crate::log!(
+                    target: $target,
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    err.backtrace = %backtrace,
+                    $($arg)+
+                )
+            },
+            (Some(source), None) => {
+                $crate::log!(
+                    target: $target,
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    $($arg)+
+                )
+            },
+            (None, Some(backtrace)) => {
+                $crate::log!(
+                    target: $target,
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.backtrace = %backtrace,
+                    $($arg)+
+                )
+            },
+            (None, None) => {
+                $crate::log!(
+                    target: $target,
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    $($arg)+
+                )
+            }
+        }
+    });
+
+    // error!(e; "a {} event", "log")
+    ($e:expr; $($arg:tt)+) => ({
+        use std::error::Error;
+        use $crate::common_error::ext::ErrorExt;
+        match ($e.source(), $e.backtrace_opt()) {
+            (Some(source), Some(backtrace)) => {
+                $crate::log!(
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    err.backtrace = %backtrace,
+                    $($arg)+
+                )
+            },
+            (Some(source), None) => {
+                $crate::log!(
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    $($arg)+
+                )
+            },
+            (None, Some(backtrace)) => {
+                $crate::log!(
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.backtrace = %backtrace,
+                    $($arg)+
+                )
+            },
+            (None, None) => {
+                $crate::log!(
+                    $crate::logging::Level::ERROR,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    $($arg)+
+                )
+            }
+        }
+    });
+
+    // error!("a {} event", "log")
+    ($($arg:tt)+) => ({
+        $crate::log!($crate::logging::Level::ERROR, $($arg)+)
+    });
+}
+
+/// Logs a message at the warn level.
+#[macro_export]
+macro_rules! warn {
+    // warn!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => {
+        $crate::log!(target: $target, $crate::logging::Level::WARN, $($arg)+)
+    };
+
+    // warn!("a {} event", "log")
+    ($($arg:tt)+) => {
+        $crate::log!($crate::logging::Level::WARN, $($arg)+)
+    };
+}
+
+/// Logs a message at the info level.
+#[macro_export]
+macro_rules! info {
+    // info!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => {
+        $crate::log!(target: $target, $crate::logging::Level::INFO, $($arg)+)
+    };
+
+    // info!("a {} event", "log")
+    ($($arg:tt)+) => {
+        $crate::log!($crate::logging::Level::INFO, $($arg)+)
+    };
+}
+
+/// Logs a message at the debug level.
+#[macro_export]
+macro_rules! debug {
+    // debug!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => {
+        $crate::log!(target: $target, $crate::logging::Level::DEBUG, $($arg)+)
+    };
+
+    // debug!("a {} event", "log")
+    ($($arg:tt)+) => {
+        $crate::log!($crate::logging::Level::DEBUG, $($arg)+)
+    };
+}
+
+/// Logs a message at the trace level.
+#[macro_export]
+macro_rules! trace {
+    // trace!(target: "my_target", "a {} event", "log")
+    (target: $target:expr, $($arg:tt)+) => {
+        $crate::log!(target: $target, $crate::logging::Level::TRACE, $($arg)+)
+    };
+
+    // trace!("a {} event", "log")
+    ($($arg:tt)+) => {
+        $crate::log!($crate::logging::Level::TRACE, $($arg)+)
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use common_error::mock::MockError;
+    use common_error::prelude::*;
+
+    use crate::logging::Level;
+
+    macro_rules! all_log_macros {
+        ($($arg:tt)*) => {
+            trace!($($arg)*);
+            debug!($($arg)*);
+            info!($($arg)*);
+            warn!($($arg)*);
+            error!($($arg)*);
+        };
+    }
+
+    #[test]
+    fn test_log_args() {
+        log!(target: "my_target", Level::TRACE, "foo");
+        log!(target: "my_target", Level::DEBUG, "foo",);
+
+        log!(target: "my_target", Level::INFO, "foo: {}", 3);
+        log!(target: "my_target", Level::WARN, "foo: {}", 3,);
+
+        log!(target: "my_target", Level::ERROR, "hello {world}", world = "world");
+        log!(target: "my_target", Level::DEBUG, "hello {world}", world = "world",);
+
+        all_log_macros!(target: "my_target", "foo");
+        all_log_macros!(target: "my_target", "foo",);
+
+        all_log_macros!(target: "my_target", "foo: {}", 3);
+        all_log_macros!(target: "my_target", "foo: {}", 3,);
+
+        all_log_macros!(target: "my_target", "hello {world}", world = "world");
+        all_log_macros!(target: "my_target", "hello {world}", world = "world",);
+    }
+
+    #[test]
+    fn test_log_no_target() {
+        log!(Level::DEBUG, "foo");
+        log!(Level::DEBUG, "foo: {}", 3);
+
+        all_log_macros!("foo");
+        all_log_macros!("foo: {}", 3);
+    }
+
+    #[test]
+    fn test_log_ref_scope_args() {
+        let bar = 35;
+        let world = "world";
+        log!(target: "my_target", Level::DEBUG, "bar: {bar}");
+        log!(target: "my_target", Level::DEBUG, "bar: {bar}, hello {}", world);
+        log!(target: "my_target", Level::DEBUG, "bar: {bar}, hello {world}",);
+
+        all_log_macros!(target: "my_target", "bar: {bar}");
+        all_log_macros!(target: "my_target", "bar: {bar}, hello {}", world);
+        all_log_macros!(target: "my_target", "bar: {bar}, hello {world}",);
+    }
+
+    #[test]
+    fn test_log_error() {
+        crate::logging::init_default_ut_logging();
+
+        let err = MockError::new(StatusCode::Unknown);
+        let err_ref = &err;
+        let err_ref2 = &err_ref;
+
+        error!(target: "my_target", "hello {}", "world");
+        // Supports both owned and reference type.
+        error!(err; target: "my_target", "hello {}", "world");
+        error!(err_ref; target: "my_target", "hello {}", "world");
+        error!(err_ref2; "hello {}", "world");
+        error!("hello {}", "world");
+
+        let err = MockError::with_backtrace(StatusCode::Internal);
+        error!(err; "Error with backtrace hello {}", "world");
+
+        let root_err = MockError::with_source(err);
+        error!(root_err; "Error with source hello {}", "world");
+    }
+}

--- a/src/common/telemetry/src/metric.rs
+++ b/src/common/telemetry/src/metric.rs
@@ -8,8 +8,6 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 pub use metrics_exporter_prometheus::PrometheusHandle;
 use once_cell::sync::Lazy;
 
-use crate::logging;
-
 static PROMETHEUS_HANDLE: Lazy<Arc<RwLock<Option<PrometheusHandle>>>> =
     Lazy::new(|| Arc::new(RwLock::new(None)));
 
@@ -26,7 +24,7 @@ fn init_prometheus_recorder() {
     metrics::clear_recorder();
     match metrics::set_boxed_recorder(Box::new(recorder)) {
         Ok(_) => (),
-        Err(err) => logging::warn!("Install prometheus recorder failed, cause: {}", err),
+        Err(err) => crate::warn!("Install prometheus recorder failed, cause: {}", err),
     };
 }
 


### PR DESCRIPTION
Implement log, trace, debug, info, warn, error macros, customize error log output format

Now printing an error log should use the new `error!` macro
```rust
error!(e; "hello {}", "world");
```