### PR TITLE
fix: further differentiate jobs' cache

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,8 @@ name: Code coverage
 
 env:
   RUST_TOOLCHAIN: nightly-2022-07-14
+  ACTIONS_RUNNER_DEBUG: true
+  ACTIONS_STEP_DEBUG: true
 
 jobs:
   grcov:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -6,6 +6,8 @@ name: Continuous integration for developing
 
 env:
   RUST_TOOLCHAIN: nightly-2022-07-14
+  ACTIONS_RUNNER_DEBUG: true
+  ACTIONS_STEP_DEBUG: true
 
 jobs:
   check:


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Our CI cache doesn't work appropriately, leads to a long running time
<img width="324" alt="图片" src="https://user-images.githubusercontent.com/15380403/195558753-d08e20e0-f714-458e-bf8e-49a4681c2d0a.png">
