### PR TITLE
chore: util workspace deps in more places

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ license = "Apache-2.0"
 arrow = "29.0"
 arrow-flight = "29.0"
 arrow-schema = { version = "29.0", features = ["serde"] }
+async-trait = "0.1"
 # TODO(LFC): Use released Datafusion when it officially dpendent on Arrow 29.0
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }
@@ -55,8 +56,13 @@ datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev 
 datafusion-optimizer = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }
 datafusion-physical-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }
 datafusion-sql = { git = "https://github.com/apache/arrow-datafusion.git", rev = "4917235a398ae20145c87d20984e6367dc1a0c1e" }
+futures = "0.3"
 parquet = "29.0"
+paste = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.28"
+tokio = { version = "1", features = ["full"] }
 
 [profile.release]
 debug = true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -11,4 +11,4 @@ client = { path = "../src/client" }
 indicatif = "0.17.1"
 itertools = "0.10.5"
 parquet.workspace = true
-tokio = { version = "1.21", features = ["full"] }
+tokio.workspace = true

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 storage = { path = "../storage" }
 table = { path = "../table" }
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true
 
 [dev-dependencies]
 chrono = "0.4"
@@ -39,4 +39,4 @@ mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }
 storage = { path = "../storage" }
 tempdir = "0.3"
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -19,13 +19,13 @@ datatypes = { path = "../datatypes" }
 enum_dispatch = "0.3"
 parking_lot = "0.12"
 rand = "0.8"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tonic = "0.8"
 
 [dev-dependencies]
 datanode = { path = "../datanode" }
 substrait = { path = "../common/substrait" }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -18,17 +18,17 @@ common-telemetry = { path = "../common/telemetry", features = [
 ] }
 datanode = { path = "../datanode" }
 frontend = { path = "../frontend" }
-futures = "0.3"
+futures.workspace = true
 meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv" }
-serde = "1.0"
+serde.workspace = true
 servers = { path = "../servers" }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tokio = { version = "1.18", features = ["full"] }
 toml = "0.5"
 
 [dev-dependencies]
-serde = "1.0"
+serde.workspace = true
 tempdir = "0.3"
 
 [build-dependencies]

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -10,4 +10,4 @@ bytes = { version = "1.1", features = ["serde"] }
 common-error = { path = "../error" }
 paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -11,7 +11,7 @@ common-telemetry = { path = "../telemetry" }
 datatypes = { path = "../../datatypes" }
 lazy_static = "1.4"
 regex = "1.6"
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 

--- a/src/common/function-macro/Cargo.toml
+++ b/src/common/function-macro/Cargo.toml
@@ -15,5 +15,5 @@ syn = "1.0"
 arc-swap = "1.0"
 common-query = { path = "../query" }
 datatypes = { path = "../../datatypes" }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 static_assertions = "1.1.0"

--- a/src/common/function/Cargo.toml
+++ b/src/common/function/Cargo.toml
@@ -18,7 +18,7 @@ num = "0.4"
 num-traits = "0.2"
 once_cell = "1.10"
 paste = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 statrs = "0.15"
 
 [dev-dependencies]

--- a/src/common/grpc-expr/Cargo.toml
+++ b/src/common/grpc-expr/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 api = { path = "../../api" }
-async-trait = "0.1"
+async-trait.workspace = true
 common-base = { path = "../base" }
 common-catalog = { path = "../catalog" }
 common-error = { path = "../error" }

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 common-error = { path = "../error" }
 common-recordbatch = { path = "../recordbatch" }
 common-time = { path = "../time" }
@@ -13,7 +13,7 @@ datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datatypes = { path = "../../datatypes" }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 statrs = "0.15"
 
 [dev-dependencies]

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -9,7 +9,7 @@ common-error = { path = "../error" }
 datafusion.workspace = true
 datafusion-common.workspace = true
 datatypes = { path = "../../datatypes" }
-futures = "0.3"
+futures.workspace = true
 paste = "1.0"
 serde = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -9,9 +9,9 @@ common-error = { path = "../error" }
 common-telemetry = { path = "../telemetry" }
 metrics = "0.20"
 once_cell = "1.12"
-paste = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
-tokio = { version = "1.18", features = ["full"] }
+paste.workspace = true
+snafu.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/common/substrait/Cargo.toml
+++ b/src/common/substrait/Cargo.toml
@@ -15,7 +15,7 @@ datafusion-expr.workspace = true
 datatypes = { path = "../../datatypes" }
 futures = "0.3"
 prost = "0.9"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 table = { path = "../../table" }
 
 [dependencies.substrait_proto]

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -9,9 +9,9 @@ default = ["python"]
 python = ["dep:script"]
 
 [dependencies]
+async-trait.workspace = true
 api = { path = "../api" }
 arrow-flight.workspace = true
-async-trait = "0.1"
 axum = "0.6"
 axum-macros = "0.3"
 backon = "0.2"

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -20,6 +20,6 @@ num = "0.4"
 num-traits = "0.2"
 ordered-float = { version = "3.0", features = ["serde"] }
 paste = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -40,7 +40,7 @@ serde = "1.0"
 serde_json = "1.0"
 servers = { path = "../servers" }
 session = { path = "../session" }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sql = { path = "../sql" }
 store-api = { path = "../store-api" }
 substrait = { path = "../common/substrait" }

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 arc-swap = "1.5"
 async-stream = "0.3"
