### PR TITLE
fix: make scripts API work again

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -94,6 +94,7 @@ async fn build_frontend(
         .await
         .context(BuildFrontendSnafu)?;
     frontend_instance.set_catalog_manager(datanode_instance.catalog_manager().clone());
+    frontend_instance.set_script_handler(datanode_instance);
     Ok(Frontend::new(fe_opts, frontend_instance))
 }
 

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -26,6 +26,7 @@ use crate::server::grpc::plan::PhysicalPlanner;
 use crate::sql::SqlHandler;
 
 mod grpc;
+mod script;
 mod sql;
 
 pub(crate) type DefaultEngine = MitoEngine<EngineImpl<LocalFileLogStore>>;

--- a/src/datanode/src/instance/script.rs
+++ b/src/datanode/src/instance/script.rs
@@ -1,0 +1,20 @@
+use async_trait::async_trait;
+use common_query::Output;
+use common_telemetry::timer;
+use servers::query_handler::ScriptHandler;
+
+use crate::instance::Instance;
+use crate::metric;
+
+#[async_trait]
+impl ScriptHandler for Instance {
+    async fn insert_script(&self, name: &str, script: &str) -> servers::error::Result<()> {
+        let _timer = timer!(metric::METRIC_HANDLE_SCRIPTS_ELAPSED);
+        self.script_executor.insert_script(name, script).await
+    }
+
+    async fn execute_script(&self, name: &str) -> servers::error::Result<Output> {
+        let _timer = timer!(metric::METRIC_RUN_SCRIPT_ELAPSED);
+        self.script_executor.execute_script(name).await
+    }
+}

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -122,12 +122,4 @@ impl SqlQueryHandler for Instance {
             })
             .context(servers::error::ExecuteQuerySnafu { query })
     }
-
-    async fn insert_script(&self, name: &str, script: &str) -> servers::error::Result<()> {
-        self.script_executor.insert_script(name, script).await
-    }
-
-    async fn execute_script(&self, name: &str) -> servers::error::Result<Output> {
-        self.script_executor.execute_script(name).await
-    }
 }

--- a/src/datanode/src/metric.rs
+++ b/src/datanode/src/metric.rs
@@ -1,3 +1,5 @@
 //! datanode metrics
 
 pub const METRIC_HANDLE_SQL_ELAPSED: &str = "datanode.handle_sql_elapsed";
+pub const METRIC_HANDLE_SCRIPTS_ELAPSED: &str = "datanode.handle_scripts_elapsed";
+pub const METRIC_RUN_SCRIPT_ELAPSED: &str = "datanode.run_script_elapsed";

