### PR TITLE
doc: add openssl install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ sudo dnf install openssl-devel
 ```
 
 For macOS:
-
 ```bash
 brew install openssl
 ```


### PR DESCRIPTION
Add openssl dependency install instructions.
Closes #98 