### PR TITLE
chore: update RustPython dependence(With a tweaked fork)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -5324,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "ahash",
  "indexmap",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "ascii",
  "cfg-if",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -5374,7 +5374,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "bincode 1.3.3",
  "bitflags",
@@ -5391,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "rustpython-derive"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "indexmap",
  "itertools",
@@ -5419,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5443,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "rustpython-pylib"
 version = "0.1.0"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "glob",
  "rustpython-compiler-core",
@@ -5453,7 +5453,7 @@ dependencies = [
 [[package]]
 name = "rustpython-stdlib"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "adler32",
  "ahash",
@@ -5517,7 +5517,7 @@ dependencies = [
 [[package]]
 name = "rustpython-vm"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "adler32",
  "ahash 0.7.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,7 +5326,7 @@ name = "rustpython-codegen"
 version = "0.1.2"
 source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "indexmap",
  "itertools",
  "log",
@@ -5421,7 +5421,7 @@ name = "rustpython-parser"
 version = "0.1.2"
 source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "anyhow",
  "itertools",
  "lalrpop",
@@ -5456,7 +5456,7 @@ version = "0.1.2"
 source = "git+https://github.com/discord9/RustPython?rev=183e8dab#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "adler32",
- "ahash",
+ "ahash 0.7.6",
  "ascii",
  "base64",
  "blake2",
@@ -5533,7 +5533,7 @@ dependencies = [
  "flate2",
  "getrandom 0.2.7",
  "glob",
- "half",
+ "half 1.8.2",
  "hex",
  "hexf-parse",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term 0.7.0",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +724,21 @@ dependencies = [
  "rustc-hash",
  "shlex",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -2062,6 +2086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,6 +2183,15 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -3041,10 +3080,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term 0.7.0",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
 name = "lalrpop-util"
 version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "lazy_static"
@@ -3665,6 +3730,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,12 +3746,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
  "memoffset",
@@ -4300,6 +4370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,6 +4517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettydiff"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4471,7 +4553,7 @@ dependencies = [
  "csv",
  "encode_unicode",
  "lazy_static",
- "term",
+ "term 0.5.2",
  "unicode-width",
 ]
 
@@ -5145,32 +5227,33 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "num-bigint",
  "rustpython-common",
+ "rustpython-compiler-core",
 ]
 
 [[package]]
-name = "rustpython-bytecode"
+name = "rustpython-codegen"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "bincode 1.3.3",
- "bitflags",
- "bstr",
+ "ahash",
+ "indexmap",
  "itertools",
- "lz4_flex",
- "num-bigint",
+ "log",
  "num-complex",
- "serde",
- "static_assertions",
+ "num-traits",
+ "rustpython-ast",
+ "rustpython-compiler-core",
+ "thiserror",
 ]
 
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "ascii",
  "cfg-if",
@@ -5193,9 +5276,9 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "rustpython-bytecode",
+ "rustpython-codegen",
  "rustpython-compiler-core",
  "rustpython-parser",
  "thiserror",
@@ -5204,22 +5287,24 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "ahash 0.7.6",
- "indexmap",
+ "bincode 1.3.3",
+ "bitflags",
+ "bstr",
  "itertools",
- "log",
+ "lz4_flex",
+ "num-bigint",
  "num-complex",
- "num-traits",
- "rustpython-ast",
- "rustpython-bytecode",
+ "serde",
+ "static_assertions",
+ "thiserror",
 ]
 
 [[package]]
 name = "rustpython-derive"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "indexmap",
  "itertools",
@@ -5227,8 +5312,9 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "rustpython-bytecode",
+ "rustpython-codegen",
  "rustpython-compiler",
+ "rustpython-compiler-core",
  "rustpython-doc",
  "syn",
  "syn-ext",
