### PR TITLE
perf: cache python interpreter in TLS

### DIFF
--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -48,7 +48,6 @@ use crate::python::error::{
 use crate::python::utils::{format_py_error, is_instance, py_vec_obj_to_array};
 use crate::python::PyVector;
 
-/// Rustpython interpreter TLS cache
 thread_local!(static INTERPRETER: RefCell<Option<Arc<Interpreter>>> = RefCell::new(None));
 
 #[cfg_attr(test, derive(Deserialize))]

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -1115,12 +1115,13 @@ pub mod tests {
     }
 
     pub fn execute_script(
+        interpreter: &rustpython_vm::Interpreter,
         script: &str,
         test_vec: Option<PyVector>,
         predicate: PredicateFn,
     ) -> Result<(PyObjectRef, Option<bool>), PyRef<rustpython_vm::builtins::PyBaseException>> {
         let mut pred_res = None;
-        rustpython_vm::Interpreter::without_stdlib(Default::default())
+        interpreter
             .enter(|vm| {
                 PyVector::make_class(&vm.ctx);
                 let scope = vm.new_scope_with_builtins();
@@ -1208,8 +1209,10 @@ pub mod tests {
                 Some(|v, vm| is_eq(v, 2.0, vm)),
             ),
         ];
+
+        let interpreter = rustpython_vm::Interpreter::without_stdlib(Default::default());
         for (code, pred) in snippet {
-            let result = execute_script(code, None, pred);
+            let result = execute_script(&interpreter, code, None, pred);
 
             println!(
                 "\u{001B}[35m{code}\u{001B}[0m: {:?}{}",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When executing a coprocessor, we always create a new python interpreter for every execution. It's unnecessary and make the execution really slow.

In this PR, we cache the interpreter in TLS, looks like it can improve the performance significantly.

Before patched:

```
$ curl  -XPOST "http://localhost:4000/v1/run-script?name=system_status"

{"code":0,"output":..., "execution_time_ms":2156}
```

After patched:

```
{"code":0,"output":...., "execution_time_ms":3}
```

And reuse the interpreter in `test_execute_script` too, it only runs about 2 seconds right now(almost 20 seconds before).

## Checklist

- []  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
