### PR TITLE
ci: Use docs instead of doc

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -4,7 +4,7 @@
     "color": "B60205"
   },
   "CHECKS": {
-    "regexp": "^(feat|fix|test|refactor|chore|style|doc|perf|build|ci|revert)(\\(.*\\))?:.*",
+    "regexp": "^(feat|fix|test|refactor|chore|style|docs|perf|build|ci|revert)(\\(.*\\))?:.*",
     "ignoreLabels" : ["ignore-title"]
   }
 }


### PR DESCRIPTION
## Changes
The pr label should be `docs` instead of `doc` according to the [`conventionalcommits`](https://www.conventionalcommits.org/)