### PR TITLE
feat: endpoint and region config for s3 storage

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -63,6 +63,7 @@ impl SubCommand {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct StandaloneOptions {
     pub http_options: Option<HttpOptions>,
     pub grpc_options: Option<GrpcOptions>,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -34,6 +34,8 @@ pub enum ObjectStoreConfig {
         root: String,
         access_key_id: String,
         secret_access_key: String,
+        endpoint: Option<String>,
+        region: Option<String>,
     },
 }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -46,6 +46,7 @@ impl Default for ObjectStoreConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct DatanodeOptions {
     pub node_id: Option<u64>,
     pub rpc_addr: String,

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -33,6 +33,7 @@ use crate::server::Services;
 use crate::Plugins;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct FrontendOptions {
     pub http_options: Option<HttpOptions>,
     pub grpc_options: Option<GrpcOptions>,

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -32,6 +32,7 @@ use crate::service::store::kv::KvStoreRef;
 pub const TABLE_ID_SEQ: &str = "table_id";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct MetaSrvOptions {
     pub bind_addr: String,
     pub server_addr: String,

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -99,6 +99,8 @@ fn get_test_store_config(
                 bucket,
                 access_key_id: key_id,
                 secret_access_key: secret_key,
+                endpoint: None,
+                region: None,
             };
 
             let store = ObjectStore::new(accessor);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:
* Adds `#[serde(default)]` attribute to all config options.
* Adds `region` and `endpoint` config for s3 storage.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
