### PR TITLE
refactor: relax memory ordering of accessing VersionControl::committed_sequence

### DIFF
--- a/src/storage/src/version.rs
+++ b/src/storage/src/version.rs
@@ -64,7 +64,7 @@ impl VersionControl {
 
     #[inline]
     pub fn committed_sequence(&self) -> SequenceNumber {
-        self.committed_sequence.load(Ordering::Acquire)
+        self.committed_sequence.load(Ordering::Relaxed)
     }
 
     /// Set committed sequence to `value`.
@@ -73,8 +73,8 @@ impl VersionControl {
     /// last sequence.
     #[inline]
     pub fn set_committed_sequence(&self, value: SequenceNumber) {
-        // Release ordering should be enough to guarantee sequence is updated at last.
-        self.committed_sequence.store(value, Ordering::Release);
+        // Relaxed ordering is enough for this update as this method requires external synchoronization.
+        self.committed_sequence.store(value, Ordering::Relaxed);
     }
 
     /// Add mutable memtables and commit.


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Change both `load` and `store` operation's ordering parameters to `Ordering::Relaxed`.

These scenarios don't require concurrent synchronization because `set_committed_sequence` is already serialized (declared in the doc comment, and I've checked all the references). I think the `AtomicU64` type of `VersionControl::committed_sequence` is only for interior mutability, i.e, it can be a `RefCell` or something else.

To make sure this change is correct, I write a little test with [loom](https://docs.rs/loom):
```rust
#[cfg(test)]
mod test {
    use loom::sync::atomic::AtomicU64;
    use loom::sync::Mutex;
    use loom::thread;

    use std::sync::atomic::Ordering::Relaxed;
    use std::sync::Arc;

    fn process(version: Arc<AtomicU64>, lock: Arc<Mutex<()>>) {
        let _gurad = lock.lock();
        let v = version.load(Relaxed);
        let new_v = v + 1;
        version.store(new_v, Relaxed);
    }

    #[test]
    fn serialized_update() {
        loom::model(|| {
            let mut handles = vec![];

            let version = Arc::new(AtomicU64::new(0));
            let lock = Arc::new(Mutex::new(()));

            for _ in 0..3 {
                let version_cloned = version.clone();
                let lock_cloned = lock.clone();
                let handle = thread::spawn(|| {
                    process(version_cloned, lock_cloned);
                });

                handles.push(handle);
            }

            for handle in handles {
                handle.join().unwrap();
            }

            let final_version = version.load(Relaxed);
            assert_eq!(final_version, 3);
        });
    }
}
```

I don't submit this test because (a) loom is very restricted (on the simulation capacity) and requires lots of condition compiling, and (b) it mocks out almost everything and cannot prevent the real logic from corruption in the future modifications.

BTW, the "separated lock" flavor (require lock in comment rather than code) around `Version` is sometimes hard to maintain. Maybe some refactors are necessary.