### PR TITLE
feat: Implement `table_info()` for `DistTable` (#536)

### DIFF
--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -185,8 +185,8 @@ pub enum Error {
         source: meta_client::error::Error,
     },
 
-    #[snafu(display("Invalid table schema in catalog, source: {:?}", source))]
-    InvalidSchemaInCatalog {
+    #[snafu(display("Invalid table info in catalog, source: {:?}", source))]
+    InvalidTableInfoInCatalog {
         #[snafu(backtrace)]
         source: datatypes::error::Error,
     },
@@ -233,7 +233,7 @@ impl ErrorExt for Error {
             Error::SystemCatalogTableScan { source } => source.status_code(),
             Error::SystemCatalogTableScanExec { source } => source.status_code(),
             Error::InvalidTableSchema { source, .. } => source.status_code(),
-            Error::InvalidSchemaInCatalog { .. } => StatusCode::Unexpected,
+            Error::InvalidTableInfoInCatalog { .. } => StatusCode::Unexpected,
             Error::Internal { source, .. } => source.status_code(),
         }
     }

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -185,7 +185,7 @@ pub enum Error {
         source: meta_client::error::Error,
     },
 
-    #[snafu(display("Invalid table info in catalog, source: {:?}", source))]
+    #[snafu(display("Invalid table info in catalog, source: {}", source))]
     InvalidTableInfoInCatalog {
         #[snafu(backtrace)]
         source: datatypes::error::Error,

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -37,7 +37,7 @@ use sql::statements::create::Partitions;
 use sql::statements::sql_value_to_value;
 use sql::statements::statement::Statement;
 use sqlparser::ast::Value as SqlValue;
-use table::metadata::RawTableMeta;
+use table::metadata::{RawTableInfo, RawTableMeta, TableIdent, TableType};
 
 use crate::catalog::FrontendCatalogManager;
 use crate::datanode::DatanodeClients;
@@ -274,11 +274,23 @@ fn create_table_global_value(
         created_on: DateTime::default(),
     };
 
+    let table_info = RawTableInfo {
+        ident: TableIdent {
+            table_id: table_route.table.id as u32,
+            version: 0,
+        },
+        name: table_name.table_name.clone(),
+        desc: create_table.desc.clone(),
+        catalog_name: table_name.catalog_name.clone(),
+        schema_name: table_name.schema_name.clone(),
+        meta,
+        table_type: TableType::Base,
+    };
+
     Ok(TableGlobalValue {
-        id: table_route.table.id as u32,
         node_id,
         regions_id_map: HashMap::new(),
-        meta,
+        table_info,
     })
 }
 

--- a/src/meta-srv/src/service/router.rs
+++ b/src/meta-srv/src/service/router.rs
@@ -184,8 +184,7 @@ async fn fetch_tables(
         }
         let tv = tv.unwrap();
 
-        let table_id = tv.id as u64;
-        let tr_key = TableRouteKey::with_table_global_key(table_id, &tk);
+        let tr_key = TableRouteKey::with_table_global_key(tv.table_id() as u64, &tk);
         let tr = get_table_route_value(kv_store, &tr_key).await?;
 
         tables.push((tv, tr));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

close #536

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)

Implement `table_info()` for `DistTable`. Originally `unimplemented!()`.

- How does this PR work? Need a brief introduction for the changed logic (optional)

Store `TableInfo` in `TableGlobalValue`, which is later stored in Meta for retrieval.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#536 
