### PR TITLE
test: ignore empty s3 bucket config and fix tests from forked repo

### DIFF
--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -104,18 +104,20 @@ async fn test_fs_backend() -> Result<()> {
 #[tokio::test]
 async fn test_s3_backend() -> Result<()> {
     logging::init_default_ut_logging();
-    if env::var("GT_S3_BUCKET").is_ok() {
-        logging::info!("Running s3 test.");
+    if let Ok(bucket) = env::var("GT_S3_BUCKET") {
+        if !bucket.is_empty() {
+            logging::info!("Running s3 test.");
 
-        let accessor = s3::Builder::default()
-            .access_key_id(&env::var("GT_S3_ACCESS_KEY_ID")?)
-            .secret_access_key(&env::var("GT_S3_ACCESS_KEY")?)
-            .bucket(&env::var("GT_S3_BUCKET")?)
-            .build()?;
+            let accessor = s3::Builder::default()
+                .access_key_id(&env::var("GT_S3_ACCESS_KEY_ID")?)
+                .secret_access_key(&env::var("GT_S3_ACCESS_KEY")?)
+                .bucket(&bucket)
+                .build()?;
 
-        let store = ObjectStore::new(accessor);
-        test_object_crud(&store).await?;
-        test_object_list(&store).await?;
+            let store = ObjectStore::new(accessor);
+            test_object_crud(&store).await?;
+            test_object_list(&store).await?;
+        }
     }
 
     Ok(())

--- a/src/query/src/expr.rs
+++ b/src/query/src/expr.rs
@@ -11,5 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

We are using repository secrets to store object storage credentials. However fork repository does not have access to these secrets. This is causing tests failure for contributors. This patch ignored empty config and skip these tests.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Expected to resolve failures in #524 