### PR TITLE
feat: make http request timeout configurable

### DIFF
--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -1,6 +1,8 @@
 mode = 'distributed'
 datanode_rpc_addr = '127.0.0.1:3001'
-http_addr = '127.0.0.1:4000'
+
+[http_options]
+addr = '127.0.0.1:4000'
 
 [meta_client_opts]
 metasrv_addrs = ['127.0.0.1:3002']

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -14,6 +14,7 @@ runtime_size = 8
 
 [http_options]
 addr = '127.0.0.1:4000'
+request_timeout_seconds = 10
 
 [mysql_options]
 addr = '127.0.0.1:4002'

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -1,6 +1,5 @@
 node_id = 0
 mode = 'standalone'
-http_addr = '127.0.0.1:4000'
 datanode_mysql_addr = '127.0.0.1:4406'
 datanode_mysql_runtime_size = 4
 wal_dir = '/tmp/greptimedb/wal/'
@@ -12,6 +11,9 @@ data_dir = '/tmp/greptimedb/data/'
 [grpc_options]
 addr = '127.0.0.1:4001'
 runtime_size = 8
+
+[http_options]
+addr = '127.0.0.1:4000'
 
 [mysql_options]
 addr = '127.0.0.1:4002'

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -294,10 +294,11 @@ mod tests {
         let fe_opts = FrontendOptions::try_from(cmd).unwrap();
         assert_eq!(Mode::Standalone, fe_opts.mode);
         assert_eq!("127.0.0.1:3001".to_string(), fe_opts.datanode_rpc_addr);
-        assert_eq!(
-            "127.0.0.1:4000".to_string(),
-            fe_opts.http_options.unwrap().addr
-        );
+
+        let http_opts = fe_opts.http_options.unwrap();
+        assert_eq!("127.0.0.1:4000".to_string(), http_opts.addr);
+        assert_eq!(Some(10), http_opts.request_timeout_seconds);
+
         assert_eq!(
             "127.0.0.1:4001".to_string(),
             fe_opts.grpc_options.unwrap().addr

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -20,6 +20,7 @@ use snafu::prelude::*;
 
 use crate::error::{self, Result};
 use crate::grpc::GrpcOptions;
+use crate::http::HttpOptions;
 use crate::influxdb::InfluxdbOptions;
 use crate::instance::FrontendInstance;
 use crate::mysql::MysqlOptions;
@@ -31,6 +32,7 @@ use crate::server::Services;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FrontendOptions {
     pub http_addr: Option<String>,
+    pub http_options: Option<HttpOptions>,
     pub grpc_options: Option<GrpcOptions>,
     pub mysql_options: Option<MysqlOptions>,
     pub postgres_options: Option<PostgresOptions>,
@@ -45,7 +47,8 @@ pub struct FrontendOptions {
 impl Default for FrontendOptions {
     fn default() -> Self {
         Self {
-            http_addr: Some("127.0.0.1:4000".to_string()),
+            http_addr: None,
+            http_options: Some(HttpOptions::default()),
             grpc_options: Some(GrpcOptions::default()),
             mysql_options: Some(MysqlOptions::default()),
             postgres_options: Some(PostgresOptions::default()),

--- a/src/frontend/src/http.rs
+++ b/src/frontend/src/http.rs
@@ -17,12 +17,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HttpOptions {
     pub addr: String,
+    pub request_timeout_seconds: Option<u64>,
 }
 
 impl Default for HttpOptions {
     fn default() -> Self {
         Self {
             addr: "127.0.0.1:4000".to_string(),
+            request_timeout_seconds: Some(30),
         }
     }
 }

--- a/src/frontend/src/http.rs
+++ b/src/frontend/src/http.rs
@@ -12,25 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
+use serde::{Deserialize, Serialize};
 
-mod catalog;
-mod datanode;
-pub mod error;
-mod expr_factory;
-pub mod frontend;
-pub mod grpc;
-pub mod http;
-pub mod influxdb;
-pub mod instance;
-pub mod mysql;
-pub mod opentsdb;
-pub mod partitioning;
-pub mod postgres;
-pub mod prometheus;
-mod server;
-pub mod spliter;
-mod sql;
-mod table;
-#[cfg(test)]
-mod tests;
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct HttpOptions {
+    pub addr: String,
+}
+
+impl Default for HttpOptions {
+    fn default() -> Self {
+        Self {
+            addr: "127.0.0.1:4000".to_string(),
+        }
+    }
+}

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -14,6 +14,7 @@
 
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_runtime::Builder as RuntimeBuilder;
 use common_telemetry::info;
@@ -137,6 +138,10 @@ impl Services {
                 http_server.set_prom_handler(instance.clone());
             }
             http_server.set_script_handler(instance.clone());
+
+            if let Some(timeout) = http_opts.request_timeout_seconds {
+                http_server.set_request_timeout(Duration::from_secs(timeout));
+            }
 
             Some((Box::new(http_server) as _, http_addr))
         } else {

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -116,8 +116,8 @@ impl Services {
             None
         };
 
-        let http_server_and_addr = if let Some(http_addr) = &opts.http_addr {
-            let http_addr = parse_addr(http_addr)?;
+        let http_server_and_addr = if let Some(http_opts) = &opts.http_options {
+            let http_addr = parse_addr(&http_opts.addr)?;
 
             let mut http_server = HttpServer::new(instance.clone());
             if opentsdb_server_and_addr.is_some() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- This PR adds `http_options` to frontend config to make HTTP server request timeout configurable.
- To keep backward compatibility, top-level `http_addr` option takes precedence if present in config file.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/463