### PR TITLE
feat: deregister table for MemoryCatalogManager

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -5,7 +5,7 @@ wal_dir = '/tmp/greptimedb/wal'
 rpc_runtime_size = 8
 mysql_addr = '127.0.0.1:4406'
 mysql_runtime_size = 4
-memory_catalog_enable = false
+enable_memory_catalog = false
 
 [storage]
 type = 'File'

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -5,6 +5,7 @@ wal_dir = '/tmp/greptimedb/wal'
 rpc_runtime_size = 8
 mysql_addr = '127.0.0.1:4406'
 mysql_runtime_size = 4
+memory_catalog_enable = false
 
 [storage]
 type = 'File'

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -2,6 +2,7 @@ node_id = 0
 mode = 'standalone'
 http_addr = '127.0.0.1:4000'
 wal_dir = '/tmp/greptimedb/wal/'
+memory_catalog_enable = false
 
 [storage]
 type = 'File'

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -2,7 +2,7 @@ node_id = 0
 mode = 'standalone'
 http_addr = '127.0.0.1:4000'
 wal_dir = '/tmp/greptimedb/wal/'
-memory_catalog_enable = false
+enable_memory_catalog = false
 
 [storage]
 type = 'File'

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -103,6 +103,9 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to register schema"))]
+    RegisterTable { source: BoxedError },
+
     #[snafu(display("Operation {} not implemented yet", operation))]
     Unimplemented {
         operation: String,
@@ -215,6 +218,8 @@ impl ErrorExt for Error {
             | Error::EmptyValue { .. }
             | Error::ValueDeserialize { .. }
             | Error::Io { .. } => StatusCode::StorageUnavailable,
+
+            Error::RegisterTable { .. } => StatusCode::Internal,
 
             Error::ReadSystemCatalog { source, .. } => source.status_code(),
             Error::SystemCatalogTypeMismatch { source, .. } => source.status_code(),

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -103,8 +103,11 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to register schema"))]
-    RegisterTable { source: BoxedError },
+    #[snafu(display("Failed to register table"))]
+    RegisterTable {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
 
     #[snafu(display("Operation {} not implemented yet", operation))]
     Unimplemented {

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -103,10 +103,10 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to register table"))]
-    RegisterTable {
-        #[snafu(backtrace)]
-        source: BoxedError,
+    #[snafu(display("Operation {} not implemented yet", operation))]
+    Unimplemented {
+        operation: String,
+        backtrace: Backtrace,
     },
 
     #[snafu(display("Failed to open table, table info: {}, source: {}", table_info, source))]
@@ -220,7 +220,6 @@ impl ErrorExt for Error {
             Error::SystemCatalogTypeMismatch { source, .. } => source.status_code(),
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
 
-            Error::RegisterTable { .. } => StatusCode::Internal,
             Error::TableExists { .. } => StatusCode::TableAlreadyExists,
             Error::SchemaExists { .. } => StatusCode::InvalidArguments,
 
@@ -235,6 +234,8 @@ impl ErrorExt for Error {
             Error::InvalidTableSchema { source, .. } => source.status_code(),
             Error::InvalidTableInfoInCatalog { .. } => StatusCode::Unexpected,
             Error::Internal { source, .. } => source.status_code(),
+
+            Error::Unimplemented { .. } => StatusCode::Unsupported,
         }
     }
 

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -84,14 +84,15 @@ pub trait CatalogManager: CatalogList {
     async fn start(&self) -> Result<()>;
 
     /// Registers a table within given catalog/schema to catalog manager,
-    /// returns table registered.
+    /// returns whether the table registered.
     async fn register_table(&self, request: RegisterTableRequest) -> Result<usize>;
 
     /// Deregisters a table within given catalog/schema to catalog manager,
-    /// returns table deregistered.
+    /// returns whether the table deregistered.
     async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<usize>;
 
-    /// Register a schema with catalog name and schema name.
+    /// Register a schema with catalog name and schema name. Retuens whether the
+    /// schema registered.
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize>;
 
     /// Register a system table, should be called before starting the manager.

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -85,15 +85,15 @@ pub trait CatalogManager: CatalogList {
 
     /// Registers a table within given catalog/schema to catalog manager,
     /// returns whether the table registered.
-    async fn register_table(&self, request: RegisterTableRequest) -> Result<usize>;
+    async fn register_table(&self, request: RegisterTableRequest) -> Result<bool>;
 
     /// Deregisters a table within given catalog/schema to catalog manager,
     /// returns whether the table deregistered.
-    async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<usize>;
+    async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<bool>;
 
     /// Register a schema with catalog name and schema name. Retuens whether the
     /// schema registered.
-    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize>;
+    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool>;
 
     /// Register a system table, should be called before starting the manager.
     async fn register_system_table(&self, request: RegisterSystemTableRequest)

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -83,9 +83,13 @@ pub trait CatalogManager: CatalogList {
     /// Starts a catalog manager.
     async fn start(&self) -> Result<()>;
 
-    /// Registers a table given given catalog/schema to catalog manager,
+    /// Registers a table within given catalog/schema to catalog manager,
     /// returns table registered.
     async fn register_table(&self, request: RegisterTableRequest) -> Result<usize>;
+
+    /// Deregisters a table within given catalog/schema to catalog manager,
+    /// returns table deregistered.
+    async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<usize>;
 
     /// Register a schema with catalog name and schema name.
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize>;
@@ -121,6 +125,14 @@ pub struct RegisterTableRequest {
     pub table_name: String,
     pub table_id: TableId,
     pub table: TableRef,
+}
+
+#[derive(Clone)]
+pub struct DeregisterTableRequest {
+    pub catalog: String,
+    pub schema: String,
+    pub table_name: String,
+    pub table_id: TableId,
 }
 
 #[derive(Debug, Clone)]

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -354,7 +354,7 @@ impl CatalogManager for LocalCatalogManager {
 
     async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
         UnimplementedSnafu {
-            operation: String::from("deregister table"),
+            operation: "deregister table",
         }
         .fail()
     }

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -36,7 +36,7 @@ use table::TableRef;
 use crate::error::{
     CatalogNotFoundSnafu, IllegalManagerStateSnafu, OpenTableSnafu, ReadSystemCatalogSnafu, Result,
     SchemaExistsSnafu, SchemaNotFoundSnafu, SystemCatalogSnafu, SystemCatalogTypeMismatchSnafu,
-    TableExistsSnafu, TableNotFoundSnafu,
+    TableExistsSnafu, TableNotFoundSnafu, UnimplementedSnafu,
 };
 use crate::local::memory::{MemoryCatalogManager, MemoryCatalogProvider, MemorySchemaProvider};
 use crate::system::{
@@ -46,8 +46,8 @@ use crate::system::{
 use crate::tables::SystemCatalog;
 use crate::{
     format_full_table_name, handle_system_table_request, CatalogList, CatalogManager,
-    CatalogProvider, CatalogProviderRef, RegisterSchemaRequest, RegisterSystemTableRequest,
-    RegisterTableRequest, SchemaProvider, SchemaProviderRef,
+    CatalogProvider, CatalogProviderRef, DeregisterTableRequest, RegisterSchemaRequest,
+    RegisterSystemTableRequest, RegisterTableRequest, SchemaProvider, SchemaProviderRef,
 };
 
 /// A `CatalogManager` consists of a system catalog and a bunch of user catalogs.
@@ -350,6 +350,13 @@ impl CatalogManager for LocalCatalogManager {
 
         schema.register_table(request.table_name, request.table)?;
         Ok(1)
+    }
+
+    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
+        UnimplementedSnafu {
+            operation: String::from("deregister table"),
+        }
+        .fail()
     }
 
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize> {

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -309,7 +309,7 @@ impl CatalogManager for LocalCatalogManager {
         self.init().await
     }
 
-    async fn register_table(&self, request: RegisterTableRequest) -> Result<usize> {
+    async fn register_table(&self, request: RegisterTableRequest) -> Result<bool> {
         let started = self.init_lock.lock().await;
 
         ensure!(
@@ -349,17 +349,17 @@ impl CatalogManager for LocalCatalogManager {
             .await?;
 
         schema.register_table(request.table_name, request.table)?;
-        Ok(1)
+        Ok(true)
     }
 
-    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
+    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<bool> {
         UnimplementedSnafu {
             operation: "deregister table",
         }
         .fail()
     }
 
-    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize> {
+    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool> {
         let started = self.init_lock.lock().await;
         ensure!(
             *started,
@@ -384,7 +384,7 @@ impl CatalogManager for LocalCatalogManager {
             .register_schema(request.catalog, schema_name.clone())
             .await?;
         catalog.register_schema(request.schema, Arc::new(MemorySchemaProvider::new()))?;
-        Ok(1)
+        Ok(true)
     }
 
     async fn register_system_table(&self, request: RegisterSystemTableRequest) -> Result<()> {

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -359,4 +359,35 @@ mod tests {
             .downcast_ref::<MemoryCatalogManager>()
             .unwrap();
     }
+
+    #[tokio::test]
+    pub async fn test_catalog_deregister_table() {
+        let catalog = MemoryCatalogManager::default();
+        let schema = catalog
+            .schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME)
+            .unwrap()
+            .unwrap();
+
+        let register_table_req = RegisterTableRequest {
+            catalog: DEFAULT_CATALOG_NAME.to_string(),
+            schema: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: "numbers".to_string(),
+            table_id: 2333,
+            table: Arc::new(NumbersTable::default()),
+        };
+        catalog.register_table(register_table_req).await.unwrap();
+        assert!(schema.table_exist("numbers").unwrap());
+
+        let deregister_table_req = DeregisterTableRequest {
+            catalog: DEFAULT_CATALOG_NAME.to_string(),
+            schema: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: "numbers".to_string(),
+            table_id: 2333,
+        };
+        catalog
+            .deregister_table(deregister_table_req)
+            .await
+            .unwrap();
+        assert!(!schema.table_exist("numbers").unwrap());
+    }
 }

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -69,7 +69,7 @@ impl CatalogManager for MemoryCatalogManager {
         Ok(())
     }
 
-    async fn register_table(&self, request: RegisterTableRequest) -> Result<usize> {
+    async fn register_table(&self, request: RegisterTableRequest) -> Result<bool> {
         let catalogs = self.catalogs.write().unwrap();
         let catalog = catalogs
             .get(&request.catalog)
@@ -84,10 +84,10 @@ impl CatalogManager for MemoryCatalogManager {
             })?;
         schema
             .register_table(request.table_name, request.table)
-            .map(|v| if v.is_some() { 0 } else { 1 })
+            .map(|v| v.is_none())
     }
 
-    async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<usize> {
+    async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<bool> {
         let catalogs = self.catalogs.write().unwrap();
         let catalog = catalogs
             .get(&request.catalog)
@@ -102,10 +102,10 @@ impl CatalogManager for MemoryCatalogManager {
             })?;
         schema
             .deregister_table(&request.table_name)
-            .map(|v| if v.is_some() { 0 } else { 1 })
+            .map(|v| v.is_some())
     }
 
-    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize> {
+    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool> {
         let catalogs = self.catalogs.write().unwrap();
         let catalog = catalogs
             .get(&request.catalog)
@@ -113,7 +113,7 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog_name: &request.catalog,
             })?;
         catalog.register_schema(request.schema, Arc::new(MemorySchemaProvider::new()))?;
-        Ok(1)
+        Ok(true)
     }
 
     async fn register_system_table(&self, _request: RegisterSystemTableRequest) -> Result<()> {

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -117,7 +117,8 @@ impl CatalogManager for MemoryCatalogManager {
     }
 
     async fn register_system_table(&self, _request: RegisterSystemTableRequest) -> Result<()> {
-        unimplemented!()
+        // TODO(ruihang): support register system table request
+        Ok(())
     }
 
     fn schema(&self, catalog: &str, schema: &str) -> Result<Option<SchemaProviderRef>> {

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -37,13 +37,13 @@ use tokio::sync::Mutex;
 
 use crate::error::{
     CatalogNotFoundSnafu, CreateTableSnafu, InvalidCatalogValueSnafu, InvalidTableSchemaSnafu,
-    OpenTableSnafu, Result, SchemaNotFoundSnafu, TableExistsSnafu,
+    OpenTableSnafu, Result, SchemaNotFoundSnafu, TableExistsSnafu, UnimplementedSnafu,
 };
 use crate::remote::{Kv, KvBackendRef};
 use crate::{
     handle_system_table_request, CatalogList, CatalogManager, CatalogProvider, CatalogProviderRef,
-    RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, SchemaProvider,
-    SchemaProviderRef,
+    DeregisterTableRequest, RegisterSchemaRequest, RegisterSystemTableRequest,
+    RegisterTableRequest, SchemaProvider, SchemaProviderRef,
 };
 
 /// Catalog manager based on metasrv.
@@ -431,6 +431,13 @@ impl CatalogManager for RemoteCatalogManager {
         }
         schema_provider.register_table(request.table_name, request.table)?;
         Ok(1)
+    }
+
+    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
+        UnimplementedSnafu {
+            operation: String::from("deregister table"),
+        }
+        .fail()
     }
 
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize> {

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -411,7 +411,7 @@ impl CatalogManager for RemoteCatalogManager {
         Ok(())
     }
 
-    async fn register_table(&self, request: RegisterTableRequest) -> Result<usize> {
+    async fn register_table(&self, request: RegisterTableRequest) -> Result<bool> {
         let catalog_name = request.catalog;
         let schema_name = request.schema;
         let catalog_provider = self.catalog(&catalog_name)?.context(CatalogNotFoundSnafu {
@@ -430,17 +430,17 @@ impl CatalogManager for RemoteCatalogManager {
             .fail();
         }
         schema_provider.register_table(request.table_name, request.table)?;
-        Ok(1)
+        Ok(true)
     }
 
-    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
+    async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<bool> {
         UnimplementedSnafu {
             operation: "deregister table",
         }
         .fail()
     }
 
-    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<usize> {
+    async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool> {
         let catalog_name = request.catalog;
         let schema_name = request.schema;
         let catalog_provider = self.catalog(&catalog_name)?.context(CatalogNotFoundSnafu {
@@ -448,7 +448,7 @@ impl CatalogManager for RemoteCatalogManager {
         })?;
         let schema_provider = self.new_schema_provider(&catalog_name, &schema_name);
         catalog_provider.register_schema(schema_name, schema_provider)?;
-        Ok(1)
+        Ok(true)
     }
 
     async fn register_system_table(&self, request: RegisterSystemTableRequest) -> Result<()> {

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -435,7 +435,7 @@ impl CatalogManager for RemoteCatalogManager {
 
     async fn deregister_table(&self, _request: DeregisterTableRequest) -> Result<usize> {
         UnimplementedSnafu {
-            operation: String::from("deregister table"),
+            operation: "deregister table",
         }
         .fail()
     }

--- a/src/catalog/tests/remote_catalog_tests.rs
+++ b/src/catalog/tests/remote_catalog_tests.rs
@@ -202,7 +202,7 @@ mod tests {
             table_id,
             table,
         };
-        assert_eq!(1, catalog_manager.register_table(reg_req).await.unwrap());
+        assert!(catalog_manager.register_table(reg_req).await.unwrap());
         assert_eq!(
             HashSet::from([table_name, "numbers".to_string()]),
             default_schema
@@ -287,7 +287,7 @@ mod tests {
             .register_schema(schema_name.clone(), schema.clone())
             .expect("Register schema should not fail");
         assert!(prev.is_none());
-        assert_eq!(1, catalog_manager.register_table(reg_req).await.unwrap());
+        assert!(catalog_manager.register_table(reg_req).await.unwrap());
 
         assert_eq!(
             HashSet::from([schema_name.clone()]),

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -71,7 +71,7 @@ pub struct StandaloneOptions {
     pub mode: Mode,
     pub wal_dir: String,
     pub storage: ObjectStoreConfig,
-    pub memory_catalog_enable: bool,
+    pub enable_memory_catalog: bool,
 }
 
 impl Default for StandaloneOptions {
@@ -87,7 +87,7 @@ impl Default for StandaloneOptions {
             mode: Mode::Standalone,
             wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
-            memory_catalog_enable: false,
+            enable_memory_catalog: false,
         }
     }
 }
@@ -112,7 +112,7 @@ impl StandaloneOptions {
         DatanodeOptions {
             wal_dir: self.wal_dir,
             storage: self.storage,
-            memory_catalog_enable: self.memory_catalog_enable,
+            enable_memory_catalog: self.enable_memory_catalog,
             ..Default::default()
         }
     }
@@ -134,13 +134,13 @@ struct StartCommand {
     influxdb_enable: bool,
     #[clap(short, long)]
     config_file: Option<String>,
-    #[clap(short, long)]
-    memory_catalog_enable: bool,
+    #[clap(short = 'm', long = "memory-catalog")]
+    enable_memory_catalog: bool,
 }
 
 impl StartCommand {
     async fn run(self) -> Result<()> {
-        let memory_catalog_enable = self.memory_catalog_enable;
+        let enable_memory_catalog = self.enable_memory_catalog;
         let config_file = self.config_file.clone();
         let fe_opts = FrontendOptions::try_from(self)?;
         let dn_opts: DatanodeOptions = {
@@ -149,7 +149,7 @@ impl StartCommand {
             } else {
                 StandaloneOptions::default()
             };
-            opts.memory_catalog_enable = memory_catalog_enable;
+            opts.enable_memory_catalog = enable_memory_catalog;
             opts.datanode_options()
         };
 
@@ -271,7 +271,7 @@ mod tests {
                 std::env::current_dir().unwrap().as_path().to_str().unwrap()
             )),
             influxdb_enable: false,
-            memory_catalog_enable: false,
+            enable_memory_catalog: false,
         };
 
         let fe_opts = FrontendOptions::try_from(cmd).unwrap();

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -47,7 +47,7 @@ pub struct DatanodeOptions {
     pub meta_client_opts: Option<MetaClientOpts>,
     pub wal_dir: String,
     pub storage: ObjectStoreConfig,
-    pub memory_catalog_enable: bool,
+    pub enable_memory_catalog: bool,
     pub mode: Mode,
 }
 
@@ -62,7 +62,7 @@ impl Default for DatanodeOptions {
             meta_client_opts: None,
             wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
-            memory_catalog_enable: false,
+            enable_memory_catalog: false,
             mode: Mode::Standalone,
         }
     }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -47,6 +47,7 @@ pub struct DatanodeOptions {
     pub meta_client_opts: Option<MetaClientOpts>,
     pub wal_dir: String,
     pub storage: ObjectStoreConfig,
+    pub memory_catalog_enable: bool,
     pub mode: Mode,
 }
 
@@ -61,6 +62,7 @@ impl Default for DatanodeOptions {
             meta_client_opts: None,
             wal_dir: "/tmp/greptimedb/wal".to_string(),
             storage: ObjectStoreConfig::default(),
+            memory_catalog_enable: false,
             mode: Mode::Standalone,
         }
     }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -99,7 +99,7 @@ impl Instance {
         // create remote catalog manager
         let (catalog_manager, factory, table_id_provider) = match opts.mode {
             Mode::Standalone => {
-                if opts.memory_catalog_enable {
+                if opts.enable_memory_catalog {
                     let catalog = Arc::new(catalog::local::MemoryCatalogManager::default());
                     let factory = QueryEngineFactory::new(catalog.clone());
 

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -19,8 +19,9 @@ use std::sync::Arc;
 use catalog::error::{self as catalog_err, InvalidCatalogValueSnafu};
 use catalog::remote::{Kv, KvBackendRef};
 use catalog::{
-    CatalogList, CatalogManager, CatalogProvider, CatalogProviderRef, RegisterSchemaRequest,
-    RegisterSystemTableRequest, RegisterTableRequest, SchemaProvider, SchemaProviderRef,
+    CatalogList, CatalogManager, CatalogProvider, CatalogProviderRef, DeregisterTableRequest,
+    RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, SchemaProvider,
+    SchemaProviderRef,
 };
 use common_catalog::{CatalogKey, SchemaKey, TableGlobalKey, TableGlobalValue};
 use futures::StreamExt;
@@ -68,6 +69,13 @@ impl CatalogManager for FrontendCatalogManager {
     async fn register_table(
         &self,
         _request: RegisterTableRequest,
+    ) -> catalog::error::Result<usize> {
+        unimplemented!()
+    }
+
+    async fn deregister_table(
+        &self,
+        _request: DeregisterTableRequest,
     ) -> catalog::error::Result<usize> {
         unimplemented!()
     }

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -66,24 +66,21 @@ impl CatalogManager for FrontendCatalogManager {
         Ok(())
     }
 
-    async fn register_table(
-        &self,
-        _request: RegisterTableRequest,
-    ) -> catalog::error::Result<usize> {
+    async fn register_table(&self, _request: RegisterTableRequest) -> catalog::error::Result<bool> {
         unimplemented!()
     }
 
     async fn deregister_table(
         &self,
         _request: DeregisterTableRequest,
-    ) -> catalog::error::Result<usize> {
+    ) -> catalog::error::Result<bool> {
         unimplemented!()
     }
 
     async fn register_schema(
         &self,
         _request: RegisterSchemaRequest,
-    ) -> catalog::error::Result<usize> {
+    ) -> catalog::error::Result<bool> {
         unimplemented!()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- **API change** Add `memory_catalog_enable` option to `standalone start` command
- Add new method `deregister_table` to trait `CatalogManager`
- Implement `deregister_table` for `MemoryCatalogManager`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Part of #497, also related to #614