@@ -5238,7 +5324,7 @@ dependencies = [
 [[package]]
 name = "rustpython-doc"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/__doc__?branch=main#66be54cd61cc5eb29bb4870314160c337a296a32"
+source = "git+https://github.com/RustPython/__doc__?branch=main#d927debd491e4c45b88e953e6e50e4718e0f2965"
 dependencies = [
  "once_cell",
 ]
@@ -5246,9 +5332,12 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
+ "anyhow",
+ "itertools",
+ "lalrpop",
  "lalrpop-util",
  "log",
  "num-bigint",
@@ -5256,6 +5345,8 @@ dependencies = [
  "phf 0.10.1",
  "phf_codegen 0.10.0",
  "rustpython-ast",
+ "rustpython-compiler-core",
+ "thiserror",
  "tiny-keccak",
  "unic-emoji-char",
  "unic-ucd-ident",
@@ -5265,16 +5356,17 @@ dependencies = [
 [[package]]
 name = "rustpython-pylib"
 version = "0.1.0"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
- "rustpython-bytecode",
+ "glob",
+ "rustpython-compiler-core",
  "rustpython-derive",
 ]
 
 [[package]]
 name = "rustpython-vm"
 version = "0.1.2"
-source = "git+https://github.com/RustPython/RustPython?rev=02a1d1d#02a1d1d7db57afbb78049599c2585cc7cd59e6d3"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
 dependencies = [
  "adler32",
  "ahash 0.7.6",
@@ -5289,7 +5381,8 @@ dependencies = [
  "exitcode",
  "flate2",
  "getrandom 0.2.7",
- "half 1.8.2",
+ "glob",
+ "half",
  "hex",
  "hexf-parse",
  "indexmap",
@@ -5315,13 +5408,12 @@ dependencies = [
  "result-like",
  "rustc_version",
  "rustpython-ast",
- "rustpython-bytecode",
+ "rustpython-codegen",
  "rustpython-common",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-derive",
  "rustpython-parser",
- "rustpython-pylib",
  "rustyline",
  "schannel",
  "serde",
@@ -5342,6 +5434,7 @@ dependencies = [
  "which",
  "widestring",
  "winapi",
+ "windows",
  "winreg",
 ]
 
@@ -5353,9 +5446,9 @@ checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -5368,7 +5461,6 @@ dependencies = [
  "nix",
  "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
@@ -5526,10 +5618,11 @@ dependencies = [
  "query",
  "ron",
  "rustpython-ast",
- "rustpython-bytecode",
+ "rustpython-codegen",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-parser",
+ "rustpython-pylib",
  "rustpython-vm",
  "serde",
  "session",
@@ -5995,12 +6088,13 @@ dependencies = [
 
 [[package]]
 name = "sre-engine"
-version = "0.1.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5872399287c284fed4bc773cb7f6041623ac88213774f5e11e89e2131681fc1"
+checksum = "a490c5c46c35dba9a6f5e7ee8e4d67e775eb2d2da0f115750b8d10e1c1ac2d28"
 dependencies = [
  "bitflags",
  "num_enum",
+ "optional",
 ]
 
 [[package]]
@@ -6128,6 +6222,19 @@ name = "strength_reduce"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ff2f71c82567c565ba4b3009a9350a96a7269eaa4001ebedae926230bc2254"
+
+[[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "stringprep"
@@ -6357,6 +6464,17 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
@@ -6969,7 +7087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.4.6",
  "static_assertions",
 ]
 
@@ -7422,16 +7540,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
+dependencies = [
+ "windows_aarch64_msvc 0.39.0",
+ "windows_i686_gnu 0.39.0",
+ "windows_i686_msvc 0.39.0",
+ "windows_x86_64_gnu 0.39.0",
+ "windows_x86_64_msvc 0.39.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
 
 [[package]]
@@ -7441,10 +7572,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7453,16 +7596,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atomic_float"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
+name = "dns-lookup"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ecafc952c4528d9b51a458d1a8904b81783feff9fde08ab6ed2545ff396872"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3080,6 +3101,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,6 +3348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac_address"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e3235c8382b7653c6408ed1b08dd379bdb9fdf990fb0bbae3db2cc0ae963"
+dependencies = [
+ "nix 0.23.1",
+ "winapi",
+]
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +3422,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -3602,6 +3651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mt19937"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12ca7f22ed370d5991a9caec16a83187e865bc8a532f889670337d5a5689e3a1"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,6 +3800,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4086,6 +4157,16 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"
@@ -4723,6 +4804,12 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "puruspe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7e158a385023d209d6d5f2585c4b468f6dcb3dd5aca9b75c4f1678c05bb375"
 
 [[package]]
 name = "quanta"
@@ -5364,6 +5451,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustpython-stdlib"
+version = "0.1.2"
+source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
+dependencies = [
+ "adler32",
+ "ahash",
+ "ascii",
+ "base64",
+ "blake2",
+ "cfg-if",
+ "crc32fast",
+ "crossbeam-utils",
+ "csv-core",
+ "digest",
+ "dns-lookup",
+ "flate2",
+ "gethostname",
+ "hex",
+ "itertools",
+ "lexical-parse-float",
+ "libc",
+ "mac_address",
+ "md-5",
+ "memchr",
+ "memmap2",
+ "mt19937",
+ "nix 0.24.2",
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "once_cell",
+ "page_size",
+ "parking_lot",
+ "paste",
+ "puruspe",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rustpython-common",
+ "rustpython-derive",
+ "rustpython-vm",
+ "schannel",
+ "sha-1",
+ "sha2",
+ "sha3",
+ "socket2",
+ "system-configuration",
+ "termios",
+ "unic-char-property",
+ "unic-normal",
+ "unic-ucd-age",
+ "unic-ucd-bidi",
+ "unic-ucd-category",
+ "unic-ucd-ident",
+ "unicode-casing",
+ "unicode_names2",
+ "uuid",
+ "widestring",
+ "winapi",
+ "xml-rs",
+]
+
+[[package]]
 name = "rustpython-vm"
 version = "0.1.2"
 source = "git+https://github.com/discord9/RustPython?branch=rspy4gpdb#183e8dabe0027e31630368e36c6be83b5f9cb3f8"
@@ -5392,7 +5543,7 @@ dependencies = [
  "log",
  "memchr",
  "memoffset",
- "nix",
+ "nix 0.24.2",
  "num-bigint",
  "num-complex",
  "num-integer",
@@ -5458,7 +5609,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.24.2",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
@@ -5623,6 +5774,7 @@ dependencies = [
  "rustpython-compiler-core",
  "rustpython-parser",
  "rustpython-pylib",
+ "rustpython-stdlib",
  "rustpython-vm",
  "serde",
  "session",
@@ -5850,6 +6002,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -6395,6 +6557,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75182f12f490e953596550b65ee31bda7c8e043d9386174b353bda50838c3fd"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "table"
 version = "0.1.0"
 dependencies = [
@@ -6495,6 +6678,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7087,7 +7279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.4.6",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -7154,6 +7346,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "unic-normal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09d64d33589a94628bc2aeb037f35c2e25f3f049c7348b5aa5580b48e6bba62"
+dependencies = [
+ "unic-ucd-normal",
+]
+
+[[package]]
+name = "unic-ucd-age"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8cfdfe71af46b871dc6af2c24fcd360e2f3392ee4c5111877f2947f311671c"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
 name = "unic-ucd-bidi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,6 +7389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unic-ucd-hangul"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb1dc690e19010e1523edb9713224cba5ef55b54894fe33424439ec9a40c0054"
+dependencies = [
+ "unic-ucd-version",
+]
+
+[[package]]
 name = "unic-ucd-ident"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7184,6 +7405,18 @@ checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
 dependencies = [
  "unic-char-property",
  "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-normal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86aed873b8202d22b13859dda5fe7c001d271412c31d411fd9b827e030569410"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-hangul",
  "unic-ucd-version",
 ]
 
@@ -7302,8 +7535,22 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
+ "atomic",
  "getrandom 0.2.7",
+ "rand 0.8.5",
  "serde",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73bc89f2894593e665241e0052c3791999e6787b7c4831daa0a5c2e637e276d8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -7642,6 +7889,12 @@ checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "zstd"

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -7,16 +7,16 @@ license = "Apache-2.0"
 [features]
 default = ["python"]
 python = [
-    "dep:datafusion",
-    "dep:datafusion-expr",
-    "dep:datafusion-physical-expr",
-    "dep:rustpython-vm",
-    "dep:rustpython-parser",
-    "dep:rustpython-compiler",
-    "dep:rustpython-compiler-core",
-    "dep:rustpython-bytecode",
-    "dep:rustpython-ast",
-    "dep:paste",
+  "dep:datafusion",
+  "dep:datafusion-expr",
+  "dep:datafusion-physical-expr",
+  "dep:rustpython-vm",
+  "dep:rustpython-parser",
+  "dep:rustpython-compiler",
+  "dep:rustpython-compiler-core",
+  "dep:rustpython-codegen",
+  "dep:rustpython-ast",
+  "dep:paste",
 ]
 
 [dependencies]
@@ -39,14 +39,16 @@ futures = "0.3"
 futures-util = "0.3"
 paste = { version = "1.0", optional = true }
 query = { path = "../query" }
-rustpython-ast = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-bytecode = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-parser = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d" }
-rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "02a1d1d", features = [
-    "default",
-    "freeze-stdlib",
+rustpython-ast = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
+# rustpython-bytecode = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "faace160be" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
+rustpython-codegen = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f"}
+rustpython-parser = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
+rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f", features = [
+  "default",
+  "freeze-stdlib",
+  "codegen"
 ] }
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -7,18 +7,18 @@ license = "Apache-2.0"
 [features]
 default = ["python"]
 python = [
-  "dep:datafusion",
-  "dep:datafusion-expr",
-  "dep:datafusion-physical-expr",
-  "dep:rustpython-vm",
-  "dep:rustpython-parser",
-  "dep:rustpython-compiler",
-  "dep:rustpython-compiler-core",
-  "dep:rustpython-codegen",
-  "dep:rustpython-ast",
-  "dep:rustpython-pylib",
-  "dep:rustpython-stdlib",
-  "dep:paste",
+    "dep:datafusion",
+    "dep:datafusion-expr",
+    "dep:datafusion-physical-expr",
+    "dep:rustpython-vm",
+    "dep:rustpython-parser",
+    "dep:rustpython-compiler",
+    "dep:rustpython-compiler-core",
+    "dep:rustpython-codegen",
+    "dep:rustpython-ast",
+    "dep:rustpython-pylib",
+    "dep:rustpython-stdlib",
+    "dep:paste",
 ]
 
 [dependencies]
@@ -48,12 +48,12 @@ rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", opt
 rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
-  "default",
-  "codegen",
+    "default",
+    "codegen",
 ] }
-rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab"  }
+rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
-  "freeze-stdlib",
+    "freeze-stdlib",
 ] }
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -41,7 +41,7 @@ futures = "0.3"
 futures-util = "0.3"
 paste = { version = "1.0", optional = true }
 query = { path = "../query" }
-# TODO: This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
+# TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -42,17 +42,17 @@ futures-util = "0.3"
 paste = { version = "1.0", optional = true }
 query = { path = "../query" }
 # TODO: This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
-rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = [
+rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
   "default",
   "codegen",
 ] }
-rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = [
+rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab"  }
+rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
   "freeze-stdlib",
 ] }
 session = { path = "../session" }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -16,6 +16,7 @@ python = [
   "dep:rustpython-compiler-core",
   "dep:rustpython-codegen",
   "dep:rustpython-ast",
+  "dep:rustpython-pylib",
   "dep:paste",
 ]
 
@@ -39,18 +40,19 @@ futures = "0.3"
 futures-util = "0.3"
 paste = { version = "1.0", optional = true }
 query = { path = "../query" }
-rustpython-ast = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
-# rustpython-bytecode = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "faace160be" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
-rustpython-codegen = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f"}
-rustpython-parser = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f" }
-rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = true, rev = "5c29c27b6f", features = [
+# TODO: This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
+rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb"}
+rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
+rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
+rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb"}
+rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
+rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = [
   "default",
   "freeze-stdlib",
   "codegen"
 ] }
 session = { path = "../session" }
+rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = ["freeze-stdlib"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -17,6 +17,7 @@ python = [
   "dep:rustpython-codegen",
   "dep:rustpython-ast",
   "dep:rustpython-pylib",
+  "dep:rustpython-stdlib",
   "dep:paste",
 ]
 
@@ -41,18 +42,20 @@ futures-util = "0.3"
 paste = { version = "1.0", optional = true }
 query = { path = "../query" }
 # TODO: This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
-rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb"}
+rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
 rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
 rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
-rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb"}
+rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
 rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
 rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = [
   "default",
+  "codegen",
+] }
+rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb" }
+rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = [
   "freeze-stdlib",
-  "codegen"
 ] }
 session = { path = "../session" }
-rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, branch = "rspy4gpdb", features = ["freeze-stdlib"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }

--- a/src/script/src/python/builtins/test.rs
+++ b/src/script/src/python/builtins/test.rs
@@ -358,7 +358,7 @@ fn run_builtin_fn_testcases() {
             let code_obj = vm
                 .compile(
                     &case.script,
-                    rustpython_vm::compile::Mode::BlockExpr,
+                    rustpython_compiler_core::Mode::BlockExpr,
                     "<embedded>".to_owned(),
                 )
                 .map_err(|err| vm.new_syntax_error(&err))
@@ -466,7 +466,7 @@ fn test_vm() {
                 r#"
 from udf_builtins import *
 sin(values)"#,
-                rustpython_vm::compile::Mode::BlockExpr,
+                rustpython_compiler_core::Mode::BlockExpr,
                 "<embedded>".to_owned(),
             )
             .map_err(|err| vm.new_syntax_error(&err))

--- a/src/script/src/python/builtins/test.rs
+++ b/src/script/src/python/builtins/test.rs
@@ -39,10 +39,6 @@ fn convert_scalar_to_py_obj_and_back() {
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
         PyVector::make_class(&vm.ctx);
-        // We are freezing the stdlib, so according to this issue:
-        // https://github.com/RustPython/RustPython/issues/4292
-        // add this line for stdlib
-        vm.add_frozen(rustpython_pylib::frozen_stdlib());
     })
     .enter(|vm| {
         let col = DFColValue::Scalar(ScalarValue::Float64(Some(1.0)));
@@ -344,11 +340,6 @@ fn run_builtin_fn_testcases() {
     let testcases: Vec<TestCase> = from_ron_string(&buf).expect("Fail to convert to testcases");
     let cached_vm = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         vm.add_native_module("greptime", Box::new(greptime_builtin::make_module));
-        // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
-        // We are freezing the stdlib, so according to this issue:
-        // https://github.com/RustPython/RustPython/issues/4292
-        // add this line for stdlib
-        vm.add_frozen(rustpython_pylib::frozen_stdlib());
         PyVector::make_class(&vm.ctx);
     });
     for (idx, case) in testcases.into_iter().enumerate() {
@@ -454,10 +445,6 @@ fn set_lst_of_vecs_in_scope(
 fn test_vm() {
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         vm.add_native_module("udf_builtins", Box::new(greptime_builtin::make_module));
-        // We are freezing the stdlib, so according to this issue:
-        // https://github.com/RustPython/RustPython/issues/4292
-        // add this line for stdlib
-        vm.add_frozen(rustpython_pylib::frozen_stdlib());
         // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
         PyVector::make_class(&vm.ctx);
     })

--- a/src/script/src/python/builtins/test.rs
+++ b/src/script/src/python/builtins/test.rs
@@ -39,6 +39,10 @@ fn convert_scalar_to_py_obj_and_back() {
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
         PyVector::make_class(&vm.ctx);
+        // We are freezing the stdlib, so according to this issue:
+        // https://github.com/RustPython/RustPython/issues/4292
+        // add this line for stdlib
+        vm.add_frozen(rustpython_pylib::frozen_stdlib());
     })
     .enter(|vm| {
         let col = DFColValue::Scalar(ScalarValue::Float64(Some(1.0)));
@@ -341,6 +345,10 @@ fn run_builtin_fn_testcases() {
     let cached_vm = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         vm.add_native_module("greptime", Box::new(greptime_builtin::make_module));
         // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
+        // We are freezing the stdlib, so according to this issue:
+        // https://github.com/RustPython/RustPython/issues/4292
+        // add this line for stdlib
+        vm.add_frozen(rustpython_pylib::frozen_stdlib());
         PyVector::make_class(&vm.ctx);
     });
     for (idx, case) in testcases.into_iter().enumerate() {
@@ -446,6 +454,10 @@ fn set_lst_of_vecs_in_scope(
 fn test_vm() {
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         vm.add_native_module("udf_builtins", Box::new(greptime_builtin::make_module));
+        // We are freezing the stdlib, so according to this issue:
+        // https://github.com/RustPython/RustPython/issues/4292
+        // add this line for stdlib
+        vm.add_frozen(rustpython_pylib::frozen_stdlib());
         // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
         PyVector::make_class(&vm.ctx);
     })

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -431,6 +431,10 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
         i.borrow_mut()
             .get_or_insert_with(|| {
                 let interpreter = Arc::new(vm::Interpreter::with_init(Default::default(), |vm| {
+                    // We are freezing the stdlib, so according to this issue:
+                    // https://github.com/RustPython/RustPython/issues/4292
+                    // add this line for stdlib
+                    vm.add_frozen(rustpython_pylib::frozen_stdlib());
                     PyVector::make_class(&vm.ctx);
                     vm.add_native_module("greptime", Box::new(greptime_builtin::make_module));
                 }));

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -436,7 +436,6 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
                 ]);
                 let interpreter = Arc::new(vm::Interpreter::with_init(Default::default(), |vm| {
                     // not using full stdlib to prevent security issue, instead filter out a few simple util module
-                    // vm.add_native_modules(rustpython_stdlib::get_module_inits());
                     vm.add_native_modules(
                         rustpython_stdlib::get_module_inits()
                             .into_iter()

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -29,7 +29,7 @@ use datatypes::arrow::compute::cast::CastOptions;
 use datatypes::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use datatypes::schema::Schema;
 use datatypes::vectors::{BooleanVector, Helper, StringVector, Vector, VectorRef};
-use rustpython_bytecode::CodeObject;
+use rustpython_compiler_core::CodeObject;
 use rustpython_vm as vm;
 use rustpython_vm::class::PyClassImpl;
 use rustpython_vm::AsObject;

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -431,7 +431,7 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
         i.borrow_mut()
             .get_or_insert_with(|| {
                 // we limit stdlib imports for safety reason, i.e `fcntl` is not allowed here
-                let native_module_white_list = HashSet::from([
+                let native_module_allow_list = HashSet::from([
                     "array", "cmath", "gc", "hashlib", "_json", "_random", "math",
                 ]);
                 let interpreter = Arc::new(vm::Interpreter::with_init(Default::default(), |vm| {
@@ -440,7 +440,7 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
                     vm.add_native_modules(
                         rustpython_stdlib::get_module_inits()
                             .into_iter()
-                            .filter(|(k, _)| native_module_white_list.contains(k.as_ref())),
+                            .filter(|(k, _)| native_module_allow_list.contains(k.as_ref())),
                     );
 
                     // We are freezing the stdlib to include the standard library inside the binary.

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -127,7 +127,7 @@ pub fn compile_script(name: &str, deco_args: &DecoratorArgs, script: &str) -> Re
         &top,
         "<embedded>".to_owned(),
         Mode::BlockExpr,
-        CompileOpts { optimize: 0 },
+        CompileOpts { optimize: 1 },
     )
     .context(PyCompileSnafu)
 }

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 //! compile script to code object
+use rustpython_codegen::compile::compile_top;
 use rustpython_compiler::{CompileOpts, Mode};
 use rustpython_compiler_core::CodeObject;
-use rustpython_codegen::compile::compile_top;
 use rustpython_parser::ast::{Located, Location};
 use rustpython_parser::{ast, parser};
 use snafu::ResultExt;

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -127,7 +127,7 @@ pub fn compile_script(name: &str, deco_args: &DecoratorArgs, script: &str) -> Re
         &top,
         "<embedded>".to_owned(),
         Mode::BlockExpr,
-        CompileOpts { optimize: 1 },
+        CompileOpts { optimize: 0 },
     )
     .context(PyCompileSnafu)
 }

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 //! compile script to code object
-
-use rustpython_bytecode::CodeObject;
-use rustpython_compiler_core::compile as python_compile;
+use rustpython_compiler::{CompileOpts, Mode};
+use rustpython_compiler_core::CodeObject;
+use rustpython_codegen::compile::compile_top;
 use rustpython_parser::ast::{Located, Location};
 use rustpython_parser::{ast, parser};
 use snafu::ResultExt;
@@ -73,7 +73,8 @@ fn gen_call(name: &str, deco_args: &DecoratorArgs, loc: &Location) -> ast::Stmt<
 /// strip type annotation
 pub fn compile_script(name: &str, deco_args: &DecoratorArgs, script: &str) -> Result<CodeObject> {
     // note that it's important to use `parser::Mode::Interactive` so the ast can be compile to return a result instead of return None in eval mode
-    let mut top = parser::parse(script, parser::Mode::Interactive).context(PyParseSnafu)?;
+    let mut top =
+        parser::parse(script, parser::Mode::Interactive, "<embedded>").context(PyParseSnafu)?;
     // erase decorator
     if let ast::Mod::Interactive { body } = &mut top {
         let stmts = body;
@@ -122,11 +123,11 @@ pub fn compile_script(name: &str, deco_args: &DecoratorArgs, script: &str) -> Re
         );
     }
     // use `compile::Mode::BlockExpr` so it return the result of statement
-    python_compile::compile_top(
+    compile_top(
         &top,
         "<embedded>".to_owned(),
-        python_compile::Mode::BlockExpr,
-        python_compile::CompileOpts { optimize: 0 },
+        Mode::BlockExpr,
+        CompileOpts { optimize: 0 },
     )
     .context(PyCompileSnafu)
 }

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -99,7 +99,7 @@ fn try_into_datatype(ty: &str, loc: &Location) -> Result<Option<DataType>> {
         "_" => Ok(None),
         // note the different between "_" and _
         _ => fail_parse_error!(
-            format!("Unknown datatype: {ty} at {}", loc),
+            format!("Unknown datatype: {ty} at {:?}", loc),
             Some(loc.to_owned())
         ),
     }
@@ -427,7 +427,7 @@ fn get_return_annotations(rets: &ast::Expr<()>) -> Result<Vec<Option<AnnotationI
 
 /// parse script and return `Coprocessor` struct with info extract from ast
 pub fn parse_and_compile_copr(script: &str) -> Result<Coprocessor> {
-    let python_ast = parser::parse_program(script).context(PyParseSnafu)?;
+    let python_ast = parser::parse_program(script, "<embedded>").context(PyParseSnafu)?;
 
     let mut coprocessor = None;
 

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -18,7 +18,7 @@ use datafusion::error::DataFusionError;
 use datatypes::arrow::error::ArrowError;
 use datatypes::error::Error as DataTypeError;
 use query::error::Error as QueryError;
-use rustpython_compiler_core::error::CompileError as CoreCompileError;
+use rustpython_codegen::error::CodegenError;
 use rustpython_parser::ast::Location;
 use rustpython_parser::error::ParseError;
 pub use snafu::ensure;
@@ -54,7 +54,7 @@ pub enum Error {
     #[snafu(display("Failed to compile script, source: {}", source))]
     PyCompile {
         backtrace: Backtrace,
-        source: CoreCompileError,
+        source: CodegenError,
     },
 
     /// rustpython problem, using python virtual machines' backtrace instead
@@ -76,7 +76,7 @@ pub enum Error {
     /// errors in coprocessors' parse check for types and etc.
     #[snafu(display("Coprocessor error: {} {}.", reason,
                     if let Some(loc) = loc{
-                        format!("at {loc}")
+                        format!("at {loc:?}")
                     }else{
                         "".into()
                     }))]

--- a/src/script/src/python/test.rs
+++ b/src/script/src/python/test.rs
@@ -192,7 +192,7 @@ fn test_type_anno() {
 def a(cpu, mem: vector[f64])->(vector[f64|None], vector[f64], vector[_], vector[ _ | None]):
     return cpu + mem, cpu - mem, cpu * mem, cpu / mem
 "#;
-    let pyast = parser::parse(python_source, parser::Mode::Interactive).unwrap();
+    let pyast = parser::parse(python_source, parser::Mode::Interactive, "<embedded>").unwrap();
     let copr = parse_and_compile_copr(python_source);
     dbg!(copr);
 }

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -470,7 +470,7 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64], vector[f64]):
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    # test if using white list for stdlib damage unrelated module
+    # test if using allow list for stdlib damage unrelated module
     from collections import deque
     import math
     math.ceil(0.2)
@@ -507,12 +507,27 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    # test if module not in whtile list can't be imported
+    # test if module not in allow list can't be imported
     import fcntl
     return cpu + mem, 1
 "#,
         predicate: ExecIsErr(
             reason: "No module named 'fcntl'"
+        )
+    ),
+    (
+        // constant column(int)
+        name: "test_neg_import_depend_stdlib",
+        code: r#"
+@copr(args=["cpu", "mem"], returns=["perf", "what"])
+def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
+    vector[f32]):
+    # test if module not in allow list can't be imported
+    import mailbox
+    return cpu + mem, 1
+"#,
+        predicate: ExecIsErr(
+            reason: "ModuleNotFoundError: No module named"
         )
     ),
 ]

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -462,5 +462,57 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64], vector[f64]):
         predicate: ParseIsErr(
             reason: "Expect a function definition, but found a"
         )
-    )
+    ),
+    (
+        // constant column(int)
+        name: "test_import_stdlib",
+        code: r#"
+@copr(args=["cpu", "mem"], returns=["perf", "what"])
+def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
+    vector[f32]):
+    # test if using white list for stdlib damage unrelated module
+    from collections import deque
+    import math
+    math.ceil(0.2)
+    import string
+    return cpu + mem, 1
+"#,
+        predicate: ExecIsOk(
+            fields: [
+                (
+                    datatype: Some(Float64),
+                    is_nullable: true
+                ),
+                (
+                    datatype: Some(Float32),
+                    is_nullable: false
+                ),
+            ],
+            columns: [
+                (
+                    ty: Float64,
+                    len: 4
+                ),
+                (
+                    ty: Float32,
+                    len: 4
+                )
+            ]
+        )
+    ),
+    (
+        // constant column(int)
+        name: "test_neg_import_stdlib",
+        code: r#"
+@copr(args=["cpu", "mem"], returns=["perf", "what"])
+def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
+    vector[f32]):
+    # test if module not in whtile list can't be imported
+    import fcntl
+    return cpu + mem, 1
+"#,
+        predicate: ExecIsErr(
+            reason: "No module named 'fcntl'"
+        )
+    ),
 ]

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -1051,13 +1051,7 @@ pub mod tests {
     /// test the paired `val_to_obj` and `pyobj_to_val` func
     #[test]
     fn test_val2pyobj2val() {
-        rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
-            // We are freezing the stdlib, so according to this issue:
-            // https://github.com/RustPython/RustPython/issues/4292
-            // add this line for frozen stdlib
-            vm.add_frozen(rustpython_pylib::frozen_stdlib());
-        })
-        .enter(|vm| {
+        rustpython_vm::Interpreter::without_stdlib(Default::default()).enter(|vm| {
             let i = value::Value::Float32(OrderedFloat(2.0));
             let j = value::Value::Int32(1);
             let dtype = i.data_type();
@@ -1099,13 +1093,7 @@ pub mod tests {
 
     #[test]
     fn test_getitem_by_index_in_vm() {
-        rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
-            // We are freezing the stdlib, so according to this issue:
-            // https://github.com/RustPython/RustPython/issues/4292
-            // add this line for frozen stdlib
-            vm.add_frozen(rustpython_pylib::frozen_stdlib());
-        })
-        .enter(|vm| {
+        rustpython_vm::Interpreter::without_stdlib(Default::default()).enter(|vm| {
             PyVector::make_class(&vm.ctx);
             let a: VectorRef = Arc::new(Int32Vector::from_vec(vec![1, 2, 3, 4]));
             let a = PyVector::from(a);
@@ -1229,12 +1217,7 @@ pub mod tests {
             ),
         ];
 
-        let interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
-            // We are freezing the stdlib, so according to this issue:
-            // https://github.com/RustPython/RustPython/issues/4292
-            // add this line for frozen stdlib
-            vm.add_frozen(rustpython_pylib::frozen_stdlib());
-        });
+        let interpreter = rustpython_vm::Interpreter::without_stdlib(Default::default());
         for (code, pred) in snippet {
             let result = execute_script(&interpreter, code, None, pred);
 

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -36,7 +36,7 @@ use rustpython_vm::protocol::{PyMappingMethods, PySequenceMethods};
 use rustpython_vm::sliceable::{SaturatedSlice, SequenceIndex, SequenceIndexOp};
 use rustpython_vm::types::{AsMapping, AsSequence, Comparable, PyComparisonOp};
 use rustpython_vm::{
-    pyclass,  AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
+    pyclass, AsObject, PyObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
 };
 
 use crate::python::utils::{is_instance, PyVectorRef};
@@ -1051,7 +1051,13 @@ pub mod tests {
     /// test the paired `val_to_obj` and `pyobj_to_val` func
     #[test]
     fn test_val2pyobj2val() {
-        rustpython_vm::Interpreter::without_stdlib(Default::default()).enter(|vm| {
+        rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+            // We are freezing the stdlib, so according to this issue:
+            // https://github.com/RustPython/RustPython/issues/4292
+            // add this line for frozen stdlib
+            vm.add_frozen(rustpython_pylib::frozen_stdlib());
+        })
+        .enter(|vm| {
             let i = value::Value::Float32(OrderedFloat(2.0));
             let j = value::Value::Int32(1);
             let dtype = i.data_type();
@@ -1093,7 +1099,13 @@ pub mod tests {
 
     #[test]
     fn test_getitem_by_index_in_vm() {
-        rustpython_vm::Interpreter::without_stdlib(Default::default()).enter(|vm| {
+        rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+            // We are freezing the stdlib, so according to this issue:
+            // https://github.com/RustPython/RustPython/issues/4292
+            // add this line for frozen stdlib
+            vm.add_frozen(rustpython_pylib::frozen_stdlib());
+        })
+        .enter(|vm| {
             PyVector::make_class(&vm.ctx);
             let a: VectorRef = Arc::new(Int32Vector::from_vec(vec![1, 2, 3, 4]));
             let a = PyVector::from(a);
@@ -1140,6 +1152,7 @@ pub mod tests {
                     .as_object()
                     .set_item("a", vm.new_pyobj(a), vm)
                     .expect("failed");
+
                 scope
                     .locals
                     .as_object()
@@ -1216,7 +1229,12 @@ pub mod tests {
             ),
         ];
 
-        let interpreter = rustpython_vm::Interpreter::without_stdlib(Default::default());
+        let interpreter = rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
+            // We are freezing the stdlib, so according to this issue:
+            // https://github.com/RustPython/RustPython/issues/4292
+            // add this line for frozen stdlib
+            vm.add_frozen(rustpython_pylib::frozen_stdlib());
+        });
         for (code, pred) in snippet {
             let result = execute_script(&interpreter, code, None, pred);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Update RustPython to a newer fork, so it doesn't block other depends from update, currently commit of RustPython require `crossbeam-utils` of `=0.8.9`, relaxed it to `0.8.9` using my forked and tweaked version of RustPython(https://github.com/discord9/RustPython branch:rspy4gpdb this branch is basically a rebase of this PR(https://github.com/RustPython/RustPython/pull/4293) to a pre 1.65 version of rustpython), so we can update it to newer version (and main branch) later when we update to rust 1.65.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.