### PR TITLE
chore: fix SequenceNotMonotonic error message

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -218,7 +218,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Sequence of region should increase monotonically ({} >= {})",
+        "Sequence of region should increase monotonically (should be {} < {})",
         prev,
         given
     ))]

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -218,7 +218,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Sequence of region should increase monotonically ({} > {})",
+        "Sequence of region should increase monotonically ({} >= {})",
         prev,
         given
     ))]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
The previous sequence in the error message should be greater than or equal to next sequence.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
NA