### PR TITLE
refactor: use "USE" keyword

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use common_query::Output;
-use common_telemetry::{debug, error};
+use common_telemetry::{error, trace};
 use opensrv_mysql::{
     AsyncMysqlShim, ErrorKind, InitWriter, ParamParser, QueryResultWriter, StatementMetaWriter,
 };
@@ -74,7 +74,7 @@ impl MysqlInstanceShim {
     }
 
     async fn do_query(&self, query: &str) -> Vec<Result<Output>> {
-        debug!("Start executing query: '{}'", query);
+        trace!("Start executing query: '{}'", query);
         let start = Instant::now();
 
         // TODO(LFC): Find a better way to deal with these special federated queries:
@@ -89,7 +89,7 @@ impl MysqlInstanceShim {
                     .await
             };
 
-        debug!(
+        trace!(
             "Finished executing query: '{}', total time costs in microseconds: {}",
             query,
             start.elapsed().as_micros()

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -102,8 +102,7 @@ impl<'a> ParserContext<'a> {
 
                     Keyword::DROP => self.parse_drop(),
 
-                    // TODO(LFC): Use "Keyword::USE" when we can upgrade to newer version of crate sqlparser.
-                    Keyword::NoKeyword if w.value.to_lowercase() == "use" => {
+                    Keyword::USE => {
                         self.parser.next_token();
 
                         let database_name =


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Since we've upgrade to newer version of sqlparser, we can use the "USE" keyword. Eliminate a TODO.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
