### PR TITLE
refactor: remove macro `define_opaque_error` 

### DIFF
--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -33,72 +33,60 @@ pub trait ErrorExt: std::error::Error {
     fn as_any(&self) -> &dyn Any;
 }
 
-/// A helper macro to define a opaque boxed error based on errors that implement [ErrorExt] trait.
-#[macro_export]
-macro_rules! define_opaque_error {
-    ($Error:ident) => {
-        /// An error behaves like `Box<dyn Error>`.
-        ///
-        /// Define this error as a new type instead of using `Box<dyn Error>` directly so we can implement
-        /// more methods or traits for it.
-        pub struct $Error {
-            inner: Box<dyn $crate::ext::ErrorExt + Send + Sync>,
-        }
-
-        impl $Error {
-            pub fn new<E: $crate::ext::ErrorExt + Send + Sync + 'static>(err: E) -> Self {
-                Self {
-                    inner: Box::new(err),
-                }
-            }
-        }
-
-        impl std::fmt::Debug for $Error {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                // Use the pretty debug format of inner error for opaque error.
-                let debug_format = $crate::format::DebugFormat::new(&*self.inner);
-                debug_format.fmt(f)
-            }
-        }
-
-        impl std::fmt::Display for $Error {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "{}", self.inner)
-            }
-        }
-
-        impl std::error::Error for $Error {
-            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-                self.inner.source()
-            }
-        }
-
-        impl $crate::ext::ErrorExt for $Error {
-            fn status_code(&self) -> $crate::status_code::StatusCode {
-                self.inner.status_code()
-            }
-
-            fn backtrace_opt(&self) -> Option<&$crate::snafu::Backtrace> {
-                self.inner.backtrace_opt()
-            }
-
-            fn as_any(&self) -> &dyn std::any::Any {
-                self.inner.as_any()
-            }
-        }
-
-        // Implement ErrorCompat for this opaque error so the backtrace is also available
-        // via `ErrorCompat::backtrace()`.
-        impl $crate::snafu::ErrorCompat for $Error {
-            fn backtrace(&self) -> Option<&$crate::snafu::Backtrace> {
-                self.inner.backtrace_opt()
-            }
-        }
-    };
+/// An opaque boxed error based on errors that implement [ErrorExt] trait.
+pub struct BoxedError {
+    inner: Box<dyn crate::ext::ErrorExt + Send + Sync>,
 }
 
