### PR TITLE
feat: pub `auth_mysql` & add auth boxed err

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -99,10 +99,6 @@ impl StartCommand {
         let mut frontend = Frontend::new(opts, instance, plugins);
         frontend.start().await.context(error::StartFrontendSnafu)
     }
-
-    pub fn user_provider(&self) -> Option<&String> {
-        self.user_provider.as_ref()
-    }
 }
 
 pub fn load_frontend_plugins(user_provider: &Option<String>) -> Result<Plugins> {

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -99,6 +99,10 @@ impl StartCommand {
         let mut frontend = Frontend::new(opts, instance, plugins);
         frontend.start().await.context(error::StartFrontendSnafu)
     }
+
+    pub fn user_provider(&self) -> Option<&String> {
+        self.user_provider.as_ref()
+    }
 }
 
 pub fn load_frontend_plugins(user_provider: &Option<String>) -> Result<Plugins> {

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -108,12 +108,6 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Tonic status error, source: {}", source))]
-    TonicStatus {
-        source: tonic::Status,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Auth failed, source: {}", source))]
     AuthBackend {
         #[snafu(backtrace)]
@@ -135,7 +129,6 @@ impl ErrorExt for Error {
         match self {
             Error::InvalidConfig { .. } => StatusCode::InvalidArguments,
             Error::Io { .. } => StatusCode::Internal,
-            Error::TonicStatus { .. } => StatusCode::Internal,
             Error::AuthBackend { .. } => StatusCode::Internal,
 
             Error::UserNotFound { .. } => StatusCode::UserNotFound,

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -116,8 +116,8 @@ pub enum Error {
 
     #[snafu(display("Auth failed, source: {}", source))]
     AuthBackend {
+        #[snafu(backtrace)]
         source: BoxedError,
-        backtrace: Backtrace,
     },
 
     #[snafu(display("User not found, username: {}", username))]
@@ -153,7 +153,7 @@ impl ErrorExt for Error {
     }
 }
 
-type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 pub mod test {

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -108,6 +108,12 @@ pub enum Error {
     #[snafu(display("Encounter IO error, source: {}", source))]
     IOErr { source: std::io::Error },
 
+    #[snafu(display("Encounter system error, msg: {}", msg))]
+    SystemErr { msg: String },
+
+    #[snafu(display("Rpc call return failed, {}: {}", code, msg))]
+    RpcResultErr { code: u32, msg: String },
+
     #[snafu(display("User not found, username: {}", username))]
     UserNotFound { username: String },
 
@@ -126,6 +132,8 @@ impl ErrorExt for Error {
         match self {
             Error::InvalidConfig { .. } => StatusCode::InvalidArguments,
             Error::IOErr { .. } => StatusCode::Internal,
+            Error::SystemErr { .. } => StatusCode::Internal,
+            Error::RpcResultErr { .. } => StatusCode::Internal,
 
             Error::UserNotFound { .. } => StatusCode::UserNotFound,
             Error::UnsupportedPasswordType { .. } => StatusCode::UnsupportedPasswordType,

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_USERNAME: &str = "greptime";
 
 use std::sync::Arc;
 
+use common_error::ext::BoxedError;
 use common_error::prelude::ErrorExt;
 use common_error::status_code::StatusCode;
 use snafu::{Backtrace, ErrorCompat, OptionExt, Snafu};
@@ -28,7 +29,7 @@ use crate::auth::user_provider::StaticUserProvider;
 pub trait UserProvider: Send + Sync {
     fn name(&self) -> &str;
 
-    async fn auth(&self, id: Identity<'_>, password: Password<'_>) -> Result<UserInfo, Error>;
+    async fn auth(&self, id: Identity<'_>, password: Password<'_>) -> Result<UserInfo>;
 }
 
 pub type UserProviderRef = Arc<dyn UserProvider>;
@@ -76,7 +77,7 @@ impl UserInfo {
     }
 }
 
-pub fn user_provider_from_option(opt: &String) -> Result<UserProviderRef, Error> {
+pub fn user_provider_from_option(opt: &String) -> Result<UserProviderRef> {
     let (name, content) = opt.split_once(':').context(InvalidConfigSnafu {
         value: opt.to_string(),
         msg: "UserProviderOption must be in format `<option>:<value>`",
@@ -99,29 +100,31 @@ pub fn user_provider_from_option(opt: &String) -> Result<UserProviderRef, Error>
 #[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display("Invalid config value: {}, {}", value, msg))]
-    InvalidConfig {
-        value: String,
-        msg: String,
+    InvalidConfig { value: String, msg: String },
+
+    #[snafu(display("IO error, source: {}", source))]
+    Io {
+        source: std::io::Error,
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Encounter IO error, source: {}", source))]
-    IOErr { source: std::io::Error },
+    #[snafu(display("Tonic status error, source: {}", source))]
+    TonicStatus {
+        source: tonic::Status,
+        backtrace: Backtrace,
+    },
 
-    #[snafu(display("Encounter system error, msg: {}", msg))]
-    SystemErr { msg: String },
-
-    #[snafu(display("Rpc call failed, {}: {}", code, msg))]
-    RpcResultErr { code: u32, msg: String },
+    #[snafu(display("Auth failed, source: {}", source))]
+    AuthBackend {
+        source: BoxedError,
+        backtrace: Backtrace,
+    },
 
     #[snafu(display("User not found, username: {}", username))]
     UserNotFound { username: String },
 
     #[snafu(display("Unsupported password type: {}", password_type))]
-    UnsupportedPasswordType {
-        password_type: String,
-        backtrace: Backtrace,
-    },
+    UnsupportedPasswordType { password_type: String },
 
     #[snafu(display("Username and password does not match, username: {}", username))]
     UserPasswordMismatch { username: String },
@@ -131,9 +134,9 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Error::InvalidConfig { .. } => StatusCode::InvalidArguments,
-            Error::IOErr { .. } => StatusCode::Internal,
-            Error::SystemErr { .. } => StatusCode::Internal,
-            Error::RpcResultErr { .. } => StatusCode::Internal,
+            Error::Io { .. } => StatusCode::Internal,
+            Error::TonicStatus { .. } => StatusCode::Internal,
+            Error::AuthBackend { .. } => StatusCode::Internal,
 
             Error::UserNotFound { .. } => StatusCode::UserNotFound,
             Error::UnsupportedPasswordType { .. } => StatusCode::UnsupportedPasswordType,
@@ -149,6 +152,8 @@ impl ErrorExt for Error {
         self
     }
 }
+
+type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 pub mod test {

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -111,7 +111,7 @@ pub enum Error {
     #[snafu(display("Encounter system error, msg: {}", msg))]
     SystemErr { msg: String },
 
-    #[snafu(display("Rpc call return failed, {}: {}", code, msg))]
+    #[snafu(display("Rpc call failed, {}: {}", code, msg))]
     RpcResultErr { code: u32, msg: String },
 
     #[snafu(display("User not found, username: {}", username))]

--- a/src/servers/src/auth/user_provider.rs
+++ b/src/servers/src/auth/user_provider.rs
@@ -140,7 +140,7 @@ pub fn auth_mysql(
     salt: Salt,
     username: String,
     save_pwd: &[u8],
-) -> Result<bool, Error> {
+) -> Result<(), Error> {
     // ref: https://github.com/mysql/mysql-server/blob/a246bad76b9271cb4333634e954040a970222e0a/sql/auth/password.cc#L62
     let hash_stage_2 = double_sha1(save_pwd);
     let tmp = sha1_two(salt, &hash_stage_2);
@@ -151,7 +151,7 @@ pub fn auth_mysql(
     }
     let candidate_stage_2 = sha1_one(&xor_result);
     if candidate_stage_2 == hash_stage_2 {
-        Ok(true)
+        Ok(())
     } else {
         UserPasswordMismatchSnafu { username }.fail()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- minor change to `auth_mysql`: add `pub` and return `Result<(), Error>` instead of `UserInfo` directly
- add `AuthBackend: BoxedError` for general auth failed scenarios

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
