### PR TITLE
refactor(frontend): minor changes around `FrontendInstance` constructor 

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -193,7 +193,6 @@ async fn build_frontend(
     datanode_instance: InstanceRef,
 ) -> Result<Frontend<FeInstance>> {
     let mut frontend_instance = FeInstance::new_standalone(datanode_instance.clone());
-    frontend_instance.set_catalog_manager(datanode_instance.catalog_manager().clone());
     frontend_instance.set_script_handler(datanode_instance);
     Ok(Frontend::new(fe_opts, frontend_instance, plugins))
 }

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -70,9 +70,9 @@ mod tests {
     use super::*;
     use crate::tests;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_exec() {
-        let instance = tests::create_frontend_instance().await;
+        let (instance, _guard) = tests::create_frontend_instance("test_exec").await;
         instance
             .exec(
                 &DataPoint::try_create(
@@ -88,9 +88,10 @@ mod tests {
             .unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_insert_opentsdb_metric() {
-        let instance = tests::create_frontend_instance().await;
+        let (instance, _guard) =
+            tests::create_frontend_instance("test_insert_opentsdb_metric").await;
 
         let data_point1 = DataPoint::new(
             "my_metric_1".to_string(),
@@ -124,7 +125,10 @@ mod tests {
         assert!(result.is_ok());
 
         let output = instance
-            .do_query("select * from my_metric_1", Arc::new(QueryContext::new()))
+            .do_query(
+                "select * from my_metric_1 order by greptime_timestamp",
+                Arc::new(QueryContext::new()),
+            )
             .await
             .unwrap();
         match output {

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -182,10 +182,11 @@ mod tests {
     use super::*;
     use crate::tests;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_prometheus_remote_write_and_read() {
         common_telemetry::init_default_ut_logging();
-        let instance = tests::create_frontend_instance().await;
+        let (instance, _guard) =
+            tests::create_frontend_instance("test_prometheus_remote_write_and_read").await;
 
         let write_request = WriteRequest {
             timeseries: prometheus::mock_timeseries(),

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_runtime::Runtime;
 use common_telemetry::logging::error;
+use common_telemetry::{debug, info, warn};
 use futures::StreamExt;
 use pgwire::tokio::process_socket;
 use tokio;
@@ -79,6 +80,13 @@ impl PostgresServer {
                 match tcp_stream {
                     Err(error) => error!("Broken pipe: {}", error), // IoError doesn't impl ErrorExt.
                     Ok(io_stream) => {
+                        match io_stream.peer_addr() {
+                            Ok(addr) => info!("PostgreSQL connection coming from {}", addr),
+                            Err(e) => {
+                                warn!("PostgreSQL connection coming from unknown, err: {}", e)
+                            }
+                        }
+
                         io_runtime.spawn(process_socket(
                             io_stream,
                             tls_acceptor.clone(),
@@ -102,6 +110,7 @@ impl Server for PostgresServer {
     async fn start(&self, listening: SocketAddr) -> Result<SocketAddr> {
         let (stream, addr) = self.base_server.bind(listening).await?;
 
+        debug!("Starting PostgreSQL with TLS option: {:?}", self.tls);
         let tls_acceptor = self
             .tls
             .setup()?

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_runtime::Runtime;
 use common_telemetry::logging::error;
-use common_telemetry::{debug, info, warn};
+use common_telemetry::{debug, warn};
 use futures::StreamExt;
 use pgwire::tokio::process_socket;
 use tokio;
@@ -81,10 +81,8 @@ impl PostgresServer {
                     Err(error) => error!("Broken pipe: {}", error), // IoError doesn't impl ErrorExt.
                     Ok(io_stream) => {
                         match io_stream.peer_addr() {
-                            Ok(addr) => info!("PostgreSQL connection coming from {}", addr),
-                            Err(e) => {
-                                warn!("PostgreSQL connection coming from unknown, err: {}", e)
-                            }
+                            Ok(addr) => debug!("PostgreSQL client coming from {}", addr),
+                            Err(e) => warn!("Failed to get PostgreSQL client addr, err: {}", e),
                         }
 
                         io_runtime.spawn(process_socket(

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -214,7 +214,6 @@ pub async fn create_test_table(
 
 async fn build_frontend_instance(datanode_instance: InstanceRef) -> FeInstance {
     let mut frontend_instance = FeInstance::new_standalone(datanode_instance.clone());
-    frontend_instance.set_catalog_manager(datanode_instance.catalog_manager().clone());
     frontend_instance.set_script_handler(datanode_instance);
     frontend_instance
 }
@@ -243,7 +242,7 @@ pub async fn setup_test_app_with_frontend(
     let mut frontend = build_frontend_instance(instance.clone()).await;
     instance.start().await.unwrap();
     create_test_table(
-        frontend.catalog_manager().as_ref().unwrap(),
+        frontend.catalog_manager(),
         instance.sql_handler(),
         ConcreteDataType::timestamp_millis_datatype(),
     )
@@ -276,9 +275,7 @@ pub async fn setup_grpc_server(
 
     let fe_grpc_addr = format!("127.0.0.1:{}", get_port());
 
-    let mut fe_instance = frontend::instance::Instance::new_standalone(instance.clone());
-    fe_instance.set_catalog_manager(instance.catalog_manager().clone());
-
+    let fe_instance = frontend::instance::Instance::new_standalone(instance.clone());
     let fe_instance_ref = Arc::new(fe_instance);
     let fe_grpc_server = Arc::new(GrpcServer::new(
         fe_instance_ref.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

minor refactor of repaying 2 todos, and others
- get `CatalogManager` from the instance on constructing, rather than set it later
- move mock constructor to test utils 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
