### PR TITLE
docs: specify protoc version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ To compile GreptimeDB from source, you'll need:
   install correct Rust version for you.
 - Protobuf: `protoc` is required for compiling `.proto` files. `protobuf` is
   available from major package manager on macos and linux distributions. You can
-  find an installation instructions
-  [here](https://grpc.io/docs/protoc-installation/).
+  find an installation instructions [here](https://grpc.io/docs/protoc-installation/).
+  **Note that `protoc` version should >= 3.15** because we have used the `optional`
+  keyword. You can check it with `protoc --version`.
+  
 
 #### Build with Docker
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To compile GreptimeDB from source, you'll need:
 - Protobuf: `protoc` is required for compiling `.proto` files. `protobuf` is
   available from major package manager on macos and linux distributions. You can
   find an installation instructions [here](https://grpc.io/docs/protoc-installation/).
-  **Note that `protoc` version should >= 3.15** because we have used the `optional`
+  **Note that `protoc` version needs to be >= 3.15** because we have used the `optional`
   keyword. You can check it with `protoc --version`.
   
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

State the `protoc` version requirement in README.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Refer to #563