### PR TITLE
feat: impl `InstantManipulator` for PromQL extension

### DIFF
--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod instant_manipulator;
+mod instant_manipulate;
 mod normalize;
 
 use datafusion::arrow::datatypes::{ArrowPrimitiveType, TimestampMillisecondType};
-pub use instant_manipulator::{
-    InstantManipulator, InstantManipulatorExec, InstantManipulatorStream,
-};
+pub use instant_manipulate::{InstantManipulate, InstantManipulateExec, InstantManipulateStream};
 pub use normalize::{SeriesNormalize, SeriesNormalizeExec, SeriesNormalizeStream};
 
 type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;

--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod instant_manipulator;
 mod normalize;
 
+use datafusion::arrow::datatypes::{ArrowPrimitiveType, TimestampMillisecondType};
+pub use instant_manipulator::{
+    InstantManipulator, InstantManipulatorExec, InstantManipulatorStream,
+};
 pub use normalize::{SeriesNormalize, SeriesNormalizeExec, SeriesNormalizeStream};
+
+type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -73,7 +73,7 @@ impl UserDefinedLogicalNode for InstantManipulate {
     fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "PromInstantManipulator: range=[{}..{}], lookback=[{}], interval=[{}], time index=[{}]",
+            "PromInstantManipulate: range=[{}..{}], lookback=[{}], interval=[{}], time index=[{}]",
             self.start, self.end, self.lookback_delta, self.interval, self.time_index_column
         )
     }
