### PR TITLE
fix: use same tmp data location as default config

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -15,10 +15,7 @@ pub enum ObjectStoreConfig {
 impl Default for ObjectStoreConfig {
     fn default() -> Self {
         ObjectStoreConfig::File {
-            data_dir: format!(
-                "/tmp/greptimedb/data/{}",
-                common_time::util::current_time_millis()
-            ),
+            data_dir: "/tmp/greptimedb/data/".to_string(),
         }
     }
 }
@@ -58,10 +55,7 @@ impl Default for DatanodeOptions {
             postgres_addr: "0.0.0.0:5432".to_string(),
             postgres_runtime_size: 2,
             meta_client_opts: MetaClientOpts::default(),
-            wal_dir: format!(
-                "/tmp/greptimedb/wal/{}",
-                common_time::util::current_time_millis()
-            ),
+            wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
             mode: Mode::Standalone,
         }


### PR DESCRIPTION
Revert default `ObjectStoreConfig` location.