### PR TITLE
feat: adds metrics, tracing and retry layer to object-store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,6 +1789,7 @@ dependencies = [
  "axum 0.6.0-rc.2",
  "axum-macros",
  "axum-test-helper",
+ "backon",
  "catalog",
  "client",
  "common-base",
@@ -3665,6 +3666,7 @@ dependencies = [
  "http",
  "log",
  "md-5",
+ "metrics",
  "once_cell",
  "parking_lot",
  "percent-encoding",
@@ -3677,6 +3679,7 @@ dependencies = [
  "thiserror",
  "time 0.3.14",
  "tokio",
+ "tracing",
  "ureq",
 ]
 

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -13,6 +13,7 @@ api = { path = "../api" }
 async-trait = "0.1"
 axum = "0.6.0-rc.2"
 axum-macros = "0.3.0-rc.1"
+backon = "0.2"
 catalog = { path = "../catalog" }
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = "0.20"
+opendal = { version = "0.20", features = ["layers-tracing", "layers-metrics"]}
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Adds more layers to opendal object-store:

* `MetricsLayer` and `TracingLayer` for better observability
* `RetryLayer` with exponential backoff strategy, prepares for s3 storage testing.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
