### PR TITLE
fix: Fix sequence decrease after flush and reopen

### DIFF
--- a/src/log-store/src/fs/log.rs
+++ b/src/log-store/src/fs/log.rs
@@ -228,7 +228,7 @@ impl LogStore for LocalFileLogStore {
             for (start_id, file) in files.iter() {
                 // TODO(hl): Use index to lookup file
                 if *start_id <= id {
-                    let s = file.create_stream(&ns, *start_id);
+                    let s = file.create_stream(&ns, id);
                     pin_mut!(s);
                     while let Some(entries) = s.next().await {
                         match entries {


### PR DESCRIPTION
## Changes
- The log store use start sequence instead of file start id to filter log stream.
  - Otherwise the log store would yield entries before `flushed_sequence` and cause the `SequenceNotMonotonic` error
- Add more tests about flush, including flush empty memtable and reopen after flush
  - Reopen after flush in `test_read_after_flush()` could help regress this sequence issue