### PR TITLE
ci: change CI unit test trigger

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

There are some S3-related unit tests that need our secret to run. But the secret is not reachable in a forked repo. I find this [article](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks) from github's blog which says change `pull_request` to `pull_request_target` can solve this problem:
>In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. This event can be used in combination with the private repository settings as well.

Don't know if this works. Let us have a try.

## Checklist

- []  I have written the necessary rustdoc comments.
- []  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
