### PR TITLE
refactor: Rename value_type to op_type

### DIFF
--- a/src/storage/benches/memtable/mod.rs
+++ b/src/storage/benches/memtable/mod.rs
@@ -14,7 +14,7 @@ use datatypes::{
 };
 use rand::{distributions::Alphanumeric, prelude::ThreadRng, Rng};
 use storage::memtable::KeyValues;
-use store_api::storage::{SequenceNumber, ValueType};
+use store_api::storage::{OpType, SequenceNumber};
 
 static NEXT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -50,7 +50,7 @@ fn random_kvs(len: usize, value_size: usize) -> (Vec<KeyTuple>, Vec<ValueTuple>)
 
 fn kvs_with_index(
     sequence: SequenceNumber,
-    value_type: ValueType,
+    op_type: OpType,
     start_index_in_batch: usize,
     keys: &[(i64, u64)],
     values: &[(Option<u64>, String)],
@@ -81,7 +81,7 @@ fn kvs_with_index(
     ];
     KeyValues {
         sequence,
-        value_type,
+        op_type,
         start_index_in_batch,
         keys: row_keys,
         values: row_values,
@@ -92,7 +92,7 @@ fn generate_kv(kv_size: usize, start_index_in_batch: usize, value_size: usize) -
     let (keys, values) = random_kvs(kv_size, value_size);
     kvs_with_index(
         get_sequence(),
-        ValueType::Put,
+        OpType::Put,
         start_index_in_batch,
         &keys,
         &values,

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -7,7 +7,7 @@ mod version;
 use std::sync::Arc;
 
 use datatypes::vectors::VectorRef;
-use store_api::storage::{consts, SequenceNumber, ValueType};
+use store_api::storage::{consts, OpType, SequenceNumber};
 
 use crate::error::Result;
 use crate::memtable::btree::BTreeMemtable;
@@ -100,7 +100,7 @@ pub type MemtableBuilderRef = Arc<dyn MemtableBuilder>;
 /// Key-value pairs in columnar format.
 pub struct KeyValues {
     pub sequence: SequenceNumber,
-    pub value_type: ValueType,
+    pub op_type: OpType,
     /// Start index of these key-value paris in batch. Each row in the same batch has
     /// a unique index to identify it.
     pub start_index_in_batch: usize,
@@ -110,8 +110,8 @@ pub struct KeyValues {
 
 impl KeyValues {
     // Note that `sequence` is not reset.
-    fn reset(&mut self, value_type: ValueType, index_in_batch: usize) {
-        self.value_type = value_type;
+    fn reset(&mut self, op_type: OpType, index_in_batch: usize) {
+        self.op_type = op_type;
         self.start_index_in_batch = index_in_batch;
         self.keys.clear();
         self.values.clear();

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -7,7 +7,7 @@ use datatypes::prelude::ScalarVector;
 use datatypes::schema::SchemaRef;
 use datatypes::vectors::{Int64Vector, NullVector, VectorRef};
 use snafu::{ensure, OptionExt};
-use store_api::storage::{ColumnDescriptor, SequenceNumber, ValueType};
+use store_api::storage::{ColumnDescriptor, OpType, SequenceNumber};
 
 use crate::error::{self, Result};
 use crate::memtable::{KeyValues, Memtable, MemtableSet};
@@ -65,7 +65,7 @@ impl Inserter {
         // Reusable KeyValues buffer.
         let mut kvs = KeyValues {
             sequence: self.sequence,
-            value_type: ValueType::Put,
+            op_type: OpType::Put,
             start_index_in_batch: self.index_in_batch,
             keys: Vec::with_capacity(total_column_num),
             values: Vec::with_capacity(total_column_num),
@@ -108,7 +108,7 @@ impl Inserter {
         let schema = memtable.schema();
         let num_rows = put_data.num_rows();
 
-        kvs.reset(ValueType::Put, self.index_in_batch);
+        kvs.reset(OpType::Put, self.index_in_batch);
 
         for key_col in schema.row_key_columns() {
             clone_put_data_column_to(put_data, &key_col.desc, &mut kvs.keys)?;

--- a/src/storage/src/memtable/version.rs
+++ b/src/storage/src/memtable/version.rs
@@ -227,7 +227,7 @@ impl MemtableSet {
 
 #[cfg(test)]
 mod tests {
-    use store_api::storage::ValueType;
+    use store_api::storage::OpType;
 
     use super::*;
     use crate::memtable::tests;
@@ -258,7 +258,7 @@ mod tests {
         tests::write_kvs(
             &*memtable,
             10, // sequence
-            ValueType::Put,
+            OpType::Put,
             &[
                 (1000, 1),
                 (1000, 2),

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -500,8 +500,8 @@ fn internal_column_descs() -> [ColumnDescriptor; 2] {
         .build()
         .unwrap(),
         ColumnDescriptorBuilder::new(
-            ReservedColumnId::value_type(),
-            consts::VALUE_TYPE_COLUMN_NAME.to_string(),
+            ReservedColumnId::op_type(),
+            consts::OP_TYPE_COLUMN_NAME.to_string(),
             ConcreteDataType::uint8_datatype(),
         )
         .is_nullable(false)
@@ -515,7 +515,7 @@ fn internal_column_descs() -> [ColumnDescriptor; 2] {
 fn is_internal_value_column(column_name: &str) -> bool {
     matches!(
         column_name,
-        consts::SEQUENCE_COLUMN_NAME | consts::VALUE_TYPE_COLUMN_NAME
+        consts::SEQUENCE_COLUMN_NAME | consts::OP_TYPE_COLUMN_NAME
     )
 }
 
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn test_build_metadata_internal_name() {
-        let names = [consts::SEQUENCE_COLUMN_NAME, consts::VALUE_TYPE_COLUMN_NAME];
+        let names = [consts::SEQUENCE_COLUMN_NAME, consts::OP_TYPE_COLUMN_NAME];
         for name in names {
             let cf = ColumnFamilyDescriptorBuilder::default()
                 .push_column(

--- a/src/storage/src/read.rs
+++ b/src/storage/src/read.rs
@@ -5,13 +5,13 @@ use datatypes::vectors::{UInt64Vector, UInt8Vector, VectorRef};
 
 use crate::error::Result;
 
-// TODO(yingwen): Maybe pack value_type with sequence (reserve 8bits in u64 for value type) like RocksDB.
+// TODO(yingwen): Maybe pack op_type with sequence (reserve 8bits in u64 for op_type) like RocksDB.
 /// Storage internal representation of a batch of rows.
 pub struct Batch {
     // Now the structure of `Batch` is still unstable, all pub fields may be changed.
     pub keys: Vec<VectorRef>,
     pub sequences: UInt64Vector,
-    pub value_types: UInt8Vector,
+    pub op_types: UInt8Vector,
     pub values: Vec<VectorRef>,
 }
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -260,7 +260,7 @@ mod tests {
     use datatypes::arrow::array::{Array, Int64Array, UInt64Array, UInt8Array};
     use datatypes::arrow::io::parquet::read::FileReader;
     use object_store::backend::fs::Backend;
-    use store_api::storage::ValueType;
+    use store_api::storage::OpType;
     use tempdir::TempDir;
 
     use super::*;
@@ -275,7 +275,7 @@ mod tests {
         memtable_tests::write_kvs(
             &*memtable,
             10, // sequence
-            ValueType::Put,
+            OpType::Put,
             &[
                 (1000, 1),
                 (1000, 2),
@@ -305,7 +305,7 @@ mod tests {
         let reader = std::fs::File::open(dir.path().join(sst_file_name)).unwrap();
         let mut file_reader = FileReader::try_new(reader, None, Some(128), None, None).unwrap();
 
-        // chunk schema: timestamp, __version, v1, __sequence, __value_type
+        // chunk schema: timestamp, __version, v1, __sequence, __op_type
         let chunk = file_reader.next().unwrap().unwrap();
         assert_eq!(5, chunk.arrays().len());
 
@@ -335,7 +335,7 @@ mod tests {
             chunk.arrays()[3]
         );
 
-        // value type
+        // op_type
         assert_eq!(
             Arc::new(UInt8Array::from_slice(&[0, 0, 0, 0, 0, 0])) as Arc<dyn Array>,
             chunk.arrays()[4]

--- a/src/storage/src/test_util/read_util.rs
+++ b/src/storage/src/test_util/read_util.rs
@@ -7,17 +7,17 @@ use datatypes::vectors::{Int64Vector, UInt64Vector, UInt8Vector};
 use crate::error::Result;
 use crate::read::{Batch, BatchReader, BoxedBatchReader};
 
-/// Build a new batch, with 0 sequence and value type.
+/// Build a new batch, with 0 sequence and op_type.
 fn new_kv_batch(key_values: &[(i64, Option<i64>)]) -> Batch {
     let key = Arc::new(Int64Vector::from_values(key_values.iter().map(|v| v.0)));
     let value = Arc::new(Int64Vector::from_iter(key_values.iter().map(|v| v.1)));
     let sequences = UInt64Vector::from_vec(vec![0; key_values.len()]);
-    let value_types = UInt8Vector::from_vec(vec![0; key_values.len()]);
+    let op_types = UInt8Vector::from_vec(vec![0; key_values.len()]);
 
     Batch {
         keys: vec![key],
         sequences,
-        value_types,
+        op_types,
         values: vec![value],
     }
 }

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -22,4 +22,4 @@ pub use self::region::{Region, WriteContext};
 pub use self::requests::{GetRequest, PutOperation, ScanRequest, WriteRequest};
 pub use self::responses::{GetResponse, ScanResponse, WriteResponse};
 pub use self::snapshot::{ReadContext, Snapshot};
-pub use self::types::{SequenceNumber, ValueType};
+pub use self::types::{OpType, SequenceNumber};

--- a/src/store-api/src/storage/consts.rs
+++ b/src/store-api/src/storage/consts.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_CF_ID: ColumnFamilyId = 1;
 enum ReservedColumnType {
     Version = 0,
     Sequence,
-    ValueType,
+    OpType,
 }
 
 /// Column id reserved by the engine.
@@ -48,9 +48,9 @@ impl ReservedColumnId {
         Self::BASE | ReservedColumnType::Sequence as ColumnId
     }
 
-    /// Id for `__value_type` column.
-    pub const fn value_type() -> ColumnId {
-        Self::BASE | ReservedColumnType::ValueType as ColumnId
+    /// Id for `__op_type` column.
+    pub const fn op_type() -> ColumnId {
+        Self::BASE | ReservedColumnType::OpType as ColumnId
     }
 }
 
@@ -70,9 +70,8 @@ pub const SEQUENCE_COLUMN_NAME: &str = "__sequence";
 /// Name for time index constraint name.
 pub const TIME_INDEX_NAME: &str = "__time_index";
 
-// TODO(yingwen): `__op_type` might be proper than `__value_type`.
-/// Name for reserved column: value_type
-pub const VALUE_TYPE_COLUMN_NAME: &str = "__value_type";
+/// Name for reserved column: op_type
+pub const OP_TYPE_COLUMN_NAME: &str = "__op_type";
 
 // -----------------------------------------------------------------------------
 
@@ -90,6 +89,6 @@ mod tests {
     fn test_reserved_id() {
         assert_eq!(0x80000000, ReservedColumnId::version());
         assert_eq!(0x80000001, ReservedColumnId::sequence());
-        assert_eq!(0x80000002, ReservedColumnId::value_type());
+        assert_eq!(0x80000002, ReservedColumnId::op_type());
     }
 }

--- a/src/store-api/src/storage/types.rs
+++ b/src/store-api/src/storage/types.rs
@@ -6,19 +6,19 @@ pub type SequenceNumber = u64;
 
 /// Operation type of the value to write to storage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ValueType {
+pub enum OpType {
     /// Put operation.
     Put,
 }
 
-impl ValueType {
+impl OpType {
     pub fn as_u8(&self) -> u8 {
         *self as u8
     }
 
-    /// Minimum value type after casting to u8.
-    pub const fn min_type() -> ValueType {
-        ValueType::Put
+    /// Minimal op type after casting to u8.
+    pub const fn min_type() -> OpType {
+        OpType::Put
     }
 }
 
@@ -27,8 +27,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_value_type() {
-        assert_eq!(0, ValueType::Put.as_u8());
-        assert_eq!(0, ValueType::min_type().as_u8());
+    fn test_op_type() {
+        assert_eq!(0, OpType::Put.as_u8());
+        assert_eq!(0, OpType::min_type().as_u8());
     }
 }


### PR DESCRIPTION
The `value_type` in the storage engine is original derived from `RocksDB`/`LevelDB`, which might be confused with `Value`, `DataType` in datatypes crate. So this PR rename `value_type` to `op_type`, according to its meaning of operation type (put, delete and so on).

Also resolves [this comment](https://github.com/GrepTimeTeam/greptimedb/pull/171#discussion_r946460663)