### PR TITLE
refactor: Make BatchIterator supertrait of Iterator

### DIFF
--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -19,8 +19,8 @@ impl ChunkReader for ChunkReaderImpl {
     }
 
     async fn next_chunk(&mut self) -> Result<Option<Chunk>> {
-        let mut batch = match self.iter.next()? {
-            Some(b) => b,
+        let mut batch = match self.iter.next() {
+            Some(b) => b?,
             None => return Ok(None),
         };
 

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -84,20 +84,13 @@ pub struct Batch {
     pub values: Vec<VectorRef>,
 }
 
-// TODO(yingwen): [flush] Let BatchIterator be a supertrait of Iterator.
 /// Iterator of memtable.
-pub trait BatchIterator: Send + Sync {
+pub trait BatchIterator: Iterator<Item = Result<Batch>> + Send + Sync {
     /// Returns the schema of this iterator.
     fn schema(&self) -> &MemtableSchema;
 
     /// Returns the ordering of the output rows from this iterator.
     fn ordering(&self) -> RowOrdering;
-
-    /// Fetch next batch from the memtable.
-    ///
-    /// # Panics
-    /// Panics if the iterator has already been exhausted.
-    fn next(&mut self) -> Result<Option<Batch>>;
 }
 
 pub type BatchIteratorPtr = Box<dyn BatchIterator>;

--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -93,9 +93,13 @@ impl BatchIterator for BTreeIterator {
     fn ordering(&self) -> RowOrdering {
         RowOrdering::Key
     }
+}
 
-    fn next(&mut self) -> Result<Option<Batch>> {
-        Ok(self.next_batch())
+impl Iterator for BTreeIterator {
+    type Item = Result<Batch>;
+
+    fn next(&mut self) -> Option<Result<Batch>> {
+        self.next_batch().map(Ok)
     }
 }
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -46,7 +46,7 @@ impl<'a> ParquetWriter<'a> {
     /// Iterates memtable and writes rows to Parquet file.
     /// A chunk of records yielded from each iteration with a size given
     /// in config will be written to a single row group.
-    async fn write_rows(mut self, extra_meta: Option<HashMap<String, String>>) -> Result<()> {
+    async fn write_rows(self, extra_meta: Option<HashMap<String, String>>) -> Result<()> {
         let schema = memtable_schema_to_arrow_schema(self.iter.schema());
         let object = self.object_store.object(self.file_name);
 
@@ -70,7 +70,8 @@ impl<'a> ParquetWriter<'a> {
         )
         .context(WriteParquetSnafu)?;
 
-        while let Some(batch) = self.iter.next()? {
+        for batch in self.iter {
+            let batch = batch?;
             sink.send(Chunk::new(
                 batch
                     .keys


### PR DESCRIPTION
Make `BatchIterator` a supertrait of `Iterator`, so we can use some combinators from `Iterator`