### PR TITLE
docs: move Docs section under Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,23 @@ You can always cleanup test database by removing `/tmp/greptimedb`.
 
 ## Resources
 
+### Installation
+
 - [Pre-built Binaries](https://github.com/GreptimeTeam/greptimedb/releases):
   downloadable pre-built binaries for Linux and MacOS
 - [Docker Images](https://hub.docker.com/r/greptime/greptimedb): pre-built
   Docker images
 - [`gtctl`](https://github.com/GreptimeTeam/gtctl): the command-line tool for
   Kubernetes deployment
+
+### Documentation
+
+- GreptimeDB [User Guide](https://docs.greptime.com/user-guide/concepts.html)
+- GreptimeDB [Developer
+  Guide](https://docs.greptime.com/developer-guide/overview.html)
+
+### SDK
+
 - [GreptimeDB Java
   Client](https://github.com/GreptimeTeam/greptimedb-client-java)
 
@@ -161,12 +172,6 @@ In addition, you may:
 - View our official [Blog](https://greptime.com/blog)
 - Connect us with [Linkedin](https://www.linkedin.com/company/greptime/)
 - Follow us on [Twitter](https://twitter.com/greptime)
-
-## Documentation
-
-- GreptimeDB [User Guide](https://docs.greptime.com/user-guide/concepts.html)
-- GreptimeDB [Developer
-  Guide](https://docs.greptime.com/developer-guide/overview.html)
 
 ## License
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Changes in README.md:
- Move the Documents Section under Resources. Hope it makes the structure clearer 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
