### PR TITLE
feat: enable atomic write for file object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,6 @@ dependencies = [
  "meta-client",
  "mito",
  "object-store",
- "opendal",
  "regex",
  "serde",
  "serde_json",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -27,7 +27,6 @@ futures = "0.3"
 futures-util = "0.3"
 lazy_static = "1.4"
 meta-client = { path = "../meta-client" }
-opendal = "0.21"
 regex = "1.6"
 serde = "1.0"
 serde_json = "1.0"
@@ -40,7 +39,6 @@ tokio = { version = "1.18", features = ["full"] }
 chrono = "0.4"
 log-store = { path = "../log-store" }
 object-store = { path = "../object-store" }
-opendal = "0.21"
 storage = { path = "../storage" }
 mito = { path = "../mito", features = ["test"] }
 tempdir = "0.3"

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -197,8 +197,11 @@ pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result
 
     info!("The storage directory is: {}", &data_dir);
 
+    let atomic_write_dir = format!("{}/.tmp/", data_dir);
+
     let accessor = Builder::default()
         .root(&data_dir)
+        .atomic_write_dir(&atomic_write_dir)
         .build()
         .context(error::InitBackendSnafu { dir: &data_dir })?;
 

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -88,10 +88,12 @@ async fn test_object_list(store: &ObjectStore) -> Result<()> {
 
 #[tokio::test]
 async fn test_fs_backend() -> Result<()> {
+    let data_dir = TempDir::new("test_fs_backend")?;
     let tmp_dir = TempDir::new("test_fs_backend")?;
     let store = ObjectStore::new(
         fs::Builder::default()
-            .root(&tmp_dir.path().to_string_lossy())
+            .root(&data_dir.path().to_string_lossy())
+            .atomic_write_dir(&tmp_dir.path().to_string_lossy())
             .build()?,
     );
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Enable atomic write for file object storage. Opendal [0.21](https://github.com/datafuselabs/opendal/releases/tag/v0.21.0) has already implemented it.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Fixes #613 