### PR TITLE
ci: add doc label support for pr too

### DIFF
--- a/.github/workflows/doc-issue.yml
+++ b/.github/workflows/doc-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
       - labeled
+  pull_request:
+    types:
+      - labeled
 
 jobs:
   doc_issue:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixes #648 and add label action to pull requests too

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
