### PR TITLE
refactor: Make TableEngine object safe

### DIFF
--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -5,7 +5,6 @@ use common_error::ext::BoxedError;
 use common_error::prelude::*;
 use datatypes::prelude::ConcreteDataType;
 use storage::error::Error as StorageError;
-use table::engine::Error as TableEngineError;
 use table::error::Error as TableError;
 
 /// Business error of datanode.
@@ -28,7 +27,7 @@ pub enum Error {
     CreateTable {
         table_name: String,
         #[snafu(backtrace)]
-        source: TableEngineError,
+        source: TableError,
     },
 
     #[snafu(display("Fail to get table: {}, {}", table_name, source))]

--- a/src/table-engine/src/engine.rs
+++ b/src/table-engine/src/engine.rs
@@ -14,8 +14,8 @@ use store_api::storage::{
 };
 use table::engine::{EngineContext, TableEngine};
 use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest};
+use table::Result as TableResult;
 use table::{
-    engine,
     metadata::{TableId, TableInfoBuilder, TableMetaBuilder, TableType},
     table::TableRef,
 };
@@ -48,7 +48,7 @@ impl<Store: StorageEngine> TableEngine for MitoEngine<Store> {
         &self,
         ctx: &EngineContext,
         request: CreateTableRequest,
-    ) -> std::result::Result<TableRef, engine::Error> {
+    ) -> TableResult<TableRef> {
         Ok(self.inner.create_table(ctx, request).await?)
     }
 
@@ -56,15 +56,11 @@ impl<Store: StorageEngine> TableEngine for MitoEngine<Store> {
         &self,
         _ctx: &EngineContext,
         _request: AlterTableRequest,
-    ) -> std::result::Result<TableRef, engine::Error> {
+    ) -> TableResult<TableRef> {
         unimplemented!();
     }
 
-    fn get_table(
-        &self,
-        ctx: &EngineContext,
-        name: &str,
-    ) -> std::result::Result<Option<TableRef>, engine::Error> {
+    fn get_table(&self, ctx: &EngineContext, name: &str) -> TableResult<Option<TableRef>> {
         Ok(self.inner.get_table(ctx, name)?)
     }
 
@@ -76,7 +72,7 @@ impl<Store: StorageEngine> TableEngine for MitoEngine<Store> {
         &self,
         _ctx: &EngineContext,
         _request: DropTableRequest,
-    ) -> std::result::Result<(), engine::Error> {
+    ) -> TableResult<()> {
         unimplemented!();
     }
 }

--- a/src/table-engine/src/error.rs
+++ b/src/table-engine/src/error.rs
@@ -13,9 +13,9 @@ pub enum Error {
     },
 }
 
-impl From<Error> for table::engine::Error {
+impl From<Error> for table::error::Error {
     fn from(e: Error) -> Self {
-        table::engine::Error::new(e)
+        table::error::Error::new(e)
     }
 }
 
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     pub fn test_opaque_error() {
         let error = throw_create_table(StatusCode::InvalidSyntax).err().unwrap();
-        let table_engine_error: table::engine::Error = error.into();
+        let table_engine_error: table::error::Error = error.into();
         assert!(table_engine_error.backtrace_opt().is_some());
         assert_eq!(StatusCode::InvalidSyntax, table_engine_error.status_code());
     }

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 
+use crate::error::Result;
 use crate::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest};
 use crate::TableRef;
-
-common_error::define_opaque_error!(Error);
 
 /// Table engine abstraction.
 #[async_trait::async_trait]
@@ -15,7 +14,7 @@ pub trait TableEngine: Send + Sync {
         &self,
         ctx: &EngineContext,
         request: CreateTableRequest,
-    ) -> Result<TableRef, Error>;
+    ) -> Result<TableRef>;
 
     /// Alter table schema, options etc. by given request,
     ///
@@ -24,17 +23,16 @@ pub trait TableEngine: Send + Sync {
         &self,
         ctx: &EngineContext,
         request: AlterTableRequest,
-    ) -> Result<TableRef, Error>;
+    ) -> Result<TableRef>;
 
     /// Returns the table by it's name.
-    fn get_table(&self, ctx: &EngineContext, name: &str) -> Result<Option<TableRef>, Error>;
+    fn get_table(&self, ctx: &EngineContext, name: &str) -> Result<Option<TableRef>>;
 
     /// Returns true when the given table is exists.
     fn table_exists(&self, ctx: &EngineContext, name: &str) -> bool;
 
     /// Drops the given table.
-    async fn drop_table(&self, ctx: &EngineContext, request: DropTableRequest)
-        -> Result<(), Error>;
+    async fn drop_table(&self, ctx: &EngineContext, request: DropTableRequest) -> Result<()>;
 }
 
 pub type TableEngineRef = Arc<dyn TableEngine>;

--- a/src/table/src/lib.rs
+++ b/src/table/src/lib.rs
@@ -4,4 +4,5 @@ pub mod metadata;
 pub mod requests;
 pub mod table;
 
+pub use crate::error::{Error, Result};
 pub use crate::table::{Table, TableRef};


### PR DESCRIPTION
- remove `Clone` trait bound for `TableEngine` to make it object safe and can be converted into a trait object.
- replace `Error` associate type from `TableEngine` with opaque error.