### PR TITLE
refactor: Use `error!(e; xxx)` pattern to log error

### DIFF
--- a/src/log-store/src/fs/file.rs
+++ b/src/log-store/src/fs/file.rs
@@ -257,7 +257,7 @@ impl LogFile {
                     batch.into_iter().for_each(AppendRequest::complete);
                 }
                 Err(e) => {
-                    error!("Failed to flush log file: {}", e);
+                    error!(e; "Failed to flush log file");
                     batch.into_iter().for_each(|r| r.fail());
                     state
                         .write_offset
@@ -265,7 +265,7 @@ impl LogFile {
                 }
             },
             Err(e) => {
-                error!("Failed to write append requests, error: {}", e);
+                error!(e; "Failed to write append requests");
                 batch.into_iter().for_each(|r| r.fail());
                 state
                     .write_offset
@@ -333,7 +333,7 @@ impl LogFile {
                     }
                 }
                 Err(e) => {
-                    error!("Error while replay log {} {:?}", log_name, e);
+                    error!(e; "Error while replay log {}", log_name);
                     break;
                 }
             }
@@ -568,7 +568,7 @@ fn file_chunk_stream(
                 continue;
             }
             Err(e) => {
-                error!("Failed to read file chunk, error: {}", &e);
+                error!(e; "Failed to read file chunk");
                 // we're going to break any way so just forget the join result.
                 let _ = tx.blocking_send(Err(e));
                 break;
@@ -600,7 +600,7 @@ fn file_chunk_stream_sync(
                     continue;
                 }
                 Err(e) => {
-                    error!("Failed to read file chunk, error: {}", &e);
+                    error!(e; "Failed to read file chunk");
                     yield Err(e);
                     break;
                 }

--- a/src/log-store/src/fs/log.rs
+++ b/src/log-store/src/fs/log.rs
@@ -199,7 +199,7 @@ impl LogStore for LocalFileLogStore {
                         continue;
                     }
                     _ => {
-                        error!("Failed to roll to next log file, error:{}", e);
+                        error!(e; "Failed to roll to next log file");
                         return Err(e);
                     }
                 },

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -42,8 +42,12 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[snafu(display("Failed to execute query: {}, error: {}", query, err_msg))]
-    ExecuteQuery { query: String, err_msg: String },
+    #[snafu(display("Failed to execute query: {}, source: {}", query, source))]
+    ExecuteQuery {
+        query: String,
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
 
     #[snafu(display("Not supported: {}", feat))]
     NotSupported { feat: String },
@@ -61,8 +65,8 @@ impl ErrorExt for Error {
             | Error::CollectRecordbatch { .. }
             | Error::StartHttp { .. }
             | Error::StartGrpc { .. }
-            | Error::TcpBind { .. }
-            | Error::ExecuteQuery { .. } => StatusCode::Internal,
+            | Error::TcpBind { .. } => StatusCode::Internal,
+            Error::ExecuteQuery { source, .. } => source.status_code(),
             Error::NotSupported { .. } => StatusCode::InvalidArguments,
         }
     }

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -359,11 +359,7 @@ impl WriterInner {
             // TODO(yingwen): We should release the write lock during waiting flush done, which
             // needs something like async condvar.
             flush_handle.join().await.map_err(|e| {
-                logging::error!(
-                    "Previous flush job failed, region: {}, err: {}",
-                    shared.name,
-                    e
-                );
+                logging::error!(e; "Previous flush job failed, region: {}", shared.name);
                 e
             })?;
         }


### PR DESCRIPTION
## Changes
- Use `error!(e; xxx)` pattern so we could get backtrace in error log.
- Also use BoxedError as error source of ExecuteQuery instead of String, so we could carry backtrace and other info in it.
