### PR TITLE
docs: refine contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ To learn about the design of GreptimeDB, please refer to the [design docs](https
 - Make sure all unit tests are passed.
 - Make sure all clippy warnings are fixed (you can check it locally by running `cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr`).
 
-
 #### `pre-commit` Hooks
 You could setup the [`pre-commit`](https://pre-commit.com/#plugins) hooks to run these checks on every commit automatically.
 
@@ -37,11 +36,10 @@ pre-commit installed at .git/hooks/pre-pus
 
 now `pre-commit` will run automatically on `git commit`.
 
-
 ### Title
 
-The titles of pull requests should be prefixed with category name listed in [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0) 
-like `feat`/`fix`/`doc`, with a concise summary of code change follows. DO NOT use last commit message as pull request title.
+The titles of pull requests should be prefixed with one of the change types listed in [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0) 
+like `feat`/`fix`/`docs`, with a concise summary of code change follows. The following scope field is optional, you can fill it with the name of sub-crate if the pull request only changes one, or just leave it blank.
 
 ### Description
 
@@ -49,15 +47,10 @@ like `feat`/`fix`/`doc`, with a concise summary of code change follows. DO NOT u
 - But if it contains large code change, make sure to state the motivation/design details of this PR so that reviewers can understand what you're trying to do.
 - If the PR contains any breaking change or API change, make sure that is clearly listed in your description.
 
-### Commit Messages
-
-All commit messages SHOULD adhere to the [Conventional Commits specification](https://conventionalcommits.org/).
-
 ## Getting help
 
 There are many ways to get help when you're stuck. It is recommended to ask for help by opening an issue, with a detailed description
 of what you were trying to do and what went wrong. You can also reach for help in our Slack channel.
-
 
 ## Bug report
 To report a bug or a security issue, you can [open a new GitHub issue](https://github.com/GrepTimeTeam/greptimedb/issues/new).


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

## Issue closed

Closes #445 

## Changes included

Refine the contributing guide's commit message part.
- type fix: change from `doc` to `docs`
- remove the requirement that enforce every commit need to follow the conventional commit. Only the PR title needs because we always squash commits when merging.
- remove the requirement that forbids PR title to be the same with commit message. It's not necessary.
- describe how the scope field is treated. 