### PR TITLE
ci: Add pr title checker

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,10 @@
+{
+  "LABEL": {
+    "name": "Invalid PR Title",
+    "color": "B60205"
+  },
+  "CHECKS": {
+    "regexp": "^(feat|fix|test|refactor|chore|style|doc|perf|build|ci|revert)(\\(.*\\))?:.*",
+    "ignoreLabels" : ["ignore-title"]
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,19 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.3.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: ".github/pr-title-checker-config.json"


### PR DESCRIPTION
## Changes
Add pr title checker, the checker config file is copied from [rinsingwave](https://github.com/singularity-data/risingwave/blob/main/.github/pr-title-checker-config.json)