### PR TITLE
feat: sql query interceptor and plugin refactoring

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -96,7 +96,7 @@ impl StartCommand {
             .context(error::StartFrontendSnafu)?;
         instance.set_plugins(plugins.clone());
 
-        let mut frontend = Frontend::new(opts.clone(), instance, plugins);
+        let mut frontend = Frontend::new(opts, instance, plugins);
         frontend.start().await.context(error::StartFrontendSnafu)
     }
 }

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -22,7 +22,7 @@ use frontend::instance::Instance;
 use frontend::mysql::MysqlOptions;
 use frontend::opentsdb::OpentsdbOptions;
 use frontend::postgres::PostgresOptions;
-use frontend::AnyMap2;
+use frontend::Plugins;
 use meta_client::MetaClientOpts;
 use servers::auth::UserProviderRef;
 use servers::http::HttpOptions;
@@ -101,8 +101,8 @@ impl StartCommand {
     }
 }
 
-pub fn load_frontend_plugins(user_provider: &Option<String>) -> Result<AnyMap2> {
-    let mut plugins = AnyMap2::new();
+pub fn load_frontend_plugins(user_provider: &Option<String>) -> Result<Plugins> {
+    let mut plugins = Plugins::new();
 
     if let Some(provider) = user_provider {
         let provider = auth::user_provider_from_option(provider).context(IllegalAuthConfigSnafu)?;

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -26,7 +26,7 @@ use frontend::mysql::MysqlOptions;
 use frontend::opentsdb::OpentsdbOptions;
 use frontend::postgres::PostgresOptions;
 use frontend::prometheus::PrometheusOptions;
-use frontend::AnyMap2;
+use frontend::Plugins;
 use serde::{Deserialize, Serialize};
 use servers::http::HttpOptions;
 use servers::tls::{TlsMode, TlsOption};
@@ -189,7 +189,7 @@ impl StartCommand {
 /// Build frontend instance in standalone mode
 async fn build_frontend(
     fe_opts: FrontendOptions,
-    plugins: Arc<AnyMap2>,
+    plugins: Arc<Plugins>,
     datanode_instance: InstanceRef,
 ) -> Result<Frontend<FeInstance>> {
     let mut frontend_instance = FeInstance::new_standalone(datanode_instance.clone());

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -30,7 +30,7 @@ use crate::opentsdb::OpentsdbOptions;
 use crate::postgres::PostgresOptions;
 use crate::prometheus::PrometheusOptions;
 use crate::server::Services;
-use crate::AnyMap2;
+use crate::Plugins;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FrontendOptions {
@@ -67,11 +67,11 @@ where
 {
     opts: FrontendOptions,
     instance: Option<T>,
-    plugins: Arc<AnyMap2>,
+    plugins: Arc<Plugins>,
 }
 
 impl<T: FrontendInstance> Frontend<T> {
-    pub fn new(opts: FrontendOptions, instance: T, plugins: Arc<AnyMap2>) -> Self {
+    pub fn new(opts: FrontendOptions, instance: T, plugins: Arc<Plugins>) -> Self {
         Self {
             opts,
             instance: Some(instance),

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 
-use anymap::AnyMap;
 use meta_client::MetaClientOpts;
 use serde::{Deserialize, Serialize};
 use servers::auth::UserProviderRef;
@@ -31,6 +30,7 @@ use crate::opentsdb::OpentsdbOptions;
 use crate::postgres::PostgresOptions;
 use crate::prometheus::PrometheusOptions;
 use crate::server::Services;
+use crate::AnyMap2;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FrontendOptions {
@@ -67,11 +67,11 @@ where
 {
     opts: FrontendOptions,
     instance: Option<T>,
-    plugins: AnyMap,
+    plugins: Arc<AnyMap2>,
 }
 
 impl<T: FrontendInstance> Frontend<T> {
-    pub fn new(opts: FrontendOptions, instance: T, plugins: AnyMap) -> Self {
+    pub fn new(opts: FrontendOptions, instance: T, plugins: Arc<AnyMap2>) -> Self {
         Self {
             opts,
             instance: Some(instance),
@@ -90,6 +90,7 @@ impl<T: FrontendInstance> Frontend<T> {
 
         let instance = Arc::new(instance);
 
+        // TODO(sunng87): merge this into instance
         let provider = self.plugins.get::<UserProviderRef>().cloned();
 
         Services::start(&self.opts, instance, provider).await

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -108,7 +108,8 @@ pub struct Instance {
     grpc_query_handler: GrpcQueryHandlerRef,
     grpc_admin_handler: GrpcAdminHandlerRef,
 
-    // plugins
+    /// plugins: this map holds extensions to customize query or auth
+    /// behaviours.
     plugins: Arc<AnyMap2>,
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -70,7 +70,7 @@ use crate::frontend::FrontendOptions;
 use crate::sql::insert_to_request;
 use crate::table::insert::insert_request_to_insert_batch;
 use crate::table::route::TableRoutes;
-use crate::AnyMap2;
+use crate::Plugins;
 
 #[async_trait]
 pub trait FrontendInstance:
@@ -111,7 +111,7 @@ pub struct Instance {
 
     /// plugins: this map holds extensions to customize query or auth
     /// behaviours.
-    plugins: Arc<AnyMap2>,
+    plugins: Arc<Plugins>,
 }
 
 impl Instance {
@@ -461,11 +461,11 @@ impl Instance {
         Ok(Output::RecordBatches(RecordBatches::empty()))
     }
 
-    pub fn set_plugins(&mut self, map: Arc<AnyMap2>) {
+    pub fn set_plugins(&mut self, map: Arc<Plugins>) {
         self.plugins = map;
     }
 
-    pub fn plugins(&self) -> Arc<AnyMap2> {
+    pub fn plugins(&self) -> Arc<Plugins> {
         self.plugins.clone()
     }
 }
@@ -1058,7 +1058,7 @@ mod tests {
         let query_ctx = Arc::new(QueryContext::new());
         let (mut instance, _guard) = tests::create_frontend_instance("test_hook").await;
 
-        let mut plugins = AnyMap2::new();
+        let mut plugins = Plugins::new();
         let counter_hook = Arc::new(AssertionHook::default());
         plugins.insert::<SqlQueryInterceptorRef>(counter_hook.clone());
         Arc::make_mut(&mut instance).set_plugins(Arc::new(plugins));
@@ -1114,7 +1114,7 @@ mod tests {
         let query_ctx = Arc::new(QueryContext::new());
         let (mut instance, _guard) = tests::create_frontend_instance("test_db_hook").await;
 
-        let mut plugins = AnyMap2::new();
+        let mut plugins = Plugins::new();
         let hook = Arc::new(DisableDBOpHook::default());
         plugins.insert::<SqlQueryInterceptorRef>(hook.clone());
         Arc::make_mut(&mut instance).set_plugins(Arc::new(plugins));

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -69,6 +69,7 @@ use crate::frontend::FrontendOptions;
 use crate::sql::insert_to_request;
 use crate::table::insert::insert_request_to_insert_batch;
 use crate::table::route::TableRoutes;
+use crate::AnyMap2;
 
 #[async_trait]
 pub trait FrontendInstance:
@@ -106,6 +107,9 @@ pub struct Instance {
     sql_handler: SqlQueryHandlerRef,
     grpc_query_handler: GrpcQueryHandlerRef,
     grpc_admin_handler: GrpcAdminHandlerRef,
+
+    // plugins
+    plugins: Arc<AnyMap2>,
 }
 
 impl Instance {
@@ -136,6 +140,7 @@ impl Instance {
             sql_handler: dist_instance_ref.clone(),
             grpc_query_handler: dist_instance_ref.clone(),
             grpc_admin_handler: dist_instance_ref,
+            plugins: Default::default(),
         })
     }
 
@@ -179,6 +184,7 @@ impl Instance {
             sql_handler: dn_instance.clone(),
             grpc_query_handler: dn_instance.clone(),
             grpc_admin_handler: dn_instance,
+            plugins: Default::default(),
         }
     }
 
@@ -451,6 +457,10 @@ impl Instance {
         query_ctx.set_current_schema(&db);
 
         Ok(Output::RecordBatches(RecordBatches::empty()))
+    }
+
+    pub fn set_plugins(&mut self, map: Arc<AnyMap2>) {
+        self.plugins = map;
     }
 }
 

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -14,7 +14,7 @@
 
 #![feature(assert_matches)]
 
-pub type AnyMap2 = anymap::Map<dyn core::any::Any + Send + Sync>;
+pub type Plugins = anymap::Map<dyn core::any::Any + Send + Sync>;
 
 mod catalog;
 mod datanode;

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![feature(assert_matches)]
 
+pub type AnyMap2 = anymap::Map<dyn core::any::Any + Send + Sync>;
+
 mod catalog;
 mod datanode;
 pub mod error;

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -37,6 +37,7 @@ openmetrics-parser = "0.4"
 opensrv-mysql = "0.3"
 pgwire = "0.6.3"
 prost = "0.11"
+query = { path = "../query" }
 rand = "0.8"
 regex = "1.6"
 rustls = "0.20"
@@ -65,7 +66,6 @@ common-base = { path = "../common/base" }
 mysql_async = { version = "0.31", default-features = false, features = [
     "default-rustls",
 ] }
-query = { path = "../query" }
 rand = "0.8"
 script = { path = "../script", features = ["python"] }
 serde_json = "1.0"

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -38,7 +38,9 @@ pub trait SqlQueryInterceptor {
         Ok(statement)
     }
 
-    /// Called before sql is actually executed.
+    /// Called before sql is actually executed. This hook is not called at the moment.
+    /// TODO(sunng87): figure out at which stage we can call this hook after Arrow
+    /// Flight adoption
     fn pre_execute(
         &self,
         _statement: Statement,

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Cow;
+
+use common_query::Output;
+use query::plan::LogicalPlan;
+use session::context::QueryContextRef;
+use sql::statements::statement::Statement;
+
+use crate::error::Result;
+
+pub trait SqlQueryInterceptor {
+    fn pre_parsing<'a>(&self, query: &'a str, _query_ctx: QueryContextRef) -> Result<Cow<'a, str>> {
+        Ok(Cow::Borrowed(query))
+    }
+
+    fn pre_planning(&self, statement: Statement, _query_ctx: QueryContextRef) -> Result<Statement> {
+        Ok(statement)
+    }
+
+    fn pre_execute(&self, _plan: &LogicalPlan, _query_ctx: QueryContextRef) -> Result<()> {
+        Ok(())
+    }
+
+    fn post_execute(&self, output: Output, _query_ctx: QueryContextRef) -> Result<Output> {
+        Ok(output)
+    }
+}

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -43,8 +43,6 @@ pub trait SqlQueryInterceptor {
     }
 
     /// Called before sql is actually executed. This hook is not called at the moment.
-    /// TODO(sunng87): figure out at which stage we can call this hook after Arrow
-    /// Flight adoption
     fn pre_execute(
         &self,
         _statement: &Statement,

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -21,19 +21,34 @@ use sql::statements::statement::Statement;
 
 use crate::error::Result;
 
+/// SqlQueryInterceptor can track life cycle of a sql query and customize or
+/// abort its execution at given point.
 pub trait SqlQueryInterceptor {
+    /// Called before a query string is parsed into sql statements.
+    /// The implementation is allowed to change the sql string if needed.
     fn pre_parsing<'a>(&self, query: &'a str, _query_ctx: QueryContextRef) -> Result<Cow<'a, str>> {
         Ok(Cow::Borrowed(query))
     }
 
-    fn pre_planning(&self, statement: Statement, _query_ctx: QueryContextRef) -> Result<Statement> {
+    /// Called after sql is parsed into statements. This interceptor is called
+    /// on each statement and the implementation can alter the statement or
+    /// abort execution by raising an error.
+    fn post_parsing(&self, statement: Statement, _query_ctx: QueryContextRef) -> Result<Statement> {
         Ok(statement)
     }
 
-    fn pre_execute(&self, _plan: &LogicalPlan, _query_ctx: QueryContextRef) -> Result<()> {
+    /// Called before sql is actually executed.
+    fn pre_execute(
+        &self,
+        _statement: Statement,
+        _plan: Option<&LogicalPlan>,
+        _query_ctx: QueryContextRef,
+    ) -> Result<()> {
         Ok(())
     }
 
+    /// Called after execution finished. The implementation can modify the
+    /// output if needed.
     fn post_execute(&self, output: Output, _query_ctx: QueryContextRef) -> Result<Output> {
         Ok(output)
     }

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -34,8 +34,12 @@ pub trait SqlQueryInterceptor {
     /// Called after sql is parsed into statements. This interceptor is called
     /// on each statement and the implementation can alter the statement or
     /// abort execution by raising an error.
-    fn post_parsing(&self, statement: Statement, _query_ctx: QueryContextRef) -> Result<Statement> {
-        Ok(statement)
+    fn post_parsing(
+        &self,
+        statements: Vec<Statement>,
+        _query_ctx: QueryContextRef,
+    ) -> Result<Vec<Statement>> {
+        Ok(statements)
     }
 
     /// Called before sql is actually executed. This hook is not called at the moment.
@@ -43,7 +47,7 @@ pub trait SqlQueryInterceptor {
     /// Flight adoption
     fn pre_execute(
         &self,
-        _statement: Statement,
+        _statement: &Statement,
         _plan: Option<&LogicalPlan>,
         _query_ctx: QueryContextRef,
     ) -> Result<()> {
@@ -68,17 +72,21 @@ impl SqlQueryInterceptor for Option<&SqlQueryInterceptorRef> {
         }
     }
 
-    fn post_parsing(&self, statement: Statement, query_ctx: QueryContextRef) -> Result<Statement> {
+    fn post_parsing(
+        &self,
+        statements: Vec<Statement>,
+        query_ctx: QueryContextRef,
+    ) -> Result<Vec<Statement>> {
         if let Some(this) = self {
-            this.post_parsing(statement, query_ctx)
+            this.post_parsing(statements, query_ctx)
         } else {
-            Ok(statement)
+            Ok(statements)
         }
     }
 
     fn pre_execute(
         &self,
-        statement: Statement,
+        statement: &Statement,
         plan: Option<&LogicalPlan>,
         query_ctx: QueryContextRef,
     ) -> Result<()> {

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -22,6 +22,7 @@ pub mod error;
 pub mod grpc;
 pub mod http;
 pub mod influxdb;
+pub mod interceptor;
 pub mod line_writer;
 pub mod mysql;
 pub mod opentsdb;

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -23,7 +23,7 @@ pub struct NoopInterceptor;
 
 impl SqlQueryInterceptor for NoopInterceptor {
     fn pre_parsing<'a>(&self, query: &'a str, _query_ctx: QueryContextRef) -> Result<Cow<'a, str>> {
-        let modified_query = format!("{};", query);
+        let modified_query = format!("{query};");
         Ok(Cow::Owned(modified_query))
     }
 }

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -1,0 +1,24 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use servers::error::Result;
+use servers::interceptor::SqlQueryInterceptor;
+use session::context::{QueryContext, QueryContextRef};
+
+pub struct NoopInterceptor;
+
+impl SqlQueryInterceptor for NoopInterceptor {
+    fn pre_parsing<'a>(&self, query: &'a str, _query_ctx: QueryContextRef) -> Result<Cow<'a, str>> {
+        let modified_query = format!("{};", query);
+        Ok(Cow::Owned(modified_query))
+    }
+}
+
+#[test]
+fn test_default_interceptor_behaviour() {
+    let di = NoopInterceptor;
+    let ctx = Arc::new(QueryContext::new());
+
+    let query = "SELECT 1";
+    assert_eq!("SELECT 1;", di.pre_parsing(query, ctx).unwrap());
+}

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -33,6 +33,7 @@ use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
 use session::context::QueryContextRef;
 
+mod interceptor;
 mod opentsdb;
 mod postgres;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch is to further enhance the foundation for our cloud service.

1. Make `plugins` available to frontend `Instance`, which can be accessed from various handler
2. Add a `SqlQueryInterceptor` to customize query handler behaviour on cloud

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
