### PR TITLE
ci: use lld linker for ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./llvm
           key: llvm
@@ -47,10 +47,9 @@ jobs:
           command: test
           args: --workspace
         env:
-          CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=unwind -Zpanic_abort_tests -Clink-arg=-fuse-ld=lld"
           GT_S3_BUCKET: ${{ secrets.S3_BUCKET }}
           GT_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           GT_S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cache LLVM and Clang
         id: cache-llvm
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./llvm
           key: llvm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache cargo assets
+        id: cache
         uses: actions/cache@v3
         with:
           path: |
+            ./llvm
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
@@ -50,6 +52,11 @@ jobs:
           unzip protoc-21.9-linux-x86_64.zip -d protoc
           sudo cp protoc/bin/protoc /usr/local/bin/
           sudo cp -r protoc/include/google /usr/local/include/
+
+      - uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
+          cached: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Install Protoc for macos
         if: contains(matrix.arch, 'darwin')
@@ -78,6 +85,8 @@ jobs:
         with:
           command: build
           args: ${{ matrix.opts }} --release --locked --target ${{ matrix.arch }}
+        env:
+          CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
 
       - name: Calculate checksum and rename binary
         shell: bash


### PR DESCRIPTION
Fixes #400 

- use `lld` as linker, reduce memory footprint
- add disk cleanup step to release more space for testing