### PR TITLE
feat: update mysql default listen port to 4406

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -3,7 +3,7 @@ mode = 'distributed'
 rpc_addr = '127.0.0.1:3001'
 wal_dir = '/tmp/greptimedb/wal'
 rpc_runtime_size = 8
-mysql_addr = '127.0.0.1:3306'
+mysql_addr = '127.0.0.1:4406'
 mysql_runtime_size = 4
 
 [storage]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -1,7 +1,7 @@
 node_id = 0
 mode = 'standalone'
 http_addr = '127.0.0.1:4000'
-datanode_mysql_addr = '127.0.0.1:3306'
+datanode_mysql_addr = '127.0.0.1:4406'
 datanode_mysql_runtime_size = 4
 wal_dir = '/tmp/greptimedb/wal/'
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -143,7 +143,7 @@ mod tests {
         let options: DatanodeOptions = cmd.try_into().unwrap();
         assert_eq!("127.0.0.1:3001".to_string(), options.rpc_addr);
         assert_eq!("/tmp/greptimedb/wal".to_string(), options.wal_dir);
-        assert_eq!("127.0.0.1:3306".to_string(), options.mysql_addr);
+        assert_eq!("127.0.0.1:4406".to_string(), options.mysql_addr);
         assert_eq!(4, options.mysql_runtime_size);
         let MetaClientOpts {
             metasrv_addrs: metasrv_addr,

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -87,7 +87,7 @@ impl Default for StandaloneOptions {
             mode: Mode::Standalone,
             wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
-            datanode_mysql_addr: "127.0.0.1:3306".to_string(),
+            datanode_mysql_addr: "127.0.0.1:4406".to_string(),
             datanode_mysql_runtime_size: 4,
         }
     }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -56,7 +56,7 @@ impl Default for DatanodeOptions {
             node_id: None,
             rpc_addr: "127.0.0.1:3001".to_string(),
             rpc_runtime_size: 8,
-            mysql_addr: "127.0.0.1:3306".to_string(),
+            mysql_addr: "127.0.0.1:4406".to_string(),
             mysql_runtime_size: 2,
             meta_client_opts: None,
             wal_dir: "/tmp/greptimedb/wal".to_string(),


### PR DESCRIPTION
Signed-off-by: azhmesoso zzhncut123@163.com
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Right now the datanode listens on 127.0.0.1:3306 for MySQL connections, it may conflict with the user's MySQL server, so I should change this default address to 127.0.0.1:4406.
Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
  updata mysql default listen port to 4406.
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
