### PR TITLE
feat: Implement delete for table

### DIFF
--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -255,7 +255,7 @@ impl<R: Region> Table for MitoTable<R> {
         let rows_num = key_column_values.values().next().unwrap().len();
 
         logging::trace!(
-            "Insert into table {} with data: {:?}",
+            "Delete from table {} where key_columns are: {:?}",
             self.table_info().name,
             key_column_values
         );

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -41,7 +41,9 @@ use table::error::Result as TableResult;
 use table::metadata::{
     FilterPushDownType, RawTableInfo, TableInfo, TableInfoRef, TableMeta, TableType,
 };
-use table::requests::{AddColumnRequest, AlterKind, AlterTableRequest, InsertRequest};
+use table::requests::{
+    AddColumnRequest, AlterKind, AlterTableRequest, DeleteRequest, InsertRequest,
+};
 use table::table::scan::SimpleTableScan;
 use table::table::{AlterContext, Table};
 use tokio::sync::Mutex;
@@ -161,6 +163,10 @@ impl<R: Region> Table for MitoTable<R> {
         Ok(Arc::new(SimpleTableScan::new(stream)))
     }
 
+    fn supports_filter_pushdown(&self, _filter: &Expr) -> table::error::Result<FilterPushDownType> {
+        Ok(FilterPushDownType::Inexact)
+    }
+
     /// Alter table changes the schemas of the table.
     async fn alter(&self, _context: AlterContext, req: AlterTableRequest) -> TableResult<()> {
         let _lock = self.alter_lock.lock().await;
@@ -237,8 +243,34 @@ impl<R: Region> Table for MitoTable<R> {
         Ok(())
     }
 
-    fn supports_filter_pushdown(&self, _filter: &Expr) -> table::error::Result<FilterPushDownType> {
-        Ok(FilterPushDownType::Inexact)
+    async fn delete(&self, request: DeleteRequest) -> TableResult<usize> {
+        if request.key_column_values.is_empty() {
+            return Ok(0);
+        }
+
+        let mut write_request = self.region.write_request();
+
+        let key_column_values = request.key_column_values;
+        // Safety: key_column_values isn't empty.
+        let rows_num = key_column_values.values().next().unwrap().len();
+
+        logging::trace!(
+            "Insert into table {} with data: {:?}",
+            self.table_info().name,
+            key_column_values
+        );
+
+        write_request
+            .delete(key_column_values)
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
+        self.region
+            .write(&WriteContext::default(), write_request)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
+
+        Ok(rows_num)
     }
 }
 

--- a/src/table/src/error.rs
+++ b/src/table/src/error.rs
@@ -102,6 +102,9 @@ pub enum Error {
 
     #[snafu(display("Failed to operate table, source: {}", source))]
     TableOperation { source: BoxedError },
+
+    #[snafu(display("Unsupported operation: {}", operation))]
+    Unsupported { operation: String },
 }
 
 impl ErrorExt for Error {
@@ -119,6 +122,7 @@ impl ErrorExt for Error {
             Error::SchemaBuild { source, .. } => source.status_code(),
             Error::TableOperation { source } => source.status_code(),
             Error::ColumnNotExists { .. } => StatusCode::TableColumnNotFound,
+            Error::Unsupported { .. } => StatusCode::Unsupported,
         }
     }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -90,3 +90,12 @@ pub struct DropTableRequest {
     pub schema_name: String,
     pub table_name: String,
 }
+
+/// Delete (by primary key) request
+#[derive(Debug)]
+pub struct DeleteRequest {
+    /// Values of each column in this table's primary key and time index.
+    ///
+    /// The key is the column name, and the value is the column value.
+    pub key_column_values: HashMap<String, VectorRef>,
+}

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -24,7 +24,7 @@ use common_query::logical_plan::Expr;
 use common_query::physical_plan::PhysicalPlanRef;
 use datatypes::schema::SchemaRef;
 
-use crate::error::Result;
+use crate::error::{Result, UnsupportedSnafu};
 use crate::metadata::{FilterPushDownType, TableId, TableInfoRef, TableType};
 use crate::requests::{AlterTableRequest, InsertRequest};
 
@@ -50,7 +50,10 @@ pub trait Table: Send + Sync {
 
     /// Insert values into table.
     async fn insert(&self, _request: InsertRequest) -> Result<usize> {
-        unimplemented!();
+        UnsupportedSnafu {
+            operation: "INSERT",
+        }
+        .fail()?
     }
 
     /// Scan the table and returns a SendableRecordBatchStream.
@@ -71,9 +74,11 @@ pub trait Table: Send + Sync {
         Ok(FilterPushDownType::Unsupported)
     }
 
-    async fn alter(&self, _context: AlterContext, request: AlterTableRequest) -> Result<()> {
-        let _ = request;
-        unimplemented!()
+    async fn alter(&self, _context: AlterContext, _request: AlterTableRequest) -> Result<()> {
+        UnsupportedSnafu {
+            operation: "ALTER TABLE",
+        }
+        .fail()?
     }
 }
 

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -26,7 +26,7 @@ use datatypes::schema::SchemaRef;
 
 use crate::error::{Result, UnsupportedSnafu};
 use crate::metadata::{FilterPushDownType, TableId, TableInfoRef, TableType};
-use crate::requests::{AlterTableRequest, InsertRequest};
+use crate::requests::{AlterTableRequest, DeleteRequest, InsertRequest};
 
 pub type AlterContext = anymap::Map<dyn Any + Send + Sync>;
 
@@ -49,6 +49,8 @@ pub trait Table: Send + Sync {
     }
 
     /// Insert values into table.
+    ///
+    /// Returns number of inserted rows.
     async fn insert(&self, _request: InsertRequest) -> Result<usize> {
         UnsupportedSnafu {
             operation: "INSERT",
@@ -74,9 +76,20 @@ pub trait Table: Send + Sync {
         Ok(FilterPushDownType::Unsupported)
     }
 
+    /// Alter table.
     async fn alter(&self, _context: AlterContext, _request: AlterTableRequest) -> Result<()> {
         UnsupportedSnafu {
             operation: "ALTER TABLE",
+        }
+        .fail()?
+    }
+
+    /// Delete rows in the table.
+    ///
+    /// Returns number of deleted rows.
+    async fn delete(&self, _request: DeleteRequest) -> Result<usize> {
+        UnsupportedSnafu {
+            operation: "DELETE",
         }
         .fail()?
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds `delete()` method to the `Table` trait and implements it for `mito` engine.
```rust
pub struct DeleteRequest {
    pub key_column_values: HashMap<String, VectorRef>,
}

#[async_trait]
pub trait Table: Send + Sync {
    // ...

    async fn delete(&self, _request: DeleteRequest) -> Result<usize> {
        UnsupportedSnafu {
            operation: "DELETE",
        }
        .fail()?
    }
}
```

It adds the Unsupported error. The default implementation of `insert`/`alter`/`delete` returns this error instead of panic.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- This PR is based on #777 
- Parts of #755 