-// Define a general boxed error.
-define_opaque_error!(BoxedError);
+impl BoxedError {
+    pub fn new<E: crate::ext::ErrorExt + Send + Sync + 'static>(err: E) -> Self {
+        Self {
+            inner: Box::new(err),
+        }
+    }
+}
+
+impl std::fmt::Debug for BoxedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Use the pretty debug format of inner error for opaque error.
+        let debug_format = crate::format::DebugFormat::new(&*self.inner);
+        debug_format.fmt(f)
+    }
+}
+
+impl std::fmt::Display for BoxedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::error::Error for BoxedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl crate::ext::ErrorExt for BoxedError {
+    fn status_code(&self) -> crate::status_code::StatusCode {
+        self.inner.status_code()
+    }
+
+    fn backtrace_opt(&self) -> Option<&crate::snafu::Backtrace> {
+        self.inner.backtrace_opt()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self.inner.as_any()
+    }
+}
+
+// Implement ErrorCompat for this opaque error so the backtrace is also available
+// via `ErrorCompat::backtrace()`.
+impl crate::snafu::ErrorCompat for BoxedError {
+    fn backtrace(&self) -> Option<&crate::snafu::Backtrace> {
+        self.inner.backtrace_opt()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -408,13 +408,16 @@ mod tests {
 
     use common_error::ext::BoxedError;
     use common_error::mock::MockError;
+    use snafu::IntoError;
 
     use super::*;
 
     fn throw_query_error() -> std::result::Result<(), query::error::Error> {
-        Err(query::error::Error::new(MockError::with_backtrace(
-            StatusCode::Internal,
-        )))
+        Err(
+            query::error::QueryExecutionSnafu.into_error(BoxedError::new(
+                MockError::with_backtrace(StatusCode::Internal),
+            )),
+        )
     }
 
     fn throw_catalog_error() -> catalog::error::Result<()> {

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -31,7 +31,7 @@ use table::engine::{EngineContext, TableEngine, TableReference};
 use table::metadata::{TableId, TableInfoBuilder, TableMetaBuilder, TableType, TableVersion};
 use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
 use table::table::TableRef;
-use table::{Result as TableResult, Table};
+use table::{error as table_error, Result as TableResult, Table};
 use tokio::sync::Mutex;
 
 use crate::config::EngineConfig;
@@ -90,7 +90,11 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
         ctx: &EngineContext,
         request: CreateTableRequest,
     ) -> TableResult<TableRef> {
-        Ok(self.inner.create_table(ctx, request).await?)
+        self.inner
+            .create_table(ctx, request)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)
     }
 
     async fn open_table(
@@ -98,7 +102,11 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
         ctx: &EngineContext,
         request: OpenTableRequest,
     ) -> TableResult<Option<TableRef>> {
-        Ok(self.inner.open_table(ctx, request).await?)
+        self.inner
+            .open_table(ctx, request)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)
     }
 
     async fn alter_table(
@@ -106,7 +114,11 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
         ctx: &EngineContext,
         req: AlterTableRequest,
     ) -> TableResult<TableRef> {
-        Ok(self.inner.alter_table(ctx, req).await?)
+        self.inner
+            .alter_table(ctx, req)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)
     }
 
     fn get_table(
@@ -126,7 +138,11 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
         _ctx: &EngineContext,
         request: DropTableRequest,
     ) -> TableResult<bool> {
-        Ok(self.inner.drop_table(request).await?)
+        self.inner
+            .drop_table(request)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)
     }
 }
 
@@ -437,14 +453,19 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                 .open_region(&engine_ctx, &region_name, &opts)
                 .await
                 .map_err(BoxedError::new)
-                .context(error::OpenRegionSnafu { region_name })?
+                .context(error::OpenRegionSnafu { region_name })
+                .map_err(BoxedError::new)
+                .context(table_error::TableOperationSnafu)?
             {
                 None => return Ok(None),
                 Some(region) => region,
             };
 
             let table = Arc::new(
-                MitoTable::open(table_name, &table_dir, region, self.object_store.clone()).await?,
+                MitoTable::open(table_name, &table_dir, region, self.object_store.clone())
+                    .await
+                    .map_err(BoxedError::new)
+                    .context(table_error::TableOperationSnafu)?,
             );
 
             self.tables

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -453,8 +453,6 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                 .open_region(&engine_ctx, &region_name, &opts)
                 .await
                 .map_err(BoxedError::new)
-                .context(error::OpenRegionSnafu { region_name })
-                .map_err(BoxedError::new)
                 .context(table_error::TableOperationSnafu)?
             {
                 None => return Ok(None),

--- a/src/mito/src/error.rs
+++ b/src/mito/src/error.rs
@@ -179,12 +179,6 @@ pub enum Error {
     },
 }
 
-impl From<Error> for table::error::Error {
-    fn from(e: Error) -> Self {
-        table::error::Error::new(e)
-    }
-}
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl ErrorExt for Error {
@@ -242,13 +236,5 @@ mod tests {
             .unwrap();
         assert_eq!(StatusCode::InvalidArguments, err.status_code());
         assert!(err.backtrace_opt().is_some());
-    }
-
-    #[test]
-    pub fn test_opaque_error() {
-        let error = throw_create_table(StatusCode::InvalidSyntax).err().unwrap();
-        let table_engine_error: table::error::Error = error.into();
-        assert!(table_engine_error.backtrace_opt().is_some());
-        assert_eq!(StatusCode::InvalidSyntax, table_engine_error.status_code());
     }
 }

