### PR TITLE
style(table-engine): Remove unnecessary TableError::from

### DIFF
--- a/src/table-engine/src/table.rs
+++ b/src/table-engine/src/table.rs
@@ -100,7 +100,7 @@ impl<R: Region> Table for MitoTable<R> {
                     .add_key_column(name, vector)
                     .map_err(TableError::new)?;
             } else if !column_schema.is_nullable {
-                return MissingColumnSnafu { name }.fail().map_err(TableError::from);
+                return MissingColumnSnafu { name }.fail()?;
             }
         }
         // Add value columns
@@ -116,7 +116,7 @@ impl<R: Region> Table for MitoTable<R> {
             if let Some(v) = vector {
                 put_op.add_value_column(name, v).map_err(TableError::new)?;
             } else if !column_schema.is_nullable {
-                return MissingColumnSnafu { name }.fail().map_err(TableError::from);
+                return MissingColumnSnafu { name }.fail()?;
             }
         }
 


### PR DESCRIPTION
## Changes
The usage of TableError::from could be replaced by `?`, which is more concise