--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -173,9 +173,13 @@ async fn test_execute_insert() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    test_util::create_test_table(&instance, ConcreteDataType::timestamp_millis_datatype())
-        .await
-        .unwrap();
+    test_util::create_test_table(
+        instance.catalog_manager(),
+        instance.sql_handler(),
+        ConcreteDataType::timestamp_millis_datatype(),
+    )
+    .await
+    .unwrap();
 
     let output = instance
         .execute_sql(
@@ -197,9 +201,13 @@ async fn test_execute_insert_query_with_i64_timestamp() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    test_util::create_test_table(&instance, ConcreteDataType::int64_datatype())
-        .await
-        .unwrap();
+    test_util::create_test_table(
+        instance.catalog_manager(),
+        instance.sql_handler(),
+        ConcreteDataType::int64_datatype(),
+    )
+    .await
+    .unwrap();
 
     let output = instance
         .execute_sql(
@@ -329,9 +337,13 @@ async fn test_execute_show_databases_tables() {
     }
 
     // creat a table
-    test_util::create_test_table(&instance, ConcreteDataType::timestamp_millis_datatype())
-        .await
-        .unwrap();
+    test_util::create_test_table(
+        instance.catalog_manager(),
+        instance.sql_handler(),
+        ConcreteDataType::timestamp_millis_datatype(),
+    )
+    .await
+    .unwrap();
 
     let output = instance.execute_sql("show tables").await.unwrap();
     match output {
@@ -440,9 +452,13 @@ async fn test_alter_table() {
     let instance = Instance::new_mock().await.unwrap();
     instance.start().await.unwrap();
 
-    test_util::create_test_table(&instance, ConcreteDataType::timestamp_millis_datatype())
-        .await
-        .unwrap();
+    test_util::create_test_table(
+        instance.catalog_manager(),
+        instance.sql_handler(),
+        ConcreteDataType::timestamp_millis_datatype(),
+    )
+    .await
+    .unwrap();
     // make sure table insertion is ok before altering table
     instance
         .execute_sql("insert into demo(host, cpu, memory, ts) values ('host1', 1.1, 100, 1000)")

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -122,6 +122,7 @@ impl Services {
             ) {
                 http_server.set_prom_handler(instance.clone());
             }
+            http_server.set_script_handler(instance.clone());
 
             Some((Box::new(http_server) as _, http_addr))
         } else {

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -2,15 +2,13 @@ use std::collections::HashMap;
 use std::time::Instant;
 
 use aide::transform::TransformOperation;
-use axum::extract::{Json, Query, RawBody, State};
-use common_error::prelude::ErrorExt;
+use axum::extract::{Json, Query, State};
 use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::http::JsonResponse;
-use crate::query_handler::SqlQueryHandlerRef;
+use crate::http::{ApiState, JsonResponse};
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SqlQuery {
@@ -21,11 +19,12 @@ pub struct SqlQuery {
 /// Handler to execute sql
 #[axum_macros::debug_handler]
 pub async fn sql(
-    State(sql_handler): State<SqlQueryHandlerRef>,
+    State(state): State<ApiState>,
     Query(params): Query<SqlQuery>,
 ) -> Json<JsonResponse> {
+    let sql_handler = &state.sql_handler;
     let start = Instant::now();
-    let resp = if let Some(ref sql) = params.sql {
+    let resp = if let Some(sql) = &params.sql {
         JsonResponse::from_output(sql_handler.do_query(sql).await).await
     } else {
         JsonResponse::with_error(
@@ -49,74 +48,4 @@ pub async fn metrics(Query(_params): Query<HashMap<String, String>>) -> String {
     } else {
         "Prometheus handle not initialized.".to_owned()
     }
-}
-
-macro_rules! json_err {
-    ($e: expr) => {{
-        return Json(JsonResponse::with_error(
-            format!("Invalid argument: {}", $e),
-            common_error::status_code::StatusCode::InvalidArguments,
-        ));
-    }};
-
-    ($msg: expr, $code: expr) => {{
-        return Json(JsonResponse::with_error($msg.to_string(), $code));
-    }};
-}
-
-macro_rules! unwrap_or_json_err {
-    ($result: expr) => {
-        match $result {
-            Ok(result) => result,
-            Err(e) => json_err!(e),
-        }
-    };
-}
-
-/// Handler to insert and compile script
-#[axum_macros::debug_handler]
-pub async fn scripts(
-    State(query_handler): State<SqlQueryHandlerRef>,
-    Query(params): Query<ScriptQuery>,
-    RawBody(body): RawBody,
-) -> Json<JsonResponse> {
-    let name = params.name.as_ref();
-
-    if name.is_none() || name.unwrap().is_empty() {
-        json_err!("invalid name");
-    }
-    let bytes = unwrap_or_json_err!(hyper::body::to_bytes(body).await);
-
-    let script = unwrap_or_json_err!(String::from_utf8(bytes.to_vec()));
-
-    let body = match query_handler.insert_script(name.unwrap(), &script).await {
-        Ok(()) => JsonResponse::with_output(None),
-        Err(e) => json_err!(format!("Insert script error: {}", e), e.status_code()),
-    };
-
-    Json(body)
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct ScriptQuery {
-    pub name: Option<String>,
-}
-
-/// Handler to execute script
-#[axum_macros::debug_handler]
-pub async fn run_script(
-    State(query_handler): State<SqlQueryHandlerRef>,
-    Query(params): Query<ScriptQuery>,
-) -> Json<JsonResponse> {
-    let start = Instant::now();
-    let name = params.name.as_ref();
-
-    if name.is_none() || name.unwrap().is_empty() {
-        json_err!("invalid name");
-    }
-
-    let output = query_handler.execute_script(name.unwrap()).await;
-    let resp = JsonResponse::from_output(output).await;
-
-    Json(resp.with_execution_time(start.elapsed().as_millis()))
 }

--- a/src/servers/src/http/script.rs
+++ b/src/servers/src/http/script.rs
@@ -1,0 +1,86 @@
+use std::time::Instant;
+
+use axum::extract::{Json, Query, RawBody, State};
+use common_error::ext::ErrorExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::http::{ApiState, JsonResponse};
+
+macro_rules! json_err {
+    ($e: expr) => {{
+        return Json(JsonResponse::with_error(
+            format!("Invalid argument: {}", $e),
+            common_error::status_code::StatusCode::InvalidArguments,
+        ));
+    }};
+
+    ($msg: expr, $code: expr) => {{
+        return Json(JsonResponse::with_error($msg.to_string(), $code));
+    }};
+}
+
+macro_rules! unwrap_or_json_err {
+    ($result: expr) => {
+        match $result {
+            Ok(result) => result,
+            Err(e) => json_err!(e),
+        }
+    };
+}
+
+/// Handler to insert and compile script
+#[axum_macros::debug_handler]
+pub async fn scripts(
+    State(state): State<ApiState>,
+    Query(params): Query<ScriptQuery>,
+    RawBody(body): RawBody,
+) -> Json<JsonResponse> {
+    if let Some(script_handler) = &state.script_handler {
+        let name = params.name.as_ref();
+
+        if name.is_none() || name.unwrap().is_empty() {
+            json_err!("invalid name");
+        }
+        let bytes = unwrap_or_json_err!(hyper::body::to_bytes(body).await);
+
+        let script = unwrap_or_json_err!(String::from_utf8(bytes.to_vec()));
+
+        let body = match script_handler.insert_script(name.unwrap(), &script).await {
+            Ok(()) => JsonResponse::with_output(None),
+            Err(e) => json_err!(format!("Insert script error: {}", e), e.status_code()),
+        };
+
+        Json(body)
+    } else {
+        json_err!("Script execution not supported, missing script handler");
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ScriptQuery {
+    pub name: Option<String>,
+}
+
+/// Handler to execute script
+#[axum_macros::debug_handler]
+pub async fn run_script(
+    State(state): State<ApiState>,
+    Query(params): Query<ScriptQuery>,
+) -> Json<JsonResponse> {
+    if let Some(script_handler) = &state.script_handler {
+        let start = Instant::now();
+        let name = params.name.as_ref();
+
+        if name.is_none() || name.unwrap().is_empty() {
+            json_err!("invalid name");
+        }
+
+        let output = script_handler.execute_script(name.unwrap()).await;
+        let resp = JsonResponse::from_output(output).await;
+
+        Json(resp.with_execution_time(start.elapsed().as_millis()))
+    } else {
+        json_err!("Script execution not supported, missing script handler");
+    }
+}

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -26,10 +26,15 @@ pub type GrpcAdminHandlerRef = Arc<dyn GrpcAdminHandler + Send + Sync>;
 pub type OpentsdbProtocolHandlerRef = Arc<dyn OpentsdbProtocolHandler + Send + Sync>;
 pub type InfluxdbLineProtocolHandlerRef = Arc<dyn InfluxdbLineProtocolHandler + Send + Sync>;
 pub type PrometheusProtocolHandlerRef = Arc<dyn PrometheusProtocolHandler + Send + Sync>;
+pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
 pub trait SqlQueryHandler {
     async fn do_query(&self, query: &str) -> Result<Output>;
+}
+
+#[async_trait]
+pub trait ScriptHandler {
     async fn insert_script(&self, name: &str, script: &str) -> Result<()>;
     async fn execute_script(&self, name: &str) -> Result<Output>;
 }

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -5,16 +5,20 @@ use axum::extract::{Json, Query, RawBody, State};
 use common_telemetry::metric;
 use metrics::counter;
 use servers::http::handler as http_handler;
-use servers::http::JsonOutput;
+use servers::http::script as script_handler;
+use servers::http::{ApiState, JsonOutput};
 use table::test_util::MemTable;
 
-use crate::create_testing_sql_query_handler;
+use crate::{create_testing_script_handler, create_testing_sql_query_handler};
 
 #[tokio::test]
 async fn test_sql_not_provided() {
-    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
     let Json(json) = http_handler::sql(
-        State(query_handler),
+        State(ApiState {
+            sql_handler,
+            script_handler: None,
+        }),
         Query(http_handler::SqlQuery::default()),
     )
     .await;
@@ -31,9 +35,16 @@ async fn test_sql_output_rows() {
     common_telemetry::init_default_ut_logging();
 
     let query = create_query();
-    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
-    let Json(json) = http_handler::sql(State(query_handler), query).await;
+    let Json(json) = http_handler::sql(
+        State(ApiState {
+            sql_handler,
+            script_handler: None,
+        }),
+        query,
+    )
+    .await;
     assert!(json.success(), "{:?}", json);
     assert!(json.error().is_none());
     match &json.output().expect("assertion failed")[0] {
@@ -64,30 +75,46 @@ def test(n):
     return n;
 "#
     .to_string();
-
-    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let script_handler = create_testing_script_handler(MemTable::default_numbers_table());
     let body = RawBody(Body::from(script.clone()));
     let invalid_query = create_invalid_script_query();
-    let Json(json) = http_handler::scripts(State(query_handler.clone()), invalid_query, body).await;
+    let Json(json) = script_handler::scripts(
+        State(ApiState {
+            sql_handler: sql_handler.clone(),
+            script_handler: Some(script_handler.clone()),
+        }),
+        invalid_query,
+        body,
+    )
+    .await;
     assert!(!json.success(), "{:?}", json);
     assert_eq!(json.error().unwrap(), "Invalid argument: invalid name");
 
     let body = RawBody(Body::from(script));
     let exec = create_script_query();
-    let Json(json) = http_handler::scripts(State(query_handler), exec, body).await;
+    let Json(json) = script_handler::scripts(
+        State(ApiState {
+            sql_handler,
+            script_handler: Some(script_handler),
+        }),
+        exec,
+        body,
+    )
+    .await;
     assert!(json.success(), "{:?}", json);
     assert!(json.error().is_none());
     assert!(json.output().is_none());
 }
 
-fn create_script_query() -> Query<http_handler::ScriptQuery> {
-    Query(http_handler::ScriptQuery {
+fn create_script_query() -> Query<script_handler::ScriptQuery> {
+    Query(script_handler::ScriptQuery {
         name: Some("test".to_string()),
     })
 }
 
-fn create_invalid_script_query() -> Query<http_handler::ScriptQuery> {
-    Query(http_handler::ScriptQuery { name: None })
+fn create_invalid_script_query() -> Query<script_handler::ScriptQuery> {
+    Query(script_handler::ScriptQuery { name: None })
 }
 
 fn create_query() -> Query<http_handler::SqlQuery> {

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -33,14 +33,6 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_query(&self, _query: &str) -> Result<Output> {
         unimplemented!()
     }
-
-    async fn insert_script(&self, _name: &str, _script: &str) -> Result<()> {
-        unimplemented!()
-    }
-
-    async fn execute_script(&self, _name: &str) -> Result<Output> {
-        unimplemented!()
-    }
 }
 
 fn make_test_app(tx: mpsc::Sender<(String, String)>) -> Router {

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -33,14 +33,6 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_query(&self, _query: &str) -> Result<Output> {
         unimplemented!()
     }
-
-    async fn insert_script(&self, _name: &str, _script: &str) -> Result<()> {
-        unimplemented!()
-    }
-
-    async fn execute_script(&self, _name: &str) -> Result<Output> {
-        unimplemented!()
-    }
 }
 
 fn make_test_app(tx: mpsc::Sender<String>) -> Router {

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -59,14 +59,6 @@ impl SqlQueryHandler for DummyInstance {
     async fn do_query(&self, _query: &str) -> Result<Output> {
         unimplemented!()
     }
-
-    async fn insert_script(&self, _name: &str, _script: &str) -> Result<()> {
-        unimplemented!()
-    }
-
-    async fn execute_script(&self, _name: &str) -> Result<Output> {
-        unimplemented!()
-    }
 }
 
 fn make_test_app(tx: mpsc::Sender<(String, Vec<u8>)>) -> Router {


### PR DESCRIPTION
Try to fix #501 
Main changes:

* Adds `ScriptHandler` to process scripts API, extract it from SQL query handler.
* Set script handler to the frontend HTTP server in standalone mode, and make scripts API work again.