### PR TITLE
fix: `task list` syntax error in pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Please explain IN DETAIL what the changes are in this PR and why they are needed
 
 ## Checklist
 
-[]  I have written the necessary rustdoc comments.
-[]  I have added the necessary unit tests and integration tests.
+- []  I have written the necessary rustdoc comments.
+- []  I have added the necessary unit tests and integration tests.
 
 ## Refer to a related PR or issue link (optional)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- `task list` syntax in markdown has a leading dash

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#523 