### PR TITLE
feat: Implements PrimitiveType and PrimitiveVector for datatypes2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
  "common-function-macro",
  "common-query",
  "common-time",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datatypes",
  "libc",
  "num",
@@ -1366,7 +1366,7 @@ dependencies = [
  "common-recordbatch",
  "common-time",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "datatypes",
  "snafu",
@@ -1380,7 +1380,7 @@ version = "0.1.0"
 dependencies = [
  "common-error",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datatypes",
  "futures",
  "paste",
@@ -1834,7 +1834,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "comfy-table 5.0.1",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "datafusion-physical-expr",
  "futures",
@@ -1849,7 +1849,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.8.5",
  "smallvec",
- "sqlparser",
+ "sqlparser 0.15.0",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -1863,7 +1863,19 @@ dependencies = [
  "arrow2",
  "ordered-float 2.10.0",
  "parquet2",
- "sqlparser",
+ "sqlparser 0.15.0",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f1ffcbc1f040c9ab99f41db1c743d95aff267bb2e7286aaa010738b7402251"
+dependencies = [
+ "arrow 26.0.0",
+ "chrono",
+ "ordered-float 3.1.0",
+ "sqlparser 0.26.0",
 ]
 
 [[package]]
@@ -1873,8 +1885,8 @@ source = "git+https://github.com/apache/arrow-datafusion.git?branch=arrow2#744b2
 dependencies = [
  "ahash 0.7.6",
  "arrow2",
- "datafusion-common",
- "sqlparser",
+ "datafusion-common 7.0.0",
+ "sqlparser 0.15.0",
 ]
 
 [[package]]
@@ -1887,7 +1899,7 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "hashbrown",
  "lazy_static",
@@ -1923,7 +1935,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datatypes",
  "frontend",
  "futures",
@@ -1961,7 +1973,7 @@ dependencies = [
  "common-base",
  "common-error",
  "common-time",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "enum_dispatch",
  "num",
  "num-traits",
@@ -1980,7 +1992,7 @@ dependencies = [
  "common-base",
  "common-error",
  "common-time",
- "datafusion-common",
+ "datafusion-common 14.0.0",
  "enum_dispatch",
  "num",
  "num-traits",
@@ -2342,7 +2354,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "datanode",
  "datatypes",
@@ -2360,7 +2372,7 @@ dependencies = [
  "servers",
  "snafu",
  "sql",
- "sqlparser",
+ "sqlparser 0.15.0",
  "store-api",
  "table",
  "tempdir",
@@ -3449,7 +3461,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datatypes",
  "futures",
  "log-store",
@@ -4626,7 +4638,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-physical-expr",
  "datatypes",
  "format_num",
@@ -5420,7 +5432,7 @@ dependencies = [
  "common-time",
  "console",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "datafusion-physical-expr",
  "datatypes",
@@ -5828,7 +5840,7 @@ dependencies = [
  "mito",
  "once_cell",
  "snafu",
- "sqlparser",
+ "sqlparser 0.15.0",
 ]
 
 [[package]]
@@ -5862,6 +5874,15 @@ name = "sqlparser"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbbea2526ad0d02ad9414a07c396078a5b944bbf9ca4fbab8f01bb4cb579081"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86be66ea0b2b22749cfa157d16e2e84bf793e626a3375f4d378dc289fa03affb"
 dependencies = [
  "log",
 ]
@@ -6169,7 +6190,7 @@ dependencies = [
  "common-recordbatch",
  "common-telemetry",
  "datafusion",
- "datafusion-common",
+ "datafusion-common 7.0.0",
  "datafusion-expr",
  "datatypes",
  "derive_builder",

--- a/src/datatypes2/Cargo.toml
+++ b/src/datatypes2/Cargo.toml
@@ -12,7 +12,7 @@ test = []
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
-datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2" }
+datafusion-common = "14.0"
 enum_dispatch = "0.3"
 num = "0.4"
 num-traits = "0.2"

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -27,7 +27,7 @@ use crate::types::{
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch(DataType)]
 pub enum ConcreteDataType {
     // Null(NullType),

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -20,7 +20,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{self, Error, Result};
 use crate::type_id::LogicalTypeId;
-use crate::types::{BinaryType, BooleanType};
+use crate::types::{
+    BinaryType, BooleanType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
@@ -31,16 +34,16 @@ pub enum ConcreteDataType {
     Boolean(BooleanType),
 
     // Numeric types:
-    // Int8(Int8Type),
-    // Int16(Int16Type),
-    // Int32(Int32Type),
-    // Int64(Int64Type),
-    // UInt8(UInt8Type),
-    // UInt16(UInt16Type),
-    // UInt32(UInt32Type),
-    // UInt64(UInt64Type),
-    // Float32(Float32Type),
-    // Float64(Float64Type),
+    Int8(Int8Type),
+    Int16(Int16Type),
+    Int32(Int32Type),
+    Int64(Int64Type),
+    UInt8(UInt8Type),
+    UInt16(UInt16Type),
+    UInt32(UInt32Type),
+    UInt64(UInt64Type),
+    Float32(Float32Type),
+    Float64(Float64Type),
 
     // String types
     Binary(BinaryType),

--- a/src/datatypes2/src/macros.rs
+++ b/src/datatypes2/src/macros.rs
@@ -12,27 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///! Some helper macros for datatypes, copied from databend.
-#[macro_export]
-macro_rules! for_all_scalar_types {
-    ($macro:tt $(, $x:tt)*) => {
-        $macro! {
-            [$($x),*],
-            { i8 },
-            { i16 },
-            { i32 },
-            { i64 },
-            { u8 },
-            { u16 },
-            { u32 },
-            { u64 },
-            { f32 },
-            { f64 },
-            { bool },
-        }
-    };
-}
+//! Some helper macros for datatypes, copied from databend.
 
+/// Apply the macro rules to all primitive types.
 #[macro_export]
 macro_rules! for_all_primitive_types {
     ($macro:tt $(, $x:tt)*) => {
@@ -52,6 +34,8 @@ macro_rules! for_all_primitive_types {
     };
 }
 
+/// Match the logical type and apply `$body` to all primitive types and
+/// `nbody` to other types.
 #[macro_export]
 macro_rules! with_match_primitive_type_id {
     ($key_type:expr, | $_:tt $T:ident | $body:tt, $nbody:tt) => {{
@@ -62,17 +46,21 @@ macro_rules! with_match_primitive_type_id {
         }
 
         use $crate::type_id::LogicalTypeId;
+        use $crate::types::{
+            Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type,
+            UInt32Type, UInt64Type, UInt8Type,
+        };
         match $key_type {
-            LogicalTypeId::Int8 => __with_ty__! { i8 },
-            LogicalTypeId::Int16 => __with_ty__! { i16 },
-            LogicalTypeId::Int32 => __with_ty__! { i32 },
-            LogicalTypeId::Int64 => __with_ty__! { i64 },
-            LogicalTypeId::UInt8 => __with_ty__! { u8 },
-            LogicalTypeId::UInt16 => __with_ty__! { u16 },
-            LogicalTypeId::UInt32 => __with_ty__! { u32 },
-            LogicalTypeId::UInt64 => __with_ty__! { u64 },
-            LogicalTypeId::Float32 => __with_ty__! { f32 },
-            LogicalTypeId::Float64 => __with_ty__! { f64 },
+            LogicalTypeId::Int8 => __with_ty__! { Int8Type },
+            LogicalTypeId::Int16 => __with_ty__! { Int16Type },
+            LogicalTypeId::Int32 => __with_ty__! { Int32Type },
+            LogicalTypeId::Int64 => __with_ty__! { Int64Type },
+            LogicalTypeId::UInt8 => __with_ty__! { UInt8Type },
+            LogicalTypeId::UInt16 => __with_ty__! { UInt16Type },
+            LogicalTypeId::UInt32 => __with_ty__! { UInt32Type },
+            LogicalTypeId::UInt64 => __with_ty__! { UInt64Type },
+            LogicalTypeId::Float32 => __with_ty__! { Float32Type },
+            LogicalTypeId::Float64 => __with_ty__! { Float64Type },
 
             _ => $nbody,
         }

--- a/src/datatypes2/src/scalars.rs
+++ b/src/datatypes2/src/scalars.rs
@@ -353,7 +353,7 @@ impl<'a> ScalarRef<'a> for &'a [u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::vectors::binary::BinaryVector;
+    use crate::vectors::{BinaryVector, Int32Vector};
 
     fn build_vector_from_slice<T: ScalarVector>(items: &[Option<T::RefItem<'_>>]) -> T {
         let mut builder = T::Builder::with_capacity(items.len());
@@ -372,12 +372,12 @@ mod tests {
         }
     }
 
-    // #[test]
-    // fn test_build_i32_vector() {
-    //     let expect = vec![Some(1), Some(2), Some(3), None, Some(5)];
-    //     let vector: Int32Vector = build_vector_from_slice(&expect);
-    //     assert_vector_eq(&expect, &vector);
-    // }
+    #[test]
+    fn test_build_i32_vector() {
+        let expect = vec![Some(1), Some(2), Some(3), None, Some(5)];
+        let vector: Int32Vector = build_vector_from_slice(&expect);
+        assert_vector_eq(&expect, &vector);
+    }
 
     #[test]
     fn test_build_binary_vector() {

--- a/src/datatypes2/src/scalars.rs
+++ b/src/datatypes2/src/scalars.rs
@@ -35,7 +35,7 @@ where
     for<'a> Self::VectorType: ScalarVector<RefItem<'a> = Self::RefType<'a>>,
 {
     type VectorType: ScalarVector<OwnedItem = Self>;
-    type RefType<'a>: ScalarRef<'a, ScalarType = Self, VectorType = Self::VectorType>
+    type RefType<'a>: ScalarRef<'a, ScalarType = Self>
     where
         Self: 'a;
     /// Get a reference of the current value.
@@ -46,7 +46,6 @@ where
 }
 
 pub trait ScalarRef<'a>: std::fmt::Debug + Clone + Copy + Send + 'a {
-    type VectorType: ScalarVector<RefItem<'a> = Self>;
     /// The corresponding [`Scalar`] type.
     type ScalarType: Scalar<RefType<'a> = Self>;
 
@@ -63,7 +62,7 @@ where
 {
     type OwnedItem: Scalar<VectorType = Self>;
     /// The reference item of this vector.
-    type RefItem<'a>: ScalarRef<'a, ScalarType = Self::OwnedItem, VectorType = Self>
+    type RefItem<'a>: ScalarRef<'a, ScalarType = Self::OwnedItem>
     where
         Self: 'a;
 
@@ -157,7 +156,6 @@ macro_rules! impl_scalar_for_native {
 
         /// Implement [`ScalarRef`] for primitive types. Note that primitive types are both [`Scalar`] and [`ScalarRef`].
         impl<'a> ScalarRef<'a> for $Native {
-            type VectorType = PrimitiveVector<$DataType>;
             type ScalarType = $Native;
 
             #[inline]
@@ -196,7 +194,6 @@ impl Scalar for bool {
 }
 
 impl<'a> ScalarRef<'a> for bool {
-    type VectorType = BooleanVector;
     type ScalarType = bool;
 
     #[inline]
@@ -246,7 +243,6 @@ impl Scalar for Vec<u8> {
 }
 
 impl<'a> ScalarRef<'a> for &'a [u8] {
-    type VectorType = BinaryVector;
     type ScalarType = Vec<u8>;
 
     #[inline]

--- a/src/datatypes2/src/scalars.rs
+++ b/src/datatypes2/src/scalars.rs
@@ -14,7 +14,11 @@
 
 use std::any::Any;
 
-use crate::vectors::{BinaryVector, BooleanVector, MutableVector, Vector};
+use crate::types::{
+    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
+};
+use crate::vectors::{BinaryVector, BooleanVector, MutableVector, PrimitiveVector, Vector};
 
 fn get_iter_capacity<T, I: Iterator<Item = T>>(iter: &I) -> usize {
     match iter.size_hint() {
@@ -133,47 +137,47 @@ pub trait ScalarVectorBuilder: MutableVector {
     fn finish(&mut self) -> Self::VectorType;
 }
 
-// macro_rules! impl_primitive_scalar_type {
-//     ($native:ident) => {
-//         impl Scalar for $native {
-//             type VectorType = PrimitiveVector<$native>;
-//             type RefType<'a> = $native;
+macro_rules! impl_scalar_for_native {
+    ($Native: ident, $DataType: ident) => {
+        impl Scalar for $Native {
+            type VectorType = PrimitiveVector<$DataType>;
+            type RefType<'a> = $Native;
 
-//             #[inline]
-//             fn as_scalar_ref(&self) -> $native {
-//                 *self
-//             }
+            #[inline]
+            fn as_scalar_ref(&self) -> $Native {
+                *self
+            }
 
-//             #[allow(clippy::needless_lifetimes)]
-//             #[inline]
-//             fn upcast_gat<'short, 'long: 'short>(long: $native) -> $native {
-//                 long
-//             }
-//         }
+            #[allow(clippy::needless_lifetimes)]
+            #[inline]
+            fn upcast_gat<'short, 'long: 'short>(long: $Native) -> $Native {
+                long
+            }
+        }
 
-//         /// Implement [`ScalarRef`] for primitive types. Note that primitive types are both [`Scalar`] and [`ScalarRef`].
-//         impl<'a> ScalarRef<'a> for $native {
-//             type VectorType = PrimitiveVector<$native>;
-//             type ScalarType = $native;
+        /// Implement [`ScalarRef`] for primitive types. Note that primitive types are both [`Scalar`] and [`ScalarRef`].
+        impl<'a> ScalarRef<'a> for $Native {
+            type VectorType = PrimitiveVector<$DataType>;
+            type ScalarType = $Native;
 
-//             #[inline]
-//             fn to_owned_scalar(&self) -> $native {
-//                 *self
-//             }
-//         }
-//     };
-// }
+            #[inline]
+            fn to_owned_scalar(&self) -> $Native {
+                *self
+            }
+        }
+    };
+}
 
-// impl_primitive_scalar_type!(u8);
-// impl_primitive_scalar_type!(u16);
-// impl_primitive_scalar_type!(u32);
-// impl_primitive_scalar_type!(u64);
-// impl_primitive_scalar_type!(i8);
-// impl_primitive_scalar_type!(i16);
-// impl_primitive_scalar_type!(i32);
-// impl_primitive_scalar_type!(i64);
-// impl_primitive_scalar_type!(f32);
-// impl_primitive_scalar_type!(f64);
+impl_scalar_for_native!(u8, UInt8Type);
+impl_scalar_for_native!(u16, UInt16Type);
+impl_scalar_for_native!(u32, UInt32Type);
+impl_scalar_for_native!(u64, UInt64Type);
+impl_scalar_for_native!(i8, Int8Type);
+impl_scalar_for_native!(i16, Int16Type);
+impl_scalar_for_native!(i32, Int32Type);
+impl_scalar_for_native!(i64, Int64Type);
+impl_scalar_for_native!(f32, Float32Type);
+impl_scalar_for_native!(f64, Float64Type);
 
 impl Scalar for bool {
     type VectorType = BooleanVector;

--- a/src/datatypes2/src/types.rs
+++ b/src/datatypes2/src/types.rs
@@ -14,6 +14,11 @@
 
 mod binary_type;
 mod boolean_type;
+mod primitive_type;
 
 pub use binary_type::BinaryType;
 pub use boolean_type::BooleanType;
+pub use primitive_type::{
+    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, LogicalPrimitiveType,
+    NativeType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};

--- a/src/datatypes2/src/types.rs
+++ b/src/datatypes2/src/types.rs
@@ -20,5 +20,5 @@ pub use binary_type::BinaryType;
 pub use boolean_type::BooleanType;
 pub use primitive_type::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, LogicalPrimitiveType,
-    NativeType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+    NativeType, UInt16Type, UInt32Type, UInt64Type, UInt8Type, WrapperType,
 };

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -112,7 +112,7 @@ pub trait LogicalPrimitiveType: 'static + Sized {
     fn build_data_type() -> ConcreteDataType;
 
     /// Return the name of the type.
-    fn type_name() -> String;
+    fn type_name() -> &'static str;
 
     /// Dynamic cast the vector to the concrete vector type.
     fn cast_vector(vector: &dyn Vector) -> Result<&PrimitiveVector<Self>>;
@@ -135,8 +135,8 @@ macro_rules! define_logical_primitive_type {
                 ConcreteDataType::$TypeId($DataType::default())
             }
 
-            fn type_name() -> String {
-                stringify!($TypeId).to_string()
+            fn type_name() -> &'static str {
+                stringify!($TypeId)
             }
 
             fn cast_vector(vector: &dyn Vector) -> Result<&PrimitiveVector<$DataType>> {

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -51,7 +51,9 @@ impl_native_type!(i64, i64);
 impl_native_type!(f32, f64);
 impl_native_type!(f64, f64);
 
-/// Type that wraps a native type.
+/// Represents the wrapper type that wraps a native type using the `newtype pattern`,
+/// such as [Date](`common_time::Date`) is a wrapper type for the underlying native
+/// type `i32`.
 pub trait WrapperType:
     Copy + Scalar + PartialEq + Into<Value> + Into<ValueRef<'static>> + Serialize
 {

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::cmp::Ordering;
 
 use arrow::datatypes::{ArrowNativeType, ArrowPrimitiveType, DataType as ArrowDataType};
@@ -13,7 +27,9 @@ use crate::value::{IntoValueRef, Value, ValueRef};
 use crate::vectors::{MutableVector, PrimitiveVector, PrimitiveVectorBuilder, Vector};
 
 /// Data types that can be used as arrow's native type.
-pub trait NativeType: ArrowNativeType + NumCast {
+pub trait NativeType:
+    ArrowNativeType + NumCast
+{
     /// Largest numeric type this primitive type can be cast to.
     type LargestType: NativeType;
 }
@@ -38,9 +54,7 @@ impl_native_type!(f32, f64);
 impl_native_type!(f64, f64);
 
 /// Type that wraps a native type.
-pub trait WrapperType:
-    Copy + Scalar + PartialEq + Into<Value> + IntoValueRef<'static> + Serialize
-{
+pub trait WrapperType: Copy + Scalar + PartialEq + Into<Value> + IntoValueRef<'static> + Serialize {
     /// Logical primitive type that this wrapper type belongs to.
     type LogicalType: LogicalPrimitiveType<Wrapper = Self, Native = Self::Native>;
     /// The underying native type.

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -1,0 +1,223 @@
+use std::cmp::Ordering;
+
+use arrow::datatypes::{ArrowNativeType, ArrowPrimitiveType, DataType as ArrowDataType};
+use num::NumCast;
+use serde::{Deserialize, Serialize};
+use snafu::OptionExt;
+
+use crate::data_type::{ConcreteDataType, DataType};
+use crate::error::{self, Result};
+use crate::scalars::{Scalar, ScalarRef, ScalarVectorBuilder};
+use crate::type_id::LogicalTypeId;
+use crate::value::{IntoValueRef, Value, ValueRef};
+use crate::vectors::{MutableVector, PrimitiveVector, PrimitiveVectorBuilder, Vector};
+
+/// Data types that can be used as arrow's native type.
+pub trait NativeType:
+    ArrowNativeType + Into<Value> + IntoValueRef<'static> + Serialize + NumCast + Scalar
+{
+    /// Largest numeric type this primitive type can be cast to.
+    type LargestType: NativeType;
+}
+
+macro_rules! impl_native_type {
+    ($Type:ident, $LargestType: ident) => {
+        impl NativeType for $Type {
+            type LargestType = $LargestType;
+        }
+    };
+}
+
+impl_native_type!(u8, u64);
+impl_native_type!(u16, u64);
+impl_native_type!(u32, u64);
+impl_native_type!(u64, u64);
+impl_native_type!(i8, i64);
+impl_native_type!(i16, i64);
+impl_native_type!(i32, i64);
+impl_native_type!(i64, i64);
+impl_native_type!(f32, f64);
+impl_native_type!(f64, f64);
+
+/// Trait bridging the logcial primitive type with [ArrowPrimitiveType].
+pub trait LogicalPrimitiveType: 'static + Sized {
+    /// Arrow primitive type of this logical type.
+    type ArrowPrimitive: ArrowPrimitiveType<Native = Self::Native>;
+    /// Native (physical) type of this logical type.
+    type Native: NativeType
+        + for<'a> Scalar<VectorType = PrimitiveVector<Self>, RefType<'a> = Self::Native>
+        + for<'a> ScalarRef<'a, ScalarType = Self::Native, VectorType = PrimitiveVector<Self>>;
+
+    /// Construct the data type struct.
+    fn build_data_type() -> ConcreteDataType;
+
+    /// Returns the name of the type.
+    fn type_name() -> String;
+
+    /// Dynamic cast the vector to the concrete vector type.
+    fn cast_vector(vector: &dyn Vector) -> Result<&PrimitiveVector<Self>>;
+
+    /// Cast value ref to the primitive type.
+    fn cast_value_ref(value: ValueRef) -> Result<Option<Self::Native>>;
+}
+
+macro_rules! define_logical_primitive_type {
+    ($Native: ident, $TypeId: ident, $DataType: ident) => {
+        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        pub struct $DataType {}
+
+        impl LogicalPrimitiveType for $DataType {
+            type ArrowPrimitive = arrow::datatypes::$DataType;
+            type Native = $Native;
+
+            fn build_data_type() -> ConcreteDataType {
+                ConcreteDataType::$TypeId($DataType::default())
+            }
+
+            fn type_name() -> String {
+                stringify!($TypeId).to_string()
+            }
+
+            fn cast_vector(vector: &dyn Vector) -> Result<&PrimitiveVector<$DataType>> {
+                vector
+                    .as_any()
+                    .downcast_ref::<PrimitiveVector<$DataType>>()
+                    .with_context(|| error::CastTypeSnafu {
+                        msg: format!(
+                            "Failed to cast {} to vector of primitive type {}",
+                            vector.vector_type_name(),
+                            stringify!($TypeId)
+                        ),
+                    })
+            }
+
+            fn cast_value_ref(value: ValueRef) -> Result<Option<$Native>> {
+                match value {
+                    ValueRef::Null => Ok(None),
+                    ValueRef::$TypeId(v) => Ok(Some(v.into())),
+                    other => error::CastTypeSnafu {
+                        msg: format!(
+                            "Failed to cast value {:?} to primitive type {}",
+                            other,
+                            stringify!($TypeId),
+                        ),
+                    }
+                    .fail(),
+                }
+            }
+        }
+
+        impl DataType for $DataType {
+            fn name(&self) -> &str {
+                stringify!($TypeId)
+            }
+
+            fn logical_type_id(&self) -> LogicalTypeId {
+                LogicalTypeId::$TypeId
+            }
+
+            fn default_value(&self) -> Value {
+                $Native::default().into()
+            }
+
+            fn as_arrow_type(&self) -> ArrowDataType {
+                ArrowDataType::$TypeId
+            }
+
+            fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+                Box::new(PrimitiveVectorBuilder::<$DataType>::with_capacity(capacity))
+            }
+        }
+    };
+}
+
+define_logical_primitive_type!(u8, UInt8, UInt8Type);
+define_logical_primitive_type!(u16, UInt16, UInt16Type);
+define_logical_primitive_type!(u32, UInt32, UInt32Type);
+define_logical_primitive_type!(u64, UInt64, UInt64Type);
+define_logical_primitive_type!(i8, Int8, Int8Type);
+define_logical_primitive_type!(i16, Int16, Int16Type);
+define_logical_primitive_type!(i32, Int32, Int32Type);
+define_logical_primitive_type!(i64, Int64, Int64Type);
+define_logical_primitive_type!(f32, Float32, Float32Type);
+define_logical_primitive_type!(f64, Float64, Float64Type);
+
+// TODO(yingwen): Should we rename it to OrdNativeType?
+/// A new type for [NativeType], complement the `Ord` feature for it. Wrapping non ordered
+/// primitive types like `f32` and `f64` in `OrdPrimitive` can make them be used in places that
+/// require `Ord`. For example, in `Median` or `Percentile` UDAFs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OrdPrimitive<T: NativeType>(pub T);
+
+impl<T: NativeType> OrdPrimitive<T> {
+    pub fn as_primitive(&self) -> T {
+        self.0
+    }
+}
+
+impl<T: NativeType> Eq for OrdPrimitive<T> {}
+
+impl<T: NativeType> PartialOrd for OrdPrimitive<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: NativeType> Ord for OrdPrimitive<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.into().cmp(&other.0.into())
+    }
+}
+
+impl<T: NativeType> From<OrdPrimitive<T>> for Value {
+    fn from(p: OrdPrimitive<T>) -> Self {
+        p.0.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BinaryHeap;
+
+    use super::*;
+
+    #[test]
+    fn test_ord_primitive() {
+        struct Foo<T>
+        where
+            T: NativeType,
+        {
+            heap: BinaryHeap<OrdPrimitive<T>>,
+        }
+
+        impl<T> Foo<T>
+        where
+            T: NativeType,
+        {
+            fn push(&mut self, value: T) {
+                let value = OrdPrimitive::<T>(value);
+                self.heap.push(value);
+            }
+        }
+
+        macro_rules! test {
+            ($Type:ident) => {
+                let mut foo = Foo::<$Type> {
+                    heap: BinaryHeap::new(),
+                };
+                foo.push($Type::default());
+            };
+        }
+
+        test!(u8);
+        test!(u16);
+        test!(u32);
+        test!(u64);
+        test!(i8);
+        test!(i16);
+        test!(i32);
+        test!(i64);
+        test!(f32);
+        test!(f64);
+    }
+}

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -59,7 +59,7 @@ pub trait WrapperType:
 {
     /// Logical primitive type that this wrapper type belongs to.
     type LogicalType: LogicalPrimitiveType<Wrapper = Self, Native = Self::Native>;
-    /// The underying native type.
+    /// The underlying native type.
     type Native: NativeType;
 
     /// Convert native type into this wrapper type.
@@ -97,7 +97,7 @@ impl_wrapper!(i64, Int64Type);
 impl_wrapper!(f32, Float32Type);
 impl_wrapper!(f64, Float64Type);
 
-/// Trait bridging the logcial primitive type with [ArrowPrimitiveType].
+/// Trait bridging the logical primitive type with [ArrowPrimitiveType].
 pub trait LogicalPrimitiveType: 'static + Sized {
     /// Arrow primitive type of this logical type.
     type ArrowPrimitive: ArrowPrimitiveType<Native = Self::Native>;
@@ -111,7 +111,7 @@ pub trait LogicalPrimitiveType: 'static + Sized {
     /// Construct the data type struct.
     fn build_data_type() -> ConcreteDataType;
 
-    /// Returns the name of the type.
+    /// Return the name of the type.
     fn type_name() -> String;
 
     /// Dynamic cast the vector to the concrete vector type.

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -27,9 +27,7 @@ use crate::value::{IntoValueRef, Value, ValueRef};
 use crate::vectors::{MutableVector, PrimitiveVector, PrimitiveVectorBuilder, Vector};
 
 /// Data types that can be used as arrow's native type.
-pub trait NativeType:
-    ArrowNativeType + NumCast
-{
+pub trait NativeType: ArrowNativeType + NumCast {
     /// Largest numeric type this primitive type can be cast to.
     type LargestType: NativeType;
 }
@@ -54,7 +52,9 @@ impl_native_type!(f32, f64);
 impl_native_type!(f64, f64);
 
 /// Type that wraps a native type.
-pub trait WrapperType: Copy + Scalar + PartialEq + Into<Value> + IntoValueRef<'static> + Serialize {
+pub trait WrapperType:
+    Copy + Scalar + PartialEq + Into<Value> + IntoValueRef<'static> + Serialize
+{
     /// Logical primitive type that this wrapper type belongs to.
     type LogicalType: LogicalPrimitiveType<Wrapper = Self, Native = Self::Native>;
     /// The underying native type.

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -121,7 +121,7 @@ pub trait LogicalPrimitiveType: 'static + Sized {
 
 macro_rules! define_logical_primitive_type {
     ($Native: ident, $TypeId: ident, $DataType: ident) => {
-        #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
         pub struct $DataType {}
 
         impl LogicalPrimitiveType for $DataType {

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -23,7 +23,7 @@ use crate::data_type::{ConcreteDataType, DataType};
 use crate::error::{self, Result};
 use crate::scalars::{Scalar, ScalarRef, ScalarVectorBuilder};
 use crate::type_id::LogicalTypeId;
-use crate::value::{IntoValueRef, Value, ValueRef};
+use crate::value::{Value, ValueRef};
 use crate::vectors::{MutableVector, PrimitiveVector, PrimitiveVectorBuilder, Vector};
 
 /// Data types that can be used as arrow's native type.
@@ -53,7 +53,7 @@ impl_native_type!(f64, f64);
 
 /// Type that wraps a native type.
 pub trait WrapperType:
-    Copy + Scalar + PartialEq + Into<Value> + IntoValueRef<'static> + Serialize
+    Copy + Scalar + PartialEq + Into<Value> + Into<ValueRef<'static>> + Serialize
 {
     /// Logical primitive type that this wrapper type belongs to.
     type LogicalType: LogicalPrimitiveType<Wrapper = Self, Native = Self::Native>;
@@ -223,7 +223,7 @@ impl<T: WrapperType> PartialOrd for OrdPrimitive<T> {
 
 impl<T: WrapperType> Ord for OrdPrimitive<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.into().cmp(&other.0.into())
+        Into::<Value>::into(self.0).cmp(&Into::<Value>::into(other.0))
     }
 }
 

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -84,7 +84,7 @@ pub trait LogicalPrimitiveType: 'static + Sized {
     type Native: NativeType;
     type Wrapper: WrapperType<LogicalType = Self, Native = Self::Native>
         + for<'a> Scalar<VectorType = PrimitiveVector<Self>, RefType<'a> = Self::Wrapper>
-        + for<'a> ScalarRef<'a, ScalarType = Self::Wrapper, VectorType = PrimitiveVector<Self>>;
+        + for<'a> ScalarRef<'a, ScalarType = Self::Wrapper>;
 
     /// Construct the data type struct.
     fn build_data_type() -> ConcreteDataType;

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -58,7 +58,7 @@ pub trait WrapperType:
     /// Logical primitive type that this wrapper type belongs to.
     type LogicalType: LogicalPrimitiveType<Wrapper = Self, Native = Self::Native>;
     /// The underying native type.
-    type Native;
+    type Native: NativeType;
 
     /// Convert native type into this wrapper type.
     fn from_native(value: Self::Native) -> Self;

--- a/src/datatypes2/src/value.rs
+++ b/src/datatypes2/src/value.rs
@@ -553,15 +553,6 @@ impl<'a> Ord for ValueRef<'a> {
     }
 }
 
-/// A helper trait to convert copyable types to `ValueRef`.
-///
-/// It could replace the usage of `Into<ValueRef<'a>>`, thus avoid confusion between `Into<Value>`
-/// and `Into<ValueRef<'a>>` in generic codes. One typical usage is the [`Primitive`](crate::primitive_traits::Primitive) trait.
-pub trait IntoValueRef<'a> {
-    /// Convert itself to [ValueRef].
-    fn into_value_ref(self) -> ValueRef<'a>;
-}
-
 macro_rules! impl_value_ref_from {
     ($Variant:ident, $Type:ident) => {
         impl From<$Type> for ValueRef<'_> {
@@ -570,24 +561,9 @@ macro_rules! impl_value_ref_from {
             }
         }
 
-        impl<'a> IntoValueRef<'a> for $Type {
-            fn into_value_ref(self) -> ValueRef<'a> {
-                ValueRef::$Variant(self.into())
-            }
-        }
-
         impl From<Option<$Type>> for ValueRef<'_> {
             fn from(value: Option<$Type>) -> Self {
                 match value {
-                    Some(v) => ValueRef::$Variant(v.into()),
-                    None => ValueRef::Null,
-                }
-            }
-        }
-
-        impl<'a> IntoValueRef<'a> for Option<$Type> {
-            fn into_value_ref(self) -> ValueRef<'a> {
-                match self {
                     Some(v) => ValueRef::$Variant(v.into()),
                     None => ValueRef::Null,
                 }

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -272,44 +272,43 @@ pub(crate) use {
     impl_try_from_arrow_array_for_vector, impl_validity_for_vector,
 };
 
-// TODO(yingwen): Make this compile.
-// #[cfg(test)]
-// pub mod tests {
-//     use arrow::array::{Array, PrimitiveArray};
-//     use serde_json;
+#[cfg(test)]
+pub mod tests {
+    use arrow::array::{Array, Int32Array, UInt8Array};
+    use serde_json;
 
-//     use super::helper::Helper;
-//     use super::*;
-//     use crate::data_type::DataType;
-//     use crate::types::PrimitiveElement;
+    use super::*;
+    use crate::data_type::DataType;
+    use crate::types::{Int32Type, LogicalPrimitiveType};
+    use crate::vectors::helper::Helper;
 
-//     #[test]
-//     fn test_df_columns_to_vector() {
-//         let df_column: Arc<dyn Array> = Arc::new(PrimitiveArray::from_slice(vec![1, 2, 3]));
-//         let vector = Helper::try_into_vector(df_column).unwrap();
-//         assert_eq!(
-//             i32::build_data_type().as_arrow_type(),
-//             vector.data_type().as_arrow_type()
-//         );
-//     }
+    #[test]
+    fn test_df_columns_to_vector() {
+        let df_column: Arc<dyn Array> = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let vector = Helper::try_into_vector(df_column).unwrap();
+        assert_eq!(
+            Int32Type::build_data_type().as_arrow_type(),
+            vector.data_type().as_arrow_type()
+        );
+    }
 
-//     #[test]
-//     fn test_serialize_i32_vector() {
-//         let df_column: Arc<dyn Array> = Arc::new(PrimitiveArray::<i32>::from_slice(vec![1, 2, 3]));
-//         let json_value = Helper::try_into_vector(df_column)
-//             .unwrap()
-//             .serialize_to_json()
-//             .unwrap();
-//         assert_eq!("[1,2,3]", serde_json::to_string(&json_value).unwrap());
-//     }
+    #[test]
+    fn test_serialize_i32_vector() {
+        let df_column: Arc<dyn Array> = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let json_value = Helper::try_into_vector(df_column)
+            .unwrap()
+            .serialize_to_json()
+            .unwrap();
+        assert_eq!("[1,2,3]", serde_json::to_string(&json_value).unwrap());
+    }
 
-//     #[test]
-//     fn test_serialize_i8_vector() {
-//         let df_column: Arc<dyn Array> = Arc::new(PrimitiveArray::from_slice(vec![1u8, 2u8, 3u8]));
-//         let json_value = Helper::try_into_vector(df_column)
-//             .unwrap()
-//             .serialize_to_json()
-//             .unwrap();
-//         assert_eq!("[1,2,3]", serde_json::to_string(&json_value).unwrap());
-//     }
-// }
+    #[test]
+    fn test_serialize_i8_vector() {
+        let df_column: Arc<dyn Array> = Arc::new(UInt8Array::from(vec![1, 2, 3]));
+        let json_value = Helper::try_into_vector(df_column)
+            .unwrap()
+            .serialize_to_json()
+            .unwrap();
+        assert_eq!("[1,2,3]", serde_json::to_string(&json_value).unwrap());
+    }
+}

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -17,9 +17,9 @@ pub mod boolean;
 pub mod operations;
 pub mod primitive;
 
-pub use binary::{BinaryVector, BinaryVectorBuilder};
-pub use boolean::{BooleanVector, BooleanVectorBuilder};
-pub use primitive::{PrimitiveVector, PrimitiveVectorBuilder};
+pub use binary::*;
+pub use boolean::*;
+pub use primitive::*;
 
 // TODO(yingwen): We need to reimplement Validity as arrow's Bitmap doesn't support null_count().
 #[derive(Debug, PartialEq)]

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -14,6 +14,7 @@ use crate::vectors::operations::VectorOp;
 
 pub mod binary;
 pub mod boolean;
+mod eq;
 pub mod operations;
 pub mod primitive;
 

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -29,11 +29,13 @@ use crate::vectors::operations::VectorOp;
 pub mod binary;
 pub mod boolean;
 mod eq;
+mod helper;
 pub mod operations;
 pub mod primitive;
 
 pub use binary::*;
 pub use boolean::*;
+pub use helper::Helper;
 pub use primitive::*;
 
 // TODO(yingwen): We need to reimplement Validity as arrow's Bitmap doesn't support null_count().

--- a/src/datatypes2/src/vectors.rs
+++ b/src/datatypes2/src/vectors.rs
@@ -15,9 +15,11 @@ use crate::vectors::operations::VectorOp;
 pub mod binary;
 pub mod boolean;
 pub mod operations;
+pub mod primitive;
 
 pub use binary::{BinaryVector, BinaryVectorBuilder};
 pub use boolean::{BooleanVector, BooleanVectorBuilder};
+pub use primitive::{PrimitiveVector, PrimitiveVectorBuilder};
 
 // TODO(yingwen): We need to reimplement Validity as arrow's Bitmap doesn't support null_count().
 #[derive(Debug, PartialEq)]

--- a/src/datatypes2/src/vectors/binary.rs
+++ b/src/datatypes2/src/vectors/binary.rs
@@ -221,9 +221,9 @@ mod tests {
 
     use super::*;
     use crate::arrow_array::BinaryArray;
-    // use crate::data_type::DataType;
+    use crate::data_type::DataType;
     use crate::serialize::Serializable;
-    // use crate::types::BinaryType;
+    use crate::types::BinaryType;
 
     #[test]
     fn test_binary_vector_misc() {
@@ -237,7 +237,7 @@ mod tests {
         assert!(!v.is_const());
         assert_eq!(Validity::AllValid, v.validity());
         assert!(!v.only_null());
-        assert_eq!(30, v.memory_size());
+        assert_eq!(128, v.memory_size());
 
         for i in 0..2 {
             assert!(!v.is_null(i));
@@ -278,14 +278,6 @@ mod tests {
             serde_json::to_string(&json_value).unwrap()
         );
     }
-
-    // #[test]
-    // fn test_from_arrow_array() {
-    //     let arrow_array = BinaryArray::from_iter_values(&[vec![1, 2, 3], vec![1, 2, 3]]);
-    //     let original = arrow_array.clone();
-    //     let vector = BinaryVector::from(arrow_array);
-    //     assert_eq!(original, vector.array);
-    // }
 
     #[test]
     fn test_from_arrow_array() {
@@ -342,23 +334,22 @@ mod tests {
         // assert!(!slots.get_bit(1));
     }
 
-    // TODO(yingwen): Impl Int32Vector and create_mutable_vector() of DataType returns vectors::Vector
-    // #[test]
-    // fn test_binary_vector_builder() {
-    //     let input = BinaryVector::from_slice(&[b"world", b"one", b"two"]);
+    #[test]
+    fn test_binary_vector_builder() {
+        let input = BinaryVector::from_slice(&[b"world", b"one", b"two"]);
 
-    //     let mut builder = BinaryType::default().create_mutable_vector(3);
-    //     builder
-    //         .push_value_ref(ValueRef::Binary("hello".as_bytes()))
-    //         .unwrap();
-    //     assert!(builder.push_value_ref(ValueRef::Int32(123)).is_err());
-    //     builder.extend_slice_of(&input, 1, 2).unwrap();
-    //     assert!(builder
-    //         .extend_slice_of(&crate::vectors::Int32Vector::from_slice(&[13]), 0, 1)
-    //         .is_err());
-    //     let vector = builder.to_vector();
+        let mut builder = BinaryType::default().create_mutable_vector(3);
+        builder
+            .push_value_ref(ValueRef::Binary("hello".as_bytes()))
+            .unwrap();
+        assert!(builder.push_value_ref(ValueRef::Int32(123)).is_err());
+        builder.extend_slice_of(&input, 1, 2).unwrap();
+        assert!(builder
+            .extend_slice_of(&crate::vectors::Int32Vector::from_slice(&[13]), 0, 1)
+            .is_err());
+        let vector = builder.to_vector();
 
-    //     let expect: VectorRef = Arc::new(BinaryVector::from_slice(&[b"hello", b"one", b"two"]));
-    //     assert_eq!(expect, vector);
-    // }
+        let expect: VectorRef = Arc::new(BinaryVector::from_slice(&[b"hello", b"one", b"two"]));
+        assert_eq!(expect, vector);
+    }
 }

--- a/src/datatypes2/src/vectors/boolean.rs
+++ b/src/datatypes2/src/vectors/boolean.rs
@@ -251,7 +251,7 @@ mod tests {
         assert!(!v.is_const());
         assert_eq!(Validity::AllValid, v.validity());
         assert!(!v.only_null());
-        assert_eq!(2, v.memory_size());
+        assert_eq!(64, v.memory_size());
 
         for (i, b) in bools.iter().enumerate() {
             assert!(!v.is_null(i));

--- a/src/datatypes2/src/vectors/boolean.rs
+++ b/src/datatypes2/src/vectors/boolean.rs
@@ -232,138 +232,138 @@ impl Serializable for BooleanVector {
 
 vectors::impl_try_from_arrow_array_for_vector!(BooleanArray, BooleanVector);
 
-// TODO(yingwen): Make them compile.
-// #[cfg(test)]
-// mod tests {
-//     use arrow::datatypes::DataType as ArrowDataType;
-//     use serde_json;
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::DataType as ArrowDataType;
+    use serde_json;
 
-//     use super::*;
-//     use crate::data_type::DataType;
-//     use crate::serialize::Serializable;
-//     use crate::types::BooleanType;
+    use super::*;
+    use crate::data_type::DataType;
+    use crate::serialize::Serializable;
+    use crate::types::BooleanType;
 
-//     #[test]
-//     fn test_boolean_vector_misc() {
-//         let bools = vec![true, false, true, true, false, false, true, true, false];
-//         let v = BooleanVector::from(bools.clone());
-//         assert_eq!(9, v.len());
-//         assert_eq!("BooleanVector", v.vector_type_name());
-//         assert!(!v.is_const());
-//         assert_eq!(Validity::AllValid, v.validity());
-//         assert!(!v.only_null());
-//         assert_eq!(2, v.memory_size());
+    #[test]
+    fn test_boolean_vector_misc() {
+        let bools = vec![true, false, true, true, false, false, true, true, false];
+        let v = BooleanVector::from(bools.clone());
+        assert_eq!(9, v.len());
+        assert_eq!("BooleanVector", v.vector_type_name());
+        assert!(!v.is_const());
+        assert_eq!(Validity::AllValid, v.validity());
+        assert!(!v.only_null());
+        assert_eq!(2, v.memory_size());
 
-//         for (i, b) in bools.iter().enumerate() {
-//             assert!(!v.is_null(i));
-//             assert_eq!(Value::Boolean(*b), v.get(i));
-//             assert_eq!(ValueRef::Boolean(*b), v.get_ref(i));
-//         }
+        for (i, b) in bools.iter().enumerate() {
+            assert!(!v.is_null(i));
+            assert_eq!(Value::Boolean(*b), v.get(i));
+            assert_eq!(ValueRef::Boolean(*b), v.get_ref(i));
+        }
 
-//         let arrow_arr = v.to_arrow_array();
-//         assert_eq!(9, arrow_arr.len());
-//         assert_eq!(&ArrowDataType::Boolean, arrow_arr.data_type());
-//     }
+        let arrow_arr = v.to_arrow_array();
+        assert_eq!(9, arrow_arr.len());
+        assert_eq!(&ArrowDataType::Boolean, arrow_arr.data_type());
+    }
 
-//     #[test]
-//     fn test_serialize_boolean_vector_to_json() {
-//         let vector = BooleanVector::from(vec![true, false, true, true, false, false]);
+    #[test]
+    fn test_serialize_boolean_vector_to_json() {
+        let vector = BooleanVector::from(vec![true, false, true, true, false, false]);
 
-//         let json_value = vector.serialize_to_json().unwrap();
-//         assert_eq!(
-//             "[true,false,true,true,false,false]",
-//             serde_json::to_string(&json_value).unwrap(),
-//         );
-//     }
+        let json_value = vector.serialize_to_json().unwrap();
+        assert_eq!(
+            "[true,false,true,true,false,false]",
+            serde_json::to_string(&json_value).unwrap(),
+        );
+    }
 
-//     #[test]
-//     fn test_serialize_boolean_vector_with_null_to_json() {
-//         let vector = BooleanVector::from(vec![Some(true), None, Some(false)]);
+    #[test]
+    fn test_serialize_boolean_vector_with_null_to_json() {
+        let vector = BooleanVector::from(vec![Some(true), None, Some(false)]);
 
-//         let json_value = vector.serialize_to_json().unwrap();
-//         assert_eq!(
-//             "[true,null,false]",
-//             serde_json::to_string(&json_value).unwrap(),
-//         );
-//     }
+        let json_value = vector.serialize_to_json().unwrap();
+        assert_eq!(
+            "[true,null,false]",
+            serde_json::to_string(&json_value).unwrap(),
+        );
+    }
 
-//     #[test]
-//     fn test_boolean_vector_from_vec() {
-//         let input = vec![false, true, false, true];
-//         let vec = BooleanVector::from(input.clone());
-//         assert_eq!(4, vec.len());
-//         for (i, v) in input.into_iter().enumerate() {
-//             assert_eq!(Some(v), vec.get_data(i), "failed at {}", i)
-//         }
-//     }
+    #[test]
+    fn test_boolean_vector_from_vec() {
+        let input = vec![false, true, false, true];
+        let vec = BooleanVector::from(input.clone());
+        assert_eq!(4, vec.len());
+        for (i, v) in input.into_iter().enumerate() {
+            assert_eq!(Some(v), vec.get_data(i), "failed at {}", i)
+        }
+    }
 
-//     #[test]
-//     fn test_boolean_vector_from_iter() {
-//         let input = vec![Some(false), Some(true), Some(false), Some(true)];
-//         let vec = input.iter().collect::<BooleanVector>();
-//         assert_eq!(4, vec.len());
-//         for (i, v) in input.into_iter().enumerate() {
-//             assert_eq!(v, vec.get_data(i), "failed at {}", i)
-//         }
-//     }
+    #[test]
+    fn test_boolean_vector_from_iter() {
+        let input = vec![Some(false), Some(true), Some(false), Some(true)];
+        let vec = input.iter().collect::<BooleanVector>();
+        assert_eq!(4, vec.len());
+        for (i, v) in input.into_iter().enumerate() {
+            assert_eq!(v, vec.get_data(i), "failed at {}", i)
+        }
+    }
 
-//     #[test]
-//     fn test_boolean_vector_from_vec_option() {
-//         let input = vec![Some(false), Some(true), None, Some(true)];
-//         let vec = BooleanVector::from(input.clone());
-//         assert_eq!(4, vec.len());
-//         for (i, v) in input.into_iter().enumerate() {
-//             assert_eq!(v, vec.get_data(i), "failed at {}", i)
-//         }
-//     }
+    #[test]
+    fn test_boolean_vector_from_vec_option() {
+        let input = vec![Some(false), Some(true), None, Some(true)];
+        let vec = BooleanVector::from(input.clone());
+        assert_eq!(4, vec.len());
+        for (i, v) in input.into_iter().enumerate() {
+            assert_eq!(v, vec.get_data(i), "failed at {}", i)
+        }
+    }
 
-//     #[test]
-//     fn test_boolean_vector_build_get() {
-//         let input = [Some(true), None, Some(false)];
-//         let mut builder = BooleanVectorBuilder::with_capacity(3);
-//         for v in input {
-//             builder.push(v);
-//         }
-//         let vector = builder.finish();
-//         assert_eq!(input.len(), vector.len());
+    #[test]
+    fn test_boolean_vector_build_get() {
+        let input = [Some(true), None, Some(false)];
+        let mut builder = BooleanVectorBuilder::with_capacity(3);
+        for v in input {
+            builder.push(v);
+        }
+        let vector = builder.finish();
+        assert_eq!(input.len(), vector.len());
 
-//         let res: Vec<_> = vector.iter_data().collect();
-//         assert_eq!(input, &res[..]);
+        let res: Vec<_> = vector.iter_data().collect();
+        assert_eq!(input, &res[..]);
 
-//         for (i, v) in input.into_iter().enumerate() {
-//             assert_eq!(v, vector.get_data(i));
-//             assert_eq!(Value::from(v), vector.get(i));
-//         }
-//     }
+        for (i, v) in input.into_iter().enumerate() {
+            assert_eq!(v, vector.get_data(i));
+            assert_eq!(Value::from(v), vector.get(i));
+        }
+    }
 
-//     #[test]
-//     fn test_boolean_vector_validity() {
-//         let vector = BooleanVector::from(vec![Some(true), None, Some(false)]);
-//         assert_eq!(1, vector.null_count());
-//         let validity = vector.validity();
-//         let slots = validity.slots().unwrap();
-//         assert_eq!(1, slots.null_count());
-//         assert!(!slots.get_bit(1));
+    // TODO(yingwen): Make them compile.
+    // #[test]
+    // fn test_boolean_vector_validity() {
+    //     let vector = BooleanVector::from(vec![Some(true), None, Some(false)]);
+    //     assert_eq!(1, vector.null_count());
+    //     let validity = vector.validity();
+    //     let slots = validity.slots().unwrap();
+    //     assert_eq!(1, slots.null_count());
+    //     assert!(!slots.get_bit(1));
 
-//         let vector = BooleanVector::from(vec![true, false, false]);
-//         assert_eq!(0, vector.null_count());
-//         assert_eq!(Validity::AllValid, vector.validity());
-//     }
+    //     let vector = BooleanVector::from(vec![true, false, false]);
+    //     assert_eq!(0, vector.null_count());
+    //     assert_eq!(Validity::AllValid, vector.validity());
+    // }
 
-//     #[test]
-//     fn test_boolean_vector_builder() {
-//         let input = BooleanVector::from_slice(&[true, false, true]);
+    #[test]
+    fn test_boolean_vector_builder() {
+        let input = BooleanVector::from_slice(&[true, false, true]);
 
-//         let mut builder = BooleanType::default().create_mutable_vector(3);
-//         builder.push_value_ref(ValueRef::Boolean(true)).unwrap();
-//         assert!(builder.push_value_ref(ValueRef::Int32(123)).is_err());
-//         builder.extend_slice_of(&input, 1, 2).unwrap();
-//         assert!(builder
-//             .extend_slice_of(&crate::vectors::Int32Vector::from_slice(&[13]), 0, 1)
-//             .is_err());
-//         let vector = builder.to_vector();
+        let mut builder = BooleanType::default().create_mutable_vector(3);
+        builder.push_value_ref(ValueRef::Boolean(true)).unwrap();
+        assert!(builder.push_value_ref(ValueRef::Int32(123)).is_err());
+        builder.extend_slice_of(&input, 1, 2).unwrap();
+        assert!(builder
+            .extend_slice_of(&crate::vectors::Int32Vector::from_slice(&[13]), 0, 1)
+            .is_err());
+        let vector = builder.to_vector();
 
-//         let expect: VectorRef = Arc::new(BooleanVector::from_slice(&[true, false, true]));
-//         assert_eq!(expect, vector);
-//     }
-// }
+        let expect: VectorRef = Arc::new(BooleanVector::from_slice(&[true, false, true]));
+        assert_eq!(expect, vector);
+    }
+}

--- a/src/datatypes2/src/vectors/eq.rs
+++ b/src/datatypes2/src/vectors/eq.rs
@@ -41,6 +41,7 @@ macro_rules! is_vector_eq {
     }};
 }
 
+// TODO(yingwen): Impl eq for other vectors.
 fn equal(lhs: &dyn Vector, rhs: &dyn Vector) -> bool {
     if lhs.data_type() != rhs.data_type() || lhs.len() != rhs.len() {
         return false;

--- a/src/datatypes2/src/vectors/eq.rs
+++ b/src/datatypes2/src/vectors/eq.rs
@@ -1,0 +1,202 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use crate::data_type::DataType;
+use crate::vectors::{BinaryVector, BooleanVector, PrimitiveVector, Vector};
+use crate::with_match_primitive_type_id;
+
+impl Eq for dyn Vector + '_ {}
+
+impl PartialEq for dyn Vector + '_ {
+    fn eq(&self, other: &dyn Vector) -> bool {
+        equal(self, other)
+    }
+}
+
+impl PartialEq<dyn Vector> for Arc<dyn Vector + '_> {
+    fn eq(&self, other: &dyn Vector) -> bool {
+        equal(&**self, other)
+    }
+}
+
+macro_rules! is_vector_eq {
+    ($VectorType: ident, $lhs: ident, $rhs: ident) => {{
+        let lhs = $lhs.as_any().downcast_ref::<$VectorType>().unwrap();
+        let rhs = $rhs.as_any().downcast_ref::<$VectorType>().unwrap();
+
+        lhs == rhs
+    }};
+}
+
+fn equal(lhs: &dyn Vector, rhs: &dyn Vector) -> bool {
+    if lhs.data_type() != rhs.data_type() || lhs.len() != rhs.len() {
+        return false;
+    }
+
+    // if lhs.is_const() || rhs.is_const() {
+    //     // Length has been checked before, so we only need to compare inner
+    //     // vector here.
+    //     return equal(
+    //         &**lhs
+    //             .as_any()
+    //             .downcast_ref::<ConstantVector>()
+    //             .unwrap()
+    //             .inner(),
+    //         &**lhs
+    //             .as_any()
+    //             .downcast_ref::<ConstantVector>()
+    //             .unwrap()
+    //             .inner(),
+    //     );
+    // }
+
+    use crate::data_type::ConcreteDataType::*;
+
+    let lhs_type = lhs.data_type();
+    match lhs.data_type() {
+        // Null(_) => true,
+        Boolean(_) => is_vector_eq!(BooleanVector, lhs, rhs),
+        Binary(_) => is_vector_eq!(BinaryVector, lhs, rhs),
+        // String(_) => is_vector_eq!(StringVector, lhs, rhs),
+        // Date(_) => is_vector_eq!(DateVector, lhs, rhs),
+        // DateTime(_) => is_vector_eq!(DateTimeVector, lhs, rhs),
+        // Timestamp(_) => is_vector_eq!(TimestampVector, lhs, rhs),
+        // List(_) => is_vector_eq!(ListVector, lhs, rhs),
+        UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_) | Int32(_) | Int64(_)
+        | Float32(_) | Float64(_) => {
+            with_match_primitive_type_id!(lhs_type.logical_type_id(), |$T| {
+                let lhs = lhs.as_any().downcast_ref::<PrimitiveVector<$T>>().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveVector<$T>>().unwrap();
+
+                lhs == rhs
+            },
+            {
+                unreachable!("should not compare {} with {}", lhs.vector_type_name(), rhs.vector_type_name())
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vectors::{
+        Float32Vector, Float64Vector, Int16Vector, Int32Vector, Int64Vector, Int8Vector,
+        UInt16Vector, UInt32Vector, UInt64Vector, UInt8Vector, VectorRef,
+    };
+
+    fn assert_vector_ref_eq(vector: VectorRef) {
+        let rhs = vector.clone();
+        assert_eq!(vector, rhs);
+        assert_dyn_vector_eq(&*vector, &*rhs);
+    }
+
+    fn assert_dyn_vector_eq(lhs: &dyn Vector, rhs: &dyn Vector) {
+        assert_eq!(lhs, rhs);
+    }
+
+    fn assert_vector_ref_ne(lhs: VectorRef, rhs: VectorRef) {
+        assert_ne!(lhs, rhs);
+    }
+
+    #[test]
+    fn test_vector_eq() {
+        assert_vector_ref_eq(Arc::new(BinaryVector::from(vec![
+            Some(b"hello".to_vec()),
+            Some(b"world".to_vec()),
+        ])));
+        assert_vector_ref_eq(Arc::new(BooleanVector::from(vec![true, false])));
+        // assert_vector_ref_eq(Arc::new(ConstantVector::new(
+        //     Arc::new(BooleanVector::from(vec![true])),
+        //     5,
+        // )));
+        assert_vector_ref_eq(Arc::new(BooleanVector::from(vec![true, false])));
+        // assert_vector_ref_eq(Arc::new(DateVector::from(vec![Some(100), Some(120)])));
+        // assert_vector_ref_eq(Arc::new(DateTimeVector::from(vec![Some(100), Some(120)])));
+        // assert_vector_ref_eq(Arc::new(TimestampVector::from_values([100, 120])));
+
+        // let mut arrow_array = MutableListArray::<i32, MutablePrimitiveArray<i64>>::new();
+        // arrow_array
+        //     .try_extend(vec![Some(vec![Some(1), Some(2), Some(3)])])
+        //     .unwrap();
+        // let arrow_array: ListArray<i32> = arrow_array.into();
+        // assert_vector_ref_eq(Arc::new(ListVector::from(arrow_array)));
+
+        // assert_vector_ref_eq(Arc::new(NullVector::new(4)));
+        // assert_vector_ref_eq(Arc::new(StringVector::from(vec![
+        //     Some("hello"),
+        //     Some("world"),
+        // ])));
+
+        assert_vector_ref_eq(Arc::new(Int8Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(UInt8Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(Int16Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(UInt16Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(Int32Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(UInt32Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(Int64Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(UInt64Vector::from_slice(&[1, 2, 3, 4])));
+        assert_vector_ref_eq(Arc::new(Float32Vector::from_slice(&[1.0, 2.0, 3.0, 4.0])));
+        assert_vector_ref_eq(Arc::new(Float64Vector::from_slice(&[1.0, 2.0, 3.0, 4.0])));
+    }
+
+    #[test]
+    fn test_vector_ne() {
+        assert_vector_ref_ne(
+            Arc::new(Int32Vector::from_slice(&[1, 2, 3, 4])),
+            Arc::new(Int32Vector::from_slice(&[1, 2])),
+        );
+        assert_vector_ref_ne(
+            Arc::new(Int32Vector::from_slice(&[1, 2, 3, 4])),
+            Arc::new(Int8Vector::from_slice(&[1, 2, 3, 4])),
+        );
+        assert_vector_ref_ne(
+            Arc::new(Int32Vector::from_slice(&[1, 2, 3, 4])),
+            Arc::new(BooleanVector::from(vec![true, true])),
+        );
+        // assert_vector_ref_ne(
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(BooleanVector::from(vec![true])),
+        //         5,
+        //     )),
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(BooleanVector::from(vec![true])),
+        //         4,
+        //     )),
+        // );
+        // assert_vector_ref_ne(
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(BooleanVector::from(vec![true])),
+        //         5,
+        //     )),
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(BooleanVector::from(vec![false])),
+        //         4,
+        //     )),
+        // );
+        // assert_vector_ref_ne(
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(BooleanVector::from(vec![true])),
+        //         5,
+        //     )),
+        //     Arc::new(ConstantVector::new(
+        //         Arc::new(Int32Vector::from_slice(vec![1])),
+        //         4,
+        //     )),
+        // );
+        // assert_vector_ref_ne(Arc::new(NullVector::new(5)), Arc::new(NullVector::new(8)));
+    }
+}

--- a/src/datatypes2/src/vectors/helper.rs
+++ b/src/datatypes2/src/vectors/helper.rs
@@ -1,0 +1,302 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Vector helper functions, inspired by databend Series mod
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef};
+use arrow::datatypes::DataType as ArrowDataType;
+use snafu::OptionExt;
+
+use crate::error::{self, Result};
+use crate::scalars::Scalar;
+use crate::vectors::{
+    BinaryVector, BooleanVector, Float32Vector, Float64Vector, Int16Vector, Int32Vector,
+    Int64Vector, Int8Vector, MutableVector, UInt16Vector, UInt32Vector, UInt64Vector, UInt8Vector,
+    Vector, VectorRef,
+};
+
+pub struct Helper;
+
+impl Helper {
+    /// Get a pointer to the underlying data of this vectors.
+    /// Can be useful for fast comparisons.
+    /// # Safety
+    /// Assumes that the `vector` is  T.
+    pub unsafe fn static_cast<T: Any>(vector: &VectorRef) -> &T {
+        let object = vector.as_ref();
+        debug_assert!(object.as_any().is::<T>());
+        &*(object as *const dyn Vector as *const T)
+    }
+
+    pub fn check_get_scalar<T: Scalar>(vector: &VectorRef) -> Result<&<T as Scalar>::VectorType> {
+        let arr = vector
+            .as_any()
+            .downcast_ref::<<T as Scalar>::VectorType>()
+            .with_context(|| error::UnknownVectorSnafu {
+                msg: format!(
+                    "downcast vector error, vector type: {:?}, expected vector: {:?}",
+                    vector.vector_type_name(),
+                    std::any::type_name::<T>(),
+                ),
+            });
+        arr
+    }
+
+    pub fn check_get<T: 'static + Vector>(vector: &VectorRef) -> Result<&T> {
+        let arr = vector
+            .as_any()
+            .downcast_ref::<T>()
+            .with_context(|| error::UnknownVectorSnafu {
+                msg: format!(
+                    "downcast vector error, vector type: {:?}, expected vector: {:?}",
+                    vector.vector_type_name(),
+                    std::any::type_name::<T>(),
+                ),
+            });
+        arr
+    }
+
+    pub fn check_get_mutable_vector<T: 'static + MutableVector>(
+        vector: &mut dyn MutableVector,
+    ) -> Result<&mut T> {
+        let ty = vector.data_type();
+        let arr = vector
+            .as_mut_any()
+            .downcast_mut()
+            .with_context(|| error::UnknownVectorSnafu {
+                msg: format!(
+                    "downcast vector error, vector type: {:?}, expected vector: {:?}",
+                    ty,
+                    std::any::type_name::<T>(),
+                ),
+            });
+        arr
+    }
+
+    pub fn check_get_scalar_vector<T: Scalar>(
+        vector: &VectorRef,
+    ) -> Result<&<T as Scalar>::VectorType> {
+        let arr = vector
+            .as_any()
+            .downcast_ref::<<T as Scalar>::VectorType>()
+            .with_context(|| error::UnknownVectorSnafu {
+                msg: format!(
+                    "downcast vector error, vector type: {:?}, expected vector: {:?}",
+                    vector.vector_type_name(),
+                    std::any::type_name::<T>(),
+                ),
+            });
+        arr
+    }
+
+    // /// Try to cast an arrow scalar value into vector
+    // ///
+    // /// # Panics
+    // /// Panic if given scalar value is not supported.
+    // pub fn try_from_scalar_value(value: ScalarValue, length: usize) -> Result<VectorRef> {
+    //     let vector = match value {
+    //         ScalarValue::Boolean(v) => {
+    //             ConstantVector::new(Arc::new(BooleanVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Float32(v) => {
+    //             ConstantVector::new(Arc::new(Float32Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Float64(v) => {
+    //             ConstantVector::new(Arc::new(Float64Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Int8(v) => {
+    //             ConstantVector::new(Arc::new(Int8Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Int16(v) => {
+    //             ConstantVector::new(Arc::new(Int16Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Int32(v) => {
+    //             ConstantVector::new(Arc::new(Int32Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Int64(v) => {
+    //             ConstantVector::new(Arc::new(Int64Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::UInt8(v) => {
+    //             ConstantVector::new(Arc::new(UInt8Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::UInt16(v) => {
+    //             ConstantVector::new(Arc::new(UInt16Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::UInt32(v) => {
+    //             ConstantVector::new(Arc::new(UInt32Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::UInt64(v) => {
+    //             ConstantVector::new(Arc::new(UInt64Vector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Utf8(v) => {
+    //             ConstantVector::new(Arc::new(StringVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::LargeUtf8(v) => {
+    //             ConstantVector::new(Arc::new(StringVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Binary(v) => {
+    //             ConstantVector::new(Arc::new(BinaryVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::LargeBinary(v) => {
+    //             ConstantVector::new(Arc::new(BinaryVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Date32(v) => {
+    //             ConstantVector::new(Arc::new(DateVector::from(vec![v])), length)
+    //         }
+    //         ScalarValue::Date64(v) => {
+    //             ConstantVector::new(Arc::new(DateTimeVector::from(vec![v])), length)
+    //         }
+    //         _ => {
+    //             return error::ConversionSnafu {
+    //                 from: format!("Unsupported scalar value: {}", value),
+    //             }
+    //             .fail()
+    //         }
+    //     };
+
+    //     Ok(Arc::new(vector))
+    // }
+
+    /// Try to cast an arrow array into vector
+    ///
+    /// # Panics
+    /// Panic if given arrow data type is not supported.
+    pub fn try_into_vector(array: impl AsRef<dyn Array>) -> Result<VectorRef> {
+        Ok(match array.as_ref().data_type() {
+            // ArrowDataType::Null => Arc::new(NullVector::try_from_arrow_array(array)?),
+            ArrowDataType::Boolean => Arc::new(BooleanVector::try_from_arrow_array(array)?),
+            ArrowDataType::Binary | ArrowDataType::LargeBinary => {
+                Arc::new(BinaryVector::try_from_arrow_array(array)?)
+            }
+            ArrowDataType::Int8 => Arc::new(Int8Vector::try_from_arrow_array(array)?),
+            ArrowDataType::Int16 => Arc::new(Int16Vector::try_from_arrow_array(array)?),
+            ArrowDataType::Int32 => Arc::new(Int32Vector::try_from_arrow_array(array)?),
+            ArrowDataType::Int64 => Arc::new(Int64Vector::try_from_arrow_array(array)?),
+            ArrowDataType::UInt8 => Arc::new(UInt8Vector::try_from_arrow_array(array)?),
+            ArrowDataType::UInt16 => Arc::new(UInt16Vector::try_from_arrow_array(array)?),
+            ArrowDataType::UInt32 => Arc::new(UInt32Vector::try_from_arrow_array(array)?),
+            ArrowDataType::UInt64 => Arc::new(UInt64Vector::try_from_arrow_array(array)?),
+            ArrowDataType::Float32 => Arc::new(Float32Vector::try_from_arrow_array(array)?),
+            ArrowDataType::Float64 => Arc::new(Float64Vector::try_from_arrow_array(array)?),
+            // ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => {
+            //     Arc::new(StringVector::try_from_arrow_array(array)?)
+            // }
+            // ArrowDataType::Date32 => Arc::new(DateVector::try_from_arrow_array(array)?),
+            // ArrowDataType::Date64 => Arc::new(DateTimeVector::try_from_arrow_array(array)?),
+            // ArrowDataType::List(_) => Arc::new(ListVector::try_from_arrow_array(array)?),
+            // ArrowDataType::Timestamp(_, _) => {
+            //     Arc::new(TimestampVector::try_from_arrow_array(array)?)
+            // }
+            _ => unimplemented!("Arrow array datatype: {:?}", array.as_ref().data_type()),
+        })
+    }
+
+    pub fn try_into_vectors(arrays: &[ArrayRef]) -> Result<Vec<VectorRef>> {
+        arrays.iter().map(Self::try_into_vector).collect()
+    }
+
+    // pub fn like_utf8(names: Vec<String>, s: &str) -> Result<VectorRef> {
+    //     let array = StringArray::from_slice(&names);
+
+    //     let filter =
+    //         compute::like::like_utf8_scalar(&array, s).context(error::ArrowComputeSnafu)?;
+
+    //     let result = compute::filter::filter(&array, &filter).context(error::ArrowComputeSnafu)?;
+    //     Helper::try_into_vector(result)
+    // }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::Int32Array;
+
+    use super::*;
+    use crate::value::Value;
+
+    #[test]
+    fn test_try_into_vectors() {
+        let arrays: Vec<ArrayRef> = vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(Int32Array::from(vec![2])),
+            Arc::new(Int32Array::from(vec![3])),
+        ];
+        let vectors = Helper::try_into_vectors(&arrays);
+        assert!(vectors.is_ok());
+        let vectors = vectors.unwrap();
+        vectors.iter().for_each(|v| assert_eq!(1, v.len()));
+        assert_eq!(Value::Int32(1), vectors[0].get(0));
+        assert_eq!(Value::Int32(2), vectors[1].get(0));
+        assert_eq!(Value::Int32(3), vectors[2].get(0));
+    }
+
+    // #[test]
+    // fn test_try_into_date_vector() {
+    //     let vector = DateVector::from(vec![Some(1), Some(2), None]);
+    //     let arrow_array = vector.to_arrow_array();
+    //     assert_eq!(&arrow::datatypes::DataType::Date32, arrow_array.data_type());
+    //     let vector_converted = Helper::try_into_vector(arrow_array).unwrap();
+    //     assert_eq!(vector.len(), vector_converted.len());
+    //     for i in 0..vector_converted.len() {
+    //         assert_eq!(vector.get(i), vector_converted.get(i));
+    //     }
+    // }
+
+    // #[test]
+    // fn test_try_from_scalar_date_value() {
+    //     let vector = Helper::try_from_scalar_value(ScalarValue::Date32(Some(42)), 3).unwrap();
+    //     assert_eq!(ConcreteDataType::date_datatype(), vector.data_type());
+    //     assert_eq!(3, vector.len());
+    //     for i in 0..vector.len() {
+    //         assert_eq!(Value::Date(Date::new(42)), vector.get(i));
+    //     }
+    // }
+
+    // #[test]
+    // fn test_try_from_scalar_datetime_value() {
+    //     let vector = Helper::try_from_scalar_value(ScalarValue::Date64(Some(42)), 3).unwrap();
+    //     assert_eq!(ConcreteDataType::datetime_datatype(), vector.data_type());
+    //     assert_eq!(3, vector.len());
+    //     for i in 0..vector.len() {
+    //         assert_eq!(Value::DateTime(DateTime::new(42)), vector.get(i));
+    //     }
+    // }
+
+    // #[test]
+    // fn test_like_utf8() {
+    //     fn assert_vector(expected: Vec<&str>, actual: &VectorRef) {
+    //         let actual = actual.as_any().downcast_ref::<StringVector>().unwrap();
+    //         assert_eq!(*actual, StringVector::from(expected));
+    //     }
+
+    //     let names: Vec<String> = vec!["greptime", "hello", "public", "world"]
+    //         .into_iter()
+    //         .map(|x| x.to_string())
+    //         .collect();
+
+    //     let ret = Helper::like_utf8(names.clone(), "%ll%").unwrap();
+    //     assert_vector(vec!["hello"], &ret);
+
+    //     let ret = Helper::like_utf8(names.clone(), "%time").unwrap();
+    //     assert_vector(vec!["greptime"], &ret);
+
+    //     let ret = Helper::like_utf8(names.clone(), "%ld").unwrap();
+    //     assert_vector(vec!["world"], &ret);
+
+    //     let ret = Helper::like_utf8(names, "%").unwrap();
+    //     assert_vector(vec!["greptime", "hello", "public", "world"], &ret);
+    // }
+}

--- a/src/datatypes2/src/vectors/operations.rs
+++ b/src/datatypes2/src/vectors/operations.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod filter;
 mod find_unique;
 mod replicate;

--- a/src/datatypes2/src/vectors/operations/filter.rs
+++ b/src/datatypes2/src/vectors/operations/filter.rs
@@ -30,100 +30,98 @@ macro_rules! filter_non_constant {
 
 pub(crate) use filter_non_constant;
 
-// #[cfg(test)]
-// mod tests {
-//     use std::sync::Arc;
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
 
-//     use crate::scalars::ScalarVector;
-//     use crate::vectors::{
-//         BooleanVector, ConstantVector, Int32Vector, NullVector, StringVector, VectorOp, VectorRef,
-//     };
+    use crate::scalars::ScalarVector;
+    use crate::vectors::{BooleanVector, Int32Vector, VectorOp, VectorRef};
 
-//     fn check_filter_primitive(expect: &[i32], input: &[i32], filter: &[bool]) {
-//         let v = Int32Vector::from_slice(&input);
-//         let filter = BooleanVector::from_slice(filter);
-//         let out = v.filter(&filter).unwrap();
+    fn check_filter_primitive(expect: &[i32], input: &[i32], filter: &[bool]) {
+        let v = Int32Vector::from_slice(&input);
+        let filter = BooleanVector::from_slice(filter);
+        let out = v.filter(&filter).unwrap();
 
-//         let expect: VectorRef = Arc::new(Int32Vector::from_slice(&expect));
-//         assert_eq!(expect, out);
-//     }
+        let expect: VectorRef = Arc::new(Int32Vector::from_slice(&expect));
+        assert_eq!(expect, out);
+    }
 
-//     #[test]
-//     fn test_filter_primitive() {
-//         check_filter_primitive(&[], &[], &[]);
-//         check_filter_primitive(&[5], &[5], &[true]);
-//         check_filter_primitive(&[], &[5], &[false]);
-//         check_filter_primitive(&[], &[5, 6], &[false, false]);
-//         check_filter_primitive(&[5, 6], &[5, 6], &[true, true]);
-//         check_filter_primitive(&[], &[5, 6, 7], &[false, false, false]);
-//         check_filter_primitive(&[5], &[5, 6, 7], &[true, false, false]);
-//         check_filter_primitive(&[6], &[5, 6, 7], &[false, true, false]);
-//         check_filter_primitive(&[7], &[5, 6, 7], &[false, false, true]);
-//         check_filter_primitive(&[5, 7], &[5, 6, 7], &[true, false, true]);
-//     }
+    #[test]
+    fn test_filter_primitive() {
+        check_filter_primitive(&[], &[], &[]);
+        check_filter_primitive(&[5], &[5], &[true]);
+        check_filter_primitive(&[], &[5], &[false]);
+        check_filter_primitive(&[], &[5, 6], &[false, false]);
+        check_filter_primitive(&[5, 6], &[5, 6], &[true, true]);
+        check_filter_primitive(&[], &[5, 6, 7], &[false, false, false]);
+        check_filter_primitive(&[5], &[5, 6, 7], &[true, false, false]);
+        check_filter_primitive(&[6], &[5, 6, 7], &[false, true, false]);
+        check_filter_primitive(&[7], &[5, 6, 7], &[false, false, true]);
+        check_filter_primitive(&[5, 7], &[5, 6, 7], &[true, false, true]);
+    }
 
-//     fn check_filter_constant(expect_length: usize, input_length: usize, filter: &[bool]) {
-//         let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[123])), input_length);
-//         let filter = BooleanVector::from_slice(filter);
-//         let out = v.filter(&filter).unwrap();
+    // fn check_filter_constant(expect_length: usize, input_length: usize, filter: &[bool]) {
+    //     let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[123])), input_length);
+    //     let filter = BooleanVector::from_slice(filter);
+    //     let out = v.filter(&filter).unwrap();
 
-//         assert!(out.is_const());
-//         assert_eq!(expect_length, out.len());
-//     }
+    //     assert!(out.is_const());
+    //     assert_eq!(expect_length, out.len());
+    // }
 
-//     #[test]
-//     fn test_filter_constant() {
-//         check_filter_constant(0, 0, &[]);
-//         check_filter_constant(1, 1, &[true]);
-//         check_filter_constant(0, 1, &[false]);
-//         check_filter_constant(1, 2, &[false, true]);
-//         check_filter_constant(2, 2, &[true, true]);
-//         check_filter_constant(1, 4, &[false, false, false, true]);
-//         check_filter_constant(2, 4, &[false, true, false, true]);
-//     }
+    // #[test]
+    // fn test_filter_constant() {
+    //     check_filter_constant(0, 0, &[]);
+    //     check_filter_constant(1, 1, &[true]);
+    //     check_filter_constant(0, 1, &[false]);
+    //     check_filter_constant(1, 2, &[false, true]);
+    //     check_filter_constant(2, 2, &[true, true]);
+    //     check_filter_constant(1, 4, &[false, false, false, true]);
+    //     check_filter_constant(2, 4, &[false, true, false, true]);
+    // }
 
-//     #[test]
-//     fn test_filter_scalar() {
-//         let v = StringVector::from_slice(&["0", "1", "2", "3"]);
-//         let filter = BooleanVector::from_slice(&[false, true, false, true]);
-//         let out = v.filter(&filter).unwrap();
+    // #[test]
+    // fn test_filter_scalar() {
+    //     let v = StringVector::from_slice(&["0", "1", "2", "3"]);
+    //     let filter = BooleanVector::from_slice(&[false, true, false, true]);
+    //     let out = v.filter(&filter).unwrap();
 
-//         let expect: VectorRef = Arc::new(StringVector::from_slice(&["1", "3"]));
-//         assert_eq!(expect, out);
-//     }
+    //     let expect: VectorRef = Arc::new(StringVector::from_slice(&["1", "3"]));
+    //     assert_eq!(expect, out);
+    // }
 
-//     #[test]
-//     fn test_filter_null() {
-//         let v = NullVector::new(5);
-//         let filter = BooleanVector::from_slice(&[false, true, false, true, true]);
-//         let out = v.filter(&filter).unwrap();
+    // #[test]
+    // fn test_filter_null() {
+    //     let v = NullVector::new(5);
+    //     let filter = BooleanVector::from_slice(&[false, true, false, true, true]);
+    //     let out = v.filter(&filter).unwrap();
 
-//         let expect: VectorRef = Arc::new(NullVector::new(3));
-//         assert_eq!(expect, out);
-//     }
+    //     let expect: VectorRef = Arc::new(NullVector::new(3));
+    //     assert_eq!(expect, out);
+    // }
 
-//     macro_rules! impl_filter_date_like_test {
-//         ($VectorType: ident, $ValueType: ident, $method: ident) => {{
-//             use std::sync::Arc;
+    // macro_rules! impl_filter_date_like_test {
+    //     ($VectorType: ident, $ValueType: ident, $method: ident) => {{
+    //         use std::sync::Arc;
 
-//             use common_time::$ValueType;
-//             use $crate::vectors::{$VectorType, VectorRef};
+    //         use common_time::$ValueType;
+    //         use $crate::vectors::{$VectorType, VectorRef};
 
-//             let v = $VectorType::from_iterator((0..5).map($ValueType::$method));
-//             let filter = BooleanVector::from_slice(&[false, true, false, true, true]);
-//             let out = v.filter(&filter).unwrap();
+    //         let v = $VectorType::from_iterator((0..5).map($ValueType::$method));
+    //         let filter = BooleanVector::from_slice(&[false, true, false, true, true]);
+    //         let out = v.filter(&filter).unwrap();
 
-//             let expect: VectorRef = Arc::new($VectorType::from_iterator(
-//                 [1, 3, 4].into_iter().map($ValueType::$method),
-//             ));
-//             assert_eq!(expect, out);
-//         }};
-//     }
+    //         let expect: VectorRef = Arc::new($VectorType::from_iterator(
+    //             [1, 3, 4].into_iter().map($ValueType::$method),
+    //         ));
+    //         assert_eq!(expect, out);
+    //     }};
+    // }
 
-//     #[test]
-//     fn test_filter_date_like() {
-//         impl_filter_date_like_test!(DateVector, Date, new);
-//         impl_filter_date_like_test!(DateTimeVector, DateTime, new);
-//         impl_filter_date_like_test!(TimestampVector, Timestamp, from_millis);
-//     }
-// }
+    // #[test]
+    // fn test_filter_date_like() {
+    //     impl_filter_date_like_test!(DateVector, Date, new);
+    //     impl_filter_date_like_test!(DateTimeVector, DateTime, new);
+    //     impl_filter_date_like_test!(TimestampVector, Timestamp, from_millis);
+    // }
+}

--- a/src/datatypes2/src/vectors/operations/find_unique.rs
+++ b/src/datatypes2/src/vectors/operations/find_unique.rs
@@ -99,262 +99,260 @@ pub(crate) fn find_unique_scalar<'a, T: ScalarVector>(
 //     }
 // }
 
-// #[cfg(test)]
-// mod tests {
-//     use std::sync::Arc;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vectors::{Int32Vector, Vector, VectorOp};
 
-//     use super::*;
-//     use crate::vectors::{Int32Vector, StringVector, VectorOp};
+    fn check_bitmap(expect: &[bool], selected: &BitVec) {
+        let actual = selected.iter().collect::<Vec<_>>();
+        assert_eq!(expect, actual);
+    }
 
-//     fn check_bitmap(expect: &[bool], selected: &BitVec) {
-//         let actual = selected.iter().collect::<Vec<_>>();
-//         assert_eq!(expect, actual);
-//     }
+    fn check_find_unique_scalar(expect: &[bool], input: &[i32], prev: Option<&[i32]>) {
+        check_find_unique_scalar_opt(expect, input.iter().map(|v| Some(*v)), prev);
+    }
 
-//     fn check_find_unique_scalar(expect: &[bool], input: &[i32], prev: Option<&[i32]>) {
-//         check_find_unique_scalar_opt(expect, input.iter().map(|v| Some(*v)), prev);
-//     }
+    fn check_find_unique_scalar_opt(
+        expect: &[bool],
+        input: impl Iterator<Item = Option<i32>>,
+        prev: Option<&[i32]>,
+    ) {
+        let input = Int32Vector::from(input.collect::<Vec<_>>());
+        let prev = prev.map(Int32Vector::from_slice);
 
-//     fn check_find_unique_scalar_opt(
-//         expect: &[bool],
-//         input: impl Iterator<Item = Option<i32>>,
-//         prev: Option<&[i32]>,
-//     ) {
-//         let input = Int32Vector::from_iter(input);
-//         let prev = prev.map(Int32Vector::from_slice);
+        let mut selected = BitVec::repeat(false, input.len());
+        input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
 
-//         let mut selected = BitVec::repeat(false, input.len());
-//         input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
+        check_bitmap(expect, &selected);
+    }
 
-//         check_bitmap(expect, &selected);
-//     }
+    #[test]
+    fn test_find_unique_scalar() {
+        check_find_unique_scalar(&[], &[], None);
+        check_find_unique_scalar(&[true], &[1], None);
+        check_find_unique_scalar(&[true, false], &[1, 1], None);
+        check_find_unique_scalar(&[true, true], &[1, 2], None);
+        check_find_unique_scalar(&[true, true, true, true], &[1, 2, 3, 4], None);
+        check_find_unique_scalar(&[true, false, true, false], &[1, 1, 3, 3], None);
+        check_find_unique_scalar(&[true, false, false, false, true], &[2, 2, 2, 2, 3], None);
 
-//     #[test]
-//     fn test_find_unique_scalar() {
-//         check_find_unique_scalar(&[], &[], None);
-//         check_find_unique_scalar(&[true], &[1], None);
-//         check_find_unique_scalar(&[true, false], &[1, 1], None);
-//         check_find_unique_scalar(&[true, true], &[1, 2], None);
-//         check_find_unique_scalar(&[true, true, true, true], &[1, 2, 3, 4], None);
-//         check_find_unique_scalar(&[true, false, true, false], &[1, 1, 3, 3], None);
-//         check_find_unique_scalar(&[true, false, false, false, true], &[2, 2, 2, 2, 3], None);
+        check_find_unique_scalar(&[true], &[5], Some(&[]));
+        check_find_unique_scalar(&[true], &[5], Some(&[3]));
+        check_find_unique_scalar(&[false], &[5], Some(&[5]));
+        check_find_unique_scalar(&[false], &[5], Some(&[4, 5]));
+        check_find_unique_scalar(&[false, true], &[5, 6], Some(&[4, 5]));
+        check_find_unique_scalar(&[false, true, false], &[5, 6, 6], Some(&[4, 5]));
+        check_find_unique_scalar(
+            &[false, true, false, true, true],
+            &[5, 6, 6, 7, 8],
+            Some(&[4, 5]),
+        );
 
-//         check_find_unique_scalar(&[true], &[5], Some(&[]));
-//         check_find_unique_scalar(&[true], &[5], Some(&[3]));
-//         check_find_unique_scalar(&[false], &[5], Some(&[5]));
-//         check_find_unique_scalar(&[false], &[5], Some(&[4, 5]));
-//         check_find_unique_scalar(&[false, true], &[5, 6], Some(&[4, 5]));
-//         check_find_unique_scalar(&[false, true, false], &[5, 6, 6], Some(&[4, 5]));
-//         check_find_unique_scalar(
-//             &[false, true, false, true, true],
-//             &[5, 6, 6, 7, 8],
-//             Some(&[4, 5]),
-//         );
+        check_find_unique_scalar_opt(
+            &[true, true, false, true, false],
+            [Some(1), Some(2), Some(2), None, None].into_iter(),
+            None,
+        );
+    }
 
-//         check_find_unique_scalar_opt(
-//             &[true, true, false, true, false],
-//             [Some(1), Some(2), Some(2), None, None].into_iter(),
-//             None,
-//         );
-//     }
+    #[test]
+    fn test_find_unique_scalar_multi_times_with_prev() {
+        let prev = Int32Vector::from_slice(&[1]);
 
-//     #[test]
-//     fn test_find_unique_scalar_multi_times_with_prev() {
-//         let prev = Int32Vector::from_slice(&[1]);
+        let v1 = Int32Vector::from_slice(&[2, 3, 4]);
+        let mut selected = BitVec::repeat(false, v1.len());
+        v1.find_unique(&mut selected, Some(&prev));
 
-//         let v1 = Int32Vector::from_slice(&[2, 3, 4]);
-//         let mut selected = BitVec::repeat(false, v1.len());
-//         v1.find_unique(&mut selected, Some(&prev));
+        // Though element in v2 are the same as prev, but we should still keep them.
+        let v2 = Int32Vector::from_slice(&[1, 1, 1]);
+        v2.find_unique(&mut selected, Some(&prev));
 
-//         // Though element in v2 are the same as prev, but we should still keep them.
-//         let v2 = Int32Vector::from_slice(&[1, 1, 1]);
-//         v2.find_unique(&mut selected, Some(&prev));
+        check_bitmap(&[true, true, true], &selected);
+    }
 
-//         check_bitmap(&[true, true, true], &selected);
-//     }
+    fn new_bitmap(bits: &[bool]) -> BitVec {
+        BitVec::from_iter(bits)
+    }
 
-//     fn new_bitmap(bits: &[bool]) -> BitVec {
-//         BitVec::from_iter(bits)
-//     }
+    #[test]
+    fn test_find_unique_scalar_with_prev() {
+        let prev = Int32Vector::from_slice(&[1]);
 
-//     #[test]
-//     fn test_find_unique_scalar_with_prev() {
-//         let prev = Int32Vector::from_slice(&[1]);
+        let mut selected = new_bitmap(&[true, false, true, false]);
+        let v = Int32Vector::from_slice(&[2, 3, 4, 5]);
+        v.find_unique(&mut selected, Some(&prev));
+        // All elements are different.
+        check_bitmap(&[true, true, true, true], &selected);
 
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = Int32Vector::from_slice(&[2, 3, 4, 5]);
-//         v.find_unique(&mut selected, Some(&prev));
-//         // All elements are different.
-//         check_bitmap(&[true, true, true, true], &selected);
+        let mut selected = new_bitmap(&[true, false, true, false]);
+        let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
+        v.find_unique(&mut selected, Some(&prev));
+        // Though first element is duplicate, but we keep the flag unchanged.
+        check_bitmap(&[true, true, true, true], &selected);
 
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
-//         v.find_unique(&mut selected, Some(&prev));
-//         // Though first element is duplicate, but we keep the flag unchanged.
-//         check_bitmap(&[true, true, true, true], &selected);
+        // Same case as above, but now `prev` is None.
+        let mut selected = new_bitmap(&[true, false, true, false]);
+        let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
+        v.find_unique(&mut selected, None);
+        check_bitmap(&[true, true, true, true], &selected);
 
-//         // Same case as above, but now `prev` is None.
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
-//         v.find_unique(&mut selected, None);
-//         check_bitmap(&[true, true, true, true], &selected);
+        // Same case as above, but now `prev` is empty.
+        let mut selected = new_bitmap(&[true, false, true, false]);
+        let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
+        v.find_unique(&mut selected, Some(&Int32Vector::from_slice(&[])));
+        check_bitmap(&[true, true, true, true], &selected);
 
-//         // Same case as above, but now `prev` is empty.
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = Int32Vector::from_slice(&[1, 2, 3, 4]);
-//         v.find_unique(&mut selected, Some(&Int32Vector::from_slice(&[])));
-//         check_bitmap(&[true, true, true, true], &selected);
+        let mut selected = new_bitmap(&[false, false, false, false]);
+        let v = Int32Vector::from_slice(&[2, 2, 4, 5]);
+        v.find_unique(&mut selected, Some(&prev));
+        // only v[1] is duplicate.
+        check_bitmap(&[true, false, true, true], &selected);
+    }
 
-//         let mut selected = new_bitmap(&[false, false, false, false]);
-//         let v = Int32Vector::from_slice(&[2, 2, 4, 5]);
-//         v.find_unique(&mut selected, Some(&prev));
-//         // only v[1] is duplicate.
-//         check_bitmap(&[true, false, true, true], &selected);
-//     }
+    // fn check_find_unique_null(len: usize) {
+    //     let input = NullVector::new(len);
+    //     let mut selected = BitVec::repeat(false, input.len());
+    //     input.find_unique(&mut selected, None);
 
-//     fn check_find_unique_null(len: usize) {
-//         let input = NullVector::new(len);
-//         let mut selected = BitVec::repeat(false, input.len());
-//         input.find_unique(&mut selected, None);
+    //     let mut expect = vec![false; len];
+    //     if !expect.is_empty() {
+    //         expect[0] = true;
+    //     }
+    //     check_bitmap(&expect, &selected);
 
-//         let mut expect = vec![false; len];
-//         if !expect.is_empty() {
-//             expect[0] = true;
-//         }
-//         check_bitmap(&expect, &selected);
+    //     let mut selected = BitVec::repeat(false, input.len());
+    //     let prev = Some(NullVector::new(1));
+    //     input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
+    //     let expect = vec![false; len];
+    //     check_bitmap(&expect, &selected);
+    // }
 
-//         let mut selected = BitVec::repeat(false, input.len());
-//         let prev = Some(NullVector::new(1));
-//         input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
-//         let expect = vec![false; len];
-//         check_bitmap(&expect, &selected);
-//     }
+    // #[test]
+    // fn test_find_unique_null() {
+    //     for len in 0..5 {
+    //         check_find_unique_null(len);
+    //     }
+    // }
 
-//     #[test]
-//     fn test_find_unique_null() {
-//         for len in 0..5 {
-//             check_find_unique_null(len);
-//         }
-//     }
+    // #[test]
+    // fn test_find_unique_null_with_prev() {
+    //     let prev = NullVector::new(1);
 
-//     #[test]
-//     fn test_find_unique_null_with_prev() {
-//         let prev = NullVector::new(1);
+    //     // Keep flags unchanged.
+    //     let mut selected = new_bitmap(&[true, false, true, false]);
+    //     let v = NullVector::new(4);
+    //     v.find_unique(&mut selected, Some(&prev));
+    //     check_bitmap(&[true, false, true, false], &selected);
 
-//         // Keep flags unchanged.
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = NullVector::new(4);
-//         v.find_unique(&mut selected, Some(&prev));
-//         check_bitmap(&[true, false, true, false], &selected);
+    //     // Keep flags unchanged.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(&mut selected, Some(&prev));
+    //     check_bitmap(&[false, false, true, false], &selected);
 
-//         // Keep flags unchanged.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(&mut selected, Some(&prev));
-//         check_bitmap(&[false, false, true, false], &selected);
+    //     // Prev is None, select first element.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(&mut selected, None);
+    //     check_bitmap(&[true, false, true, false], &selected);
 
-//         // Prev is None, select first element.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(&mut selected, None);
-//         check_bitmap(&[true, false, true, false], &selected);
+    //     // Prev is empty, select first element.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(&mut selected, Some(&NullVector::new(0)));
+    //     check_bitmap(&[true, false, true, false], &selected);
+    // }
 
-//         // Prev is empty, select first element.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(&mut selected, Some(&NullVector::new(0)));
-//         check_bitmap(&[true, false, true, false], &selected);
-//     }
+    // fn check_find_unique_constant(len: usize) {
+    //     let input = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[8])), len);
+    //     let mut selected = BitVec::repeat(false, len);
+    //     input.find_unique(&mut selected, None);
 
-//     fn check_find_unique_constant(len: usize) {
-//         let input = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[8])), len);
-//         let mut selected = BitVec::repeat(false, len);
-//         input.find_unique(&mut selected, None);
+    //     let mut expect = vec![false; len];
+    //     if !expect.is_empty() {
+    //         expect[0] = true;
+    //     }
+    //     check_bitmap(&expect, &selected);
 
-//         let mut expect = vec![false; len];
-//         if !expect.is_empty() {
-//             expect[0] = true;
-//         }
-//         check_bitmap(&expect, &selected);
+    //     let mut selected = BitVec::repeat(false, len);
+    //     let prev = Some(ConstantVector::new(
+    //         Arc::new(Int32Vector::from_slice(&[8])),
+    //         1,
+    //     ));
+    //     input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
+    //     let expect = vec![false; len];
+    //     check_bitmap(&expect, &selected);
+    // }
 
-//         let mut selected = BitVec::repeat(false, len);
-//         let prev = Some(ConstantVector::new(
-//             Arc::new(Int32Vector::from_slice(&[8])),
-//             1,
-//         ));
-//         input.find_unique(&mut selected, prev.as_ref().map(|v| v as _));
-//         let expect = vec![false; len];
-//         check_bitmap(&expect, &selected);
-//     }
+    // #[test]
+    // fn test_find_unique_constant() {
+    //     for len in 0..5 {
+    //         check_find_unique_constant(len);
+    //     }
+    // }
 
-//     #[test]
-//     fn test_find_unique_constant() {
-//         for len in 0..5 {
-//             check_find_unique_constant(len);
-//         }
-//     }
+    // #[test]
+    // fn test_find_unique_constant_with_prev() {
+    //     let prev = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[1])), 1);
 
-//     #[test]
-//     fn test_find_unique_constant_with_prev() {
-//         let prev = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[1])), 1);
+    //     // Keep flags unchanged.
+    //     let mut selected = new_bitmap(&[true, false, true, false]);
+    //     let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[1])), 4);
+    //     v.find_unique(&mut selected, Some(&prev));
+    //     check_bitmap(&[true, false, true, false], &selected);
 
-//         // Keep flags unchanged.
-//         let mut selected = new_bitmap(&[true, false, true, false]);
-//         let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[1])), 4);
-//         v.find_unique(&mut selected, Some(&prev));
-//         check_bitmap(&[true, false, true, false], &selected);
+    //     // Keep flags unchanged.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(&mut selected, Some(&prev));
+    //     check_bitmap(&[false, false, true, false], &selected);
 
-//         // Keep flags unchanged.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(&mut selected, Some(&prev));
-//         check_bitmap(&[false, false, true, false], &selected);
+    //     // Prev is None, select first element.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(&mut selected, None);
+    //     check_bitmap(&[true, false, true, false], &selected);
 
-//         // Prev is None, select first element.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(&mut selected, None);
-//         check_bitmap(&[true, false, true, false], &selected);
+    //     // Prev is empty, select first element.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     v.find_unique(
+    //         &mut selected,
+    //         Some(&ConstantVector::new(
+    //             Arc::new(Int32Vector::from_slice(&[1])),
+    //             0,
+    //         )),
+    //     );
+    //     check_bitmap(&[true, false, true, false], &selected);
 
-//         // Prev is empty, select first element.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         v.find_unique(
-//             &mut selected,
-//             Some(&ConstantVector::new(
-//                 Arc::new(Int32Vector::from_slice(&[1])),
-//                 0,
-//             )),
-//         );
-//         check_bitmap(&[true, false, true, false], &selected);
+    //     // Different constant vector.
+    //     let mut selected = new_bitmap(&[false, false, true, false]);
+    //     let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[2])), 4);
+    //     v.find_unique(&mut selected, Some(&prev));
+    //     check_bitmap(&[true, false, true, false], &selected);
+    // }
 
-//         // Different constant vector.
-//         let mut selected = new_bitmap(&[false, false, true, false]);
-//         let v = ConstantVector::new(Arc::new(Int32Vector::from_slice(&[2])), 4);
-//         v.find_unique(&mut selected, Some(&prev));
-//         check_bitmap(&[true, false, true, false], &selected);
-//     }
+    // #[test]
+    // fn test_find_unique_string() {
+    //     let input = StringVector::from_slice(&["a", "a", "b", "c"]);
+    //     let mut selected = BitVec::repeat(false, 4);
+    //     input.find_unique(&mut selected, None);
+    //     let expect = vec![true, false, true, true];
+    //     check_bitmap(&expect, &selected);
+    // }
 
-//     #[test]
-//     fn test_find_unique_string() {
-//         let input = StringVector::from_slice(&["a", "a", "b", "c"]);
-//         let mut selected = BitVec::repeat(false, 4);
-//         input.find_unique(&mut selected, None);
-//         let expect = vec![true, false, true, true];
-//         check_bitmap(&expect, &selected);
-//     }
+    // macro_rules! impl_find_unique_date_like_test {
+    //     ($VectorType: ident, $ValueType: ident, $method: ident) => {{
+    //         use common_time::$ValueType;
+    //         use $crate::vectors::$VectorType;
 
-//     macro_rules! impl_find_unique_date_like_test {
-//         ($VectorType: ident, $ValueType: ident, $method: ident) => {{
-//             use common_time::$ValueType;
-//             use $crate::vectors::$VectorType;
+    //         let v = $VectorType::from_iterator([8, 8, 9, 10].into_iter().map($ValueType::$method));
+    //         let mut selected = BitVec::repeat(false, 4);
+    //         v.find_unique(&mut selected, None);
+    //         let expect = vec![true, false, true, true];
+    //         check_bitmap(&expect, &selected);
+    //     }};
+    // }
 
-//             let v = $VectorType::from_iterator([8, 8, 9, 10].into_iter().map($ValueType::$method));
-//             let mut selected = BitVec::repeat(false, 4);
-//             v.find_unique(&mut selected, None);
-//             let expect = vec![true, false, true, true];
-//             check_bitmap(&expect, &selected);
-//         }};
-//     }
-
-//     #[test]
-//     fn test_find_unique_date_like() {
-//         impl_find_unique_date_like_test!(DateVector, Date, new);
-//         impl_find_unique_date_like_test!(DateTimeVector, DateTime, new);
-//         impl_find_unique_date_like_test!(TimestampVector, Timestamp, from_millis);
-//     }
-// }
+    // #[test]
+    // fn test_find_unique_date_like() {
+    //     impl_find_unique_date_like_test!(DateVector, Date, new);
+    //     impl_find_unique_date_like_test!(DateTimeVector, DateTime, new);
+    //     impl_find_unique_date_like_test!(TimestampVector, Timestamp, from_millis);
+    // }
+}

--- a/src/datatypes2/src/vectors/operations/replicate.rs
+++ b/src/datatypes2/src/vectors/operations/replicate.rs
@@ -17,7 +17,7 @@ use crate::prelude::*;
 // pub(crate) use crate::vectors::date::replicate_date;
 // pub(crate) use crate::vectors::datetime::replicate_datetime;
 // pub(crate) use crate::vectors::null::replicate_null;
-// pub(crate) use crate::vectors::primitive::replicate_primitive;
+pub(crate) use crate::vectors::primitive::replicate_primitive;
 // pub(crate) use crate::vectors::timestamp::replicate_timestamp;
 
 pub(crate) fn replicate_scalar<C: ScalarVector>(c: &C, offsets: &[usize]) -> VectorRef {

--- a/src/datatypes2/src/vectors/operations/replicate.rs
+++ b/src/datatypes2/src/vectors/operations/replicate.rs
@@ -39,109 +39,109 @@ pub(crate) fn replicate_scalar<C: ScalarVector>(c: &C, offsets: &[usize]) -> Vec
     builder.to_vector()
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use std::sync::Arc;
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
 
-//     use super::*;
-//     use crate::vectors::{ConstantVector, Int32Vector, NullVector, StringVector, VectorOp};
+    use super::*;
+    use crate::vectors::{Int32Vector, VectorOp};
 
-//     #[test]
-//     fn test_replicate_primitive() {
-//         let v = Int32Vector::from_iterator(0..5);
-//         let offsets = [0, 1, 2, 3, 4];
+    #[test]
+    fn test_replicate_primitive() {
+        let v = Int32Vector::from_iterator(0..5);
+        let offsets = [0, 1, 2, 3, 4];
 
-//         let v = v.replicate(&offsets);
-//         assert_eq!(4, v.len());
+        let v = v.replicate(&offsets);
+        assert_eq!(4, v.len());
 
-//         for i in 0..4 {
-//             assert_eq!(Value::Int32(i as i32 + 1), v.get(i));
-//         }
-//     }
+        for i in 0..4 {
+            assert_eq!(Value::Int32(i as i32 + 1), v.get(i));
+        }
+    }
 
-//     #[test]
-//     fn test_replicate_nullable_primitive() {
-//         let v = Int32Vector::from(vec![None, Some(1), None, Some(2)]);
-//         let offsets = [2, 4, 6, 8];
-//         let v = v.replicate(&offsets);
-//         assert_eq!(8, v.len());
+    #[test]
+    fn test_replicate_nullable_primitive() {
+        let v = Int32Vector::from(vec![None, Some(1), None, Some(2)]);
+        let offsets = [2, 4, 6, 8];
+        let v = v.replicate(&offsets);
+        assert_eq!(8, v.len());
 
-//         let expect: VectorRef = Arc::new(Int32Vector::from(vec![
-//             None,
-//             None,
-//             Some(1),
-//             Some(1),
-//             None,
-//             None,
-//             Some(2),
-//             Some(2),
-//         ]));
-//         assert_eq!(expect, v);
-//     }
+        let expect: VectorRef = Arc::new(Int32Vector::from(vec![
+            None,
+            None,
+            Some(1),
+            Some(1),
+            None,
+            None,
+            Some(2),
+            Some(2),
+        ]));
+        assert_eq!(expect, v);
+    }
 
-//     #[test]
-//     fn test_replicate_scalar() {
-//         let v = StringVector::from_slice(&["0", "1", "2", "3"]);
-//         let offsets = [1, 3, 5, 6];
+    // #[test]
+    // fn test_replicate_scalar() {
+    //     let v = StringVector::from_slice(&["0", "1", "2", "3"]);
+    //     let offsets = [1, 3, 5, 6];
 
-//         let v = v.replicate(&offsets);
-//         assert_eq!(6, v.len());
+    //     let v = v.replicate(&offsets);
+    //     assert_eq!(6, v.len());
 
-//         let expect: VectorRef = Arc::new(StringVector::from_slice(&["0", "1", "1", "2", "2", "3"]));
-//         assert_eq!(expect, v);
-//     }
+    //     let expect: VectorRef = Arc::new(StringVector::from_slice(&["0", "1", "1", "2", "2", "3"]));
+    //     assert_eq!(expect, v);
+    // }
 
-//     #[test]
-//     fn test_replicate_constant() {
-//         let v = Arc::new(StringVector::from_slice(&["hello"]));
-//         let cv = ConstantVector::new(v.clone(), 2);
-//         let offsets = [1, 4];
+    // #[test]
+    // fn test_replicate_constant() {
+    //     let v = Arc::new(StringVector::from_slice(&["hello"]));
+    //     let cv = ConstantVector::new(v.clone(), 2);
+    //     let offsets = [1, 4];
 
-//         let cv = cv.replicate(&offsets);
-//         assert_eq!(4, cv.len());
+    //     let cv = cv.replicate(&offsets);
+    //     assert_eq!(4, cv.len());
 
-//         let expect: VectorRef = Arc::new(ConstantVector::new(v, 4));
-//         assert_eq!(expect, cv);
-//     }
+    //     let expect: VectorRef = Arc::new(ConstantVector::new(v, 4));
+    //     assert_eq!(expect, cv);
+    // }
 
-//     #[test]
-//     fn test_replicate_null() {
-//         let v = NullVector::new(0);
-//         let offsets = [];
-//         let v = v.replicate(&offsets);
-//         assert!(v.is_empty());
+    // #[test]
+    // fn test_replicate_null() {
+    //     let v = NullVector::new(0);
+    //     let offsets = [];
+    //     let v = v.replicate(&offsets);
+    //     assert!(v.is_empty());
 
-//         let v = NullVector::new(3);
-//         let offsets = [1, 3, 5];
+    //     let v = NullVector::new(3);
+    //     let offsets = [1, 3, 5];
 
-//         let v = v.replicate(&offsets);
-//         assert_eq!(5, v.len());
-//     }
+    //     let v = v.replicate(&offsets);
+    //     assert_eq!(5, v.len());
+    // }
 
-//     macro_rules! impl_replicate_date_like_test {
-//         ($VectorType: ident, $ValueType: ident, $method: ident) => {{
-//             use common_time::$ValueType;
-//             use $crate::vectors::$VectorType;
+    // macro_rules! impl_replicate_date_like_test {
+    //     ($VectorType: ident, $ValueType: ident, $method: ident) => {{
+    //         use common_time::$ValueType;
+    //         use $crate::vectors::$VectorType;
 
-//             let v = $VectorType::from_iterator((0..5).map($ValueType::$method));
-//             let offsets = [0, 1, 2, 3, 4];
+    //         let v = $VectorType::from_iterator((0..5).map($ValueType::$method));
+    //         let offsets = [0, 1, 2, 3, 4];
 
-//             let v = v.replicate(&offsets);
-//             assert_eq!(4, v.len());
+    //         let v = v.replicate(&offsets);
+    //         assert_eq!(4, v.len());
 
-//             for i in 0..4 {
-//                 assert_eq!(
-//                     Value::$ValueType($ValueType::$method((i as i32 + 1).into())),
-//                     v.get(i)
-//                 );
-//             }
-//         }};
-//     }
+    //         for i in 0..4 {
+    //             assert_eq!(
+    //                 Value::$ValueType($ValueType::$method((i as i32 + 1).into())),
+    //                 v.get(i)
+    //             );
+    //         }
+    //     }};
+    // }
 
-//     #[test]
-//     fn test_replicate_date_like() {
-//         impl_replicate_date_like_test!(DateVector, Date, new);
-//         impl_replicate_date_like_test!(DateTimeVector, DateTime, new);
-//         impl_replicate_date_like_test!(TimestampVector, Timestamp, from_millis);
-//     }
-// }
+    // #[test]
+    // fn test_replicate_date_like() {
+    //     impl_replicate_date_like_test!(DateVector, Date, new);
+    //     impl_replicate_date_like_test!(DateTimeVector, DateTime, new);
+    //     impl_replicate_date_like_test!(TimestampVector, Timestamp, from_millis);
+    // }
+}

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::any::Any;
 use std::fmt;
 use std::sync::Arc;

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -30,7 +30,7 @@ use crate::types::{
     Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, LogicalPrimitiveType,
     UInt16Type, UInt32Type, UInt64Type, UInt8Type, WrapperType,
 };
-use crate::value::{IntoValueRef, Value, ValueRef};
+use crate::value::{Value, ValueRef};
 use crate::vectors::{self, MutableVector, Validity, Vector, VectorRef};
 
 pub type UInt8Vector = PrimitiveVector<UInt8Type>;
@@ -172,7 +172,7 @@ impl<T: LogicalPrimitiveType> Vector for PrimitiveVector<T> {
         if self.array.is_valid(index) {
             // Safety: The index have been checked by `is_valid()`.
             let wrapper = unsafe { T::Wrapper::from_native(self.array.value_unchecked(index)) };
-            wrapper.into_value_ref()
+            wrapper.into()
         } else {
             ValueRef::Null
         }

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -264,7 +264,7 @@ impl<T> ScalarVectorBuilder for PrimitiveVectorBuilder<T>
 where
     T: LogicalPrimitiveType,
     T::Wrapper: Scalar<VectorType = PrimitiveVector<T>>,
-    for<'a> T::Wrapper: ScalarRef<'a, ScalarType = T::Wrapper, VectorType = PrimitiveVector<T>>,
+    for<'a> T::Wrapper: ScalarRef<'a, ScalarType = T::Wrapper>,
     for<'a> T::Wrapper: Scalar<RefType<'a> = T::Wrapper>,
 {
     type VectorType = PrimitiveVector<T>;

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -33,7 +33,6 @@ pub type Float32Vector = PrimitiveVector<Float32Type>;
 pub type Float64Vector = PrimitiveVector<Float64Type>;
 
 /// Vector for primitive data types.
-#[derive(PartialEq)]
 pub struct PrimitiveVector<T: LogicalPrimitiveType> {
     array: PrimitiveArray<T::ArrowPrimitive>,
 }
@@ -233,6 +232,12 @@ impl<T: LogicalPrimitiveType> Serializable for PrimitiveVector<T> {
             .map(serde_json::to_value)
             .collect::<serde_json::Result<_>>()
             .context(error::SerializeSnafu)
+    }
+}
+
+impl<T: LogicalPrimitiveType> PartialEq for PrimitiveVector<T> {
+    fn eq(&self, other: &PrimitiveVector<T>) -> bool {
+        self.array == other.array
     }
 }
 

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -12,9 +12,25 @@ use crate::data_type::ConcreteDataType;
 use crate::error::{Result, SerializeSnafu};
 use crate::scalars::{Scalar, ScalarRef, ScalarVector, ScalarVectorBuilder};
 use crate::serialize::Serializable;
-use crate::types::{LogicalPrimitiveType, WrapperType};
+use crate::types::{
+    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type, LogicalPrimitiveType,
+    UInt16Type, UInt32Type, UInt64Type, UInt8Type, WrapperType,
+};
 use crate::value::{IntoValueRef, Value, ValueRef};
 use crate::vectors::{self, MutableVector, Validity, Vector, VectorRef};
+
+pub type UInt8Vector = PrimitiveVector<UInt8Type>;
+pub type UInt16Vector = PrimitiveVector<UInt16Type>;
+pub type UInt32Vector = PrimitiveVector<UInt32Type>;
+pub type UInt64Vector = PrimitiveVector<UInt64Type>;
+
+pub type Int8Vector = PrimitiveVector<Int8Type>;
+pub type Int16Vector = PrimitiveVector<Int16Type>;
+pub type Int32Vector = PrimitiveVector<Int32Type>;
+pub type Int64Vector = PrimitiveVector<Int64Type>;
+
+pub type Float32Vector = PrimitiveVector<Float32Type>;
+pub type Float64Vector = PrimitiveVector<Float64Type>;
 
 /// Vector for primitive data types.
 #[derive(PartialEq)]
@@ -158,21 +174,13 @@ impl<T: LogicalPrimitiveType> From<PrimitiveArray<T::ArrowPrimitive>> for Primit
     }
 }
 
-// impl<T: Primitive> From<Vec<Option<T>>> for PrimitiveVector<T> {
-//     fn from(v: Vec<Option<T>>) -> Self {
-//         Self {
-//             array: PrimitiveArray::<T>::from(v),
-//         }
-//     }
-// }
-
-// impl<T: Primitive, Ptr: std::borrow::Borrow<Option<T>>> FromIterator<Ptr> for PrimitiveVector<T> {
-//     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
-//         Self {
-//             array: MutablePrimitiveArray::<T>::from_iter(iter).into(),
-//         }
-//     }
-// }
+impl<T: LogicalPrimitiveType> From<Vec<Option<T::Native>>> for PrimitiveVector<T> {
+    fn from(v: Vec<Option<T::Native>>) -> Self {
+        Self {
+            array: PrimitiveArray::from_iter(v),
+        }
+    }
+}
 
 pub struct PrimitiveIter<'a, T: LogicalPrimitiveType> {
     iter: ArrayIter<&'a PrimitiveArray<T::ArrowPrimitive>>,
@@ -221,6 +229,19 @@ impl<T: LogicalPrimitiveType> Serializable for PrimitiveVector<T> {
             .context(SerializeSnafu)
     }
 }
+
+pub type UInt8VectorBuilder = PrimitiveVectorBuilder<UInt8Type>;
+pub type UInt16VectorBuilder = PrimitiveVectorBuilder<UInt16Type>;
+pub type UInt32VectorBuilder = PrimitiveVectorBuilder<UInt32Type>;
+pub type UInt64VectorBuilder = PrimitiveVectorBuilder<UInt64Type>;
+
+pub type Int8VectorBuilder = PrimitiveVectorBuilder<Int8Type>;
+pub type Int16VectorBuilder = PrimitiveVectorBuilder<Int16Type>;
+pub type Int32VectorBuilder = PrimitiveVectorBuilder<Int32Type>;
+pub type Int64VectorBuilder = PrimitiveVectorBuilder<Int64Type>;
+
+pub type Float32VectorBuilder = PrimitiveVectorBuilder<Float32Type>;
+pub type Float64VectorBuilder = PrimitiveVectorBuilder<Float64Type>;
 
 /// Builder to build a primitive vector.
 pub struct PrimitiveVectorBuilder<T: LogicalPrimitiveType> {
@@ -294,17 +315,6 @@ where
         }
     }
 }
-
-// impl<T: PrimitiveElement> PrimitiveVectorBuilder<T> {
-//     fn with_type_capacity(data_type: ConcreteDataType, capacity: usize) -> Self {
-//         Self {
-//             mutable_array: MutablePrimitiveArray::with_capacity_from(
-//                 capacity,
-//                 data_type.as_arrow_type(),
-//             ),
-//         }
-//     }
-// }
 
 pub(crate) fn replicate_primitive<T: LogicalPrimitiveType>(
     vector: &PrimitiveVector<T>,

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -197,7 +197,7 @@ impl<'a, T: LogicalPrimitiveType> Iterator for PrimitiveIter<'a, T> {
     fn next(&mut self) -> Option<Option<T::Wrapper>> {
         self.iter
             .next()
-            .map(|item| item.map(|v| T::Wrapper::from_native(v)))
+            .map(|item| item.map(T::Wrapper::from_native))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/datatypes2/src/vectors/primitive.rs
+++ b/src/datatypes2/src/vectors/primitive.rs
@@ -1,0 +1,317 @@
+use std::any::Any;
+use std::fmt;
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayBuilder, ArrayData, ArrayIter, ArrayRef, PrimitiveArray, PrimitiveBuilder,
+};
+use serde_json::Value as JsonValue;
+use snafu::ResultExt;
+
+use crate::data_type::ConcreteDataType;
+use crate::error::{Result, SerializeSnafu};
+use crate::scalars::{Scalar, ScalarRef, ScalarVector, ScalarVectorBuilder};
+use crate::serialize::Serializable;
+use crate::types::LogicalPrimitiveType;
+use crate::value::{IntoValueRef, Value, ValueRef};
+use crate::vectors::{self, MutableVector, Validity, Vector, VectorRef};
+
+/// Vector for primitive data types.
+#[derive(PartialEq)]
+pub struct PrimitiveVector<T: LogicalPrimitiveType> {
+    // TODO(yingwen): Maybe we don't need to pub this field.
+    pub(crate) array: PrimitiveArray<T::ArrowPrimitive>,
+}
+
+impl<T: LogicalPrimitiveType> PrimitiveVector<T> {
+    pub fn new(array: PrimitiveArray<T::ArrowPrimitive>) -> Self {
+        Self { array }
+    }
+
+    pub fn try_from_arrow_array(array: impl AsRef<dyn Array>) -> Result<Self> {
+        let data = array.as_ref().data().clone();
+        // TODO(yingwen): Should we check the array type?
+        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(data);
+        Ok(Self::new(concrete_array))
+    }
+
+    pub fn from_slice<P: AsRef<[T::Native]>>(slice: P) -> Self {
+        let iter = slice.as_ref().iter().copied();
+        Self {
+            array: PrimitiveArray::from_iter_values(iter),
+        }
+    }
+
+    pub fn from_vec(array: Vec<T::Native>) -> Self {
+        Self {
+            array: PrimitiveArray::from_iter_values(array),
+        }
+    }
+
+    pub fn from_values<I: IntoIterator<Item = T::Native>>(iter: I) -> Self {
+        Self {
+            array: PrimitiveArray::from_iter_values(iter),
+        }
+    }
+
+    pub(crate) fn as_arrow(&self) -> &PrimitiveArray<T::ArrowPrimitive> {
+        &self.array
+    }
+
+    fn to_array_data(&self) -> ArrayData {
+        self.array.data().clone()
+    }
+
+    fn from_array_data(data: ArrayData) -> Self {
+        Self {
+            array: PrimitiveArray::from(data),
+        }
+    }
+
+    // To distinguish with `Vector::slice()`.
+    fn get_slice(&self, offset: usize, length: usize) -> Self {
+        let data = self.array.data().slice(offset, length);
+        Self::from_array_data(data)
+    }
+}
+
+impl<T: LogicalPrimitiveType> Vector for PrimitiveVector<T> {
+    fn data_type(&self) -> ConcreteDataType {
+        T::build_data_type()
+    }
+
+    fn vector_type_name(&self) -> String {
+        format!("{}Vector", T::type_name())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.array.len()
+    }
+
+    fn to_arrow_array(&self) -> ArrayRef {
+        let data = self.to_array_data();
+        Arc::new(PrimitiveArray::<T::ArrowPrimitive>::from(data))
+    }
+
+    fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
+        let data = self.to_array_data();
+        Box::new(PrimitiveArray::<T::ArrowPrimitive>::from(data))
+    }
+
+    fn validity(&self) -> Validity {
+        vectors::impl_validity_for_vector!(self.array)
+    }
+
+    fn memory_size(&self) -> usize {
+        self.array.get_buffer_memory_size()
+    }
+
+    fn null_count(&self) -> usize {
+        self.array.null_count()
+    }
+
+    fn is_null(&self, row: usize) -> bool {
+        self.array.is_null(row)
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> VectorRef {
+        let data = self.array.data().slice(offset, length);
+        Arc::new(Self::from_array_data(data))
+    }
+
+    fn get(&self, index: usize) -> Value {
+        vectors::impl_get_for_vector!(self.array, index)
+    }
+
+    fn get_ref(&self, index: usize) -> ValueRef {
+        if self.array.is_valid(index) {
+            // Safety: The index have been checked by `is_valid()`.
+            unsafe { self.array.value_unchecked(index).into_value_ref() }
+        } else {
+            ValueRef::Null
+        }
+    }
+}
+
+impl<T: LogicalPrimitiveType> fmt::Debug for PrimitiveVector<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("PrimitiveVector")
+            .field("array", &self.array)
+            .finish()
+    }
+}
+
+// impl<T: Primitive> From<PrimitiveArray<T>> for PrimitiveVector<T> {
+//     fn from(array: PrimitiveArray<T>) -> Self {
+//         Self { array }
+//     }
+// }
+
+// impl<T: Primitive> From<Vec<Option<T>>> for PrimitiveVector<T> {
+//     fn from(v: Vec<Option<T>>) -> Self {
+//         Self {
+//             array: PrimitiveArray::<T>::from(v),
+//         }
+//     }
+// }
+
+// impl<T: Primitive, Ptr: std::borrow::Borrow<Option<T>>> FromIterator<Ptr> for PrimitiveVector<T> {
+//     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+//         Self {
+//             array: MutablePrimitiveArray::<T>::from_iter(iter).into(),
+//         }
+//     }
+// }
+
+impl<T> ScalarVector for PrimitiveVector<T>
+where
+    T: LogicalPrimitiveType,
+{
+    type OwnedItem = T::Native;
+    type RefItem<'a> = T::Native;
+    type Iter<'a> = ArrayIter<&'a PrimitiveArray<T::ArrowPrimitive>>;
+    type Builder = PrimitiveVectorBuilder<T>;
+
+    fn get_data(&self, idx: usize) -> Option<Self::RefItem<'_>> {
+        if self.array.is_valid(idx) {
+            Some(self.array.value(idx))
+        } else {
+            None
+        }
+    }
+
+    fn iter_data(&self) -> Self::Iter<'_> {
+        self.array.iter()
+    }
+}
+
+impl<T: LogicalPrimitiveType> Serializable for PrimitiveVector<T> {
+    fn serialize_to_json(&self) -> Result<Vec<JsonValue>> {
+        self.array
+            .iter()
+            .map(serde_json::to_value)
+            .collect::<serde_json::Result<_>>()
+            .context(SerializeSnafu)
+    }
+}
+
+/// Builder to build a primitive vector.
+pub struct PrimitiveVectorBuilder<T: LogicalPrimitiveType> {
+    mutable_array: PrimitiveBuilder<T::ArrowPrimitive>,
+}
+
+impl<T: LogicalPrimitiveType> MutableVector for PrimitiveVectorBuilder<T> {
+    fn data_type(&self) -> ConcreteDataType {
+        T::build_data_type()
+    }
+
+    fn len(&self) -> usize {
+        self.mutable_array.len()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn to_vector(&mut self) -> VectorRef {
+        Arc::new(self.finish())
+    }
+
+    fn push_value_ref(&mut self, value: ValueRef) -> Result<()> {
+        let primitive = T::cast_value_ref(value)?;
+        match primitive {
+            Some(v) => self.mutable_array.append_value(v),
+            None => self.mutable_array.append_null(),
+        }
+        Ok(())
+    }
+
+    fn extend_slice_of(&mut self, vector: &dyn Vector, offset: usize, length: usize) -> Result<()> {
+        let primitive = T::cast_vector(vector)?;
+        // Slice the underlying array to avoid creating a new Arc.
+        let slice = primitive.get_slice(offset, length);
+        for v in slice.iter_data() {
+            self.push(v);
+        }
+        Ok(())
+    }
+}
+
+impl<T> ScalarVectorBuilder for PrimitiveVectorBuilder<T>
+where
+    T: LogicalPrimitiveType,
+    T::Native: Scalar<VectorType = PrimitiveVector<T>>,
+    for<'a> T::Native: ScalarRef<'a, ScalarType = T::Native, VectorType = PrimitiveVector<T>>,
+    for<'a> T::Native: Scalar<RefType<'a> = T::Native>,
+{
+    type VectorType = PrimitiveVector<T>;
+
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            mutable_array: PrimitiveBuilder::with_capacity(capacity),
+        }
+    }
+
+    fn push(&mut self, value: Option<<Self::VectorType as ScalarVector>::RefItem<'_>>) {
+        self.mutable_array.append_option(value);
+    }
+
+    fn finish(&mut self) -> Self::VectorType {
+        PrimitiveVector {
+            array: self.mutable_array.finish(),
+        }
+    }
+}
+
+// impl<T: PrimitiveElement> PrimitiveVectorBuilder<T> {
+//     fn with_type_capacity(data_type: ConcreteDataType, capacity: usize) -> Self {
+//         Self {
+//             mutable_array: MutablePrimitiveArray::with_capacity_from(
+//                 capacity,
+//                 data_type.as_arrow_type(),
+//             ),
+//         }
+//     }
+// }
+
+pub(crate) fn replicate_primitive<T: LogicalPrimitiveType>(
+    vector: &PrimitiveVector<T>,
+    offsets: &[usize],
+) -> PrimitiveVector<T> {
+    assert_eq!(offsets.len(), vector.len());
+
+    if offsets.is_empty() {
+        return vector.get_slice(0, 0);
+    }
+
+    let mut builder = PrimitiveVectorBuilder::<T>::with_capacity(*offsets.last().unwrap() as usize);
+
+    let mut previous_offset = 0;
+
+    for (offset, value) in offsets.iter().zip(vector.array.iter()) {
+        let repeat_times = *offset - previous_offset;
+        match value {
+            Some(data) => {
+                unsafe {
+                    // Safety: std::iter::Repeat and std::iter::Take implement TrustedLen.
+                    builder
+                        .mutable_array
+                        .append_trusted_len_iter(std::iter::repeat(data).take(repeat_times));
+                }
+            }
+            None => {
+                builder.mutable_array.append_nulls(repeat_times);
+            }
+        }
+        previous_offset = *offset;
+    }
+    builder.finish()
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR implements PrimitiveType and PrimitiveVector for `datatypes2` crate.
- Renames the `Primitive` to `NativeType`, and adds the `ArrowNativeType` trait bound to it.
- Introduces `WrapperType` to represent wrappers like `Date`, `Timestamp` to allow the primitive vector returns a wrapper type.
- Replaces `PrimitiveElement` with `LogicalPrimitiveType`.
- Implements the `PrimitiveVector`, using the official arrow's `PrimitiveArray`.
- Passes more tests.

### LogicalPrimitiveType
Now we can use the `LogicalPrimitiveType` to associate the arrow's `ArrowPrimitiveType` with our `NativeType` and `WrapperType`.


```rust
pub trait LogicalPrimitiveType: 'static + Sized {
    /// Arrow primitive type of this logical type.
    type ArrowPrimitive: ArrowPrimitiveType<Native = Self::Native>;
    /// Native (physical) type of this logical type.
    type Native: NativeType;
    /// Wrapper type that the vector returns.
    type Wrapper: WrapperType<LogicalType = Self, Native = Self::Native>
        + for<'a> Scalar<VectorType = PrimitiveVector<Self>, RefType<'a> = Self::Wrapper>
        + for<'a> ScalarRef<'a, ScalarType = Self::Wrapper>;

    // ...
}
```

We also use the wrapper type, instead of the native type as our vector's scalar type, so we can define a `DateVector` as `PrimitiveVector<DateType>` in the future.

 **Thanks to the compiler, the following trait works!🎉🎉🎉**

 **Thanks to the reviewer, it is really not easy to review such a tremendous amount of changes.🍺🍺🍺**

## Checklist
- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#555