### PR TITLE
perf: enlarge write row group size

### DIFF
--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use common_telemetry::logging;
 use common_time::RangeMillis;
 use store_api::logstore::LogStore;
+use store_api::storage::consts::WRITE_ROW_GROUP_SIZE;
 use store_api::storage::SequenceNumber;
 use uuid::Uuid;
 
@@ -164,6 +165,8 @@ impl<S: LogStore> FlushJob<S> {
         let mut futures = Vec::with_capacity(self.memtables.len());
         let iter_ctx = IterContext {
             for_flush: true,
+            // TODO(ruihang): dynamic row group size based on content (#412)
+            batch_size: WRITE_ROW_GROUP_SIZE,
             ..Default::default()
         };
         for m in &self.memtables {

--- a/src/store-api/src/storage/consts.rs
+++ b/src/store-api/src/storage/consts.rs
@@ -79,6 +79,8 @@ pub const OP_TYPE_COLUMN_NAME: &str = "__op_type";
 
 pub const READ_BATCH_SIZE: usize = 256;
 
+pub const WRITE_ROW_GROUP_SIZE: usize = 4096;
+
 // -----------------------------------------------------------------------------
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

## Desc

Related to #412 

Notice this is a short term parameter adjusting. #412 describes a more detailed solution.

## Perf
- row group size 256
  - avg ~430 row groups per file
  - avg ~7.6 kB per row group
  - total 129MB data generated
  - write takes ~4mins
- row group size 4096
  - avg ~25 row groups per file
  - avg ~83 kB per row group
  - total 66MB data generated
  - write takes ~40s