### PR TITLE
feat: Impl Query and DDL functionality of Arrow Flight service for Frontend Instance

### DIFF
--- a/src/catalog/src/helper.rs
+++ b/src/catalog/src/helper.rs
@@ -132,7 +132,6 @@ impl TableGlobalKey {
 pub struct TableGlobalValue {
     /// Id of datanode that created the global table info kv. only for debugging.
     pub node_id: u64,
-    // TODO(LFC): Maybe remove it?
     /// Allocation of region ids across all datanodes.
     pub regions_id_map: HashMap<u64, Vec<u32>>,
     pub table_info: RawTableInfo,

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -23,9 +23,8 @@ use store_api::storage::RegionId;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Failed to connect Datanode at {}, source: {}", addr, source))]
-    ConnectDatanode {
-        addr: String,
+    #[snafu(display("Invalid ObjectResult, source: {}", source))]
+    InvalidObjectResult {
         #[snafu(backtrace)]
         source: client::Error,
     },
@@ -488,7 +487,7 @@ impl ErrorExt for Error {
             | Error::VectorComputation { source }
             | Error::ConvertArrowSchema { source } => source.status_code(),
 
-            Error::ConnectDatanode { source, .. } | Error::RequestDatanode { source } => {
+            Error::InvalidObjectResult { source, .. } | Error::RequestDatanode { source } => {
                 source.status_code()
             }
 

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -353,7 +353,7 @@ impl DistInstance {
     // GRPC InsertRequest to Table InsertRequest, than split Table InsertRequest, than assemble each GRPC InsertRequest, is rather inefficient,
     // should operate on GRPC InsertRequest directly.
     // Also remember to check the "region_number" carried in InsertRequest, too.
-    async fn handle_dist_insert(&self, request: InsertRequest) -> Result<usize> {
+    async fn handle_dist_insert(&self, request: InsertRequest) -> Result<Output> {
         let table_name = &request.table_name;
         // TODO(LFC): InsertRequest should carry catalog name, too.
         let table = self

--- a/src/frontend/src/instance/distributed/flight.rs
+++ b/src/frontend/src/instance/distributed/flight.rs
@@ -1,0 +1,143 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+
+use api::v1::ddl_request::Expr as DdlExpr;
+use api::v1::object_expr::Request as GrpcRequest;
+use api::v1::ObjectExpr;
+use arrow_flight::flight_service_server::FlightService;
+use arrow_flight::{
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
+};
+use async_trait::async_trait;
+use datanode::instance::flight::to_flight_data_stream;
+use futures::Stream;
+use prost::Message;
+use snafu::{OptionExt, ResultExt};
+use tonic::{Request, Response, Status, Streaming};
+
+use crate::error::{IncompleteGrpcResultSnafu, InvalidFlightTicketSnafu};
+use crate::instance::distributed::DistInstance;
+
+type TonicResult<T> = Result<T, Status>;
+type TonicStream<T> = Pin<Box<dyn Stream<Item = TonicResult<T>> + Send + Sync + 'static>>;
+
+#[async_trait]
+impl FlightService for DistInstance {
+    type HandshakeStream = TonicStream<HandshakeResponse>;
+
+    async fn handshake(
+        &self,
+        _: Request<Streaming<HandshakeRequest>>,
+    ) -> TonicResult<Response<Self::HandshakeStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type ListFlightsStream = TonicStream<FlightInfo>;
+
+    async fn list_flights(
+        &self,
+        _: Request<Criteria>,
+    ) -> TonicResult<Response<Self::ListFlightsStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    async fn get_flight_info(
+        &self,
+        _: Request<FlightDescriptor>,
+    ) -> TonicResult<Response<FlightInfo>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    async fn get_schema(
+        &self,
+        _: Request<FlightDescriptor>,
+    ) -> TonicResult<Response<SchemaResult>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoGetStream = TonicStream<FlightData>;
+
+    async fn do_get(&self, request: Request<Ticket>) -> TonicResult<Response<Self::DoGetStream>> {
+        let ticket = request.into_inner().ticket;
+        let request = ObjectExpr::decode(ticket.as_slice())
+            .context(InvalidFlightTicketSnafu)?
+            .request
+            .context(IncompleteGrpcResultSnafu {
+                err_msg: "Missing 'request' in ObjectExpr",
+            })?;
+        let output = match request {
+            GrpcRequest::Insert(request) => self.handle_dist_insert(request).await?,
+            GrpcRequest::Query(_) => {
+                unreachable!("Query should have been handled directly in Frontend Instance!")
+            }
+            GrpcRequest::Ddl(request) => {
+                let expr = request.expr.context(IncompleteGrpcResultSnafu {
+                    err_msg: "Missing 'expr' in DDL request",
+                })?;
+                match expr {
+                    DdlExpr::CreateDatabase(expr) => self.handle_create_database(expr).await?,
+                    DdlExpr::CreateTable(mut expr) => {
+                        // TODO(LFC): Support creating distributed table through GRPC interface.
+                        // Currently only SQL supports it; how to design the fields in CreateTableExpr?
+                        self.create_table(&mut expr, None).await?
+                    }
+                    DdlExpr::Alter(expr) => self.handle_alter_table(expr).await?,
+                    DdlExpr::DropTable(_) => {
+                        // TODO(LFC): Implement distributed drop table.
+                        // Seems the whole "drop table through GRPC interface" feature is not implemented?
+                        return Err(Status::unimplemented("Not yet implemented"));
+                    }
+                }
+            }
+        };
+        let stream = to_flight_data_stream(output);
+        Ok(Response::new(stream))
+    }
+
+    type DoPutStream = TonicStream<PutResult>;
+
+    async fn do_put(
+        &self,
+        _: Request<Streaming<FlightData>>,
+    ) -> TonicResult<Response<Self::DoPutStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoExchangeStream = TonicStream<FlightData>;
+
+    async fn do_exchange(
+        &self,
+        _: Request<Streaming<FlightData>>,
+    ) -> TonicResult<Response<Self::DoExchangeStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type DoActionStream = TonicStream<arrow_flight::Result>;
+
+    async fn do_action(&self, _: Request<Action>) -> TonicResult<Response<Self::DoActionStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+
+    type ListActionsStream = TonicStream<ActionType>;
+
+    async fn list_actions(
+        &self,
+        _: Request<Empty>,
+    ) -> TonicResult<Response<Self::ListActionsStream>> {
+        Err(Status::unimplemented("Not yet implemented"))
+    }
+}

--- a/src/frontend/src/instance/flight.rs
+++ b/src/frontend/src/instance/flight.rs
@@ -517,7 +517,7 @@ CREATE TABLE {table_name} (
         let table = table.as_any().downcast_ref::<DistTable>().unwrap();
 
         let TableGlobalValue { regions_id_map, .. } = table
-            .table_global_value(TableGlobalKey {
+            .table_global_value(&TableGlobalKey {
                 catalog_name: "greptime".to_string(),
                 schema_name: "public".to_string(),
                 table_name: table_name.to_string(),

--- a/src/frontend/src/instance/flight.rs
+++ b/src/frontend/src/instance/flight.rs
@@ -23,14 +23,19 @@ use arrow_flight::{
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
 use async_trait::async_trait;
+use client::RpcOutput;
 use datanode::instance::flight::to_flight_data_stream;
 use futures::Stream;
 use prost::Message;
+use servers::query_handler::GrpcQueryHandler;
 use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
 use tonic::{Request, Response, Status, Streaming};
 
-use crate::error::{IncompleteGrpcResultSnafu, InvalidFlightTicketSnafu, InvalidSqlSnafu};
+use crate::error::{
+    IncompleteGrpcResultSnafu, InvalidFlightTicketSnafu, InvalidObjectResultSnafu, InvalidSqlSnafu,
+    InvokeGrpcServerSnafu,
+};
 use crate::instance::{parse_stmt, Instance};
 
 type TonicResult<T> = Result<T, Status>;
@@ -104,9 +109,15 @@ impl FlightService for Instance {
                     }
                 }
             }
-            GrpcRequest::Ddl(_request) => {
-                // TODO(LFC): Implement it.
-                unimplemented!()
+            GrpcRequest::Ddl(request) => {
+                let query = ObjectExpr {
+                    request: Some(GrpcRequest::Ddl(request)),
+                };
+                let result = GrpcQueryHandler::do_query(&*self.grpc_query_handler, query)
+                    .await
+                    .context(InvokeGrpcServerSnafu)?;
+                let result: RpcOutput = result.try_into().context(InvalidObjectResultSnafu)?;
+                result.into()
             }
         };
         let stream = to_flight_data_stream(output);
@@ -149,43 +160,82 @@ impl FlightService for Instance {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use api::v1::column::{SemanticType, Values};
-    use api::v1::{Column, ColumnDataType, InsertRequest, QueryRequest};
+    use api::v1::ddl_request::Expr as DdlExpr;
+    use api::v1::{
+        alter_expr, AddColumn, AddColumns, AlterExpr, Column, ColumnDataType, ColumnDef,
+        CreateDatabaseExpr, CreateTableExpr, DdlRequest, InsertRequest, QueryRequest,
+    };
+    use catalog::helper::{TableGlobalKey, TableGlobalValue};
     use client::RpcOutput;
     use common_grpc::flight;
+    use common_query::Output;
+    use common_recordbatch::RecordBatches;
 
     use super::*;
+    use crate::table::DistTable;
     use crate::tests;
+    use crate::tests::MockDistributedInstance;
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_distributed_insert_and_query() {
-        common_telemetry::init_default_ut_logging();
-
+    async fn test_distributed_handle_ddl_request() {
         let instance =
-            tests::create_distributed_instance("test_distributed_insert_and_query").await;
+            tests::create_distributed_instance("test_distributed_handle_ddl_request").await;
+        let frontend = &instance.frontend;
 
-        test_insert_and_query(&instance.frontend).await
+        test_handle_ddl_request(frontend).await
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_standalone_insert_and_query() {
-        common_telemetry::init_default_ut_logging();
+    async fn test_standalone_handle_ddl_request() {
+        let standalone =
+            tests::create_standalone_instance("test_standalone_handle_ddl_request").await;
+        let instance = &standalone.instance;
 
-        let (instance, _) =
-            tests::create_standalone_instance("test_standalone_insert_and_query").await;
-
-        test_insert_and_query(&instance).await
+        test_handle_ddl_request(instance).await
     }
 
-    async fn test_insert_and_query(instance: &Arc<Instance>) {
+    async fn test_handle_ddl_request(instance: &Arc<Instance>) {
         let ticket = Request::new(Ticket {
             ticket: ObjectExpr {
-                request: Some(GrpcRequest::Query(QueryRequest {
-                    query: Some(Query::Sql(
-                        "CREATE TABLE my_table (a INT, ts TIMESTAMP, TIME INDEX (ts))".to_string(),
-                    )),
+                request: Some(GrpcRequest::Ddl(DdlRequest {
+                    expr: Some(DdlExpr::CreateDatabase(CreateDatabaseExpr {
+                        database_name: "database_created_through_grpc".to_string(),
+                    })),
+                })),
+            }
+            .encode_to_vec(),
+        });
+        let output = boarding(instance, ticket).await;
+        assert!(matches!(output, RpcOutput::AffectedRows(1)));
+
+        let ticket = Request::new(Ticket {
+            ticket: ObjectExpr {
+                request: Some(GrpcRequest::Ddl(DdlRequest {
+                    expr: Some(DdlExpr::CreateTable(CreateTableExpr {
+                        catalog_name: "greptime".to_string(),
+                        schema_name: "database_created_through_grpc".to_string(),
+                        table_name: "table_created_through_grpc".to_string(),
+                        column_defs: vec![
+                            ColumnDef {
+                                name: "a".to_string(),
+                                datatype: ColumnDataType::String as _,
+                                is_nullable: true,
+                                default_constraint: vec![],
+                            },
+                            ColumnDef {
+                                name: "ts".to_string(),
+                                datatype: ColumnDataType::TimestampMillisecond as _,
+                                is_nullable: false,
+                                default_constraint: vec![],
+                            },
+                        ],
+                        time_index: "ts".to_string(),
+                        ..Default::default()
+                    })),
                 })),
             }
             .encode_to_vec(),
@@ -193,24 +243,216 @@ mod test {
         let output = boarding(instance, ticket).await;
         assert!(matches!(output, RpcOutput::AffectedRows(0)));
 
+        let ticket = Request::new(Ticket {
+            ticket: ObjectExpr {
+                request: Some(GrpcRequest::Ddl(DdlRequest {
+                    expr: Some(DdlExpr::Alter(AlterExpr {
+                        catalog_name: "greptime".to_string(),
+                        schema_name: "database_created_through_grpc".to_string(),
+                        table_name: "table_created_through_grpc".to_string(),
+                        kind: Some(alter_expr::Kind::AddColumns(AddColumns {
+                            add_columns: vec![AddColumn {
+                                column_def: Some(ColumnDef {
+                                    name: "b".to_string(),
+                                    datatype: ColumnDataType::Int32 as _,
+                                    is_nullable: true,
+                                    default_constraint: vec![],
+                                }),
+                                is_key: false,
+                            }],
+                        })),
+                    })),
+                })),
+            }
+            .encode_to_vec(),
+        });
+        let output = boarding(instance, ticket).await;
+        assert!(matches!(output, RpcOutput::AffectedRows(0)));
+
+        let ticket = Request::new(Ticket {
+            ticket: ObjectExpr {
+                request: Some(GrpcRequest::Query(QueryRequest {
+                    query: Some(Query::Sql("INSERT INTO database_created_through_grpc.table_created_through_grpc (a, b, ts) VALUES ('s', 1, 1672816466000)".to_string()))
+                }))
+            }.encode_to_vec()
+        });
+        let output = boarding(instance, ticket).await;
+        assert!(matches!(output, RpcOutput::AffectedRows(1)));
+
+        let ticket = Request::new(Ticket {
+            ticket: ObjectExpr {
+                request: Some(GrpcRequest::Query(QueryRequest {
+                    query: Some(Query::Sql("SELECT ts, a, b FROM database_created_through_grpc.table_created_through_grpc".to_string()))
+                }))
+            }.encode_to_vec()
+        });
+        let output = boarding(instance, ticket).await;
+        let RpcOutput::RecordBatches(recordbatches) = output else { unreachable!() };
+        let expected = "\
++---------------------+---+---+
+| ts                  | a | b |
++---------------------+---+---+
+| 2023-01-04T07:14:26 | s | 1 |
++---------------------+---+---+";
+        assert_eq!(recordbatches.pretty_print().unwrap(), expected);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_distributed_insert_and_query() {
+        common_telemetry::init_default_ut_logging();
+
+        let instance =
+            tests::create_distributed_instance("test_distributed_insert_and_query").await;
+        let frontend = &instance.frontend;
+
+        let table_name = "my_dist_table";
+        let sql = format!(
+            r"
+CREATE TABLE {table_name} (
+    a INT, 
+    ts TIMESTAMP, 
+    TIME INDEX (ts)
+) PARTITION BY RANGE COLUMNS(a) (
+    PARTITION r0 VALUES LESS THAN (10),
+    PARTITION r1 VALUES LESS THAN (20),
+    PARTITION r2 VALUES LESS THAN (50),
+    PARTITION r3 VALUES LESS THAN (MAXVALUE),
+)"
+        );
+        create_table(frontend, sql).await;
+
+        test_insert_and_query_on_existing_table(frontend, table_name).await;
+
+        verify_data_distribution(
+            &instance,
+            table_name,
+            HashMap::from([
+                (
+                    0u32,
+                    "\
++---------------------+---+
+| ts                  | a |
++---------------------+---+
+| 2023-01-01T07:26:12 | 1 |
+| 2023-01-01T07:26:14 |   |
++---------------------+---+",
+                ),
+                (
+                    1u32,
+                    "\
++---------------------+----+
+| ts                  | a  |
++---------------------+----+
+| 2023-01-01T07:26:13 | 11 |
++---------------------+----+",
+                ),
+                (
+                    2u32,
+                    "\
++---------------------+----+
+| ts                  | a  |
++---------------------+----+
+| 2023-01-01T07:26:15 | 20 |
+| 2023-01-01T07:26:16 | 22 |
++---------------------+----+",
+                ),
+                (
+                    3u32,
+                    "\
++---------------------+----+
+| ts                  | a  |
++---------------------+----+
+| 2023-01-01T07:26:17 | 50 |
+| 2023-01-01T07:26:18 | 55 |
+| 2023-01-01T07:26:19 | 99 |
++---------------------+----+",
+                ),
+            ]),
+        )
+        .await;
+
+        test_insert_and_query_on_auto_created_table(frontend).await;
+
+        // Auto created table has only one region.
+        verify_data_distribution(
+            &instance,
+            "auto_created_table",
+            HashMap::from([(
+                0u32,
+                "\
++---------------------+---+
+| ts                  | a |
++---------------------+---+
+| 2023-01-01T07:26:15 | 4 |
+| 2023-01-01T07:26:16 |   |
+| 2023-01-01T07:26:17 | 6 |
+| 2023-01-01T07:26:18 |   |
+| 2023-01-01T07:26:19 |   |
+| 2023-01-01T07:26:20 |   |
++---------------------+---+",
+            )]),
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_standalone_insert_and_query() {
+        common_telemetry::init_default_ut_logging();
+
+        let standalone =
+            tests::create_standalone_instance("test_standalone_insert_and_query").await;
+        let instance = &standalone.instance;
+
+        let table_name = "my_table";
+        let sql = format!("CREATE TABLE {table_name} (a INT, ts TIMESTAMP, TIME INDEX (ts))");
+        create_table(instance, sql).await;
+
+        test_insert_and_query_on_existing_table(instance, table_name).await;
+
+        test_insert_and_query_on_auto_created_table(instance).await
+    }
+
+    async fn create_table(frontend: &Arc<Instance>, sql: String) {
+        let ticket = Request::new(Ticket {
+            ticket: ObjectExpr {
+                request: Some(GrpcRequest::Query(QueryRequest {
+                    query: Some(Query::Sql(sql)),
+                })),
+            }
+            .encode_to_vec(),
+        });
+        let output = boarding(frontend, ticket).await;
+        assert!(matches!(output, RpcOutput::AffectedRows(0)));
+    }
+
+    async fn test_insert_and_query_on_existing_table(instance: &Arc<Instance>, table_name: &str) {
         let insert = InsertRequest {
             schema_name: "public".to_string(),
-            table_name: "my_table".to_string(),
+            table_name: table_name.to_string(),
             columns: vec![
                 Column {
                     column_name: "a".to_string(),
                     values: Some(Values {
-                        i32_values: vec![1, 3],
+                        i32_values: vec![1, 11, 20, 22, 50, 55, 99],
                         ..Default::default()
                     }),
-                    null_mask: vec![2],
+                    null_mask: vec![4],
                     semantic_type: SemanticType::Field as i32,
                     datatype: ColumnDataType::Int32 as i32,
                 },
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672557972000, 1672557973000, 1672557974000],
+                        ts_millisecond_values: vec![
+                            1672557972000,
+                            1672557973000,
+                            1672557974000,
+                            1672557975000,
+                            1672557976000,
+                            1672557977000,
+                            1672557978000,
+                            1672557979000,
+                        ],
                         ..Default::default()
                     }),
                     semantic_type: SemanticType::Timestamp as i32,
@@ -218,7 +460,7 @@ mod test {
                     ..Default::default()
                 },
             ],
-            row_count: 3,
+            row_count: 8,
             ..Default::default()
         };
 
@@ -229,14 +471,15 @@ mod test {
             .encode_to_vec(),
         });
 
-        // Test inserting to exist table.
         let output = boarding(instance, ticket).await;
-        assert!(matches!(output, RpcOutput::AffectedRows(3)));
+        assert!(matches!(output, RpcOutput::AffectedRows(8)));
 
         let ticket = Request::new(Ticket {
             ticket: ObjectExpr {
                 request: Some(GrpcRequest::Query(QueryRequest {
-                    query: Some(Query::Sql("SELECT ts, a FROM my_table".to_string())),
+                    query: Some(Query::Sql(format!(
+                        "SELECT ts, a FROM {table_name} ORDER BY ts"
+                    ))),
                 })),
             }
             .encode_to_vec(),
@@ -245,15 +488,68 @@ mod test {
         let output = boarding(instance, ticket).await;
         let RpcOutput::RecordBatches(recordbatches) = output else { unreachable!() };
         let expected = "\
-+---------------------+---+
-| ts                  | a |
-+---------------------+---+
-| 2023-01-01T07:26:12 | 1 |
-| 2023-01-01T07:26:13 |   |
-| 2023-01-01T07:26:14 | 3 |
-+---------------------+---+";
++---------------------+----+
+| ts                  | a  |
++---------------------+----+
+| 2023-01-01T07:26:12 | 1  |
+| 2023-01-01T07:26:13 | 11 |
+| 2023-01-01T07:26:14 |    |
+| 2023-01-01T07:26:15 | 20 |
+| 2023-01-01T07:26:16 | 22 |
+| 2023-01-01T07:26:17 | 50 |
+| 2023-01-01T07:26:18 | 55 |
+| 2023-01-01T07:26:19 | 99 |
++---------------------+----+";
         assert_eq!(recordbatches.pretty_print().unwrap(), expected);
+    }
 
+    async fn verify_data_distribution(
+        instance: &MockDistributedInstance,
+        table_name: &str,
+        expected_distribution: HashMap<u32, &str>,
+    ) {
+        let table = instance
+            .frontend
+            .catalog_manager()
+            .table("greptime", "public", table_name)
+            .unwrap()
+            .unwrap();
+        let table = table.as_any().downcast_ref::<DistTable>().unwrap();
+
+        let TableGlobalValue { regions_id_map, .. } = table
+            .table_global_value(TableGlobalKey {
+                catalog_name: "greptime".to_string(),
+                schema_name: "public".to_string(),
+                table_name: table_name.to_string(),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let region_to_dn_map = regions_id_map
+            .iter()
+            .map(|(k, v)| (v[0], *k))
+            .collect::<HashMap<u32, u64>>();
+        assert_eq!(region_to_dn_map.len(), expected_distribution.len());
+
+        for (region, dn) in region_to_dn_map.iter() {
+            let dn = instance.datanodes.get(dn).unwrap();
+            let output = dn
+                .execute_sql(
+                    &format!("SELECT ts, a FROM {table_name} ORDER BY ts"),
+                    QueryContext::arc(),
+                )
+                .await
+                .unwrap();
+            let Output::Stream(stream) = output else { unreachable!() };
+            let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+            let actual = recordbatches.pretty_print().unwrap();
+
+            let expected = expected_distribution.get(region).unwrap();
+            assert_eq!(&actual, expected);
+        }
+    }
+
+    async fn test_insert_and_query_on_auto_created_table(instance: &Arc<Instance>) {
         let insert = InsertRequest {
             schema_name: "public".to_string(),
             table_name: "auto_created_table".to_string(),

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -72,7 +72,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_exec() {
-        let (instance, _guard) = tests::create_standalone_instance("test_exec").await;
+        let standalone = tests::create_standalone_instance("test_exec").await;
+        let instance = standalone.instance;
         instance
             .exec(
                 &DataPoint::try_create(
@@ -90,8 +91,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_insert_opentsdb_metric() {
-        let (instance, _guard) =
-            tests::create_standalone_instance("test_insert_opentsdb_metric").await;
+        let standalone = tests::create_standalone_instance("test_insert_opentsdb_metric").await;
+        let instance = standalone.instance;
 
         let data_point1 = DataPoint::new(
             "my_metric_1".to_string(),

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -177,9 +177,9 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_prometheus_remote_write_and_read() {
-        common_telemetry::init_default_ut_logging();
-        let (instance, _guard) =
+        let standalone =
             tests::create_standalone_instance("test_prometheus_remote_write_and_read").await;
+        let instance = standalone.instance;
 
         let write_request = WriteRequest {
             timeseries: prometheus::mock_timeseries(),

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -385,7 +385,10 @@ impl DistTable {
         Ok(partition_rule)
     }
 
-    async fn table_global_value(&self, key: &TableGlobalKey) -> Result<Option<TableGlobalValue>> {
+    pub(crate) async fn table_global_value(
+        &self,
+        key: &TableGlobalKey,
+    ) -> Result<Option<TableGlobalValue>> {
         let raw = self
             .backend
             .get(key.to_string().as_bytes())

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -1027,7 +1027,7 @@ mod test {
         let schema = Arc::new(Schema::new(column_schemas.clone()));
 
         let instance = crate::tests::create_distributed_instance(test_name).await;
-        let dist_instance = instance.frontend.dist_instance.as_ref().unwrap();
+        let dist_instance = &instance.dist_instance;
         let datanode_instances = instance.datanodes;
 
         let catalog_manager = dist_instance.catalog_manager();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR is part of a series of changes to gradually adopt the Arrow Flight, and remove the old GRPC interface finally.

This PR implements Query and DDL functionality of Arrow Flight service (handles `QueryRequest` and `DdlRequest` in `do_get`) for Frontend instance.

Also add more the tests for distribute mode.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#381 