### PR TITLE
fix: remove start from LogStore; fix error message

### DIFF
--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -141,12 +141,6 @@ pub enum Error {
         source: log_store::error::Error,
     },
 
-    #[snafu(display("Failed to star log store gc task, source: {}", source))]
-    StartLogStore {
-        #[snafu(backtrace)]
-        source: log_store::error::Error,
-    },
-
     #[snafu(display("Failed to storage engine, source: {}", source))]
     OpenStorageEngine { source: StorageError },
 
@@ -382,7 +376,6 @@ impl ErrorExt for Error {
             Error::BumpTableId { source, .. } => source.status_code(),
             Error::MissingNodeId { .. } => StatusCode::InvalidArguments,
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
-            Error::StartLogStore { source, .. } => source.status_code(),
             Error::PollRecordbatchStream { source } => source.status_code(),
         }
     }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -36,13 +36,12 @@ use servers::Mode;
 use snafu::prelude::*;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;
-use store_api::logstore::LogStore;
 use table::table::TableIdProviderRef;
 
 use crate::datanode::{DatanodeOptions, ObjectStoreConfig};
 use crate::error::{
     self, CatalogSnafu, MetaClientInitSnafu, MissingMetasrvOptsSnafu, MissingNodeIdSnafu,
-    NewCatalogSnafu, OpenLogStoreSnafu, Result, StartLogStoreSnafu,
+    NewCatalogSnafu, OpenLogStoreSnafu, Result,
 };
 use crate::heartbeat::HeartbeatTask;
 use crate::script::ScriptExecutor;
@@ -63,7 +62,6 @@ pub struct Instance {
     pub(crate) script_executor: ScriptExecutor,
     pub(crate) table_id_provider: Option<TableIdProviderRef>,
     pub(crate) heartbeat_task: Option<HeartbeatTask>,
-    pub(crate) logstore: Arc<RaftEngineLogStore>,
 }
 
 pub type InstanceRef = Arc<Instance>;
@@ -161,12 +159,10 @@ impl Instance {
             script_executor,
             heartbeat_task,
             table_id_provider,
-            logstore,
         })
     }
 
     pub async fn start(&self) -> Result<()> {
-        self.logstore.start().await.context(StartLogStoreSnafu)?;
         self.catalog_manager
             .start()
             .await
@@ -305,6 +301,8 @@ pub(crate) async fn create_log_store(path: impl AsRef<str>) -> Result<RaftEngine
         ..Default::default()
     };
 
-    let logstore = RaftEngineLogStore::try_new(log_config).context(OpenLogStoreSnafu)?;
+    let logstore = RaftEngineLogStore::try_new(log_config)
+        .await
+        .context(OpenLogStoreSnafu)?;
     Ok(logstore)
 }

