### PR TITLE
feat: UI improvement for integration test runner

### DIFF
--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -57,8 +57,8 @@ fn region_id(table_id: TableId, n: u32) -> RegionId {
 }
 
 #[inline]
-fn table_dir(schema_name: &str, table_name: &str) -> String {
-    format!("{}/{}/", schema_name, table_name)
+fn table_dir(schema_name: &str, table_name: &str, table_id: TableId) -> String {
+    format!("{}/{}_{}/", schema_name, table_name, table_id)
 }
 
 /// [TableEngine] implementation.
@@ -317,7 +317,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             }
         }
 
-        let table_dir = table_dir(schema_name, table_name);
+        let table_dir = table_dir(schema_name, table_name, table_id);
         let opts = CreateOptions {
             parent_dir: table_dir.clone(),
         };
@@ -396,13 +396,13 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                 return Ok(Some(table));
             }
 
+            let table_id = request.table_id;
             let engine_ctx = StorageEngineContext::default();
-            let table_dir = table_dir(schema_name, table_name);
+            let table_dir = table_dir(schema_name, table_name, table_id);
             let opts = OpenOptions {
                 parent_dir: table_dir.to_string(),
             };
 
-            let table_id = request.table_id;
             // TODO(dennis): supports multi regions;
             assert_eq!(request.region_numbers.len(), 1);
             let region_number = request.region_numbers[0];
@@ -642,8 +642,14 @@ mod tests {
 
     #[test]
     fn test_table_dir() {
-        assert_eq!("public/test_table/", table_dir("public", "test_table"));
-        assert_eq!("prometheus/demo/", table_dir("prometheus", "demo"));
+        assert_eq!(
+            "public/test_table_1024/",
+            table_dir("public", "test_table", 1024)
+        );
+        assert_eq!(
+            "prometheus/demo_1024/",
+            table_dir("prometheus", "demo", 1024)
+        );
     }
 
     #[tokio::test]

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -21,7 +21,7 @@ mod util;
 #[tokio::main]
 async fn main() {
     let config = ConfigBuilder::default()
-        .case_dir("../cases".to_string())
+        .case_dir(util::get_case_dir())
         .build()
         .unwrap();
     let runner = Runner::new_with_config(config, Env {}).await.unwrap();

--- a/tests/runner/src/util.rs
+++ b/tests/runner/src/util.rs
@@ -158,12 +158,5 @@ pub async fn check_port(ip_addr: SocketAddr, timeout: Duration) -> bool {
         }
     };
 
-    tokio::select! {
-        _ = check_task => {
-            true
-        },
-        _ = time::sleep(timeout) => {
-            false
-        }
-    }
+    tokio::time::timeout(timeout, check_task).await.is_ok()
 }

--- a/tests/runner/src/util.rs
+++ b/tests/runner/src/util.rs
@@ -131,6 +131,17 @@ pub fn get_workspace_root() -> String {
     runner_crate_path.into_os_string().into_string().unwrap()
 }
 
+pub fn get_binary_dir(mode: &str) -> String {
+    // first go to the workspace root.
+    let mut workspace_root = PathBuf::from(get_workspace_root());
+
+    // change directory to target dir (workspace/target/<build mode>/)
+    workspace_root.push("target");
+    workspace_root.push(mode);
+
+    workspace_root.into_os_string().into_string().unwrap()
+}
+
 /// Spin-waiting a socket address is avaliable, or timeout.
 /// Returns whether the addr is up.
 pub async fn check_port(ip_addr: SocketAddr, timeout: Duration) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Improvements:
- Able to run under project root dir with `cargo run --bin sqlness-runner`
- Force to run with the newest DB build.
- Hook build output. Redirect server log to file.
- No orphan process will leave.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
