### PR TITLE
feat: Implements schema for datatypes2

### DIFF
--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -107,13 +107,6 @@ impl ConcreteDataType {
     //     )
     // }
 
-    // pub fn is_timestamp(&self) -> bool {
-    //     matches!(
-    //         self,
-    //         ConcreteDataType::Timestamp(_) | ConcreteDataType::Int64(_)
-    //     )
-    // }
-
     // pub fn numerics() -> Vec<ConcreteDataType> {
     //     vec![
     //         ConcreteDataType::int8_datatype(),
@@ -262,6 +255,7 @@ pub type DataTypeRef = Arc<dyn DataType>;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::datatypes::Field;
 
     #[test]
     fn test_concrete_type_as_datatype_trait() {
@@ -335,14 +329,14 @@ mod tests {
             ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8),
             ConcreteDataType::String(_)
         ));
-        // assert_eq!(
-        //     ConcreteDataType::from_arrow_type(&ArrowDataType::List(Box::new(Field::new(
-        //         "item",
-        //         ArrowDataType::Int32,
-        //         true,
-        //     )))),
-        //     ConcreteDataType::List(ListType::new(ConcreteDataType::int32_datatype()))
-        // );
+        assert_eq!(
+            ConcreteDataType::from_arrow_type(&ArrowDataType::List(Box::new(Field::new(
+                "item",
+                ArrowDataType::Int32,
+                true,
+            )))),
+            ConcreteDataType::List(ListType::new(ConcreteDataType::int32_datatype()))
+        );
         assert!(matches!(
             ConcreteDataType::from_arrow_type(&ArrowDataType::Date32),
             ConcreteDataType::Date(_)

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -254,8 +254,9 @@ pub type DataTypeRef = Arc<dyn DataType>;
 // TODO(yingwen): Pass all tests.
 #[cfg(test)]
 mod tests {
-    use super::*;
     use arrow::datatypes::Field;
+
+    use super::*;
 
     #[test]
     fn test_concrete_type_as_datatype_trait() {

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -372,9 +372,15 @@ mod tests {
     #[test]
     fn test_is_timestamp_compatible() {
         assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Second).is_timestamp_compatible());
-        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Millisecond).is_timestamp_compatible());
-        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Microsecond).is_timestamp_compatible());
-        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond).is_timestamp_compatible());
+        assert!(
+            ConcreteDataType::timestamp_datatype(TimeUnit::Millisecond).is_timestamp_compatible()
+        );
+        assert!(
+            ConcreteDataType::timestamp_datatype(TimeUnit::Microsecond).is_timestamp_compatible()
+        );
+        assert!(
+            ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond).is_timestamp_compatible()
+        );
         assert!(ConcreteDataType::timestamp_second_datatype().is_timestamp_compatible());
         assert!(ConcreteDataType::timestamp_millisecond_datatype().is_timestamp_compatible());
         assert!(ConcreteDataType::timestamp_microsecond_datatype().is_timestamp_compatible());

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -248,8 +248,12 @@ pub trait DataType: std::fmt::Debug + Send + Sync {
     /// Convert this type as [arrow::datatypes::DataType].
     fn as_arrow_type(&self) -> ArrowDataType;
 
-    /// Create a mutable vector with given `capacity` of this type.
+    /// Creates a mutable vector with given `capacity` of this type.
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector>;
+
+    /// Returns true if the data type is compatible with timestamp type so we can
+    /// use it as a timestamp.
+    fn is_timestamp_compatible(&self) -> bool;
 }
 
 pub type DataTypeRef = Arc<dyn DataType>;
@@ -365,15 +369,26 @@ mod tests {
     //     );
     // }
 
-    // #[test]
-    // fn test_is_timestamp() {
-    //     assert!(ConcreteDataType::timestamp_millis_datatype().is_timestamp());
-    //     assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Second).is_timestamp());
-    //     assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Millisecond).is_timestamp());
-    //     assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Microsecond).is_timestamp());
-    //     assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond).is_timestamp());
-    //     assert!(ConcreteDataType::int64_datatype().is_timestamp());
-    // }
+    #[test]
+    fn test_is_timestamp_compatible() {
+        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Second).is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Millisecond).is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Microsecond).is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond).is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_second_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_millisecond_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_microsecond_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::timestamp_nanosecond_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::int64_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::null_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::binary_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::boolean_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::date_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::datetime_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::string_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::int32_datatype().is_timestamp_compatible());
+        assert!(ConcreteDataType::uint64_datatype().is_timestamp_compatible());
+    }
 
     // #[test]
     // fn test_is_null() {

--- a/src/datatypes2/src/data_type.rs
+++ b/src/datatypes2/src/data_type.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use arrow::datatypes::DataType as ArrowDataType;
+use arrow::datatypes::{DataType as ArrowDataType, TimeUnit as ArrowTimeUnit};
 use common_time::timestamp::TimeUnit;
 use paste::paste;
 use serde::{Deserialize, Serialize};
@@ -154,7 +154,7 @@ impl TryFrom<&ArrowDataType> for ConcreteDataType {
             ArrowDataType::Float64 => Self::float64_datatype(),
             ArrowDataType::Date32 => Self::date_datatype(),
             ArrowDataType::Date64 => Self::datetime_datatype(),
-            // ArrowDataType::Timestamp(u, _) => ConcreteDataType::from_arrow_time_unit(u),
+            ArrowDataType::Timestamp(u, _) => ConcreteDataType::from_arrow_time_unit(u),
             ArrowDataType::Binary | ArrowDataType::LargeBinary => Self::binary_datatype(),
             ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => Self::string_datatype(),
             ArrowDataType::List(field) => Self::List(ListType::new(
@@ -218,6 +218,16 @@ impl ConcreteDataType {
             TimeUnit::Millisecond => Self::timestamp_millisecond_datatype(),
             TimeUnit::Microsecond => Self::timestamp_microsecond_datatype(),
             TimeUnit::Nanosecond => Self::timestamp_nanosecond_datatype(),
+        }
+    }
+
+    /// Converts from arrow timestamp unit to
+    pub fn from_arrow_time_unit(t: &ArrowTimeUnit) -> Self {
+        match t {
+            ArrowTimeUnit::Second => Self::timestamp_second_datatype(),
+            ArrowTimeUnit::Millisecond => Self::timestamp_millisecond_datatype(),
+            ArrowTimeUnit::Microsecond => Self::timestamp_microsecond_datatype(),
+            ArrowTimeUnit::Nanosecond => Self::timestamp_nanosecond_datatype(),
         }
     }
 
@@ -344,25 +354,25 @@ mod tests {
         ));
     }
 
