### PR TITLE
refactor: directly invoke Datanode methods in standalone mode (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,6 @@ dependencies = [
  "datafusion",
  "datafusion-common 7.0.0",
  "datatypes",
- "frontend",
  "futures",
  "hyper",
  "log-store",

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -25,12 +25,6 @@ pub enum Error {
         source: datanode::error::Error,
     },
 
-    #[snafu(display("Failed to build frontend, source: {}", source))]
-    BuildFrontend {
-        #[snafu(backtrace)]
-        source: frontend::error::Error,
-    },
-
     #[snafu(display("Failed to start frontend, source: {}", source))]
     StartFrontend {
         #[snafu(backtrace)]
@@ -75,7 +69,6 @@ impl ErrorExt for Error {
                 StatusCode::InvalidArguments
             }
             Error::IllegalConfig { .. } => StatusCode::InvalidArguments,
-            Error::BuildFrontend { source, .. } => source.status_code(),
         }
     }
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -78,7 +78,7 @@ impl StartCommand {
         let opts: FrontendOptions = self.try_into()?;
         let mut frontend = Frontend::new(
             opts.clone(),
-            Instance::try_new(&opts)
+            Instance::try_new_distributed(&opts)
                 .await
                 .context(error::StartFrontendSnafu)?,
         );
@@ -213,7 +213,6 @@ mod tests {
 
         let fe_opts = FrontendOptions::try_from(command).unwrap();
         assert_eq!(Mode::Distributed, fe_opts.mode);
-        assert_eq!("127.0.0.1:3001".to_string(), fe_opts.datanode_rpc_addr);
         assert_eq!(
             "127.0.0.1:4000".to_string(),
             fe_opts.http_options.as_ref().unwrap().addr

--- a/src/common/grpc/src/select.rs
+++ b/src/common/grpc/src/select.rs
@@ -23,7 +23,7 @@ use common_base::BitVec;
 use common_error::prelude::ErrorExt;
 use common_error::status_code::StatusCode;
 use common_query::Output;
-use common_recordbatch::{util, RecordBatches, SendableRecordBatchStream};
+use common_recordbatch::{RecordBatches, SendableRecordBatchStream};
 use datatypes::arrow::array::{Array, BooleanArray, PrimitiveArray};
 use datatypes::arrow_array::{BinaryArray, StringArray};
 use datatypes::schema::SchemaRef;
@@ -47,13 +47,9 @@ pub async fn to_object_result(output: std::result::Result<Output, impl ErrorExt>
     }
 }
 async fn collect(stream: SendableRecordBatchStream) -> Result<ObjectResult> {
-    let schema = stream.schema();
-
-    let recordbatches = util::collect(stream)
+    let recordbatches = RecordBatches::try_collect(stream)
         .await
-        .and_then(|batches| RecordBatches::try_new(schema, batches))
         .context(error::CollectRecordBatchesSnafu)?;
-
     let object_result = build_result(recordbatches)?;
     Ok(object_result)
 }

--- a/src/common/recordbatch/src/lib.rs
+++ b/src/common/recordbatch/src/lib.rs
@@ -81,13 +81,9 @@ impl RecordBatches {
     }
 
     pub async fn try_collect(stream: SendableRecordBatchStream) -> Result<Self> {
+        let schema = stream.schema();
         let batches = stream.try_collect::<Vec<_>>().await?;
-        if batches.is_empty() {
-            Ok(Self::empty())
-        } else {
-            let schema = batches[0].schema.clone();
-            Self::try_new(schema, batches)
-        }
+        Ok(Self { schema, batches })
     }
 
     #[inline]

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -29,7 +29,6 @@ datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = 
     "simd",
 ] }
 datatypes = { path = "../datatypes" }
-frontend = { path = "../frontend" }
 futures = "0.3"
 hyper = { version = "0.14", features = ["full"] }
 log-store = { path = "../log-store" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -26,7 +26,7 @@ datafusion = { git = "https://github.com/apache/arrow-datafusion.git", branch = 
 ] }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2" }
 datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", branch = "arrow2" }
-
+datanode = { path = "../datanode" }
 datatypes = { path = "../datatypes" }
 futures = "0.3"
 futures-util = "0.3"

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -59,6 +59,16 @@ impl FrontendCatalogManager {
     pub(crate) fn backend(&self) -> KvBackendRef {
         self.backend.clone()
     }
+
+    #[cfg(test)]
+    pub(crate) fn table_routes(&self) -> Arc<TableRoutes> {
+        self.table_routes.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn datanode_clients(&self) -> Arc<DatanodeClients> {
+        self.datanode_clients.clone()
+    }
 }
 
 // FIXME(hl): Frontend only needs a CatalogList, should replace with trait upcasting

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -437,15 +437,6 @@ pub enum Error {
         source: substrait::error::Error,
     },
 
-    #[snafu(display(
-        "Failed to invoke Datanode instance in standalone mode, source: {}",
-        source
-    ))]
-    InvokeDnInstance {
-        #[snafu(backtrace)]
-        source: datanode::error::Error,
-    },
-
     #[snafu(display("Failed to invoke GRPC server, source: {}", source))]
     InvokeGrpcServer {
         #[snafu(backtrace)]
@@ -542,7 +533,6 @@ impl ErrorExt for Error {
             Error::LeaderNotFound { .. } => StatusCode::StorageUnavailable,
             Error::TableAlreadyExist { .. } => StatusCode::TableAlreadyExists,
             Error::EncodeSubstraitLogicalPlan { source } => source.status_code(),
-            Error::InvokeDnInstance { source } => source.status_code(),
         }
     }
 

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -40,7 +40,6 @@ pub struct FrontendOptions {
     pub influxdb_options: Option<InfluxdbOptions>,
     pub prometheus_options: Option<PrometheusOptions>,
     pub mode: Mode,
-    pub datanode_rpc_addr: String,
     pub meta_client_opts: Option<MetaClientOpts>,
 }
 
