### PR TITLE
fix: correctly detach spawned mysql listener task

### DIFF
--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -184,7 +184,6 @@ async fn test_query_concurrently() -> Result<()> {
 
                 let should_recreate_conn = expected == 1;
                 if should_recreate_conn {
-                    connection.disconnect().await.unwrap();
                     connection = create_connection(server_port, index % 2 == 0)
                         .await
                         .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix a bug that cause two or more mysql clients to block. Formerly I mistakenly `await` on a spawned mysql listening task (that loop endlessly). 

Also a unit test was mis-interpret, revert.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