@@ -211,7 +211,7 @@ impl ExecutionPlan for InstantManipulateExec {
             DisplayFormatType::Default => {
                 write!(
                     f,
-                    "PromInstantManipulatorExec: range=[{}..{}], lookback=[{}], interval=[{}], time index=[{}]",
+                    "PromInstantManipulateExec: range=[{}..{}], lookback=[{}], interval=[{}], time index=[{}]",
                    self.start,self.end, self.lookback_delta, self.interval, self.time_index_column
                 )
             }

--- a/src/promql/src/extension_plan/instant_manipulator.rs
+++ b/src/promql/src/extension_plan/instant_manipulator.rs
@@ -1,0 +1,370 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use datafusion::arrow::array::{Array, TimestampMillisecondArray, UInt64Array};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::DFSchemaRef;
+use datafusion::error::Result as DataFusionResult;
+use datafusion::execution::context::TaskContext;
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_expr::PhysicalSortExpr;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::{
+    DisplayFormatType, ExecutionPlan, Partitioning, PhysicalExpr, RecordBatchStream,
+    SendableRecordBatchStream, Statistics,
+};
+use datatypes::arrow::compute;
+use datatypes::arrow::error::Result as ArrowResult;
+use futures::{Stream, StreamExt};
+
+use crate::extension_plan::Millisecond;
+
+#[derive(Debug)]
+pub struct InstantManipulator {
+    start: Millisecond,
+    end: Millisecond,
+    lookback_delta: Millisecond,
+    interval: Millisecond,
+
+    time_index_column: String,
+    value_columns: Vec<String>,
+
+    exprs: Vec<Expr>,
+    input: LogicalPlan,
+}
+
+impl UserDefinedLogicalNode for InstantManipulator {
+    fn as_any(&self) -> &dyn Any {
+        self as _
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        self.input.schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        self.exprs.clone()
+    }
+
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "PromInstantManipulator: lookback=[{}], interval=[{}], time index=[{}]",
+            self.lookback_delta, self.interval, self.time_index_column
+        )?;
+        for (i, expr_item) in self.exprs.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{:?}", expr_item)?;
+        }
+        Ok(())
+    }
+
+    fn from_template(
+        &self,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
+    ) -> Arc<dyn UserDefinedLogicalNode> {
+        assert!(!inputs.is_empty());
+
+        Arc::new(Self {
+            start: self.start,
+            end: self.end,
+            lookback_delta: self.lookback_delta,
+            interval: self.interval,
+            time_index_column: self.time_index_column.clone(),
+            value_columns: self.value_columns.clone(),
+            exprs: exprs.to_vec(),
+            input: inputs[0].clone(),
+        })
+    }
+}
+
+impl InstantManipulator {
+    pub fn new<E: AsRef<[Expr]>>(
+        start: Millisecond,
+        end: Millisecond,
+        lookback_delta: Millisecond,
+        interval: Millisecond,
+        time_index_column: String,
+        value_columns: Vec<String>,
+        exprs: E,
+        input: LogicalPlan,
+    ) -> Self {
+        Self {
+            start,
+            end,
+            lookback_delta,
+            interval,
+            time_index_column,
+            value_columns,
+            exprs: exprs.as_ref().to_vec(),
+            input,
+        }
+    }
+
+    pub fn to_execution_plan(
+        &self,
+        exec_input: Arc<dyn ExecutionPlan>,
+        physical_exprs: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Arc<dyn ExecutionPlan> {
+        Arc::new(InstantManipulatorExec {
+            start: self.start,
+            end: self.end,
+            lookback_delta: self.lookback_delta,
+            interval: self.interval,
+            time_index_column: self.time_index_column.clone(),
+            value_columns: self.value_columns.clone(),
+            input: exec_input,
+            exprs: physical_exprs,
+            metric: ExecutionPlanMetricsSet::new(),
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct InstantManipulatorExec {
+    start: Millisecond,
+    end: Millisecond,
+    lookback_delta: Millisecond,
+    interval: Millisecond,
+
+    time_index_column: String,
+    value_columns: Vec<String>,
+
+    input: Arc<dyn ExecutionPlan>,
+    exprs: Vec<Arc<dyn PhysicalExpr>>,
+
+    metric: ExecutionPlanMetricsSet,
+}
+
+impl ExecutionPlan for InstantManipulatorExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.input.schema()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        self.input.output_partitioning()
+    }
+
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        self.input.output_ordering()
+    }
+
+    fn maintains_input_order(&self) -> bool {
+        true
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        assert!(!children.is_empty());
+        Ok(Arc::new(Self {
+            start: self.start,
+            end: self.end,
+            lookback_delta: self.lookback_delta,
+            interval: self.interval,
+            time_index_column: self.time_index_column.clone(),
+            value_columns: self.value_columns.clone(),
+            exprs: self.exprs.clone(),
+            input: children[0].clone(),
+            metric: self.metric.clone(),
+        }))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let baseline_metric = BaselineMetrics::new(&self.metric, partition);
+
+        let input = self.input.execute(partition, context)?;
+        let schema = input.schema();
+        let time_index = schema
+            .column_with_name(&self.time_index_column)
+            .expect("time index column not found")
+            .0;
+        Ok(Box::pin(InstantManipulatorStream {
+            start: self.start,
+            end: self.end,
+            lookback_delta: self.lookback_delta,
+            interval: self.interval,
+            time_index,
+            schema,
+            input,
+            metric: baseline_metric,
+        }))
+    }
+
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default => {
+                write!(
+                    f,
+                    "PromInstantManipulatorExec: lookback=[{}], interval=[{}], time index=[{}]",
+                    self.lookback_delta, self.interval, self.time_index_column
+                )
+            }
+        }
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metric.clone_inner())
+    }
+
+    fn statistics(&self) -> Statistics {
+        let input_stats = self.input.statistics();
+
+        let estimated_row_num = (self.end - self.start) as f64 / self.interval as f64;
+        let estimated_total_bytes = input_stats
+            .total_byte_size
+            .zip(input_stats.num_rows)
+            .map(|(size, rows)| (size as f64 / rows as f64) * estimated_row_num)
+            .map(|size| size.floor() as _);
+
+        Statistics {
+            num_rows: Some(estimated_row_num.floor() as _),
+            total_byte_size: estimated_total_bytes,
+            // TODO(ruihang): support this column statistics
+            column_statistics: None,
+            is_exact: false,
+        }
+    }
+}
+
+pub struct InstantManipulatorStream {
+    start: Millisecond,
+    end: Millisecond,
+    lookback_delta: Millisecond,
+    interval: Millisecond,
+    // Column index of TIME INDEX column's position in schema
+    time_index: usize,
+
+    schema: SchemaRef,
+    input: SendableRecordBatchStream,
+    metric: BaselineMetrics,
+}
+
+impl RecordBatchStream for InstantManipulatorStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl Stream for InstantManipulatorStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let poll = match self.input.poll_next_unpin(cx) {
+            Poll::Ready(batch) => {
+                let _timer = self.metric.elapsed_compute().timer();
+                Poll::Ready(batch.map(|batch| batch.and_then(|batch| self.manipulate(batch))))
+            }
+            Poll::Pending => Poll::Pending,
+        };
+        self.metric.record_poll(poll)
+    }
+}
+
+impl InstantManipulatorStream {
+    /// Manipulate the input record batch to make it suit for Instant Operator.
+    ///
+    /// This plan will try to align the input time series, for every timestamp between
+    /// `start` and `end` with step `interval`. Find in the `lookback` range if data
+    /// is missing at the given timestamp.
+    pub fn manipulate(&self, input: RecordBatch) -> ArrowResult<RecordBatch> {
+        let mut take_indices = Vec::with_capacity(input.num_rows());
+        // TODO(ruihang): maybe the input is not timestamp millisecond array
+        let ts_column = input
+            .column(self.time_index)
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .unwrap();
+
+        // prepare two vectors
+        let mut cursor = 0;
+        let expected_iter = (self.start..=self.end).step_by(self.interval as usize);
+
+        // calculate the offsets to take
+        'next: for expected_ts in expected_iter {
+            // first, search toward end to see if there is matched timestamp
+            while cursor < ts_column.len() {
+                let curr = ts_column.value(cursor);
+                if curr == expected_ts {
+                    take_indices.push(Some(cursor as u64));
+                    continue 'next;
+                } else if curr > expected_ts {
+                    break;
+                }
+                cursor += 1;
+            }
+            // then, search backward to lookback
+            loop {
+                let curr = ts_column.value(cursor);
+                if curr + self.lookback_delta < expected_ts {
+                    // not found in lookback, leave this field blank
+                    take_indices.push(None);
+                    break;
+                } else if curr < expected_ts && curr + self.lookback_delta >= expected_ts {
+                    // find the expected value, push and break
+                    take_indices.push(Some(cursor as u64));
+                    break;
+                } else if cursor == 0 {
+                    // reach the first value and not found in lookback, leave this field blank
+                    break;
+                }
+                cursor -= 1;
+            }
+        }
+
+        // take record batch
+        Self::take_record_batch_optional(input, take_indices)
+    }
+
+    /// Helper function to apply "take" on record batch.
+    fn take_record_batch_optional(
+        record_batch: RecordBatch,
+        take_indices: Vec<Option<u64>>,
+    ) -> ArrowResult<RecordBatch> {
+        let indices_array = UInt64Array::from(take_indices);
+        let arrays = record_batch
+            .columns()
+            .iter()
+            .map(|array| compute::take(array, &indices_array, None))
+            .collect::<ArrowResult<Vec<_>>>()?;
+
+        RecordBatch::try_new(record_batch.schema(), arrays)
+    }
+}

