### PR TITLE
fix: cargo sort in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: e6a795bc6b2c0958f9ef52af4863bbd7cc17238f
     hooks:
     -    id: cargo-sort
-         args: ["--workspace", "--print"]
+         args: ["--workspace"]
 
 -   repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ members = [
     "src/common/function",
     "src/common/function-macro",
     "src/common/grpc",
+    "src/common/grpc-expr",
     "src/common/query",
     "src/common/recordbatch",
     "src/common/runtime",
     "src/common/substrait",
-    "src/common/grpc-expr",
     "src/common/telemetry",
     "src/common/time",
     "src/datanode",
@@ -24,6 +24,7 @@ members = [
     "src/log-store",
     "src/meta-client",
     "src/meta-srv",
+    "src/mito",
     "src/object-store",
     "src/query",
     "src/script",
@@ -33,10 +34,9 @@ members = [
     "src/storage",
     "src/store-api",
     "src/table",
-    "src/mito",
-    "tests/runner",
     "tests-integration"
-]
+,
+    "tests/runner"]
 
 [profile.release]
 debug = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 
 [dependencies]
 common-base = { path = "../common/base" }
-common-time = { path = "../common/time" }
 common-error = { path = "../common/error" }
+common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
 prost = "0.11"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -38,8 +38,8 @@ tokio = { version = "1.18", features = ["full"] }
 [dev-dependencies]
 chrono = "0.4"
 log-store = { path = "../log-store" }
+mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }
 storage = { path = "../storage" }
-mito = { path = "../mito", features = ["test"] }
 tempdir = "0.3"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -11,9 +11,9 @@ async-stream = "0.3"
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
+common-grpc-expr = { path = "../common/grpc-expr" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-common-grpc-expr = { path = "../common/grpc-expr" }
 common-time = { path = "../common/time" }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2", features = [
     "simd",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -15,13 +15,13 @@ common-error = { path = "../common/error" }
 common-telemetry = { path = "../common/telemetry", features = [
     "deadlock_detection",
 ] }
-meta-client = { path = "../meta-client" }
 datanode = { path = "../datanode" }
 frontend = { path = "../frontend" }
 futures = "0.3"
+meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv" }
 serde = "1.0"
-servers = {path = "../servers"}
+servers = { path = "../servers" }
 snafu = { version = "0.7", features = ["backtraces"] }
 tokio = { version = "1.18", features = ["full"] }
 toml = "0.5"

--- a/src/common/function/Cargo.toml
+++ b/src/common/function/Cargo.toml
@@ -9,8 +9,8 @@ arc-swap = "1.0"
 chrono-tz = "0.6"
 common-error = { path = "../error" }
 common-function-macro = { path = "../function-macro" }
-common-time = { path = "../time" }
 common-query = { path = "../query" }
+common-time = { path = "../time" }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2" }
 datatypes = { path = "../../datatypes" }
 libc = "0.2"

--- a/src/common/grpc-expr/Cargo.toml
+++ b/src/common/grpc-expr/Cargo.toml
@@ -8,12 +8,12 @@ license = "Apache-2.0"
 api = { path = "../../api" }
 async-trait = "0.1"
 common-base = { path = "../base" }
+common-catalog = { path = "../catalog" }
 common-error = { path = "../error" }
 common-grpc = { path = "../grpc" }
+common-query = { path = "../query" }
 common-telemetry = { path = "../telemetry" }
 common-time = { path = "../time" }
-common-catalog = { path = "../catalog" }
-common-query = { path = "../query" }
 datatypes = { path = "../../datatypes" }
 snafu = { version = "0.7", features = ["backtraces"] }
 table = { path = "../../table" }

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -12,11 +12,11 @@ common-error = { path = "../error" }
 common-query = { path = "../query" }
 common-recordbatch = { path = "../recordbatch" }
 common-runtime = { path = "../runtime" }
-datatypes = { path = "../../datatypes" }
 dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2", features = [
     "simd",
 ] }
