### PR TITLE
chore: Bump OpenDAL to v0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,9 +3661,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b17b778cf11d10fbaaae4a5a0f82d5c6f527f96a9e4843f4e2dd6cd0dbe580"
+checksum = "8c9be1e30ca12b989107a5ee5bb75468a7f538059e43255ccd4743089b42aeeb"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3687,7 +3687,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
  "time 0.3.14",
  "tokio",
  "tracing",
@@ -4727,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22524be78041476bf8673f2720fa1000f34432b384d9ad5846b024569a4b150"
+checksum = "d34ea360414ee77ddab3a8360a0c241fc77ab5e27892dcde1d2cfcc29d4e0f55"
 dependencies = [
  "anyhow",
  "backon",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -27,7 +27,7 @@ futures = "0.3"
 futures-util = "0.3"
 lazy_static = "1.4"
 meta-client = { path = "../meta-client" }
-opendal = "0.20"
+opendal = "0.21"
 regex = "1.6"
 serde = "1.0"
 serde_json = "1.0"
@@ -40,7 +40,7 @@ tokio = { version = "1.18", features = ["full"] }
 chrono = "0.4"
 log-store = { path = "../log-store" }
 object-store = { path = "../object-store" }
-opendal = "0.20"
+opendal = "0.21"
 storage = { path = "../storage" }
 mito = { path = "../mito", features = ["test"] }
 tempdir = "0.3"

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -456,7 +456,7 @@ mod tests {
     pub async fn prepare_table_engine() -> (TempDir, TableEngineRef) {
         let dir = TempDir::new("system-table-test").unwrap();
         let store_dir = dir.path().to_string_lossy();
-        let accessor = opendal::services::fs::Builder::default()
+        let accessor = object_store::backend::fs::Builder::default()
             .root(&store_dir)
             .build()
             .unwrap();

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -145,7 +145,7 @@ pub enum Error {
     #[snafu(display("Failed to init backend, dir: {}, source: {}", dir, source))]
     InitBackend {
         dir: String,
-        source: std::io::Error,
+        source: object_store::Error,
         backtrace: Backtrace,
     },
 

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.20", features = ["layers-tracing", "layers-metrics"]}
+opendal = { version = "0.21", features = ["layers-tracing", "layers-metrics"]}
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use opendal::io_util::SeekableReader;
+pub use opendal::raw::{Accessor, ObjectEntry, SeekableReader};
 pub use opendal::{
-    layers, services, Accessor, Layer, Object, ObjectEntry, ObjectMetadata, ObjectMode,
-    ObjectStreamer, Operator as ObjectStore,
+    layers, services, Error, ErrorKind, Layer, Object, ObjectLister, ObjectMetadata, ObjectMode,
+    Operator as ObjectStore,
 };
 pub mod backend;
 pub mod util;

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use opendal::raw::{Accessor, ObjectEntry, SeekableReader};
+pub use opendal::raw::SeekableReader;
 pub use opendal::{
     layers, services, Error, ErrorKind, Layer, Object, ObjectLister, ObjectMetadata, ObjectMode,
     Operator as ObjectStore,

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -14,9 +14,9 @@
 
 use futures::TryStreamExt;
 
-use crate::{ObjectEntry, ObjectStreamer};
+use crate::{Object, ObjectLister};
 
-pub async fn collect(stream: ObjectStreamer) -> Result<Vec<ObjectEntry>, std::io::Error> {
+pub async fn collect(stream: ObjectLister) -> Result<Vec<Object>, opendal::Error> {
     stream.try_collect::<Vec<_>>().await
 }
 

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -17,7 +17,7 @@ use std::env;
 use anyhow::Result;
 use common_telemetry::logging;
 use object_store::backend::{fs, s3};
-use object_store::{util, Object, ObjectMode, ObjectStore, ObjectStreamer};
+use object_store::{util, Object, ObjectLister, ObjectMode, ObjectStore};
 use tempdir::TempDir;
 
 async fn test_object_crud(store: &ObjectStore) -> Result<()> {
@@ -61,7 +61,7 @@ async fn test_object_list(store: &ObjectStore) -> Result<()> {
 
     // List objects
     let o: Object = store.object("/");
-    let obs: ObjectStreamer = o.list().await?;
+    let obs: ObjectLister = o.list().await?;
     let objects = util::collect(obs).await?;
     assert_eq!(3, objects.len());
 
@@ -74,7 +74,7 @@ async fn test_object_list(store: &ObjectStore) -> Result<()> {
     assert_eq!(1, objects.len());
 
     // Only o2 is exists
-    let o2 = &objects[0].clone().into_object();
+    let o2 = &objects[0].clone();
     let bs = o2.read().await?;
     assert_eq!("Hello, object2!", String::from_utf8(bs)?);
     // Delete o2

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -48,7 +48,7 @@ pub enum Error {
 
     #[snafu(display("Failed to write columns, source: {}", source))]
     FlushIo {
-        source: std::io::Error,
+        source: object_store::Error,
         backtrace: Backtrace,
     },
 
@@ -62,28 +62,28 @@ pub enum Error {
     ReadObject {
         path: String,
         backtrace: Backtrace,
-        source: IoError,
+        source: object_store::Error,
     },
 
     #[snafu(display("Fail to write object into path: {}, source: {}", path, source))]
     WriteObject {
         path: String,
         backtrace: Backtrace,
-        source: IoError,
+        source: object_store::Error,
     },
 
     #[snafu(display("Fail to delete object from path: {}, source: {}", path, source))]
     DeleteObject {
         path: String,
         backtrace: Backtrace,
-        source: IoError,
+        source: object_store::Error,
     },
 
     #[snafu(display("Fail to list objects in path: {}, source: {}", path, source))]
     ListObjects {
         path: String,
         backtrace: Backtrace,
-        source: IoError,
+        source: object_store::Error,
     },
 
     #[snafu(display("Fail to create str from bytes, source: {}", source))]
@@ -457,7 +457,14 @@ mod tests {
             ))
         }
 
-        let error = throw_io_error().context(FlushIoSnafu).err().unwrap();
+        let error = throw_io_error()
+            .map_err(|err| {
+                object_store::Error::new(object_store::ErrorKind::Unexpected, "writer close failed")
+                    .set_source(err)
+            })
+            .context(FlushIoSnafu)
+            .err()
+            .unwrap();
         assert_eq!(StatusCode::StorageUnavailable, error.status_code());
         assert!(error.backtrace_opt().is_some());
     }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR will bump OpenDAL to v0.21.1.

Recent changes:

- https://github.com/datafuselabs/opendal/discussions/1004
- https://github.com/datafuselabs/opendal/discussions/1008

Please take a review on the error related changes. Thanks in advance!

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