-    // #[test]
-    // fn test_from_arrow_timestamp() {
-    //     assert_eq!(
-    //         ConcreteDataType::timestamp_millis_datatype(),
-    //         ConcreteDataType::from_arrow_time_unit(&arrow::datatypes::TimeUnit::Millisecond)
-    //     );
-    //     assert_eq!(
-    //         ConcreteDataType::timestamp_datatype(TimeUnit::Microsecond),
-    //         ConcreteDataType::from_arrow_time_unit(&arrow::datatypes::TimeUnit::Microsecond)
-    //     );
-    //     assert_eq!(
-    //         ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond),
-    //         ConcreteDataType::from_arrow_time_unit(&arrow::datatypes::TimeUnit::Nanosecond)
-    //     );
-    //     assert_eq!(
-    //         ConcreteDataType::timestamp_datatype(TimeUnit::Second),
-    //         ConcreteDataType::from_arrow_time_unit(&arrow::datatypes::TimeUnit::Second)
-    //     );
-    // }
+    #[test]
+    fn test_from_arrow_timestamp() {
+        assert_eq!(
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            ConcreteDataType::from_arrow_time_unit(&ArrowTimeUnit::Millisecond)
+        );
+        assert_eq!(
+            ConcreteDataType::timestamp_microsecond_datatype(),
+            ConcreteDataType::from_arrow_time_unit(&ArrowTimeUnit::Microsecond)
+        );
+        assert_eq!(
+            ConcreteDataType::timestamp_nanosecond_datatype(),
+            ConcreteDataType::from_arrow_time_unit(&ArrowTimeUnit::Nanosecond)
+        );
+        assert_eq!(
+            ConcreteDataType::timestamp_second_datatype(),
+            ConcreteDataType::from_arrow_time_unit(&ArrowTimeUnit::Second)
+        );
+    }
 
     #[test]
     fn test_is_timestamp_compatible() {
@@ -387,8 +397,8 @@ mod tests {
         assert!(!ConcreteDataType::date_datatype().is_timestamp_compatible());
         assert!(!ConcreteDataType::datetime_datatype().is_timestamp_compatible());
         assert!(!ConcreteDataType::string_datatype().is_timestamp_compatible());
-        assert!(ConcreteDataType::int32_datatype().is_timestamp_compatible());
-        assert!(ConcreteDataType::uint64_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::int32_datatype().is_timestamp_compatible());
+        assert!(!ConcreteDataType::uint64_datatype().is_timestamp_compatible());
     }
 
     // #[test]

--- a/src/datatypes2/src/lib.rs
+++ b/src/datatypes2/src/lib.rs
@@ -21,7 +21,6 @@ pub mod error;
 pub mod macros;
 pub mod prelude;
 mod scalars;
-// TODO(yingwen): schema mod
 pub mod schema;
 pub mod serialize;
 mod timestamp;

--- a/src/datatypes2/src/lib.rs
+++ b/src/datatypes2/src/lib.rs
@@ -22,6 +22,7 @@ pub mod macros;
 pub mod prelude;
 mod scalars;
 // TODO(yingwen): schema mod
+pub mod schema;
 pub mod serialize;
 mod timestamp;
 pub mod type_id;

--- a/src/datatypes2/src/schema.rs
+++ b/src/datatypes2/src/schema.rs
@@ -32,7 +32,7 @@ pub use crate::schema::raw::RawSchema;
 const VERSION_KEY: &str = "greptime:version";
 
 /// A common schema, should be immutable.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Schema {
     column_schemas: Vec<ColumnSchema>,
     name_to_index: HashMap<String, usize>,

--- a/src/datatypes2/src/schema.rs
+++ b/src/datatypes2/src/schema.rs
@@ -1,0 +1,429 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod column_schema;
+mod constraint;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::datatypes::{Field, Schema as ArrowSchema};
+use snafu::{ensure, ResultExt};
+
+use crate::data_type::DataType;
+use crate::error::{self, Error, Result};
+// pub use crate::schema::raw::RawSchema;
+pub use crate::schema::column_schema::{ColumnSchema, Metadata};
+pub use crate::schema::constraint::ColumnDefaultConstraint;
+
+/// Key used to store version number of the schema in metadata.
+const VERSION_KEY: &str = "greptime:version";
+
+/// A common schema, should be immutable.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Schema {
+    column_schemas: Vec<ColumnSchema>,
+    name_to_index: HashMap<String, usize>,
+    arrow_schema: Arc<ArrowSchema>,
+    /// Index of the timestamp key column.
+    ///
+    /// Timestamp key column is the column holds the timestamp and forms part of
+    /// the primary key. None means there is no timestamp key column.
+    timestamp_index: Option<usize>,
+    /// Version of the schema.
+    ///
+    /// Initial value is zero. The version should bump after altering schema.
+    version: u32,
+}
+
+impl Schema {
+    /// Initial version of the schema.
+    pub const INITIAL_VERSION: u32 = 0;
+
+    /// Create a schema from a vector of [ColumnSchema].
+    ///
+    /// # Panics
+    /// Panics when ColumnSchema's `default_constraint` can't be serialized into json.
+    pub fn new(column_schemas: Vec<ColumnSchema>) -> Schema {
+        // Builder won't fail in this case
+        SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .build()
+            .unwrap()
+    }
+
+    /// Try to Create a schema from a vector of [ColumnSchema].
+    pub fn try_new(column_schemas: Vec<ColumnSchema>) -> Result<Schema> {
+        SchemaBuilder::try_from(column_schemas)?.build()
+    }
+
+    #[inline]
+    pub fn arrow_schema(&self) -> &Arc<ArrowSchema> {
+        &self.arrow_schema
+    }
+
+    #[inline]
+    pub fn column_schemas(&self) -> &[ColumnSchema] {
+        &self.column_schemas
+    }
+
+    pub fn column_schema_by_name(&self, name: &str) -> Option<&ColumnSchema> {
+        self.name_to_index
+            .get(name)
+            .map(|index| &self.column_schemas[*index])
+    }
+
+    /// Retrieve the column's name by index
+    /// # Panics
+    /// This method **may** panic if the index is out of range of column schemas.
+    #[inline]
+    pub fn column_name_by_index(&self, idx: usize) -> &str {
+        &self.column_schemas[idx].name
+    }
+
+    #[inline]
+    pub fn column_index_by_name(&self, name: &str) -> Option<usize> {
+        self.name_to_index.get(name).copied()
+    }
+
+    #[inline]
+    pub fn contains_column(&self, name: &str) -> bool {
+        self.name_to_index.contains_key(name)
+    }
+
+    #[inline]
+    pub fn num_columns(&self) -> usize {
+        self.column_schemas.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.column_schemas.is_empty()
+    }
+
+    /// Returns index of the timestamp key column.
+    #[inline]
+    pub fn timestamp_index(&self) -> Option<usize> {
+        self.timestamp_index
+    }
+
+    #[inline]
+    pub fn timestamp_column(&self) -> Option<&ColumnSchema> {
+        self.timestamp_index.map(|idx| &self.column_schemas[idx])
+    }
+
+    #[inline]
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+
+    #[inline]
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.arrow_schema.metadata
+    }
+}
+
+#[derive(Default)]
+pub struct SchemaBuilder {
+    column_schemas: Vec<ColumnSchema>,
+    name_to_index: HashMap<String, usize>,
+    fields: Vec<Field>,
+    timestamp_index: Option<usize>,
+    version: u32,
+    metadata: HashMap<String, String>,
+}
+
+impl TryFrom<Vec<ColumnSchema>> for SchemaBuilder {
+    type Error = Error;
+
+    fn try_from(column_schemas: Vec<ColumnSchema>) -> Result<SchemaBuilder> {
+        SchemaBuilder::try_from_columns(column_schemas)
+    }
+}
+
+impl SchemaBuilder {
+    pub fn try_from_columns(column_schemas: Vec<ColumnSchema>) -> Result<Self> {
+        let FieldsAndIndices {
+            fields,
+            name_to_index,
+            timestamp_index,
+        } = collect_fields(&column_schemas)?;
+
+        Ok(Self {
+            column_schemas,
+            name_to_index,
+            fields,
+            timestamp_index,
+            ..Default::default()
+        })
+    }
+
+    pub fn version(mut self, version: u32) -> Self {
+        self.version = version;
+        self
+    }
+
+    /// Add key value pair to metadata.
+    ///
+    /// Old metadata with same key would be overwritten.
+    pub fn add_metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.metadata.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn build(mut self) -> Result<Schema> {
+        if let Some(timestamp_index) = self.timestamp_index {
+            validate_timestamp_index(&self.column_schemas, timestamp_index)?;
+        }
+
+        self.metadata
+            .insert(VERSION_KEY.to_string(), self.version.to_string());
+
+        let arrow_schema = ArrowSchema::new(self.fields).with_metadata(self.metadata);
+
+        Ok(Schema {
+            column_schemas: self.column_schemas,
+            name_to_index: self.name_to_index,
+            arrow_schema: Arc::new(arrow_schema),
+            timestamp_index: self.timestamp_index,
+            version: self.version,
+        })
+    }
+}
+
+struct FieldsAndIndices {
+    fields: Vec<Field>,
+    name_to_index: HashMap<String, usize>,
+    timestamp_index: Option<usize>,
+}
+
+fn collect_fields(column_schemas: &[ColumnSchema]) -> Result<FieldsAndIndices> {
+    let mut fields = Vec::with_capacity(column_schemas.len());
+    let mut name_to_index = HashMap::with_capacity(column_schemas.len());
+    let mut timestamp_index = None;
+    for (index, column_schema) in column_schemas.iter().enumerate() {
+        if column_schema.is_time_index() {
+            ensure!(
+                timestamp_index.is_none(),
+                error::DuplicateTimestampIndexSnafu {
+                    exists: timestamp_index.unwrap(),
+                    new: index,
+                }
+            );
+            timestamp_index = Some(index);
+        }
+        let field = Field::try_from(column_schema)?;
+        fields.push(field);
+        name_to_index.insert(column_schema.name.clone(), index);
+    }
+
+    Ok(FieldsAndIndices {
+        fields,
+        name_to_index,
+        timestamp_index,
+    })
+}
+
+fn validate_timestamp_index(column_schemas: &[ColumnSchema], timestamp_index: usize) -> Result<()> {
+    ensure!(
+        timestamp_index < column_schemas.len(),
+        error::InvalidTimestampIndexSnafu {
+            index: timestamp_index,
+        }
+    );
+
+    let column_schema = &column_schemas[timestamp_index];
+    ensure!(
+        column_schema.data_type.is_timestamp_compatible(),
+        error::InvalidTimestampIndexSnafu {
+            index: timestamp_index,
+        }
+    );
+    ensure!(
+        column_schema.is_time_index(),
+        error::InvalidTimestampIndexSnafu {
+            index: timestamp_index,
+        }
+    );
+
+    Ok(())
+}
+
+pub type SchemaRef = Arc<Schema>;
+
+impl TryFrom<Arc<ArrowSchema>> for Schema {
+    type Error = Error;
+
+    fn try_from(arrow_schema: Arc<ArrowSchema>) -> Result<Schema> {
+        let mut column_schemas = Vec::with_capacity(arrow_schema.fields.len());
+        let mut name_to_index = HashMap::with_capacity(arrow_schema.fields.len());
+        for field in &arrow_schema.fields {
+            let column_schema = ColumnSchema::try_from(field)?;
+            name_to_index.insert(field.name().to_string(), column_schemas.len());
+            column_schemas.push(column_schema);
+        }
+
+        let mut timestamp_index = None;
+        for (index, column_schema) in column_schemas.iter().enumerate() {
+            if column_schema.is_time_index() {
+                validate_timestamp_index(&column_schemas, index)?;
+                ensure!(
+                    timestamp_index.is_none(),
+                    error::DuplicateTimestampIndexSnafu {
+                        exists: timestamp_index.unwrap(),
+                        new: index,
+                    }
+                );
+                timestamp_index = Some(index);
+            }
+        }
+
+        let version = try_parse_version(&arrow_schema.metadata, VERSION_KEY)?;
+
+        Ok(Self {
+            column_schemas,
+            name_to_index,
+            arrow_schema,
+            timestamp_index,
+            version,
+        })
+    }
+}
+
+impl TryFrom<ArrowSchema> for Schema {
+    type Error = Error;
+
+    fn try_from(arrow_schema: ArrowSchema) -> Result<Schema> {
+        let arrow_schema = Arc::new(arrow_schema);
+
+        Schema::try_from(arrow_schema)
+    }
+}
+
+fn try_parse_version(metadata: &HashMap<String, String>, key: &str) -> Result<u32> {
+    if let Some(value) = metadata.get(key) {
+        let version = value
+            .parse()
+            .context(error::ParseSchemaVersionSnafu { value })?;
+
+        Ok(version)
+    } else {
+        Ok(Schema::INITIAL_VERSION)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_type::ConcreteDataType;
+
+    #[test]
+    fn test_build_empty_schema() {
+        let schema = SchemaBuilder::default().build().unwrap();
+        assert_eq!(0, schema.num_columns());
+        assert!(schema.is_empty());
+    }
+
+    #[test]
+    fn test_schema_no_timestamp() {
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new("col2", ConcreteDataType::float64_datatype(), true),
+        ];
+        let schema = Schema::new(column_schemas.clone());
+
+        assert_eq!(2, schema.num_columns());
+        assert!(!schema.is_empty());
+        assert!(schema.timestamp_index().is_none());
+        assert!(schema.timestamp_column().is_none());
+        assert_eq!(Schema::INITIAL_VERSION, schema.version());
+
+        for column_schema in &column_schemas {
+            let found = schema.column_schema_by_name(&column_schema.name).unwrap();
+            assert_eq!(column_schema, found);
+        }
+        assert!(schema.column_schema_by_name("col3").is_none());
+
+        let new_schema = Schema::try_from(schema.arrow_schema().clone()).unwrap();
+
+        assert_eq!(schema, new_schema);
+        assert_eq!(column_schemas, schema.column_schemas());
+    }
+
+    #[test]
+    fn test_metadata() {
+        let column_schemas = vec![ColumnSchema::new(
+            "col1",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )];
+        let schema = SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .add_metadata("k1", "v1")
+            .build()
+            .unwrap();
+
+        assert_eq!("v1", schema.metadata().get("k1").unwrap());
+    }
+
+    #[test]
+    fn test_schema_with_timestamp() {
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        ];
+        let schema = SchemaBuilder::try_from(column_schemas.clone())
+            .unwrap()
+            .version(123)
+            .build()
+            .unwrap();
+
+        assert_eq!(1, schema.timestamp_index().unwrap());
+        assert_eq!(&column_schemas[1], schema.timestamp_column().unwrap());
+        assert_eq!(123, schema.version());
+
+        let new_schema = Schema::try_from(schema.arrow_schema().clone()).unwrap();
+        assert_eq!(1, schema.timestamp_index().unwrap());
+        assert_eq!(schema, new_schema);
+    }
+
+    #[test]
+    fn test_schema_wrong_timestamp() {
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true)
+                .with_time_index(true),
+            ColumnSchema::new("col2", ConcreteDataType::float64_datatype(), false),
+        ];
+        assert!(SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .build()
+            .is_err());
+
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new("col2", ConcreteDataType::float64_datatype(), false)
+                .with_time_index(true),
+        ];
+
+        assert!(SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .build()
+            .is_err());
+    }
+}

