### PR TITLE
ci: fix doc label task on forked repo

### DIFF
--- a/.github/workflows/doc-issue.yml
+++ b/.github/workflows/doc-issue.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 
@@ -19,7 +19,8 @@ jobs:
           owner: GreptimeTeam
           repo: docs
           token: ${{ secrets.DOCS_REPO_TOKEN }}
-          title: Update docs for {{ github.event.issue.title }}
+          title: Update docs for ${{ github.event.issue.title || github.event.pull_request.title }}
           body: |
-            A document change request is generated from ${{ github.event.issue.html_url }}
-          assignees: ${{ github.event.issue.user.login }}
+            A document change request is generated from
+            ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+          assignees: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

OMG this is my 3rd attempt to make this action running. 

When using `pull_request` event, the action has no access to secrets. Here we changes event type to `pull_request_target` and action runs against original repo.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
