### PR TITLE
feat: move_value & delete_route

### DIFF
--- a/src/api/greptime/v1/meta/route.proto
+++ b/src/api/greptime/v1/meta/route.proto
@@ -5,6 +5,8 @@ package greptime.v1.meta;
 import "greptime/v1/meta/common.proto";
 
 service Router {
+  rpc Create(CreateRequest) returns (RouteResponse) {}
+
   // Fetch routing information for tables. The smallest unit is the complete
   // routing information(all regions) of a table.
   // 
@@ -26,7 +28,14 @@ service Router {
   //
   rpc Route(RouteRequest) returns (RouteResponse) {}
 
-  rpc Create(CreateRequest) returns (RouteResponse) {}
+  rpc Delete(DeleteRequest) returns (RouteResponse) {}
+}
+
+message CreateRequest {
+  RequestHeader header = 1;
+
+  TableName table_name = 2;
+  repeated Partition partitions = 3;
 }
 
 message RouteRequest {
@@ -35,18 +44,17 @@ message RouteRequest {
   repeated TableName table_names = 2;
 }
 
+message DeleteRequest {
+  RequestHeader header = 1;
+
+  TableName table_name = 2; 
+}
+
 message RouteResponse {
   ResponseHeader header = 1;
 
   repeated Peer peers = 2;
   repeated TableRoute table_routes = 3;
-}
-
-message CreateRequest {
-  RequestHeader header = 1;
-
-  TableName table_name = 2;
-  repeated Partition partitions = 3;
 }
 
 message TableRoute {

--- a/src/api/greptime/v1/meta/store.proto
+++ b/src/api/greptime/v1/meta/store.proto
@@ -20,6 +20,9 @@ service Store {
 
   // DeleteRange deletes the given range from the key-value store.
   rpc DeleteRange(DeleteRangeRequest) returns (DeleteRangeResponse);
+
+  // MoveValue atomically renames the key to the given updated key.
+  rpc MoveValue(MoveValueRequest) returns (MoveValueResponse);
 }
 
 message RangeRequest {
@@ -135,4 +138,22 @@ message DeleteRangeResponse {
   // If prev_kv is set in the request, the previous key-value pairs will be
   // returned.
   repeated KeyValue prev_kvs = 3;
+}
+
+message MoveValueRequest {
+  RequestHeader header = 1;
+
+  // If from_key dose not exist, return the value of to_key (if it exists).
+  // If from_key exists, move the value of from_key to to_key (i.e. rename),
+  // and return the value.
+  bytes from_key = 2;
+  bytes to_key = 3;
+}
+
+message MoveValueResponse {
+  ResponseHeader header = 1;
+
+  // If from_key dose not exist, return the value of to_key (if it exists).
+  // If from_key exists, return the value of from_key.
+  KeyValue kv = 2;
 }

--- a/src/api/src/v1/meta.rs
+++ b/src/api/src/v1/meta.rs
@@ -145,10 +145,12 @@ gen_set_header!(HeartbeatRequest);
 gen_set_header!(RouteRequest);
 gen_set_header!(CreateRequest);
 gen_set_header!(RangeRequest);
+gen_set_header!(DeleteRequest);
 gen_set_header!(PutRequest);
 gen_set_header!(BatchPutRequest);
 gen_set_header!(CompareAndPutRequest);
 gen_set_header!(DeleteRangeRequest);
+gen_set_header!(MoveValueRequest);
 
 #[cfg(test)]
 mod tests {

--- a/src/meta-client/src/rpc.rs
+++ b/src/meta-client/src/rpc.rs
@@ -28,7 +28,8 @@ pub use router::{
 use serde::{Deserialize, Serialize};
 pub use store::{
     BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
-    DeleteRangeRequest, DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
+    DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest,
+    PutResponse, RangeRequest, RangeResponse,
 };
 
 #[derive(Debug, Clone)]

--- a/src/meta-client/src/rpc/store.rs
+++ b/src/meta-client/src/rpc/store.rs
@@ -17,6 +17,7 @@ use api::v1::meta::{
     CompareAndPutRequest as PbCompareAndPutRequest,
     CompareAndPutResponse as PbCompareAndPutResponse, DeleteRangeRequest as PbDeleteRangeRequest,
     DeleteRangeResponse as PbDeleteRangeResponse, KeyValue as PbKeyValue,
+    MoveValueRequest as PbMoveValueRequest, MoveValueResponse as PbMoveValueResponse,
     PutRequest as PbPutRequest, PutResponse as PbPutResponse, RangeRequest as PbRangeRequest,
     RangeResponse as PbRangeResponse,
 };
@@ -521,6 +522,65 @@ impl DeleteRangeResponse {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct MoveValueRequest {
+    /// If from_key dose not exist, return the value of to_key (if it exists).
+    /// If from_key exists, move the value of from_key to to_key (i.e. rename),
+    /// and return the value.
+    pub from_key: Vec<u8>,
+    pub to_key: Vec<u8>,
+}
+
+impl From<MoveValueRequest> for PbMoveValueRequest {
+    fn from(req: MoveValueRequest) -> Self {
+        Self {
+            header: None,
+            from_key: req.from_key,
+            to_key: req.to_key,
+        }
+    }
+}
+
+impl MoveValueRequest {
+    #[inline]
+    pub fn new(from_key: impl Into<Vec<u8>>, to_key: impl Into<Vec<u8>>) -> Self {
+        Self {
+            from_key: from_key.into(),
+            to_key: to_key.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MoveValueResponse(PbMoveValueResponse);
+
+impl TryFrom<PbMoveValueResponse> for MoveValueResponse {
+    type Error = error::Error;
+
+    fn try_from(pb: PbMoveValueResponse) -> Result<Self> {
+        util::check_response_header(pb.header.as_ref())?;
+
+        Ok(Self::new(pb))
+    }
+}
+
+impl MoveValueResponse {
+    #[inline]
+    pub fn new(res: PbMoveValueResponse) -> Self {
+        Self(res)
+    }
+
+    #[inline]
+    pub fn take_header(&mut self) -> Option<ResponseHeader> {
+        self.0.header.take().map(ResponseHeader::new)
+    }
+
+    #[inline]
+    pub fn take_kv(&mut self) -> Option<KeyValue> {
+        self.0.kv.take().map(KeyValue::new)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use api::v1::meta::{
@@ -528,8 +588,10 @@ mod tests {
         CompareAndPutRequest as PbCompareAndPutRequest,
         CompareAndPutResponse as PbCompareAndPutResponse,
         DeleteRangeRequest as PbDeleteRangeRequest, DeleteRangeResponse as PbDeleteRangeResponse,
-        KeyValue as PbKeyValue, PutRequest as PbPutRequest, PutResponse as PbPutResponse,
-        RangeRequest as PbRangeRequest, RangeResponse as PbRangeResponse,
+        KeyValue as PbKeyValue, MoveValueRequest as PbMoveValueRequest,
+        MoveValueResponse as PbMoveValueResponse, PutRequest as PbPutRequest,
+        PutResponse as PbPutResponse, RangeRequest as PbRangeRequest,
+        RangeResponse as PbRangeResponse,
     };
 
     use super::*;
@@ -774,5 +836,36 @@ mod tests {
         assert_eq!(b"k2".to_vec(), kv1.take_key());
         assert_eq!(b"v2".to_vec(), kv1.value().to_vec());
         assert_eq!(b"v2".to_vec(), kv1.take_value());
+    }
+
+    #[test]
+    fn test_move_value_request_trans() {
+        let (from_key, to_key) = (b"test_key1".to_vec(), b"test_key2".to_vec());
+
+        let req = MoveValueRequest::new(from_key.clone(), to_key.clone());
+
+        let into_req: PbMoveValueRequest = req.into();
+        assert!(into_req.header.is_none());
+        assert_eq!(from_key, into_req.from_key);
+        assert_eq!(to_key, into_req.to_key);
+    }
+
+    #[test]
+    fn test_move_value_response_trans() {
+        let pb_res = PbMoveValueResponse {
+            header: None,
+            kv: Some(PbKeyValue {
+                key: b"k1".to_vec(),
+                value: b"v1".to_vec(),
+            }),
+        };
+
+        let mut res = MoveValueResponse::new(pb_res);
+        assert!(res.take_header().is_none());
+        let mut kv = res.take_kv().unwrap();
+        assert_eq!(b"k1".to_vec(), kv.key().to_vec());
+        assert_eq!(b"k1".to_vec(), kv.take_key());
+        assert_eq!(b"v1".to_vec(), kv.value().to_vec());
+        assert_eq!(b"v1".to_vec(), kv.take_value());
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -123,6 +123,9 @@ pub enum Error {
 
     #[snafu(display("MetaSrv has no leader at this moment"))]
     NoLeader { backtrace: Backtrace },
+
+    #[snafu(display("Table {} not found", name))]
+    TableNotFound { name: String, backtrace: Backtrace },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -163,6 +166,7 @@ impl ErrorExt for Error {
             | Error::TableRouteNotFound { .. }
             | Error::NextSequence { .. }
             | Error::InvalidTxnResult { .. } => StatusCode::Unexpected,
+            Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
         }
     }

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -24,6 +24,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use crate::error;
 use crate::error::Result;
 
+pub(crate) const REMOVED_PREFIX: &str = "__removed";
 pub(crate) const DN_LEASE_PREFIX: &str = "__meta_dnlease";
 pub(crate) const SEQ_PREFIX: &str = "__meta_seq";
 pub(crate) const TABLE_ROUTE_PREFIX: &str = "__meta_table_route";
@@ -149,6 +150,7 @@ impl<'a> TableRouteKey<'a> {
         }
     }
 
+    #[inline]
     pub fn prefix(&self) -> String {
         format!(
             "{}-{}-{}-{}",
@@ -156,8 +158,14 @@ impl<'a> TableRouteKey<'a> {
         )
     }
 
+    #[inline]
     pub fn key(&self) -> String {
         format!("{}-{}", self.prefix(), self.table_id)
+    }
+
+    #[inline]
+    pub fn removed_key(&self) -> String {
+        format!("{}-{}", REMOVED_PREFIX, self.key())
     }
 }
 

--- a/src/meta-srv/src/sequence.rs
+++ b/src/meta-srv/src/sequence.rs
@@ -205,6 +205,13 @@ mod tests {
             ) -> Result<api::v1::meta::DeleteRangeResponse> {
                 unreachable!()
             }
+
+            async fn move_value(
+                &self,
+                _: api::v1::meta::MoveValueRequest,
+            ) -> Result<api::v1::meta::MoveValueResponse> {
+                unreachable!()
+            }
         }
 
         let kv_store = Arc::new(Noop {});

--- a/src/meta-srv/src/service/store.rs
+++ b/src/meta-srv/src/service/store.rs
@@ -18,7 +18,8 @@ pub mod memory;
 
 use api::v1::meta::{
     store_server, BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
-    DeleteRangeRequest, DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
+    DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest,
+    PutResponse, RangeRequest, RangeResponse,
 };
 use tonic::{Request, Response};
 
@@ -64,6 +65,13 @@ impl store_server::Store for MetaSrv {
     ) -> GrpcResult<DeleteRangeResponse> {
         let req = req.into_inner();
         let res = self.kv_store().delete_range(req).await?;
+
+        Ok(Response::new(res))
+    }
+
+    async fn move_value(&self, req: Request<MoveValueRequest>) -> GrpcResult<MoveValueResponse> {
+        let req = req.into_inner();
+        let res = self.kv_store().move_value(req).await?;
 
         Ok(Response::new(res))
     }
@@ -127,6 +135,16 @@ mod tests {
         let meta_srv = MetaSrv::new(MetaSrvOptions::default(), kv_store, None, None).await;
         let req = DeleteRangeRequest::default();
         let res = meta_srv.delete_range(req.into_request()).await;
+
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_move_value() {
+        let kv_store = Arc::new(MemStore::new());
+        let meta_srv = MetaSrv::new(MetaSrvOptions::default(), kv_store, None, None).await;
+        let req = MoveValueRequest::default();
+        let res = meta_srv.move_value(req.into_request()).await;
 
         assert!(res.is_ok());
     }

--- a/src/meta-srv/src/service/store/kv.rs
+++ b/src/meta-srv/src/service/store/kv.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 
 use api::v1::meta::{
     BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
-    DeleteRangeRequest, DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
+    DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest,
+    PutResponse, RangeRequest, RangeResponse,
 };
 
 use crate::error::Result;
@@ -34,4 +35,6 @@ pub trait KvStore: Send + Sync {
     async fn compare_and_put(&self, req: CompareAndPutRequest) -> Result<CompareAndPutResponse>;
 
     async fn delete_range(&self, req: DeleteRangeRequest) -> Result<DeleteRangeResponse>;
+
+    async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse>;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Part of DROP TABLE in distributed mode, drop route in meta service:

1. We need to delete the routing information (logical delete) when executing drop table.
2. In order to implement logical delete, the following API is added: `move_value(from_key, to_key)`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Part of #497 