--- a/src/datatypes2/src/schema.rs
+++ b/src/datatypes2/src/schema.rs
@@ -14,6 +14,7 @@
 
 mod column_schema;
 mod constraint;
+mod raw;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -23,9 +24,9 @@ use snafu::{ensure, ResultExt};
 
 use crate::data_type::DataType;
 use crate::error::{self, Error, Result};
-// pub use crate::schema::raw::RawSchema;
 pub use crate::schema::column_schema::{ColumnSchema, Metadata};
 pub use crate::schema::constraint::ColumnDefaultConstraint;
+pub use crate::schema::raw::RawSchema;
 
 /// Key used to store version number of the schema in metadata.
 const VERSION_KEY: &str = "greptime:version";

--- a/src/datatypes2/src/schema/column_schema.rs
+++ b/src/datatypes2/src/schema/column_schema.rs
@@ -31,7 +31,7 @@ const TIME_INDEX_KEY: &str = "greptime:time_index";
 const DEFAULT_CONSTRAINT_KEY: &str = "greptime:default_constraint";
 
 /// Schema of a column, used as an immutable struct.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ColumnSchema {
     pub name: String,
     pub data_type: ConcreteDataType,

--- a/src/datatypes2/src/schema/column_schema.rs
+++ b/src/datatypes2/src/schema/column_schema.rs
@@ -1,0 +1,305 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+
+use arrow::datatypes::Field;
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt};
+
+use crate::data_type::{ConcreteDataType, DataType};
+use crate::error::{self, Error, Result};
+use crate::schema::constraint::ColumnDefaultConstraint;
+use crate::vectors::VectorRef;
+
+pub type Metadata = BTreeMap<String, String>;
+
+/// Key used to store whether the column is time index in arrow field's metadata.
+const TIME_INDEX_KEY: &str = "greptime:time_index";
+/// Key used to store default constraint in arrow field's metadata.
+const DEFAULT_CONSTRAINT_KEY: &str = "greptime:default_constraint";
+
+/// Schema of a column, used as an immutable struct.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ColumnSchema {
+    pub name: String,
+    pub data_type: ConcreteDataType,
+    is_nullable: bool,
+    is_time_index: bool,
+    default_constraint: Option<ColumnDefaultConstraint>,
+    metadata: Metadata,
+}
+
+impl ColumnSchema {
+    pub fn new<T: Into<String>>(
+        name: T,
+        data_type: ConcreteDataType,
+        is_nullable: bool,
+    ) -> ColumnSchema {
+        ColumnSchema {
+            name: name.into(),
+            data_type,
+            is_nullable,
+            is_time_index: false,
+            default_constraint: None,
+            metadata: Metadata::new(),
+        }
+    }
+
+    #[inline]
+    pub fn is_time_index(&self) -> bool {
+        self.is_time_index
+    }
+
+    #[inline]
+    pub fn is_nullable(&self) -> bool {
+        self.is_nullable
+    }
+
+    #[inline]
+    pub fn default_constraint(&self) -> Option<&ColumnDefaultConstraint> {
+        self.default_constraint.as_ref()
+    }
+
+    #[inline]
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    pub fn with_time_index(mut self, is_time_index: bool) -> Self {
+        self.is_time_index = is_time_index;
+        if is_time_index {
+            self.metadata
+                .insert(TIME_INDEX_KEY.to_string(), "true".to_string());
+        } else {
+            self.metadata.remove(TIME_INDEX_KEY);
+        }
+        self
+    }
+
+    pub fn with_default_constraint(
+        mut self,
+        default_constraint: Option<ColumnDefaultConstraint>,
+    ) -> Result<Self> {
+        if let Some(constraint) = &default_constraint {
+            constraint.validate(&self.data_type, self.is_nullable)?;
+        }
+
+        self.default_constraint = default_constraint;
+        Ok(self)
+    }
+
+    /// Creates a new [`ColumnSchema`] with given metadata.
+    pub fn with_metadata(mut self, metadata: Metadata) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    pub fn create_default_vector(&self, num_rows: usize) -> Result<Option<VectorRef>> {
+        match &self.default_constraint {
+            Some(c) => c
+                .create_default_vector(&self.data_type, self.is_nullable, num_rows)
+                .map(Some),
+            None => {
+                if self.is_nullable {
+                    // No default constraint, use null as default value.
+                    // TODO(yingwen): Use NullVector once it supports setting logical type.
+                    ColumnDefaultConstraint::null_value()
+                        .create_default_vector(&self.data_type, self.is_nullable, num_rows)
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<&Field> for ColumnSchema {
+    type Error = Error;
+
+    fn try_from(field: &Field) -> Result<ColumnSchema> {
+        let data_type = ConcreteDataType::try_from(field.data_type())?;
+        let mut metadata = field.metadata().cloned().unwrap_or_default();
+        let default_constraint = match metadata.remove(DEFAULT_CONSTRAINT_KEY) {
+            Some(json) => {
+                Some(serde_json::from_str(&json).context(error::DeserializeSnafu { json })?)
+            }
+            None => None,
+        };
+        let is_time_index = metadata.contains_key(TIME_INDEX_KEY);
+
+        Ok(ColumnSchema {
+            name: field.name().clone(),
+            data_type,
+            is_nullable: field.is_nullable(),
+            is_time_index,
+            default_constraint,
+            metadata,
+        })
+    }
+}
+
+impl TryFrom<&ColumnSchema> for Field {
+    type Error = Error;
+
+    fn try_from(column_schema: &ColumnSchema) -> Result<Field> {
+        let mut metadata = column_schema.metadata.clone();
+        if let Some(value) = &column_schema.default_constraint {
+            // Adds an additional metadata to store the default constraint.
+            let old = metadata.insert(
+                DEFAULT_CONSTRAINT_KEY.to_string(),
+                serde_json::to_string(&value).context(error::SerializeSnafu)?,
+            );
+
+            ensure!(
+                old.is_none(),
+                error::DuplicateMetaSnafu {
+                    key: DEFAULT_CONSTRAINT_KEY,
+                }
+            );
+        }
+
+        Ok(Field::new(
+            &column_schema.name,
+            column_schema.data_type.as_arrow_type(),
+            column_schema.is_nullable(),
+        )
+        .with_metadata(Some(metadata)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::datatypes::DataType as ArrowDataType;
+
+    use super::*;
+    use crate::value::Value;
+
+    #[test]
+    fn test_column_schema() {
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true);
+        let field = Field::try_from(&column_schema).unwrap();
+        assert_eq!("test", field.name());
+        assert_eq!(ArrowDataType::Int32, *field.data_type());
+        assert!(field.is_nullable());
+
+        let new_column_schema = ColumnSchema::try_from(&field).unwrap();
+        assert_eq!(column_schema, new_column_schema);
+    }
+
+    #[test]
+    fn test_column_schema_with_default_constraint() {
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true)
+            .with_default_constraint(Some(ColumnDefaultConstraint::Value(Value::from(99))))
+            .unwrap();
+        assert!(column_schema
+            .metadata()
+            .get(DEFAULT_CONSTRAINT_KEY)
+            .is_none());
+
+        let field = Field::try_from(&column_schema).unwrap();
+        assert_eq!("test", field.name());
+        assert_eq!(ArrowDataType::Int32, *field.data_type());
+        assert!(field.is_nullable());
+        assert_eq!(
+            "{\"Value\":{\"Int32\":99}}",
+            field
+                .metadata()
+                .unwrap()
+                .get(DEFAULT_CONSTRAINT_KEY)
+                .unwrap()
+        );
+
+        let new_column_schema = ColumnSchema::try_from(&field).unwrap();
+        assert_eq!(column_schema, new_column_schema);
+    }
+
+    #[test]
+    fn test_column_schema_with_metadata() {
+        let mut metadata = Metadata::new();
+        metadata.insert("k1".to_string(), "v1".to_string());
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true)
+            .with_metadata(metadata)
+            .with_default_constraint(Some(ColumnDefaultConstraint::null_value()))
+            .unwrap();
+        assert_eq!("v1", column_schema.metadata().get("k1").unwrap());
+        assert!(column_schema
+            .metadata()
+            .get(DEFAULT_CONSTRAINT_KEY)
+            .is_none());
+
+        let field = Field::try_from(&column_schema).unwrap();
+        assert_eq!("v1", field.metadata().unwrap().get("k1").unwrap());
+        assert!(field
+            .metadata()
+            .unwrap()
+            .get(DEFAULT_CONSTRAINT_KEY)
+            .is_some());
+
+        let new_column_schema = ColumnSchema::try_from(&field).unwrap();
+        assert_eq!(column_schema, new_column_schema);
+    }
+
+    #[test]
+    fn test_column_schema_with_duplicate_metadata() {
+        let mut metadata = Metadata::new();
+        metadata.insert(DEFAULT_CONSTRAINT_KEY.to_string(), "v1".to_string());
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true)
+            .with_metadata(metadata)
+            .with_default_constraint(Some(ColumnDefaultConstraint::null_value()))
+            .unwrap();
+        Field::try_from(&column_schema).unwrap_err();
+    }
+
+    #[test]
+    fn test_column_schema_invalid_default_constraint() {
+        ColumnSchema::new("test", ConcreteDataType::int32_datatype(), false)
+            .with_default_constraint(Some(ColumnDefaultConstraint::null_value()))
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_column_default_constraint_try_into_from() {
+        let default_constraint = ColumnDefaultConstraint::Value(Value::from(42i64));
+
+        let bytes: Vec<u8> = default_constraint.clone().try_into().unwrap();
+        let from_value = ColumnDefaultConstraint::try_from(&bytes[..]).unwrap();
+
+        assert_eq!(default_constraint, from_value);
+    }
+
+    #[test]
+    fn test_column_schema_create_default_null() {
+        // Implicit default null.
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true);
+        let v = column_schema.create_default_vector(5).unwrap().unwrap();
+        assert_eq!(5, v.len());
+        assert!(v.only_null());
+
+        // Explicit default null.
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), true)
+            .with_default_constraint(Some(ColumnDefaultConstraint::null_value()))
+            .unwrap();
+        let v = column_schema.create_default_vector(5).unwrap().unwrap();
+        assert_eq!(5, v.len());
+        assert!(v.only_null());
+    }
+
+    #[test]
+    fn test_column_schema_no_default() {
+        let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), false);
+        assert!(column_schema.create_default_vector(5).unwrap().is_none());
+    }
+}

