### PR TITLE
feat: support "use" stmt part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servers",
+ "session",
  "snafu",
  "sql",
  "storage",
@@ -2225,6 +2226,7 @@ dependencies = [
  "serde",
  "serde_json",
  "servers",
+ "session",
  "snafu",
  "sql",
  "sqlparser",
@@ -4508,6 +4510,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "session",
  "snafu",
  "sql",
  "statrs",
@@ -5359,6 +5362,7 @@ dependencies = [
  "rustpython-parser",
  "rustpython-vm",
  "serde",
+ "session",
  "snafu",
  "sql",
  "storage",
@@ -5528,6 +5532,7 @@ dependencies = [
  "script",
  "serde",
  "serde_json",
+ "session",
  "snafu",
  "snap",
  "table",
@@ -5541,6 +5546,13 @@ dependencies = [
  "tonic-reflection",
  "tower",
  "tower-http",
+]
+
+[[package]]
+name = "session"
+version = "0.1.0"
+dependencies = [
+ "arc-swap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,6 +5553,7 @@ name = "session"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "common-telemetry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "src/query",
     "src/script",
     "src/servers",
+    "src/session",
     "src/sql",
     "src/storage",
     "src/store-api",

--- a/src/common/catalog/src/helper.rs
+++ b/src/common/catalog/src/helper.rs
@@ -28,31 +28,42 @@ use crate::error::{
     DeserializeCatalogEntryValueSnafu, Error, InvalidCatalogSnafu, SerializeCatalogEntryValueSnafu,
 };
 
+const ALPHANUMERICS_NAME_PATTERN: &str = "[a-zA-Z_][a-zA-Z0-9_]*";
+
 lazy_static! {
-    static ref CATALOG_KEY_PATTERN: Regex =
-        Regex::new(&format!("^{}-([a-zA-Z_]+)$", CATALOG_KEY_PREFIX)).unwrap();
+    static ref CATALOG_KEY_PATTERN: Regex = Regex::new(&format!(
+        "^{}-({})$",
+        CATALOG_KEY_PREFIX, ALPHANUMERICS_NAME_PATTERN
+    ))
+    .unwrap();
 }
 
 lazy_static! {
     static ref SCHEMA_KEY_PATTERN: Regex = Regex::new(&format!(
-        "^{}-([a-zA-Z_]+)-([a-zA-Z_]+)$",
-        SCHEMA_KEY_PREFIX
+        "^{}-({})-({})$",
+        SCHEMA_KEY_PREFIX, ALPHANUMERICS_NAME_PATTERN, ALPHANUMERICS_NAME_PATTERN
     ))
     .unwrap();
 }
 
 lazy_static! {
     static ref TABLE_GLOBAL_KEY_PATTERN: Regex = Regex::new(&format!(
-        "^{}-([a-zA-Z_]+)-([a-zA-Z_]+)-([a-zA-Z0-9_]+)$",
-        TABLE_GLOBAL_KEY_PREFIX
+        "^{}-({})-({})-({})$",
+        TABLE_GLOBAL_KEY_PREFIX,
+        ALPHANUMERICS_NAME_PATTERN,
+        ALPHANUMERICS_NAME_PATTERN,
+        ALPHANUMERICS_NAME_PATTERN
     ))
     .unwrap();
 }
 
 lazy_static! {
     static ref TABLE_REGIONAL_KEY_PATTERN: Regex = Regex::new(&format!(
-        "^{}-([a-zA-Z_]+)-([a-zA-Z_]+)-([a-zA-Z0-9_]+)-([0-9]+)$",
-        TABLE_REGIONAL_KEY_PREFIX
+        "^{}-({})-({})-({})-([0-9]+)$",
+        TABLE_REGIONAL_KEY_PREFIX,
+        ALPHANUMERICS_NAME_PATTERN,
+        ALPHANUMERICS_NAME_PATTERN,
+        ALPHANUMERICS_NAME_PATTERN
     ))
     .unwrap();
 }

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -37,6 +37,7 @@ meta-srv = { path = "../meta-srv", features = ["mock"] }
 metrics = "0.20"
 object-store = { path = "../object-store" }
 query = { path = "../query" }
+session = { path = "../session" }
 script = { path = "../script", features = ["python"], optional = true }
 serde = "1.0"
 serde_json = "1.0"

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -28,7 +28,7 @@ use common_grpc_expr::insertion_expr_to_request;
 use common_query::Output;
 use query::plan::LogicalPlan;
 use servers::query_handler::{GrpcAdminHandler, GrpcQueryHandler};
-use session::context::SessionContext;
+use session::context::QueryContext;
 use snafu::prelude::*;
 use substrait::{DFLogicalSubstraitConvertor, SubstraitPlan};
 use table::requests::CreateDatabaseRequest;
@@ -114,8 +114,7 @@ impl Instance {
         let expr = select_expr.expr;
         match expr {
             Some(select_expr::Expr::Sql(sql)) => {
-                self.execute_sql(&sql, Arc::new(SessionContext::new()))
-                    .await
+                self.execute_sql(&sql, Arc::new(QueryContext::new())).await
             }
             Some(select_expr::Expr::LogicalPlan(plan)) => self.execute_logical(plan).await,
             Some(select_expr::Expr::PhysicalPlan(api::v1::PhysicalPlan { original_ql, plan })) => {

--- a/src/datanode/src/server/grpc/ddl.rs
+++ b/src/datanode/src/server/grpc/ddl.rs
@@ -21,7 +21,7 @@ use common_grpc_expr::{alter_expr_to_request, create_expr_to_request};
 use common_query::Output;
 use common_telemetry::{error, info};
 use futures::TryFutureExt;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use snafu::prelude::*;
 use table::requests::DropTableRequest;
 
@@ -78,7 +78,7 @@ impl Instance {
             .and_then(|request| {
                 self.sql_handler().execute(
                     SqlRequest::CreateTable(request),
-                    Arc::new(SessionContext::new()),
+                    Arc::new(QueryContext::new()),
                 )
             })
             .await;
@@ -113,7 +113,7 @@ impl Instance {
         let result = futures::future::ready(request)
             .and_then(|request| {
                 self.sql_handler()
-                    .execute(SqlRequest::Alter(request), Arc::new(SessionContext::new()))
+                    .execute(SqlRequest::Alter(request), Arc::new(QueryContext::new()))
             })
             .await;
         match result {
@@ -137,7 +137,7 @@ impl Instance {
         };
         let result = self
             .sql_handler()
-            .execute(SqlRequest::DropTable(req), Arc::new(SessionContext::new()))
+            .execute(SqlRequest::DropTable(req), Arc::new(QueryContext::new()))
             .await;
         match result {
             Ok(Output::AffectedRows(rows)) => AdminResultBuilder::default()

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use catalog::CatalogManagerRef;
 use common_query::Output;
 use common_telemetry::error;
 use query::query_engine::QueryEngineRef;
 use query::sql::{describe_table, explain, show_databases, show_tables};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use snafu::{OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
 use sql::statements::explain::Explain;
@@ -75,7 +73,7 @@ impl SqlHandler {
     pub async fn execute(
         &self,
         request: SqlRequest,
-        session_ctx: Arc<SessionContext>,
+        session_ctx: SessionContextRef,
     ) -> Result<Output> {
         let result = match request {
             SqlRequest::Insert(req) => self.insert(req).await,

--- a/src/datanode/src/sql/create.rs
+++ b/src/datanode/src/sql/create.rs
@@ -23,10 +23,10 @@ use common_telemetry::tracing::log::error;
 use datatypes::schema::SchemaBuilder;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::ast::TableConstraint;
+use sql::statements::column_def_to_schema;
 use sql::statements::create::CreateTable;
-use sql::statements::{column_def_to_schema, table_idents_to_full_name};
 use store_api::storage::consts::TIME_INDEX_NAME;
-use table::engine::EngineContext;
+use table::engine::{EngineContext, TableReference};
 use table::metadata::TableId;
 use table::requests::*;
 
@@ -114,12 +114,10 @@ impl SqlHandler {
         &self,
         table_id: TableId,
         stmt: CreateTable,
+        table_ref: TableReference,
     ) -> Result<CreateTableRequest> {
         let mut ts_index = usize::MAX;
         let mut primary_keys = vec![];
-
-        let (catalog_name, schema_name, table_name) =
-            table_idents_to_full_name(&stmt.name).context(error::ParseSqlSnafu)?;
 
         let col_map = stmt
             .columns
@@ -187,8 +185,8 @@ impl SqlHandler {
 
         if primary_keys.is_empty() {
             info!(
-                "Creating table: {:?}.{:?}.{} but primary key not set, use time index column: {}",
-                catalog_name, schema_name, table_name, ts_index
+                "Creating table: {} with time index column: {} upon primary keys absent",
+                table_ref, ts_index
             );
             primary_keys.push(ts_index);
         }
@@ -211,9 +209,9 @@ impl SqlHandler {
 
         let request = CreateTableRequest {
             id: table_id,
-            catalog_name,
-            schema_name,
-            table_name,
+            catalog_name: table_ref.catalog.to_string(),
+            schema_name: table_ref.schema.to_string(),
+            table_name: table_ref.table.to_string(),
             desc: None,
             schema,
             region_numbers: vec![0],
@@ -261,7 +259,9 @@ mod tests {
                        TIME INDEX (ts),
                        PRIMARY KEY(host)) engine=mito with(regions=1);"#,
         );
-        let c = handler.create_to_request(42, parsed_stmt).unwrap();
+        let c = handler
+            .create_to_request(42, parsed_stmt, TableReference::bare("demo_table"))
+            .unwrap();
         assert_eq!("demo_table", c.table_name);
         assert_eq!(42, c.id);
         assert!(!c.create_if_not_exists);
@@ -282,7 +282,9 @@ mod tests {
                       memory double,
                       PRIMARY KEY(host)) engine=mito with(regions=1);"#,
         );
-        let error = handler.create_to_request(42, parsed_stmt).unwrap_err();
+        let error = handler
+            .create_to_request(42, parsed_stmt, TableReference::bare("demo_table"))
+            .unwrap_err();
         assert_matches!(error, Error::MissingTimestampColumn { .. });
     }
 
@@ -299,7 +301,9 @@ mod tests {
                       memory double,
                       TIME INDEX (ts)) engine=mito with(regions=1);"#,
         );
-        let c = handler.create_to_request(42, parsed_stmt).unwrap();
+        let c = handler
+            .create_to_request(42, parsed_stmt, TableReference::bare("demo_table"))
+            .unwrap();
         assert_eq!(1, c.primary_key_indices.len());
         assert_eq!(
             c.schema.timestamp_index().unwrap(),
@@ -318,7 +322,9 @@ mod tests {
                 TIME INDEX (ts)) engine=mito with(regions=1);"#,
         );
 
-        let error = handler.create_to_request(42, parsed_stmt).unwrap_err();
+        let error = handler
+            .create_to_request(42, parsed_stmt, TableReference::bare("demo_table"))
+            .unwrap_err();
         assert_matches!(error, Error::KeyColumnNotFound { .. });
     }
 
@@ -338,7 +344,9 @@ mod tests {
 
         let handler = create_mock_sql_handler().await;
 
-        let error = handler.create_to_request(42, create_table).unwrap_err();
+        let error = handler
+            .create_to_request(42, create_table, TableReference::full("c", "s", "demo"))
+            .unwrap_err();
         assert_matches!(error, Error::InvalidPrimaryKey { .. });
     }
 
@@ -358,7 +366,9 @@ mod tests {
 
         let handler = create_mock_sql_handler().await;
 
-        let request = handler.create_to_request(42, create_table).unwrap();
+        let request = handler
+            .create_to_request(42, create_table, TableReference::full("c", "s", "demo"))
+            .unwrap();
 
         assert_eq!(42, request.id);
         assert_eq!("c".to_string(), request.catalog_name);

--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_query::Output;
 use common_recordbatch::util;
 use datafusion::arrow_print;
@@ -19,6 +22,7 @@ use datafusion_common::record_batch::RecordBatch as DfRecordBatch;
 use datatypes::arrow::array::{Int64Array, UInt64Array, Utf8Array};
 use datatypes::arrow_array::StringArray;
 use datatypes::prelude::ConcreteDataType;
+use session::context::SessionContext;
 
 use crate::instance::Instance;
 use crate::tests::test_util;
@@ -32,39 +36,33 @@ async fn test_create_database_and_insert_query() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    let output = instance.execute_sql("create database test").await.unwrap();
+    let output = execute_sql(&instance, "create database test").await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql(
-            r#"create table greptime.test.demo(
+    let output = execute_sql(
+        &instance,
+        r#"create table greptime.test.demo(
              host STRING,
              cpu DOUBLE,
              memory DOUBLE,
              ts bigint,
              TIME INDEX(ts)
 )"#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql(
-            r#"insert into test.demo(host, cpu, memory, ts) values
+    let output = execute_sql(
+        &instance,
+        r#"insert into test.demo(host, cpu, memory, ts) values
                            ('host1', 66.6, 1024, 1655276557000),
                            ('host2', 88.8,  333.3, 1655276558000)
                            "#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(2)));
 
-    let query_output = instance
-        .execute_sql("select ts from test.demo order by ts")
-        .await
-        .unwrap();
-
+    let query_output = execute_sql(&instance, "select ts from test.demo order by ts").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
@@ -88,54 +86,50 @@ async fn test_issue477_same_table_name_in_different_databases() {
     instance.start().await.unwrap();
 
     // Create database a and b
-    let output = instance.execute_sql("create database a").await.unwrap();
+    let output = execute_sql(&instance, "create database a").await;
     assert!(matches!(output, Output::AffectedRows(1)));
-    let output = instance.execute_sql("create database b").await.unwrap();
+    let output = execute_sql(&instance, "create database b").await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
     // Create table a.demo and b.demo
-    let output = instance
-        .execute_sql(
-            r#"create table a.demo(
+    let output = execute_sql(
+        &instance,
+        r#"create table a.demo(
              host STRING,
              ts bigint,
              TIME INDEX(ts)
 )"#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql(
-            r#"create table b.demo(
+    let output = execute_sql(
+        &instance,
+        r#"create table b.demo(
              host STRING,
              ts bigint,
              TIME INDEX(ts)
 )"#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
     // Insert different data into a.demo and b.demo
-    let output = instance
-        .execute_sql(
-            r#"insert into a.demo(host, ts) values
+    let output = execute_sql(
+        &instance,
+        r#"insert into a.demo(host, ts) values
                            ('host1', 1655276557000)
                            "#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
-    let output = instance
-        .execute_sql(
-            r#"insert into b.demo(host, ts) values
+    let output = execute_sql(
+        &instance,
+        r#"insert into b.demo(host, ts) values
                            ('host2',1655276558000)
                            "#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
     // Query data and assert
@@ -157,7 +151,7 @@ async fn test_issue477_same_table_name_in_different_databases() {
 }
 
 async fn assert_query_result(instance: &Instance, sql: &str, ts: i64, host: &str) {
-    let query_output = instance.execute_sql(sql).await.unwrap();
+    let query_output = execute_sql(instance, sql).await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
@@ -200,15 +194,14 @@ async fn setup_test_instance() -> Instance {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_execute_insert() {
     let instance = setup_test_instance().await;
-    let output = instance
-        .execute_sql(
-            r#"insert into demo(host, cpu, memory, ts) values
+    let output = execute_sql(
+        &instance,
+        r#"insert into demo(host, cpu, memory, ts) values
                            ('host1', 66.6, 1024, 1655276557000),
                            ('host2', 88.8,  333.3, 1655276558000)
                            "#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(2)));
 }
 
@@ -228,22 +221,17 @@ async fn test_execute_insert_query_with_i64_timestamp() {
     .await
     .unwrap();
 
-    let output = instance
-        .execute_sql(
-            r#"insert into demo(host, cpu, memory, ts) values
+    let output = execute_sql(
+        &instance,
+        r#"insert into demo(host, cpu, memory, ts) values
                            ('host1', 66.6, 1024, 1655276557000),
                            ('host2', 88.8,  333.3, 1655276558000)
                            "#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(2)));
 
-    let query_output = instance
-        .execute_sql("select ts from demo order by ts")
-        .await
-        .unwrap();
-
+    let query_output = execute_sql(&instance, "select ts from demo order by ts").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
@@ -257,11 +245,7 @@ async fn test_execute_insert_query_with_i64_timestamp() {
         _ => unreachable!(),
     }
 
-    let query_output = instance
-        .execute_sql("select ts as time from demo order by ts")
-        .await
-        .unwrap();
-
+    let query_output = execute_sql(&instance, "select ts as time from demo order by ts").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
@@ -282,10 +266,7 @@ async fn test_execute_query() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    let output = instance
-        .execute_sql("select sum(number) from numbers limit 20")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "select sum(number) from numbers limit 20").await;
     match output {
         Output::Stream(recordbatch) => {
             let numbers = util::collect(recordbatch).await.unwrap();
@@ -309,7 +290,7 @@ async fn test_execute_show_databases_tables() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    let output = instance.execute_sql("show databases").await.unwrap();
+    let output = execute_sql(&instance, "show databases").await;
     match output {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
@@ -325,10 +306,7 @@ async fn test_execute_show_databases_tables() {
         _ => unreachable!(),
     }
 
-    let output = instance
-        .execute_sql("show databases like '%bl%'")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "show databases like '%bl%'").await;
     match output {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
@@ -344,7 +322,7 @@ async fn test_execute_show_databases_tables() {
         _ => unreachable!(),
     }
 
-    let output = instance.execute_sql("show tables").await.unwrap();
+    let output = execute_sql(&instance, "show tables").await;
     match output {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
@@ -364,7 +342,7 @@ async fn test_execute_show_databases_tables() {
     .await
     .unwrap();
 
-    let output = instance.execute_sql("show tables").await.unwrap();
+    let output = execute_sql(&instance, "show tables").await;
     match output {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
@@ -376,10 +354,7 @@ async fn test_execute_show_databases_tables() {
     }
 
     // show tables like [string]
-    let output = instance
-        .execute_sql("show tables like 'de%'")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "show tables like 'de%'").await;
     match output {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
@@ -404,9 +379,9 @@ pub async fn test_execute_create() {
     let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
     instance.start().await.unwrap();
 
-    let output = instance
-        .execute_sql(
-            r#"create table test_table(
+    let output = execute_sql(
+        &instance,
+        r#"create table test_table(
                             host string,
                             ts timestamp,
                             cpu double default 0,
@@ -414,56 +389,24 @@ pub async fn test_execute_create() {
                             TIME INDEX (ts),
                             PRIMARY KEY(host)
                         ) engine=mito with(regions=1);"#,
-        )
-        .await
-        .unwrap();
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 }
 
-#[tokio::test(flavor = "multi_thread")]
-pub async fn test_create_table_illegal_timestamp_type() {
-    common_telemetry::init_default_ut_logging();
-
-    let (opts, _guard) =
-        test_util::create_tmp_dir_and_datanode_opts("create_table_illegal_timestamp_type");
-    let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
-    instance.start().await.unwrap();
-
-    let output = instance
-        .execute_sql(
-            r#"create table test_table(
-                            host string,
-                            ts bigint,
-                            cpu double default 0,
-                            memory double,
-                            TIME INDEX (ts),
-                            PRIMARY KEY(host)
-                        ) engine=mito with(regions=1);"#,
-        )
-        .await
-        .unwrap();
-    match output {
-        Output::AffectedRows(rows) => {
-            assert_eq!(1, rows);
-        }
-        _ => unreachable!(),
-    }
-}
-
 async fn check_output_stream(output: Output, expected: Vec<&str>) {
-    match output {
-        Output::Stream(stream) => {
-            let recordbatches = util::collect(stream).await.unwrap();
-            let recordbatch = recordbatches
-                .into_iter()
-                .map(|r| r.df_recordbatch)
-                .collect::<Vec<DfRecordBatch>>();
-            let pretty_print = arrow_print::write(&recordbatch);
-            let pretty_print = pretty_print.lines().collect::<Vec<&str>>();
-            assert_eq!(pretty_print, expected);
-        }
+    let recordbatches = match output {
+        Output::Stream(stream) => util::collect(stream).await.unwrap(),
+        Output::RecordBatches(recordbatches) => recordbatches.take(),
         _ => unreachable!(),
-    }
+    };
+    let recordbatches = recordbatches
+        .into_iter()
+        .map(|r| r.df_recordbatch)
+        .collect::<Vec<DfRecordBatch>>();
+    let pretty_print = arrow_print::write(&recordbatches);
+    let pretty_print = pretty_print.lines().collect::<Vec<&str>>();
+    assert_eq!(pretty_print, expected);
 }
 
 #[tokio::test]
@@ -479,35 +422,30 @@ async fn test_alter_table() {
     .await
     .unwrap();
     // make sure table insertion is ok before altering table
-    instance
-        .execute_sql("insert into demo(host, cpu, memory, ts) values ('host1', 1.1, 100, 1000)")
-        .await
-        .unwrap();
+    execute_sql(
+        &instance,
+        "insert into demo(host, cpu, memory, ts) values ('host1', 1.1, 100, 1000)",
+    )
+    .await;
 
     // Add column
-    let output = instance
-        .execute_sql("alter table demo add my_tag string null")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "alter table demo add my_tag string null").await;
     assert!(matches!(output, Output::AffectedRows(0)));
 
-    let output = instance
-        .execute_sql(
-            "insert into demo(host, cpu, memory, ts, my_tag) values ('host2', 2.2, 200, 2000, 'hello')",
-        )
-        .await
-        .unwrap();
+    let output = execute_sql(
+        &instance,
+        "insert into demo(host, cpu, memory, ts, my_tag) values ('host2', 2.2, 200, 2000, 'hello')",
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
-    let output = instance
-        .execute_sql("insert into demo(host, cpu, memory, ts) values ('host3', 3.3, 300, 3000)")
-        .await
-        .unwrap();
+    let output = execute_sql(
+        &instance,
+        "insert into demo(host, cpu, memory, ts) values ('host3', 3.3, 300, 3000)",
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql("select * from demo order by ts")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "select * from demo order by ts").await;
     let expected = vec![
         "+-------+-----+--------+---------------------+--------+",
         "| host  | cpu | memory | ts                  | my_tag |",
@@ -520,16 +458,10 @@ async fn test_alter_table() {
     check_output_stream(output, expected).await;
 
     // Drop a column
-    let output = instance
-        .execute_sql("alter table demo drop column memory")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "alter table demo drop column memory").await;
     assert!(matches!(output, Output::AffectedRows(0)));
 
-    let output = instance
-        .execute_sql("select * from demo order by ts")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "select * from demo order by ts").await;
     let expected = vec![
         "+-------+-----+---------------------+--------+",
         "| host  | cpu | ts                  | my_tag |",
@@ -542,16 +474,14 @@ async fn test_alter_table() {
     check_output_stream(output, expected).await;
 
     // insert a new row
-    let output = instance
-        .execute_sql("insert into demo(host, cpu, ts, my_tag) values ('host4', 400, 4000, 'world')")
-        .await
-        .unwrap();
+    let output = execute_sql(
+        &instance,
+        "insert into demo(host, cpu, ts, my_tag) values ('host4', 400, 4000, 'world')",
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql("select * from demo order by ts")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "select * from demo order by ts").await;
     let expected = vec![
         "+-------+-----+---------------------+--------+",
         "| host  | cpu | ts                  | my_tag |",
@@ -580,27 +510,26 @@ async fn test_insert_with_default_value_for_type(type_name: &str) {
     ) engine=mito with(regions=1);"#,
         type_name
     );
-    let output = instance.execute_sql(&create_sql).await.unwrap();
+    let output = execute_sql(&instance, &create_sql).await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
     // Insert with ts.
-    instance
-        .execute_sql("insert into test_table(host, cpu, ts) values ('host1', 1.1, 1000)")
-        .await
-        .unwrap();
+    let output = execute_sql(
+        &instance,
+        "insert into test_table(host, cpu, ts) values ('host1', 1.1, 1000)",
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
     // Insert without ts, so it should be filled by default value.
-    let output = instance
-        .execute_sql("insert into test_table(host, cpu) values ('host2', 2.2)")
-        .await
-        .unwrap();
+    let output = execute_sql(
+        &instance,
+        "insert into test_table(host, cpu) values ('host2', 2.2)",
+    )
+    .await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let output = instance
-        .execute_sql("select host, cpu from test_table")
-        .await
-        .unwrap();
+    let output = execute_sql(&instance, "select host, cpu from test_table").await;
     let expected = vec![
         "+-------+-----+",
         "| host  | cpu |",
@@ -618,4 +547,71 @@ async fn test_insert_with_default_value() {
 
     test_insert_with_default_value_for_type("timestamp").await;
     test_insert_with_default_value_for_type("bigint").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_use_database() {
+    let (opts, _guard) = test_util::create_tmp_dir_and_datanode_opts("use_database");
+    let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
+    instance.start().await.unwrap();
+
+    let output = execute_sql(&instance, "create database db1").await;
+    assert!(matches!(output, Output::AffectedRows(1)));
+
+    let output = execute_sql_in_db(
+        &instance,
+        "create table tb1(col_i32 int, ts bigint, TIME INDEX(ts))",
+        "db1",
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(1)));
+
+    let output = execute_sql_in_db(&instance, "show tables", "db1").await;
+    let expected = vec![
+        "+--------+",
+        "| Tables |",
+        "+--------+",
+        "| tb1    |",
+        "+--------+",
+    ];
+    check_output_stream(output, expected).await;
+
+    let output = execute_sql_in_db(
+        &instance,
+        r#"insert into tb1(col_i32, ts) values (1, 1655276557000)"#,
+        "db1",
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(1)));
+
+    let output = execute_sql_in_db(&instance, "select col_i32 from tb1", "db1").await;
+    let expected = vec![
+        "+---------+",
+        "| col_i32 |",
+        "+---------+",
+        "| 1       |",
+        "+---------+",
+    ];
+    check_output_stream(output, expected).await;
+
+    // Making a particular database the default by means of the USE statement does not preclude
+    // accessing tables in other databases.
+    let output = execute_sql(&instance, "select number from public.numbers limit 1").await;
+    let expected = vec![
+        "+--------+",
+        "| number |",
+        "+--------+",
+        "| 0      |",
+        "+--------+",
+    ];
+    check_output_stream(output, expected).await;
+}
+
+async fn execute_sql(instance: &Instance, sql: &str) -> Output {
+    execute_sql_in_db(instance, sql, DEFAULT_SCHEMA_NAME).await
+}
+
+async fn execute_sql_in_db(instance: &Instance, sql: &str, db: &str) -> Output {
+    let session_ctx = Arc::new(SessionContext::with_current_schema(db.to_string()));
+    instance.execute_sql(sql, session_ctx).await.unwrap()
 }

--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -22,7 +22,7 @@ use datafusion_common::record_batch::RecordBatch as DfRecordBatch;
 use datatypes::arrow::array::{Int64Array, UInt64Array, Utf8Array};
 use datatypes::arrow_array::StringArray;
 use datatypes::prelude::ConcreteDataType;
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 use crate::instance::Instance;
 use crate::tests::test_util;
@@ -612,6 +612,6 @@ async fn execute_sql(instance: &Instance, sql: &str) -> Output {
 }
 
 async fn execute_sql_in_db(instance: &Instance, sql: &str, db: &str) -> Output {
-    let session_ctx = Arc::new(SessionContext::with_current_schema(db.to_string()));
-    instance.execute_sql(sql, session_ctx).await.unwrap()
+    let query_ctx = Arc::new(QueryContext::with_current_schema(db.to_string()));
+    instance.execute_sql(sql, query_ctx).await.unwrap()
 }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -38,6 +38,7 @@ prost = "0.11"
 query = { path = "../query" }
 serde = "1.0"
 serde_json = "1.0"
+session = { path = "../session" }
 sqlparser = "0.15"
 servers = { path = "../servers" }
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -33,7 +33,7 @@ use meta_client::rpc::{
 };
 use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::create::Partitions;
 use sql::statements::sql_value_to_value;
@@ -133,23 +133,23 @@ impl DistInstance {
         &self,
         sql: &str,
         stmt: Statement,
-        session_ctx: SessionContextRef,
+        query_ctx: QueryContextRef,
     ) -> Result<Output> {
         match stmt {
             Statement::Query(_) => {
                 let plan = self
                     .query_engine
-                    .statement_to_plan(stmt, session_ctx)
+                    .statement_to_plan(stmt, query_ctx)
                     .context(error::ExecuteSqlSnafu { sql })?;
                 self.query_engine.execute(&plan).await
             }
             Statement::ShowDatabases(stmt) => show_databases(stmt, self.catalog_manager.clone()),
             Statement::ShowTables(stmt) => {
-                show_tables(stmt, self.catalog_manager.clone(), session_ctx)
+                show_tables(stmt, self.catalog_manager.clone(), query_ctx)
             }
             Statement::DescribeTable(stmt) => describe_table(stmt, self.catalog_manager.clone()),
             Statement::Explain(stmt) => {
-                explain(Box::new(stmt), self.query_engine.clone(), session_ctx).await
+                explain(Box::new(stmt), self.query_engine.clone(), query_ctx).await
             }
             _ => unreachable!(),
         }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -33,7 +33,7 @@ use meta_client::rpc::{
 };
 use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::create::Partitions;
 use sql::statements::sql_value_to_value;
@@ -133,7 +133,7 @@ impl DistInstance {
         &self,
         sql: &str,
         stmt: Statement,
-        session_ctx: Arc<SessionContext>,
+        session_ctx: SessionContextRef,
     ) -> Result<Output> {
         match stmt {
             Statement::Query(_) => {

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -60,9 +60,12 @@ impl Instance {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use common_query::Output;
     use datafusion::arrow_print;
     use servers::query_handler::SqlQueryHandler;
+    use session::context::SessionContext;
 
     use super::*;
     use crate::tests;
@@ -121,7 +124,7 @@ mod tests {
         assert!(result.is_ok());
 
         let output = instance
-            .do_query("select * from my_metric_1")
+            .do_query("select * from my_metric_1", Arc::new(SessionContext::new()))
             .await
             .unwrap();
         match output {

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -65,7 +65,7 @@ mod tests {
     use common_query::Output;
     use datafusion::arrow_print;
     use servers::query_handler::SqlQueryHandler;
-    use session::context::SessionContext;
+    use session::context::QueryContext;
 
     use super::*;
     use crate::tests;
@@ -124,7 +124,7 @@ mod tests {
         assert!(result.is_ok());
 
         let output = instance
-            .do_query("select * from my_metric_1", Arc::new(SessionContext::new()))
+            .do_query("select * from my_metric_1", Arc::new(QueryContext::new()))
             .await
             .unwrap();
         match output {

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -27,7 +27,7 @@ use servers::error::{self, Result as ServerResult};
 use servers::prometheus::{self, Metrics};
 use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse};
 use servers::Mode;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use snafu::{OptionExt, ResultExt};
 
 use crate::instance::{parse_stmt, Instance};
@@ -97,9 +97,8 @@ impl Instance {
             let object_result = if let Some(dist_instance) = &self.dist_instance {
                 let output = futures::future::ready(parse_stmt(&sql))
                     .and_then(|stmt| {
-                        let session_ctx =
-                            Arc::new(SessionContext::with_current_schema(db.to_string()));
-                        dist_instance.handle_sql(&sql, stmt, session_ctx)
+                        let query_ctx = Arc::new(QueryContext::with_current_schema(db.to_string()));
+                        dist_instance.handle_sql(&sql, stmt, query_ctx)
                     })
                     .await;
                 to_object_result(output).await.try_into()

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -27,6 +27,7 @@ metrics = "0.20"
 once_cell = "1.10"
 serde = "1.0"
 serde_json = "1.0"
+session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -32,7 +32,7 @@ use common_recordbatch::{EmptyRecordBatchStream, SendableRecordBatchStream};
 use common_telemetry::timer;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::ExecutionPlan;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use snafu::{OptionExt, ResultExt};
 use sql::dialect::GenericDialect;
 use sql::parser::ParserContext;
@@ -80,7 +80,7 @@ impl QueryEngine for DatafusionQueryEngine {
     fn statement_to_plan(
         &self,
         stmt: Statement,
-        session_ctx: Arc<SessionContext>,
+        session_ctx: SessionContextRef,
     ) -> Result<LogicalPlan> {
         let context_provider = DfContextProviderAdapter::new(self.state.clone(), session_ctx);
         let planner = DfPlanner::new(&context_provider);
@@ -88,7 +88,7 @@ impl QueryEngine for DatafusionQueryEngine {
         planner.statement_to_plan(stmt)
     }
 
-    fn sql_to_plan(&self, sql: &str, session_ctx: Arc<SessionContext>) -> Result<LogicalPlan> {
+    fn sql_to_plan(&self, sql: &str, session_ctx: SessionContextRef) -> Result<LogicalPlan> {
         let _timer = timer!(metric::METRIC_PARSE_SQL_ELAPSED);
         let stmt = self.sql_to_statement(sql)?;
         self.statement_to_plan(stmt, session_ctx)

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -21,7 +21,7 @@ use datafusion::physical_plan::udaf::AggregateUDF;
 use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use datatypes::arrow::datatypes::DataType;
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use snafu::ResultExt;
 use sql::statements::explain::Explain;
 use sql::statements::query::Query;
@@ -94,12 +94,12 @@ where
 
 pub(crate) struct DfContextProviderAdapter {
     state: QueryEngineState,
-    session_ctx: SessionContextRef,
+    query_ctx: QueryContextRef,
 }
 
 impl DfContextProviderAdapter {
-    pub(crate) fn new(state: QueryEngineState, session_ctx: SessionContextRef) -> Self {
-        Self { state, session_ctx }
+    pub(crate) fn new(state: QueryEngineState, query_ctx: QueryContextRef) -> Self {
+        Self { state, query_ctx }
     }
 }
 
@@ -107,7 +107,7 @@ impl DfContextProviderAdapter {
 ///                           manage UDFs, UDAFs, variables by ourself in future.
 impl ContextProvider for DfContextProviderAdapter {
     fn get_table_provider(&self, name: TableReference) -> Option<Arc<dyn TableProvider>> {
-        let schema = self.session_ctx.current_schema();
+        let schema = self.query_ctx.current_schema();
         let execution_ctx = self.state.df_context().state.lock();
         match name {
             TableReference::Bare { table } if schema.is_some() => {

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -21,7 +21,7 @@ use datafusion::physical_plan::udaf::AggregateUDF;
 use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use datatypes::arrow::datatypes::DataType;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use snafu::ResultExt;
 use sql::statements::explain::Explain;
 use sql::statements::query::Query;
@@ -94,11 +94,11 @@ where
 
 pub(crate) struct DfContextProviderAdapter {
     state: QueryEngineState,
-    session_ctx: Arc<SessionContext>,
+    session_ctx: SessionContextRef,
 }
 
 impl DfContextProviderAdapter {
-    pub(crate) fn new(state: QueryEngineState, session_ctx: Arc<SessionContext>) -> Self {
+    pub(crate) fn new(state: QueryEngineState, session_ctx: SessionContextRef) -> Self {
         Self { state, session_ctx }
     }
 }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -86,7 +86,8 @@ where
             | Statement::CreateDatabase(_)
             | Statement::Alter(_)
             | Statement::Insert(_)
-            | Statement::DropTable(_) => unreachable!(),
+            | Statement::DropTable(_)
+            | Statement::Use(_) => unreachable!(),
         }
     }
 }

--- a/src/query/src/executor.rs
+++ b/src/query/src/executor.rs
@@ -18,14 +18,14 @@ use common_query::physical_plan::PhysicalPlan;
 use common_recordbatch::SendableRecordBatchStream;
 
 use crate::error::Result;
-use crate::query_engine::QueryContext;
+use crate::query_engine::QueryEngineContext;
 
 /// Executor to run [ExecutionPlan].
 #[async_trait::async_trait]
 pub trait QueryExecutor {
     async fn execute_stream(
         &self,
-        ctx: &QueryContext,
+        ctx: &QueryEngineContext,
         plan: &Arc<dyn PhysicalPlan>,
     ) -> Result<SendableRecordBatchStream>;
 }

--- a/src/query/src/lib.rs
+++ b/src/query/src/lib.rs
@@ -26,4 +26,6 @@ pub mod planner;
 pub mod query_engine;
 pub mod sql;
 
-pub use crate::query_engine::{QueryContext, QueryEngine, QueryEngineFactory, QueryEngineRef};
+pub use crate::query_engine::{
+    QueryEngine, QueryEngineContext, QueryEngineFactory, QueryEngineRef,
+};

--- a/src/query/src/logical_optimizer.rs
+++ b/src/query/src/logical_optimizer.rs
@@ -14,12 +14,12 @@
 
 use crate::error::Result;
 use crate::plan::LogicalPlan;
-use crate::query_engine::QueryContext;
+use crate::query_engine::QueryEngineContext;
 
 pub trait LogicalOptimizer {
     fn optimize_logical_plan(
         &self,
-        ctx: &mut QueryContext,
+        ctx: &mut QueryEngineContext,
         plan: &LogicalPlan,
     ) -> Result<LogicalPlan>;
 }

--- a/src/query/src/physical_optimizer.rs
+++ b/src/query/src/physical_optimizer.rs
@@ -17,12 +17,12 @@ use std::sync::Arc;
 use common_query::physical_plan::PhysicalPlan;
 
 use crate::error::Result;
-use crate::query_engine::QueryContext;
+use crate::query_engine::QueryEngineContext;
 
 pub trait PhysicalOptimizer {
     fn optimize_physical_plan(
         &self,
-        ctx: &mut QueryContext,
+        ctx: &mut QueryEngineContext,
         plan: Arc<dyn PhysicalPlan>,
     ) -> Result<Arc<dyn PhysicalPlan>>;
 }

--- a/src/query/src/physical_planner.rs
+++ b/src/query/src/physical_planner.rs
@@ -18,7 +18,7 @@ use common_query::physical_plan::PhysicalPlan;
 
 use crate::error::Result;
 use crate::plan::LogicalPlan;
-use crate::query_engine::QueryContext;
+use crate::query_engine::QueryEngineContext;
 
 /// Physical query planner that converts a `LogicalPlan` to an
 /// `ExecutionPlan` suitable for execution.
@@ -27,7 +27,7 @@ pub trait PhysicalPlanner {
     /// Create a physical plan from a logical plan
     async fn create_physical_plan(
         &self,
-        ctx: &mut QueryContext,
+        ctx: &mut QueryEngineContext,
         logical_plan: &LogicalPlan,
     ) -> Result<Arc<dyn PhysicalPlan>>;
 }

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -23,7 +23,7 @@ use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
 use common_query::physical_plan::PhysicalPlan;
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use sql::statements::statement::Statement;
 
 use crate::datafusion::DatafusionQueryEngine;
@@ -41,10 +41,10 @@ pub trait QueryEngine: Send + Sync {
     fn statement_to_plan(
         &self,
         stmt: Statement,
-        session_ctx: Arc<SessionContext>,
+        session_ctx: SessionContextRef,
     ) -> Result<LogicalPlan>;
 
-    fn sql_to_plan(&self, sql: &str, session_ctx: Arc<SessionContext>) -> Result<LogicalPlan>;
+    fn sql_to_plan(&self, sql: &str, session_ctx: SessionContextRef) -> Result<LogicalPlan>;
 
     async fn execute(&self, plan: &LogicalPlan) -> Result<Output>;
 

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -23,13 +23,13 @@ use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
 use common_query::physical_plan::PhysicalPlan;
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use sql::statements::statement::Statement;
 
 use crate::datafusion::DatafusionQueryEngine;
 use crate::error::Result;
 use crate::plan::LogicalPlan;
-pub use crate::query_engine::context::QueryContext;
+pub use crate::query_engine::context::QueryEngineContext;
 pub use crate::query_engine::state::QueryEngineState;
 
 #[async_trait::async_trait]
@@ -38,13 +38,10 @@ pub trait QueryEngine: Send + Sync {
 
     fn sql_to_statement(&self, sql: &str) -> Result<Statement>;
 
-    fn statement_to_plan(
-        &self,
-        stmt: Statement,
-        session_ctx: SessionContextRef,
-    ) -> Result<LogicalPlan>;
+    fn statement_to_plan(&self, stmt: Statement, query_ctx: QueryContextRef)
+        -> Result<LogicalPlan>;
 
-    fn sql_to_plan(&self, sql: &str, session_ctx: SessionContextRef) -> Result<LogicalPlan>;
+    fn sql_to_plan(&self, sql: &str, query_ctx: QueryContextRef) -> Result<LogicalPlan>;
 
     async fn execute(&self, plan: &LogicalPlan) -> Result<Output>;
 

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -23,6 +23,7 @@ use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
 use common_query::physical_plan::PhysicalPlan;
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
+use session::context::SessionContext;
 use sql::statements::statement::Statement;
 
 use crate::datafusion::DatafusionQueryEngine;
@@ -37,9 +38,13 @@ pub trait QueryEngine: Send + Sync {
 
     fn sql_to_statement(&self, sql: &str) -> Result<Statement>;
 
-    fn statement_to_plan(&self, stmt: Statement) -> Result<LogicalPlan>;
+    fn statement_to_plan(
+        &self,
+        stmt: Statement,
+        session_ctx: Arc<SessionContext>,
+    ) -> Result<LogicalPlan>;
 
-    fn sql_to_plan(&self, sql: &str) -> Result<LogicalPlan>;
+    fn sql_to_plan(&self, sql: &str, session_ctx: Arc<SessionContext>) -> Result<LogicalPlan>;
 
     async fn execute(&self, plan: &LogicalPlan) -> Result<Output>;
 

--- a/src/query/src/query_engine/context.rs
+++ b/src/query/src/query_engine/context.rs
@@ -16,11 +16,11 @@
 use crate::query_engine::state::QueryEngineState;
 
 #[derive(Debug)]
-pub struct QueryContext {
+pub struct QueryEngineContext {
     state: QueryEngineState,
 }
 
-impl QueryContext {
+impl QueryEngineContext {
     pub fn new(state: QueryEngineState) -> Self {
         Self { state }
     }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -22,7 +22,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::{Helper, StringVector};
 use once_cell::sync::Lazy;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
 use sql::statements::explain::Explain;
@@ -113,7 +113,7 @@ pub fn show_databases(stmt: ShowDatabases, catalog_manager: CatalogManagerRef) -
 pub fn show_tables(
     stmt: ShowTables,
     catalog_manager: CatalogManagerRef,
-    session_ctx: Arc<SessionContext>,
+    session_ctx: SessionContextRef,
 ) -> Result<Output> {
     // TODO(LFC): supports WHERE
     ensure!(
@@ -155,7 +155,7 @@ pub fn show_tables(
 pub async fn explain(
     stmt: Box<Explain>,
     query_engine: QueryEngineRef,
-    session_ctx: Arc<SessionContext>,
+    session_ctx: SessionContextRef,
 ) -> Result<Output> {
     let plan = query_engine.statement_to_plan(Statement::Explain(*stmt), session_ctx)?;
     query_engine.execute(&plan).await

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -22,7 +22,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::{Helper, StringVector};
 use once_cell::sync::Lazy;
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
 use sql::statements::explain::Explain;
@@ -113,7 +113,7 @@ pub fn show_databases(stmt: ShowDatabases, catalog_manager: CatalogManagerRef) -
 pub fn show_tables(
     stmt: ShowTables,
     catalog_manager: CatalogManagerRef,
-    session_ctx: SessionContextRef,
+    query_ctx: QueryContextRef,
 ) -> Result<Output> {
     // TODO(LFC): supports WHERE
     ensure!(
@@ -126,7 +126,7 @@ pub fn show_tables(
     let schema = if let Some(database) = stmt.database {
         database
     } else {
-        session_ctx
+        query_ctx
             .current_schema()
             .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string())
     };
@@ -155,9 +155,9 @@ pub fn show_tables(
 pub async fn explain(
     stmt: Box<Explain>,
     query_engine: QueryEngineRef,
-    session_ctx: SessionContextRef,
+    query_ctx: QueryContextRef,
 ) -> Result<Output> {
-    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt), session_ctx)?;
+    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt), query_ctx)?;
     query_engine.execute(&plan).await
 }
 

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -22,6 +22,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::{Helper, StringVector};
 use once_cell::sync::Lazy;
+use session::context::SessionContext;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::describe::DescribeTable;
 use sql::statements::explain::Explain;
@@ -109,7 +110,11 @@ pub fn show_databases(stmt: ShowDatabases, catalog_manager: CatalogManagerRef) -
     Ok(Output::RecordBatches(records))
 }
 
-pub fn show_tables(stmt: ShowTables, catalog_manager: CatalogManagerRef) -> Result<Output> {
+pub fn show_tables(
+    stmt: ShowTables,
+    catalog_manager: CatalogManagerRef,
+    session_ctx: Arc<SessionContext>,
+) -> Result<Output> {
     // TODO(LFC): supports WHERE
     ensure!(
         matches!(stmt.kind, ShowKind::All | ShowKind::Like(_)),
@@ -118,9 +123,15 @@ pub fn show_tables(stmt: ShowTables, catalog_manager: CatalogManagerRef) -> Resu
         }
     );
 
-    let schema = stmt.database.as_deref().unwrap_or(DEFAULT_SCHEMA_NAME);
+    let schema = if let Some(database) = stmt.database {
+        database
+    } else {
+        session_ctx
+            .current_schema()
+            .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string())
+    };
     let schema = catalog_manager
-        .schema(DEFAULT_CATALOG_NAME, schema)
+        .schema(DEFAULT_CATALOG_NAME, &schema)
         .context(error::CatalogSnafu)?
         .context(error::SchemaNotFoundSnafu { schema })?;
     let tables = schema.table_names().context(error::CatalogSnafu)?;
@@ -141,8 +152,12 @@ pub fn show_tables(stmt: ShowTables, catalog_manager: CatalogManagerRef) -> Resu
     Ok(Output::RecordBatches(records))
 }
 
-pub async fn explain(stmt: Box<Explain>, query_engine: QueryEngineRef) -> Result<Output> {
-    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt))?;
+pub async fn explain(
+    stmt: Box<Explain>,
+    query_engine: QueryEngineRef,
+    session_ctx: Arc<SessionContext>,
+) -> Result<Output> {
+    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt), session_ctx)?;
     query_engine.execute(&plan).await
 }
 

--- a/src/query/tests/argmax_test.rs
+++ b/src/query/tests/argmax_test.rs
@@ -24,7 +24,7 @@ use datatypes::types::PrimitiveElement;
 use function::{create_query_engine, get_numbers_from_table};
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 #[tokio::test]
 async fn test_argmax_aggregator() -> Result<()> {
@@ -97,7 +97,7 @@ async fn execute_argmax<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/argmax_test.rs
+++ b/src/query/tests/argmax_test.rs
@@ -24,6 +24,7 @@ use datatypes::types::PrimitiveElement;
 use function::{create_query_engine, get_numbers_from_table};
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 
 #[tokio::test]
 async fn test_argmax_aggregator() -> Result<()> {
@@ -95,7 +96,9 @@ async fn execute_argmax<'a>(
         "select ARGMAX({}) as argmax from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/argmin_test.rs
+++ b/src/query/tests/argmin_test.rs
@@ -25,7 +25,7 @@ use datatypes::types::PrimitiveElement;
 use function::{create_query_engine, get_numbers_from_table};
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 #[tokio::test]
 async fn test_argmin_aggregator() -> Result<()> {
@@ -98,7 +98,7 @@ async fn execute_argmin<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/argmin_test.rs
+++ b/src/query/tests/argmin_test.rs
@@ -25,6 +25,7 @@ use datatypes::types::PrimitiveElement;
 use function::{create_query_engine, get_numbers_from_table};
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 
 #[tokio::test]
 async fn test_argmin_aggregator() -> Result<()> {
@@ -96,7 +97,9 @@ async fn execute_argmin<'a>(
         "select argmin({}) as argmin from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/function.rs
+++ b/src/query/tests/function.rs
@@ -27,7 +27,7 @@ use datatypes::vectors::PrimitiveVector;
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use table::test_util::MemTable;
 
 pub fn create_query_engine() -> Arc<dyn QueryEngine> {
@@ -82,7 +82,7 @@ where
 {
     let sql = format!("SELECT {} FROM {}", column_name, table_name);
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/function.rs
+++ b/src/query/tests/function.rs
@@ -27,6 +27,7 @@ use datatypes::vectors::PrimitiveVector;
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
+use session::context::SessionContext;
 use table::test_util::MemTable;
 
 pub fn create_query_engine() -> Arc<dyn QueryEngine> {
@@ -80,7 +81,9 @@ where
     for<'a> T: Scalar<RefType<'a> = T>,
 {
     let sql = format!("SELECT {} FROM {}", column_name, table_name);
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/mean_test.rs
+++ b/src/query/tests/mean_test.rs
@@ -28,7 +28,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 #[tokio::test]
 async fn test_mean_aggregator() -> Result<()> {
@@ -91,7 +91,7 @@ async fn execute_mean<'a>(
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select MEAN({}) as mean from {}", column_name, table_name);
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/mean_test.rs
+++ b/src/query/tests/mean_test.rs
@@ -28,6 +28,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 
 #[tokio::test]
 async fn test_mean_aggregator() -> Result<()> {
@@ -89,7 +90,9 @@ async fn execute_mean<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select MEAN({}) as mean from {}", column_name, table_name);
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/my_sum_udaf_example.rs
+++ b/src/query/tests/my_sum_udaf_example.rs
@@ -36,7 +36,7 @@ use datatypes::with_match_primitive_type_id;
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngineFactory;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use table::test_util::MemTable;
 
 #[derive(Debug, Default)]
@@ -229,7 +229,7 @@ where
         "select MY_SUM({}) as my_sum from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql, Arc::new(SessionContext::new()))?;
+    let plan = engine.sql_to_plan(&sql, Arc::new(QueryContext::new()))?;
 
     let output = engine.execute(&plan).await?;
     let recordbatch_stream = match output {

--- a/src/query/tests/my_sum_udaf_example.rs
+++ b/src/query/tests/my_sum_udaf_example.rs
@@ -36,6 +36,7 @@ use datatypes::with_match_primitive_type_id;
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngineFactory;
+use session::context::SessionContext;
 use table::test_util::MemTable;
 
 #[derive(Debug, Default)]
@@ -228,7 +229,7 @@ where
         "select MY_SUM({}) as my_sum from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql)?;
+    let plan = engine.sql_to_plan(&sql, Arc::new(SessionContext::new()))?;
 
     let output = engine.execute(&plan).await?;
     let recordbatch_stream = match output {

--- a/src/query/tests/percentile_test.rs
+++ b/src/query/tests/percentile_test.rs
@@ -30,7 +30,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::{QueryEngine, QueryEngineFactory};
-use session::context::SessionContext;
+use session::context::QueryContext;
 use table::test_util::MemTable;
 
 #[tokio::test]
@@ -55,7 +55,7 @@ async fn test_percentile_correctness() -> Result<()> {
     let engine = create_correctness_engine();
     let sql = String::from("select PERCENTILE(corr_number,88.0) as percentile from corr_numbers");
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
@@ -117,7 +117,7 @@ async fn execute_percentile<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/percentile_test.rs
+++ b/src/query/tests/percentile_test.rs
@@ -30,6 +30,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::{QueryEngine, QueryEngineFactory};
+use session::context::SessionContext;
 use table::test_util::MemTable;
 
 #[tokio::test]
@@ -53,7 +54,9 @@ async fn test_percentile_aggregator() -> Result<()> {
 async fn test_percentile_correctness() -> Result<()> {
     let engine = create_correctness_engine();
     let sql = String::from("select PERCENTILE(corr_number,88.0) as percentile from corr_numbers");
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {
@@ -113,7 +116,9 @@ async fn execute_percentile<'a>(
         "select PERCENTILE({},50.0) as percentile from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/polyval_test.rs
+++ b/src/query/tests/polyval_test.rs
@@ -26,7 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 #[tokio::test]
 async fn test_polyval_aggregator() -> Result<()> {
@@ -94,7 +94,7 @@ async fn execute_polyval<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/polyval_test.rs
+++ b/src/query/tests/polyval_test.rs
@@ -26,6 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 
 #[tokio::test]
 async fn test_polyval_aggregator() -> Result<()> {
@@ -92,7 +93,9 @@ async fn execute_polyval<'a>(
         "select POLYVAL({}, 0) as polyval from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/query_engine_test.rs
+++ b/src/query/tests/query_engine_test.rs
@@ -37,7 +37,7 @@ use query::plan::LogicalPlan;
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use table::table::adapter::DfTableProviderAdapter;
 use table::table::numbers::NumbersTable;
 use table::test_util::MemTable;
@@ -137,7 +137,7 @@ async fn test_udf() -> Result<()> {
 
     let plan = engine.sql_to_plan(
         "select pow(number, number) as p from numbers limit 10",
-        Arc::new(SessionContext::new()),
+        Arc::new(QueryContext::new()),
     )?;
 
     let output = engine.execute(&plan).await?;
@@ -247,7 +247,7 @@ where
 {
     let sql = format!("SELECT {} FROM {}", column_name, table_name);
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
@@ -337,7 +337,7 @@ async fn execute_median<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/query_engine_test.rs
+++ b/src/query/tests/query_engine_test.rs
@@ -37,6 +37,7 @@ use query::plan::LogicalPlan;
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
+use session::context::SessionContext;
 use table::table::adapter::DfTableProviderAdapter;
 use table::table::numbers::NumbersTable;
 use table::test_util::MemTable;
@@ -134,7 +135,10 @@ async fn test_udf() -> Result<()> {
 
     engine.register_udf(udf);
 
-    let plan = engine.sql_to_plan("select pow(number, number) as p from numbers limit 10")?;
+    let plan = engine.sql_to_plan(
+        "select pow(number, number) as p from numbers limit 10",
+        Arc::new(SessionContext::new()),
+    )?;
 
     let output = engine.execute(&plan).await?;
     let recordbatch = match output {
@@ -242,7 +246,9 @@ where
     for<'a> T: Scalar<RefType<'a> = T>,
 {
     let sql = format!("SELECT {} FROM {}", column_name, table_name);
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {
@@ -330,7 +336,9 @@ async fn execute_median<'a>(
         "select MEDIAN({}) as median from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/scipy_stats_norm_cdf_test.rs
+++ b/src/query/tests/scipy_stats_norm_cdf_test.rs
@@ -26,6 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 use statrs::distribution::{ContinuousCDF, Normal};
 use statrs::statistics::Statistics;
 
@@ -94,7 +95,9 @@ async fn execute_scipy_stats_norm_cdf<'a>(
         "select SCIPYSTATSNORMCDF({},2.0) as scipy_stats_norm_cdf from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/scipy_stats_norm_cdf_test.rs
+++ b/src/query/tests/scipy_stats_norm_cdf_test.rs
@@ -26,7 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use statrs::distribution::{ContinuousCDF, Normal};
 use statrs::statistics::Statistics;
 
@@ -96,7 +96,7 @@ async fn execute_scipy_stats_norm_cdf<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/scipy_stats_norm_pdf.rs
+++ b/src/query/tests/scipy_stats_norm_pdf.rs
@@ -26,6 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
+use session::context::SessionContext;
 use statrs::distribution::{Continuous, Normal};
 use statrs::statistics::Statistics;
 
@@ -94,7 +95,9 @@ async fn execute_scipy_stats_norm_pdf<'a>(
         "select SCIPYSTATSNORMPDF({},2.0) as scipy_stats_norm_pdf from {}",
         column_name, table_name
     );
-    let plan = engine.sql_to_plan(&sql).unwrap();
+    let plan = engine
+        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
     let recordbatch_stream = match output {

--- a/src/query/tests/scipy_stats_norm_pdf.rs
+++ b/src/query/tests/scipy_stats_norm_pdf.rs
@@ -26,7 +26,7 @@ use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
 use query::QueryEngine;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use statrs::distribution::{Continuous, Normal};
 use statrs::statistics::Statistics;
 
@@ -96,7 +96,7 @@ async fn execute_scipy_stats_norm_pdf<'a>(
         column_name, table_name
     );
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -48,6 +48,7 @@ rustpython-vm = { git = "https://github.com/RustPython/RustPython", optional = t
   "default",
   "freeze-stdlib",
 ] }
+session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -26,7 +26,7 @@ use common_recordbatch::{RecordBatch, RecordBatchStream, SendableRecordBatchStre
 use datatypes::schema::SchemaRef;
 use futures::Stream;
 use query::QueryEngineRef;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use snafu::{ensure, ResultExt};
 use sql::statements::statement::Statement;
 
@@ -96,7 +96,7 @@ impl Script for PyScript {
             );
             let plan = self
                 .query_engine
-                .statement_to_plan(stmt, Arc::new(SessionContext::new()))?;
+                .statement_to_plan(stmt, Arc::new(QueryContext::new()))?;
             let res = self.query_engine.execute(&plan).await?;
             let copr = self.copr.clone();
             match res {

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -26,6 +26,7 @@ use common_recordbatch::{RecordBatch, RecordBatchStream, SendableRecordBatchStre
 use datatypes::schema::SchemaRef;
 use futures::Stream;
 use query::QueryEngineRef;
+use session::context::SessionContext;
 use snafu::{ensure, ResultExt};
 use sql::statements::statement::Statement;
 
@@ -93,7 +94,9 @@ impl Script for PyScript {
                 matches!(stmt, Statement::Query { .. }),
                 error::UnsupportedSqlSnafu { sql }
             );
-            let plan = self.query_engine.statement_to_plan(stmt)?;
+            let plan = self
+                .query_engine
+                .statement_to_plan(stmt, Arc::new(SessionContext::new()))?;
             let res = self.query_engine.execute(&plan).await?;
             let copr = self.copr.clone();
             match res {

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -28,7 +28,7 @@ use datatypes::prelude::{ConcreteDataType, ScalarVector};
 use datatypes::schema::{ColumnSchema, Schema, SchemaBuilder};
 use datatypes::vectors::{StringVector, TimestampVector, VectorRef};
 use query::QueryEngineRef;
-use session::context::SessionContext;
+use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
 use table::requests::{CreateTableRequest, InsertRequest};
 
@@ -152,7 +152,7 @@ impl ScriptsTable {
 
         let plan = self
             .query_engine
-            .sql_to_plan(&sql, Arc::new(SessionContext::new()))
+            .sql_to_plan(&sql, Arc::new(QueryContext::new()))
             .context(FindScriptSnafu { name })?;
 
         let stream = match self

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -28,6 +28,7 @@ use datatypes::prelude::{ConcreteDataType, ScalarVector};
 use datatypes::schema::{ColumnSchema, Schema, SchemaBuilder};
 use datatypes::vectors::{StringVector, TimestampVector, VectorRef};
 use query::QueryEngineRef;
+use session::context::SessionContext;
 use snafu::{ensure, OptionExt, ResultExt};
 use table::requests::{CreateTableRequest, InsertRequest};
 
@@ -151,7 +152,7 @@ impl ScriptsTable {
 
         let plan = self
             .query_engine
-            .sql_to_plan(&sql)
+            .sql_to_plan(&sql, Arc::new(SessionContext::new()))
             .context(FindScriptSnafu { name })?;
 
         let stream = match self

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8"
 schemars = "0.8"
 serde = "1.0"
 serde_json = "1.0"
+session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 snap = "1"
 table = { path = "../table" }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -487,6 +487,7 @@ mod test {
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{StringVector, UInt32Vector};
+    use session::context::SessionContext;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -498,7 +499,7 @@ mod test {
 
     #[async_trait]
     impl SqlQueryHandler for DummyInstance {
-        async fn do_query(&self, _query: &str) -> Result<Output> {
+        async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
             unimplemented!()
         }
     }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -487,7 +487,7 @@ mod test {
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{StringVector, UInt32Vector};
-    use session::context::SessionContext;
+    use session::context::SessionContextRef;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -499,7 +499,7 @@ mod test {
 
     #[async_trait]
     impl SqlQueryHandler for DummyInstance {
-        async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
+        async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
             unimplemented!()
         }
     }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -487,7 +487,7 @@ mod test {
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{StringVector, UInt32Vector};
-    use session::context::SessionContextRef;
+    use session::context::QueryContextRef;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -499,7 +499,7 @@ mod test {
 
     #[async_trait]
     impl SqlQueryHandler for DummyInstance {
-        async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
+        async fn do_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
             unimplemented!()
         }
     }

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Instant;
 
 use aide::transform::TransformOperation;
@@ -21,6 +22,7 @@ use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use session::context::SessionContext;
 
 use crate::http::{ApiState, JsonResponse};
 
@@ -39,7 +41,9 @@ pub async fn sql(
     let sql_handler = &state.sql_handler;
     let start = Instant::now();
     let resp = if let Some(sql) = &params.sql {
-        JsonResponse::from_output(sql_handler.do_query(sql).await).await
+        // TODO(LFC): Sessions in http server.
+        let session_ctx = Arc::new(SessionContext::new());
+        JsonResponse::from_output(sql_handler.do_query(sql, session_ctx).await).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -22,7 +22,7 @@ use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 use crate::http::{ApiState, JsonResponse};
 
@@ -42,8 +42,8 @@ pub async fn sql(
     let start = Instant::now();
     let resp = if let Some(sql) = &params.sql {
         // TODO(LFC): Sessions in http server.
-        let session_ctx = Arc::new(SessionContext::new());
-        JsonResponse::from_output(sql_handler.do_query(sql, session_ctx).await).await
+        let query_ctx = Arc::new(QueryContext::new());
+        JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -26,7 +26,7 @@ use datatypes::vectors::StringVector;
 use once_cell::sync::Lazy;
 use regex::bytes::RegexSet;
 use regex::Regex;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 
 // TODO(LFC): Include GreptimeDB's version and git commit tag etc.
 const MYSQL_VERSION: &str = "8.0.26";
@@ -252,7 +252,7 @@ fn check_show_variables(query: &str) -> Option<Output> {
 }
 
 // Check for SET or others query, this is the final check of the federated query.
-fn check_others(query: &str, session_ctx: Arc<SessionContext>) -> Option<Output> {
+fn check_others(query: &str, session_ctx: SessionContextRef) -> Option<Output> {
     if OTHER_NOT_SUPPORTED_STMT.is_match(query.as_bytes()) {
         return Some(Output::RecordBatches(RecordBatches::empty()));
     }
@@ -277,7 +277,7 @@ fn check_others(query: &str, session_ctx: Arc<SessionContext>) -> Option<Output>
 
 // Check whether the query is a federated or driver setup command,
 // and return some faked results if there are any.
-pub(crate) fn check(query: &str, session_ctx: Arc<SessionContext>) -> Option<Output> {
+pub(crate) fn check(query: &str, session_ctx: SessionContextRef) -> Option<Output> {
     // First to check the query is like "select @@variables".
     let output = check_select_variable(query);
     if output.is_some() {
@@ -296,6 +296,8 @@ pub(crate) fn check(query: &str, session_ctx: Arc<SessionContext>) -> Option<Out
 
 #[cfg(test)]
 mod test {
+    use session::context::SessionContext;
+
     use super::*;
 
     #[test]

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -26,21 +26,25 @@ use datatypes::vectors::StringVector;
 use once_cell::sync::Lazy;
 use regex::bytes::RegexSet;
 use regex::Regex;
+use session::context::SessionContext;
 
 // TODO(LFC): Include GreptimeDB's version and git commit tag etc.
 const MYSQL_VERSION: &str = "8.0.26";
 
 static SELECT_VAR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new("(?i)^(SELECT @@(.*))").unwrap());
 static MYSQL_CONN_JAVA_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new("(?i)^(/\\* mysql-connector-java(.*))").unwrap());
+    Lazy::new(|| Regex::new("(?i)^(/\\* mysql-connector-j(.*))").unwrap());
 static SHOW_LOWER_CASE_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(SHOW VARIABLES LIKE 'lower_case_table_names'(.*))").unwrap());
 static SHOW_COLLATION_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(show collation where(.*))").unwrap());
 static SHOW_VARIABLES_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(SHOW VARIABLES(.*))").unwrap());
+
 static SELECT_VERSION_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?i)^(SELECT VERSION\(\s*\))").unwrap());
+static SELECT_DATABASE_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^(SELECT DATABASE\(\s*\))").unwrap());
 
 // SELECT TIMEDIFF(NOW(), UTC_TIMESTAMP());
 static SELECT_TIME_DIFF_FUNC_PATTERN: Lazy<Regex> =
@@ -248,13 +252,18 @@ fn check_show_variables(query: &str) -> Option<Output> {
 }
 
 // Check for SET or others query, this is the final check of the federated query.
-fn check_others(query: &str) -> Option<Output> {
+fn check_others(query: &str, session_ctx: Arc<SessionContext>) -> Option<Output> {
     if OTHER_NOT_SUPPORTED_STMT.is_match(query.as_bytes()) {
         return Some(Output::RecordBatches(RecordBatches::empty()));
     }
 
     let recordbatches = if SELECT_VERSION_PATTERN.is_match(query) {
         Some(select_function("version()", MYSQL_VERSION))
+    } else if SELECT_DATABASE_PATTERN.is_match(query) {
+        let schema = session_ctx
+            .current_schema()
+            .unwrap_or_else(|| "NULL".to_string());
+        Some(select_function("database()", &schema))
     } else if SELECT_TIME_DIFF_FUNC_PATTERN.is_match(query) {
         Some(select_function(
             "TIMEDIFF(NOW(), UTC_TIMESTAMP())",
@@ -268,7 +277,7 @@ fn check_others(query: &str) -> Option<Output> {
 
 // Check whether the query is a federated or driver setup command,
 // and return some faked results if there are any.
-pub fn check(query: &str) -> Option<Output> {
+pub(crate) fn check(query: &str, session_ctx: Arc<SessionContext>) -> Option<Output> {
     // First to check the query is like "select @@variables".
     let output = check_select_variable(query);
     if output.is_some() {
@@ -282,7 +291,7 @@ pub fn check(query: &str) -> Option<Output> {
     }
 
     // Last check.
-    check_others(query)
+    check_others(query, session_ctx)
 }
 
 #[cfg(test)]
@@ -292,15 +301,15 @@ mod test {
     #[test]
     fn test_check() {
         let query = "select 1";
-        let result = check(query);
+        let result = check(query, Arc::new(SessionContext::new()));
         assert!(result.is_none());
 
         let query = "select versiona";
-        let output = check(query);
+        let output = check(query, Arc::new(SessionContext::new()));
         assert!(output.is_none());
 
         fn test(query: &str, expected: Vec<&str>) {
-            let output = check(query);
+            let output = check(query, Arc::new(SessionContext::new()));
             match output.unwrap() {
                 Output::RecordBatches(r) => {
                     assert_eq!(r.pretty_print().lines().collect::<Vec<_>>(), expected)

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -27,7 +27,7 @@ use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{text_query_response, FieldInfo, Response, Tag, TextDataRowEncoder};
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{PgWireError, PgWireResult};
-use session::context::SessionContext;
+use session::context::QueryContext;
 
 use crate::error::{self, Error, Result};
 use crate::query_handler::SqlQueryHandlerRef;
@@ -49,10 +49,10 @@ impl SimpleQueryHandler for PostgresServerHandler {
         C: ClientInfo + Unpin + Send + Sync,
     {
         // TODO(LFC): Sessions in pg server.
-        let session_ctx = Arc::new(SessionContext::new());
+        let query_ctx = Arc::new(QueryContext::new());
         let output = self
             .query_handler
-            .do_query(query, session_ctx)
+            .do_query(query, query_ctx)
             .await
             .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
 

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_query::Output;
@@ -26,6 +27,7 @@ use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{text_query_response, FieldInfo, Response, Tag, TextDataRowEncoder};
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{PgWireError, PgWireResult};
+use session::context::SessionContext;
 
 use crate::error::{self, Error, Result};
 use crate::query_handler::SqlQueryHandlerRef;
@@ -46,9 +48,11 @@ impl SimpleQueryHandler for PostgresServerHandler {
     where
         C: ClientInfo + Unpin + Send + Sync,
     {
+        // TODO(LFC): Sessions in pg server.
+        let session_ctx = Arc::new(SessionContext::new());
         let output = self
             .query_handler
-            .do_query(query)
+            .do_query(query, session_ctx)
             .await
             .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
 

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -18,7 +18,7 @@ use api::prometheus::remote::{ReadRequest, WriteRequest};
 use api::v1::{AdminExpr, AdminResult, ObjectExpr, ObjectResult};
 use async_trait::async_trait;
 use common_query::Output;
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 
 use crate::error::Result;
 use crate::influxdb::InfluxdbRequest;
@@ -45,7 +45,7 @@ pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
 pub trait SqlQueryHandler {
-    async fn do_query(&self, query: &str, session_ctx: SessionContextRef) -> Result<Output>;
+    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -18,6 +18,7 @@ use api::prometheus::remote::{ReadRequest, WriteRequest};
 use api::v1::{AdminExpr, AdminResult, ObjectExpr, ObjectResult};
 use async_trait::async_trait;
 use common_query::Output;
+use session::context::SessionContext;
 
 use crate::error::Result;
 use crate::influxdb::InfluxdbRequest;
@@ -44,7 +45,7 @@ pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
 pub trait SqlQueryHandler {
-    async fn do_query(&self, query: &str) -> Result<Output>;
+    async fn do_query(&self, query: &str, session_ctx: Arc<SessionContext>) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -18,7 +18,7 @@ use api::prometheus::remote::{ReadRequest, WriteRequest};
 use api::v1::{AdminExpr, AdminResult, ObjectExpr, ObjectResult};
 use async_trait::async_trait;
 use common_query::Output;
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 
 use crate::error::Result;
 use crate::influxdb::InfluxdbRequest;
@@ -45,7 +45,7 @@ pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
 pub trait SqlQueryHandler {
-    async fn do_query(&self, query: &str, session_ctx: Arc<SessionContext>) -> Result<Output>;
+    async fn do_query(&self, query: &str, session_ctx: SessionContextRef) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -23,7 +23,7 @@ use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::{InfluxdbLineProtocolHandler, SqlQueryHandler};
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -45,7 +45,7 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -23,7 +23,7 @@ use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::{InfluxdbLineProtocolHandler, SqlQueryHandler};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -45,7 +45,7 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -23,6 +23,7 @@ use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::{InfluxdbLineProtocolHandler, SqlQueryHandler};
+use session::context::SessionContext;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -44,7 +45,7 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _query: &str) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -22,7 +22,7 @@ use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
 use servers::query_handler::{OpentsdbProtocolHandler, SqlQueryHandler};
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -45,7 +45,7 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -22,6 +22,7 @@ use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
 use servers::query_handler::{OpentsdbProtocolHandler, SqlQueryHandler};
+use session::context::SessionContext;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -44,7 +45,7 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _query: &str) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -22,7 +22,7 @@ use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
 use servers::query_handler::{OpentsdbProtocolHandler, SqlQueryHandler};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -45,7 +45,7 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -27,7 +27,7 @@ use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
 use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse, SqlQueryHandler};
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -70,7 +70,7 @@ impl PrometheusProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: QueryContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -27,6 +27,7 @@ use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
 use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse, SqlQueryHandler};
+use session::context::SessionContext;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -69,7 +70,7 @@ impl PrometheusProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _query: &str) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -27,7 +27,7 @@ use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
 use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse, SqlQueryHandler};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 use tokio::sync::mpsc;
 
 struct DummyInstance {
@@ -70,7 +70,7 @@ impl PrometheusProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, _: &str, _: Arc<SessionContext>) -> Result<Output> {
+    async fn do_query(&self, _: &str, _: SessionContextRef) -> Result<Output> {
         unimplemented!()
     }
 }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -31,6 +31,8 @@ mod http;
 mod mysql;
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
+use session::context::SessionContext;
+
 mod opentsdb;
 mod postgres;
 
@@ -52,8 +54,8 @@ impl DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, query: &str) -> Result<Output> {
-        let plan = self.query_engine.sql_to_plan(query).unwrap();
+    async fn do_query(&self, query: &str, session_ctx: Arc<SessionContext>) -> Result<Output> {
+        let plan = self.query_engine.sql_to_plan(query, session_ctx).unwrap();
         Ok(self.query_engine.execute(&plan).await.unwrap())
     }
 }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -31,7 +31,7 @@ mod http;
 mod mysql;
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
-use session::context::SessionContextRef;
+use session::context::QueryContextRef;
 
 mod opentsdb;
 mod postgres;
@@ -54,8 +54,8 @@ impl DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, query: &str, session_ctx: SessionContextRef) -> Result<Output> {
-        let plan = self.query_engine.sql_to_plan(query, session_ctx).unwrap();
+    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Result<Output> {
+        let plan = self.query_engine.sql_to_plan(query, query_ctx).unwrap();
         Ok(self.query_engine.execute(&plan).await.unwrap())
     }
 }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -31,7 +31,7 @@ mod http;
 mod mysql;
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
-use session::context::SessionContext;
+use session::context::SessionContextRef;
 
 mod opentsdb;
 mod postgres;
@@ -54,7 +54,7 @@ impl DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    async fn do_query(&self, query: &str, session_ctx: Arc<SessionContext>) -> Result<Output> {
+    async fn do_query(&self, query: &str, session_ctx: SessionContextRef) -> Result<Output> {
         let plan = self.query_engine.sql_to_plan(query, session_ctx).unwrap();
         Ok(self.query_engine.execute(&plan).await.unwrap())
     }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -6,3 +6,4 @@ license = "Apache-2.0"
 
 [dependencies]
 arc-swap = "1.5"
+common-telemetry = { path = "../common/telemetry" }

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "session"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+arc-swap = "1.5"

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -17,19 +17,19 @@ use std::sync::Arc;
 use arc_swap::ArcSwapOption;
 use common_telemetry::info;
 
-pub type SessionContextRef = Arc<SessionContext>;
+pub type QueryContextRef = Arc<QueryContext>;
 
-pub struct SessionContext {
+pub struct QueryContext {
     current_schema: ArcSwapOption<String>,
 }
 
-impl Default for SessionContext {
+impl Default for QueryContext {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl SessionContext {
+impl QueryContext {
     pub fn new() -> Self {
         Self {
             current_schema: ArcSwapOption::new(None),

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -15,6 +15,9 @@
 use std::sync::Arc;
 
 use arc_swap::ArcSwapOption;
+use common_telemetry::info;
+
+pub type SessionContextRef = Arc<SessionContext>;
 
 pub struct SessionContext {
     current_schema: ArcSwapOption<String>,
@@ -40,13 +43,14 @@ impl SessionContext {
     }
 
     pub fn current_schema(&self) -> Option<String> {
-        self.current_schema
-            .load()
-            .as_ref()
-            .map(|x| String::clone(x))
+        self.current_schema.load().as_deref().cloned()
     }
 
-    pub fn set_current_schema(&self, schema: String) {
-        let _ = self.current_schema.swap(Some(Arc::new(schema)));
+    pub fn set_current_schema(&self, schema: &str) {
+        let last = self.current_schema.swap(Some(Arc::new(schema.to_string())));
+        info!(
+            "set new session default schema: {:?}, swap old: {:?}",
+            schema, last
+        )
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwapOption;
+
+pub struct SessionContext {
+    current_schema: ArcSwapOption<String>,
+}
+
+impl Default for SessionContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionContext {
+    pub fn new() -> Self {
+        Self {
+            current_schema: ArcSwapOption::new(None),
+        }
+    }
+
+    pub fn with_current_schema(schema: String) -> Self {
+        Self {
+            current_schema: ArcSwapOption::new(Some(Arc::new(schema))),
+        }
+    }
+
+    pub fn current_schema(&self) -> Option<String> {
+        self.current_schema
+            .load()
+            .as_ref()
+            .map(|x| String::clone(x))
+    }
+
+    pub fn set_current_schema(&self, schema: String) {
+        let _ = self.current_schema.swap(Some(Arc::new(schema)));
+    }
+}

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -16,21 +16,21 @@ pub mod context;
 
 use std::sync::Arc;
 
-use crate::context::{SessionContext, SessionContextRef};
+use crate::context::{QueryContext, QueryContextRef};
 
 #[derive(Default)]
 pub struct Session {
-    session_ctx: SessionContextRef,
+    query_ctx: QueryContextRef,
 }
 
 impl Session {
     pub fn new() -> Self {
         Session {
-            session_ctx: Arc::new(SessionContext::new()),
+            query_ctx: Arc::new(QueryContext::new()),
         }
     }
 
-    pub fn context(&self) -> SessionContextRef {
-        self.session_ctx.clone()
+    pub fn context(&self) -> QueryContextRef {
+        self.query_ctx.clone()
     }
 }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -16,11 +16,11 @@ pub mod context;
 
 use std::sync::Arc;
 
-use crate::context::SessionContext;
+use crate::context::{SessionContext, SessionContextRef};
 
 #[derive(Default)]
 pub struct Session {
-    session_ctx: Arc<SessionContext>,
+    session_ctx: SessionContextRef,
 }
 
 impl Session {
@@ -30,7 +30,7 @@ impl Session {
         }
     }
 
-    pub fn context(&self) -> Arc<SessionContext> {
+    pub fn context(&self) -> SessionContextRef {
         self.session_ctx.clone()
     }
 }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod context;
+
+use std::sync::Arc;
+
+use crate::context::SessionContext;
+
+#[derive(Default)]
+pub struct Session {
+    session_ctx: Arc<SessionContext>,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        Session {
+            session_ctx: Arc::new(SessionContext::new()),
+        }
+    }
+
+    pub fn context(&self) -> Arc<SessionContext> {
+        self.session_ctx.clone()
+    }
+}

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -102,6 +102,21 @@ impl<'a> ParserContext<'a> {
 
                     Keyword::DROP => self.parse_drop(),
 
+                    // TODO(LFC): Use "Keyword::USE" when we can upgrade to newer version of crate sqlparser.
+                    Keyword::NoKeyword if w.value.to_lowercase() == "use" => {
+                        self.parser.next_token();
+
+                        let database_name =
+                            self.parser
+                                .parse_identifier()
+                                .context(error::UnexpectedSnafu {
+                                    sql: self.sql,
+                                    expected: "a database name",
+                                    actual: self.peek_token_as_string(),
+                                })?;
+                        Ok(Statement::Use(database_name.value))
+                    }
+
                     // todo(hl) support more statements.
                     _ => self.unsupported(self.peek_token_as_string()),
                 }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -42,6 +42,8 @@ use crate::error::{
     SerializeColumnDefaultConstraintSnafu, UnsupportedDefaultValueSnafu,
 };
 
+// TODO(LFC): Get rid of this function, use session context aware version of "table_idents_to_full_name" instead.
+// Current obstacles remain in some usage in Frontend, and other SQLs like "describe", "drop" etc.
 /// Converts maybe fully-qualified table name (`<catalog>.<schema>.<table>` or `<table>` when
 /// catalog and schema are default) to tuple.
 pub fn table_idents_to_full_name(obj_name: &ObjectName) -> Result<(String, String, String)> {

--- a/src/sql/src/statements/insert.rs
+++ b/src/sql/src/statements/insert.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sqlparser::ast::{SetExpr, Statement, UnaryOperator, Values};
+use sqlparser::ast::{ObjectName, SetExpr, Statement, UnaryOperator, Values};
 use sqlparser::parser::ParserError;
 
 use crate::ast::{Expr, Value};
@@ -29,6 +29,13 @@ impl Insert {
     pub fn full_table_name(&self) -> Result<(String, String, String)> {
         match &self.inner {
             Statement::Insert { table_name, .. } => table_idents_to_full_name(table_name),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn table_name(&self) -> &ObjectName {
+        match &self.inner {
+            Statement::Insert { table_name, .. } => table_name,
             _ => unreachable!(),
         }
     }
@@ -109,15 +116,6 @@ mod tests {
 
     use super::*;
     use crate::parser::ParserContext;
-
-    #[test]
-    pub fn test_insert_convert() {
-        let sql = r"INSERT INTO tables_0 VALUES ( 'field_0', 0) ";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
-        assert_eq!(1, stmts.len());
-        let insert = stmts.pop().unwrap();
-        let _stmt: Statement = insert.try_into().unwrap();
-    }
 
     #[test]
     fn test_insert_value_with_unary_op() {

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -47,6 +47,7 @@ pub enum Statement {
     DescribeTable(DescribeTable),
     // EXPLAIN QUERY
     Explain(Explain),
+    Use(String),
 }
 
 /// Comment hints from SQL.

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -26,6 +26,27 @@ pub struct TableReference<'a> {
     pub table: &'a str,
 }
 
+// TODO(LFC): Find a better place for `TableReference`,
+// so that we can reuse the default catalog and schema consts.
+// Could be done together with issue #559.
+impl<'a> TableReference<'a> {
+    pub fn bare(table: &'a str) -> Self {
+        TableReference {
+            catalog: "greptime",
+            schema: "public",
+            table,
+        }
+    }
+
+    pub fn full(catalog: &'a str, schema: &'a str, table: &'a str) -> Self {
+        TableReference {
+            catalog,
+            schema,
+            table,
+        }
+    }
+}
+
 impl<'a> Display for TableReference<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{}.{}", self.catalog, self.schema, self.table)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. A bare sketch of session
2. Parsing "use" stmt in MySQL server
3. Modify insertion and selection related codes in Datanode

Because Frontend calls Datanode in grpc, either in standalone mode or distributed; and our grpc service is under fundamentally rewriting, I only support part of "use" functionality in this PR.

Specifically, execute "use" stmt, stores "database" in session context, and only happened in datanode (checkout the "instance_test" in datanode).

some screenshots:

<img width="563" alt="image" src="https://user-images.githubusercontent.com/990479/204951590-91f8c64d-2a08-4b91-85ed-906753d401a0.png">


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#670 