### PR TITLE
ci: remove assignees which is causing error

### DIFF
--- a/.github/workflows/doc-issue.yml
+++ b/.github/workflows/doc-issue.yml
@@ -23,4 +23,3 @@ jobs:
           body: |
             A document change request is generated from
             ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
-          assignees: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

4th attempt, we cannot specify assignee because it's not allowed.

## Checklist

- []  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
