### PR TITLE
chore: remote issue title prefix from template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,7 @@
 ---
 name: Bug report
 description: Is something not working? Help us fix it!
-title: "[Bug]: <Title>"
-labels: ["bug", "triage"]
+labels: [ "bug" ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,7 +1,6 @@
 ---
 name: Enhancement
 description: Suggest an enhancement to existing functionality
-title: "[Enhancement]: <Title>"
 labels: [ "enhancement" ]
 body:
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 description: Suggest a new feature for GreptimeDB
-title: "[Feature]: <Feature name>"
 labels: [ "feature-request" ]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 description: Suggest a new feature for GreptimeDB
-labels: [ "feature-request" ]
+labels: [ "feature request" ]
 body:
   - type: markdown
     id: info


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove title prefix (like `[Enhancement]` or `[Bug]`) as they are included in lables.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