+datatypes = { path = "../../datatypes" }
 snafu = { version = "0.7", features = ["backtraces"] }
 tokio = { version = "1.0", features = ["full"] }
 tonic = "0.8"

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -19,42 +19,42 @@ common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
+common-grpc-expr = { path = "../common/grpc-expr" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-grpc-expr = { path = "../common/grpc-expr" }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2", features = [
   "simd",
 ] }
 datatypes = { path = "../datatypes" }
+frontend = { path = "../frontend" }
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 log-store = { path = "../log-store" }
 meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv", features = ["mock"] }
 metrics = "0.20"
+mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }
 query = { path = "../query" }
-session = { path = "../session" }
 script = { path = "../script", features = ["python"], optional = true }
 serde = "1.0"
 serde_json = "1.0"
 servers = { path = "../servers" }
+session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 storage = { path = "../storage" }
 store-api = { path = "../store-api" }
 substrait = { path = "../common/substrait" }
 table = { path = "../table" }
-mito = { path = "../mito", features = ["test"] }
 tokio = { version = "1.18", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
-frontend = { path = "../frontend" }
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -12,15 +12,15 @@ catalog = { path = "../catalog" }
 chrono = "0.4"
 client = { path = "../client" }
 common-base = { path = "../common/base" }
+common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
+common-grpc-expr = { path = "../common/grpc-expr" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-common-catalog = { path = "../common/catalog" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-grpc-expr = { path = "../common/grpc-expr" }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2", features = [
     "simd",
 ] }
@@ -36,17 +36,17 @@ moka = { version = "0.9", features = ["future"] }
 openmetrics-parser = "0.4"
 prost = "0.11"
 query = { path = "../query" }
+rustls = "0.20"
 serde = "1.0"
 serde_json = "1.0"
-session = { path = "../session" }
-sqlparser = "0.15"
 servers = { path = "../servers" }
+session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
+sqlparser = "0.15"
 store-api = { path = "../store-api" }
 table = { path = "../table" }
 tokio = { version = "1.18", features = ["full"] }
-rustls = "0.20"
 
 [dev-dependencies]
 datanode = { path = "../datanode" }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.21", features = ["layers-tracing", "layers-metrics"]}
+opendal = { version = "0.21", features = ["layers-tracing", "layers-metrics"] }
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -56,10 +56,10 @@ tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]
 log-store = { path = "../log-store" }
+mito = { path = "../mito", features = ["test"] }
 ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 storage = { path = "../storage" }
-mito = { path = "../mito", features = ["test"] }
 tempdir = "0.3"
 tokio = { version = "1.18", features = ["full"] }
 tokio-test = "0.4"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -23,8 +23,8 @@ common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
 futures = "0.3"
 hex = { version = "0.4" }
-hyper = { version = "0.14", features = ["full"] }
 humantime-serde = "1.1"
+hyper = { version = "0.14", features = ["full"] }
 influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", branch = "feat/line-protocol" }
 metrics = "0.20"
 num_cpus = "1.13"
@@ -33,8 +33,10 @@ openmetrics-parser = "0.4"
 opensrv-mysql = "0.3"
 pgwire = "0.5"
 prost = "0.11"
-regex = "1.6"
 rand = "0.8"
+regex = "1.6"
+rustls = "0.20"
+rustls-pemfile = "1.0"
 schemars = "0.8"
 serde = "1.0"
 serde_json = "1.0"
@@ -43,14 +45,12 @@ snafu = { version = "0.7", features = ["backtraces"] }
 snap = "1"
 table = { path = "../table" }
 tokio = { version = "1.20", features = ["full"] }
+tokio-rustls = "0.23"
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"
 tonic-reflection = "0.5"
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
-tokio-rustls = "0.23"
-rustls = "0.20"
-rustls-pemfile = "1.0"
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -12,7 +12,7 @@ common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
 itertools = "0.10"
+mito = { path = "../mito" }
 once_cell = "1.10"
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.15.0"
-mito = { path = "../mito" }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. remove `--print` param of cargo sort in `.pre-commit-config.yaml` file
2. rerun pre-commit to sort all `Cargo.toml` files

## Checklist

## Refer to a related PR or issue link (optional)
