### PR TITLE
feat: drop column for alter table

### DIFF
--- a/src/api/greptime/v1/admin.proto
+++ b/src/api/greptime/v1/admin.proto
@@ -51,6 +51,7 @@ message AlterExpr {
   string table_name = 3;
   oneof kind {
     AddColumns add_columns = 4;
+    DropColumns drop_columns = 5;
   }
 }
 
@@ -58,9 +59,17 @@ message AddColumns {
   repeated AddColumn add_columns = 1;
 }
 
+message DropColumns {
+  repeated DropColumn drop_columns = 1;
+}
+
 message AddColumn {
   ColumnDef column_def = 1;
   bool is_key = 2;
+}
+
+message DropColumn {
+  string name = 1;
 }
 
 message CreateDatabaseExpr {

--- a/src/datanode/src/server/grpc/ddl.rs
+++ b/src/datanode/src/server/grpc/ddl.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use api::helper::ColumnDataTypeWrapper;
 use api::result::AdminResultBuilder;
 use api::v1::alter_expr::Kind;
-use api::v1::{AdminResult, AlterExpr, ColumnDef, CreateExpr};
+use api::v1::{AdminResult, AlterExpr, ColumnDef, CreateExpr, DropColumns};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::prelude::{ErrorExt, StatusCode};
 use common_query::Output;
@@ -181,6 +181,19 @@ fn alter_expr_to_request(expr: AlterExpr) -> Result<Option<AlterTableRequest>> {
 
             let alter_kind = AlterKind::AddColumns {
                 columns: add_column_requests,
+            };
+
+            let request = AlterTableRequest {
+                catalog_name: expr.catalog_name,
+                schema_name: expr.schema_name,
+                table_name: expr.table_name,
+                alter_kind,
+            };
+            Ok(Some(request))
+        }
+        Some(Kind::DropColumns(DropColumns { drop_columns })) => {
+            let alter_kind = AlterKind::DropColumns {
+                names: drop_columns.into_iter().map(|c| c.name).collect(),
             };
 
             let request = AlterTableRequest {

--- a/src/datanode/src/sql/alter.rs
+++ b/src/datanode/src/sql/alter.rs
@@ -72,6 +72,9 @@ impl SqlHandler {
                     is_key: false,
                 }],
             },
+            AlterTableOperation::DropColumn { name } => AlterKind::DropColumns {
+                names: vec![name.value.clone()],
+            },
         };
         Ok(AlterTableRequest {
             catalog_name: Some(catalog_name),

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -952,7 +952,7 @@ mod tests {
             catalog_name: None,
             schema_name: None,
             table_name: TABLE_NAME.to_string(),
-            alter_kind: AlterKind::RemoveColumns {
+            alter_kind: AlterKind::DropColumns {
                 names: vec![String::from("memory"), String::from("my_field")],
             },
         };

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -481,7 +481,7 @@ fn create_alter_operation(
         AlterKind::AddColumns { columns } => {
             create_add_columns_operation(table_name, columns, table_meta)
         }
-        AlterKind::RemoveColumns { names } => Ok(AlterOperation::DropColumns {
+        AlterKind::DropColumns { names } => Ok(AlterOperation::DropColumns {
             names: names.to_vec(),
         }),
     }

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -102,7 +102,13 @@ mod tests {
 
     #[test]
     fn test_parse_alter_drop_column() {
-        let sql = "ALTER TABLE my_metric_1 DROP column a";
+        let sql = "ALTER TABLE my_metric_1 DROP a";
+        let result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap_err();
+        assert!(result
+            .to_string()
+            .contains("expect keyword COLUMN after DROP"));
+
+        let sql = "ALTER TABLE my_metric_1 DROP COLUMN a";
         let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
         assert_eq!(1, result.len());
 

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -106,7 +106,7 @@ mod tests {
         let result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap_err();
         assert!(result
             .to_string()
-            .contains("expect keyword COLUMN after DROP"));
+            .contains("expect keyword COLUMN after ALTER TABLE DROP"));
 
         let sql = "ALTER TABLE my_metric_1 DROP COLUMN a";
         let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -47,7 +47,7 @@ impl<'a> ParserContext<'a> {
                 AlterTableOperation::DropColumn { name }
             } else {
                 return Err(ParserError::ParserError(format!(
-                    "expect keyword COLUMN after DROP, found {}",
+                    "expect keyword COLUMN after ALTER TABLE DROP, found {}",
                     parser.peek_token()
                 )));
             }

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -41,9 +41,19 @@ impl<'a> ParserContext<'a> {
                 let column_def = parser.parse_column_def()?;
                 AlterTableOperation::AddColumn { column_def }
             }
+        } else if parser.parse_keyword(Keyword::DROP) {
+            if parser.parse_keyword(Keyword::COLUMN) {
+                let name = self.parser.parse_identifier()?;
+                AlterTableOperation::DropColumn { name }
+            } else {
+                return Err(ParserError::ParserError(format!(
+                    "expect keyword COLUMN after DROP, found {}",
+                    parser.peek_token()
+                )));
+            }
         } else {
             return Err(ParserError::ParserError(format!(
-                "expect ADD or DROP after ALTER TABLE, found {}",
+                "expect keyword ADD or DROP after ALTER TABLE, found {}",
                 parser.peek_token()
             )));
         };
@@ -82,6 +92,31 @@ mod tests {
                             .options
                             .iter()
                             .any(|o| matches!(o.option, ColumnOption::Null)));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_parse_alter_drop_column() {
+        let sql = "ALTER TABLE my_metric_1 DROP column a";
+        let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
+        assert_eq!(1, result.len());
+
+        let statement = result.remove(0);
+        assert_matches!(statement, Statement::Alter { .. });
+        match statement {
+            Statement::Alter(alter_table) => {
+                assert_eq!("my_metric_1", alter_table.table_name().0[0].value);
+
+                let alter_operation = alter_table.alter_operation();
+                assert_matches!(alter_operation, AlterTableOperation::DropColumn { .. });
+                match alter_operation {
+                    AlterTableOperation::DropColumn { name } => {
+                        assert_eq!("a", name.value);
                     }
                     _ => unreachable!(),
                 }

--- a/src/sql/src/statements/alter.rs
+++ b/src/sql/src/statements/alter.rs
@@ -75,9 +75,7 @@ impl TryFrom<AlterTable> for AlterExpr {
             }
             AlterTableOperation::DropColumn { name } => {
                 alter_expr::Kind::DropColumns(api::v1::DropColumns {
-                    drop_columns: vec![DropColumn {
-                        name: name.value.clone(),
-                    }],
+                    drop_columns: vec![DropColumn { name: name.value }],
                 })
             }
         };

--- a/src/sql/src/statements/alter.rs
+++ b/src/sql/src/statements/alter.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use api::v1::{alter_expr, AddColumn, AlterExpr};
-use sqlparser::ast::{ColumnDef, ObjectName, TableConstraint};
+use api::v1::{alter_expr, AddColumn, AlterExpr, DropColumn};
+use sqlparser::ast::{ColumnDef, Ident, ObjectName, TableConstraint};
 
 use crate::error::UnsupportedAlterTableStatementSnafu;
 use crate::statements::{sql_column_def_to_grpc_column_def, table_idents_to_full_name};
@@ -47,7 +47,8 @@ pub enum AlterTableOperation {
     AddConstraint(TableConstraint),
     /// `ADD [ COLUMN ] <column_def>`
     AddColumn { column_def: ColumnDef },
-    // TODO(hl): support remove column
+    /// `DROP COLUMN <name>`
+    DropColumn { name: Ident },
 }
 
 /// Convert `AlterTable` statement to `AlterExpr` for gRPC
@@ -69,6 +70,13 @@ impl TryFrom<AlterTable> for AlterExpr {
                     add_columns: vec![AddColumn {
                         column_def: Some(sql_column_def_to_grpc_column_def(column_def)?),
                         is_key: false,
+                    }],
+                })
+            }
+            AlterTableOperation::DropColumn { name } => {
+                alter_expr::Kind::DropColumns(api::v1::DropColumns {
+                    drop_columns: vec![DropColumn {
+                        name: name.value.clone(),
                     }],
                 })
             }

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -576,7 +576,7 @@ mod tests {
         // Add more columns so we have enough candidate columns to remove.
         let meta = add_columns_to_meta(&meta);
 
-        let alter_kind = AlterKind::RemoveColumns {
+        let alter_kind = AlterKind::DropColumns {
             names: vec![String::from("col2"), String::from("my_field")],
         };
         let new_meta = meta
@@ -625,7 +625,7 @@ mod tests {
             .unwrap();
 
         // Remove columns in reverse order to test whether timestamp index is valid.
-        let alter_kind = AlterKind::RemoveColumns {
+        let alter_kind = AlterKind::DropColumns {
             names: vec![String::from("col3"), String::from("col1")],
         };
         let new_meta = meta
@@ -685,7 +685,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let alter_kind = AlterKind::RemoveColumns {
+        let alter_kind = AlterKind::DropColumns {
             names: vec![String::from("unknown")],
         };
 
@@ -708,7 +708,7 @@ mod tests {
             .unwrap();
 
         // Remove column in primary key.
-        let alter_kind = AlterKind::RemoveColumns {
+        let alter_kind = AlterKind::DropColumns {
             names: vec![String::from("col1")],
         };
 
@@ -719,7 +719,7 @@ mod tests {
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
 
         // Remove timestamp column.
-        let alter_kind = AlterKind::RemoveColumns {
+        let alter_kind = AlterKind::DropColumns {
             names: vec![String::from("ts")],
         };
 

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -130,7 +130,7 @@ impl TableMeta {
     ) -> Result<TableMetaBuilder> {
         match alter_kind {
             AlterKind::AddColumns { columns } => self.add_columns(table_name, columns),
-            AlterKind::RemoveColumns { names } => self.remove_columns(table_name, names),
+            AlterKind::DropColumns { names } => self.remove_columns(table_name, names),
         }
     }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -77,7 +77,7 @@ pub struct AddColumnRequest {
 #[derive(Debug)]
 pub enum AlterKind {
     AddColumns { columns: Vec<AddColumnRequest> },
-    RemoveColumns { names: Vec<String> },
+    DropColumns { names: Vec<String> },
 }
 
 /// Drop table request


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Try to fix #466, which supports `alter table drop column [name]`:

```sh
mysql> create table test(host STRING, ts timestamp, time index(ts));
Query OK, 1 row affected (0.03 sec)

mysql> insert into test values('a', 1);
Query OK, 1 row affected (0.03 sec)

mysql> insert into test values('b', 2);
Query OK, 1 row affected (0.04 sec)

mysql> select * from test;
+------+---------------------+
| host | ts                  |
+------+---------------------+
| a    | 1970-01-01 00:00:00 |
| b    | 1970-01-01 00:00:00 |
+------+---------------------+
2 rows in set (0.01 sec)
mysql> alter table test drop column host;
Query OK, 0 rows affected (0.03 sec)

mysql> select * from test;
+---------------------+
| ts                  |
+---------------------+
| 1970-01-01 00:00:00 |
| 1970-01-01 00:00:00 |
+---------------------+
2 rows in set (0.01 sec)
```


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
