### PR TITLE
feat: bump opendal version to 0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,9 +3998,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.21.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9be1e30ca12b989107a5ee5bb75468a7f538059e43255ccd4743089b42aeeb"
+checksum = "e2ce68ece2dc033c0faf446fe654b0182de8e8b876aef36d733cca7c95e2601a"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -4028,6 +4028,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -5094,9 +5095,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.6.6"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34ea360414ee77ddab3a8360a0c241fc77ab5e27892dcde1d2cfcc29d4e0f55"
+checksum = "605c196ac197a563c908b62470d96968ce4880fdcb64e296f55880fd21c8ad65"
 dependencies = [
  "anyhow",
  "backon",

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -194,7 +194,7 @@ pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result
         object_store
             .layer(RetryLayer::new(ExponentialBackoff::default().with_jitter()))
             .layer(MetricsLayer)
-            .layer(LoggingLayer)
+            .layer(LoggingLayer::default())
             .layer(TracingLayer)
     })
 }

--- a/src/datatypes2/Cargo.toml
+++ b/src/datatypes2/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test = []
 
 [dependencies]
+arrow = "26.0"
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
@@ -21,4 +22,3 @@ paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
-arrow = "26.0"

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.21", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics"] }
 tokio = { version = "1.0", features = ["full"] }
 
 [dev-dependencies]

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -43,17 +43,17 @@ paste = { version = "1.0", optional = true }
 query = { path = "../query" }
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
-rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
+rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
+    "freeze-stdlib",
+] }
+rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
 rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
     "default",
     "codegen",
-] }
-rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }
-rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab", features = [
-    "freeze-stdlib",
 ] }
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump opendal to 0.22, refer to https://github.com/datafuselabs/opendal/releases

We want to improve temp file organization when enabling atomic write in the file backend.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
