### PR TITLE
refactor(mito): change the table path to `schema/table_id`

### DIFF
--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -58,8 +58,8 @@ fn region_id(table_id: TableId, n: u32) -> RegionId {
 }
 
 #[inline]
-fn table_dir(schema_name: &str, table_name: &str, table_id: TableId) -> String {
-    format!("{}/{}_{}/", schema_name, table_name, table_id)
+fn table_dir(schema_name: &str, table_id: TableId) -> String {
+    format!("{}/{}/", schema_name, table_id)
 }
 
 /// [TableEngine] implementation.
@@ -341,7 +341,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             }
         }
 
-        let table_dir = table_dir(schema_name, table_name, table_id);
+        let table_dir = table_dir(schema_name, table_id);
         let opts = CreateOptions {
             parent_dir: table_dir.clone(),
         };
@@ -422,7 +422,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
 
             let table_id = request.table_id;
             let engine_ctx = StorageEngineContext::default();
-            let table_dir = table_dir(schema_name, table_name, table_id);
+            let table_dir = table_dir(schema_name, table_id);
             let opts = OpenOptions {
                 parent_dir: table_dir.to_string(),
             };
@@ -666,14 +666,8 @@ mod tests {
 
     #[test]
     fn test_table_dir() {
-        assert_eq!(
-            "public/test_table_1024/",
-            table_dir("public", "test_table", 1024)
-        );
-        assert_eq!(
-            "prometheus/demo_1024/",
-            table_dir("prometheus", "demo", 1024)
-        );
+        assert_eq!("public/1024/", table_dir("public", 1024));
+        assert_eq!("prometheus/1024/", table_dir("prometheus", 1024));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

using table id as the table data path to support RENAME TABLE, the relevant logic has already been validated in the unit test `test_open_table`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
more details in #660 