### PR TITLE
refactor: manifest version and service

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -5,7 +5,7 @@ use std::str::Utf8Error;
 use common_error::prelude::*;
 use datatypes::arrow;
 use serde_json::error::Error as JsonError;
-use store_api::manifest::Version;
+use store_api::manifest::ManifestVersion;
 
 use crate::metadata::Error as MetadataError;
 
@@ -98,8 +98,8 @@ pub enum Error {
 
     #[snafu(display("Invalid scan index, start: {}, end: {}", start, end))]
     InvalidScanIndex {
-        start: Version,
-        end: Version,
+        start: ManifestVersion,
+        end: ManifestVersion,
         backtrace: Backtrace,
     },
 

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 use crate::background::{Context, Job, JobHandle, JobPoolRef};
 use crate::error::{CancelledSnafu, Result};
 use crate::manifest::action::*;
+use crate::manifest::region::RegionManifest;
 use crate::memtable::{IterContext, MemtableId, MemtableRef};
 use crate::region::RegionWriterRef;
 use crate::region::SharedDataRef;
@@ -148,6 +149,8 @@ pub struct FlushJob {
     pub sst_layer: AccessLayerRef,
     /// Region writer, used to persist log entry that points to the latest manifest file.
     pub writer: RegionWriterRef,
+    /// Region manifest service, used to persist metadata.
+    pub manifest: RegionManifest,
 }
 
 impl FlushJob {
@@ -198,10 +201,7 @@ impl FlushJob {
             files_to_remove: Vec::default(),
         };
         logging::debug!("Write region edit: {:?} to manifest.", edit);
-        self.shared
-            .manifest
-            .update(RegionMetaAction::Edit(edit))
-            .await
+        self.manifest.update(RegionMetaAction::Edit(edit)).await
     }
 
     /// Generates random SST file name in format: `^[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}.parquet$`

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -82,13 +82,13 @@ impl<S> RegionImpl<S> {
                 id,
                 name,
                 version_control: Arc::new(version_control),
-                manifest,
             }),
             writer: Arc::new(RegionWriter::new(memtable_builder)),
             wal,
             flush_strategy: Arc::new(SizeBasedStrategy::default()),
             flush_scheduler,
             sst_layer,
+            manifest,
         });
 
         RegionImpl { inner }
@@ -107,7 +107,6 @@ pub struct SharedData {
     pub name: String,
     // TODO(yingwen): Maybe no need to use Arc for version control.
     pub version_control: VersionControlRef,
-    pub manifest: RegionManifest,
 }
 
 pub type SharedDataRef = Arc<SharedData>;
@@ -119,6 +118,7 @@ struct RegionInner<S> {
     flush_strategy: FlushStrategyRef,
     flush_scheduler: FlushSchedulerRef,
     sst_layer: AccessLayerRef,
+    manifest: RegionManifest,
 }
 
 impl<S> RegionInner<S> {
@@ -151,6 +151,7 @@ impl<S> RegionInner<S> {
             sst_layer: &self.sst_layer,
             wal: &self.wal,
             writer: &self.writer,
+            manifest: &self.manifest,
         };
         // Now altering schema is not allowed, so it is safe to validate schema outside of the lock.
         self.writer.write(ctx, request, writer_ctx).await

--- a/src/store-api/src/manifest.rs
+++ b/src/store-api/src/manifest.rs
@@ -7,7 +7,9 @@ use object_store::ObjectStore;
 use serde::{de::DeserializeOwned, Serialize};
 pub use storage::*;
 
-pub type ManifestVersion = Version;
+pub type ManifestVersion = u64;
+pub const MIN_VERSION: u64 = 0;
+pub const MAX_VERSION: u64 = u64::MAX;
 
 pub trait Metadata: Clone {}
 
@@ -32,12 +34,12 @@ pub trait Manifest: Send + Sync + Clone + 'static {
     fn new(id: Self::MetadataId, manifest_dir: &str, object_store: ObjectStore) -> Self;
 
     /// Update metadata by the action
-    async fn update(&self, action: Self::MetaAction) -> Result<Version, Self::Error>;
+    async fn update(&self, action: Self::MetaAction) -> Result<ManifestVersion, Self::Error>;
 
     /// Retrieve the latest metadata
     async fn load(&self) -> Result<Option<Self::Metadata>, Self::Error>;
 
-    async fn checkpoint(&self) -> Result<Version, Self::Error>;
+    async fn checkpoint(&self) -> Result<ManifestVersion, Self::Error>;
 
     fn metadata_id(&self) -> Self::MetadataId;
 }

--- a/src/store-api/src/manifest/storage.rs
+++ b/src/store-api/src/manifest/storage.rs
@@ -1,15 +1,13 @@
 use async_trait::async_trait;
 use common_error::ext::ErrorExt;
 
-pub type Version = u64;
-pub const MIN_VERSION: u64 = 0;
-pub const MAX_VERSION: u64 = u64::MAX;
+use crate::manifest::ManifestVersion;
 
 #[async_trait]
 pub trait LogIterator: Send + Sync {
     type Error: ErrorExt + Send + Sync;
 
-    async fn next_log(&mut self) -> Result<Option<(Version, Vec<u8>)>, Self::Error>;
+    async fn next_log(&mut self) -> Result<Option<(ManifestVersion, Vec<u8>)>, Self::Error>;
 }
 
 #[async_trait]
@@ -18,17 +16,26 @@ pub trait ManifestLogStorage {
     type Iter: LogIterator<Error = Self::Error>;
 
     /// Scan the logs in [start, end)
-    async fn scan(&self, start: Version, end: Version) -> Result<Self::Iter, Self::Error>;
+    async fn scan(
+        &self,
+        start: ManifestVersion,
+        end: ManifestVersion,
+    ) -> Result<Self::Iter, Self::Error>;
 
     /// Save  a log
-    async fn save(&self, version: Version, bytes: &[u8]) -> Result<(), Self::Error>;
+    async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<(), Self::Error>;
 
     /// Delete logs in [start, end)
-    async fn delete(&self, start: Version, end: Version) -> Result<(), Self::Error>;
+    async fn delete(&self, start: ManifestVersion, end: ManifestVersion)
+        -> Result<(), Self::Error>;
 
     /// Save a checkpoint
-    async fn save_checkpoint(&self, version: Version, bytes: &[u8]) -> Result<(), Self::Error>;
+    async fn save_checkpoint(
+        &self,
+        version: ManifestVersion,
+        bytes: &[u8],
+    ) -> Result<(), Self::Error>;
 
     /// Load the latest checkpoint
-    async fn load_checkpoint(&self) -> Result<Option<(Version, Vec<u8>)>, Self::Error>;
+    async fn load_checkpoint(&self) -> Result<Option<(ManifestVersion, Vec<u8>)>, Self::Error>;
 }


### PR DESCRIPTION
Main changes:

* Rename `Version` in manifest to `ManifestVersion`.
* Move out `manifest` service from region `ShareData`.
