### PR TITLE
feat: Prom `SeriesNormalize` plan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,9 @@ name = "promql"
 version = "0.1.0"
 dependencies = [
  "common-error",
+ "datafusion",
+ "datatypes",
+ "futures",
  "promql-parser",
  "snafu",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,6 +5047,7 @@ dependencies = [
  "futures",
  "promql-parser",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/src/datatypes/src/schema.rs
+++ b/src/datatypes/src/schema.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema as ArrowSchema};
+pub use column_schema::TIME_INDEX_KEY;
 use datafusion_common::DFSchemaRef;
 use snafu::{ensure, ResultExt};
 
@@ -30,7 +31,7 @@ pub use crate::schema::constraint::ColumnDefaultConstraint;
 pub use crate::schema::raw::RawSchema;
 
 /// Key used to store version number of the schema in metadata.
-const VERSION_KEY: &str = "greptime:version";
+pub const VERSION_KEY: &str = "greptime:version";
 
 /// A common schema, should be immutable.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -26,7 +26,7 @@ use crate::vectors::VectorRef;
 pub type Metadata = HashMap<String, String>;
 
 /// Key used to store whether the column is time index in arrow field's metadata.
-const TIME_INDEX_KEY: &str = "greptime:time_index";
+pub const TIME_INDEX_KEY: &str = "greptime:time_index";
 /// Key used to store default constraint in arrow field's metadata.
 const DEFAULT_CONSTRAINT_KEY: &str = "greptime:default_constraint";
 

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -11,3 +11,6 @@ datatypes = { path = "../datatypes" }
 futures = "0.3"
 promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", rev = "71d8a90" }
 snafu = { version = "0.7", features = ["backtraces"] }
+
+[dev-dependencies]
+tokio = { version = "1.23", features = ["full"] }

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -6,5 +6,8 @@ license.workspace = true
 
 [dependencies]
 common-error = { path = "../common/error" }
+datafusion.workspace = true
+datatypes = { path = "../datatypes" }
+futures = "0.3"
 promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", rev = "71d8a90" }
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -1,0 +1,3 @@
+mod normalize;
+
+pub use normalize::{SeriesNormalize, SeriesNormalizeExec, SeriesNormalizeStream};

--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod normalize;
 
 pub use normalize::{SeriesNormalize, SeriesNormalizeExec, SeriesNormalizeStream};

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -297,7 +297,7 @@ mod test {
 
         let expected = String::from(
             "+---------------------+-------+------+\
-            \n| timestamp           | value | path |\
+            \n| greptime:time_index | value | path |\
             \n+---------------------+-------+------+\
             \n| 1970-01-01T00:00:00 | 10    | foo  |\
             \n| 1970-01-01T00:00:30 | 100   | foo  |\
@@ -328,7 +328,7 @@ mod test {
 
         let expected = String::from(
             "+---------------------+-------+------+\
-            \n| timestamp           | value | path |\
+            \n| greptime:time_index | value | path |\
             \n+---------------------+-------+------+\
             \n| 1969-12-31T23:59:59 | 10    | foo  |\
             \n| 1970-01-01T00:00:29 | 100   | foo  |\

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -205,7 +205,7 @@ pub struct SeriesNormalizeStream {
 
 impl SeriesNormalizeStream {
     pub fn normalize(&self, input: RecordBatch) -> ArrowResult<RecordBatch> {
-        // todo: maybe the input is not timestamp millisecond array
+        // TODO(ruihang): maybe the input is not timestamp millisecond array
         let ts_column = input
             .column(self.time_index)
             .as_any()

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -1,0 +1,189 @@
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use datafusion::arrow::compute;
+use datafusion::common::DFSchemaRef;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream, SendableRecordBatchStream};
+use datatypes::arrow::array::{ArrowPrimitiveType, PrimitiveArray, TimestampMillisecondArray};
+use datatypes::arrow::datatypes::{SchemaRef, TimestampMillisecondType};
+use datatypes::arrow::error::Result as ArrowResult;
+use datatypes::arrow::record_batch::RecordBatch;
+use futures::{Stream, StreamExt};
+
+type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;
+
+const TIMESTAMP_COLUMN_NAME: &str = "timestamp";
+
+/// Normalize the input record batch. Notice that for simplicity, this method assumes
+/// the input batch only contains sample points from one time series, and the value
+/// column's name is [`VALUE_COLUMN_NAME`] and timestamp column's name is [`TIMESTAMP_COLUMN_NAME`].
+///
+/// Roughly speaking, this method does these things:
+/// - bias sample's timestamp by offset
+/// - sort the record batch based on timestamp column
+#[derive(Debug)]
+pub struct SeriesNormalize {
+    offset: Millisecond,
+
+    input: LogicalPlan,
+}
+
+impl UserDefinedLogicalNode for SeriesNormalize {
+    fn as_any(&self) -> &dyn Any {
+        self as _
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.input.schema()
+    }
+
+    fn expressions(&self) -> Vec<datafusion::logical_expr::Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        todo!()
+    }
+
+    fn from_template(
+        &self,
+        _exprs: &[datafusion::logical_expr::Expr],
+        _inputs: &[LogicalPlan],
+    ) -> std::sync::Arc<dyn UserDefinedLogicalNode> {
+        todo!()
+    }
+}
+
+impl SeriesNormalize {
+    pub fn new(offset: Duration, input: LogicalPlan) -> Self {
+        Self {
+            offset: offset.as_millis() as i64,
+            input,
+        }
+    }
+
+    pub fn to_execution_plan(&self, exec_input: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        Arc::new(SeriesNormalizeExec {
+            offset: self.offset,
+            input: exec_input,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct SeriesNormalizeExec {
+    offset: Millisecond,
+
+    input: Arc<dyn ExecutionPlan>,
+}
+
+impl ExecutionPlan for SeriesNormalizeExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn output_partitioning(&self) -> datafusion::physical_plan::Partitioning {
+        self.input.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[datafusion::physical_expr::PhysicalSortExpr]> {
+        self.input.output_ordering()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        todo!()
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> datafusion::common::Result<SendableRecordBatchStream> {
+        let input = self.input.execute(partition, context)?;
+        Ok(Box::pin(SeriesNormalizeStream {
+            offset: self.offset,
+            schema: input.schema(),
+            input,
+        }))
+    }
+
+    fn statistics(&self) -> datafusion::common::Statistics {
+        todo!()
+    }
+}
+
+pub struct SeriesNormalizeStream {
+    offset: Millisecond,
+
+    schema: SchemaRef,
+    input: SendableRecordBatchStream,
+}
+
+impl SeriesNormalizeStream {
+    pub fn normalize(&self, input: RecordBatch) -> ArrowResult<RecordBatch> {
+        let ts_column_idx = self
+            .schema
+            .column_with_name(TIMESTAMP_COLUMN_NAME)
+            .expect("timestamp column not found")
+            .0;
+        // todo: maybe the input is not timestamp millisecond array
+        let ts_column = input
+            .column(ts_column_idx)
+            .as_any()
+            .downcast_ref::<Arc<PrimitiveArray<TimestampMillisecondType>>>()
+            .unwrap();
+
+        // bias the timestamp column by offset
+        let ts_column_biased = Arc::new(TimestampMillisecondArray::from_iter(
+            ts_column.iter().map(|ts| ts.map(|ts| ts - self.offset)),
+        ));
+        let mut columns = input.columns().to_vec();
+        columns[ts_column_idx] = ts_column_biased;
+
+        // sort the record batch
+        let ordered_indices = compute::sort_to_indices(&columns[ts_column_idx], None, None)?;
+        let ordered_columns = columns
+            .iter()
+            .map(|array| compute::take(array, &ordered_indices, None))
+            .collect::<ArrowResult<Vec<_>>>()?;
+        RecordBatch::try_new(input.schema(), ordered_columns)
+    }
+}
+
+impl RecordBatchStream for SeriesNormalizeStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl Stream for SeriesNormalizeStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.input.poll_next_unpin(cx) {
+            Poll::Ready(batch) => {
+                Poll::Ready(batch.map(|batch| batch.map(|batch| self.normalize(batch)).flatten()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::any::Any;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/src/promql/src/lib.rs
+++ b/src/promql/src/lib.rs
@@ -12,5 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(result_flattening)]
+
 pub mod engine;
 pub mod error;
+pub mod extension_plan;

--- a/src/promql/src/lib.rs
+++ b/src/promql/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(result_flattening)]
-
 pub mod engine;
 pub mod error;
 pub mod extension_plan;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `SeriesNormalize` plan described in the [RFC](https://github.com/GreptimeTeam/greptimedb/blob/develop/docs/rfcs/2022-12-20-promql-in-rust/rfc.md).

It only biases the timestamp column with "offset" and sorts the input.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#596