### PR TITLE
ci: Skip some actions if the PR is a draft

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - "main"
@@ -12,6 +13,7 @@ env:
 
 jobs:
   grcov:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,4 +1,6 @@
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 name: Continuous integration for developing
 
@@ -8,6 +10,7 @@ env:
 jobs:
   check:
     name: Check
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,6 +27,7 @@ jobs:
 
   test:
     name: Test Suite
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +49,7 @@ jobs:
 
   fmt:
     name: Rustfmt
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -62,6 +67,7 @@ jobs:
 
   clippy:
     name: Clippy
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Changes
- Don't run github actions on draft pull requests
- Now the title checker won't be affected, seems due to it was triggered by `pull_request_target`, not `pull_request` event

## Reference
- [discussions#25722](https://github.com/orgs/community/discussions/25722)