### PR TITLE
feat: Bump OpenDAL to 0.24 for better seekable support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,9 +4393,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.22.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d1ff77f4919836ec2002b7b42366722b2856c2b718102d3d1cd58db5e56e3e"
+checksum = "97541724cf371973b28f5a873404f2a2a4f7bb1efe7ca36a27836c13958781c2"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5401,9 +5401,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
 dependencies = [
  "memchr",
  "serde",
@@ -5664,9 +5664,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e209415378d7a5e169615faee53d9961ee1f1046d9d00991045a6a2de9f3f6"
+checksum = "1c97ac0f771c78ddf4bcb73c8454c76565a7249780e7296767f7e89661b0e045"
 dependencies = [
  "anyhow",
  "backon",

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.22", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.24", features = ["layers-tracing", "layers-metrics"] }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use opendal::raw::SeekableReader;
 pub use opendal::{
     layers, services, Error, ErrorKind, Layer, Object, ObjectLister, ObjectMetadata, ObjectMode,
     Operator as ObjectStore, Result,

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -281,7 +281,9 @@ mod tests {
         let reader = BufReader::new(
             object_store
                 .object(sst_file_name)
-                .seekable_reader(..)
+                .reader()
+                .await
+                .unwrap()
                 .compat(),
         );
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -33,7 +33,8 @@ use table::predicate::Predicate;
 use tokio::io::BufReader;
 
 use crate::error::{
-    self, NewRecordBatchSnafu, ReadParquetSnafu, Result, WriteObjectSnafu, WriteParquetSnafu,
+    self, NewRecordBatchSnafu, ReadObjectSnafu, ReadParquetSnafu, Result, WriteObjectSnafu,
+    WriteParquetSnafu,
 };
 use crate::memtable::BoxedBatchIterator;
 use crate::read::{Batch, BatchReader};
@@ -140,7 +141,14 @@ impl<'a> ParquetReader<'a> {
 
     pub async fn chunk_stream(&self) -> Result<ChunkStream> {
         let operator = self.object_store.clone();
-        let reader = operator.object(self.file_path).seekable_reader(..).compat();
+        let reader = operator
+            .object(self.file_path)
+            .reader()
+            .await
+            .context(ReadObjectSnafu {
+                path: self.file_path,
+            })?
+            .compat();
         let buf_reader = BufReader::new(reader);
         let builder = ParquetRecordBatchStreamBuilder::new(buf_reader)
             .await


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR will bump OpenDAL to the latest v0.24 version.

Changes include:

## [v0.24.2] - 2023-01-08

### Changed

- refactor: Use dep: to make our features more clean (#1153)

### Fixed

- fix: ghac shall return ObjectAlreadyExists for writing the same path (#1156)
- fix: futures read_to_end will lead to performance regression (#1158)

## [v0.24.1] - 2023-01-08

### Fixed

- fix: Allow range_read to be retired (#1149)

## [v0.24.0] - 2023-01-07

### Added

- Add support for SAS tokens in Azure blob storage (#1124)
- feat: Add github action cache service support (#1111)
- docs: Add docs for ghac service (#1126)
- feat: Implement offset seekable reader for zero cost read (#1133)
- feat: Implement fuzz test on ObjectReader (#1140)

### Changed

- chore(deps): update quick-xml requirement from 0.26 to 0.27 (#1101)
- ci: Enable rust cache for CI (#1107)
- deps(oay,oli): Update dependences of oay and oli (#1122)
- refactor: Only add content length hint if we already know length (#1123)
- refactor: Redesign outpu bytes reader trait (#1127)
- refactor: Remove open related APIs (#1129)
- refactor: Merge and cleanup io & io_util modules (#1136)

### Fixed

- ci: Fix build for oay and oli (#1097)
- fix: Fix rustls support for suppaftp (#1102)
- fix(services/ghac): Fix pkg version not used correctly (#1125)

## [v0.23.0] - 2022-12-22

### Added

- feat: Implement object handler so that we can do seek on file (#1091)
- feat: Implement blocking for hdfs (#1092)
- feat(services/hdfs): Implement open and blocking open (#1093)
- docs: Add mozilla/sccache into projects (#1094)

## [v0.22.6] - 2022-12-20

### Added

- feat(io): make BlockingBytesRead Send + Sync (#1083)
- feat(fs): skip seek if offset is 0 (#1082)
- RFC-1085: Object Handler (#1085)
- feat(services/s3,gcs): Allow accepting signer directly (#1087)

[v0.24.2]: https://github.com/datafuselabs/opendal/compare/v0.24.1...v0.24.2
[v0.24.1]: https://github.com/datafuselabs/opendal/compare/v0.24.0...v0.24.1
[v0.24.0]: https://github.com/datafuselabs/opendal/compare/v0.23.0...v0.24.0
[v0.23.0]: https://github.com/datafuselabs/opendal/compare/v0.22.6...v0.23.0
[v0.22.6]: https://github.com/datafuselabs/opendal/compare/v0.22.5...v0.22.6

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
