### PR TITLE
fix: also run CI in develop branch

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -3,6 +3,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
+      - develop
       - main
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Our main branch only run coverage. It should run tests as well.

This may also fix the action cache.