### PR TITLE
refactor: simplify how Frontend instance handles other protocols

### DIFF
--- a/src/common/substrait/src/types.rs
+++ b/src/common/substrait/src/types.rs
@@ -151,8 +151,15 @@ pub(crate) fn scalar_value_as_literal_type(v: &ScalarValue) -> Result<LiteralTyp
             ScalarValue::Int64(Some(v)) => LiteralType::I64(*v),
             ScalarValue::LargeUtf8(Some(v)) => LiteralType::String(v.clone()),
             ScalarValue::LargeBinary(Some(v)) => LiteralType::Binary(v.clone()),
+            ScalarValue::TimestampSecond(Some(seconds), _) => {
+                LiteralType::Timestamp(*seconds * 1_000_000)
+            }
             ScalarValue::TimestampMillisecond(Some(millis), _) => {
                 LiteralType::Timestamp(*millis * 1000)
+            }
+            ScalarValue::TimestampMicrosecond(Some(micros), _) => LiteralType::Timestamp(*micros),
+            ScalarValue::TimestampNanosecond(Some(nanos), _) => {
+                LiteralType::Timestamp(*nanos / 1000)
             }
             ScalarValue::Utf8(Some(s)) => LiteralType::String(s.clone()),
             // TODO(LFC): Implement other conversions: ScalarValue => LiteralType

--- a/src/common/substrait/src/types.rs
+++ b/src/common/substrait/src/types.rs
@@ -151,10 +151,14 @@ pub(crate) fn scalar_value_as_literal_type(v: &ScalarValue) -> Result<LiteralTyp
             ScalarValue::Int64(Some(v)) => LiteralType::I64(*v),
             ScalarValue::LargeUtf8(Some(v)) => LiteralType::String(v.clone()),
             ScalarValue::LargeBinary(Some(v)) => LiteralType::Binary(v.clone()),
+            ScalarValue::TimestampMillisecond(Some(millis), _) => {
+                LiteralType::Timestamp(*millis * 1000)
+            }
+            ScalarValue::Utf8(Some(s)) => LiteralType::String(s.clone()),
             // TODO(LFC): Implement other conversions: ScalarValue => LiteralType
             _ => {
                 return error::UnsupportedExprSnafu {
-                    name: format!("{v:?}"),
+                    name: format!("ScalarValue: {v:?}"),
                 }
                 .fail()
             }
@@ -191,6 +195,7 @@ pub(crate) fn literal_type_to_scalar_value(t: LiteralType) -> Result<ScalarValue
         LiteralType::Fp64(v) => ScalarValue::Float64(Some(v)),
         LiteralType::String(v) => ScalarValue::LargeUtf8(Some(v)),
         LiteralType::Binary(v) => ScalarValue::LargeBinary(Some(v)),
