### PR TITLE
fix: remove datanode mysql options in standalone mode

### DIFF
--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -1,8 +1,6 @@
 node_id = 0
 mode = 'standalone'
 http_addr = '127.0.0.1:4000'
-datanode_mysql_addr = '127.0.0.1:4406'
-datanode_mysql_runtime_size = 4
 wal_dir = '/tmp/greptimedb/wal/'
 
 [storage]

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -71,8 +71,6 @@ pub struct StandaloneOptions {
     pub mode: Mode,
     pub wal_dir: String,
     pub storage: ObjectStoreConfig,
-    pub datanode_mysql_addr: String,
-    pub datanode_mysql_runtime_size: usize,
 }
 
 impl Default for StandaloneOptions {
@@ -88,8 +86,6 @@ impl Default for StandaloneOptions {
             mode: Mode::Standalone,
             wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
-            datanode_mysql_addr: "127.0.0.1:4406".to_string(),
-            datanode_mysql_runtime_size: 4,
         }
     }
 }
@@ -114,8 +110,6 @@ impl StandaloneOptions {
         DatanodeOptions {
             wal_dir: self.wal_dir,
             storage: self.storage,
-            mysql_addr: self.datanode_mysql_addr,
-            mysql_runtime_size: self.datanode_mysql_runtime_size,
             ..Default::default()
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove `datanode_mysql_addr`/`datanode_mysql_runtime_size` from `StandaloneOptions`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
NA