### PR TITLE
fix: ease the restriction of the original "SelectExpr"

### DIFF
--- a/src/api/greptime/v1/database.proto
+++ b/src/api/greptime/v1/database.proto
@@ -18,15 +18,12 @@ message ObjectExpr {
   ExprHeader header = 1;
   oneof expr {
     InsertExpr insert = 2;
-    SelectExpr select = 3;
-    UpdateExpr update = 4;
-    DeleteExpr delete = 5;
+    QueryRequest query = 3;
   }
 }
 
-// TODO(fys): Only support sql now, and will support promql etc in the future
-message SelectExpr {
-  oneof expr {
+message QueryRequest {
+  oneof query {
     string sql = 1;
     bytes logical_plan = 2;
   }
@@ -47,11 +44,6 @@ message InsertExpr {
   // The region number of current insert request.
   uint32 region_number = 5;
 }
-
-// TODO(jiachun)
-message UpdateExpr {}
-// TODO(jiachun)
-message DeleteExpr {}
 
 message ObjectResult {
   ResultHeader header = 1;

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -721,9 +721,9 @@ mod tests {
 
     use api::v1::column::SemanticType;
     use api::v1::{
-        admin_expr, admin_result, column, object_expr, object_result, select_expr, Column,
+        admin_expr, admin_result, column, object_expr, object_result, query_request, Column,
         ColumnDataType, ColumnDef as GrpcColumnDef, ExprHeader, FlightDataRaw, MutateResult,
-        SelectExpr,
+        QueryRequest,
     };
     use common_grpc::flight::{raw_flight_data_to_message, FlightMessage};
     use common_recordbatch::RecordBatch;
@@ -930,8 +930,8 @@ mod tests {
         // select
         let object_expr = ObjectExpr {
             header: Some(ExprHeader::default()),
-            expr: Some(object_expr::Expr::Select(SelectExpr {
-                expr: Some(select_expr::Expr::Sql("select * from demo".to_string())),
+            expr: Some(Expr::Query(QueryRequest {
+                query: Some(query_request::Query::Sql("select * from demo".to_string())),
             })),
         };
         let result = GrpcQueryHandler::do_query(&*instance, object_expr)


### PR DESCRIPTION
fix: ease the restriction of the original "SelectExpr" since we used to pass SQLs other than selection in the related GRPC interface

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix https://github.com/GreptimeTeam/greptimedb/pull/770#issuecomment-1365667080

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
