### PR TITLE
chore: ignore vscode config directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,5 @@ debug/
 **/__unittest_logs
 logs/
 
-.DS_store
-.gitignore
-
 # cpython's generated python byte code
 **/__pycache__/


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Ignore the `.vscode` dir which contains local IDE configs