-async-trait = "0.1"
 base64 = "0.13"
 byteorder = "1.4"
 bytes = "1.1"
@@ -16,7 +16,7 @@ common-error = { path = "../common/error" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 crc = "3.0"
-futures = "0.3"
+futures.workspace = true
 futures-util = "0.3"
 hex = "0.4"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/meta-client/Cargo.toml
+++ b/src/meta-client/Cargo.toml
@@ -13,7 +13,7 @@ common-telemetry = { path = "../common/telemetry" }
 etcd-client = "0.10"
 rand = "0.8"
 serde = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tokio = { version = "1.18", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -19,7 +19,7 @@ common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
 etcd-client = "0.10"
-futures = "0.3"
+futures.workspace = true
 h2 = "0.3"
 http-body = "0.4"
 lazy_static = "1.4"
@@ -28,7 +28,7 @@ prost = "0.11"
 regex = "1.6"
 serde = "1.0"
 serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tokio = { version = "1.0", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.8"

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -22,12 +22,12 @@ common-time = { path = "../common/time" }
 datafusion.workspace = true
 datafusion-common.workspace = true
 datatypes = { path = "../datatypes" }
-futures = "0.3"
+futures.workspace = true
 log-store = { path = "../log-store" }
 object-store = { path = "../object-store" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 storage = { path = "../storage" }
 store-api = { path = "../store-api" }
 table = { path = "../table" }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 futures = { version = "0.3" }
 opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 futures-util = "0.3"
 metrics = "0.20"
 once_cell = "1.10"
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -23,7 +23,7 @@ python = [
 ]
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 catalog = { path = "../catalog" }
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
@@ -38,9 +38,9 @@ datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
 datatypes = { path = "../datatypes" }
-futures = "0.3"
+futures.workspace = true
 futures-util = "0.3"
-paste = { version = "1.0", optional = true }
+paste = { workspace = true, optional = true }
 query = { path = "../query" }
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "183e8dab" }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -43,7 +43,7 @@ regex = "1.6"
 rustls = "0.20"
 rustls-pemfile = "1.0"
 schemars = "0.8"
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 session = { path = "../session" }
 sha1 = "0.10"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -18,22 +18,22 @@ common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-futures = "0.3"
+futures.workspace = true
 futures-util = "0.3"
 lazy_static = "1.4"
 object-store = { path = "../object-store" }
 parquet = { workspace = true, features = ["async"] }
-paste = "1.0"
+paste.workspace = true
 planus = "0.2"
 prost = "0.11"
 regex = "1.5"
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 serde_json = "1.0"
 sluice = "0.5"
 snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
 table = { path = "../table" }
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true
 tonic = "0.8"
 uuid = { version = "1.1", features = ["v4"] }
 

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 bytes = "1.1"
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
@@ -13,9 +13,9 @@ common-query = { path = "../common/query" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
 derive_builder = "0.11"
-futures = "0.3"
-serde = { version = "1.0", features = ["derive"] }
-snafu = { version = "0.7", features = ["backtraces"] }
+futures.workspace = true
+serde.workspace = true
+snafu.workspace = true
 
 [dev-dependencies]
 async-stream = "0.3"

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -17,7 +17,7 @@ datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datatypes = { path = "../datatypes" }
 derive_builder = "0.11"
-futures = "0.3"
+futures.workspace = true
 parquet-format-async-temp = "0.2"
 paste = "1.0"
 serde = "1.0.136"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -23,15 +23,15 @@ mito = { path = "../src/mito", features = ["test"] }
 object-store = { path = "../src/object-store" }
 once_cell = "1.16"
 rand = "0.8"
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 servers = { path = "../src/servers" }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sql = { path = "../src/sql" }
 table = { path = "../src/table" }
 tempdir = "0.3"
-tokio = { version = "1.20", features = ["full"] }
+tokio.workspace = true
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
-paste = "1.0"
+paste.workspace = true

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -10,4 +10,4 @@ client = { path = "../../src/client" }
 comfy-table = "6.1"
 common-base = { path = "../../src/common/base" }
 sqlness = { git = "https://github.com/ceresdb/sqlness.git" }
-tokio = { version = "1.21", features = ["full"] }
+tokio.workspace = true


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

In https://github.com/GreptimeTeam/greptimedb/pull/782 @MichaelScofield changes arrow/parquet/datafusion into workspace dependencies. As discussed in https://github.com/GreptimeTeam/greptimedb/pull/782#issuecomment-1362816554, I count other deps we are using:
```
➜  greptimedb git:(dev) ✗ sort deps | uniq -cd | sort -nr
  11 tokio v1.23.0 (*)
  10 snafu v0.7.3 (*)
   7 serde v1.0.151 (*)
   5 futures v0.3.25 (*)
   5 async-trait v0.1.60 (proc-macro) (*)
   4 paste v1.0.11 (proc-macro)
   4 datafusion v15.0.0 (https://github.com/apache/arrow-datafusion.git?rev=4917235a398ae20145c87d20984e6367dc1a0c1e#4917235a) (*)
   3 tempdir v0.3.7 (*)
   3 serde_json v1.0.91 (*)
   3 once_cell v1.16.0
   3 arc-swap v1.5.1
   2 futures-util v0.3.25 (*)
   2 datafusion-expr v15.0.0 (https://github.com/apache/arrow-datafusion.git?rev=4917235a398ae20145c87d20984e6367dc1a0c1e#4917235a) (*)
```
And turn things referred more than 4 times into workspace deps.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
