### PR TITLE
feat: use Python Script as UDF in SQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5773,7 +5773,7 @@ dependencies = [
 [[package]]
 name = "rustpython-ast"
 version = "0.1.0"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "num-bigint",
  "rustpython-common",
@@ -5783,7 +5783,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "ahash 0.7.6",
  "bitflags",
@@ -5800,7 +5800,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.0.0"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "ascii",
  "cfg-if 1.0.0",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -5834,7 +5834,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "bincode 1.3.3",
  "bitflags",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "rustpython-derive"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "rustpython-compiler",
  "rustpython-derive-impl",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "rustpython-derive-impl"
 version = "0.0.0"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "indexmap",
  "itertools",
@@ -5887,7 +5887,7 @@ dependencies = [
 [[package]]
 name = "rustpython-parser"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -5912,7 +5912,7 @@ dependencies = [
 [[package]]
 name = "rustpython-pylib"
 version = "0.1.0"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "glob",
  "rustpython-compiler-core",
@@ -5922,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "rustpython-stdlib"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "adler32",
  "ahash 0.7.6",
@@ -5987,7 +5987,7 @@ dependencies = [
 [[package]]
 name = "rustpython-vm"
 version = "0.1.2"
-source = "git+https://github.com/discord9/RustPython?rev=f89b1537#f89b1537b9c789ff566717d1c2ad3d0777cbf5d6"
+source = "git+https://github.com/discord9/RustPython?rev=2e126345#2e12634569d01674724490193eb9638f056e51ca"
 dependencies = [
  "adler32",
  "ahash 0.7.6",

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -24,7 +24,6 @@ use datatypes::error::Error as DataTypeError;
 use datatypes::prelude::ConcreteDataType;
 use statrs::StatsError;
 
-
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
@@ -33,7 +32,10 @@ pub enum Error {
         // TODO(discord9): find a way that prevent circle depend(query<-script<-query) and can use script's error type
         msg: String,
     },
-    #[snafu(display("Fail to create temporary recordbatch when eval Python UDF, source: {}", source))]
+    #[snafu(display(
+        "Fail to create temporary recordbatch when eval Python UDF, source: {}",
+        source
+    ))]
     UdfTempRecordBatch {
         #[snafu(backtrace)]
         source: RecordbatchError,

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -31,6 +31,7 @@ pub enum Error {
     PyUdf {
         // TODO(discord9): find a way that prevent circle depend(query<-script<-query) and can use script's error type
         msg: String,
+        backtrace: Backtrace,
     },
 
     #[snafu(display(

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
         // TODO(discord9): find a way that prevent circle depend(query<-script<-query) and can use script's error type
         msg: String,
     },
+
     #[snafu(display(
         "Fail to create temporary recordbatch when eval Python UDF, source: {}",
         source
@@ -40,6 +41,7 @@ pub enum Error {
         #[snafu(backtrace)]
         source: RecordbatchError,
     },
+
     #[snafu(display("Fail to execute function, source: {}", source))]
     ExecuteFunction {
         source: DataFusionError,

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -45,16 +45,16 @@ once_cell = "1.17.0"
 paste = { workspace = true, optional = true }
 query = { path = "../query" }
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After Update toolchain to 1.65
-rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537", features = [
+rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-compiler-core = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-parser = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-pylib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345", features = [
     "freeze-stdlib",
 ] }
-rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537" }
-rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, rev = "f89b1537", features = [
+rustpython-stdlib = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345" }
+rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = true, rev = "2e126345", features = [
     "default",
     "codegen",
 ] }

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -58,6 +58,10 @@ impl ScriptManager {
 
         logging::info!("Compiled and cached script: {}", name);
 
+        script.as_ref().register_udf();
+
+        logging::info!("Script register as UDF: {}", name);
+
         Ok(script)
     }
 

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -371,7 +371,11 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
                 let native_module_allow_list = HashSet::from([
                     "array", "cmath", "gc", "hashlib", "_json", "_random", "math",
                 ]);
-                let interpreter = Arc::new(vm::Interpreter::with_init(Default::default(), |vm| {
+                // TODO(discord9): edge cases, can't use "..Default::default" because Settings is `#[non_exhaustive]`
+                // so more in here: https://internals.rust-lang.org/t/allow-constructing-non-exhaustive-structs-using-default-default/13868
+                let mut settings = vm::Settings::default();
+                settings.no_sig_int = true;
+                let interpreter = Arc::new(vm::Interpreter::with_init(settings, |vm| {
                     // not using full stdlib to prevent security issue, instead filter out a few simple util module
                     vm.add_native_modules(
                         rustpython_stdlib::get_module_inits()

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -94,6 +94,7 @@ fn try_into_datatype(ty: &str, loc: &Location) -> Result<Option<ConcreteDataType
         "i64" => Ok(Some(ConcreteDataType::int64_datatype())),
         "f32" => Ok(Some(ConcreteDataType::float32_datatype())),
         "f64" => Ok(Some(ConcreteDataType::float64_datatype())),
+        "str" => Ok(Some(ConcreteDataType::string_datatype())),
         // for any datatype
         "_" => Ok(None),
         // note the different between "_" and _

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use datatypes::arrow::datatypes::DataType;
+use datatypes::prelude::ConcreteDataType;
 use rustpython_parser::ast::{Arguments, Location};
 use rustpython_parser::{ast, parser};
 #[cfg(test)]
@@ -81,20 +81,19 @@ fn pylist_to_vec(lst: &ast::Expr<()>) -> Result<Vec<String>> {
     }
 }
 
-fn try_into_datatype(ty: &str, loc: &Location) -> Result<Option<DataType>> {
+fn try_into_datatype(ty: &str, loc: &Location) -> Result<Option<ConcreteDataType>> {
     match ty {
-        "bool" => Ok(Some(DataType::Boolean)),
-        "u8" => Ok(Some(DataType::UInt8)),
-        "u16" => Ok(Some(DataType::UInt16)),
-        "u32" => Ok(Some(DataType::UInt32)),
-        "u64" => Ok(Some(DataType::UInt64)),
-        "i8" => Ok(Some(DataType::Int8)),
-        "i16" => Ok(Some(DataType::Int16)),
-        "i32" => Ok(Some(DataType::Int32)),
-        "i64" => Ok(Some(DataType::Int64)),
-        "f16" => Ok(Some(DataType::Float16)),
-        "f32" => Ok(Some(DataType::Float32)),
-        "f64" => Ok(Some(DataType::Float64)),
+        "bool" => Ok(Some(ConcreteDataType::boolean_datatype())),
+        "u8" => Ok(Some(ConcreteDataType::uint8_datatype())),
+        "u16" => Ok(Some(ConcreteDataType::uint16_datatype())),
+        "u32" => Ok(Some(ConcreteDataType::uint32_datatype())),
+        "u64" => Ok(Some(ConcreteDataType::uint64_datatype())),
+        "i8" => Ok(Some(ConcreteDataType::int8_datatype())),
+        "i16" => Ok(Some(ConcreteDataType::int16_datatype())),
+        "i32" => Ok(Some(ConcreteDataType::int32_datatype())),
+        "i64" => Ok(Some(ConcreteDataType::int64_datatype())),
+        "f32" => Ok(Some(ConcreteDataType::float32_datatype())),
+        "f64" => Ok(Some(ConcreteDataType::float64_datatype())),
         // for any datatype
         "_" => Ok(None),
         // note the different between "_" and _

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -126,7 +126,7 @@ impl Function for PyUdf {
                     ),
                 }
                 .fail();
-            }// if more than one columns, just return first one
+            } // if more than one columns, just return first one
         }
         // TODO(discord9): more error handling
         let res0 = res.column(0);

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -147,7 +147,7 @@ pub struct PyScript {
 impl PyScript {
     /// Register Current Script as UDF, register name is same as script name
     /// FIXME(discord9): possible inject attack?
-    pub(crate) fn register_udf(&self) {
+    pub fn register_udf(&self) {
         let udf = PyUdf::from_copr(self.copr.clone());
         PyUdf::register_as_udf(udf.clone());
         PyUdf::register_to_query_engine(udf, self.query_engine.to_owned());

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -89,7 +89,12 @@ impl Function for PyUdf {
         _input_types: &[datatypes::prelude::ConcreteDataType],
     ) -> common_query::error::Result<datatypes::prelude::ConcreteDataType> {
         // TODO: use correct return annotation if exist
-        Ok(ConcreteDataType::float64_datatype())
+        Ok(self.copr.return_types[0]
+            .clone()
+            .map_or(ConcreteDataType::float64_datatype(), |anno| {
+                anno.datatype
+                    .unwrap_or(ConcreteDataType::float64_datatype())
+            }))
     }
 
     fn signature(&self) -> common_query::prelude::Signature {

--- a/src/script/src/python/test.rs
+++ b/src/script/src/python/test.rs
@@ -132,7 +132,7 @@ fn run_ron_testcases() {
                     .zip(res.schema.column_schemas())
                     .for_each(|(anno, real)| {
                         assert!(
-                            anno.datatype.as_ref().unwrap() == &real.data_type.as_arrow_type()
+                            anno.datatype.as_ref().unwrap() == &real.data_type
                                 && anno.is_nullable == real.is_nullable(),
                             "Fields expected to be {anno:#?}, actual {real:#?}"
                         );

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -24,21 +24,21 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64], vector[f64|None], vecto
                 ),
                 arg_types: [
                     Some((
-                        datatype: Some(Float32),
+                        datatype: Some(Float32(())),
                         is_nullable: false
                     )),
                     Some((
-                        datatype: Some(Float64),
+                        datatype: Some(Float64(())),
                         is_nullable: false
                     )),
                 ],
                 return_types: [
                     Some((
-                        datatype: Some(Float64),
+                        datatype: Some(Float64(())),
                         is_nullable: false
                     )),
                     Some((
-                        datatype: Some(Float64),
+                        datatype: Some(Float64(())),
                         is_nullable: true
                     )),
                     Some((
@@ -246,11 +246,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Float64),
+                    datatype: Some(Float64(())),
                     is_nullable: true
                 ),
                 (
-                    datatype: Some(Float32),
+                    datatype: Some(Float32(())),
                     is_nullable: false
                 ),
             ],
@@ -278,11 +278,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Float64),
+                    datatype: Some(Float64(())),
                     is_nullable: true
                 ),
                 (
-                    datatype: Some(Float32),
+                    datatype: Some(Float32(())),
                     is_nullable: false
                 ),
             ],
@@ -310,11 +310,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Float64),
+                    datatype: Some(Float64(())),
                     is_nullable: true
                 ),
                 (
-                    datatype: Some(Float32),
+                    datatype: Some(Float32(())),
                     is_nullable: false
                 ),
             ],
@@ -342,11 +342,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Float64),
+                    datatype: Some(Float64(())),
                     is_nullable: true
                 ),
                 (
-                    datatype: Some(Float32),
+                    datatype: Some(Float32(())),
                     is_nullable: false
                 ),
             ],
@@ -372,7 +372,7 @@ def a(cpu: vector[f32], mem: vector[f64]):
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Utf8),
+                    datatype: Some(String(())),
                     is_nullable: false,
                 ),
             ],
@@ -480,11 +480,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         predicate: ExecIsOk(
             fields: [
                 (
-                    datatype: Some(Float64),
+                    datatype: Some(Float64(())),
                     is_nullable: true
                 ),
                 (
-                    datatype: Some(Float32),
+                    datatype: Some(Float32(())),
                     is_nullable: false
                 ),
             ],

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -37,6 +37,8 @@ mod interceptor;
 mod opentsdb;
 mod postgres;
 
+mod py_script;
+
 struct DummyInstance {
     query_engine: QueryEngineRef,
     py_engine: Arc<PyEngine>,
@@ -82,6 +84,7 @@ impl ScriptHandler for DummyInstance {
             .compile(script, CompileContext::default())
             .await
             .unwrap();
+        script.register_udf();
         self.scripts
             .write()
             .unwrap()

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -50,8 +50,6 @@ def double_that(col)->vector[u32]:
             let col = first.column(0);
             let val = col.get(1);
             assert_eq!(val, datatypes::value::Value::UInt32(2));
-            let pretty_print = batches.pretty_print().unwrap();
-            println!("{pretty_print}");
         }
     }
     Ok(())

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 
 use servers::error::Result;

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -22,7 +22,7 @@ use table::test_util::MemTable;
 use crate::create_testing_instance;
 
 #[tokio::test]
-async fn test_insert_udf_and_query() -> Result<()> {
+async fn test_insert_py_udf_and_query() -> Result<()> {
     let query_ctx = Arc::new(QueryContext::new());
     let table = MemTable::default_numbers_table();
 

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use servers::error::Result;
+use servers::query_handler::{ScriptHandler, SqlQueryHandler};
+use session::context::QueryContext;
+use table::test_util::MemTable;
+
+use crate::create_testing_instance;
+
+#[tokio::test]
+async fn test_insert_udf_and_query() -> Result<()> {
+    let query_ctx = Arc::new(QueryContext::new());
+    let table = MemTable::default_numbers_table();
+
+    let instance = create_testing_instance(table);
+    let src = r#"
+@coprocessor(args=["uint32s"], returns = ["ret"])
+def double_that(col)->vector[u32]:
+    return col*2
+    "#;
+    instance.insert_script("double_that", src).await?;
+    let res = instance
+        .do_query("select double_that(uint32s) from numbers", query_ctx)
+        .await
+        .remove(0)
+        .unwrap();
+    match res {
+        common_query::Output::AffectedRows(_) => (),
+        common_query::Output::RecordBatches(_) => {
+            unreachable!()
+        }
+        common_query::Output::Stream(s) => {
+            let batches = common_recordbatch::util::collect_batches(s).await.unwrap();
+            assert_eq!(batches.iter().count(), 1);
+            let first = batches.iter().next().unwrap();
+            let col = first.column(0);
+            let val = col.get(1);
+            assert_eq!(val, datatypes::value::Value::UInt32(2));
+            let pretty_print = batches.pretty_print().unwrap();
+            println!("{pretty_print}");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

So now you can use sql query like this:
```sql
mysql> select system_status(cpu_util, memory_util, disk_util) from system_metrics;
+--------------------------------------------------------------------------------------------+
| system_status(system_metrics.cpu_util,system_metrics.memory_util,system_metrics.disk_util) |
+--------------------------------------------------------------------------------------------+
| green                                                                                      |
| yellow                                                                                     |
| red                                                                                        |
+--------------------------------------------------------------------------------------------+
3 rows in set (0.01 sec)
```
where `system_status` is this python script:
```python
@coprocessor(args=["cpu_util", "memory_util", "disk_util"],
             returns = ["status"])
def system_status(cpus, memories, disks)->vector[str]:
    statuses = []
    for cpu, memory, disk in zip(cpus, memories, disks):
        if cpu > 80 or memory > 80 or disk > 80:
            statuses.append("red")
            continue

        status = cpu * 0.4 + memory * 0.4 + disk * 0.2

        if status > 80:
            statuses.append("yellow")
        elif status > 50:
            statuses.append("yellow")
        else:
            statuses.append("green")

    return statuses

```

- Now every time PyScript get insert&compile it will insert a UDF with same name
the relevant type is `PyUdf`

- Need to write explict return type in python script i.e. above `-> vector[str]`, so UDF know its' type
- Can only return one value due to limitation of UDF(Even more vectors are returned, it will be ignore by UDF's `eval()` function
## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link
#675 however still havn't support this feature of creating UDF in SQL(Might need to extend sql parser)
Also fix #232 with `Settings` to not let Python VM set SIGINT handler(so our tokio can take ctrl_c handler)