--- a/src/promql/src/extension_plan/instant_manipulator.rs
+++ b/src/promql/src/extension_plan/instant_manipulator.rs
@@ -41,7 +41,7 @@ use crate::extension_plan::Millisecond;
 ///
 /// This plan will try to align the input time series, for every timestamp between
 /// `start` and `end` with step `interval`. Find in the `lookback` range if data
-/// is missing at the given timestamp. If data is absent in some timestmap, all columns
+/// is missing at the given timestamp. If data is absent in some timestamp, all columns
 /// except the time index will left blank.
 #[derive(Debug)]
 pub struct InstantManipulator {

--- a/src/promql/src/extension_plan/instant_manipulator.rs
+++ b/src/promql/src/extension_plan/instant_manipulator.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::cmp::Ordering;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -297,11 +298,13 @@ impl InstantManipulatorStream {
             // first, search toward end to see if there is matched timestamp
             while cursor < ts_column.len() {
                 let curr = ts_column.value(cursor);
-                if curr == expected_ts {
-                    take_indices.push(Some(cursor as u64));
-                    continue 'next;
-                } else if curr > expected_ts {
-                    break;
+                match curr.cmp(&expected_ts) {
+                    Ordering::Equal => {
+                        take_indices.push(Some(cursor as u64));
+                        continue 'next;
+                    }
+                    Ordering::Greater => break,
+                    Ordering::Less => {}
                 }
                 cursor += 1;
             }

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -33,7 +33,7 @@ use datatypes::arrow::error::Result as ArrowResult;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
 
-use super::Millisecond;
+use crate::extension_plan::Millisecond;
 
 /// Normalize the input record batch. Notice that for simplicity, this method assumes
 /// the input batch only contains sample points from one time series.

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -27,13 +27,13 @@ use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSe
 use datafusion::physical_plan::{
     DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream,
 };
-use datatypes::arrow::array::{ArrowPrimitiveType, TimestampMillisecondArray};
-use datatypes::arrow::datatypes::{SchemaRef, TimestampMillisecondType};
+use datatypes::arrow::array::TimestampMillisecondArray;
+use datatypes::arrow::datatypes::SchemaRef;
 use datatypes::arrow::error::Result as ArrowResult;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
 
-type Millisecond = <TimestampMillisecondType as ArrowPrimitiveType>::Native;
+use super::Millisecond;
 
 /// Normalize the input record batch. Notice that for simplicity, this method assumes
 /// the input batch only contains sample points from one time series.
@@ -67,7 +67,11 @@ impl UserDefinedLogicalNode for SeriesNormalize {
     }
 
     fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "PromSeriesNormalize: offset=[{}]", self.offset)
+        write!(
+            f,
+            "PromSeriesNormalize: offset=[{}], time index=[{}]",
+            self.offset, self.time_index_column_name
+        )
     }
 
     fn from_template(
@@ -180,7 +184,11 @@ impl ExecutionPlan for SeriesNormalizeExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default => {
-                write!(f, "PromSeriesNormalizeExec: offset=[{}]", self.offset)
+                write!(
+                    f,
+                    "PromSeriesNormalizeExec: offset=[{}], time index=[{}]",
+                    self.offset, self.time_index_column_name
+                )
             }
         }
     }
@@ -196,6 +204,7 @@ impl ExecutionPlan for SeriesNormalizeExec {
 
 pub struct SeriesNormalizeStream {
     offset: Millisecond,
+    // Column index of TIME INDEX column's position in schema
     time_index: usize,
 
     schema: SchemaRef,
@@ -257,7 +266,9 @@ impl Stream for SeriesNormalizeStream {
 #[cfg(test)]
 mod test {
     use datafusion::arrow::array::Float64Array;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::datatypes::{
+        ArrowPrimitiveType, DataType, Field, Schema, TimestampMillisecondType,
+    };
     use datafusion::from_slice::FromSlice;
     use datafusion::physical_plan::memory::MemoryExec;
     use datafusion::prelude::SessionContext;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Implement `InstantSelector` for PromQL. This plan can align input data based on `interval` and `lookback`, to simulate the behavior of `InstantSelector` in PromQL. This plan can then be used by instant operators in PromQL like those unary or binary operators.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
