### PR TITLE
ci: add lto and strip to weekly build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
         run: protoc --version ; cargo version ; rustc --version ; gcc --version ; g++ --version
 
       - name: Run cargo build
-        run: cargo build ${{ matrix.opts }} --release --locked --target ${{ matrix.arch }}
+        run: cargo build ${{ matrix.opts }} --profile weekly --locked --target ${{ matrix.arch }}
 
       - name: Calculate checksum and rename binary
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,11 @@ repos:
     -    id: conventional-pre-commit
          stages: [commit-msg]
 
--   repo: https://github.com/DevinR528/cargo-sort
-    rev: e6a795bc6b2c0958f9ef52af4863bbd7cc17238f
-    hooks:
-    -    id: cargo-sort
-         args: ["--workspace"]
+# -   repo: https://github.com/DevinR528/cargo-sort
+#     rev: e6a795bc6b2c0958f9ef52af4863bbd7cc17238f
+#     hooks:
+#     -    id: cargo-sort
+#          args: ["--workspace"]
 
 -   repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,10 @@ tonic = "0.8"
 
 [profile.release]
 debug = true
+
+[profile.weekly]
+inherits = "release"
+strip = true
+lto = true
+debug = false
+incremental = false


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Our weekly build is now over 200MB in size. Here I add strip and lto for weekly build.

This patch also disable `cargo-sort` until it's support for new workspace toml lands.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
