### PR TITLE
refactor: do not call use upon mysql connection

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -249,6 +249,9 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_grpc::error::Error,
     },
+
+    #[snafu(display("Cannot find requested database: {}-{}", catalog, schema))]
+    DatabaseNotFound { catalog: String, schema: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -306,6 +309,8 @@ impl ErrorExt for Error {
             | InvalidAuthorizationHeader { .. }
             | InvalidBase64Value { .. }
             | InvalidUtf8Value { .. } => StatusCode::InvalidAuthHeader,
+
+            DatabaseNotFound { .. } => StatusCode::DatabaseNotFound,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch removes auto use upon mysql connection, to make it more flexible to initial session context.  

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
