### PR TITLE
chore: make election mod public

### DIFF
--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod etcd;
+pub mod etcd;
 
 use crate::error::Result;
 

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -14,7 +14,7 @@
 
 #![feature(btree_drain_filter)]
 pub mod bootstrap;
-mod election;
+pub mod election;
 pub mod error;
 pub mod handler;
 mod keys;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly make `election mod` publlic.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
