### PR TITLE
refactor: Move test_util to datanode/src

### DIFF
--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -6,3 +6,5 @@ pub mod instance;
 mod metric;
 pub mod server;
 mod sql;
+#[cfg(test)]
+mod tests;

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -1,0 +1,4 @@
+mod grpc_test;
+mod http_test;
+mod instance_test;
+mod test_util;

--- a/src/datanode/src/tests/grpc_test.rs
+++ b/src/datanode/src/tests/grpc_test.rs
@@ -1,14 +1,14 @@
-mod test_util;
-
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use api::v1::{codec::InsertBatch, column, select_expr, Column, SelectExpr};
 use client::{Client, Database, ObjectResult};
-use datanode::instance::Instance;
 use servers::grpc::GrpcServer;
 use servers::server::Server;
+
+use crate::instance::Instance;
+use crate::tests::test_util;
 
 #[tokio::test]
 async fn test_insert_and_select() {

--- a/src/datanode/src/tests/http_test.rs
+++ b/src/datanode/src/tests/http_test.rs
@@ -1,13 +1,13 @@
-mod test_util;
-
 use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum::Router;
 use axum_test_helper::TestClient;
-use datanode::instance::Instance;
 use servers::http::HttpServer;
 use test_util::TestGuard;
+
+use crate::instance::Instance;
+use crate::tests::test_util;
 
 async fn make_test_app() -> (Router, TestGuard) {
     let (opts, guard) = test_util::create_tmp_dir_and_datanode_opts();

--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -1,9 +1,9 @@
-mod test_util;
-
 use arrow::array::UInt64Array;
 use common_recordbatch::util;
-use datanode::instance::Instance;
 use query::Output;
+
+use crate::instance::Instance;
+use crate::tests::test_util;
 
 #[tokio::test]
 async fn test_execute_insert() {

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -1,9 +1,6 @@
 use std::sync::Arc;
 
 use catalog::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use datanode::datanode::{DatanodeOptions, ObjectStoreConfig};
-use datanode::error::{CreateTableSnafu, Result};
-use datanode::instance::Instance;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, SchemaBuilder};
 use snafu::ResultExt;
@@ -11,6 +8,10 @@ use table::engine::EngineContext;
 use table::engine::TableEngineRef;
 use table::requests::CreateTableRequest;
 use tempdir::TempDir;
+
+use crate::datanode::{DatanodeOptions, ObjectStoreConfig};
+use crate::error::{CreateTableSnafu, Result};
+use crate::instance::Instance;
 
 /// Create a tmp dir(will be deleted once it goes out of scope.) and a default `DatanodeOptions`,
 /// Only for test.
@@ -38,10 +39,6 @@ pub fn create_tmp_dir_and_datanode_opts() -> (DatanodeOptions, TestGuard) {
     )
 }
 
-// It's actually not dead codes, at least been used in instance_test.rs and grpc_test.rs
-// However, clippy keeps warning us, so I temporary add an "allow" to bypass it.
-// TODO(LFC): further investigate why clippy falsely warning "dead_code"
-#[allow(dead_code)]
 pub async fn create_test_table(instance: &Instance) -> Result<()> {
     let column_schemas = vec![
         ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),


### PR DESCRIPTION
This also fixes the dead code warning of `create_test_table()` as the files under `datanode/tests` are considered as individual libs. Moves them to src dir makes sharing codes much easier.