### PR TITLE
feat: http api csv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ name = "common-recordbatch"
 version = "0.1.0"
 dependencies = [
  "common-error",
+ "csv",
  "datafusion",
  "datafusion-common",
  "datatypes",
@@ -5426,6 +5427,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-time",
+ "csv",
  "datatypes",
  "futures",
  "hex",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -10,6 +10,7 @@ api = { path = "../api" }
 async-trait = "0.1"
 axum = "0.6.0-rc.2"
 axum-macros = "0.3.0-rc.1"
+# axum-streams = { version = "0.8", features=["json", "csv"] }
 bytes = "1.2"
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }
@@ -20,6 +21,7 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+csv = "1.1"
 datatypes = { path = "../datatypes" }
 futures = "0.3"
 hex = { version = "0.4" }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -10,7 +10,6 @@ api = { path = "../api" }
 async-trait = "0.1"
 axum = "0.6.0-rc.2"
 axum-macros = "0.3.0-rc.1"
-# axum-streams = { version = "0.8", features=["json", "csv"] }
 bytes = "1.2"
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -17,37 +17,40 @@ use std::time::Instant;
 
 use aide::transform::TransformOperation;
 use axum::extract::{Json, Query, State};
+use axum::response::{IntoResponse, Response};
 use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::handle_sql_output;
 use crate::http::{ApiState, JsonResponse};
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SqlQuery {
     pub database: Option<String>,
     pub sql: Option<String>,
+    pub format: Option<String>,
+    pub chunked: Option<bool>,
 }
 
 /// Handler to execute sql
 #[axum_macros::debug_handler]
-pub async fn sql(
-    State(state): State<ApiState>,
-    Query(params): Query<SqlQuery>,
-) -> Json<JsonResponse> {
+pub async fn sql(State(state): State<ApiState>, Query(params): Query<SqlQuery>) -> Response {
     let sql_handler = &state.sql_handler;
-    let start = Instant::now();
-    let resp = if let Some(sql) = &params.sql {
-        JsonResponse::from_output(sql_handler.do_query(sql).await).await
+    // let start = Instant::now();
+    let format = params.format.unwrap_or("csv".to_string());
+
+    if let Some(sql) = &params.sql {
+        let output = sql_handler.do_query(sql).await;
+        handle_sql_output(output, &format).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),
             StatusCode::InvalidArguments,
         )
-    };
-
-    Json(resp.with_execution_time(start.elapsed().as_millis()))
+        .into_response()
+    }
 }
 
 pub(crate) fn sql_docs(op: TransformOperation) -> TransformOperation {

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use aide::transform::TransformOperation;
 use axum::extract::{Json, Query, State};
@@ -23,8 +22,7 @@ use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::handle_sql_output;
-use crate::http::{ApiState, JsonResponse};
+use crate::http::{handle_sql_output, ApiState, JsonResponse};
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SqlQuery {
@@ -38,8 +36,7 @@ pub struct SqlQuery {
 #[axum_macros::debug_handler]
 pub async fn sql(State(state): State<ApiState>, Query(params): Query<SqlQuery>) -> Response {
     let sql_handler = &state.sql_handler;
-    // let start = Instant::now();
-    let format = params.format.unwrap_or("csv".to_string());
+    let format = params.format.unwrap_or_else(|| "csv".to_string());
 
     if let Some(sql) = &params.sql {
         let output = sql_handler.do_query(sql).await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

#577  add csv format support for `/sql` api.

For the format of the return value.

1. first use query param "format=", optional values are json, csv
2. second use Accept Header, optional values are Accept: application/json or Accept: application/csv
3. If neither is available, the default value (csv) is used.

For stream, if query param "chunked=false" is passed, then streaming is not applicable, otherwise streaming is enabled by default.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- []  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
