### PR TITLE
feat: datanode support report the number of regions to meta

### DIFF
--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -19,7 +19,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use common_telemetry::info;
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use table::engine::{EngineContext, TableEngineRef};
 use table::metadata::TableId;
 use table::requests::CreateTableRequest;
@@ -207,4 +207,38 @@ pub(crate) async fn handle_system_table_request<'a, M: CatalogManager>(
         }
     }
     Ok(())
+}
+
+/// The number of regions in the datanode node.
+pub fn region_number(catalog_manager: CatalogManagerRef) -> Result<u64> {
+    let mut region_number: u64 = 0;
+
+    for catalog_name in catalog_manager.catalog_names()? {
+        let catalog =
+            catalog_manager
+                .catalog(&catalog_name)?
+                .context(error::CatalogNotFoundSnafu {
+                    catalog_name: &catalog_name,
+                })?;
+
+        for schema_name in catalog.schema_names()? {
+            let schema = catalog
+                .schema(&schema_name)?
+                .context(error::SchemaNotFoundSnafu {
+                    schema_info: &schema_name,
+                })?;
+
+            for table_name in schema.table_names()? {
+                let table = schema
+                    .table(&table_name)?
+                    .context(error::TableNotFoundSnafu {
+                        table_info: &table_name,
+                    })?;
+
+                let region_numbers = &table.table_info().meta.region_numbers;
+                region_number += region_numbers.len() as u64;
+            }
+        }
+    }
+    Ok(region_number)
 }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -148,6 +148,7 @@ impl Instance {
                 opts.node_id.context(MissingNodeIdSnafu)?,
                 opts.rpc_addr.clone(),
                 meta_client.as_ref().unwrap().clone(),
+                catalog_manager.clone(),
             )),
         };
         Ok(Self {

--- a/src/datanode/src/mock.rs
+++ b/src/datanode/src/mock.rs
@@ -71,6 +71,7 @@ impl Instance {
             opts.node_id.unwrap_or(42),
             opts.rpc_addr.clone(),
             meta_client.clone(),
+            catalog_manager.clone(),
         );
         Ok(Self {
             query_engine: query_engine.clone(),

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -15,6 +15,7 @@
 pub(crate) mod check_leader;
 pub(crate) mod datanode_lease;
 pub(crate) mod response_header;
+pub(crate) mod status;
 
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/src/meta-srv/src/handler/status.rs
+++ b/src/meta-srv/src/handler/status.rs
@@ -1,10 +1,10 @@
-// Copyright 2022 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/meta-srv/src/handler/status.rs
+++ b/src/meta-srv/src/handler/status.rs
@@ -1,0 +1,130 @@
+// Copyright 2022 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::meta::{HeartbeatRequest, PutRequest};
+
+use super::{HeartbeatAccumulator, HeartbeatHandler};
+use crate::error::Result;
+use crate::keys::{StatusKey, StatusValue};
+use crate::metasrv::Context;
+
+pub struct StatusHandler;
+
+#[async_trait::async_trait]
+impl HeartbeatHandler for StatusHandler {
+    async fn handle(
+        &self,
+        req: &HeartbeatRequest,
+        ctx: &Context,
+        _acc: &mut HeartbeatAccumulator,
+    ) -> Result<()> {
+        if ctx.is_skip_all() {
+            return Ok(());
+        }
+
+        let HeartbeatRequest {
+            header,
+            peer,
+            node_stat,
+            ..
+        } = req;
+
+        let peer = if let Some(peer) = peer {
+            peer
+        } else {
+            return Ok(());
+        };
+
+        let node_stat = if let Some(node_stat) = node_stat {
+            node_stat
+        } else {
+            return Ok(());
+        };
+
+        let key = StatusKey {
+            cluster_id: header.as_ref().map_or(0, |h| h.cluster_id),
+            node_id: peer.id,
+        }
+        .into();
+
+        let value = StatusValue {
+            region_number: node_stat.region_num,
+        }
+        .try_into()?;
+
+        let put = PutRequest {
+            key,
+            value,
+            ..Default::default()
+        };
+
+        ctx.kv_store.put(put).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    use api::v1::meta::{NodeStat, Peer, RangeRequest, RequestHeader};
+
+    use super::*;
+    use crate::service::store::memory::MemStore;
+
+    #[tokio::test]
+    async fn test_handle_datanode_status() {
+        let kv_store = Arc::new(MemStore::new());
+        let ctx = Context {
+            datanode_lease_secs: 30,
+            server_addr: "127.0.0.1:0000".to_string(),
+            kv_store,
+            election: None,
+            skip_all: Arc::new(AtomicBool::new(false)),
+        };
+
+        let req = HeartbeatRequest {
+            header: Some(RequestHeader::new((1, 2))),
+            peer: Some(Peer {
+                id: 3,
+                addr: "127.0.0.1:1111".to_string(),
+            }),
+            node_stat: Some(NodeStat {
+                region_num: 3,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut acc = HeartbeatAccumulator::default();
+
+        let status_handler = StatusHandler;
+        status_handler.handle(&req, &ctx, &mut acc).await.unwrap();
+
+        let key = StatusKey {
+            cluster_id: 1,
+            node_id: 3,
+        };
+
+        let req = RangeRequest {
+            key: key.try_into().unwrap(),
+            ..Default::default()
+        };
+
+        let res = ctx.kv_store.range(req).await.unwrap();
+
+        assert_eq!(1, res.kvs.len());
+    }
+}

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -23,6 +23,7 @@ use crate::election::Election;
 use crate::handler::check_leader::CheckLeaderHandler;
 use crate::handler::datanode_lease::DatanodeLeaseHandler;
 use crate::handler::response_header::ResponseHeaderHandler;
+use crate::handler::status::StatusHandler;
 use crate::handler::HeartbeatHandlerGroup;
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::selector::Selector;
@@ -99,6 +100,7 @@ impl MetaSrv {
         handler_group.add_handler(ResponseHeaderHandler).await;
         handler_group.add_handler(CheckLeaderHandler).await;
         handler_group.add_handler(DatanodeLeaseHandler).await;
+        handler_group.add_handler(StatusHandler).await;
 
         Self {
             started,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Datanode support report the number of regions to metasrv.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
