### PR TITLE
feat: add http `/health` api

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -380,6 +380,11 @@ impl HttpServer {
 
         router = router.route("/metrics", routing::get(handler::metrics));
 
+        router = router.route(
+            "/health",
+            routing::get(handler::health).post(handler::health),
+        );
+
         router
             // middlewares
             .layer(

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -63,3 +63,17 @@ pub async fn metrics(Query(_params): Query<HashMap<String, String>>) -> String {
         "Prometheus handle not initialized.".to_owned()
     }
 }
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct HealthQuery {}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct HealthResponse {}
+
+/// Handler to export healthy check  
+///      
+/// Currently simply return status "200 OK" (default) with an empty json payload "{}"
+#[axum_macros::debug_handler]
+pub async fn health(Query(_params): Query<HealthQuery>) -> Json<HealthResponse> {
+    Json(HealthResponse {})
+}

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -135,3 +135,18 @@ fn create_query() -> Query<http_handler::SqlQuery> {
         database: None,
     })
 }
+
+/// Currently the payload of response should be simply an empty json "{}";
+#[tokio::test]
+async fn test_health() {
+    let expected_json = http_handler::HealthResponse {};
+    let expected_json_str = "{}".to_string();
+
+    let query = http_handler::HealthQuery {};
+    let Json(json) = http_handler::health(Query(query)).await;
+    assert_eq!(json, expected_json);
+    assert_eq!(
+        serde_json::ser::to_string(&json).unwrap(),
+        expected_json_str
+    );
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `/health` http api for healthy check purpose.
Users are able to visit the api using either `GET` or `POST` methods. Both of them return same response.
The response of this api currently is simply an empty json `{}` with `200 OK` http status code.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

[#636 ](https://github.com/GreptimeTeam/greptimedb/issues/636)