--- a/src/datatypes2/src/schema/constraint.rs
+++ b/src/datatypes2/src/schema/constraint.rs
@@ -1,0 +1,306 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use common_time::util;
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt};
+
+use crate::data_type::{ConcreteDataType, DataType};
+use crate::error::{self, Result};
+use crate::value::Value;
+use crate::vectors::{Int64Vector, TimestampMillisecondVector, VectorRef};
+
+const CURRENT_TIMESTAMP: &str = "current_timestamp()";
+
+/// Column's default constraint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ColumnDefaultConstraint {
+    // A function invocation
+    // TODO(dennis): we save the function expression here, maybe use a struct in future.
+    Function(String),
+    // A value
+    Value(Value),
+}
+
+impl TryFrom<&[u8]> for ColumnDefaultConstraint {
+    type Error = error::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self> {
+        let json = String::from_utf8_lossy(bytes);
+        serde_json::from_str(&json).context(error::DeserializeSnafu { json })
+    }
+}
+
+impl TryFrom<ColumnDefaultConstraint> for Vec<u8> {
+    type Error = error::Error;
+
+    fn try_from(value: ColumnDefaultConstraint) -> std::result::Result<Self, Self::Error> {
+        let s = serde_json::to_string(&value).context(error::SerializeSnafu)?;
+        Ok(s.into_bytes())
+    }
+}
+
+impl Display for ColumnDefaultConstraint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnDefaultConstraint::Function(expr) => write!(f, "{}", expr),
+            ColumnDefaultConstraint::Value(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+impl ColumnDefaultConstraint {
+    /// Returns a default null constraint.
+    pub fn null_value() -> ColumnDefaultConstraint {
+        ColumnDefaultConstraint::Value(Value::Null)
+    }
+
+    /// Check whether the constraint is valid for columns with given `data_type`
+    /// and `is_nullable` attributes.
+    pub fn validate(&self, data_type: &ConcreteDataType, is_nullable: bool) -> Result<()> {
+        ensure!(is_nullable || !self.maybe_null(), error::NullDefaultSnafu);
+
+        match self {
+            ColumnDefaultConstraint::Function(expr) => {
+                ensure!(
+                    expr == CURRENT_TIMESTAMP,
+                    error::UnsupportedDefaultExprSnafu { expr }
+                );
+                ensure!(
+                    data_type.is_timestamp_compatible(),
+                    error::DefaultValueTypeSnafu {
+                        reason: "return value of the function must has timestamp type",
+                    }
+                );
+            }
+            ColumnDefaultConstraint::Value(v) => {
+                if !v.is_null() {
+                    // Whether the value could be nullable has been checked before, only need
+                    // to check the type compatibility here.
+                    ensure!(
+                        data_type.logical_type_id() == v.logical_type_id(),
+                        error::DefaultValueTypeSnafu {
+                            reason: format!(
+                                "column has type {:?} but default value has type {:?}",
+                                data_type.logical_type_id(),
+                                v.logical_type_id()
+                            ),
+                        }
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Create a vector that contains `num_rows` default values for given `data_type`.
+    ///
+    /// If `is_nullable` is `true`, then this method would returns error if the created
+    /// default value is null.
+    ///
+    /// # Panics
+    /// Panics if `num_rows == 0`.
+    pub fn create_default_vector(
+        &self,
+        data_type: &ConcreteDataType,
+        is_nullable: bool,
+        num_rows: usize,
+    ) -> Result<VectorRef> {
+        assert!(num_rows > 0);
+
+        match self {
+            ColumnDefaultConstraint::Function(expr) => {
+                // Functions should also ensure its return value is not null when
+                // is_nullable is true.
+                match &expr[..] {
+                    // TODO(dennis): we only supports current_timestamp right now,
+                    //   it's better to use a expression framework in future.
+                    CURRENT_TIMESTAMP => create_current_timestamp_vector(data_type, num_rows),
+                    _ => error::UnsupportedDefaultExprSnafu { expr }.fail(),
+                }
+            }
+            ColumnDefaultConstraint::Value(v) => {
+                ensure!(is_nullable || !v.is_null(), error::NullDefaultSnafu);
+
+                // TODO(yingwen):
+                // 1. For null value, we could use NullVector once it supports custom logical type.
+                // 2. For non null value, we could use ConstantVector, but it would cause all codes
+                //  attempt to downcast the vector fail if they don't check whether the vector is const
+                //  first.
+                let mut mutable_vector = data_type.create_mutable_vector(1);
+                mutable_vector.push_value_ref(v.as_value_ref())?;
+                let base_vector = mutable_vector.to_vector();
+                Ok(base_vector.replicate(&[num_rows]))
+            }
+        }
+    }
+
+    /// Returns true if this constraint might creates NULL.
+    fn maybe_null(&self) -> bool {
+        // Once we support more functions, we may return true if given function
+        // could return null.
+        matches!(self, ColumnDefaultConstraint::Value(Value::Null))
+    }
+}
+
+fn create_current_timestamp_vector(
+    data_type: &ConcreteDataType,
+    num_rows: usize,
+) -> Result<VectorRef> {
+    // FIXME(yingwen): We should implements cast in VectorOp so we could cast the millisecond vector
+    // to other data type and avoid this match.
+    match data_type {
+        ConcreteDataType::Timestamp(_) => Ok(Arc::new(TimestampMillisecondVector::from_values(
+            std::iter::repeat(util::current_time_millis()).take(num_rows),
+        ))),
+        ConcreteDataType::Int64(_) => Ok(Arc::new(Int64Vector::from_values(
+            std::iter::repeat(util::current_time_millis()).take(num_rows),
+        ))),
+        _ => error::DefaultValueTypeSnafu {
+            reason: format!(
+                "Not support to assign current timestamp to {:?} type",
+                data_type
+            ),
+        }
+        .fail(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::Error;
+    use crate::vectors::Int32Vector;
+
+    #[test]
+    fn test_null_default_constraint() {
+        let constraint = ColumnDefaultConstraint::null_value();
+        assert!(constraint.maybe_null());
+        let constraint = ColumnDefaultConstraint::Value(Value::Int32(10));
+        assert!(!constraint.maybe_null());
+    }
+
+    #[test]
+    fn test_validate_null_constraint() {
+        let constraint = ColumnDefaultConstraint::null_value();
+        let data_type = ConcreteDataType::int32_datatype();
+        constraint.validate(&data_type, false).unwrap_err();
+        constraint.validate(&data_type, true).unwrap();
+    }
+
+    #[test]
+    fn test_validate_value_constraint() {
+        let constraint = ColumnDefaultConstraint::Value(Value::Int32(10));
+        let data_type = ConcreteDataType::int32_datatype();
+        constraint.validate(&data_type, false).unwrap();
+        constraint.validate(&data_type, true).unwrap();
+
+        constraint
+            .validate(&ConcreteDataType::uint32_datatype(), true)
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_validate_function_constraint() {
+        let constraint = ColumnDefaultConstraint::Function(CURRENT_TIMESTAMP.to_string());
+        constraint
+            .validate(&ConcreteDataType::timestamp_millisecond_datatype(), false)
+            .unwrap();
+        constraint
+            .validate(&ConcreteDataType::boolean_datatype(), false)
+            .unwrap_err();
+
+        let constraint = ColumnDefaultConstraint::Function("hello()".to_string());
+        constraint
+            .validate(&ConcreteDataType::timestamp_millisecond_datatype(), false)
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_create_default_vector_by_null() {
+        let constraint = ColumnDefaultConstraint::null_value();
+        let data_type = ConcreteDataType::int32_datatype();
+        constraint
+            .create_default_vector(&data_type, false, 10)
+            .unwrap_err();
+
+        let constraint = ColumnDefaultConstraint::null_value();
+        let v = constraint
+            .create_default_vector(&data_type, true, 3)
+            .unwrap();
+        assert_eq!(3, v.len());
+        for i in 0..v.len() {
+            assert_eq!(Value::Null, v.get(i));
+        }
+    }
+
+    #[test]
+    fn test_create_default_vector_by_value() {
+        let constraint = ColumnDefaultConstraint::Value(Value::Int32(10));
+        let data_type = ConcreteDataType::int32_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        let expect: VectorRef = Arc::new(Int32Vector::from_values(vec![10; 4]));
+        assert_eq!(expect, v);
+    }
+
+    #[test]
+    fn test_create_default_vector_by_func() {
+        let constraint = ColumnDefaultConstraint::Function(CURRENT_TIMESTAMP.to_string());
+        // Timestamp type.
+        let data_type = ConcreteDataType::timestamp_millisecond_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        assert_eq!(4, v.len());
+        assert!(
+            matches!(v.get(0), Value::Timestamp(_)),
+            "v {:?} is not timestamp",
+            v.get(0)
+        );
+
+        // Int64 type.
+        let data_type = ConcreteDataType::int64_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        assert_eq!(4, v.len());
+        assert!(
+            matches!(v.get(0), Value::Int64(_)),
+            "v {:?} is not timestamp",
+            v.get(0)
+        );
+
+        let constraint = ColumnDefaultConstraint::Function("no".to_string());
+        let data_type = ConcreteDataType::timestamp_millisecond_datatype();
+        constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap_err();
+    }
+
+    #[test]
+    fn test_create_by_func_and_invalid_type() {
+        let constraint = ColumnDefaultConstraint::Function(CURRENT_TIMESTAMP.to_string());
+        let data_type = ConcreteDataType::boolean_datatype();
+        let err = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap_err();
+        assert!(matches!(err, Error::DefaultValueType { .. }), "{:?}", err);
+    }
+}

--- a/src/datatypes2/src/schema/raw.rs
+++ b/src/datatypes2/src/schema/raw.rs
@@ -20,7 +20,7 @@ use crate::schema::{ColumnSchema, Schema, SchemaBuilder};
 /// Struct used to serialize and deserialize [`Schema`](crate::schema::Schema).
 ///
 /// This struct only contains necessary data to recover the Schema.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RawSchema {
     pub column_schemas: Vec<ColumnSchema>,
     pub timestamp_index: Option<usize>,

--- a/src/datatypes2/src/schema/raw.rs
+++ b/src/datatypes2/src/schema/raw.rs
@@ -1,0 +1,77 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+use crate::schema::{ColumnSchema, Schema, SchemaBuilder};
+
+/// Struct used to serialize and deserialize [`Schema`](crate::schema::Schema).
+///
+/// This struct only contains necessary data to recover the Schema.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RawSchema {
+    pub column_schemas: Vec<ColumnSchema>,
+    pub timestamp_index: Option<usize>,
+    pub version: u32,
+}
+
+impl TryFrom<RawSchema> for Schema {
+    type Error = Error;
+
+    fn try_from(raw: RawSchema) -> Result<Schema> {
+        SchemaBuilder::try_from(raw.column_schemas)?
+            .version(raw.version)
+            .build()
+    }
+}
+
+impl From<&Schema> for RawSchema {
+    fn from(schema: &Schema) -> RawSchema {
+        RawSchema {
+            column_schemas: schema.column_schemas.clone(),
+            timestamp_index: schema.timestamp_index,
+            version: schema.version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_type::ConcreteDataType;
+
+    #[test]
+    fn test_raw_convert() {
+        let column_schemas = vec![
+            ColumnSchema::new("col1", ConcreteDataType::int32_datatype(), true),
+            ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            )
+            .with_time_index(true),
+        ];
+        let schema = SchemaBuilder::try_from(column_schemas)
+            .unwrap()
+            .version(123)
+            .build()
+            .unwrap();
+
+        let raw = RawSchema::from(&schema);
+        let schema_new = Schema::try_from(raw).unwrap();
+
+        assert_eq!(schema, schema_new);
+    }
+}

--- a/src/datatypes2/src/types/binary_type.rs
+++ b/src/datatypes2/src/types/binary_type.rs
@@ -53,7 +53,7 @@ impl DataType for BinaryType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(BinaryVectorBuilder::with_capacity(capacity))
     }
-    
+
     fn is_timestamp_compatible(&self) -> bool {
         false
     }

--- a/src/datatypes2/src/types/binary_type.rs
+++ b/src/datatypes2/src/types/binary_type.rs
@@ -53,4 +53,8 @@ impl DataType for BinaryType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(BinaryVectorBuilder::with_capacity(capacity))
     }
+    
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }

--- a/src/datatypes2/src/types/boolean_type.rs
+++ b/src/datatypes2/src/types/boolean_type.rs
@@ -52,7 +52,7 @@ impl DataType for BooleanType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(BooleanVectorBuilder::with_capacity(capacity))
     }
-    
+
     fn is_timestamp_compatible(&self) -> bool {
         false
     }

--- a/src/datatypes2/src/types/boolean_type.rs
+++ b/src/datatypes2/src/types/boolean_type.rs
@@ -52,4 +52,8 @@ impl DataType for BooleanType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(BooleanVectorBuilder::with_capacity(capacity))
     }
+    
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }

--- a/src/datatypes2/src/types/date_type.rs
+++ b/src/datatypes2/src/types/date_type.rs
@@ -49,6 +49,10 @@ impl DataType for DateType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(DateVectorBuilder::with_capacity(capacity))
     }
+
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }
 
 impl LogicalPrimitiveType for DateType {

--- a/src/datatypes2/src/types/datetime_type.rs
+++ b/src/datatypes2/src/types/datetime_type.rs
@@ -47,7 +47,7 @@ impl DataType for DateTimeType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(DateTimeVectorBuilder::with_capacity(capacity))
     }
-    
+
     fn is_timestamp_compatible(&self) -> bool {
         false
     }

--- a/src/datatypes2/src/types/datetime_type.rs
+++ b/src/datatypes2/src/types/datetime_type.rs
@@ -47,6 +47,10 @@ impl DataType for DateTimeType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(DateTimeVectorBuilder::with_capacity(capacity))
     }
+    
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }
 
 impl LogicalPrimitiveType for DateTimeType {

--- a/src/datatypes2/src/types/list_type.rs
+++ b/src/datatypes2/src/types/list_type.rs
@@ -67,6 +67,10 @@ impl DataType for ListType {
             capacity,
         ))
     }
