### PR TITLE
fix: StringVector use Utf8Array

### DIFF
--- a/src/catalog/src/tables.rs
+++ b/src/catalog/src/tables.rs
@@ -299,16 +299,16 @@ mod tests {
             let batch = t.unwrap().df_recordbatch;
             assert_eq!(1, batch.num_rows());
             assert_eq!(4, batch.num_columns());
-            assert_eq!(&DataType::LargeUtf8, batch.column(0).data_type());
-            assert_eq!(&DataType::LargeUtf8, batch.column(1).data_type());
-            assert_eq!(&DataType::LargeUtf8, batch.column(2).data_type());
-            assert_eq!(&DataType::LargeUtf8, batch.column(3).data_type());
+            assert_eq!(&DataType::Utf8, batch.column(0).data_type());
+            assert_eq!(&DataType::Utf8, batch.column(1).data_type());
+            assert_eq!(&DataType::Utf8, batch.column(2).data_type());
+            assert_eq!(&DataType::Utf8, batch.column(3).data_type());
             assert_eq!(
                 "test_catalog",
                 batch
                     .column(0)
                     .as_any()
-                    .downcast_ref::<Utf8Array<i64>>()
+                    .downcast_ref::<Utf8Array<i32>>()
                     .unwrap()
                     .value(0)
             );
@@ -318,7 +318,7 @@ mod tests {
                 batch
                     .column(1)
                     .as_any()
-                    .downcast_ref::<Utf8Array<i64>>()
+                    .downcast_ref::<Utf8Array<i32>>()
                     .unwrap()
                     .value(0)
             );
@@ -328,7 +328,7 @@ mod tests {
                 batch
                     .column(2)
                     .as_any()
-                    .downcast_ref::<Utf8Array<i64>>()
+                    .downcast_ref::<Utf8Array<i32>>()
                     .unwrap()
                     .value(0)
             );
@@ -338,7 +338,7 @@ mod tests {
                 batch
                     .column(3)
                     .as_any()
-                    .downcast_ref::<Utf8Array<i64>>()
+                    .downcast_ref::<Utf8Array<i32>>()
                     .unwrap()
                     .value(0)
             );

--- a/src/common/grpc/src/physical/plan.rs
+++ b/src/common/grpc/src/physical/plan.rs
@@ -152,7 +152,7 @@ impl ExecutionPlan for MockExecution {
 
     fn schema(&self) -> arrow::datatypes::SchemaRef {
         let field1 = Field::new("id", DataType::UInt32, false);
-        let field2 = Field::new("name", DataType::LargeUtf8, false);
+        let field2 = Field::new("name", DataType::Utf8, false);
         let field3 = Field::new("age", DataType::UInt32, false);
         Arc::new(arrow::datatypes::Schema::new(vec![field1, field2, field3]))
     }
@@ -190,7 +190,7 @@ impl ExecutionPlan for MockExecution {
         let age_array = Arc::new(PrimitiveArray::from_slice([25u32, 28, 27, 35, 25]));
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::UInt32, false),
-            Field::new("name", DataType::LargeUtf8, false),
+            Field::new("name", DataType::Utf8, false),
             Field::new("age", DataType::UInt32, false),
         ]));
         let record_batch =

--- a/src/common/query/src/logical_plan/accumulator.rs
+++ b/src/common/query/src/logical_plan/accumulator.rs
@@ -178,7 +178,7 @@ fn try_into_scalar_value(value: Value, datatype: &ConcreteDataType) -> Result<Sc
         Value::Int64(v) => ScalarValue::Int64(Some(v)),
         Value::Float32(v) => ScalarValue::Float32(Some(v.0)),
         Value::Float64(v) => ScalarValue::Float64(Some(v.0)),
-        Value::String(v) => ScalarValue::LargeUtf8(Some(v.as_utf8().to_string())),
+        Value::String(v) => ScalarValue::Utf8(Some(v.as_utf8().to_string())),
         Value::Binary(v) => ScalarValue::LargeBinary(Some(v.to_vec())),
         Value::Date(v) => ScalarValue::Date32(Some(v.val())),
         Value::DateTime(v) => ScalarValue::Date64(Some(v.val())),
