### PR TITLE
chore: set CI timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,7 @@ jobs:
   grcov:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -12,6 +12,7 @@ jobs:
     name: Check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1
@@ -31,6 +32,7 @@ jobs:
     name: Test Suite
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1
@@ -56,6 +58,7 @@ jobs:
     name: Rustfmt
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1
@@ -76,6 +79,7 @@ jobs:
     name: Clippy
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
       - uses: arduino/setup-protoc@v1

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: thehanimo/pr-title-checker@v1.3.4
         with:


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Closes #357 

Set the CI timeout limit. All set to 60 mins except the PR title checker (is set to 10). The default value is 360 mins.