### PR TITLE
fix: Only convert LogicalTypeId to ConcreteDataType in tests

### DIFF
--- a/src/common/function/src/scalars/aggregate/diff.rs
+++ b/src/common/function/src/scalars/aggregate/diff.rs
@@ -168,7 +168,7 @@ impl AggregateFunctionCreator for DiffAccumulatorCreator {
         with_match_primitive_type_id!(
             input_types[0].logical_type_id(),
             |$S| {
-                Ok(ConcreteDataType::list_datatype(PrimitiveType::<<$S as Primitive>::LargestType>::default().logical_type_id().data_type()))
+                Ok(ConcreteDataType::list_datatype(PrimitiveType::<<$S as Primitive>::LargestType>::default().into()))
             },
             {
                 unreachable!()
@@ -182,7 +182,7 @@ impl AggregateFunctionCreator for DiffAccumulatorCreator {
         with_match_primitive_type_id!(
             input_types[0].logical_type_id(),
             |$S| {
-                Ok(vec![ConcreteDataType::list_datatype(PrimitiveType::<$S>::default().logical_type_id().data_type())])
+                Ok(vec![ConcreteDataType::list_datatype(PrimitiveType::<$S>::default().into())])
             },
             {
                 unreachable!()

--- a/src/common/function/src/scalars/aggregate/polyval.rs
+++ b/src/common/function/src/scalars/aggregate/polyval.rs
@@ -237,7 +237,7 @@ impl AggregateFunctionCreator for PolyvalAccumulatorCreator {
         with_match_primitive_type_id!(
             input_type,
             |$S| {
-                Ok(PrimitiveType::<<$S as Primitive>::LargestType>::default().logical_type_id().data_type())
+                Ok(PrimitiveType::<<$S as Primitive>::LargestType>::default().into())
             },
             {
                 unreachable!()

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -3,6 +3,10 @@ name = "datatypes"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+test = []
+
 [dependencies.arrow]
 package = "arrow2"
 version = "0.10"

--- a/src/datatypes/src/type_id.rs
+++ b/src/datatypes/src/type_id.rs
@@ -36,8 +36,12 @@ pub enum LogicalTypeId {
 }
 
 impl LogicalTypeId {
+    /// Create ConcreteDataType based on this id. This method is for test only as it
+    /// would lost some info.
+    ///
     /// # Panics
     /// Panics if data type is not supported.
+    #[cfg(any(test, feature = "test"))]
     pub fn data_type(&self) -> ConcreteDataType {
         match self {
             LogicalTypeId::Null => ConcreteDataType::null_datatype(),

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -37,6 +37,7 @@ uuid = { version = "1.1" , features=["v4"]}
 [dev-dependencies]
 atomic_float="0.1"
 criterion = "0.3"
+datatypes = { path = "../datatypes", features = ["test"] }
 rand = "0.8"
 tempdir = "0.3"
 

--- a/src/table-engine/Cargo.toml
+++ b/src/table-engine/Cargo.toml
@@ -32,6 +32,5 @@ tempdir = { version = "0.3", optional = true }
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
-datatypes = { path = "../datatypes" }
 tempdir = { version = "0.3" }
 tokio = { version = "1.18", features = ["full"] }


### PR DESCRIPTION
## Changes
`LogicalTypeId` is considered as the catalog (or kind) of a logical type (`DataType` or `ConcreteDataType`), may not carry enough type info to build its corresponding `ConcreteDataType`: e.g. `LogicalTypeId::List` doesn't store the inner data type of the `ListType`.

Thus , converting from `LogicalTypeId` to `ConcreteDataType` is only allowed in tests, in order to simplify some test codes. This PR
- fixes some incorrect usage of getting a `ConcreteDataType` from `LogicalTypeId`, such as `Int32DataType.logical_type_id().data_type()` should be replaced by `Int32DataType.into()`
- add a `cfg` attribute to restrict that the conversion is only allowed in test codes (or with feature `test` enabled).