+
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/datatypes2/src/types/null_type.rs
+++ b/src/datatypes2/src/types/null_type.rs
@@ -51,7 +51,7 @@ impl DataType for NullType {
     fn create_mutable_vector(&self, _capacity: usize) -> Box<dyn MutableVector> {
         Box::new(NullVectorBuilder::default())
     }
-    
+
     fn is_timestamp_compatible(&self) -> bool {
         false
     }

--- a/src/datatypes2/src/types/null_type.rs
+++ b/src/datatypes2/src/types/null_type.rs
@@ -51,4 +51,8 @@ impl DataType for NullType {
     fn create_mutable_vector(&self, _capacity: usize) -> Box<dyn MutableVector> {
         Box::new(NullVectorBuilder::default())
     }
+    
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }

--- a/src/datatypes2/src/types/primitive_type.rs
+++ b/src/datatypes2/src/types/primitive_type.rs
@@ -236,6 +236,12 @@ macro_rules! define_logical_primitive_type {
                 }
             }
         }
+    };
+}
+
+macro_rules! define_non_timestamp_primitive {
+    ($Native: ident, $TypeId: ident, $DataType: ident) => {
+        define_logical_primitive_type!($Native, $TypeId, $DataType);
 
         impl DataType for $DataType {
             fn name(&self) -> &str {
@@ -257,20 +263,52 @@ macro_rules! define_logical_primitive_type {
             fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
                 Box::new(PrimitiveVectorBuilder::<$DataType>::with_capacity(capacity))
             }
+
+            fn is_timestamp_compatible(&self) -> bool {
+                false
+            }
         }
     };
 }
 
-define_logical_primitive_type!(u8, UInt8, UInt8Type);
-define_logical_primitive_type!(u16, UInt16, UInt16Type);
-define_logical_primitive_type!(u32, UInt32, UInt32Type);
-define_logical_primitive_type!(u64, UInt64, UInt64Type);
-define_logical_primitive_type!(i8, Int8, Int8Type);
-define_logical_primitive_type!(i16, Int16, Int16Type);
-define_logical_primitive_type!(i32, Int32, Int32Type);
+define_non_timestamp_primitive!(u8, UInt8, UInt8Type);
+define_non_timestamp_primitive!(u16, UInt16, UInt16Type);
+define_non_timestamp_primitive!(u32, UInt32, UInt32Type);
+define_non_timestamp_primitive!(u64, UInt64, UInt64Type);
+define_non_timestamp_primitive!(i8, Int8, Int8Type);
+define_non_timestamp_primitive!(i16, Int16, Int16Type);
+define_non_timestamp_primitive!(i32, Int32, Int32Type);
+define_non_timestamp_primitive!(f32, Float32, Float32Type);
+define_non_timestamp_primitive!(f64, Float64, Float64Type);
+
+// Timestamp primitive:
 define_logical_primitive_type!(i64, Int64, Int64Type);
-define_logical_primitive_type!(f32, Float32, Float32Type);
-define_logical_primitive_type!(f64, Float64, Float64Type);
+
+impl DataType for Int64Type {
+    fn name(&self) -> &str {
+        "Int64"
+    }
+
+    fn logical_type_id(&self) -> LogicalTypeId {
+        LogicalTypeId::Int64
+    }
+
+    fn default_value(&self) -> Value {
+        Value::Int64(0)
+    }
+
+    fn as_arrow_type(&self) -> ArrowDataType {
+        ArrowDataType::Int64
+    }
+
+    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+        Box::new(PrimitiveVectorBuilder::<Int64Type>::with_capacity(capacity))
+    }
+
+    fn is_timestamp_compatible(&self) -> bool {
+        true
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/datatypes2/src/types/string_type.rs
+++ b/src/datatypes2/src/types/string_type.rs
@@ -53,4 +53,8 @@ impl DataType for StringType {
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(StringVectorBuilder::with_capacity(capacity))
     }
+
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
 }

--- a/src/datatypes2/src/types/timestamp_type.rs
+++ b/src/datatypes2/src/types/timestamp_type.rs
@@ -76,7 +76,7 @@ macro_rules! impl_data_type_for_timestamp {
                 fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
                     Box::new([<Timestamp $unit Vector Builder>]::with_capacity(capacity))
                 }
-                
+
                 fn is_timestamp_compatible(&self) -> bool {
                     true
                 }

--- a/src/datatypes2/src/types/timestamp_type.rs
+++ b/src/datatypes2/src/types/timestamp_type.rs
@@ -76,6 +76,10 @@ macro_rules! impl_data_type_for_timestamp {
                 fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
                     Box::new([<Timestamp $unit Vector Builder>]::with_capacity(capacity))
                 }
+                
+                fn is_timestamp_compatible(&self) -> bool {
+                    true
+                }
             }
 
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR implements schema mod for `datatypes2` crate.
- Ports `Schema`, `ColumnSchema` and `RawSchema` from `datatypes`
- Adds the `is_timestamp_compatible()` method to the `DataType` trait.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #555