### PR TITLE
fix: Fix deleting table with non null column

### DIFF
--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -53,8 +53,10 @@ pub fn new_insert_request(
 pub fn schema_for_test() -> Schema {
     let column_schemas = vec![
         ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+        // Nullable value column: cpu
         ColumnSchema::new("cpu", ConcreteDataType::float64_datatype(), true),
-        ColumnSchema::new("memory", ConcreteDataType::float64_datatype(), true),
+        // Non-null value column: memory
+        ColumnSchema::new("memory", ConcreteDataType::float64_datatype(), false),
         ColumnSchema::new(
             "ts",
             ConcreteDataType::timestamp_datatype(common_time::timestamp::TimeUnit::Millisecond),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
If the table has a non-null column, we need to use default value instead of null to fill the value columns in the record batch for deletion. Otherwise, we can't create the record batch since the schema check doesn't allow null in the non-null column.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #848 