--- a/src/datanode/src/mock.rs
+++ b/src/datanode/src/mock.rs
@@ -83,7 +83,6 @@ impl Instance {
             script_executor,
             table_id_provider: Some(Arc::new(LocalTableIdProvider::default())),
             heartbeat_task: Some(heartbeat_task),
-            logstore,
         })
     }
 }

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -57,10 +57,6 @@ impl LogStore for NoopLogStore {
     type Namespace = NamespaceImpl;
     type Entry = EntryImpl;
 
-    async fn start(&self) -> Result<()> {
-        Ok(())
-    }
-
     async fn stop(&self) -> Result<()> {
         Ok(())
     }
@@ -131,7 +127,6 @@ mod tests {
     #[tokio::test]
     async fn test_noop_logstore() {
         let mut store = NoopLogStore::default();
-        store.start().await.unwrap();
         let e = store.entry("".as_bytes(), 1, NamespaceImpl::default());
         store.append(e.clone()).await.unwrap();
         store

--- a/src/log-store/src/test_util/log_store_util.rs
+++ b/src/log-store/src/test_util/log_store_util.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use store_api::logstore::LogStore;
 use tempdir::TempDir;
 
 use crate::raft_engine::log_store::RaftEngineLogStore;
@@ -29,7 +28,6 @@ pub async fn create_tmp_local_file_log_store(dir: &str) -> (RaftEngineLogStore, 
         ..Default::default()
     };
 
-    let logstore = RaftEngineLogStore::try_new(cfg).unwrap();
-    logstore.start().await.unwrap();
+    let logstore = RaftEngineLogStore::try_new(cfg).await.unwrap();
     (logstore, dir)
 }

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -107,7 +107,6 @@ mod tests {
     use mito::engine::MitoEngine;
     use storage::config::EngineConfig as StorageEngineConfig;
     use storage::EngineImpl;
-    use store_api::logstore::LogStore;
     use tempdir::TempDir;
 
     #[tokio::test]
@@ -122,9 +121,7 @@ mod tests {
             ..Default::default()
         };
 
-        let log_store = RaftEngineLogStore::try_new(log_config).unwrap();
-        log_store.start().await.unwrap();
-
+        let log_store = RaftEngineLogStore::try_new(log_config).await.unwrap();
         let mock_engine = Arc::new(DefaultEngine::new(
             TableEngineConfig::default(),
             EngineImpl::new(

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -205,11 +205,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to mark WAL as stable, region id: {}, source: {}",
+        "Failed to mark WAL as obsolete, region id: {}, source: {}",
         region_id,
         source
     ))]
-    MarkWalStable {
+    MarkWalObsolete {
         region_id: u64,
         #[snafu(backtrace)]
         source: BoxedError,
@@ -508,7 +508,7 @@ impl ErrorExt for Error {
             PushBatch { source, .. } => source.status_code(),
             CreateDefault { source, .. } => source.status_code(),
             ConvertChunk { source, .. } => source.status_code(),
-            MarkWalStable { source, .. } => source.status_code(),
+            MarkWalObsolete { source, .. } => source.status_code(),
         }
     }
 

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -18,7 +18,6 @@ use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::LogConfig;
 use object_store::backend::fs::Builder;
 use object_store::ObjectStore;
-use store_api::logstore::LogStore;
 
 use crate::background::JobPoolImpl;
 use crate::engine;
@@ -51,8 +50,7 @@ pub async fn new_store_config(
         log_file_dir: log_store_dir(store_dir),
         ..Default::default()
     };
-    let log_store = Arc::new(RaftEngineLogStore::try_new(log_config).unwrap());
-    log_store.start().await.unwrap();
+    let log_store = Arc::new(RaftEngineLogStore::try_new(log_config).await.unwrap());
 
     StoreConfig {
         log_store,

--- a/src/storage/src/wal.rs
+++ b/src/storage/src/wal.rs
@@ -25,7 +25,7 @@ use store_api::storage::{RegionId, SequenceNumber};
 
 use crate::codec::{Decoder, Encoder};
 use crate::error::{
-    DecodeWalHeaderSnafu, EncodeWalHeaderSnafu, Error, MarkWalStableSnafu, ReadWalSnafu, Result,
+    DecodeWalHeaderSnafu, EncodeWalHeaderSnafu, Error, MarkWalObsoleteSnafu, ReadWalSnafu, Result,
     WalDataCorruptedSnafu, WriteWalSnafu,
 };
 use crate::proto::wal::{self, WalHeader};
@@ -68,7 +68,7 @@ impl<S: LogStore> Wal<S> {
             .obsolete(self.namespace.clone(), seq)
             .await
             .map_err(BoxedError::new)
-            .context(MarkWalStableSnafu {
+            .context(MarkWalObsoleteSnafu {
                 region_id: self.region_id,
             })
     }

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -31,9 +31,6 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     type Namespace: Namespace;
     type Entry: Entry;
 
-    /// Start the components and background tasks of logstore.
-    async fn start(&self) -> Result<(), Self::Error>;
-
     /// Stop components of logstore.
     async fn stop(&self) -> Result<(), Self::Error>;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Remove `start` from `LogStore` trait.
- Call start as soon as `RaftEngineLogStore` is instantiated.
- Fix some error message

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
