### PR TITLE
feat: Implement Arrow Flight Service (except gRPC server) for selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-flight"
+version = "29.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb6e49945f93a8fbd3ec0568167f42097b56134b88686602b9e639a7042ef38"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "proc-macro2",
+ "prost 0.11.3",
+ "prost-build 0.11.3",
+ "prost-derive 0.11.2",
+ "tokio",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1467,7 @@ name = "common-grpc"
 version = "0.1.0"
 dependencies = [
  "api",
+ "arrow-flight",
  "async-trait",
  "common-base",
  "common-error",
@@ -1455,6 +1478,8 @@ dependencies = [
  "dashmap",
  "datafusion",
  "datatypes",
+ "futures",
+ "prost 0.11.3",
  "rand 0.8.5",
  "snafu",
  "tokio",
@@ -2137,6 +2162,7 @@ name = "datanode"
 version = "0.1.0"
 dependencies = [
  "api",
+ "arrow-flight",
  "async-trait",
  "axum",
  "axum-macros",
@@ -2165,6 +2191,8 @@ dependencies = [
  "metrics",
  "mito",
  "object-store",
+ "pin-project",
+ "prost 0.11.3",
  "query",
  "script",
  "serde",
@@ -5030,9 +5058,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -5100,9 +5128,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
+checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -7149,6 +7177,7 @@ dependencies = [
  "client",
  "common-catalog",
  "common-error",
+ "common-grpc",
  "common-runtime",
  "common-telemetry",
  "datanode",
@@ -7521,7 +7550,7 @@ checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.11.4",
+ "prost-build 0.11.3",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 arrow = "29.0"
+arrow-flight = "29.0"
 arrow-schema = { version = "29.0", features = ["serde"] }
 # TODO(LFC): Use released Datafusion when it officially dpendent on Arrow 29.0
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }

--- a/src/api/greptime/v1/database.proto
+++ b/src/api/greptime/v1/database.proto
@@ -58,9 +58,15 @@ message ObjectResult {
   oneof result {
     SelectResult select = 2;
     MutateResult mutate = 3;
+    FlightDataRaw flight_data = 4;
   }
 }
 
+// TODO(LFC): replace with flight data
 message SelectResult {
   bytes raw_data = 1;
+}
+
+message FlightDataRaw {
+  repeated bytes raw_data = 1;
 }

--- a/src/api/src/result.rs
+++ b/src/api/src/result.rs
@@ -24,6 +24,7 @@ pub const PROTOCOL_VERSION: u32 = 1;
 
 pub type Success = u32;
 pub type Failure = u32;
+type FlightDataRaw = Vec<Vec<u8>>;
 
 #[derive(Default)]
 pub struct ObjectResultBuilder {
@@ -36,6 +37,7 @@ pub struct ObjectResultBuilder {
 pub enum Body {
     Mutate((Success, Failure)),
     Select(SelectResult),
+    FlightDataRaw(FlightDataRaw),
 }
 
 impl ObjectResultBuilder {
@@ -72,6 +74,11 @@ impl ObjectResultBuilder {
         self
     }
 
+    pub fn flight_data(mut self, flight_data: FlightDataRaw) -> Self {
+        self.result = Some(Body::FlightDataRaw(flight_data));
+        self
+    }
+
     pub fn build(self) -> ObjectResult {
         let header = Some(ResultHeader {
             version: self.version,
@@ -89,6 +96,9 @@ impl ObjectResultBuilder {
             Some(Body::Select(select)) => Some(object_result::Result::Select(SelectResultRaw {
                 raw_data: select.into(),
             })),
+            Some(Body::FlightDataRaw(raw_data)) => Some(object_result::Result::FlightData(
+                crate::v1::FlightDataRaw { raw_data },
+            )),
             None => None,
         };
 

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 api = { path = "../../api" }
+arrow-flight.workspace = true
 async-trait = "0.1"
 common-base = { path = "../base" }
 common-error = { path = "../error" }
@@ -15,6 +16,8 @@ common-runtime = { path = "../runtime" }
 dashmap = "5.4"
 datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
+futures = "0.3"
+prost = "0.11"
 snafu = { version = "0.7", features = ["backtraces"] }
 tokio = { version = "1.0", features = ["full"] }
 tonic = "0.8"

--- a/src/common/grpc/src/flight.rs
+++ b/src/common/grpc/src/flight.rs
@@ -1,0 +1,181 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use api::result::ObjectResultBuilder;
+use api::v1::ObjectResult;
+use arrow_flight::utils::flight_data_to_arrow_batch;
+use arrow_flight::FlightData;
+use common_error::prelude::StatusCode;
+use common_recordbatch::{RecordBatch, RecordBatches};
+use datatypes::arrow::datatypes::Schema as ArrowSchema;
+use datatypes::arrow::ipc::{root_as_message, MessageHeader};
+use datatypes::schema::{Schema, SchemaRef};
+use futures::TryStreamExt;
+use prost::Message;
+use snafu::{OptionExt, ResultExt};
+use tonic::codegen::futures_core::Stream;
+use tonic::Response;
+
+use crate::error::{self, InvalidFlightDataSnafu, Result};
+
+type TonicResult<T> = std::result::Result<T, tonic::Status>;
+type TonicStream<T> = Pin<Box<dyn Stream<Item = TonicResult<T>> + Send + Sync + 'static>>;
+
+#[derive(Debug)]
+pub enum FlightMessage {
+    Schema(SchemaRef),
+    Recordbatch(RecordBatch),
+}
+
+#[derive(Default)]
+pub struct FlightDecoder {
+    schema: Option<SchemaRef>,
+}
+
+impl FlightDecoder {
+    pub fn try_decode(&mut self, flight_data: FlightData) -> Result<FlightMessage> {
+        let message = root_as_message(flight_data.data_header.as_slice()).map_err(|e| {
+            InvalidFlightDataSnafu {
+                reason: e.to_string(),
+            }
+            .build()
+        })?;
+        match message.header_type() {
+            MessageHeader::Schema => {
+                let arrow_schema = ArrowSchema::try_from(&flight_data).map_err(|e| {
+                    InvalidFlightDataSnafu {
+                        reason: e.to_string(),
+                    }
+                    .build()
+                })?;
+                let schema = Arc::new(
+                    Schema::try_from(arrow_schema).context(error::ConvertArrowSchemaSnafu)?,
+                );
+
+                self.schema = Some(schema.clone());
+
+                Ok(FlightMessage::Schema(schema))
+            }
+            MessageHeader::RecordBatch => {
+                let schema = self.schema.clone().context(InvalidFlightDataSnafu {
+                    reason: "Should have decoded schema first!",
+                })?;
+                let arrow_schema = schema.arrow_schema().clone();
+
+                let arrow_batch =
+                    flight_data_to_arrow_batch(&flight_data, arrow_schema, &HashMap::new())
+                        .map_err(|e| {
+                            InvalidFlightDataSnafu {
+                                reason: e.to_string(),
+                            }
+                            .build()
+                        })?;
+                let recordbatch = RecordBatch::try_from_df_record_batch(schema, arrow_batch)
+                    .context(error::CreateRecordBatchSnafu)?;
+                Ok(FlightMessage::Recordbatch(recordbatch))
+            }
+            other => {
+                let name = other.variant_name().unwrap_or("UNKNOWN");
+                InvalidFlightDataSnafu {
+                    reason: format!("Unsupported FlightData type: {name}"),
+                }
+                .fail()
+            }
+        }
+    }
+}
+
+// TODO(LFC): Remove it once we completely get rid of old GRPC interface.
+pub async fn flight_data_to_object_result(
+    response: Response<TonicStream<FlightData>>,
+) -> Result<ObjectResult> {
+    let stream = response.into_inner();
+    let result: TonicResult<Vec<FlightData>> = stream.try_collect().await;
+    match result {
+        Ok(flight_data) => {
+            let flight_data = flight_data
+                .into_iter()
+                .map(|x| x.encode_to_vec())
+                .collect::<Vec<Vec<u8>>>();
+            Ok(ObjectResultBuilder::new()
+                .status_code(StatusCode::Success as u32)
+                .flight_data(flight_data)
+                .build())
+        }
+        Err(e) => Ok(ObjectResultBuilder::new()
+            .status_code(StatusCode::Internal as _)
+            .err_msg(e.to_string())
+            .build()),
+    }
+}
+
+pub fn raw_flight_data_to_message(raw_data: Vec<Vec<u8>>) -> Result<Vec<FlightMessage>> {
+    let flight_data = raw_data
+        .into_iter()
+        .map(|x| FlightData::decode(x.as_slice()).context(error::DecodeFlightDataSnafu))
+        .collect::<Result<Vec<FlightData>>>()?;
+
+    let decoder = &mut FlightDecoder::default();
+    flight_data
+        .into_iter()
+        .map(|x| decoder.try_decode(x))
+        .collect()
+}
+
+pub fn flight_messages_to_recordbatches(messages: Vec<FlightMessage>) -> Result<RecordBatches> {
+    if messages.is_empty() {
+        Ok(RecordBatches::empty())
+    } else {
+        let mut recordbatches = Vec::with_capacity(messages.len() - 1);
+
+        let schema = match &messages[0] {
+            FlightMessage::Schema(schema) => schema.clone(),
+            _ => {
+                return InvalidFlightDataSnafu {
+                    reason: "First Flight Message must be schema!",
+                }
+                .fail()
+            }
+        };
+
+        for message in messages.into_iter().skip(1) {
+            match message {
+                FlightMessage::Recordbatch(recordbatch) => recordbatches.push(recordbatch),
+                _ => {
+                    return InvalidFlightDataSnafu {
+                        reason: "Expect the following Flight Messages are all Recordbatches!",
+                    }
+                    .fail()
+                }
+            }
+        }
+
+        RecordBatches::try_new(schema, recordbatches).context(error::CreateRecordBatchSnafu)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_try_decode() {
+        let decoder = &mut FlightDecoder::default();
+        assert!(decoder.schema.is_none());
+    }
+}

--- a/src/common/grpc/src/lib.rs
+++ b/src/common/grpc/src/lib.rs
@@ -14,6 +14,7 @@
 
 pub mod channel_manager;
 pub mod error;
+pub mod flight;
 pub mod select;
 pub mod writer;
 

--- a/src/common/grpc/src/select.rs
+++ b/src/common/grpc/src/select.rs
@@ -34,6 +34,7 @@ use snafu::{OptionExt, ResultExt};
 
 use crate::error::{self, ConversionSnafu, Result};
 
+// TODO(LFC): replace with FlightData
 pub async fn to_object_result(output: std::result::Result<Output, impl ErrorExt>) -> ObjectResult {
     let result = match output {
         Ok(Output::AffectedRows(rows)) => Ok(ObjectResultBuilder::new()
@@ -53,7 +54,7 @@ pub async fn to_object_result(output: std::result::Result<Output, impl ErrorExt>
 async fn collect(stream: SendableRecordBatchStream) -> Result<ObjectResult> {
     let recordbatches = RecordBatches::try_collect(stream)
         .await
-        .context(error::CollectRecordBatchesSnafu)?;
+        .context(error::CreateRecordBatchSnafu)?;
     let object_result = build_result(recordbatches)?;
     Ok(object_result)
 }

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -10,6 +10,7 @@ python = ["dep:script"]
 
 [dependencies]
 api = { path = "../api" }
+arrow-flight.workspace = true
 async-trait = "0.1"
 axum = "0.6"
 axum-macros = "0.3"
@@ -35,6 +36,8 @@ meta-srv = { path = "../meta-srv", features = ["mock"] }
 metrics = "0.20"
 mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }
+pin-project = "1.0"
+prost = "0.11"
 query = { path = "../query" }
 script = { path = "../script", features = ["python"], optional = true }
 serde = "1.0"

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -160,9 +160,6 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Unsupported expr type: {}", name))]
-    UnsupportedExpr { name: String },
-
     #[snafu(display("Runtime resource error, source: {}", source))]
     RuntimeResource {
         #[snafu(backtrace)]
@@ -209,12 +206,6 @@ pub enum Error {
     RegisterSchema {
         #[snafu(backtrace)]
         source: catalog::error::Error,
-    },
-
-    #[snafu(display("Failed to decode as physical plan, source: {}", source))]
-    IntoPhysicalPlan {
-        #[snafu(backtrace)]
-        source: common_grpc::Error,
     },
 
     #[snafu(display("Failed to convert alter expr to request: {}", source))]
@@ -301,6 +292,33 @@ pub enum Error {
 
     #[snafu(display("Missing node id option in distributed mode"))]
     MissingMetasrvOpts { backtrace: Backtrace },
+
+    #[snafu(display("Invalid Flight ticket, source: {}", source))]
+    InvalidFlightTicket {
+        source: api::DecodeError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Missing required field: {}", name))]
+    MissingRequiredField { name: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to poll recordbatch stream, source: {}", source))]
+    PollRecordbatchStream {
+        #[snafu(backtrace)]
+        source: common_recordbatch::error::Error,
+    },
+
+    #[snafu(display("Invalid FlightData, source: {}", source))]
+    InvalidFlightData {
+        #[snafu(backtrace)]
+        source: common_grpc::Error,
+    },
+
+    #[snafu(display("Failed to do Flight get, source: {}", source))]
+    FlightGet {
+        source: tonic::Status,
+        backtrace: Backtrace,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -328,7 +346,11 @@ impl ErrorExt for Error {
             }
 
             Error::AlterExprToRequest { source, .. }
-            | Error::CreateExprToRequest { source, .. } => source.status_code(),
+            | Error::CreateExprToRequest { source }
+            | Error::InsertData { source } => source.status_code(),
+
+            Error::InvalidFlightData { source } => source.status_code(),
+
             Error::CreateSchema { source, .. }
             | Error::ConvertSchema { source, .. }
             | Error::VectorComputation { source } => source.status_code(),
@@ -351,9 +373,10 @@ impl ErrorExt for Error {
             | Error::CreateDir { .. }
             | Error::InsertSystemCatalog { .. }
             | Error::RegisterSchema { .. }
-            | Error::IntoPhysicalPlan { .. }
-            | Error::UnsupportedExpr { .. }
-            | Error::Catalog { .. } => StatusCode::Internal,
+            | Error::Catalog { .. }
+            | Error::MissingRequiredField { .. }
+            | Error::FlightGet { .. }
+            | Error::InvalidFlightTicket { .. } => StatusCode::Internal,
 
             Error::InitBackend { .. } => StatusCode::StorageUnavailable,
             Error::OpenLogStore { source } => source.status_code(),
@@ -361,13 +384,13 @@ impl ErrorExt for Error {
             Error::OpenStorageEngine { source } => source.status_code(),
             Error::RuntimeResource { .. } => StatusCode::RuntimeResourcesExhausted,
             Error::MetaClientInit { source, .. } => source.status_code(),
-            Error::InsertData { source, .. } => source.status_code(),
             Error::EmptyInsertBatch => StatusCode::InvalidArguments,
             Error::TableIdProviderNotFound { .. } => StatusCode::Unsupported,
             Error::BumpTableId { source, .. } => source.status_code(),
             Error::MissingNodeId { .. } => StatusCode::InvalidArguments,
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
             Error::StartLogStore { source, .. } => source.status_code(),
+            Error::PollRecordbatchStream { source } => source.status_code(),
         }
     }
 

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -48,6 +48,7 @@ use crate::heartbeat::HeartbeatTask;
 use crate::script::ScriptExecutor;
 use crate::sql::SqlHandler;
 
+mod flight;
 mod grpc;
 mod script;
 mod sql;

--- a/src/datanode/src/instance/flight.rs
+++ b/src/datanode/src/instance/flight.rs
@@ -1,0 +1,164 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod stream;
+
+use std::pin::Pin;
+
+use api::v1::object_expr::Expr;
+use api::v1::select_expr::Expr as SelectExpr;
+use api::v1::ObjectExpr;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
+};
+use async_trait::async_trait;
+use common_query::Output;
+use futures::Stream;
+use prost::Message;
+use session::context::QueryContext;
+use snafu::{ensure, OptionExt, ResultExt};
+use sql::statements::statement::Statement;
+use tonic::{Request, Response, Streaming};
+
+use crate::error::{self, Result};
+use crate::instance::flight::stream::GetStream;
+use crate::instance::Instance;
+
+type TonicResult<T> = std::result::Result<T, tonic::Status>;
+type TonicStream<T> = Pin<Box<dyn Stream<Item = TonicResult<T>> + Send + Sync + 'static>>;
+
+#[async_trait]
+impl FlightService for Instance {
+    type HandshakeStream = TonicStream<HandshakeResponse>;
+
+    async fn handshake(
+        &self,
+        _request: Request<Streaming<HandshakeRequest>>,
+    ) -> TonicResult<Response<Self::HandshakeStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+
+    type ListFlightsStream = TonicStream<FlightInfo>;
+
+    async fn list_flights(
+        &self,
+        _request: Request<Criteria>,
+    ) -> TonicResult<Response<Self::ListFlightsStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+    async fn get_flight_info(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> TonicResult<Response<FlightInfo>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+    async fn get_schema(
+        &self,
+        _request: Request<FlightDescriptor>,
+    ) -> TonicResult<Response<SchemaResult>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoGetStream = TonicStream<FlightData>;
+
+    async fn do_get(&self, request: Request<Ticket>) -> TonicResult<Response<Self::DoGetStream>> {
+        let ticket = request.into_inner().ticket;
+        let expr = ObjectExpr::decode(ticket.as_slice())
+            .context(error::InvalidFlightTicketSnafu)?
+            .expr
+            .context(error::MissingRequiredFieldSnafu { name: "expr" })?;
+        match expr {
+            Expr::Select(select_expr) => {
+                let select_expr = select_expr
+                    .expr
+                    .context(error::MissingRequiredFieldSnafu { name: "expr" })?;
+                let stream = self.handle_select_expr(select_expr).await?;
+                Ok(Response::new(Box::pin(stream) as TonicStream<FlightData>))
+            }
+            // TODO(LFC): Implement Insertion Flight interface.
+            Expr::Insert(_) => Err(tonic::Status::unimplemented("Not yet implemented")),
+            Expr::Update(_) | Expr::Delete(_) => {
+                Err(tonic::Status::unimplemented("Not yet implemented"))
+            }
+        }
+    }
+
+    type DoPutStream = TonicStream<PutResult>;
+
+    async fn do_put(
+        &self,
+        _request: Request<Streaming<FlightData>>,
+    ) -> TonicResult<Response<Self::DoPutStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoExchangeStream = TonicStream<FlightData>;
+
+    async fn do_exchange(
+        &self,
+        _request: Request<Streaming<FlightData>>,
+    ) -> TonicResult<Response<Self::DoExchangeStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoActionStream = TonicStream<arrow_flight::Result>;
+
+    async fn do_action(
+        &self,
+        _request: Request<Action>,
+    ) -> TonicResult<Response<Self::DoActionStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+
+    type ListActionsStream = TonicStream<ActionType>;
+
+    async fn list_actions(
+        &self,
+        _request: Request<Empty>,
+    ) -> TonicResult<Response<Self::ListActionsStream>> {
+        Err(tonic::Status::unimplemented("Not yet implemented"))
+    }
+}
+
+impl Instance {
+    async fn handle_select_expr(&self, select_expr: SelectExpr) -> Result<GetStream> {
+        let output = match select_expr {
+            SelectExpr::Sql(sql) => {
+                let stmt = self
+                    .query_engine
+                    .sql_to_statement(&sql)
+                    .context(error::ExecuteSqlSnafu)?;
+                ensure!(
+                    matches!(stmt, Statement::Query(_)),
+                    error::InvalidSqlSnafu {
+                        msg: format!("expect SQL to be selection, actual: {sql}")
+                    }
+                );
+                self.execute_stmt(stmt, QueryContext::arc()).await?
+            }
+            SelectExpr::LogicalPlan(plan) => self.execute_logical(plan).await?,
+        };
+
+        let recordbatch_stream = match output {
+            Output::Stream(stream) => stream,
+            Output::RecordBatches(x) => x.as_stream(),
+            Output::AffectedRows(_) => {
+                unreachable!("SELECT should not have returned affected rows!")
+            }
+        };
+        Ok(GetStream::new(recordbatch_stream))
+    }
+}

--- a/src/datanode/src/instance/flight/stream.rs
+++ b/src/datanode/src/instance/flight/stream.rs
@@ -1,0 +1,184 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use arrow_flight::utils::flight_data_from_arrow_batch;
+use arrow_flight::{FlightData, SchemaAsIpc};
+use common_recordbatch::SendableRecordBatchStream;
+use common_telemetry::warn;
+use datatypes::arrow;
+use futures::channel::mpsc;
+use futures::channel::mpsc::Sender;
+use futures::{SinkExt, Stream, StreamExt};
+use pin_project::{pin_project, pinned_drop};
+use snafu::ResultExt;
+use tokio::task::JoinHandle;
+
+use crate::error;
+use crate::instance::flight::TonicResult;
+
+#[pin_project(PinnedDrop)]
+pub(super) struct GetStream {
+    #[pin]
+    rx: mpsc::Receiver<Result<FlightData, tonic::Status>>,
+    join_handle: JoinHandle<()>,
+    done: bool,
+}
+
+impl GetStream {
+    pub(super) fn new(recordbatches: SendableRecordBatchStream) -> Self {
+        let (tx, rx) = mpsc::channel::<TonicResult<FlightData>>(1);
+        let join_handle =
+            common_runtime::spawn_read(
+                async move { Self::flight_data_stream(recordbatches, tx).await },
+            );
+        Self {
+            rx,
+            join_handle,
+            done: false,
+        }
+    }
+
+    async fn flight_data_stream(
+        mut recordbatches: SendableRecordBatchStream,
+        mut tx: Sender<TonicResult<FlightData>>,
+    ) {
+        let schema = recordbatches.schema();
+        let options = arrow::ipc::writer::IpcWriteOptions::default();
+        let schema_flight_data: FlightData =
+            SchemaAsIpc::new(schema.arrow_schema(), &options).into();
+        if let Err(e) = tx.send(Ok(schema_flight_data)).await {
+            warn!("stop sending Flight data, err: {e}");
+            return;
+        }
+
+        while let Some(batch_or_err) = recordbatches.next().await {
+            match batch_or_err {
+                Ok(batch) => {
+                    let (flight_dictionaries, flight_batch) =
+                        flight_data_from_arrow_batch(batch.df_record_batch(), &options);
+
+                    // TODO(LFC): Handle dictionary as FlightData here, when we supported Arrow's Dictionary DataType.
+                    // Currently we don't have a datatype corresponding to Arrow's Dictionary DataType,
+                    // so there won't be any "dictionaries" here. Assert to be sure about it, and
+                    // perform a "testing guard" in case we forgot to handle the possible "dictionaries"
+                    // here in the future.
+                    debug_assert_eq!(flight_dictionaries.len(), 0);
+
+                    if let Err(e) = tx.send(Ok(flight_batch)).await {
+                        warn!("stop sending Flight data, err: {e}");
+                        return;
+                    }
+                }
+                Err(e) => {
+                    let e = Err(e).context(error::PollRecordbatchStreamSnafu);
+                    if let Err(e) = tx.send(e.map_err(|x| x.into())).await {
+                        warn!("stop sending Flight data, err: {e}");
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+#[pinned_drop]
+impl PinnedDrop for GetStream {
+    fn drop(self: Pin<&mut Self>) {
+        self.join_handle.abort();
+    }
+}
+
+impl Stream for GetStream {
+    type Item = TonicResult<FlightData>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        if *this.done {
+            Poll::Ready(None)
+        } else {
+            match this.rx.poll_next(cx) {
+                Poll::Ready(None) => {
+                    *this.done = true;
+                    Poll::Ready(None)
+                }
+                e @ Poll::Ready(Some(Err(_))) => {
+                    *this.done = true;
+                    e
+                }
+                other => other,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use common_grpc::flight::{FlightDecoder, FlightMessage};
+    use common_recordbatch::{RecordBatch, RecordBatches};
+    use datatypes::prelude::*;
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_stream() {
+        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
+            "a",
+            ConcreteDataType::int32_datatype(),
+            false,
+        )]));
+
+        let v: VectorRef = Arc::new(Int32Vector::from_slice(&[1, 2]));
+        let recordbatch = RecordBatch::new(schema.clone(), vec![v]).unwrap();
+
+        let recordbatches = RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()])
+            .unwrap()
+            .as_stream();
+        let mut get_stream = GetStream::new(recordbatches);
+
+        let mut raw_data = Vec::with_capacity(2);
+        raw_data.push(get_stream.next().await.unwrap().unwrap());
+        raw_data.push(get_stream.next().await.unwrap().unwrap());
+        assert!(get_stream.next().await.is_none());
+        assert!(get_stream.done);
+
+        let decoder = &mut FlightDecoder::default();
+        let mut flight_messages = raw_data
+            .into_iter()
+            .map(|x| decoder.try_decode(x).unwrap())
+            .collect::<Vec<FlightMessage>>();
+        assert_eq!(flight_messages.len(), 2);
+
+        match flight_messages.remove(0) {
+            FlightMessage::Schema(actual_schema) => {
+                assert_eq!(actual_schema, schema);
+            }
+            _ => unreachable!(),
+        }
+
+        match flight_messages.remove(0) {
+            FlightMessage::Recordbatch(actual_recordbatch) => {
+                assert_eq!(actual_recordbatch, recordbatch);
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -251,12 +251,6 @@ pub enum Error {
         source: client::Error,
     },
 
-    #[snafu(display("Failed to select from table, source: {}", source))]
-    Select {
-        #[snafu(backtrace)]
-        source: client::Error,
-    },
-
     #[snafu(display("Failed to create table on insertion, source: {}", source))]
     CreateTableOnInsertion {
         #[snafu(backtrace)]
@@ -411,18 +405,6 @@ pub enum Error {
         source: datatypes::error::Error,
     },
 
-    #[snafu(display("Failed to collect Recordbatch stream, source: {}", source))]
-    CollectRecordbatchStream {
-        #[snafu(backtrace)]
-        source: common_recordbatch::error::Error,
-    },
-
-    #[snafu(display("Failed to create Recordbatches, source: {}", source))]
-    CreateRecordbatches {
-        #[snafu(backtrace)]
-        source: common_recordbatch::error::Error,
-    },
-
     #[snafu(display("Missing meta_client_opts section in config"))]
     MissingMetasrvOpts { backtrace: Backtrace },
 
@@ -459,6 +441,12 @@ pub enum Error {
     InvokeGrpcServer {
         #[snafu(backtrace)]
         source: servers::error::Error,
+    },
+
+    #[snafu(display("Failed to convert Flight Message, source: {}", source))]
+    ConvertFlightMessage {
+        #[snafu(backtrace)]
+        source: common_grpc::error::Error,
     },
 }
 
@@ -532,7 +520,6 @@ impl ErrorExt for Error {
             Error::SchemaNotFound { .. } => StatusCode::InvalidArguments,
             Error::CatalogNotFound { .. } => StatusCode::InvalidArguments,
             Error::CreateTable { source, .. }
-            | Error::Select { source, .. }
             | Error::CreateDatabase { source, .. }
             | Error::CreateTableOnInsertion { source, .. }
             | Error::AlterTableOnInsertion { source, .. }
@@ -544,15 +531,13 @@ impl ErrorExt for Error {
             Error::ExecuteSql { source, .. } => source.status_code(),
             Error::ExecuteStatement { source, .. } => source.status_code(),
             Error::InsertBatchToRequest { source, .. } => source.status_code(),
-            Error::CollectRecordbatchStream { source } | Error::CreateRecordbatches { source } => {
-                source.status_code()
-            }
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
             Error::AlterExprToRequest { source, .. } => source.status_code(),
             Error::LeaderNotFound { .. } => StatusCode::StorageUnavailable,
             Error::TableAlreadyExist { .. } => StatusCode::TableAlreadyExists,
             Error::EncodeSubstraitLogicalPlan { source } => source.status_code(),
             Error::BuildVector { source, .. } => source.status_code(),
+            Error::ConvertFlightMessage { source } => source.status_code(),
         }
     }
 

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -89,8 +89,8 @@ impl Table for DistTable {
         let spliter = WriteSpliter::with_partition_rule(partition_rule);
         let inserts = spliter.split(request).map_err(TableError::new)?;
         let result = match self.dist_insert(inserts).await.map_err(TableError::new)? {
-            client::ObjectResult::Select(_) => unreachable!(),
             client::ObjectResult::Mutate(result) => result,
+            _ => unreachable!(),
         };
         Ok(result.success as usize)
     }

--- a/src/frontend/src/table/insert.rs
+++ b/src/frontend/src/table/insert.rs
@@ -71,8 +71,8 @@ impl DistTable {
         for join in joins {
             let object_result = join.await.context(error::JoinTaskSnafu)??;
             let result = match object_result {
-                client::ObjectResult::Select(_) => unreachable!(),
-                client::ObjectResult::Mutate(result) => result,
+                ObjectResult::Mutate(result) => result,
+                ObjectResult::Select(_) | ObjectResult::FlightData(_) => unreachable!(),
             };
             success += result.success;
             failure += result.failure;

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -12,6 +12,7 @@ catalog = { path = "../src/catalog" }
 client = { path = "../src/client" }
 common-catalog = { path = "../src/common/catalog" }
 common-error = { path = "../src/common/error" }
+common-grpc = { path = "../src/common/grpc" }
 common-runtime = { path = "../src/common/runtime" }
 common-telemetry = { path = "../src/common/telemetry" }
 datanode = { path = "../src/datanode" }

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -142,6 +142,8 @@ impl Display for ResultDisplayer {
                 ObjectResult::Mutate(mutate_result) => {
                     write!(f, "{mutate_result:?}")
                 }
+                // TODO(LFC): Implement it.
+                ObjectResult::FlightData(_) => unimplemented!(),
             },
             Err(e) => write!(f, "Failed to execute, error: {e:?}"),
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR is part of a series of changes to gradually adopt the Arrow Flight, and remove the old GRPC interface finally.

This PR implement Arrow Flight Service for Datanode instance. 

However, instead of creating a new GRPC server and listening a new port, I reuse the old GRPC server, bridge some methods (`do_get` in Arrow Flight vs `do_query` in old GRPC) and datatypes (`FlightData` in Arrow Flight vs `ObjectResult` in old GRPC). 

The actual Arrow Flight server that is started using Tonic will be done in the following PRs.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#381 