### PR TITLE
fix: fix nightly build error of missing git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release
 env:
   RUST_TOOLCHAIN: nightly-2022-07-14
 
-  # FIXME(zyy17): It's better to fetch the latest tag from git, but for a long time, we will stay at 'v0.1.0-alpha-*'
+  # FIXME(zyy17): Would be better to use `gh release list -L 1 | cut -f 3` to get the latest release version tag, but for a long time, we will stay at 'v0.1.0-alpha-*'.
   NIGHTLY_BUILD_VERSION_PREFIX: v0.1.0-alpha
 
 jobs:
@@ -121,11 +121,18 @@ jobs:
           NIGHTLY_VERSION=${{ env.NIGHTLY_BUILD_VERSION_PREFIX }}-$buildTime-nigthly
           echo "VERSION=${NIGHTLY_VERSION}" >> $GITHUB_ENV
 
-      - name: Publish nigthly release # configure the different release title.
+      - name: Create nigthly git tag
+        if: github.event_name == 'schedule'
+        run: |
+          git tag ${{ env.NIGHTLY_VERSION }}
+
+      - name: Publish nigthly release # configure the different release title and tags.
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'schedule'
         with:
           name: "Release ${{ env.NIGHTLY_VERSION }}"
+          tag_name: ${{ env.NIGHTLY_VERSION }}
+          generate_release_notes: true
           files: |
             **/greptime-*
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix nightly build error of missing git tag, the error message is in [5864923014](https://github.com/GreptimeTeam/greptimedb/actions/runs/3501105200/jobs/5864923014).

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