--- a/src/mito/src/error.rs
+++ b/src/mito/src/error.rs
@@ -27,13 +27,6 @@ pub enum Error {
         source: BoxedError,
     },
 
-    #[snafu(display("Failed to open region, region: {}, source: {}", region_name, source))]
-    OpenRegion {
-        region_name: String,
-        #[snafu(backtrace)]
-        source: BoxedError,
-    },
-
     #[snafu(display(
         "Failed to build table meta for table: {}, source: {}",
         table_name,
@@ -186,7 +179,7 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            CreateRegion { source, .. } | OpenRegion { source, .. } => source.status_code(),
+            CreateRegion { source, .. } => source.status_code(),
 
             AlterTable { source, .. } => source.status_code(),
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -36,7 +36,8 @@ use store_api::storage::{
     AddColumn, AlterOperation, AlterRequest, ChunkReader, ReadContext, Region, RegionMeta,
     ScanRequest, SchemaRef, Snapshot, WriteContext, WriteRequest,
 };
-use table::error::{Error as TableError, Result as TableResult};
+use table::error as table_error;
+use table::error::Result as TableResult;
 use table::metadata::{
     FilterPushDownType, RawTableInfo, TableInfo, TableInfoRef, TableMeta, TableType,
 };
@@ -94,13 +95,17 @@ impl<R: Region> Table for MitoTable<R> {
             columns_values
         );
 
-        write_request.put(columns_values).map_err(TableError::new)?;
+        write_request
+            .put(columns_values)
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
         let _resp = self
             .region
             .write(&WriteContext::default(), write_request)
             .await
-            .map_err(TableError::new)?;
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
         Ok(rows_num)
     }
