### PR TITLE
fix: /metrics endpoint

### DIFF
--- a/src/datanode/src/tests/http_test.rs
+++ b/src/datanode/src/tests/http_test.rs
@@ -98,7 +98,7 @@ async fn test_metrics_api() {
     assert_eq!(res.status(), StatusCode::OK);
 
     // Call metrics api
-    let res = client.get("/v1/metrics").send().await;
+    let res = client.get("/metrics").send().await;
     assert_eq!(res.status(), StatusCode::OK);
     let body = res.text().await;
     assert!(body.contains("datanode_handle_sql_elapsed"));

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -304,8 +304,7 @@ impl HttpServer {
             router = router.nest(&format!("/{}/prometheus", HTTP_API_VERSION), prom_router);
         }
 
-        let metrics_router = Router::new().route("/", routing::get(handler::metrics));
-        router = router.nest(&format!("/{}/metrics", HTTP_API_VERSION), metrics_router);
+        router = router.route("/metrics", routing::get(handler::metrics));
 
         router
             // middlewares


### PR DESCRIPTION
Prometheus `/metrics` endpoint  is a root path in convention, not nested by other paths.

