### PR TITLE
fix: start datanode instance before frontend services

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -88,9 +88,18 @@ impl Datanode {
 
     pub async fn start(&mut self) -> Result<()> {
         info!("Starting datanode instance...");
-        self.instance.start().await?;
-        self.services.start(&self.opts).await?;
-        Ok(())
+        self.start_instance().await?;
+        self.start_services().await
+    }
+
+    /// Start only the internal component of datanode.
+    pub async fn start_instance(&mut self) -> Result<()> {
+        self.instance.start().await
+    }
+
+    /// Start services of datanode. This method call will block until services are shutdown.
+    pub async fn start_services(&mut self) -> Result<()> {
+        self.services.start(&self.opts).await
     }
 
     pub fn get_instance(&self) -> InstanceRef {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Break datanode startup process into "start components" and "start services"
- When running in standalone mode, start datanode components before frontend services, to avoid receiving request under a initializing state,

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
