### PR TITLE
fix: split code and output in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ about Kubernetes deployment, check our [docs](https://docs.greptime.com/).
 4. Query the data:
 
    ```SQL
-   mysql> SELECT * FROM monitor;
+   SELECT * FROM monitor;
+   ```
+
+   ```TEXT
    +-------+---------------------+------+--------+
    | host  | ts                  | cpu  | memory |
    +-------+---------------------+------+--------+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Split the  SQL and its output in README. So the user can copy the SQL and run it directly.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
