### PR TITLE
ci: Fix codecov.yml syntax

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,8 @@
 # codecov config
 coverage:
   status:
-    patch: off # disable patch status
     project:
       default:
-        enable: yes
         threshold: 1%
 ignore:
   - "**/error*.rs" # ignore all error.rs files


### PR DESCRIPTION
## Changes
This PR fixes the `codecov.yml` and makes it pass the `codecov`'s validation. Now our `codecov.yml` should work.