### PR TITLE
refactor: move parse methods out of QueryEngine trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
+ "promql-parser",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/src/datanode/src/instance/flight.rs
+++ b/src/datanode/src/instance/flight.rs
@@ -31,6 +31,7 @@ use common_grpc::flight::{FlightEncoder, FlightMessage};
 use common_query::Output;
 use futures::Stream;
 use prost::Message;
+use query::parser::QueryLanguageParser;
 use session::context::QueryContext;
 use snafu::{OptionExt, ResultExt};
 use tonic::{Request, Response, Streaming};
@@ -140,10 +141,7 @@ impl Instance {
     async fn handle_query(&self, query: Query) -> Result<Output> {
         Ok(match query {
             Query::Sql(sql) => {
-                let stmt = self
-                    .query_engine
-                    .sql_to_statement(&sql)
-                    .context(ExecuteSqlSnafu)?;
+                let stmt = QueryLanguageParser::parse_sql(&sql).context(ExecuteSqlSnafu)?;
                 self.execute_stmt(stmt, QueryContext::arc()).await?
             }
             Query::LogicalPlan(plan) => self.execute_logical(plan).await?,

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -19,6 +19,7 @@ use common_query::Output;
 use common_recordbatch::RecordBatches;
 use common_telemetry::logging::{error, info};
 use common_telemetry::timer;
+use query::parser::{QueryLanguageParser, QueryStatement};
 use servers::query_handler::SqlQueryHandler;
 use session::context::QueryContextRef;
 use snafu::prelude::*;
@@ -35,11 +36,11 @@ use crate::sql::SqlRequest;
 impl Instance {
     pub async fn execute_stmt(
         &self,
-        stmt: Statement,
+        stmt: QueryStatement,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         match stmt {
-            Statement::Query(_) => {
+            QueryStatement::SQL(Statement::Query(_)) | QueryStatement::PromQL(_) => {
                 let logical_plan = self
                     .query_engine
                     .statement_to_plan(stmt, query_ctx)
@@ -50,7 +51,7 @@ impl Instance {
                     .await
                     .context(ExecuteSqlSnafu)
             }
-            Statement::Insert(i) => {
+            QueryStatement::SQL(Statement::Insert(i)) => {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(i.table_name(), query_ctx.clone())?;
                 let table_ref = TableReference::full(&catalog, &schema, &table);
@@ -62,7 +63,7 @@ impl Instance {
                 self.sql_handler.execute(request, query_ctx).await
             }
 
-            Statement::CreateDatabase(c) => {
+            QueryStatement::SQL(Statement::CreateDatabase(c)) => {
                 let request = CreateDatabaseRequest {
                     db_name: c.name.to_string(),
                 };
@@ -74,7 +75,7 @@ impl Instance {
                     .await
             }
 
-            Statement::CreateTable(c) => {
+            QueryStatement::SQL(Statement::CreateTable(c)) => {
                 let table_id = self
                     .table_id_provider
                     .as_ref()
@@ -99,7 +100,7 @@ impl Instance {
                     .execute(SqlRequest::CreateTable(request), query_ctx)
                     .await
             }
-            Statement::Alter(alter_table) => {
+            QueryStatement::SQL(Statement::Alter(alter_table)) => {
                 let name = alter_table.table_name().clone();
                 let (catalog, schema, table) = table_idents_to_full_name(&name, query_ctx.clone())?;
                 let table_ref = TableReference::full(&catalog, &schema, &table);
@@ -108,36 +109,36 @@ impl Instance {
                     .execute(SqlRequest::Alter(req), query_ctx)
                     .await
             }
-            Statement::DropTable(drop_table) => {
+            QueryStatement::SQL(Statement::DropTable(drop_table)) => {
                 let req = self.sql_handler.drop_table_to_request(drop_table);
                 self.sql_handler
                     .execute(SqlRequest::DropTable(req), query_ctx)
                     .await
             }
-            Statement::ShowDatabases(stmt) => {
+            QueryStatement::SQL(Statement::ShowDatabases(stmt)) => {
                 self.sql_handler
                     .execute(SqlRequest::ShowDatabases(stmt), query_ctx)
                     .await
             }
-            Statement::ShowTables(stmt) => {
+            QueryStatement::SQL(Statement::ShowTables(stmt)) => {
                 self.sql_handler
                     .execute(SqlRequest::ShowTables(stmt), query_ctx)
                     .await
             }
-            Statement::Explain(stmt) => {
+            QueryStatement::SQL(Statement::Explain(stmt)) => {
                 self.sql_handler
                     .execute(SqlRequest::Explain(Box::new(stmt)), query_ctx)
                     .await
             }
-            Statement::DescribeTable(stmt) => {
+            QueryStatement::SQL(Statement::DescribeTable(stmt)) => {
                 self.sql_handler
                     .execute(SqlRequest::DescribeTable(stmt), query_ctx)
                     .await
             }
-            Statement::ShowCreateTable(_stmt) => {
+            QueryStatement::SQL(Statement::ShowCreateTable(_stmt)) => {
                 unimplemented!("SHOW CREATE TABLE is unimplemented yet");
             }
-            Statement::Use(db) => {
+            QueryStatement::SQL(Statement::Use(db)) => {
                 ensure!(
                     self.catalog_manager
                         .schema(DEFAULT_CATALOG_NAME, &db)
@@ -154,10 +155,7 @@ impl Instance {
     }
 
     pub async fn execute_sql(&self, sql: &str, query_ctx: QueryContextRef) -> Result<Output> {
-        let stmt = self
-            .query_engine
-            .sql_to_statement(sql)
-            .context(ExecuteSqlSnafu)?;
+        let stmt = QueryLanguageParser::parse_sql(sql).context(ExecuteSqlSnafu)?;
         self.execute_stmt(stmt, query_ctx).await
     }
 }
@@ -219,7 +217,7 @@ impl SqlQueryHandler for Instance {
         query_ctx: QueryContextRef,
     ) -> servers::error::Result<Output> {
         let _timer = timer!(metric::METRIC_HANDLE_SQL_ELAPSED);
-        self.execute_stmt(stmt, query_ctx)
+        self.execute_stmt(QueryStatement::SQL(stmt), query_ctx)
             .await
             .map_err(|e| {
                 error!(e; "Instance failed to execute sql");

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -130,6 +130,7 @@ mod tests {
     use mito::engine::MitoEngine;
     use object_store::services::fs::Builder;
     use object_store::ObjectStore;
+    use query::parser::{QueryLanguageParser, QueryStatement};
     use query::QueryEngineFactory;
     use sql::statements::statement::Statement;
     use storage::config::EngineConfig as StorageEngineConfig;
@@ -254,8 +255,8 @@ mod tests {
         let query_engine = factory.query_engine();
         let sql_handler = SqlHandler::new(table_engine, catalog_list.clone(), query_engine.clone());
 
-        let stmt = match query_engine.sql_to_statement(sql).unwrap() {
-            Statement::Insert(i) => i,
+        let stmt = match QueryLanguageParser::parse_sql(sql).unwrap() {
+            QueryStatement::SQL(Statement::Insert(i)) => i,
             _ => {
                 unreachable!()
             }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -42,6 +42,7 @@ use meta_client::rpc::{
     TableName, TableRoute,
 };
 use prost::Message;
+use query::parser::QueryStatement;
 use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
 use servers::error as server_error;
@@ -158,7 +159,7 @@ impl DistInstance {
             Statement::Query(_) => {
                 let plan = self
                     .query_engine
-                    .statement_to_plan(stmt, query_ctx)
+                    .statement_to_plan(QueryStatement::SQL(stmt), query_ctx)
                     .context(error::ExecuteStatementSnafu {})?;
                 self.query_engine.execute(&plan).await
             }

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -26,6 +26,7 @@ futures = "0.3"
 futures-util = "0.3"
 metrics = "0.20"
 once_cell = "1.10"
+promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", rev = "488cc2603ba513eed795c0167f24633e55b82eb2" }
 serde.workspace = true
 serde_json = "1.0"
 session = { path = "../session" }

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -62,6 +62,12 @@ pub enum Error {
 
     #[snafu(display("Failure during query planning, source: {}", source))]
     QueryPlan { source: BoxedError },
+
+    #[snafu(display("Failure during query parsing, query: {}, source: {}", query, source))]
+    QueryParse { query: String, source: BoxedError },
+
+    #[snafu(display("The SQL string has multiple statements, query: {}", query))]
+    MultipleStatements { query: String, backtrace: Backtrace },
 }
 
 impl ErrorExt for Error {
@@ -69,6 +75,7 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
+            QueryParse { .. } | MultipleStatements { .. } => StatusCode::InvalidSyntax,
             UnsupportedExpr { .. }
             | CatalogNotFound { .. }
             | SchemaNotFound { .. }

--- a/src/query/src/lib.rs
+++ b/src/query/src/lib.rs
@@ -19,6 +19,7 @@ mod function;
 pub mod logical_optimizer;
 mod metric;
 mod optimizer;
+pub mod parser;
 pub mod physical_optimizer;
 pub mod physical_planner;
 pub mod plan;

--- a/src/query/src/parser.rs
+++ b/src/query/src/parser.rs
@@ -1,0 +1,36 @@
+use common_error::prelude::BoxedError;
+use common_telemetry::timer;
+use promql_parser::parser::EvalStmt;
+use snafu::ResultExt;
+use sql::dialect::GenericDialect;
+use sql::parser::ParserContext;
+use sql::statements::statement::Statement;
+
+use crate::error::{MultipleStatementsSnafu, QueryParseSnafu, Result};
+use crate::metric::METRIC_PARSE_SQL_ELAPSED;
+
+pub enum QueryStatement {
+    SQL(Statement),
+    PromQL(EvalStmt),
+}
+
+pub struct QueryLanguageParser {}
+
+impl QueryLanguageParser {
+    pub fn parse_sql(sql: &str) -> Result<QueryStatement> {
+        let _timer = timer!(METRIC_PARSE_SQL_ELAPSED);
+        let mut statement = ParserContext::create_with_dialect(sql, &GenericDialect {})
+            .map_err(BoxedError::new)
+            .context(QueryParseSnafu {
+                query: sql.to_string(),
+            })?;
+        if statement.len() != 1 {
+            MultipleStatementsSnafu {
+                query: sql.to_string(),
+            }
+            .fail()
+        } else {
+            Ok(QueryStatement::SQL(statement.pop().unwrap()))
+        }
+    }
+}

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -17,6 +17,7 @@ mod state;
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use catalog::CatalogListRef;
 use common_function::scalars::aggregate::AggregateFunctionMetaRef;
 use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
@@ -24,24 +25,23 @@ use common_query::physical_plan::PhysicalPlan;
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
 use session::context::QueryContextRef;
-use sql::statements::statement::Statement;
 
 use crate::datafusion::DatafusionQueryEngine;
 use crate::error::Result;
+use crate::parser::QueryStatement;
 use crate::plan::LogicalPlan;
 pub use crate::query_engine::context::QueryEngineContext;
 pub use crate::query_engine::state::QueryEngineState;
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait QueryEngine: Send + Sync {
     fn name(&self) -> &str;
 
-    fn sql_to_statement(&self, sql: &str) -> Result<Statement>;
-
-    fn statement_to_plan(&self, stmt: Statement, query_ctx: QueryContextRef)
-        -> Result<LogicalPlan>;
-
-    fn sql_to_plan(&self, sql: &str, query_ctx: QueryContextRef) -> Result<LogicalPlan>;
+    fn statement_to_plan(
+        &self,
+        stmt: QueryStatement,
+        query_ctx: QueryContextRef,
+    ) -> Result<LogicalPlan>;
 
     async fn execute(&self, plan: &LogicalPlan) -> Result<Output>;
 

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -30,6 +30,7 @@ use sql::statements::show::{ShowDatabases, ShowKind, ShowTables};
 use sql::statements::statement::Statement;
 
 use crate::error::{self, Result};
+use crate::parser::QueryStatement;
 use crate::QueryEngineRef;
 
 const SCHEMAS_COLUMN: &str = "Schemas";
@@ -157,7 +158,8 @@ pub async fn explain(
     query_engine: QueryEngineRef,
     query_ctx: QueryContextRef,
 ) -> Result<Output> {
-    let plan = query_engine.statement_to_plan(Statement::Explain(*stmt), query_ctx)?;
+    let plan = query_engine
+        .statement_to_plan(QueryStatement::SQL(Statement::Explain(*stmt)), query_ctx)?;
     query_engine.execute(&plan).await
 }
 

--- a/src/query/tests/argmax_test.rs
+++ b/src/query/tests/argmax_test.rs
@@ -23,6 +23,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -83,8 +84,9 @@ async fn execute_argmax<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select ARGMAX({column_name}) as argmax from {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/argmin_test.rs
+++ b/src/query/tests/argmin_test.rs
@@ -23,6 +23,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -83,8 +84,9 @@ async fn execute_argmin<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select argmin({column_name}) as argmin from {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/function.rs
+++ b/src/query/tests/function.rs
@@ -26,6 +26,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::types::WrapperType;
 use datatypes::vectors::Helper;
+use query::parser::QueryLanguageParser;
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
@@ -82,8 +83,9 @@ where
     T: WrapperType,
 {
     let sql = format!("SELECT {column_name} FROM {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/mean_test.rs
+++ b/src/query/tests/mean_test.rs
@@ -26,6 +26,7 @@ use datatypes::value::OrderedFloat;
 use format_num::NumberFormat;
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -79,8 +80,9 @@ async fn execute_mean<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select MEAN({column_name}) as mean from {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/my_sum_udaf_example.rs
+++ b/src/query/tests/my_sum_udaf_example.rs
@@ -33,6 +33,7 @@ use datatypes::vectors::Helper;
 use datatypes::with_match_primitive_type_id;
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngineFactory;
 use session::context::QueryContext;
 use table::test_util::MemTable;
@@ -218,7 +219,10 @@ where
     )));
 
     let sql = format!("select MY_SUM({column_name}) as my_sum from {table_name}");
-    let plan = engine.sql_to_plan(&sql, Arc::new(QueryContext::new()))?;
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let plan = engine
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await?;
     let recordbatch_stream = match output {

--- a/src/query/tests/percentile_test.rs
+++ b/src/query/tests/percentile_test.rs
@@ -27,6 +27,7 @@ use datatypes::vectors::Int32Vector;
 use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::{QueryEngine, QueryEngineFactory};
 use session::context::QueryContext;
 use table::test_util::MemTable;
@@ -52,8 +53,9 @@ async fn test_percentile_aggregator() -> Result<()> {
 async fn test_percentile_correctness() -> Result<()> {
     let engine = create_correctness_engine();
     let sql = String::from("select PERCENTILE(corr_number,88.0) as percentile from corr_numbers");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();
@@ -96,8 +98,9 @@ async fn execute_percentile<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select PERCENTILE({column_name},50.0) as percentile from {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/polyval_test.rs
+++ b/src/query/tests/polyval_test.rs
@@ -23,6 +23,7 @@ use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -79,8 +80,9 @@ async fn execute_polyval<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select POLYVAL({column_name}, 0) as polyval from {table_name}");
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/query_engine_test.rs
+++ b/src/query/tests/query_engine_test.rs
@@ -34,6 +34,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::UInt32Vector;
 use query::error::{QueryExecutionSnafu, Result};
+use query::parser::QueryLanguageParser;
 use query::plan::LogicalPlan;
 use query::query_engine::QueryEngineFactory;
 use session::context::QueryContext;
@@ -144,10 +145,12 @@ async fn test_udf() -> Result<()> {
 
     engine.register_udf(udf);
 
-    let plan = engine.sql_to_plan(
-        "select my_pow(number, number) as p from numbers limit 10",
-        Arc::new(QueryContext::new()),
-    )?;
+    let stmt =
+        QueryLanguageParser::parse_sql("select my_pow(number, number) as p from numbers limit 10")
+            .unwrap();
+    let plan = engine
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
+        .unwrap();
 
     let output = engine.execute(&plan).await?;
     let recordbatch = match output {

--- a/src/query/tests/scipy_stats_norm_cdf_test.rs
+++ b/src/query/tests/scipy_stats_norm_cdf_test.rs
@@ -22,6 +22,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 use statrs::distribution::{ContinuousCDF, Normal};
@@ -78,8 +79,9 @@ async fn execute_scipy_stats_norm_cdf<'a>(
     let sql = format!(
         "select SCIPYSTATSNORMCDF({column_name},2.0) as scipy_stats_norm_cdf from {table_name}",
     );
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/query/tests/scipy_stats_norm_pdf.rs
+++ b/src/query/tests/scipy_stats_norm_pdf.rs
@@ -22,6 +22,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
+use query::parser::QueryLanguageParser;
 use query::QueryEngine;
 use session::context::QueryContext;
 use statrs::distribution::{Continuous, Normal};
@@ -78,8 +79,9 @@ async fn execute_scipy_stats_norm_pdf<'a>(
     let sql = format!(
         "select SCIPYSTATSNORMPDF({column_name},2.0) as scipy_stats_norm_pdf from {table_name}"
     );
+    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
     let plan = engine
-        .sql_to_plan(&sql, Arc::new(QueryContext::new()))
+        .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
 
     let output = engine.execute(&plan).await.unwrap();

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -25,6 +25,7 @@ use common_recordbatch::error::{ExternalSnafu, Result as RecordBatchResult};
 use common_recordbatch::{RecordBatch, RecordBatchStream, SendableRecordBatchStream};
 use datatypes::schema::SchemaRef;
 use futures::Stream;
+use query::parser::{QueryLanguageParser, QueryStatement};
 use query::QueryEngineRef;
 use session::context::QueryContext;
 use snafu::{ensure, ResultExt};
@@ -89,9 +90,9 @@ impl Script for PyScript {
 
     async fn execute(&self, _ctx: EvalContext) -> Result<Output> {
         if let Some(sql) = &self.copr.deco_args.sql {
-            let stmt = self.query_engine.sql_to_statement(sql)?;
+            let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
             ensure!(
-                matches!(stmt, Statement::Query { .. }),
+                matches!(stmt, QueryStatement::SQL(Statement::Query { .. })),
                 error::UnsupportedSqlSnafu { sql }
             );
             let plan = self

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -25,6 +25,7 @@ use common_time::util;
 use datatypes::prelude::{ConcreteDataType, ScalarVector};
 use datatypes::schema::{ColumnSchema, Schema, SchemaBuilder};
 use datatypes::vectors::{StringVector, TimestampMillisecondVector, Vector, VectorRef};
+use query::parser::QueryLanguageParser;
 use query::QueryEngineRef;
 use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -144,11 +145,11 @@ impl ScriptsTable {
         // TODO(dennis): we use sql to find the script, the better way is use a function
         //               such as `find_record_by_primary_key` in table_engine.
         let sql = format!("select script from {} where name='{}'", self.name(), name);
-
+        let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
         let plan = self
             .query_engine
-            .sql_to_plan(&sql, Arc::new(QueryContext::new()))
-            .context(FindScriptSnafu { name })?;
+            .statement_to_plan(stmt, Arc::new(QueryContext::new()))
+            .unwrap();
 
         let stream = match self
             .query_engine

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -20,6 +20,7 @@ use catalog::local::{MemoryCatalogManager, MemoryCatalogProvider, MemorySchemaPr
 use catalog::{CatalogList, CatalogProvider, SchemaProvider};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::Output;
+use query::parser::QueryLanguageParser;
 use query::{QueryEngineFactory, QueryEngineRef};
 use servers::error::Result;
 use servers::query_handler::{
@@ -56,7 +57,11 @@ impl DummyInstance {
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
     async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
-        let plan = self.query_engine.sql_to_plan(query, query_ctx).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(query,).unwrap();
+        let plan = self
+            .query_engine
+            .statement_to_plan(stmt, query_ctx)
+            .unwrap();
         let output = self.query_engine.execute(&plan).await.unwrap();
         vec![Ok(output)]
     }


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch
- remove parse methods (`sql_*`) from `QueryEngine` trait
- Add a standalone parse util struct `QueryLanguageParser` and an enum of variant statements `QueryStatement`
- and fixes the compile errors come from above changes

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes #830