### PR TITLE
feat: UDAF implementation with fixed datatype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "datafusion-expr",
  "datatypes",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -14,3 +14,6 @@ datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git" , b
 datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git" , branch = "arrow2"}
 datatypes = { path = "../../datatypes"}
 snafu = { version = "0.7", features = ["backtraces"] }
+
+[dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }

--- a/src/common/query/src/logical_plan/accumulator.rs
+++ b/src/common/query/src/logical_plan/accumulator.rs
@@ -1,0 +1,74 @@
+//! Accumulator module contains the trait definition for aggregation function's accumulators.
+
+use std::fmt::Debug;
+
+use arrow::array::ArrayRef;
+use datafusion_common::Result as DfResult;
+use datafusion_common::ScalarValue;
+use datafusion_expr::Accumulator as DfAccumulator;
+use datatypes::error::Result as DtResult;
+use datatypes::vectors::Helper as VectorHelper;
+use datatypes::vectors::VectorRef;
+use snafu::ResultExt;
+
+use crate::error::{Error, FromScalarValueSnafu, Result};
+
+/// An accumulator represents a stateful object that lives throughout the evaluation of multiple rows and
+/// generically accumulates values.
+///
+/// An accumulator knows how to:
+/// * update its state from inputs via `update_batch`
+/// * convert its internal state to a vector of scalar values
+/// * update its state from multiple accumulators' states via `merge_batch`
+/// * compute the final value from its internal state via `evaluate`
+///
+/// Modified from DataFusion.
+pub trait Accumulator: Send + Sync + Debug {
+    /// Returns the state of the accumulator at the end of the accumulation.
+    // in the case of an average on which we track `sum` and `n`, this function should return a vector
+    // of two values, sum and n.
+    fn state(&self) -> Result<Vec<ScalarValue>>;
+
+    /// updates the accumulator's state from a vector of arrays.
+    fn update_batch(&mut self, values: &[VectorRef]) -> Result<()>;
+
+    /// updates the accumulator's state from a vector of states.
+    fn merge_batch(&mut self, states: &[VectorRef]) -> Result<()>;
+
+    /// returns its value based on its current state.
+    fn evaluate(&self) -> Result<ScalarValue>;
+}
+
+/// A wrapper newtype for our Accumulator to DataFusion's Accumulator,
+/// so to make our Accumulator able to be executed by DataFusion query engine.
+#[derive(Debug)]
+pub struct DfAccumulatorWrapper(pub Box<dyn Accumulator>);
+
+impl DfAccumulator for DfAccumulatorWrapper {
+    fn state(&self) -> DfResult<Vec<ScalarValue>> {
+        self.0.state().map_err(|e| e.into())
+    }
+
+    fn update_batch(&mut self, values: &[ArrayRef]) -> DfResult<()> {
+        let vectors = try_into_vectors(values)?;
+        self.0.update_batch(&vectors).map_err(|e| e.into())
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> DfResult<()> {
+        let vectors = try_into_vectors(states)?;
+        self.0.merge_batch(&vectors).map_err(|e| e.into())
+    }
+
+    fn evaluate(&self) -> DfResult<ScalarValue> {
+        self.0.evaluate().map_err(|e| e.into())
+    }
+}
+
+fn try_into_vectors(arrays: &[ArrayRef]) -> Result<Vec<VectorRef>> {
+    arrays
+        .iter()
+        .map(VectorHelper::try_into_vector)
+        .collect::<DtResult<Vec<VectorRef>>>()
+        .context(FromScalarValueSnafu)
+        .map_err(Error::from)
+}

--- a/src/common/query/src/logical_plan/udaf.rs
+++ b/src/common/query/src/logical_plan/udaf.rs
@@ -1,0 +1,106 @@
+//! Udaf module contains functions and structs supporting user-defined aggregate functions.
+//!
+//! Modified from DataFusion.
+
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+
+use arrow::datatypes::DataType as ArrowDataType;
+use datafusion_expr::AccumulatorFunctionImplementation as DfAccumulatorFunctionImplementation;
+use datafusion_expr::AggregateUDF as DfAggregateUdf;
+use datafusion_expr::StateTypeFunction as DfStateTypeFunction;
+use datatypes::prelude::{ConcreteDataType, DataType};
+
+use crate::function::{
+    to_df_return_type, AccumulatorFunctionImplementation, ReturnTypeFunction, StateTypeFunction,
+};
+use crate::logical_plan::accumulator::DfAccumulatorWrapper;
+use crate::signature::Signature;
+
+/// Logical representation of a user-defined aggregate function (UDAF)
+/// A UDAF is different from a UDF in that it is stateful across batches.
+#[derive(Clone)]
+pub struct AggregateUdf {
+    /// name
+    pub name: String,
+    /// signature
+    pub signature: Signature,
+    /// Return type
+    pub return_type: ReturnTypeFunction,
+    /// actual implementation
+    pub accumulator: AccumulatorFunctionImplementation,
+    /// the accumulator's state's description as a function of the return type
+    pub state_type: StateTypeFunction,
+}
+
+impl Debug for AggregateUdf {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.debug_struct("AggregateUDF")
+            .field("name", &self.name)
+            .field("signature", &self.signature)
+            .field("fun", &"<FUNC>")
+            .finish()
+    }
+}
+
+impl PartialEq for AggregateUdf {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.signature == other.signature
+    }
+}
+
+impl AggregateUdf {
+    /// Create a new AggregateUDF
+    pub fn new(
+        name: &str,
+        signature: &Signature,
+        return_type: &ReturnTypeFunction,
+        accumulator: &AccumulatorFunctionImplementation,
+        state_type: &StateTypeFunction,
+    ) -> Self {
+        Self {
+            name: name.to_owned(),
+            signature: signature.clone(),
+            return_type: return_type.clone(),
+            accumulator: accumulator.clone(),
+            state_type: state_type.clone(),
+        }
+    }
+}
+
+impl From<AggregateUdf> for DfAggregateUdf {
+    fn from(udaf: AggregateUdf) -> Self {
+        DfAggregateUdf::new(
+            &udaf.name,
+            &udaf.signature.into(),
+            &to_df_return_type(udaf.return_type),
+            &to_df_accumulator_func(udaf.accumulator),
+            &to_df_state_type(udaf.state_type),
+        )
+    }
+}
+
+fn to_df_accumulator_func(
+    func: AccumulatorFunctionImplementation,
+) -> DfAccumulatorFunctionImplementation {
+    Arc::new(move || {
+        let acc = func()?;
+        Ok(Box::new(DfAccumulatorWrapper(acc)))
+    })
+}
+
+fn to_df_state_type(func: StateTypeFunction) -> DfStateTypeFunction {
+    let df_func = move |data_type: &ArrowDataType| {
+        // DataFusion DataType -> ConcreteDataType
+        let concrete_data_type = ConcreteDataType::from_arrow_type(data_type);
+
+        // evaluate ConcreteDataType
+        let eval_result = (func)(&concrete_data_type);
+
+        // ConcreteDataType -> DataFusion DataType
+        eval_result
+            .map(|ts| Arc::new(ts.iter().map(|t| t.as_arrow_type()).collect()))
+            .map_err(|e| e.into())
+    };
+    Arc::new(df_func)
+}

--- a/src/common/query/src/prelude.rs
+++ b/src/common/query/src/prelude.rs
@@ -3,6 +3,7 @@ pub use datafusion_common::ScalarValue;
 pub use crate::columnar_value::ColumnarValue;
 pub use crate::function::*;
 pub use crate::logical_plan::create_udf;
+pub use crate::logical_plan::AggregateUdf;
 pub use crate::logical_plan::Expr;
 pub use crate::logical_plan::ScalarUdf;
 pub use crate::signature::{Signature, TypeSignature, Volatility};

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use common_function::scalars::udf::create_udf;
 use common_function::scalars::FunctionRef;
+use common_query::prelude::AggregateUdf;
 use common_query::prelude::ScalarUdf;
 use common_recordbatch::{EmptyRecordBatchStream, SendableRecordBatchStream};
 use common_telemetry::timer;
@@ -85,6 +86,17 @@ impl QueryEngine for DatafusionQueryEngine {
 
     fn register_udf(&self, udf: ScalarUdf) {
         self.state.register_udf(udf);
+    }
+
+    /// Note in SQL queries, aggregate names are looked up using
+    /// lowercase unless the query uses quotes. For example,
+    ///
+    /// `SELECT MY_UDAF(x)...` will look for an aggregate named `"my_udaf"`
+    /// `SELECT "my_UDAF"(x)` will look for an aggregate named `"my_UDAF"`
+    ///
+    /// So it's better to make UDAF name lowercase when creating one.
+    fn register_udaf(&self, udaf: AggregateUdf) {
+        self.state.register_udaf(udaf);
     }
 
     fn register_function(&self, func: FunctionRef) {

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -4,6 +4,7 @@ mod state;
 use std::sync::Arc;
 
 use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
+use common_query::prelude::AggregateUdf;
 use common_query::prelude::ScalarUdf;
 use common_recordbatch::SendableRecordBatchStream;
 use sql::statements::statement::Statement;
@@ -34,6 +35,8 @@ pub trait QueryEngine: Send + Sync {
     async fn execute(&self, plan: &LogicalPlan) -> Result<Output>;
 
     fn register_udf(&self, udf: ScalarUdf);
+
+    fn register_udaf(&self, udaf: AggregateUdf);
 
     fn register_function(&self, func: FunctionRef);
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::sync::Arc;
 
+use common_query::prelude::AggregateUdf;
 use common_query::prelude::ScalarUdf;
 use datafusion::prelude::{ExecutionConfig, ExecutionContext};
 
@@ -52,6 +53,15 @@ impl QueryEngineState {
             .lock()
             .scalar_functions
             .insert(udf.name.clone(), Arc::new(udf.into_df_udf()));
+    }
+
+    // TODO(LFC) Same as UDF, manage UDAFs by ourself.
+    pub fn register_udaf(&self, udaf: AggregateUdf) {
+        self.df_context
+            .state
+            .lock()
+            .aggregate_functions
+            .insert(udaf.name.clone(), Arc::new(udaf.into()));
     }
 
     #[inline]

--- a/src/query/tests/median.rs
+++ b/src/query/tests/median.rs
@@ -1,0 +1,172 @@
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
+use common_query::error::Result;
+use common_query::error::{Error, ExecuteFunctionSnafu};
+use common_query::logical_plan::Accumulator;
+use datafusion_common::ScalarValue;
+use datatypes::vectors::VectorRef;
+use snafu::ResultExt;
+
+// This median calculation algorithm's details can be found at
+// https://leetcode.cn/problems/find-median-from-data-stream/
+//
+// Basically, it uses two heaps, a maximum heap and a minimum. The maximum heap stores numbers that
+// are not greater than the median, and the minimum heap stores the greater. In a steaming of
+// numbers, when a number is arrived, we adjust the heaps' tops, so that either one top is the
+// median or both tops can be averaged to get the median.
+//
+// The time complexity to update the median is O(logn), O(1) to get the median; and the space
+// complexity is O(n). (Ignore the costs for heap expansion.)
+//
+// Why not use the [quick select](https://en.wikipedia.org/wiki/Quickselect) or just simply sort to
+// calculate the median? Because both ways need to either modified the stored internal state in the
+// final `evaluate` in `Accumulator`, which requires a mutable `self` and is against the method's
+// signature; or worse, clone the whole stored numbers.
+#[derive(Debug)]
+pub struct Median {
+    greater: BinaryHeap<Reverse<u32>>,
+    not_greater: BinaryHeap<u32>,
+}
+
+/// The implementation for this Median UDAF is modified from DataFusion's geometric mean UDAF
+/// example, the comments are left unchanged for future reference.
+impl Median {
+    pub fn new() -> Self {
+        Median {
+            greater: BinaryHeap::new(),
+            not_greater: BinaryHeap::new(),
+        }
+    }
+
+    // this function receives one entry per argument of this accumulator.
+    // DataFusion calls this function on every row, and expects this function to update the
+    // accumulator's state.
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
+        assert_eq!(1, values.len());
+        // this is a one-argument UDAF, and thus we use `0`.
+        let value = &values[0];
+        match value {
+            // here we map `ScalarValue` to our internal state. `UInt32` indicates that this function
+            // only accepts UInt32 as its argument (DataFusion does try to coerce arguments to this type)
+            //
+            // Note that `.map` here ensures that we ignore Nulls.
+            ScalarValue::UInt32(e) => e.map(|value| {
+                self.push(value);
+            }),
+            _ => unreachable!(""),
+        };
+        Ok(())
+    }
+
+    fn push(&mut self, value: u32) {
+        if self.not_greater.is_empty() {
+            self.not_greater.push(value);
+            return;
+        }
+        // The `unwrap`s below are safe because there are `push`s before them.
+        if value <= *self.not_greater.peek().unwrap() {
+            self.not_greater.push(value);
+            if self.not_greater.len() > self.greater.len() + 1 {
+                self.greater.push(Reverse(self.not_greater.pop().unwrap()));
+            }
+        } else {
+            self.greater.push(Reverse(value));
+            if self.greater.len() > self.not_greater.len() {
+                self.not_greater.push(self.greater.pop().unwrap().0);
+            }
+        }
+    }
+
+    // this function receives states from other accumulators (Vec<ScalarValue>)
+    // and updates the accumulator.
+    fn merge(&mut self, states: Vec<ScalarValue>) -> Result<()> {
+        states
+            .into_iter()
+            .filter_map(|x| match x {
+                ScalarValue::LargeUtf8(e) => e,
+                _ => unreachable!(),
+            })
+            .for_each(|value| {
+                value
+                    .split(',')
+                    .filter_map(|n| n.parse::<u32>().ok())
+                    .for_each(|n| self.push(n))
+            });
+        Ok(())
+    }
+}
+
+impl Default for Median {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// UDAFs are built using the trait `Accumulator`, that offers DataFusion the necessary functions
+// to use them.
+impl Accumulator for Median {
+    // This function serializes our state to `ScalarValue`, which DataFusion uses to pass this
+    // state between execution stages. Note that this can be arbitrary data.
+    //
+    // TODO(LFC) Use List datatype if there's one.
+    fn state(&self) -> Result<Vec<ScalarValue>> {
+        let nums = self
+            .greater
+            .iter()
+            .map(|x| x.0)
+            .chain(self.not_greater.iter().copied())
+            .map(|n| n.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+        Ok(vec![ScalarValue::LargeUtf8(Some(nums))])
+    }
+
+    // DataFusion calls this function to update the accumulator's state for a batch of inputs rows.
+    fn update_batch(&mut self, values: &[VectorRef]) -> Result<()> {
+        if values.is_empty() {
+            return Ok(());
+        };
+        (0..values[0].len()).try_for_each(|index| {
+            let v = values
+                .iter()
+                .map(|array| {
+                    ScalarValue::try_from_array(&array.to_arrow_array(), index)
+                        .context(ExecuteFunctionSnafu)
+                        .map_err(Error::from)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            self.update(&v)
+        })
+    }
+
+    // Optimization hint: this trait also supports `update_batch` and `merge_batch`,
+    // that can be used to perform these operations on arrays instead of single values.
+    // By default, these methods call `update` and `merge` row by row
+    fn merge_batch(&mut self, states: &[VectorRef]) -> Result<()> {
+        if states.is_empty() {
+            return Ok(());
+        };
+        (0..states[0].len()).try_for_each(|index| {
+            let v = states
+                .iter()
+                .map(|array| {
+                    ScalarValue::try_from_array(&array.to_arrow_array(), index)
+                        .context(ExecuteFunctionSnafu)
+                        .map_err(Error::from)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            self.merge(v)
+        })
+    }
+
+    // DataFusion expects this function to return the final value of this aggregator.
+    fn evaluate(&self) -> Result<ScalarValue> {
+        let median = if self.not_greater.len() > self.greater.len() {
+            *self.not_greater.peek().unwrap()
+        } else {
+            (*self.not_greater.peek().unwrap() >> 1) + (self.greater.peek().unwrap().0 >> 1)
+        };
+        Ok(ScalarValue::from(median))
+    }
+}


### PR DESCRIPTION
Directly Transplant DataFusion's UDAF related structs, traits and functions, like `AggregateUDF`, `Accumulator` or `create_udaf` etc.

Implement median UDAF on top of it and used in unit testing, but only works for u32 datatype.

Refs: #61