### PR TITLE
fix: set default value when fail to get git info instead of panic

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const DEFAULT_VALUE: &str = "unknown";
 fn main() {
-    build_data::set_GIT_BRANCH();
-    build_data::set_GIT_COMMIT();
-    build_data::set_GIT_DIRTY();
+    println!(
+        "cargo:rustc-env=GIT_COMMIT={}",
+        build_data::get_git_commit().unwrap_or_else(|_| DEFAULT_VALUE.to_string())
+    );
+    println!(
+        "cargo:rustc-env=GIT_BRANCH={}",
+        build_data::get_git_branch().unwrap_or_else(|_| DEFAULT_VALUE.to_string())
+    );
+    println!(
+        "cargo:rustc-env=GIT_DIRTY={}",
+        build_data::get_git_dirty().map_or(DEFAULT_VALUE.to_string(), |v| v.to_string())
+    );
 }

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -77,7 +77,9 @@ fn print_version() -> &'static str {
         "\ncommit: ",
         env!("GIT_COMMIT"),
         "\ndirty: ",
-        env!("GIT_DIRTY")
+        env!("GIT_DIRTY"),
+        "\nversion: ",
+        env!("CARGO_PKG_VERSION")
     )
 }
 


### PR DESCRIPTION
Signed-off-by: Zheming Li <nkdudu@126.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Discussed in https://github.com/GreptimeTeam/greptimedb/pull/632#issuecomment-1335171406

- use default value `unknown` for git info when fail to get to avoid panic in `build.rs`.
- add `CARGO_PKG_VERSION` in `-V` output.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