@@ -120,9 +125,16 @@ impl<R: Region> Table for MitoTable<R> {
         _limit: Option<usize>,
     ) -> TableResult<PhysicalPlanRef> {
         let read_ctx = ReadContext::default();
-        let snapshot = self.region.snapshot(&read_ctx).map_err(TableError::new)?;
+        let snapshot = self
+            .region
+            .snapshot(&read_ctx)
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
-        let projection = self.transform_projection(&self.region, projection.cloned())?;
+        let projection = self
+            .transform_projection(&self.region, projection.cloned())
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
         let filters = filters.into();
         let scan_request = ScanRequest {
             projection,
@@ -132,7 +144,8 @@ impl<R: Region> Table for MitoTable<R> {
         let mut reader = snapshot
             .scan(&read_ctx, scan_request)
             .await
-            .map_err(TableError::new)?
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?
             .reader;
 
         let schema = reader.schema().clone();
@@ -158,7 +171,9 @@ impl<R: Region> Table for MitoTable<R> {
         let mut new_meta = table_meta
             .builder_with_alter_kind(table_name, &req.alter_kind)?
             .build()
-            .context(error::BuildTableMetaSnafu { table_name })?;
+            .context(error::BuildTableMetaSnafu { table_name })
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
         let alter_op = create_alter_operation(table_name, &req.alter_kind, &mut new_meta)?;
 
@@ -182,7 +197,9 @@ impl<R: Region> Table for MitoTable<R> {
             .await
             .context(UpdateTableManifestSnafu {
                 table_name: &self.table_info().name,
-            })?;
+            })
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
         // TODO(yingwen): Error handling. Maybe the region need to provide a method to
         // validate the request first.
@@ -199,7 +216,11 @@ impl<R: Region> Table for MitoTable<R> {
             table_name,
             alter_req,
         );
-        region.alter(alter_req).await.map_err(TableError::new)?;
+        region
+            .alter(alter_req)
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
 
         // Update in memory metadata of the table.
         self.set_table_info(new_info);

--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -16,18 +16,16 @@ use std::any::Any;
 
 use common_error::prelude::*;
 
-common_error::define_opaque_error!(Error);
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-pub enum InnerError {
+pub enum Error {
     #[snafu(display("Unsupported expr type: {}", name))]
     UnsupportedExpr { name: String, backtrace: Backtrace },
 }
 
-impl ErrorExt for InnerError {
+impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
-        use InnerError::*;
+        use Error::*;
         match self {
             UnsupportedExpr { .. } => StatusCode::InvalidArguments,
         }
@@ -38,12 +36,6 @@ impl ErrorExt for InnerError {
 
     fn as_any(&self) -> &dyn Any {
         self
-    }
-}
-
-impl From<InnerError> for Error {
-    fn from(e: InnerError) -> Error {
-        Error::new(e)
     }
 }
 

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_error::prelude::BoxedError;
 use common_query::logical_plan::create_aggregate_function;
 use datafusion::catalog::TableReference;
 use datafusion::error::Result as DfResult;
@@ -30,7 +31,7 @@ use sql::statements::query::Query;
 use sql::statements::statement::Statement;
 
 use crate::datafusion::error;
-use crate::error::Result;
+use crate::error::{QueryPlanSnafu, Result};
 use crate::plan::LogicalPlan;
 use crate::planner::Planner;
 use crate::query_engine::QueryEngineState;
@@ -53,7 +54,9 @@ impl<'a, S: ContextProvider + Send + Sync> DfPlanner<'a, S> {
         let result = self
             .sql_to_rel
             .query_to_plan(query.inner, &mut PlannerContext::default())
-            .context(error::PlanSqlSnafu { sql })?;
+            .context(error::PlanSqlSnafu { sql })
+            .map_err(BoxedError::new)
+            .context(QueryPlanSnafu)?;
 
         Ok(LogicalPlan::DfPlan(result))
     }
@@ -65,7 +68,9 @@ impl<'a, S: ContextProvider + Send + Sync> DfPlanner<'a, S> {
             .sql_statement_to_plan(explain.inner.clone())
             .context(error::PlanSqlSnafu {
                 sql: explain.to_string(),
-            })?;
+            })
+            .map_err(BoxedError::new)
+            .context(QueryPlanSnafu)?;
 
         Ok(LogicalPlan::DfPlan(result))
     }

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -18,11 +18,11 @@ use common_error::prelude::*;
 use datafusion::error::DataFusionError;
 use snafu::{Backtrace, ErrorCompat, Snafu};
 
-common_error::define_opaque_error!(Error);
+// common_error::define_opaque_error!(Error);
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-pub enum InnerError {
+pub enum Error {
     #[snafu(display("Unsupported expr type: {}", name))]
     UnsupportedExpr { name: String, backtrace: Backtrace },
 
@@ -58,11 +58,17 @@ pub enum InnerError {
         #[snafu(backtrace)]
         source: common_recordbatch::error::Error,
     },
+
+    #[snafu(display("Failure during query execution, source: {}", source))]
+    QueryExecution { source: BoxedError },
+
+    #[snafu(display("Failure during query planning, source: {}", source))]
+    QueryPlan { source: BoxedError },
 }
 
-impl ErrorExt for InnerError {
+impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
-        use InnerError::*;
+        use Error::*;
 
         match self {
             UnsupportedExpr { .. }
@@ -72,6 +78,7 @@ impl ErrorExt for InnerError {
             Catalog { source } => source.status_code(),
             VectorComputation { source } => source.status_code(),
             CreateRecordBatch { source } => source.status_code(),
+            QueryExecution { source } | QueryPlan { source } => source.status_code(),
         }
     }
 
@@ -84,22 +91,10 @@ impl ErrorExt for InnerError {
     }
 }
 
-impl From<InnerError> for Error {
-    fn from(e: InnerError) -> Error {
-        Error::new(e)
-    }
-}
-
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl From<Error> for DataFusionError {
     fn from(e: Error) -> DataFusionError {
         DataFusionError::External(Box::new(e))
-    }
-}
-
-impl From<catalog::error::Error> for Error {
-    fn from(e: catalog::error::Error) -> Self {
-        Error::new(e)
     }
 }

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -18,8 +18,6 @@ use common_error::prelude::*;
 use datafusion::error::DataFusionError;
 use snafu::{Backtrace, ErrorCompat, Snafu};
 
-// common_error::define_opaque_error!(Error);
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -292,9 +292,9 @@ mod test {
         let stmt = DescribeTable::new("unknown".to_string(), schema_name, table_name.to_string());
 
         let err = describe_table(stmt, catalog_manager).err().unwrap();
-        let err = err.as_any().downcast_ref::<error::InnerError>().unwrap();
+        let err = err.as_any().downcast_ref::<error::Error>().unwrap();
 
-        if let error::InnerError::CatalogNotFound { catalog, .. } = err {
+        if let error::Error::CatalogNotFound { catalog, .. } = err {
             assert_eq!(catalog, "unknown");
         } else {
             panic!("describe table returned incorrect error");
@@ -320,9 +320,9 @@ mod test {
         let stmt = DescribeTable::new(catalog_name, "unknown".to_string(), table_name.to_string());
 
         let err = describe_table(stmt, catalog_manager).err().unwrap();
-        let err = err.as_any().downcast_ref::<error::InnerError>().unwrap();
+        let err = err.as_any().downcast_ref::<error::Error>().unwrap();
 
-        if let error::InnerError::SchemaNotFound { schema, .. } = err {
+        if let error::Error::SchemaNotFound { schema, .. } = err {
             assert_eq!(schema, "unknown");
         } else {
             panic!("describe table returned incorrect error");
@@ -348,9 +348,9 @@ mod test {
         let stmt = DescribeTable::new(catalog_name, schema_name, "unknown".to_string());
 
         let err = describe_table(stmt, catalog_manager).err().unwrap();
-        let err = err.as_any().downcast_ref::<error::InnerError>().unwrap();
+        let err = err.as_any().downcast_ref::<error::Error>().unwrap();
 
-        if let error::InnerError::TableNotFound { table, .. } = err {
+        if let error::Error::TableNotFound { table, .. } = err {
             assert_eq!(table, "unknown");
         } else {
             panic!("describe table returned incorrect error");

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -227,21 +227,21 @@ pub fn get_error_reason_loc(err: &Error) -> (String, Option<Location>) {
 
 #[cfg(test)]
 mod tests {
-    use common_error::mock::MockError;
-    use common_error::prelude::BoxedError;
-    use snafu::{IntoError, ResultExt};
+    use snafu::ResultExt;
 
     use super::*;
 
     fn throw_query_error() -> query::error::Result<()> {
-        let mock_err = MockError::with_backtrace(StatusCode::TableColumnNotFound);
-        Err(query::error::QueryExecutionSnafu.into_error(BoxedError::new(mock_err)))
+        query::error::TableNotFoundSnafu {
+            table: String::new(),
+        }
+        .fail()
     }
 
     #[test]
     fn test_error() {
         let err = throw_query_error().context(DatabaseQuerySnafu).unwrap_err();
-        assert_eq!(StatusCode::TableColumnNotFound, err.status_code());
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
         assert!(err.backtrace_opt().is_some());
     }
 }

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -228,13 +228,14 @@ pub fn get_error_reason_loc(err: &Error) -> (String, Option<Location>) {
 #[cfg(test)]
 mod tests {
     use common_error::mock::MockError;
-    use snafu::ResultExt;
+    use common_error::prelude::BoxedError;
+    use snafu::{IntoError, ResultExt};
 
     use super::*;
 
     fn throw_query_error() -> query::error::Result<()> {
         let mock_err = MockError::with_backtrace(StatusCode::TableColumnNotFound);
-        Err(query::error::Error::new(mock_err))
+        Err(query::error::QueryExecutionSnafu.into_error(BoxedError::new(mock_err)))
     }
 
     #[test]

--- a/src/table/src/error.rs
+++ b/src/table/src/error.rs
@@ -19,20 +19,12 @@ use common_recordbatch::error::Error as RecordBatchError;
 use datafusion::error::DataFusionError;
 use datatypes::arrow::error::ArrowError;
 
-common_error::define_opaque_error!(Error);
-
 pub type Result<T> = std::result::Result<T, Error>;
-
-impl From<Error> for DataFusionError {
-    fn from(e: Error) -> Self {
-        Self::External(Box::new(e))
-    }
-}
 
 /// Default error implementation of table.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
-pub enum InnerError {
+pub enum Error {
     #[snafu(display("Datafusion error: {}", source))]
     Datafusion {
         source: DataFusionError,
@@ -107,22 +99,26 @@ pub enum InnerError {
         column_name: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Failed to operate table, source: {}", source))]
+    TableOperation { source: BoxedError },
 }
 
-impl ErrorExt for InnerError {
+impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            InnerError::Datafusion { .. }
-            | InnerError::PollStream { .. }
-            | InnerError::SchemaConversion { .. }
-            | InnerError::TableProjection { .. } => StatusCode::EngineExecuteQuery,
-            InnerError::RemoveColumnInIndex { .. } | InnerError::BuildColumnDescriptor { .. } => {
+            Error::Datafusion { .. }
+            | Error::PollStream { .. }
+            | Error::SchemaConversion { .. }
+            | Error::TableProjection { .. } => StatusCode::EngineExecuteQuery,
+            Error::RemoveColumnInIndex { .. } | Error::BuildColumnDescriptor { .. } => {
                 StatusCode::InvalidArguments
             }
-            InnerError::TablesRecordBatch { .. } => StatusCode::Unexpected,
-            InnerError::ColumnExists { .. } => StatusCode::TableColumnExists,
-            InnerError::SchemaBuild { source, .. } => source.status_code(),
-            InnerError::ColumnNotExists { .. } => StatusCode::TableColumnNotFound,
+            Error::TablesRecordBatch { .. } => StatusCode::Unexpected,
+            Error::ColumnExists { .. } => StatusCode::TableColumnExists,
+            Error::SchemaBuild { source, .. } => source.status_code(),
+            Error::TableOperation { source } => source.status_code(),
+            Error::ColumnNotExists { .. } => StatusCode::TableColumnNotFound,
         }
     }
 
@@ -135,20 +131,14 @@ impl ErrorExt for InnerError {
     }
 }
 
-impl From<InnerError> for Error {
-    fn from(err: InnerError) -> Self {
-        Self::new(err)
-    }
-}
-
-impl From<InnerError> for DataFusionError {
-    fn from(e: InnerError) -> DataFusionError {
+impl From<Error> for DataFusionError {
+    fn from(e: Error) -> DataFusionError {
         DataFusionError::External(Box::new(e))
     }
 }
 
-impl From<InnerError> for RecordBatchError {
-    fn from(e: InnerError) -> RecordBatchError {
+impl From<Error> for RecordBatchError {
+    fn from(e: Error) -> RecordBatchError {
         RecordBatchError::External {
             source: BoxedError::new(e),
         }
@@ -163,7 +153,7 @@ mod tests {
         Err(DataFusionError::NotImplemented("table test".to_string())).context(DatafusionSnafu)?
     }
 
-    fn throw_column_exists_inner() -> std::result::Result<(), InnerError> {
+    fn throw_column_exists_inner() -> std::result::Result<(), Error> {
         ColumnExistsSnafu {
             column_name: "col",
             table_name: "test",
@@ -172,7 +162,7 @@ mod tests {
     }
 
     fn throw_missing_column() -> Result<()> {
-        Ok(throw_column_exists_inner()?)
+        throw_column_exists_inner()
     }
 
     fn throw_arrow() -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`define_opaque_error` provides a convenient way to define opaque error type. It's useful for util shim type like `BoxedError`, but it also gets confused when applied to normal errors. It creates a way to bypass pre-defined error enumerations, and place an arbitrary source error into one type.

This might be useful when trying to expose an error type in the trait method, but it can also be done by defining a generic error type that accepts `BoxedError`, like `QueryExecution`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
