### PR TITLE
refactor: bump axum 0.6, use recommended way to nest routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,11 +51,11 @@ dependencies = [
 
 [[package]]
 name = "aide"
-version = "0.6.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c350c121222a7d8cc7d2efad0856ddd3a903eb62f0f5e982efb27d811c94c"
+checksum = "befdff0b4683a0824fc8719ce639a252d9d62cd89c8d0004c39e2417128c1eb8"
 dependencies = [
- "axum 0.6.0-rc.2",
+ "axum 0.6.1",
  "bytes",
  "cfg-if",
  "http",
@@ -407,12 +407,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.0-rc.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2628a243073c55aef15a1c1fe45c87f21b84f9e89ca9e7b262a180d3d03543d"
+checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
- "axum-core 0.3.0-rc.2",
+ "axum-core 0.3.0",
  "bitflags",
  "bytes",
  "futures-util",
@@ -420,13 +420,15 @@ dependencies = [
  "http-body",
  "hyper",
  "itoa 1.0.3",
- "matchit 0.6.0",
+ "matchit 0.7.0",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -454,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0-rc.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473bd0762170028bb6b5068be9e97de2a9f0af3bf2084498d840498f47194d3d"
+checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
 dependencies = [
  "async-trait",
  "bytes",
@@ -464,15 +466,16 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.3.0-rc.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247a599903eb2e02abbaf2facc6396140df7af6dcc84e64ce3b71d117702fa22"
+checksum = "e4df0fc33ada14a338b799002f7e8657711422b25d4e16afb032708d6b185621"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -1798,7 +1801,7 @@ version = "0.1.0"
 dependencies = [
  "api",
  "async-trait",
- "axum 0.6.0-rc.2",
+ "axum 0.6.1",
  "axum-macros",
  "axum-test-helper",
  "backon",
@@ -3108,9 +3111,9 @@ checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "matchit"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfc802da7b1cf80aefffa0c7b2f77247c8b32206cc83c270b61264f5b360a80"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
 
 [[package]]
 name = "matrixmultiply"
@@ -5461,6 +5464,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5479,7 +5491,7 @@ dependencies = [
  "aide",
  "api",
  "async-trait",
- "axum 0.6.0-rc.2",
+ "axum 0.6.1",
  "axum-macros",
  "axum-test-helper",
  "bytes",
@@ -6178,7 +6190,7 @@ name = "tests-integration"
 version = "0.1.0"
 dependencies = [
  "api",
- "axum 0.6.0-rc.2",
+ "axum 0.6.1",
  "axum-test-helper",
  "catalog",
  "client",
@@ -6611,9 +6623,9 @@ dependencies = [
 
 [[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -11,8 +11,8 @@ python = ["dep:script"]
 [dependencies]
 api = { path = "../api" }
 async-trait = "0.1"
-axum = "0.6.0-rc.2"
-axum-macros = "0.3.0-rc.1"
+axum = "0.6"
+axum-macros = "0.3"
 backon = "0.2"
 catalog = { path = "../catalog" }
 common-base = { path = "../common/base" }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-aide = { version = "0.6", features = ["axum"] }
+aide = { version = "0.9", features = ["axum"] }
 api = { path = "../api" }
 async-trait = "0.1"
-axum = "0.6.0-rc.2"
-axum-macros = "0.3.0-rc.1"
+axum = "0.6"
+axum-macros = "0.3"
 bytes = "1.2"
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 api = { path = "../src/api" }
-axum = "0.6.0-rc.2"
+axum = "0.6"
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
 catalog = { path = "../src/catalog" }
 client = { path = "../src/client" }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- bump axum 0.6 from rc; refactor the way to nest routes and with_state
- ref: https://docs.rs/axum/0.6.1/axum/routing/struct.Router.html#method.with_state


## Refer to a related PR or issue link (optional)
(#642)