### PR TITLE
fix: test_server_require_secure_client_secure

### DIFF
--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -149,7 +149,7 @@ async fn test_server_prefer_secure_client_secure() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_server_require_secure_client_secure() -> Result<()> {
     let server_tls = Arc::new(TlsOption {
         mode: servers::tls::TlsMode::Require,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix test case `tls handshake eof` bug

Please explain IN DETAIL what the changes are in this PR and why they are needed:
increase tokio test worker thread number

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/677