@@ -201,7 +201,7 @@ fn try_convert_null_value(datatype: &ConcreteDataType) -> Result<ScalarValue> {
         ConcreteDataType::Float32(_) => ScalarValue::Float32(None),
         ConcreteDataType::Float64(_) => ScalarValue::Float64(None),
         ConcreteDataType::Binary(_) => ScalarValue::LargeBinary(None),
-        ConcreteDataType::String(_) => ScalarValue::LargeUtf8(None),
+        ConcreteDataType::String(_) => ScalarValue::Utf8(None),
         _ => {
             return error::BadAccumulatorImplSnafu {
                 err_msg: format!(
@@ -330,10 +330,10 @@ mod tests {
             .unwrap()
         );
         assert_eq!(
-            ScalarValue::LargeUtf8(Some("hello".to_string())),
+            ScalarValue::Utf8(Some("hello".to_string())),
             try_into_scalar_value(
                 Value::String(StringBytes::from("hello")),
-                &ConcreteDataType::string_datatype()
+                &ConcreteDataType::string_datatype(),
             )
             .unwrap()
         );
@@ -394,7 +394,7 @@ mod tests {
             try_into_scalar_value(Value::Null, &ConcreteDataType::float64_datatype()).unwrap()
         );
         assert_eq!(
-            ScalarValue::LargeUtf8(None),
+            ScalarValue::Utf8(None),
             try_into_scalar_value(Value::Null, &ConcreteDataType::string_datatype()).unwrap()
         );
         assert_eq!(

--- a/src/datanode/src/tests/http_test.rs
+++ b/src/datanode/src/tests/http_test.rs
@@ -64,7 +64,7 @@ async fn test_sql_api() {
     let body = res.text().await;
     assert_eq!(
         body,
-        r#"{"success":true,"output":{"Rows":[{"schema":{"fields":[{"name":"host","data_type":"LargeUtf8","is_nullable":false,"metadata":{}},{"name":"cpu","data_type":"Float64","is_nullable":true,"metadata":{}},{"name":"memory","data_type":"Float64","is_nullable":true,"metadata":{}},{"name":"ts","data_type":"Int64","is_nullable":true,"metadata":{}}],"metadata":{"greptime:timestamp_column":"ts","greptime:version":"0"}},"columns":[["host"],[66.6],[1024.0],[0]]}]}}"#
+        r#"{"success":true,"output":{"Rows":[{"schema":{"fields":[{"name":"host","data_type":"Utf8","is_nullable":false,"metadata":{}},{"name":"cpu","data_type":"Float64","is_nullable":true,"metadata":{}},{"name":"memory","data_type":"Float64","is_nullable":true,"metadata":{}},{"name":"ts","data_type":"Int64","is_nullable":true,"metadata":{}}],"metadata":{"greptime:timestamp_column":"ts","greptime:version":"0"}},"columns":[["host"],[66.6],[1024.0],[0]]}]}}"#
     );
 
     // select with projections

--- a/src/datatypes/src/arrow_array.rs
+++ b/src/datatypes/src/arrow_array.rs
@@ -10,8 +10,8 @@ use crate::value::Value;
 
 pub type BinaryArray = ArrowBinaryArray<i64>;
 pub type MutableBinaryArray = ArrowMutableBinaryArray<i64>;
-pub type MutableStringArray = MutableUtf8Array<i64>;
-pub type StringArray = Utf8Array<i64>;
+pub type MutableStringArray = MutableUtf8Array<i32>;
+pub type StringArray = Utf8Array<i32>;
 
 macro_rules! cast_array {
     ($arr: ident, $CastType: ty) => {

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -268,7 +268,7 @@ mod tests {
             ConcreteDataType::String(_)
         ));
         assert!(matches!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::LargeUtf8),
+            ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8),
             ConcreteDataType::String(_)
         ));
         assert_eq!(

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -30,6 +30,6 @@ impl DataType for StringType {
     }
 
     fn as_arrow_type(&self) -> ArrowDataType {
-        ArrowDataType::LargeUtf8
+        ArrowDataType::Utf8
     }
 }

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -117,7 +117,7 @@ impl Vector for StringVector {
 impl ScalarVector for StringVector {
     type OwnedItem = String;
     type RefItem<'a> = &'a str;
-    type Iter<'a> = ZipValidity<'a, &'a str, Utf8ValuesIter<'a, i64>>;
+    type Iter<'a> = ZipValidity<'a, &'a str, Utf8ValuesIter<'a, i32>>;
     type Builder = StringVectorBuilder;
 
     fn get_data(&self, idx: usize) -> Option<Self::RefItem<'_>> {
@@ -218,7 +218,7 @@ mod tests {
 
         let arrow_arr = v.to_arrow_array();
         assert_eq!(3, arrow_arr.len());
-        assert_eq!(&ArrowDataType::LargeUtf8, arrow_arr.data_type());
+        assert_eq!(&ArrowDataType::Utf8, arrow_arr.data_type());
     }
 
     #[test]


### PR DESCRIPTION
Change inner representation of `StringVector` from `Utf8Array<i64>` to `Utf8Array<i32>` and corresponding data type from `LargeUtf8` to `Utf8`.

The reason to this change is in currently depended arrow-datafusion version it [does not handle string type coercion when evaluating binary eq op](https://github.com/apache/arrow-datafusion/blob/arrow2/datafusion-physical-expr/src/coercion_rule/binary_rule.rs#L97-L107). It is a bug and is [already fixed in recent arrow-datafusion releases](https://github.com/apache/arrow-datafusion/pull/2258/files).

This change serves as a temporary fix to #220 . The ultimate solution would be using an active upstream version of datafusion, either by upgrading datafusion or maintaining another fork of datafusion, I created another issue #221  for this discussion.