### PR TITLE
feat: add catalog name resolution for postgres and http interface

### DIFF
--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -255,7 +255,10 @@ mod test {
         let bare = ObjectName(vec![my_table.into()]);
 
         let using_schema = "foo";
-        let query_ctx = Arc::new(QueryContext::with_current_schema(using_schema.to_string()));
+        let query_ctx = Arc::new(QueryContext::with(
+            DEFAULT_CATALOG_NAME.to_owned(),
+            using_schema.to_string(),
+        ));
         let empty_ctx = Arc::new(QueryContext::new());
 
         assert_eq!(

--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::Output;
 use common_recordbatch::util;
 use datatypes::data_type::ConcreteDataType;
@@ -559,6 +559,9 @@ async fn execute_sql(instance: &MockInstance, sql: &str) -> Output {
 }
 
 async fn execute_sql_in_db(instance: &MockInstance, sql: &str, db: &str) -> Output {
-    let query_ctx = Arc::new(QueryContext::with_current_schema(db.to_string()));
+    let query_ctx = Arc::new(QueryContext::with(
+        DEFAULT_CATALOG_NAME.to_owned(),
+        db.to_string(),
+    ));
     instance.inner().execute_sql(sql, query_ctx).await.unwrap()
 }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -404,9 +404,12 @@ impl Instance {
     }
 
     fn handle_use(&self, db: String, query_ctx: QueryContextRef) -> Result<Output> {
+        let catalog = query_ctx.current_catalog();
+        let catalog = catalog.as_deref().unwrap_or(DEFAULT_CATALOG_NAME);
+
         ensure!(
             self.catalog_manager
-                .schema(DEFAULT_CATALOG_NAME, &db)
+                .schema(catalog, &db)
                 .context(error::CatalogSnafu)?
                 .is_some(),
             error::SchemaNotFoundSnafu { schema_info: &db }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -204,6 +204,7 @@ impl DistInstance {
     /// Handles distributed database creation
     async fn handle_create_database(&self, expr: CreateDatabaseExpr) -> Result<()> {
         let key = SchemaKey {
+            // TODO(sunng87): custom catalog
             catalog_name: DEFAULT_CATALOG_NAME.to_string(),
             schema_name: expr.database_name,
         };

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -130,8 +130,11 @@ pub fn show_tables(
             .current_schema()
             .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string())
     };
+    // TODO(sunng87): move this function into query_ctx
+    let catalog = query_ctx.current_catalog();
+    let catalog = catalog.as_deref().unwrap_or(DEFAULT_CATALOG_NAME);
     let schema = catalog_manager
-        .schema(DEFAULT_CATALOG_NAME, &schema)
+        .schema(catalog, &schema)
         .context(error::CatalogSnafu)?
         .context(error::SchemaNotFoundSnafu { schema })?;
     let tables = schema.table_names().context(error::CatalogSnafu)?;

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -13,13 +13,11 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Instant;
 
 use aide::transform::TransformOperation;
 use axum::extract::{Json, Query, State};
 use axum::Extension;
-use common_catalog::consts::DEFAULT_CATALOG_NAME;
 use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
@@ -45,26 +43,12 @@ pub async fn sql(
     let sql_handler = &state.sql_handler;
     let start = Instant::now();
     let resp = if let Some(sql) = &params.sql {
-        let query_ctx = Arc::new(QueryContext::new());
-        if let Some(db) = &params.database {
-            match sql_handler.is_valid_schema(DEFAULT_CATALOG_NAME, db) {
-                Ok(true) => query_ctx.set_current_schema(db),
-                Ok(false) => {
-                    return Json(JsonResponse::with_error(
-                        format!("Database not found: {db}"),
-                        StatusCode::DatabaseNotFound,
-                    ));
-                }
-                Err(e) => {
-                    return Json(JsonResponse::with_error(
-                        format!("Error checking database: {db}, {e}"),
-                        StatusCode::Internal,
-                    ));
-                }
+        match super::query_context_from_db(sql_handler.clone(), params.database) {
+            Ok(query_ctx) => {
+                JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
             }
+            Err(resp) => resp,
         }
-
-        JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -22,7 +22,7 @@ use common_error::status_code::StatusCode;
 use common_telemetry::metric;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use session::context::{QueryContext, UserInfo};
+use session::context::UserInfo;
 
 use crate::http::{ApiState, JsonResponse};
 

--- a/src/servers/src/http/script.rs
+++ b/src/servers/src/http/script.rs
@@ -90,6 +90,8 @@ pub async fn run_script(
             json_err!("invalid name");
         }
 
+        // TODO(sunng87): query_context and db name resolution
+
         let output = script_handler.execute_script(name.unwrap()).await;
         let resp = JsonResponse::from_output(vec![output]).await;
 

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -39,3 +39,50 @@ pub enum Mode {
     Standalone,
     Distributed,
 }
+
+/// Attempt to parse catalog and schema from given database name
+///
+/// The database name may come from different sources:
+///
+/// - MySQL `schema` name in MySQL protocol login request: it's optional and user
+/// and switch database using `USE` command
+/// - Postgres `database` parameter in Postgres wire protocol, required
+/// - HTTP RESTful API: the database parameter, optional
+///
+/// When database name is provided, we attempt to parse catalog and schema from
+/// it. We assume the format `[<catalog>-]<schema>`:
+///
+/// - If `[<catalog>-]` part is not provided, we use whole database name as
+/// schema name
+/// - if `[<catalog>-]` is provided, we split database name with `-` and use
+/// `<catalog>` and `<schema>`.
+pub(crate) fn parse_catalog_and_schema_from_client_database_name(db: &str) -> (Option<&str>, &str) {
+    let parts = db.splitn(2, '-').collect::<Vec<&str>>();
+    if parts.len() == 2 {
+        (Some(parts[0]), parts[1])
+    } else {
+        (None, db)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_parse_catalog_and_schema_from_client_database_name() {
+        assert_eq!(
+            (None, "fullschema"),
+            super::parse_catalog_and_schema_from_client_database_name("fullschema")
+        );
+
+        assert_eq!(
+            (Some("catalog"), "schema"),
+            super::parse_catalog_and_schema_from_client_database_name("catalog-schema")
+        );
+
+        assert_eq!(
+            (Some("catalog"), "schema1-schema2"),
+            super::parse_catalog_and_schema_from_client_database_name("catalog-schema1-schema2")
+        );
+    }
+}

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -18,5 +18,9 @@ mod server;
 
 pub(crate) const METADATA_USER: &str = "user";
 pub(crate) const METADATA_DATABASE: &str = "database";
+/// key to store our parsed catalog
+pub(crate) const METADATA_CATALOG: &str = "catalog";
+/// key to store our parsed schema
+pub(crate) const METADATA_SCHEMA: &str = "schema";
 
 pub use server::PostgresServer;

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -47,7 +47,10 @@ where
     C: ClientInfo,
 {
     let query_context = QueryContext::new();
-    if let Some(current_schema) = client.metadata().get(super::METADATA_DATABASE) {
+    if let Some(current_catalog) = client.metadata().get(super::METADATA_CATALOG) {
+        query_context.set_current_catalog(current_catalog);
+    }
+    if let Some(current_schema) = client.metadata().get(super::METADATA_SCHEMA) {
         query_context.set_current_schema(current_schema);
     }
 

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -23,6 +23,7 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 
 pub struct QueryContext {
     current_schema: ArcSwapOption<String>,
+    current_catalog: ArcSwapOption<String>,
 }
 
 impl Default for QueryContext {
@@ -39,12 +40,14 @@ impl QueryContext {
     pub fn new() -> Self {
         Self {
             current_schema: ArcSwapOption::new(None),
+            current_catalog: ArcSwapOption::new(None),
         }
     }
 
-    pub fn with_current_schema(schema: String) -> Self {
+    pub fn with(catalog: String, schema: String) -> Self {
         Self {
             current_schema: ArcSwapOption::new(Some(Arc::new(schema))),
+            current_catalog: ArcSwapOption::new(Some(Arc::new(catalog))),
         }
     }
 
@@ -52,11 +55,25 @@ impl QueryContext {
         self.current_schema.load().as_deref().cloned()
     }
 
+    pub fn current_catalog(&self) -> Option<String> {
+        self.current_catalog.load().as_deref().cloned()
+    }
+
     pub fn set_current_schema(&self, schema: &str) {
         let last = self.current_schema.swap(Some(Arc::new(schema.to_string())));
         info!(
             "set new session default schema: {:?}, swap old: {:?}",
             schema, last
+        )
+    }
+
+    pub fn set_current_catalog(&self, catalog: &str) {
+        let last = self
+            .current_catalog
+            .swap(Some(Arc::new(catalog.to_string())));
+        info!(
+            "set new session default catalog: {:?}, swap old: {:?}",
+            catalog, last
         )
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -22,8 +22,8 @@ pub type QueryContextRef = Arc<QueryContext>;
 pub type ConnInfoRef = Arc<ConnInfo>;
 
 pub struct QueryContext {
-    current_schema: ArcSwapOption<String>,
     current_catalog: ArcSwapOption<String>,
+    current_schema: ArcSwapOption<String>,
 }
 
 impl Default for QueryContext {
@@ -39,15 +39,15 @@ impl QueryContext {
 
     pub fn new() -> Self {
         Self {
-            current_schema: ArcSwapOption::new(None),
             current_catalog: ArcSwapOption::new(None),
+            current_schema: ArcSwapOption::new(None),
         }
     }
 
     pub fn with(catalog: String, schema: String) -> Self {
         Self {
-            current_schema: ArcSwapOption::new(Some(Arc::new(schema))),
             current_catalog: ArcSwapOption::new(Some(Arc::new(catalog))),
+            current_schema: ArcSwapOption::new(Some(Arc::new(schema))),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch resolves catalog from dbname, for postgres and http rest api, as described in #798, 

To be implemented in next patches:

- Mysql support is to be implemented in next patch because it has slightly difference with how postgres uses database context.
- influxdb
- opentsdb
- gRPC

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