+        LiteralType::Timestamp(v) => ScalarValue::TimestampMicrosecond(Some(v), None),
         // TODO(LFC): Implement other conversions: LiteralType => ScalarValue
         _ => {
             return error::UnsupportedSubstraitTypeSnafu {

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -225,27 +225,8 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to bump table id when creating table, source: {}", source))]
-    BumpTableId {
-        #[snafu(backtrace)]
-        source: table::error::Error,
-    },
-
-    #[snafu(display("Failed to create database: {}, source: {}", name, source))]
-    CreateDatabase {
-        name: String,
-        #[snafu(backtrace)]
-        source: client::Error,
-    },
-
     #[snafu(display("Failed to insert values to table, source: {}", source))]
     Insert {
-        #[snafu(backtrace)]
-        source: client::Error,
-    },
-
-    #[snafu(display("Failed to create table on insertion, source: {}", source))]
-    CreateTableOnInsertion {
         #[snafu(backtrace)]
         source: client::Error,
     },
@@ -287,15 +268,6 @@ pub enum Error {
     Table {
         #[snafu(backtrace)]
         source: table::error::Error,
-    },
-
-    #[snafu(display("Failed to get catalog manager"))]
-    CatalogManager { backtrace: Backtrace },
-
-    #[snafu(display("Failed to get full table name, source: {}", source))]
-    FullTableName {
-        #[snafu(backtrace)]
-        source: sql::error::Error,
     },
 
     #[snafu(display("Failed to find region routes for table {}", table_name))]
@@ -352,23 +324,10 @@ pub enum Error {
     #[snafu(display("Cannot find primary key column by name: {}", msg))]
     PrimaryKeyNotFound { msg: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to execute sql: {}, source: {}", sql, source))]
-    ExecuteSql {
-        sql: String,
-        #[snafu(backtrace)]
-        source: query::error::Error,
-    },
-
     #[snafu(display("Failed to execute statement, source: {}", source))]
     ExecuteStatement {
         #[snafu(backtrace)]
         source: query::error::Error,
-    },
-
-    #[snafu(display("Failed to do vector computation, source: {}", source))]
-    VectorComputation {
-        #[snafu(backtrace)]
-        source: datatypes::error::Error,
     },
 
     #[snafu(display("Failed to build DataFusion logical plan, source: {}", source))]
@@ -460,7 +419,6 @@ impl ErrorExt for Error {
             | Error::InvalidInsertRequest { .. }
             | Error::FindPartitionColumn { .. }
             | Error::ColumnValuesNumberMismatch { .. }
-            | Error::CatalogManager { .. }
             | Error::RegionKeysSize { .. }
             | Error::InvalidFlightTicket { .. } => StatusCode::InvalidArguments,
 
@@ -472,13 +430,10 @@ impl ErrorExt for Error {
 
             Error::ParseSql { source } => source.status_code(),
 
-            Error::FullTableName { source, .. } => source.status_code(),
-
             Error::Table { source } => source.status_code(),
 
             Error::ConvertColumnDefaultConstraint { source, .. }
             | Error::ConvertScalarValue { source, .. }
-            | Error::VectorComputation { source }
             | Error::ConvertArrowSchema { source } => source.status_code(),
 
             Error::InvalidObjectResult { source, .. } | Error::RequestDatanode { source } => {
@@ -516,17 +471,13 @@ impl ErrorExt for Error {
             Error::StartMetaClient { source } | Error::RequestMeta { source } => {
                 source.status_code()
             }
-            Error::BumpTableId { source, .. } => source.status_code(),
             Error::SchemaNotFound { .. } => StatusCode::InvalidArguments,
             Error::CatalogNotFound { .. } => StatusCode::InvalidArguments,
-            Error::CreateDatabase { source, .. }
-            | Error::CreateTableOnInsertion { source, .. }
-            | Error::Insert { source, .. } => source.status_code(),
+            Error::Insert { source, .. } => source.status_code(),
             Error::BuildCreateExprOnInsertion { source, .. } => source.status_code(),
             Error::FindNewColumnsOnInsertion { source, .. } => source.status_code(),
             Error::ToTableInsertRequest { source, .. } => source.status_code(),
             Error::PrimaryKeyNotFound { .. } => StatusCode::InvalidArguments,
-            Error::ExecuteSql { source, .. } => source.status_code(),
             Error::ExecuteStatement { source, .. } => source.status_code(),
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
             Error::AlterExprToRequest { source, .. } => source.status_code(),

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -271,12 +271,6 @@ pub enum Error {
         source: common_grpc_expr::error::Error,
     },
 
-    #[snafu(display("Failed to deserialize insert batching: {}", source))]
-    InsertBatchToRequest {
-        #[snafu(backtrace)]
-        source: common_grpc_expr::error::Error,
-    },
-
     #[snafu(display("Failed to find catalog by name: {}", catalog_name))]
     CatalogNotFound {
         catalog_name: String,
@@ -534,7 +528,6 @@ impl ErrorExt for Error {
             Error::PrimaryKeyNotFound { .. } => StatusCode::InvalidArguments,
             Error::ExecuteSql { source, .. } => source.status_code(),
             Error::ExecuteStatement { source, .. } => source.status_code(),
-            Error::InsertBatchToRequest { source, .. } => source.status_code(),
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
             Error::AlterExprToRequest { source, .. } => source.status_code(),
             Error::LeaderNotFound { .. } => StatusCode::StorageUnavailable,

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -12,115 +12,88 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
-use api::v1::{Column, InsertRequest as GrpcInsertRequest};
 use async_trait::async_trait;
-use common_catalog::consts::DEFAULT_CATALOG_NAME;
 use common_error::prelude::BoxedError;
-use common_grpc_expr::column_to_vector;
+use servers::error as server_error;
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::InfluxdbLineProtocolHandler;
-use servers::{error as server_error, Mode};
-use snafu::{OptionExt, ResultExt};
-use table::requests::InsertRequest;
+use snafu::ResultExt;
 
-use crate::error;
-use crate::error::{InsertBatchToRequestSnafu, Result};
 use crate::instance::Instance;
 
 #[async_trait]
 impl InfluxdbLineProtocolHandler for Instance {
     async fn exec(&self, request: &InfluxdbRequest) -> servers::error::Result<()> {
-        match self.mode {
-            Mode::Standalone => {
-                self.handle_inserts(request.try_into()?)
-                    .await
-                    .map_err(BoxedError::new)
-                    .context(server_error::ExecuteQuerySnafu {
-                        query: &request.lines,
-                    })?;
-            }
-            Mode::Distributed => {
-                self.dist_insert(request.try_into()?)
-                    .await
-                    .map_err(BoxedError::new)
-                    .context(server_error::ExecuteInsertSnafu {
-                        msg: "execute insert failed",
-                    })?;
-            }
-        }
-
+        let requests = request.try_into()?;
+        self.handle_inserts(requests)
+            .await
+            .map_err(BoxedError::new)
+            .with_context(|_| server_error::ExecuteQuerySnafu {
+                query: format!("{request:?}"),
+            })?;
         Ok(())
     }
 }
 
-impl Instance {
-    pub(crate) async fn dist_insert(&self, inserts: Vec<GrpcInsertRequest>) -> Result<usize> {
-        let mut joins = Vec::with_capacity(inserts.len());
-        let catalog_name = DEFAULT_CATALOG_NAME;
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
 
-        for insert in inserts {
-            let self_clone = self.clone();
+    use common_query::Output;
+    use common_recordbatch::RecordBatches;
+    use servers::query_handler::SqlQueryHandler;
+    use session::context::QueryContext;
 
-            let schema_name = insert.schema_name.to_string();
-            let table_name = insert.table_name.to_string();
+    use super::*;
+    use crate::tests;
 
-            let columns = &insert.columns;
-            let row_count = insert.row_count;
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_standalone_put_influxdb_lines() {
+        let standalone =
+            tests::create_standalone_instance("test_standalone_put_influxdb_lines").await;
+        let instance = &standalone.instance;
 
-            self.create_or_alter_table_on_demand(catalog_name, &schema_name, &table_name, columns)
-                .await?;
-
-            let request = Self::columns_to_request(
-                catalog_name,
-                &schema_name,
-                &table_name,
-                columns,
-                row_count,
-            )?;
-
-            // TODO(fys): need a separate runtime here
-            let self_clone = self_clone.clone();
-            let join = tokio::spawn(async move {
-                let catalog = self_clone.get_catalog(catalog_name)?;
-                let schema = Self::get_schema(catalog, &schema_name)?;
-                let table = schema
-                    .table(&table_name)
-                    .context(error::CatalogSnafu)?
-                    .context(error::TableNotFoundSnafu { table_name })?;
-
-                table.insert(request).await.context(error::TableSnafu)
-            });
-            joins.push(join);
-        }
-
-        let mut affected = 0;
-
-        for join in joins {
-            affected += join.await.context(error::JoinTaskSnafu)??;
-        }
-
-        Ok(affected)
+        test_put_influxdb_lines(instance).await;
     }
 
-    fn columns_to_request(
-        catalog_name: &str,
-        schema_name: &str,
-        table_name: &str,
-        columns: &[Column],
-        row_count: u32,
-    ) -> Result<InsertRequest> {
-        let mut vectors = HashMap::with_capacity(columns.len());
-        for col in columns {
-            let vector = column_to_vector(col, row_count).context(InsertBatchToRequestSnafu)?;
-            vectors.insert(col.column_name.clone(), vector);
-        }
-        Ok(InsertRequest {
-            catalog_name: catalog_name.to_string(),
-            schema_name: schema_name.to_string(),
-            table_name: table_name.to_string(),
-            columns_values: vectors,
-        })
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_distributed_put_influxdb_lines() {
+        let instance =
+            tests::create_distributed_instance("test_distributed_put_influxdb_lines").await;
+        let instance = &instance.frontend;
+
+        test_put_influxdb_lines(instance).await;
+    }
+
+    async fn test_put_influxdb_lines(instance: &Arc<Instance>) {
+        let lines = r"
+monitor1,host=host1 cpu=66.6,memory=1024 1663840496100023100
+monitor1,host=host2 memory=1027 1663840496400340001";
+        let request = InfluxdbRequest {
+            precision: None,
+            db: "public".to_string(),
+            lines: lines.to_string(),
+        };
+        instance.exec(&request).await.unwrap();
+
+        let mut output = instance
+            .do_query(
+                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+                QueryContext::arc(),
+            )
+            .await;
+        let output = output.remove(0).unwrap();
+        let Output::Stream(stream) = output else { unreachable!() };
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        assert_eq!(
+            recordbatches.pretty_print().unwrap(),
+            "\
++-------------------------+-------+------+--------+
+| ts                      | host  | cpu  | memory |
++-------------------------+-------+------+--------+
+| 2022-09-22T09:54:56.100 | host1 | 66.6 | 1024   |
+| 2022-09-22T09:54:56.400 | host2 |      | 1027   |
++-------------------------+-------+------+--------+"
+        );
     }
 }

--- a/src/servers/src/opentsdb/codec.rs
+++ b/src/servers/src/opentsdb/codec.rs
@@ -15,11 +15,8 @@
 use api::v1::column::SemanticType;
 use api::v1::{column, Column, ColumnDataType, InsertRequest as GrpcInsertRequest};
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
-use common_grpc::writer::Precision;
-use table::requests::InsertRequest;
 
 use crate::error::{self, Result};
-use crate::line_writer::LineWriter;
 
 pub const OPENTSDB_TIMESTAMP_COLUMN_NAME: &str = "greptime_timestamp";
 pub const OPENTSDB_VALUE_COLUMN_NAME: &str = "greptime_value";
@@ -128,24 +125,6 @@ impl DataPoint {
         self.value
     }
 
-    pub fn as_insert_request(&self) -> InsertRequest {
-        let mut line_writer = LineWriter::with_lines(DEFAULT_SCHEMA_NAME, self.metric.clone(), 1);
-        line_writer.write_ts(
-            OPENTSDB_TIMESTAMP_COLUMN_NAME,
-            (self.ts_millis(), Precision::Millisecond),
-        );
-
-        line_writer.write_f64(OPENTSDB_VALUE_COLUMN_NAME, self.value);
-
-        for (tagk, tagv) in self.tags.iter() {
-            line_writer.write_tag(tagk, tagv);
-        }
-        line_writer.commit();
-        line_writer.finish()
-    }
-
-    // TODO(LFC): opentsdb and influxdb insertions should go through the Table trait directly.
-    // Currently: line protocol -> grpc request -> grpc interface -> table trait
     pub fn as_grpc_insert(&self) -> GrpcInsertRequest {
         let schema_name = DEFAULT_SCHEMA_NAME.to_string();
         let mut columns = Vec::with_capacity(2 + self.tags.len());
@@ -211,13 +190,6 @@ impl DataPoint {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
-    use common_time::timestamp::TimeUnit;
-    use common_time::Timestamp;
-    use datatypes::value::Value;
-    use datatypes::vectors::Vector;
-
     use super::*;
 
     #[test]
@@ -277,43 +249,6 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_as_insert_request() {
-        let data_point = DataPoint {
-            metric: "my_metric_1".to_string(),
-            ts_millis: 1000,
-            value: 1.0,
-            tags: vec![
-                ("tagk1".to_string(), "tagv1".to_string()),
-                ("tagk2".to_string(), "tagv2".to_string()),
-            ],
-        };
-        let insert_request = data_point.as_insert_request();
-        assert_eq!("my_metric_1", insert_request.table_name);
-        let columns = insert_request.columns_values;
-        assert_eq!(4, columns.len());
-        let ts = columns.get(OPENTSDB_TIMESTAMP_COLUMN_NAME).unwrap();
-        let expected = vec![datatypes::prelude::Value::Timestamp(Timestamp::new(
-            1000,
-            TimeUnit::Millisecond,
-        ))];
-        assert_vector(&expected, ts);
-        let val = columns.get(OPENTSDB_VALUE_COLUMN_NAME).unwrap();
-        assert_vector(&[1.0.into()], val);
-        let tagk1 = columns.get("tagk1").unwrap();
-        assert_vector(&["tagv1".into()], tagk1);
-        let tagk2 = columns.get("tagk2").unwrap();
-        assert_vector(&["tagv2".into()], tagk2);
-    }
-
-    fn assert_vector(expected: &[Value], vector: &Arc<dyn Vector>) {
-        for (idx, expected) in expected.iter().enumerate() {
-            let val = vector.get(idx);
-            assert_eq!(*expected, val);
-        }
-    }
-
-    // TODO(fys): will remove in the future.
     #[test]
     fn test_as_grpc_insert() {
         let data_point = DataPoint {

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -21,17 +21,14 @@ use api::prometheus::remote::label_matcher::Type as MatcherType;
 use api::prometheus::remote::{Label, Query, Sample, TimeSeries, WriteRequest};
 use api::v1::column::SemanticType;
 use api::v1::{column, Column, ColumnDataType, InsertRequest as GrpcInsertRequest};
-use common_grpc::writer::Precision::Millisecond;
 use common_recordbatch::{RecordBatch, RecordBatches};
 use common_time::timestamp::TimeUnit;
 use datatypes::prelude::{ConcreteDataType, Value};
 use openmetrics_parser::{MetricsExposition, PrometheusType, PrometheusValue};
 use snafu::{ensure, OptionExt, ResultExt};
 use snap::raw::{Decoder, Encoder};
-use table::requests::InsertRequest;
 
 use crate::error::{self, Result};
-use crate::line_writer::LineWriter;
 
 const TIMESTAMP_COLUMN_NAME: &str = "greptime_timestamp";
 const VALUE_COLUMN_NAME: &str = "greptime_value";
@@ -287,58 +284,6 @@ fn recordbatch_to_timeseries(table: &str, recordbatch: RecordBatch) -> Result<Ve
     Ok(timeseries_map.into_values().collect())
 }
 
-/// Cast a remote write request into InsertRequest
-pub fn write_request_to_insert_reqs(
-    db: &str,
-    mut request: WriteRequest,
-) -> Result<Vec<InsertRequest>> {
-    let timeseries = std::mem::take(&mut request.timeseries);
-
-    timeseries
-        .into_iter()
-        .map(|timeseries| timeseries_to_insert_request(db, timeseries))
-        .collect()
-}
-
-fn timeseries_to_insert_request(db: &str, mut timeseries: TimeSeries) -> Result<InsertRequest> {
-    // TODO(dennis): save exemplars into a column
-    let labels = std::mem::take(&mut timeseries.labels);
-    let samples = std::mem::take(&mut timeseries.samples);
-
-    let mut table_name = None;
-    for label in &labels {
-        // The metric name is a special label
-        if label.name == METRIC_NAME_LABEL {
-            table_name = Some(&label.value);
-        }
-    }
-    let table_name = table_name.context(error::InvalidPromRemoteRequestSnafu {
-        msg: "missing '__name__' label in timeseries",
-    })?;
-
-    let row_count = samples.len();
-    let mut line_writer = LineWriter::with_lines(db, table_name, row_count);
-
-    for sample in samples {
-        let ts_millis = sample.timestamp;
-        let val = sample.value;
-
-        line_writer.write_ts(TIMESTAMP_COLUMN_NAME, (ts_millis, Millisecond));
-        line_writer.write_f64(VALUE_COLUMN_NAME, val);
-
-        labels
-            .iter()
-            .filter(|label| label.name != METRIC_NAME_LABEL)
-            .for_each(|label| {
-                line_writer.write_tag(&label.name, &label.value);
-            });
-
-        line_writer.commit();
-    }
-    Ok(line_writer.finish())
-}
-
-// TODO(fys): it will remove in the future.
 pub fn to_grpc_insert_requests(
     database: &str,
     mut request: WriteRequest,
@@ -351,7 +296,6 @@ pub fn to_grpc_insert_requests(
         .collect()
 }
 
-// TODO(fys): it will remove in the future.
 fn to_grpc_insert_request(database: &str, mut timeseries: TimeSeries) -> Result<GrpcInsertRequest> {
     let schema_name = database.to_string();
 
@@ -506,11 +450,8 @@ mod tests {
     use std::sync::Arc;
 
     use api::prometheus::remote::LabelMatcher;
-    use common_time::timestamp::TimeUnit;
-    use common_time::Timestamp;
     use datatypes::schema::{ColumnSchema, Schema};
-    use datatypes::value::Value;
-    use datatypes::vectors::{Float64Vector, StringVector, TimestampMillisecondVector, Vector};
+    use datatypes::vectors::{Float64Vector, StringVector, TimestampMillisecondVector};
 
     use super::*;
 
@@ -568,94 +509,6 @@ mod tests {
         let (table, sql) = query_to_sql("public", &q).unwrap();
         assert_eq!("test", table);
         assert_eq!("select * from public.test where greptime_timestamp>=1000 AND greptime_timestamp<=2000 AND job~'*prom*' AND instance!='localhost' order by greptime_timestamp", sql);
-    }
-
-    #[test]
-    fn test_write_request_to_insert_reqs() {
-        let write_request = WriteRequest {
-            timeseries: mock_timeseries(),
-            ..Default::default()
-        };
-
-        let reqs = write_request_to_insert_reqs("public", write_request).unwrap();
-
-        assert_eq!(3, reqs.len());
-
-        let req1 = reqs.get(0).unwrap();
-        assert_eq!("public", req1.schema_name);
-        assert_eq!("metric1", req1.table_name);
-
-        let columns = &req1.columns_values;
-        let job = columns.get("job").unwrap();
-        let expected: Vec<Value> = vec!["spark".into(), "spark".into()];
-        assert_vector(&expected, job);
-
-        let ts = columns.get(TIMESTAMP_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![
-            datatypes::prelude::Value::Timestamp(Timestamp::new(1000, TimeUnit::Millisecond)),
-            datatypes::prelude::Value::Timestamp(Timestamp::new(2000, TimeUnit::Millisecond)),
-        ];
-        assert_vector(&expected, ts);
-
-        let val = columns.get(VALUE_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![1.0_f64.into(), 2.0_f64.into()];
-        assert_vector(&expected, val);
-
-        let req2 = reqs.get(1).unwrap();
-        assert_eq!("public", req2.schema_name);
-        assert_eq!("metric2", req2.table_name);
-
-        let columns = &req2.columns_values;
-        let instance = columns.get("instance").unwrap();
-        let expected: Vec<Value> = vec!["test_host1".into(), "test_host1".into()];
-        assert_vector(&expected, instance);
-
-        let idc = columns.get("idc").unwrap();
-        let expected: Vec<Value> = vec!["z001".into(), "z001".into()];
-        assert_vector(&expected, idc);
-
-        let ts = columns.get(TIMESTAMP_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![
-            datatypes::prelude::Value::Timestamp(Timestamp::new(1000, TimeUnit::Millisecond)),
-            datatypes::prelude::Value::Timestamp(Timestamp::new(2000, TimeUnit::Millisecond)),
-        ];
-        assert_vector(&expected, ts);
-
-        let val = columns.get(VALUE_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![3.0_f64.into(), 4.0_f64.into()];
-        assert_vector(&expected, val);
-
-        let req3 = reqs.get(2).unwrap();
-        assert_eq!("public", req3.schema_name);
-        assert_eq!("metric3", req3.table_name);
-
-        let columns = &req3.columns_values;
-        let idc = columns.get("idc").unwrap();
-        let expected: Vec<Value> = vec!["z002".into(), "z002".into(), "z002".into()];
-        assert_vector(&expected, idc);
-
-        let app = columns.get("app").unwrap();
-        let expected: Vec<Value> = vec!["biz".into(), "biz".into(), "biz".into()];
-        assert_vector(&expected, app);
-
-        let ts = columns.get(TIMESTAMP_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![
-            datatypes::prelude::Value::Timestamp(Timestamp::new(1000, TimeUnit::Millisecond)),
-            datatypes::prelude::Value::Timestamp(Timestamp::new(2000, TimeUnit::Millisecond)),
-            datatypes::prelude::Value::Timestamp(Timestamp::new(3000, TimeUnit::Millisecond)),
-        ];
-        assert_vector(&expected, ts);
-
-        let val = columns.get(VALUE_COLUMN_NAME).unwrap();
-        let expected: Vec<Value> = vec![5.0_f64.into(), 6.0_f64.into(), 7.0_f64.into()];
-        assert_vector(&expected, val);
-    }
-
-    fn assert_vector(expected: &[Value], vector: &Arc<dyn Vector>) {
-        for (idx, expected) in expected.iter().enumerate() {
-            let val = vector.get(idx);
-            assert_eq!(*expected, val);
-        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR is part of a series of changes to gradually adopt the Arrow Flight, and remove the old GRPC interface finally.

This PR refactors how Frontend instance handles the read/write of influxdb, opentsdb and prometheus protocols. Now they all go through the GRPC interface, greatly unify and simplify the Frontend instance either in standalone or distributed mode. 

Should be ready when #827 is merged.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
