### PR TITLE
fix: append table id to table data dir

### DIFF
--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -57,8 +57,8 @@ fn region_id(table_id: TableId, n: u32) -> RegionId {
 }
 
 #[inline]
-fn table_dir(schema_name: &str, table_name: &str) -> String {
-    format!("{}/{}/", schema_name, table_name)
+fn table_dir(schema_name: &str, table_name: &str, table_id: TableId) -> String {
+    format!("{}/{}_{}/", schema_name, table_name, table_id)
 }
 
 /// [TableEngine] implementation.
@@ -317,7 +317,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             }
         }
 
-        let table_dir = table_dir(schema_name, table_name);
+        let table_dir = table_dir(schema_name, table_name, table_id);
         let opts = CreateOptions {
             parent_dir: table_dir.clone(),
         };
@@ -396,13 +396,13 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                 return Ok(Some(table));
             }
 
+            let table_id = request.table_id;
             let engine_ctx = StorageEngineContext::default();
-            let table_dir = table_dir(schema_name, table_name);
+            let table_dir = table_dir(schema_name, table_name, table_id);
             let opts = OpenOptions {
                 parent_dir: table_dir.to_string(),
             };
 
-            let table_id = request.table_id;
             // TODO(dennis): supports multi regions;
             assert_eq!(request.region_numbers.len(), 1);
             let region_number = request.region_numbers[0];
@@ -642,8 +642,14 @@ mod tests {
 
     #[test]
     fn test_table_dir() {
-        assert_eq!("public/test_table/", table_dir("public", "test_table"));
-        assert_eq!("prometheus/demo/", table_dir("prometheus", "demo"));
+        assert_eq!(
+            "public/test_table_1024/",
+            table_dir("public", "test_table", 1024)
+        );
+        assert_eq!(
+            "prometheus/demo_1024/",
+            table_dir("prometheus", "demo", 1024)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

- append table id to table name as data directory, format like: /{schema_name}/{table_name}_{table_id}/

## Checklist

- []  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
(#631)