### PR TITLE
refactor: Set unittest's logging dir to "/tmp" to not pollute source codes' dir…

### DIFF
--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -31,7 +31,7 @@ pub fn init_default_ut_logging() {
         let mut g = GLOBAL_UT_LOG_GUARD.as_ref().lock().unwrap();
         *g = Some(init_global_logging(
             "unittest",
-            "__unittest_logs",
+            "/tmp/__unittest_logs",
             "DEBUG",
             false,
         ));


### PR DESCRIPTION
… when running unittests from IDE.