### PR TITLE
chore: open userinfo constructor

### DIFF
--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -69,7 +69,6 @@ impl UserInfo {
         &self.username
     }
 
-    #[cfg(test)]
     pub fn new(username: impl Into<String>) -> Self {
         Self {
             username: username.into(),
@@ -165,9 +164,7 @@ pub mod test {
                     Password::PlainText(password) => {
                         if username == "greptime" {
                             if password == "greptime" {
-                                return Ok(UserInfo {
-                                    username: "greptime".to_string(),
-                                });
+                                return Ok(UserInfo::new("greptime"));
                             } else {
                                 return super::UserPasswordMismatchSnafu {
                                     username: username.to_string(),

--- a/src/servers/src/auth/user_provider.rs
+++ b/src/servers/src/auth/user_provider.rs
@@ -113,9 +113,7 @@ impl UserProvider for StaticUserProvider {
                 match input_pwd {
                     Password::PlainText(pwd) => {
                         return if save_pwd == pwd.as_bytes() {
-                            Ok(UserInfo {
-                                username: username.to_string(),
-                            })
+                            Ok(UserInfo::new(username))
                         } else {
                             UserPasswordMismatchSnafu {
                                 username: username.to_string(),
@@ -152,7 +150,7 @@ fn auth_mysql(
     }
     let candidate_stage_2 = sha1_one(&xor_result);
     if candidate_stage_2 == hash_stage_2 {
-        Ok(UserInfo { username })
+        Ok(UserInfo::new(username))
     } else {
         UserPasswordMismatchSnafu { username }.fail()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr removes `#[cfg(test)]` on `UserInfo::new` so that the constructor can be called outside the original crate.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
