### PR TITLE
ci: add action to create doc issue when change labelled

### DIFF
--- a/.github/workflows/doc-issue.yml
+++ b/.github/workflows/doc-issue.yml
@@ -1,0 +1,22 @@
+name: Create Issue in docs repo on doc related changes
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  doc_issue:
+    if: github.event.label.name == 'doc update required'
+    runs-on: ubuntu-latest
+    steps:
+      - name: create an issue in doc repo
+        uses: dacbd/create-issue-action@main
+        with:
+          owner: GreptimeTeam
+          repo: docs
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          title: Update docs for {{ github.event.issue.title }}
+          body: |
+            A document change request is generated from ${{ github.event.issue.html_url }}
+          assignees: ${{ github.event.issue.user.login }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The change introduces a github action to respond the label: `doc update required`.

When any issue or pull request labelled, it automatically creates an issue in https://github.com/GrepTimeTeam/docs/ to track the doc change. 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
