### PR TITLE
fix: make nullable as default when alter table

### DIFF
--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -261,11 +261,10 @@ pub fn sql_column_def_to_grpc_column_def(col: ColumnDef) -> Result<api::v1::Colu
     let name = col.name.value.clone();
     let data_type = sql_data_type_to_concrete_data_type(&col.data_type)?;
 
-    let nullable = col.options.is_empty()
-        || col
-            .options
-            .iter()
-            .any(|o| matches!(o.option, ColumnOption::Null));
+    let nullable = !col
+        .options
+        .iter()
+        .any(|o| matches!(o.option, ColumnOption::NotNull));
 
     let default_constraint = parse_column_default_constraint(&name, &data_type, &col.options)?
         .map(ColumnDefaultConstraint::try_into) // serialize default constraint to bytes

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -260,10 +260,12 @@ pub fn column_def_to_schema(column_def: &ColumnDef, is_time_index: bool) -> Resu
 pub fn sql_column_def_to_grpc_column_def(col: ColumnDef) -> Result<api::v1::ColumnDef> {
     let name = col.name.value.clone();
     let data_type = sql_data_type_to_concrete_data_type(&col.data_type)?;
-    let nullable = col
-        .options
-        .iter()
-        .any(|o| matches!(o.option, ColumnOption::Null));
+
+    let nullable = col.options.is_empty()
+        || col
+            .options
+            .iter()
+            .any(|o| matches!(o.option, ColumnOption::Null));
 
     let default_constraint = parse_column_default_constraint(&name, &data_type, &col.options)?
         .map(ColumnDefaultConstraint::try_into) // serialize default constraint to bytes


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Fix bug https://github.com/GreptimeTeam/greptimedb/issues/364
Make nullable as default when alter table.

Please explain IN DETAIL what the changes are in this PR and why they are needed:
- Summarize your change (**mandatory**)
   Make nullable as default when alter table
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- []  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
