### PR TITLE
feat: add Makefile to aggregate the commands that developers always use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ fmt: ## Format all the Rust code.
 	cargo fmt --all
 
 .PHONY: docker-image
-docker-image: ## Build Docker image.
+docker-image: ## Build docker image.
 	docker build --network host -f docker/Dockerfile -t ${IMAGE_REGISTRY}:${IMAGE_TAG} .
 
 ##@ Test
@@ -33,12 +33,16 @@ unit-test: ## Run unit test.
 integration-test: ## Run integation test.
 	cargo test integration
 
+.PHONY: sqlness-test
+sqlness-test: ## Run sqlness test.
+	cargo run --bin sqlness-runner
+
 .PHONY: check
 check: ## Cargo check all the targets.
 	cargo check --workspace --all-targets
 
 .PHONY: clippy
-clippy: ## Check Clippy rules.
+clippy: ## Check clippy rules.
 	cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr
 
 .PHONY: fmt-check

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ build: ## Build debug version greptime.
 release:  ## Build release version greptime.
 	cargo build --release
 
+.PHONY: clean
+clean: ## Clean the project.
+	cargo clean
+
 .PHONY: fmt
 fmt: ## Format all the Rust code.
 	cargo fmt --all
@@ -20,6 +24,10 @@ docker-image: ## Build Docker image.
 	docker build --network host -f docker/Dockerfile -t ${IMAGE_REGISTRY}:${IMAGE_TAG} .
 
 ##@ Test
+
+.PHONY: unit-test
+unit-test: ## Run unit test.
+	cargo test --workspace
 
 .PHONY: integration-test
 integration-test: ## Run integation test.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+IMAGE_REGISTRY ?= greptimedb
+IMAGE_TAG ?= latest
+
+##@ Build
+
+.PHONY: build
+build: ## Build debug version greptime.
+	cargo build
+
+.PHONY: release
+release:  ## Build release version greptime.
+	cargo build --release
+
+.PHONY: fmt
+fmt: ## Format all the Rust code.
+	cargo fmt --all
+
+.PHONY: docker-image
+docker-image: ## Build Docker image.
+	docker build --network host -f docker/Dockerfile -t ${IMAGE_REGISTRY}:${IMAGE_TAG} .
+
+##@ Test
+
+.PHONY: integration-test
+integration-test: ## Run integation test.
+	cargo test integration
+
+.PHONY: check
+check: ## Cargo check all the targets.
+	cargo check --workspace --all-targets
+
+.PHONY: clippy
+clippy: ## Check Clippy rules.
+	cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr
+
+.PHONY: fmt-check
+fmt-check: ## Check code format.
+	cargo fmt --all -- --check
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# https://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display help messages.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add Makefile to aggregate the commands that developers always use.

Run `make help`, it will output the following targets:

```console
$ make help

Usage:
  make <target>

Build
  build                 Build debug version greptime.
  release               Build release version greptime.
  fmt                   Format all the rust code.
  docker-image          Build Docker image.

Test
  integration-test      Run integation test.
  check                 Cargo check all the targets.
  clippy                Check Clippy rules.
  fmt-check             Check code format.

General
  help                  Display help messages.

```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
