### PR TITLE
feat: add 'scripts/install.sh' to make the installation more easy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
 
 name: Release
 
@@ -13,20 +14,20 @@ jobs:
     name: Build binary
     strategy:
       matrix:
-        # The file format is greptime-<tag>.<os>-<arch>
+        # The file format is greptime-<os>-<arch>
         include:
           - arch: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            file: greptime-${{ github.ref_name }}.linux-amd64
+            file: greptime-linux-amd64
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            file: greptime-${{ github.ref_name }}.linux-arm64
+            file: greptime-linux-arm64
           - arch: aarch64-apple-darwin
             os: macos-latest
-            file: greptime-${{ github.ref_name }}.darwin-arm64
+            file: greptime-darwin-arm64
           - arch: x86_64-apple-darwin
             os: macos-latest
-            file: greptime-${{ github.ref_name }}.darwin-amd64
+            file: greptime-darwin-amd64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
@@ -84,14 +85,15 @@ jobs:
         shell: bash
         run: |
           cd target/${{ matrix.arch }}/release
-          cp greptime ${{ matrix.file }}
-          echo $(shasum -a 256 greptime | cut -f1 -d' ') > ${{ matrix.file }}.sha256sum
+          chmod +x greptime
+          tar -zcvf ${{ matrix.file }}.tgz greptime
+          echo $(shasum -a 256 ${{ matrix.file }}.tgz | cut -f1 -d' ') > ${{ matrix.file }}.sha256sum
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.file }}
-          path: target/${{ matrix.arch }}/release/${{ matrix.file }}
+          path: target/${{ matrix.arch }}/release/${{ matrix.file }}.tgz
 
       - name: Upload checksum of artifacts
         uses: actions/upload-artifact@v3
@@ -114,7 +116,7 @@ jobs:
         with:
           name: "Release ${{ github.ref_name }}"
           files: |
-            **/greptime-${{ github.ref_name }}.*
+            **/greptime-*
 
   docker:
     name: Build docker image
@@ -127,27 +129,26 @@ jobs:
       - name: Download amd64 binary
         uses: actions/download-artifact@v3
         with:
-          name: greptime-${{ github.ref_name }}.linux-amd64
+          name: greptime-linux-amd64
           path: amd64
 
-      - name: Rename amd64 binary
+      - name: Unzip the amd64 artifacts
         run: |
-          mv amd64/greptime-${{ github.ref_name }}.linux-amd64 amd64/greptime
+          cd amd64
+          tar xvf greptime-linux-amd64.tgz
+          rm greptime-linux-amd64.tgz
 
       - name: Download arm64 binary
         uses: actions/download-artifact@v3
         with:
-          name: greptime-${{ github.ref_name }}.linux-arm64
+          name: greptime-linux-arm64
           path: arm64
 
-      - name: Rename arm64 binary
+      - name: Unzip the arm64 artifacts
         run: |
-          mv arm64/greptime-${{ github.ref_name }}.linux-arm64 arm64/greptime
-
-      - name: Set file permissions
-        shell: bash
-        run: |
-          chmod +x amd64/greptime arm64/greptime
+          cd arm64
+          tar xvf greptime-linux-arm64.tgz
+          rm greptime-linux-arm64.tgz
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -ue
+
+OS_TYPE=
+ARCH_TYPE=
+VERSION=${1:-latest}
+GITHUB_ORG=GreptimeTeam
+GITHUB_REPO=greptimedb
+BIN=greptimedb
+
+get_os_type() {
+    os_type="$(uname -s)"
+
+    case "$os_type" in
+    Darwin)
+        OS_TYPE=darwin
+        ;;
+    Linux)
+        OS_TYPE=linux
+        ;;
+    *)
+        echo "Error: Unknown OS type: $os_type"
+        exit 1
+    esac
+}
+
+get_arch_type() {
+    arch_type="$(uname -m)"
+
+    case "$arch_type" in
+    arm64)
+        ARCH_TYPE=arm64
+        ;;
+    aarch64)
+        ARCH_TYPE=arm64
+        ;;
+    x86_64)
+        ARCH_TYPE=amd64
+        ;;
+    amd64)
+        ARCH_TYPE=amd64
+        ;;
+    *)
+        echo "Error: Unknown CPU type: $arch_type"
+        exit 1
+    esac
+}
+
+get_os_type
+get_arch_type
+
+if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
+    echo "Downloading ${BIN}, OS: ${OS_TYPE}, Arch: ${ARCH_TYPE}, Version: ${VERSION}"
+
+    if [ "${VERSION}" = "latest" ]; then
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest/download/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+    else
+        wget "https://github.com/${GITHUB_ORG}/${GITHUB_REPO}/releases/download/${VERSION}/${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz"
+    fi
+
+    tar xvf ${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz && rm ${BIN}-${OS_TYPE}-${ARCH_TYPE}.tgz && echo "Run '${BIN} --help' to get started"
+fi


### PR DESCRIPTION
- Modify artifacts name as `greptime-<os>-<arch>`;

- Upload the compressed artifacts to boost up download performance;

- Add `scripts/install.sh` to make the installation more easy, you can(after open source):

   ```
   # Download the latest version
   $ curl -L https://github.com/GreptimeTeam/greptimedb/blob/main/scripts/install.sh | sh

   # Download the specific version
   $ curl -L https://github.com/GreptimeTeam/greptimedb/blob/main/scripts/install.sh | sh -s v0.1.0
   ```
