### PR TITLE
feat: influxdb batch write

### DIFF
--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -65,6 +65,24 @@ impl Database {
         self.object(expr).await?.try_into()
     }
 
+    pub async fn batch_insert(&self, insert_exprs: Vec<InsertExpr>) -> Result<Vec<ObjectResult>> {
+        let header = ExprHeader {
+            version: PROTOCOL_VERSION,
+        };
+        let obj_exprs = insert_exprs
+            .into_iter()
+            .map(|expr| ObjectExpr {
+                header: Some(header.clone()),
+                expr: Some(object_expr::Expr::Insert(expr)),
+            })
+            .collect();
+        self.objects(obj_exprs)
+            .await?
+            .into_iter()
+            .map(|result| result.try_into())
+            .collect()
+    }
+
     pub async fn select(&self, expr: Select) -> Result<ObjectResult> {
         let select_expr = match expr {
             Select::Sql(sql) => SelectExpr {

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -1,45 +1,23 @@
-use api::v1::{insert_expr::Expr, InsertExpr};
+use api::v1::InsertExpr;
 use async_trait::async_trait;
 use common_error::prelude::BoxedError;
 use servers::influxdb::InfluxdbRequest;
-use servers::{
-    error::ExecuteQuerySnafu, influxdb::InsertBatches, query_handler::InfluxdbLineProtocolHandler,
-};
+use servers::{error::ExecuteQuerySnafu, query_handler::InfluxdbLineProtocolHandler};
 use snafu::ResultExt;
 
-use crate::error::RequestDatanodeSnafu;
-use crate::error::Result;
 use crate::instance::Instance;
 
 #[async_trait]
 impl InfluxdbLineProtocolHandler for Instance {
     async fn exec(&self, request: &InfluxdbRequest) -> servers::error::Result<()> {
-        // TODO(fys): use batch insert
-        self.do_insert(request.try_into()?)
+        let exprs: Vec<InsertExpr> = request.try_into()?;
+        self.db
+            .batch_insert(exprs)
             .await
             .map_err(BoxedError::new)
             .context(ExecuteQuerySnafu {
                 query: &request.lines,
             })?;
-        Ok(())
-    }
-}
-
-impl Instance {
-    async fn do_insert(&self, insert_batches: InsertBatches) -> Result<()> {
-        for (table_name, batch) in insert_batches.data {
-            let expr = Expr::Values(api::v1::insert_expr::Values {
-                values: vec![batch.into()],
-            });
-            let _object_result = self
-                .db
-                .insert(InsertExpr {
-                    table_name,
-                    expr: Some(expr),
-                })
-                .await
-                .context(RequestDatanodeSnafu)?;
-        }
         Ok(())
     }
 }

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use api::v1::InsertExpr;
 use async_trait::async_trait;
 use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
 use servers::error::Result;
 use servers::http::HttpServer;
-use servers::influxdb::{InfluxdbRequest, InsertBatches};
+use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::{InfluxdbLineProtocolHandler, SqlQueryHandler};
 use tokio::sync::mpsc;
 
@@ -17,10 +18,10 @@ struct DummyInstance {
 #[async_trait]
 impl InfluxdbLineProtocolHandler for DummyInstance {
     async fn exec(&self, request: &InfluxdbRequest) -> Result<()> {
-        let batches: InsertBatches = request.try_into()?;
+        let exprs: Vec<InsertExpr> = request.try_into()?;
 
-        for (table_name, _) in batches.data {
-            let _ = self.tx.send(table_name).await;
+        for expr in exprs {
+            let _ = self.tx.send(expr.table_name).await;
         }
 
         Ok(())


### PR DESCRIPTION
This PR implements influxdb batch write.
## Changes
- Grpc client add a function,  as follows:
```
pub async fn batch_insert(&self, insert_exprs: Vec<InsertExpr>) -> Result<Vec<ObjectResult>>
```
- Influxdb write use **batch_insert**, instead of **insert**.
-  Remove unnecessary structure