### PR TITLE
feat: support `explain` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ debug/
 
 # JetBrains IDE config directory
 .idea/
+*.iml
 
 # VSCode IDE config directory
 .vscode/

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -139,7 +139,11 @@ impl Instance {
         };
         Ok(Self {
             query_engine: query_engine.clone(),
-            sql_handler: SqlHandler::new(table_engine, catalog_manager.clone()),
+            sql_handler: SqlHandler::new(
+                table_engine,
+                catalog_manager.clone(),
+                query_engine.clone(),
+            ),
             catalog_manager,
             physical_planner: PhysicalPlanner::new(query_engine),
             script_executor,

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -115,8 +115,10 @@ impl Instance {
             Statement::ShowTables(stmt) => {
                 self.sql_handler.execute(SqlRequest::ShowTables(stmt)).await
             }
-            Statement::Explain(_explain) => {
-                unimplemented!()
+            Statement::Explain(stmt) => {
+                self.sql_handler
+                    .execute(SqlRequest::Explain(Box::new(stmt)))
+                    .await
             }
             Statement::DescribeTable(stmt) => {
                 self.sql_handler

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -115,6 +115,9 @@ impl Instance {
             Statement::ShowTables(stmt) => {
                 self.sql_handler.execute(SqlRequest::ShowTables(stmt)).await
             }
+            Statement::Explain(_explain) => {
+                unimplemented!()
+            }
             Statement::DescribeTable(stmt) => {
                 self.sql_handler
                     .execute(SqlRequest::DescribeTable(stmt))

--- a/src/datanode/src/mock.rs
+++ b/src/datanode/src/mock.rs
@@ -58,7 +58,11 @@ impl Instance {
         let factory = QueryEngineFactory::new(catalog_manager.clone());
         let query_engine = factory.query_engine();
 
-        let sql_handler = SqlHandler::new(mock_engine.clone(), catalog_manager.clone());
+        let sql_handler = SqlHandler::new(
+            mock_engine.clone(),
+            catalog_manager.clone(),
+            query_engine.clone(),
+        );
         let physical_planner = PhysicalPlanner::new(query_engine.clone());
         let script_executor = ScriptExecutor::new(catalog_manager.clone(), query_engine.clone())
             .await
@@ -123,7 +127,11 @@ impl Instance {
         );
         Ok(Self {
             query_engine: query_engine.clone(),
-            sql_handler: SqlHandler::new(table_engine, catalog_manager.clone()),
+            sql_handler: SqlHandler::new(
+                table_engine,
+                catalog_manager.clone(),
+                query_engine.clone(),
+            ),
             catalog_manager,
             physical_planner: PhysicalPlanner::new(query_engine),
             script_executor,

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -32,7 +32,6 @@ mod alter;
 mod create;
 mod insert;
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SqlRequest {
     Insert(InsertRequest),

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -16,9 +16,11 @@
 
 use catalog::CatalogManagerRef;
 use common_query::Output;
-use query::sql::{describe_table, show_databases, show_tables};
+use query::query_engine::QueryEngineRef;
+use query::sql::{describe_table, explain, show_databases, show_tables};
 use snafu::{OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
+use sql::statements::explain::Explain;
 use sql::statements::show::{ShowDatabases, ShowTables};
 use table::engine::{EngineContext, TableEngineRef, TableReference};
 use table::requests::*;
@@ -30,6 +32,7 @@ mod alter;
 mod create;
 mod insert;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SqlRequest {
     Insert(InsertRequest),
@@ -39,19 +42,26 @@ pub enum SqlRequest {
     ShowDatabases(ShowDatabases),
     ShowTables(ShowTables),
     DescribeTable(DescribeTable),
+    Explain(Box<Explain>),
 }
 
 // Handler to execute SQL except query
 pub struct SqlHandler {
     table_engine: TableEngineRef,
     catalog_manager: CatalogManagerRef,
+    query_engine: QueryEngineRef,
 }
 
 impl SqlHandler {
-    pub fn new(table_engine: TableEngineRef, catalog_manager: CatalogManagerRef) -> Self {
+    pub fn new(
+        table_engine: TableEngineRef,
+        catalog_manager: CatalogManagerRef,
+        query_engine: QueryEngineRef,
+    ) -> Self {
         Self {
             table_engine,
             catalog_manager,
+            query_engine,
         }
     }
 
@@ -70,6 +80,9 @@ impl SqlHandler {
             SqlRequest::DescribeTable(stmt) => {
                 describe_table(stmt, self.catalog_manager.clone()).context(error::ExecuteSqlSnafu)
             }
+            SqlRequest::Explain(stmt) => explain(stmt, self.query_engine.clone())
+                .await
+                .context(error::ExecuteSqlSnafu),
         }
     }
 
@@ -216,7 +229,7 @@ mod tests {
         );
         let factory = QueryEngineFactory::new(catalog_list.clone());
         let query_engine = factory.query_engine();
-        let sql_handler = SqlHandler::new(table_engine, catalog_list);
+        let sql_handler = SqlHandler::new(table_engine, catalog_list, query_engine.clone());
 
         let stmt = match query_engine.sql_to_statement(sql).unwrap() {
             Statement::Insert(i) => i,

--- a/src/datanode/src/sql/create.rs
+++ b/src/datanode/src/sql/create.rs
@@ -172,7 +172,7 @@ impl SqlHandler {
                     return ConstraintNotSupportedSnafu {
                         constraint: format!("{:?}", c),
                     }
-                    .fail()
+                    .fail();
                 }
             }
         }

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -21,6 +21,7 @@ use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, SchemaBuilder};
 use mito::config::EngineConfig;
 use mito::table::test_util::{new_test_object_store, MockEngine, MockMitoEngine};
+use query::QueryEngineFactory;
 use servers::Mode;
 use snafu::ResultExt;
 use table::engine::{EngineContext, TableEngineRef};
@@ -121,5 +122,9 @@ pub async fn create_mock_sql_handler() -> SqlHandler {
             .await
             .unwrap(),
     );
-    SqlHandler::new(mock_engine, catalog_manager)
+
+    let catalog_list = catalog::local::new_memory_catalog_list().unwrap();
+    let factory = QueryEngineFactory::new(catalog_list);
+
+    SqlHandler::new(mock_engine, catalog_manager, factory.query_engine())
 }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -275,6 +275,11 @@ impl Instance {
             .context(AlterTableSnafu)
     }
 
+    /// Handle explain expr
+    pub async fn handle_explain(&self) -> Result<Output> {
+        todo!()
+    }
+
     /// Handle batch inserts
     pub async fn handle_inserts(&self, insert_expr: &[InsertExpr]) -> Result<Output> {
         let mut success = 0;
@@ -634,6 +639,10 @@ impl SqlQueryHandler for Instance {
                 .await
                 .map_err(BoxedError::new)
                 .context(server_error::ExecuteQuerySnafu { query }),
+            Statement::Explain(_explain) => {
+                // self.handle_explain()
+                unimplemented!()
+            }
             Statement::ShowCreateTable(_) => {
                 return server_error::NotSupportedSnafu { feat: query }.fail()
             }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -30,7 +30,7 @@ use meta_client::rpc::{
     CreateRequest as MetaCreateRequest, Partition as MetaPartition, PutRequest, RouteResponse,
     TableName, TableRoute,
 };
-use query::sql::{describe_table, show_databases, show_tables};
+use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::create::Partitions;
@@ -142,6 +142,9 @@ impl DistInstance {
             Statement::ShowTables(stmt) => show_tables(stmt, self.catalog_manager.clone())
                 .context(error::ExecuteSqlSnafu { sql }),
             Statement::DescribeTable(stmt) => describe_table(stmt, self.catalog_manager.clone())
+                .context(error::ExecuteSqlSnafu { sql }),
+            Statement::Explain(stmt) => explain(Box::new(stmt), self.query_engine.clone())
+                .await
                 .context(error::ExecuteSqlSnafu { sql }),
             _ => unreachable!(),
         }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -55,7 +55,7 @@ impl<'a, S: ContextProvider + Send + Sync> DfPlanner<'a, S> {
         Ok(LogicalPlan::DfPlan(result))
     }
 
-    /// Converts QUERY statement to logical plan.
+    /// Converts EXPLAIN statement to logical plan.
     pub fn explain_to_plan(&self, explain: Explain) -> Result<LogicalPlan> {
         let result = self
             .sql_to_rel

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -22,6 +22,7 @@ use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use datatypes::arrow::datatypes::DataType;
 use snafu::ResultExt;
+use sql::statements::explain::Explain;
 use sql::statements::query::Query;
 use sql::statements::statement::Statement;
 
@@ -53,6 +54,18 @@ impl<'a, S: ContextProvider + Send + Sync> DfPlanner<'a, S> {
 
         Ok(LogicalPlan::DfPlan(result))
     }
+
+    /// Converts QUERY statement to logical plan.
+    pub fn explain_to_plan(&self, explain: Explain) -> Result<LogicalPlan> {
+        let result = self
+            .sql_to_rel
+            .sql_statement_to_plan(explain.inner.clone())
+            .context(error::PlanSqlSnafu {
+                sql: explain.to_string(),
+            })?;
+
+        Ok(LogicalPlan::DfPlan(result))
+    }
 }
 
 impl<'a, S> Planner for DfPlanner<'a, S>
@@ -63,6 +76,7 @@ where
     fn statement_to_plan(&self, statement: Statement) -> Result<LogicalPlan> {
         match statement {
             Statement::Query(qb) => self.query_to_plan(qb),
+            Statement::Explain(explain) => self.explain_to_plan(explain),
             Statement::ShowTables(_)
             | Statement::ShowDatabases(_)
             | Statement::ShowCreateTable(_)
@@ -70,7 +84,6 @@ where
             | Statement::CreateTable(_)
             | Statement::CreateDatabase(_)
             | Statement::Alter(_)
-            | Statement::Explain(_)
             | Statement::Insert(_) => unreachable!(),
         }
     }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -70,6 +70,7 @@ where
             | Statement::CreateTable(_)
             | Statement::CreateDatabase(_)
             | Statement::Alter(_)
+            | Statement::Explain(_)
             | Statement::Insert(_) => unreachable!(),
         }
     }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -24,9 +24,12 @@ use datatypes::vectors::{Helper, StringVector};
 use once_cell::sync::Lazy;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
+use sql::statements::explain::Explain;
 use sql::statements::show::{ShowDatabases, ShowKind, ShowTables};
+use sql::statements::statement::Statement;
 
 use crate::error::{self, Result};
+use crate::QueryEngineRef;
 
 const SCHEMAS_COLUMN: &str = "Schemas";
 const TABLES_COLUMN: &str = "Tables";
@@ -136,6 +139,11 @@ pub fn show_tables(stmt: ShowTables, catalog_manager: CatalogManagerRef) -> Resu
     let records = RecordBatches::try_from_columns(schema, vec![tables])
         .context(error::CreateRecordBatchSnafu)?;
     Ok(Output::RecordBatches(records))
+}
+
+pub async fn explain(stmt: Box<Explain>, query_engine: QueryEngineRef) -> Result<Output> {
+    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt))?;
+    query_engine.execute(&plan).await
 }
 
 pub fn describe_table(stmt: DescribeTable, catalog_manager: CatalogManagerRef) -> Result<Output> {

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -259,7 +259,6 @@ impl<'a> ParserContext<'a> {
     }
 
     fn parse_explain(&mut self) -> Result<Statement> {
-        //TODO Catch `explain <table_name>`
         let explain_statement =
             self.parser
                 .parse_explain(false)
@@ -339,6 +338,7 @@ impl<'a> ParserContext<'a> {
 mod tests {
     use std::assert_matches::assert_matches;
 
+    use sqlparser::ast::{Query as SpQuery, Statement as SpStatement};
     use sqlparser::dialect::GenericDialect;
 
     use super::*;
@@ -481,5 +481,55 @@ mod tests {
                 database: Some(_),
             })
         );
+    }
+
+    #[test]
+    pub fn test_explain() {
+        let sql = "EXPLAIN select * from foo";
+        let result = ParserContext::create_with_dialect(sql, &GenericDialect {});
+        let stmts = result.unwrap();
+        assert_eq!(1, stmts.len());
+
+        let select = sqlparser::ast::Select {
+            distinct: false,
+            top: None,
+            projection: vec![sqlparser::ast::SelectItem::Wildcard],
+            from: vec![sqlparser::ast::TableWithJoins {
+                relation: sqlparser::ast::TableFactor::Table {
+                    name: sqlparser::ast::ObjectName(vec![sqlparser::ast::Ident::new("foo")]),
+                    alias: None,
+                    args: vec![],
+                    with_hints: vec![],
+                },
+                joins: vec![],
+            }],
+            lateral_views: vec![],
+            selection: None,
+            group_by: vec![],
+            cluster_by: vec![],
+            distribute_by: vec![],
+            sort_by: vec![],
+            having: None,
+        };
+
+        let sp_statement = SpStatement::Query(Box::new(SpQuery {
+            with: None,
+            body: sqlparser::ast::SetExpr::Select(Box::new(select)),
+            order_by: vec![],
+            limit: None,
+            offset: None,
+            fetch: None,
+            lock: None,
+        }));
+
+        let explain = Explain::try_from(SpStatement::Explain {
+            describe_alias: false,
+            analyze: false,
+            verbose: false,
+            statement: Box::new(sp_statement),
+        })
+        .unwrap();
+
+        assert_eq!(stmts[0], Statement::Explain(explain))
     }
 }

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -269,23 +269,14 @@ impl<'a> ParserContext<'a> {
             _ => false,
         };
 
-        let explain_statement = if has_describe_alias {
+        let explain_statement =
             self.parser
-                .parse_explain(false)
+                .parse_explain(has_describe_alias)
                 .with_context(|_| error::UnexpectedSnafu {
                     sql: self.sql,
                     expected: "a statement",
                     actual: self.peek_token_as_string(),
-                })?
-        } else {
-            self.parser
-                .parse_explain(false)
-                .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
-                    expected: "a statement",
-                    actual: self.peek_token_as_string(),
-                })?
-        };
+                })?;
 
         Ok(Statement::Explain(Explain::try_from(explain_statement)?))
     }

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -21,10 +21,9 @@ use sqlparser::tokenizer::{Token, Tokenizer};
 use crate::error::{
     self, InvalidDatabaseNameSnafu, InvalidTableNameSnafu, Result, SyntaxSnafu, TokenizerSnafu,
 };
-use crate::statements::explain::Explain;
 use crate::statements::describe::DescribeTable;
+use crate::statements::explain::Explain;
 use crate::statements::show::{ShowCreateTable, ShowDatabases, ShowKind, ShowTables};
-use crate::statements::statement::*;
 use crate::statements::statement::Statement;
 use crate::statements::table_idents_to_full_name;
 
@@ -260,21 +259,12 @@ impl<'a> ParserContext<'a> {
     }
 
     fn parse_explain(&mut self) -> Result<Statement> {
-        let has_describe_alias = match self.parser.next_token() {
-            Token::Word(word) => match word.keyword {
-                Keyword::DESC => true,
-                Keyword::DESCRIBE => true,
-                _ => false,
-            },
-            _ => false,
-        };
-
         let explain_statement =
             self.parser
-                .parse_explain(has_describe_alias)
+                .parse_explain(false)
                 .with_context(|_| error::UnexpectedSnafu {
                     sql: self.sql,
-                    expected: "a statement",
+                    expected: "a table name or select statement",
                     actual: self.peek_token_as_string(),
                 })?;
 

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -259,12 +259,13 @@ impl<'a> ParserContext<'a> {
     }
 
     fn parse_explain(&mut self) -> Result<Statement> {
+        //TODO Catch `explain <table_name>`
         let explain_statement =
             self.parser
                 .parse_explain(false)
                 .with_context(|_| error::UnexpectedSnafu {
                     sql: self.sql,
-                    expected: "a table name or select statement",
+                    expected: "a query statement",
                     actual: self.peek_token_as_string(),
                 })?;
 

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -14,6 +14,7 @@
 
 pub mod alter;
 pub mod create;
+pub mod explain;
 pub mod describe;
 pub mod insert;
 pub mod query;

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -14,8 +14,8 @@
 
 pub mod alter;
 pub mod create;
-pub mod explain;
 pub mod describe;
+pub mod explain;
 pub mod insert;
 pub mod query;
 pub mod show;

--- a/src/sql/src/statements/explain.rs
+++ b/src/sql/src/statements/explain.rs
@@ -26,12 +26,6 @@ impl TryFrom<SpStatement> for Explain {
     type Error = Error;
 
     fn try_from(value: SpStatement) -> Result<Self, Self::Error> {
-        match value {
-            SpStatement::ExplainTable { .. } => {}
-            SpStatement::Explain { .. } => {}
-            _ => {}
-        }
-
         Ok(Explain { inner: value })
     }
 }

--- a/src/sql/src/statements/explain.rs
+++ b/src/sql/src/statements/explain.rs
@@ -12,20 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sqlparser::ast::Statement;
-
-/// Explain statement instance.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Explain {
-    pub inner: Statement,
-}
+use sqlparser::ast::Statement as SpStatement;
 
 use crate::error::Error;
 
-impl TryFrom<Statement> for Explain {
+/// Explain statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Explain {
+    pub inner: SpStatement,
+}
+
+impl TryFrom<SpStatement> for Explain {
     type Error = Error;
 
-    fn try_from(value: Statement) -> Result<Self, Self::Error> {
+    fn try_from(value: SpStatement) -> Result<Self, Self::Error> {
+        match value {
+            SpStatement::ExplainTable { .. } => {}
+            SpStatement::Explain { .. } => {}
+            _ => {}
+        }
+
         Ok(Explain { inner: value })
+    }
+}
+
+impl ToString for Explain {
+    fn to_string(&self) -> String {
+        self.inner.to_string()
     }
 }

--- a/src/sql/src/statements/explain.rs
+++ b/src/sql/src/statements/explain.rs
@@ -1,0 +1,31 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sqlparser::ast::Statement;
+
+/// Explain statement instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Explain {
+    pub inner: Statement,
+}
+
+use crate::error::Error;
+
+impl TryFrom<Statement> for Explain {
+    type Error = Error;
+
+    fn try_from(value: Statement) -> Result<Self, Self::Error> {
+        Ok(Explain { inner: value })
+    }
+}

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -17,6 +17,7 @@ use sqlparser::parser::ParserError;
 
 use crate::statements::alter::AlterTable;
 use crate::statements::create::{CreateDatabase, CreateTable};
+use crate::statements::explain::Explain;
 use crate::statements::describe::DescribeTable;
 use crate::statements::insert::Insert;
 use crate::statements::query::Query;
@@ -43,6 +44,8 @@ pub enum Statement {
     ShowCreateTable(ShowCreateTable),
     // DESCRIBE TABLE
     DescribeTable(DescribeTable),
+    // EXPLAIN [[ DESCRIBE| DESC ]] select_statement
+    Explain(Explain),
 }
 
 /// Converts Statement to sqlparser statement
@@ -68,6 +71,7 @@ impl TryFrom<Statement> for SpStatement {
             Statement::CreateDatabase(_) | Statement::CreateTable(_) | Statement::Alter(_) => {
                 unimplemented!()
             }
+            Statement::Explain(e) => Ok(e.inner),
         }
     }
 }

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -17,13 +17,14 @@ use sqlparser::parser::ParserError;
 
 use crate::statements::alter::AlterTable;
 use crate::statements::create::{CreateDatabase, CreateTable};
-use crate::statements::explain::Explain;
 use crate::statements::describe::DescribeTable;
+use crate::statements::explain::Explain;
 use crate::statements::insert::Insert;
 use crate::statements::query::Query;
 use crate::statements::show::{ShowCreateTable, ShowDatabases, ShowTables};
 
 /// Tokens parsed by `DFParser` are converted into these values.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Statement {
     // Query
@@ -44,7 +45,7 @@ pub enum Statement {
     ShowCreateTable(ShowCreateTable),
     // DESCRIBE TABLE
     DescribeTable(DescribeTable),
-    // EXPLAIN [[ DESCRIBE| DESC ]] select_statement
+    // EXPLAIN QUERY
     Explain(Explain),
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Support explain syntax like this:

```SQL
explain select * from foo
```

## Checklist

- [x]  Add `explain` to sql parser
- [x]  Add `explain` test to sql parser 
- [x]  Handle `explain` in DataNode
- [x]  Handle `explain` in Frontend


## Refer to a related PR or issue link (optional)

Closes #531 