### PR TITLE
ci: disable lld in release workflow for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ./llvm
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
@@ -52,11 +51,6 @@ jobs:
           unzip protoc-21.9-linux-x86_64.zip -d protoc
           sudo cp protoc/bin/protoc /usr/local/bin/
           sudo cp -r protoc/include/google /usr/local/include/
-
-      - uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "14.0"
-          cached: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Install Protoc for macos
         if: contains(matrix.arch, 'darwin')
@@ -85,8 +79,6 @@ jobs:
         with:
           command: build
           args: ${{ matrix.opts }} --release --locked --target ${{ matrix.arch }}
-        env:
-          CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
 
       - name: Calculate checksum and rename binary
         shell: bash


### PR DESCRIPTION
Using lld in cross-compile scenario leads to some weird issues.