### PR TITLE
feat: enable freeze-stdlib feature in rust-python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4887,6 +4887,10 @@ dependencies = [
 name = "rustpython-pylib"
 version = "0.1.0"
 source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+dependencies = [
+ "rustpython-bytecode",
+ "rustpython-derive",
+]
 
 [[package]]
 name = "rustpython-vm"

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -43,7 +43,7 @@ rustpython-bytecode = { git = "https://github.com/RustPython/RustPython", option
 rustpython-compiler = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
 rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
 rustpython-parser = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
+rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d", features = ["default", "freeze-stdlib"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }


### PR DESCRIPTION
 We have to use the `freeze-stdlib` feature to include the standard library inside the binary.