@@ -55,15 +54,8 @@ impl Default for FrontendOptions {
             influxdb_options: Some(InfluxdbOptions::default()),
             prometheus_options: Some(PrometheusOptions::default()),
             mode: Mode::Standalone,
-            datanode_rpc_addr: "127.0.0.1:3001".to_string(),
             meta_client_opts: None,
         }
-    }
-}
-
-impl FrontendOptions {
-    pub(crate) fn datanode_grpc_addr(&self) -> String {
-        self.datanode_rpc_addr.clone()
     }
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -173,7 +173,7 @@ impl Instance {
         Instance {
             catalog_manager: None,
             script_handler: None,
-            create_expr_factory: Arc::new(DefaultCreateExprFactory {}),
+            create_expr_factory: Arc::new(DefaultCreateExprFactory),
             mode: Mode::Standalone,
             dist_instance: None,
             sql_handler: dn_instance.clone(),

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -20,50 +20,49 @@ mod prometheus;
 use std::sync::Arc;
 use std::time::Duration;
 
-use api::result::ObjectResultBuilder;
+use api::result::{ObjectResultBuilder, PROTOCOL_VERSION};
 use api::v1::alter_expr::Kind;
 use api::v1::object_expr::Expr;
 use api::v1::{
-    admin_expr, select_expr, AddColumns, AdminExpr, AdminResult, AlterExpr, Column,
-    CreateDatabaseExpr, CreateExpr, DropTableExpr, InsertExpr, ObjectExpr,
+    admin_expr, AddColumns, AdminExpr, AdminResult, AlterExpr, Column, CreateDatabaseExpr,
+    CreateExpr, DropTableExpr, ExprHeader, InsertExpr, ObjectExpr,
     ObjectResult as GrpcObjectResult,
 };
 use async_trait::async_trait;
 use catalog::remote::MetaKvBackend;
 use catalog::{CatalogManagerRef, CatalogProviderRef, SchemaProviderRef};
-use client::admin::{admin_result_to_output, Admin};
-use client::{Client, Database, Select};
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use common_error::prelude::{BoxedError, StatusCode};
+use client::admin::admin_result_to_output;
+use client::ObjectResult;
+use common_catalog::consts::DEFAULT_CATALOG_NAME;
+use common_error::prelude::BoxedError;
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
-use common_grpc::select::to_object_result;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
-use common_telemetry::{debug, error, info};
+use common_telemetry::{debug, info};
+use datanode::instance::InstanceRef as DnInstanceRef;
 use distributed::DistInstance;
-use meta_client::client::MetaClientBuilder;
+use meta_client::client::{MetaClient, MetaClientBuilder};
 use meta_client::MetaClientOpts;
 use servers::query_handler::{
-    GrpcAdminHandler, GrpcQueryHandler, InfluxdbLineProtocolHandler, OpentsdbProtocolHandler,
-    PrometheusProtocolHandler, ScriptHandler, ScriptHandlerRef, SqlQueryHandler,
+    GrpcAdminHandler, GrpcAdminHandlerRef, GrpcQueryHandler, GrpcQueryHandlerRef,
+    InfluxdbLineProtocolHandler, OpentsdbProtocolHandler, PrometheusProtocolHandler, ScriptHandler,
+    ScriptHandlerRef, SqlQueryHandler, SqlQueryHandlerRef,
 };
 use servers::{error as server_error, Mode};
-use session::context::{QueryContext, QueryContextRef};
+use session::context::QueryContextRef;
 use snafu::prelude::*;
 use sql::dialect::GenericDialect;
 use sql::parser::ParserContext;
 use sql::statements::create::Partitions;
-use sql::statements::explain::Explain;
 use sql::statements::insert::Insert;
 use sql::statements::statement::Statement;
 
 use crate::catalog::FrontendCatalogManager;
 use crate::datanode::DatanodeClients;
 use crate::error::{
-    self, AlterTableOnInsertionSnafu, AlterTableSnafu, CatalogNotFoundSnafu, CatalogSnafu,
-    CreateDatabaseSnafu, CreateTableSnafu, DropTableSnafu, FindNewColumnsOnInsertionSnafu,
-    InsertSnafu, MissingMetasrvOptsSnafu, Result, SchemaNotFoundSnafu, SelectSnafu,
-    UnsupportedExprSnafu,
+    self, AlterTableOnInsertionSnafu, CatalogNotFoundSnafu, CatalogSnafu, CreateDatabaseSnafu,
+    CreateTableSnafu, FindNewColumnsOnInsertionSnafu, InsertSnafu, MissingMetasrvOptsSnafu, Result,
+    SchemaNotFoundSnafu,
 };
 use crate::expr_factory::{CreateExprFactoryRef, DefaultCreateExprFactory};
 use crate::frontend::FrontendOptions;
@@ -91,9 +90,6 @@ pub type FrontendInstanceRef = Arc<dyn FrontendInstance>;
 
 #[derive(Clone)]
 pub struct Instance {
-    // TODO(hl): In standalone mode, there is only one client.
-    // But in distribute mode, frontend should fetch datanodes' addresses from metasrv.
-    client: Client,
     /// catalog manager is None in standalone mode, datanode will keep their own
     catalog_manager: Option<CatalogManagerRef>,
     /// Script handler is None in distributed mode, only works on standalone mode.
@@ -103,94 +99,87 @@ pub struct Instance {
     // Standalone and Distributed, then the code behind it doesn't need to use so
     // many match statements.
     mode: Mode,
-    // TODO(LFC): Refactor consideration: Can we split Frontend to DistInstance and EmbedInstance?
+
+    // TODO(LFC): Remove `dist_instance` together with Arrow Flight adoption refactor.
     dist_instance: Option<DistInstance>,
+
+    sql_handler: SqlQueryHandlerRef,
+    grpc_query_handler: GrpcQueryHandlerRef,
+    grpc_admin_handler: GrpcAdminHandlerRef,
 }
 
-impl Default for Instance {
-    fn default() -> Self {
-        Self {
-            client: Client::default(),
+impl Instance {
+    pub async fn try_new_distributed(opts: &FrontendOptions) -> Result<Self> {
+        let meta_client = Self::create_meta_client(opts).await?;
+
+        let meta_backend = Arc::new(MetaKvBackend {
+            client: meta_client.clone(),
+        });
+        let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
+        let datanode_clients = Arc::new(DatanodeClients::new());
+        let catalog_manager = Arc::new(FrontendCatalogManager::new(
+            meta_backend,
+            table_routes,
+            datanode_clients.clone(),
+        ));
+
+        let dist_instance =
+            DistInstance::new(meta_client, catalog_manager.clone(), datanode_clients);
+        let dist_instance_ref = Arc::new(dist_instance.clone());
+
+        Ok(Instance {
+            catalog_manager: Some(catalog_manager),
+            script_handler: None,
+            create_expr_factory: Arc::new(DefaultCreateExprFactory),
+            mode: Mode::Distributed,
+            dist_instance: Some(dist_instance),
+            sql_handler: dist_instance_ref.clone(),
+            grpc_query_handler: dist_instance_ref.clone(),
+            grpc_admin_handler: dist_instance_ref,
+        })
+    }
+
+    async fn create_meta_client(opts: &FrontendOptions) -> Result<Arc<MetaClient>> {
+        let metasrv_addr = &opts
+            .meta_client_opts
+            .as_ref()
+            .context(MissingMetasrvOptsSnafu)?
+            .metasrv_addrs;
+        info!(
+            "Creating Frontend instance in distributed mode with Meta server addr {:?}",
+            metasrv_addr
+        );
+
+        let meta_config = MetaClientOpts::default();
+        let channel_config = ChannelConfig::new()
+            .timeout(Duration::from_millis(meta_config.timeout_millis))
+            .connect_timeout(Duration::from_millis(meta_config.connect_timeout_millis))
+            .tcp_nodelay(meta_config.tcp_nodelay);
+        let channel_manager = ChannelManager::with_config(channel_config);
+
+        let mut meta_client = MetaClientBuilder::new(0, 0)
+            .enable_router()
+            .enable_store()
+            .channel_manager(channel_manager)
+            .build();
+        meta_client
+            .start(metasrv_addr)
+            .await
+            .context(error::StartMetaClientSnafu)?;
+        Ok(Arc::new(meta_client))
+    }
+
+    pub fn new_standalone(dn_instance: DnInstanceRef) -> Self {
+        Instance {
             catalog_manager: None,
             script_handler: None,
             create_expr_factory: Arc::new(DefaultCreateExprFactory {}),
             mode: Mode::Standalone,
             dist_instance: None,
+            sql_handler: dn_instance.clone(),
+            grpc_query_handler: dn_instance.clone(),
+            grpc_admin_handler: dn_instance,
         }
-    }
-}
-
-impl Instance {
-    pub async fn try_new(opts: &FrontendOptions) -> Result<Self> {
-        let mut instance = Instance {
-            mode: opts.mode.clone(),
-            ..Default::default()
-        };
-
-        let addr = opts.datanode_grpc_addr();
-        instance.client.start(vec![addr]);
-
-        instance.dist_instance = match &opts.mode {
-            Mode::Standalone => None,
-            Mode::Distributed => {
-                let metasrv_addr = &opts
-                    .meta_client_opts
-                    .as_ref()
-                    .context(MissingMetasrvOptsSnafu)?
-                    .metasrv_addrs;
-                info!(
-                    "Creating Frontend instance in distributed mode with Meta server addr {:?}",
-                    metasrv_addr
-                );
-
-                let meta_config = MetaClientOpts::default();
-                let channel_config = ChannelConfig::new()
-                    .timeout(Duration::from_millis(meta_config.timeout_millis))
-                    .connect_timeout(Duration::from_millis(meta_config.connect_timeout_millis))
-                    .tcp_nodelay(meta_config.tcp_nodelay);
-
-                let channel_manager = ChannelManager::with_config(channel_config);
-
-                let mut meta_client = MetaClientBuilder::new(0, 0)
-                    .enable_router()
-                    .enable_store()
-                    .channel_manager(channel_manager)
-                    .build();
-                meta_client
-                    .start(metasrv_addr)
-                    .await
-                    .context(error::StartMetaClientSnafu)?;
-                let meta_client = Arc::new(meta_client);
-
-                let meta_backend = Arc::new(MetaKvBackend {
-                    client: meta_client.clone(),
-                });
-                let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
-                let datanode_clients = Arc::new(DatanodeClients::new());
-                let catalog_manager = Arc::new(FrontendCatalogManager::new(
-                    meta_backend,
-                    table_routes,
-                    datanode_clients.clone(),
-                ));
-
-                instance.catalog_manager = Some(catalog_manager.clone());
-
-                Some(DistInstance::new(
-                    meta_client,
-                    catalog_manager,
-                    datanode_clients,
-                ))
-            }
-        };
-        Ok(instance)
-    }
-
-    pub fn database(&self, database: &str) -> Database {
-        Database::new(database, self.client.clone())
-    }
-
-    pub fn admin(&self, database: &str) -> Admin {
-        Admin::new(database, self.client.clone())
     }
 
     pub fn catalog_manager(&self) -> &Option<CatalogManagerRef> {
@@ -213,27 +202,6 @@ impl Instance {
         self.script_handler = Some(handler);
     }
 
-    async fn handle_select(
-        &self,
-        expr: Select,
-        stmt: Statement,
-        query_ctx: QueryContextRef,
-    ) -> Result<Output> {
-        if let Some(dist_instance) = &self.dist_instance {
-            let Select::Sql(sql) = expr;
-            dist_instance.handle_sql(&sql, stmt, query_ctx).await
-        } else {
-            // TODO(LFC): Refactor consideration: Datanode should directly execute statement in standalone mode to avoid parse SQL again.
-            // Find a better way to execute query between Frontend and Datanode in standalone mode.
-            // Otherwise we have to parse SQL first to get schema name. Maybe not GRPC.
-            self.database(DEFAULT_SCHEMA_NAME)
-                .select(expr)
-                .await
-                .and_then(Output::try_from)
-                .context(SelectSnafu)
-        }
-    }
-
     /// Handle create expr.
     pub async fn handle_create_table(
         &self,
@@ -243,81 +211,38 @@ impl Instance {
         if let Some(v) = &self.dist_instance {
             v.create_table(&mut expr, partitions).await
         } else {
-            // Currently standalone mode does not support multi partitions/regions.
+            let expr = AdminExpr {
+                header: Some(ExprHeader {
+                    version: PROTOCOL_VERSION,
+                }),
+                expr: Some(admin_expr::Expr::Create(expr)),
+            };
             let result = self
-                .admin(expr.schema_name.as_deref().unwrap_or(DEFAULT_SCHEMA_NAME))
-                .create(expr.clone())
-                .await;
-            if let Err(e) = &result {
-                error!(e; "Failed to create table by expr: {:?}", expr);
-            }
-            result
-                .and_then(admin_result_to_output)
-                .context(CreateTableSnafu)
+                .grpc_admin_handler
+                .exec_admin_request(expr)
+                .await
+                .context(error::InvokeGrpcServerSnafu)?;
+            admin_result_to_output(result).context(CreateTableSnafu)
         }
     }
 
     /// Handle create database expr.
     pub async fn handle_create_database(&self, expr: CreateDatabaseExpr) -> Result<Output> {
         let database_name = expr.database_name.clone();
-        if let Some(dist_instance) = &self.dist_instance {
-            dist_instance.handle_create_database(expr).await
-        } else {
-            // FIXME(hl): In order to get admin client to create schema, we need to use the default schema admin
-            self.admin(DEFAULT_SCHEMA_NAME)
-                .create_database(expr)
-                .await
-                .and_then(admin_result_to_output)
-                .context(CreateDatabaseSnafu {
-                    name: database_name,
-                })
-        }
-    }
-
-    /// Handle alter expr
-    pub async fn handle_alter(&self, expr: AlterExpr) -> Result<Output> {
-        match &self.dist_instance {
-            Some(dist_instance) => dist_instance.handle_alter_table(expr).await,
-            None => self
-                .admin(expr.schema_name.as_deref().unwrap_or(DEFAULT_SCHEMA_NAME))
-                .alter(expr)
-                .await
-                .and_then(admin_result_to_output)
-                .context(AlterTableSnafu),
-        }
-    }
-
-    /// Handle drop table expr
-    pub async fn handle_drop_table(&self, expr: DropTableExpr) -> Result<Output> {
-        match self.mode {
-            Mode::Standalone => self
-                .admin(&expr.schema_name)
-                .drop_table(expr)
-                .await
-                .and_then(admin_result_to_output)
-                .context(DropTableSnafu),
-            // TODO(ruihang): support drop table in distributed mode
-            Mode::Distributed => UnsupportedExprSnafu {
-                name: "Distributed DROP TABLE",
-            }
-            .fail(),
-        }
-    }
-
-    /// Handle explain expr
-    pub async fn handle_explain(
-        &self,
-        sql: &str,
-        explain_stmt: Explain,
-        query_ctx: QueryContextRef,
-    ) -> Result<Output> {
-        if let Some(dist_instance) = &self.dist_instance {
-            dist_instance
-                .handle_sql(sql, Statement::Explain(explain_stmt), query_ctx)
-                .await
-        } else {
-            Ok(Output::AffectedRows(0))
-        }
+        let expr = AdminExpr {
+            header: Some(ExprHeader {
+                version: PROTOCOL_VERSION,
+            }),
+            expr: Some(admin_expr::Expr::CreateDatabase(expr)),
+        };
+        let result = self
+            .grpc_admin_handler
+            .exec_admin_request(expr)
+            .await
+            .context(error::InvokeGrpcServerSnafu)?;
+        admin_result_to_output(result).context(CreateDatabaseSnafu {
+            name: database_name,
+        })
     }
 
     /// Handle batch inserts
@@ -333,7 +258,7 @@ impl Instance {
     }
 
     /// Handle insert. for 'values' insertion, create/alter the destination table on demand.
-    pub async fn handle_insert(&self, mut insert_expr: InsertExpr) -> Result<Output> {
+    async fn handle_insert(&self, mut insert_expr: InsertExpr) -> Result<Output> {
         let table_name = &insert_expr.table_name;
         let catalog_name = DEFAULT_CATALOG_NAME;
         let schema_name = &insert_expr.schema_name;
@@ -345,11 +270,17 @@ impl Instance {
 
         insert_expr.region_number = 0;
 
-        self.database(schema_name)
-            .insert(insert_expr)
+        let query = ObjectExpr {
+            header: Some(ExprHeader {
+                version: PROTOCOL_VERSION,
+            }),
+            expr: Some(Expr::Insert(insert_expr)),
+        };
+        let result = GrpcQueryHandler::do_query(&*self.grpc_query_handler, query)
             .await
-            .and_then(Output::try_from)
-            .context(InsertSnafu)
+            .context(error::InvokeGrpcServerSnafu)?;
+        let result: ObjectResult = result.try_into().context(InsertSnafu)?;
+        result.try_into().context(InsertSnafu)
     }
 
     // check if table already exist:
@@ -455,11 +386,19 @@ impl Instance {
             catalog_name: Some(catalog_name.to_string()),
             kind: Some(Kind::AddColumns(add_columns)),
         };
-        self.admin(schema_name)
-            .alter(expr)
+
+        let expr = AdminExpr {
+            header: Some(ExprHeader {
+                version: PROTOCOL_VERSION,
+            }),
+            expr: Some(admin_expr::Expr::Alter(expr)),
+        };
+        let result = self
+            .grpc_admin_handler
+            .exec_admin_request(expr)
             .await
-            .and_then(admin_result_to_output)
-            .context(AlterTableOnInsertionSnafu)
+            .context(error::InvokeGrpcServerSnafu)?;
+        admin_result_to_output(result).context(AlterTableOnInsertionSnafu)
     }
 
     fn get_catalog(&self, catalog_name: &str) -> Result<CatalogProviderRef> {
@@ -547,20 +486,6 @@ impl FrontendInstance for Instance {
     }
 }
 
-#[cfg(test)]
-impl Instance {
-    pub fn with_client_and_catalog_manager(client: Client, catalog: CatalogManagerRef) -> Self {
-        Self {
-            client,
-            catalog_manager: Some(catalog),
-            script_handler: None,
-            create_expr_factory: Arc::new(DefaultCreateExprFactory),
-            mode: Mode::Standalone,
-            dist_instance: None,
-        }
-    }
-}
-
 fn parse_stmt(sql: &str) -> Result<Statement> {
     let mut stmt = ParserContext::create_with_dialect(sql, &GenericDialect {})
         .context(error::ParseSqlSnafu)?;
@@ -590,9 +515,9 @@ impl SqlQueryHandler for Instance {
             Statement::ShowDatabases(_)
             | Statement::ShowTables(_)
             | Statement::DescribeTable(_)
+            | Statement::Explain(_)
             | Statement::Query(_) => {
-                self.handle_select(Select::Sql(query.to_string()), stmt, query_ctx)
-                    .await
+                return self.sql_handler.do_query(query, query_ctx).await;
             }
             Statement::Insert(insert) => match self.mode {
                 Mode::Standalone => {
@@ -647,12 +572,17 @@ impl SqlQueryHandler for Instance {
                 self.handle_create_database(expr).await
             }
             Statement::Alter(alter_stmt) => {
-                self.handle_alter(
-                    AlterExpr::try_from(alter_stmt)
-                        .map_err(BoxedError::new)
-                        .context(server_error::ExecuteAlterSnafu { query })?,
-                )
-                .await
+                let expr = AlterExpr::try_from(alter_stmt)
+                    .map_err(BoxedError::new)
+                    .context(server_error::ExecuteAlterSnafu { query })?;
+                let expr = AdminExpr {
+                    header: Some(ExprHeader {
+                        version: PROTOCOL_VERSION,
+                    }),
+                    expr: Some(admin_expr::Expr::Alter(expr)),
+                };
+                let result = self.grpc_admin_handler.exec_admin_request(expr).await?;
+                admin_result_to_output(result).context(error::InvalidAdminResultSnafu)
             }
             Statement::DropTable(drop_stmt) => {
                 let expr = DropTableExpr {
@@ -660,10 +590,14 @@ impl SqlQueryHandler for Instance {
                     schema_name: drop_stmt.schema_name,
                     table_name: drop_stmt.table_name,
                 };
-                self.handle_drop_table(expr).await
-            }
-            Statement::Explain(explain_stmt) => {
-                self.handle_explain(query, explain_stmt, query_ctx).await
+                let expr = AdminExpr {
+                    header: Some(ExprHeader {
+                        version: PROTOCOL_VERSION,
+                    }),
+                    expr: Some(admin_expr::Expr::DropTable(expr)),
+                };
+                let result = self.grpc_admin_handler.exec_admin_request(expr).await?;
+                admin_result_to_output(result).context(error::InvalidAdminResultSnafu)
             }
             Statement::ShowCreateTable(_) => {
                 return server_error::NotSupportedSnafu { feat: query }.fail();
@@ -703,79 +637,32 @@ impl ScriptHandler for Instance {
 #[async_trait]
 impl GrpcQueryHandler for Instance {
     async fn do_query(&self, query: ObjectExpr) -> server_error::Result<GrpcObjectResult> {
-        if let Some(expr) = &query.expr {
-            match expr {
-                Expr::Insert(insert) => {
-                    // TODO(fys): refactor, avoid clone
-                    let result = self.handle_insert(insert.clone()).await;
-                    result
-                        .map(|o| match o {
-                            Output::AffectedRows(rows) => ObjectResultBuilder::new()
-                                .status_code(StatusCode::Success as u32)
-                                .mutate_result(rows as u32, 0u32)
-                                .build(),
-                            _ => {
-                                unreachable!()
-                            }
-                        })
-                        .map_err(BoxedError::new)
-                        .with_context(|_| server_error::ExecuteQuerySnafu {
-                            query: format!("{:?}", query),
-                        })
-                }
-                Expr::Select(select) => {
-                    let select = select
-                        .expr
-                        .as_ref()
-                        .context(server_error::InvalidQuerySnafu {
-                            reason: "empty query",
-                        })?;
-                    match select {
-                        select_expr::Expr::Sql(sql) => {
-                            let query_ctx = Arc::new(QueryContext::new());
-                            let output = SqlQueryHandler::do_query(self, sql, query_ctx).await;
-                            Ok(to_object_result(output).await)
-                        }
-                        _ => {
-                            if self.dist_instance.is_some() {
-                                return server_error::NotSupportedSnafu {
-                                    feat: "Executing plan directly in Frontend.",
-                                }
-                                .fail();
-                            }
-                            // FIXME(hl): refactor
-                            self.database(DEFAULT_SCHEMA_NAME)
-                                .object(query.clone())
-                                .await
-                                .map_err(BoxedError::new)
-                                .with_context(|_| server_error::ExecuteQuerySnafu {
-                                    query: format!("{:?}", query),
-                                })
-                        }
-                    }
-                }
-                _ => server_error::NotSupportedSnafu {
-                    feat: "Currently only insert and select is supported in GRPC service.",
-                }
-                .fail(),
+        let expr = query
+            .clone()
+            .expr
+            .context(server_error::InvalidQuerySnafu {
+                reason: "empty expr",
+            })?;
+        match expr {
+            Expr::Insert(insert_expr) => {
+                let output = self
+                    .handle_insert(insert_expr.clone())
+                    .await
+                    .map_err(BoxedError::new)
+                    .with_context(|_| server_error::ExecuteQuerySnafu {
+                        query: format!("{:?}", insert_expr),
+                    })?;
+                let object_result = match output {
+                    Output::AffectedRows(rows) => ObjectResultBuilder::default()
+                        .mutate_result(rows as _, 0)
+                        .build(),
+                    _ => unreachable!(),
+                };
+                Ok(object_result)
             }
-        } else {
-            server_error::InvalidQuerySnafu {
-                reason: "empty query",
-            }
-            .fail()
+            _ => GrpcQueryHandler::do_query(&*self.grpc_query_handler, query).await,
         }
     }
-}
-
-fn get_schema_name(expr: &AdminExpr) -> &str {
-    let schema_name = match &expr.expr {
-        Some(admin_expr::Expr::Create(expr)) => expr.schema_name.as_deref(),
-        Some(admin_expr::Expr::Alter(expr)) => expr.schema_name.as_deref(),
-        Some(admin_expr::Expr::CreateDatabase(_)) | None => Some(DEFAULT_SCHEMA_NAME),
-        Some(admin_expr::Expr::DropTable(expr)) => Some(expr.schema_name.as_ref()),
-    };
-    schema_name.unwrap_or(DEFAULT_SCHEMA_NAME)
 }
 
 #[async_trait]
@@ -786,13 +673,7 @@ impl GrpcAdminHandler for Instance {
         if let Some(api::v1::admin_expr::Expr::Create(create)) = &mut expr.expr {
             create.table_id = None;
         }
-        self.admin(get_schema_name(&expr))
-            .do_request(expr.clone())
-            .await
-            .map_err(BoxedError::new)
-            .with_context(|_| server_error::ExecuteQuerySnafu {
-                query: format!("{:?}", expr),
-            })
+        self.grpc_admin_handler.exec_admin_request(expr).await
     }
 }
 
@@ -808,6 +689,7 @@ mod tests {
     };
     use datatypes::schema::ColumnDefaultConstraint;
     use datatypes::value::Value;
+    use session::context::QueryContext;
 
     use super::*;
     use crate::tests;
@@ -853,7 +735,8 @@ mod tests {
             .await
             .unwrap();
         match output {
-            Output::RecordBatches(recordbatches) => {
+            Output::Stream(stream) => {
+                let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
                 let pretty_print = recordbatches.pretty_print();
                 let pretty_print = pretty_print.lines().collect::<Vec<&str>>();
                 let expected = vec![
@@ -875,7 +758,8 @@ mod tests {
             .await
             .unwrap();
         match output {
-            Output::RecordBatches(recordbatches) => {
+            Output::Stream(stream) => {
+                let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
                 let pretty_print = recordbatches.pretty_print();
                 let pretty_print = pretty_print.lines().collect::<Vec<&str>>();
                 let expected = vec![

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -16,13 +16,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use api::helper::ColumnDataTypeWrapper;
-use catalog::helper::{SchemaKey, SchemaValue, TableGlobalKey, TableGlobalValue};
 use api::result::AdminResultBuilder;
 use api::v1::{
     admin_expr, AdminExpr, AdminResult, AlterExpr, CreateDatabaseExpr, CreateExpr, ObjectExpr,
     ObjectResult,
 };
 use async_trait::async_trait;
+use catalog::helper::{SchemaKey, SchemaValue, TableGlobalKey, TableGlobalValue};
 use catalog::CatalogList;
 use chrono::DateTime;
 use client::admin::{admin_result_to_output, Admin};
@@ -158,9 +158,7 @@ impl DistInstance {
                 Ok(Output::AffectedRows(1))
             }
             Statement::CreateTable(stmt) => {
-                let create_expr = &mut DefaultCreateExprFactory {}
-                    .create_expr_by_stmt(&stmt)
-                    .await?;
+                let create_expr = &mut DefaultCreateExprFactory.create_expr_by_stmt(&stmt).await?;
                 Ok(self.create_table(create_expr, stmt.partitions).await?)
             }
             Statement::ShowDatabases(stmt) => show_databases(stmt, self.catalog_manager.clone()),
@@ -565,9 +563,10 @@ ENGINE=mito",
             let result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
             match &result[0] {
                 Statement::CreateTable(c) => {
-                    common_telemetry::info!("{}", sql);
-                    let factory = DefaultCreateExprFactory {};
-                    let expr = factory.create_expr_by_stmt(c).await.unwrap();
+                    let expr = DefaultCreateExprFactory
+                        .create_expr_by_stmt(c)
+                        .await
+                        .unwrap();
                     let partitions = parse_partitions(&expr, c.partitions.clone()).unwrap();
                     let json = serde_json::to_string(&partitions).unwrap();
                     assert_eq!(json, expected);

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -583,7 +583,7 @@ ENGINE=mito",
 
         let sql = "create database test_show_databases";
         let output = dist_instance
-            .handle_sql(sql, QueryContext::new_ref())
+            .handle_sql(sql, QueryContext::arc())
             .await
             .unwrap();
         match output {
@@ -593,7 +593,7 @@ ENGINE=mito",
 
         let sql = "show databases";
         let output = dist_instance
-            .handle_sql(sql, QueryContext::new_ref())
+            .handle_sql(sql, QueryContext::arc())
             .await
             .unwrap();
         match output {
@@ -628,7 +628,7 @@ ENGINE=mito",
 
         let sql = "create database test_show_tables";
         dist_instance
-            .handle_sql(sql, QueryContext::new_ref())
+            .handle_sql(sql, QueryContext::arc())
             .await
             .unwrap();
 
@@ -646,16 +646,13 @@ ENGINE=mito",
             )
             ENGINE=mito";
         dist_instance
-            .handle_sql(sql, QueryContext::new_ref())
+            .handle_sql(sql, QueryContext::arc())
             .await
             .unwrap();
 
         async fn assert_show_tables(instance: SqlQueryHandlerRef) {
             let sql = "show tables in test_show_tables";
-            let output = instance
-                .do_query(sql, QueryContext::new_ref())
-                .await
-                .unwrap();
+            let output = instance.do_query(sql, QueryContext::arc()).await.unwrap();
             match output {
                 Output::RecordBatches(r) => {
                     let expected = vec![

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -616,7 +616,7 @@ ENGINE=mito",
                 ];
                 let pretty = r.pretty_print();
                 let lines = pretty.lines().collect::<Vec<_>>();
-                assert!(&lines == &expected1 || &lines == &expected2)
+                assert!(lines == expected1 || lines == expected2)
             }
             _ => unreachable!(),
         }

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -47,13 +47,12 @@ impl OpentsdbProtocolHandler for Instance {
 impl Instance {
     async fn insert_opentsdb_metric(&self, data_point: &DataPoint) -> server_error::Result<()> {
         let insert_expr = data_point.as_grpc_insert();
-        let _ = self
-            .handle_insert(insert_expr)
+        self.handle_insert(insert_expr)
             .await
             .map_err(BoxedError::new)
             .with_context(|_| server_error::ExecuteQuerySnafu {
                 query: format!("{:?}", data_point),
-            });
+            })?;
         Ok(())
     }
 }

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -19,7 +19,6 @@ use servers::query_handler::OpentsdbProtocolHandler;
 use servers::{error as server_error, Mode};
 use snafu::prelude::*;
 
-use crate::error::Result;
 use crate::instance::Instance;
 
 #[async_trait]
@@ -29,12 +28,7 @@ impl OpentsdbProtocolHandler for Instance {
         // metric table and tags can be created upon insertion.
         match self.mode {
             Mode::Standalone => {
-                self.insert_opentsdb_metric(data_point)
-                    .await
-                    .map_err(BoxedError::new)
-                    .with_context(|_| server_error::PutOpentsdbDataPointSnafu {
-                        data_point: format!("{:?}", data_point),
-                    })?;
+                self.insert_opentsdb_metric(data_point).await?;
             }
             Mode::Distributed => {
                 self.dist_insert(vec![data_point.as_grpc_insert()])
@@ -51,9 +45,15 @@ impl OpentsdbProtocolHandler for Instance {
 }
 
 impl Instance {
-    async fn insert_opentsdb_metric(&self, data_point: &DataPoint) -> Result<()> {
-        let expr = data_point.as_grpc_insert();
-        self.handle_insert(expr).await?;
+    async fn insert_opentsdb_metric(&self, data_point: &DataPoint) -> server_error::Result<()> {
+        let insert_expr = data_point.as_grpc_insert();
+        let _ = self
+            .handle_insert(insert_expr)
+            .await
+            .map_err(BoxedError::new)
+            .with_context(|_| server_error::ExecuteQuerySnafu {
+                query: format!("{:?}", data_point),
+            });
         Ok(())
     }
 }
@@ -63,6 +63,7 @@ mod tests {
     use std::sync::Arc;
 
     use common_query::Output;
+    use common_recordbatch::RecordBatches;
     use datafusion::arrow_print;
     use servers::query_handler::SqlQueryHandler;
     use session::context::QueryContext;
@@ -128,7 +129,8 @@ mod tests {
             .await
             .unwrap();
         match output {
-            Output::RecordBatches(recordbatches) => {
+            Output::Stream(stream) => {
+                let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
                 let recordbatches = recordbatches
                     .take()
                     .into_iter()

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -932,8 +932,10 @@ mod test {
             _ => unreachable!(),
         };
 
-        let factory = DefaultCreateExprFactory {};
-        let mut expr = factory.create_expr_by_stmt(&create_table).await.unwrap();
+        let mut expr = DefaultCreateExprFactory
+            .create_expr_by_stmt(&create_table)
+            .await
+            .unwrap();
         let _result = dist_instance
             .create_table(&mut expr, create_table.partitions)
             .await

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -35,11 +35,10 @@ async fn create_datanode_instance() -> Arc<DatanodeInstance> {
 pub(crate) async fn create_frontend_instance() -> Arc<Instance> {
     let datanode_instance: Arc<DatanodeInstance> = create_datanode_instance().await;
     let dn_catalog_manager = datanode_instance.catalog_manager().clone();
-    let (_, client) = create_datanode_client(datanode_instance).await;
-    Arc::new(Instance::with_client_and_catalog_manager(
-        client,
-        dn_catalog_manager,
-    ))
+
+    let mut frontend_instance = Instance::new_standalone(datanode_instance);
+    frontend_instance.set_catalog_manager(dn_catalog_manager);
+    Arc::new(frontend_instance)
 }
 
 pub(crate) async fn create_datanode_client(

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -12,17 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
+use catalog::remote::MetaKvBackend;
 use client::Client;
 use common_grpc::channel_manager::ChannelManager;
 use common_runtime::Builder as RuntimeBuilder;
+use datanode::datanode::{DatanodeOptions, ObjectStoreConfig};
 use datanode::instance::Instance as DatanodeInstance;
+use meta_client::client::MetaClientBuilder;
+use meta_client::rpc::Peer;
+use meta_srv::metasrv::MetaSrvOptions;
+use meta_srv::mocks::MockInfo;
+use meta_srv::service::store::kv::KvStoreRef;
+use meta_srv::service::store::memory::MemStore;
 use servers::grpc::GrpcServer;
+use tempdir::TempDir;
 use tonic::transport::Server;
 use tower::service_fn;
 
+use crate::catalog::FrontendCatalogManager;
+use crate::datanode::DatanodeClients;
+use crate::instance::distributed::DistInstance;
 use crate::instance::Instance;
+use crate::table::route::TableRoutes;
 
 async fn create_datanode_instance() -> Arc<DatanodeInstance> {
     // TODO(LFC) Use real Mito engine when we can alter its region schema,
@@ -94,4 +109,92 @@ pub(crate) async fn create_datanode_client(
         addr.to_string(),
         Client::with_manager_and_urls(channel_manager, vec![addr]),
     )
+}
+
+async fn create_dist_datanode_instance(
+    datanode_id: u64,
+    meta_srv: MockInfo,
+) -> Arc<DatanodeInstance> {
+    let current = common_time::util::current_time_millis();
+    let wal_tmp_dir = TempDir::new_in("/tmp", &format!("dist_datanode-wal-{}", current)).unwrap();
+    let data_tmp_dir = TempDir::new_in("/tmp", &format!("dist_datanode-data-{}", current)).unwrap();
+    let opts = DatanodeOptions {
+        node_id: Some(datanode_id),
+        wal_dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
+        storage: ObjectStoreConfig::File {
+            data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+        },
+        ..Default::default()
+    };
+
+    let instance = Arc::new(
+        DatanodeInstance::with_mock_meta_server(&opts, meta_srv)
+            .await
+            .unwrap(),
+    );
+    instance.start().await.unwrap();
+    instance
+}
+
+async fn wait_datanodes_alive(kv_store: KvStoreRef) {
+    let wait = 10;
+    for _ in 0..wait {
+        let datanodes = meta_srv::lease::alive_datanodes(1000, &kv_store, |_, _| true)
+            .await
+            .unwrap();
+        if datanodes.len() >= 4 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await
+    }
+    panic!()
+}
+
+pub(crate) async fn create_dist_instance() -> (DistInstance, HashMap<u64, Arc<DatanodeInstance>>) {
+    let kv_store: KvStoreRef = Arc::new(MemStore::default()) as _;
+    let meta_srv = meta_srv::mocks::mock(MetaSrvOptions::default(), kv_store.clone(), None).await;
+
+    let datanode_clients = Arc::new(DatanodeClients::new());
+
+    let mut datanode_instances = HashMap::new();
+    for datanode_id in 1..=4 {
+        let dn_instance = create_dist_datanode_instance(datanode_id, meta_srv.clone()).await;
+        datanode_instances.insert(datanode_id, dn_instance.clone());
+
+        let (addr, client) = create_datanode_client(dn_instance).await;
+        datanode_clients
+            .insert_client(Peer::new(datanode_id, addr), client)
+            .await;
+    }
+
+    let MockInfo {
+        server_addr,
+        channel_manager,
+    } = meta_srv.clone();
+    let mut meta_client = MetaClientBuilder::new(1000, 0)
+        .enable_router()
+        .enable_store()
+        .channel_manager(channel_manager)
+        .build();
+    meta_client.start(&[&server_addr]).await.unwrap();
+    let meta_client = Arc::new(meta_client);
+
+    let meta_backend = Arc::new(MetaKvBackend {
+        client: meta_client.clone(),
+    });
+    let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
+    let catalog_manager = Arc::new(FrontendCatalogManager::new(
+        meta_backend,
+        table_routes.clone(),
+        datanode_clients.clone(),
+    ));
+
+    wait_datanodes_alive(kv_store).await;
+
+    let dist_instance = DistInstance::new(
+        meta_client.clone(),
+        catalog_manager,
+        datanode_clients.clone(),
+    );
+    (dist_instance, datanode_instances)
 }

--- a/src/script/src/python/builtins/mod.rs
+++ b/src/script/src/python/builtins/mod.rs
@@ -15,7 +15,6 @@
 //!  Builtin module contains GreptimeDB builtin udf/udaf
 
 #[cfg(test)]
-#[allow(clippy::print_stdout)]
 mod test;
 
 use datafusion_common::{DataFusionError, ScalarValue};

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -1039,6 +1039,7 @@ pub mod tests {
 
     use std::sync::Arc;
 
+    use common_telemetry::info;
     use datatypes::vectors::{Float32Vector, Int32Vector, NullVector};
     use rustpython_vm::builtins::PyList;
     use rustpython_vm::class::PyClassImpl;
@@ -1170,9 +1171,10 @@ pub mod tests {
     }
 
     #[test]
-    #[allow(clippy::print_stdout)]
     // for debug purpose, also this is already a test function so allow print_stdout shouldn't be a problem?
     fn test_execute_script() {
+        common_telemetry::init_default_ut_logging();
+
         fn is_eq<T: std::cmp::PartialEq + rustpython_vm::TryFromObject>(
             v: PyResult,
             i: T,
@@ -1221,7 +1223,7 @@ pub mod tests {
         for (code, pred) in snippet {
             let result = execute_script(&interpreter, code, None, pred);
 
-            println!(
+            info!(
                 "\u{001B}[35m{code}\u{001B}[0m: {:?}{}",
                 result.clone().map(|v| v.0),
                 result

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -30,6 +30,10 @@ impl Default for QueryContext {
 }
 
 impl QueryContext {
+    pub fn new_ref() -> QueryContextRef {
+        Arc::new(QueryContext::new())
+    }
+
     pub fn new() -> Self {
         Self {
             current_schema: ArcSwapOption::new(None),

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -30,7 +30,7 @@ impl Default for QueryContext {
 }
 
 impl QueryContext {
-    pub fn new_ref() -> QueryContextRef {
+    pub fn arc() -> QueryContextRef {
         Arc::new(QueryContext::new())
     }
 

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -61,14 +61,13 @@ macro_rules! grpc_tests {
 }
 
 pub async fn test_auto_create_table(store_type: StorageType) {
-    let (addr, mut guard, fe_grpc_server, dn_grpc_server) =
+    let (addr, mut guard, fe_grpc_server) =
         setup_grpc_server(store_type, "auto_create_table").await;
 
     let grpc_client = Client::with_urls(vec![addr]);
     let db = Database::new("greptime", grpc_client);
     insert_and_assert(&db).await;
     let _ = fe_grpc_server.shutdown().await;
-    let _ = dn_grpc_server.shutdown().await;
     guard.remove_all().await;
 }
 
@@ -128,7 +127,7 @@ fn expect_data() -> (Column, Column, Column, Column) {
 
 pub async fn test_insert_and_select(store_type: StorageType) {
     common_telemetry::init_default_ut_logging();
-    let (addr, mut guard, fe_grpc_server, dn_grpc_server) =
+    let (addr, mut guard, fe_grpc_server) =
         setup_grpc_server(store_type, "insert_and_select").await;
 
     let grpc_client = Client::with_urls(vec![addr]);
@@ -173,7 +172,6 @@ pub async fn test_insert_and_select(store_type: StorageType) {
     insert_and_assert(&db).await;
 
     let _ = fe_grpc_server.shutdown().await;
-    let _ = dn_grpc_server.shutdown().await;
     guard.remove_all().await;
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR removes the GRPC invocations between frontend and datanode in standalone mode.

In standalone mode, frontend is started with datanode instance, proxy most of the request to datanode instance, via the "QueryHandler" traits.

> "most" is not included the insertion, which has some "table creation upon insertion" mechanism, needs some special care.

`DistInstance` has implemented the "QueryHandler" traits, for the unification of some code logic.

Also note that some GRPC related codes are not updated as well, because we are facing the fundamental rewrite of whole GRPC framework, and the related codes will be rewritten from there.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#682 

close #584 