### PR TITLE
refactor: rename to_vec to take for RecordBatches

### DIFF
--- a/src/common/recordbatch/src/lib.rs
+++ b/src/common/recordbatch/src/lib.rs
@@ -71,8 +71,7 @@ impl RecordBatches {
         self.schema.clone()
     }
 
-    // TODO: a new name that to avoid misunderstanding it as an allocation operation
-    pub fn to_vec(self) -> Vec<RecordBatch> {
+    pub fn take(self) -> Vec<RecordBatch> {
         self.batches
     }
 }
@@ -115,6 +114,6 @@ mod tests {
 
         let batches = RecordBatches::try_new(schema1.clone(), vec![batch1.clone()]).unwrap();
         assert_eq!(schema1, batches.schema());
-        assert_eq!(vec![batch1], batches.to_vec());
+        assert_eq!(vec![batch1], batches.take());
     }
 }

--- a/src/datanode/src/server/grpc/select.rs
+++ b/src/datanode/src/server/grpc/select.rs
@@ -21,7 +21,7 @@ pub async fn to_object_result(result: Result<Output>) -> ObjectResult {
             .mutate_result(rows as u32, 0)
             .build(),
         Ok(Output::Stream(stream)) => record_batchs(stream).await,
-        Ok(Output::RecordBatches(recordbatches)) => build_result(recordbatches.to_vec()).await,
+        Ok(Output::RecordBatches(recordbatches)) => build_result(recordbatches.take()).await,
         Err(err) => ObjectResultBuilder::new()
             .status_code(err.status_code() as u32)
             .err_msg(err.to_string())

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -287,7 +287,7 @@ mod tests {
             _ => unreachable!(),
         }
 
-        let sql = r#"insert into demo(host, cpu, memory, ts) values 
+        let sql = r#"insert into demo(host, cpu, memory, ts) values
                                 ('frontend.host1', 1.1, 100, 1000),
                                 ('frontend.host2', null, null, 2000),
                                 ('frontend.host3', 3.3, 300, 3000)
@@ -307,7 +307,7 @@ mod tests {
         match output {
             Output::RecordBatches(recordbatches) => {
                 let recordbatches = recordbatches
-                    .to_vec()
+                    .take()
                     .into_iter()
                     .map(|r| r.df_recordbatch)
                     .collect::<Vec<DfRecordBatch>>();

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -86,7 +86,7 @@ impl JsonResponse {
                 Err(e) => Self::with_error(Some(format!("Recordbatch error: {}", e))),
             },
             Ok(Output::RecordBatches(recordbatches)) => {
-                Self::with_output(Some(JsonOutput::Rows(recordbatches.to_vec())))
+                Self::with_output(Some(JsonOutput::Rows(recordbatches.take())))
             }
             Err(e) => Self::with_error(Some(format!("Query engine output error: {}", e))),
         }

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -48,7 +48,7 @@ impl<'a, W: io::Write> MysqlResultWriter<'a, W> {
                 Output::RecordBatches(recordbatches) => {
                     let query_result = QueryResult {
                         schema: recordbatches.schema(),
-                        recordbatches: recordbatches.to_vec(),
+                        recordbatches: recordbatches.take(),
                     };
                     Self::write_query_result(query_result, writer)?
                 }

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -51,7 +51,7 @@ impl SimpleQueryHandler for PostgresServerHandler {
             }
             Output::RecordBatches(recordbatches) => {
                 let schema = recordbatches.schema();
-                recordbatches_to_query_response(recordbatches.to_vec().iter(), schema)
+                recordbatches_to_query_response(recordbatches.take().iter(), schema)
             }
         }
     }


### PR DESCRIPTION
Renaming `to_vec` to `take` as we discussed in #229 