### PR TITLE
feat: in memory storage on meta leader

### DIFF
--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -17,7 +17,7 @@ pub mod etcd;
 use crate::error::Result;
 
 pub const LEASE_SECS: i64 = 3;
-pub const PROCLAIM_PERIOD_SECS: u64 = LEASE_SECS as u64 * 2 / 3;
+pub const KEEP_ALIVE_PERIOD_SECS: u64 = LEASE_SECS as u64 * 2 / 3;
 pub const ELECTION_KEY: &str = "__meta_srv_election";
 
 #[async_trait::async_trait]

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -27,6 +27,13 @@ pub trait Election: Send + Sync {
     /// Returns `true` if current node is the leader.
     fn is_leader(&self) -> bool;
 
+    /// When a new leader is born, it may need some initialization
+    /// operations (asynchronous), this method tells us when these
+    /// initialization operations can be performed.
+    ///
+    /// note: a new leader will only return true on the first call.
+    fn in_infancy(&self) -> bool;
+
     /// Campaign waits to acquire leadership in an election.
     ///
     /// Multiple sessions can participate in the election,

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -20,7 +20,7 @@ use common_telemetry::{info, warn};
 use etcd_client::Client;
 use snafu::{OptionExt, ResultExt};
 
-use crate::election::{Election, ELECTION_KEY, LEASE_SECS, PROCLAIM_PERIOD_SECS};
+use crate::election::{Election, ELECTION_KEY, KEEP_ALIVE_PERIOD_SECS, LEASE_SECS};
 use crate::error;
 use crate::error::Result;
 use crate::metasrv::{ElectionRef, LeaderValue};
@@ -67,22 +67,21 @@ impl Election for EtcdElection {
             .context(error::EtcdFailedSnafu)?;
         let lease_id = res.id();
 
-        info!("Election grant ttl: {:?}, id: {:?}", res.ttl(), lease_id);
+        info!("Election grant ttl: {:?}, lease: {:?}", res.ttl(), lease_id);
 
-        // campaign
+        // Campaign, waits to acquire leadership in an election, returning
+        // a LeaderKey representing the leadership if successful.
+        //
+        // The method will be blocked until the election is won, and after
+        // passing the method, it is necessary to execute `keep_alive` immediately
+        // to confirm that it is a valid leader, because it is possible that the
+        // election's lease expires.
         let res = election_client
             .campaign(ELECTION_KEY, self.leader_value.clone(), lease_id)
             .await
             .context(error::EtcdFailedSnafu)?;
 
         if let Some(leader) = res.leader() {
-            info!(
-                "[{}] becoming leader: {:?}, lease: {}",
-                &self.leader_value,
-                leader.name_str(),
-                leader.lease()
-            );
-
             let (mut keeper, mut receiver) = self
                 .client
                 .lease_client()
@@ -90,17 +89,30 @@ impl Election for EtcdElection {
                 .await
                 .context(error::EtcdFailedSnafu)?;
 
-            let mut interval = tokio::time::interval(Duration::from_secs(PROCLAIM_PERIOD_SECS));
+            let mut keep_alive_interval =
+                tokio::time::interval(Duration::from_secs(KEEP_ALIVE_PERIOD_SECS));
             loop {
-                interval.tick().await;
+                keep_alive_interval.tick().await;
                 keeper.keep_alive().await.context(error::EtcdFailedSnafu)?;
 
                 if let Some(res) = receiver.message().await.context(error::EtcdFailedSnafu)? {
                     if res.ttl() > 0 {
-                        self.is_leader.store(true, Ordering::Relaxed);
+                        // Only after a successful `keep_alive` is the leader considered official.
+                        if self
+                            .is_leader
+                            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                            .is_ok()
+                        {
+                            info!(
+                                "[{}] becoming leader: {:?}, lease: {}",
+                                &self.leader_value,
+                                leader.name_str(),
+                                leader.lease()
+                            );
+                        }
                     } else {
                         warn!(
-                            "Already lost leader status, lease: {}, will re-initiate election",
+                            "Failed to keep-alive, lease: {}, will re-initiate election",
                             leader.lease()
                         );
                         break;

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -14,12 +14,14 @@
 
 pub use check_leader_handler::CheckLeaderHandler;
 pub use collect_stats_handler::CollectStatsHandler;
+pub use initialize_memory_handler::InitializeMemoryHandler;
 pub use keep_lease_handler::KeepLeaseHandler;
 pub use persist_stats_handler::PersistStatsHandler;
 pub use response_header_handler::ResponseHeaderHandler;
 
 mod check_leader_handler;
 mod collect_stats_handler;
+mod initialize_memory_handler;
 mod instruction;
 mod keep_lease_handler;
 pub(crate) mod node_stat;

--- a/src/meta-srv/src/handler/check_leader_handler.rs
+++ b/src/meta-srv/src/handler/check_leader_handler.rs
@@ -26,7 +26,7 @@ impl HeartbeatHandler for CheckLeaderHandler {
     async fn handle(
         &self,
         _req: &HeartbeatRequest,
-        ctx: &Context,
+        ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         if let Some(election) = &ctx.election {

--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -58,7 +58,7 @@ impl HeartbeatHandler for CollectStatsHandler {
             return Ok(());
         }
 
-        match Stat::try_from(req) {
+        match Stat::try_from(req.clone()) {
             Ok(stat) => {
                 let key = (stat.cluster_id, stat.id);
                 match self.cache.entry(key) {

--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -51,7 +51,7 @@ impl HeartbeatHandler for CollectStatsHandler {
     async fn handle(
         &self,
         req: &HeartbeatRequest,
-        ctx: &Context,
+        ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         if ctx.is_skip_all() {

--- a/src/meta-srv/src/handler/initialize_memory_handler.rs
+++ b/src/meta-srv/src/handler/initialize_memory_handler.rs
@@ -1,0 +1,50 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use api::v1::meta::HeartbeatRequest;
+
+use crate::error::Result;
+use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
+use crate::metasrv::Context;
+use crate::service::store::memory::MemStore;
+
+#[derive(Default)]
+pub struct InitializeMemoryHandler {
+    in_memory: Arc<MemStore>,
+}
+
+impl InitializeMemoryHandler {
+    pub fn new(in_memory: Arc<MemStore>) -> Self {
+        Self { in_memory }
+    }
+}
+
+#[async_trait::async_trait]
+impl HeartbeatHandler for InitializeMemoryHandler {
+    async fn handle(
+        &self,
+        _req: &HeartbeatRequest,
+        ctx: &Context,
+        _acc: &mut HeartbeatAccumulator,
+    ) -> Result<()> {
+        if let Some(election) = &ctx.election {
+            if election.in_infancy() {
+                self.in_memory.clear();
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/meta-srv/src/handler/keep_lease_handler.rs
+++ b/src/meta-srv/src/handler/keep_lease_handler.rs
@@ -58,7 +58,7 @@ impl HeartbeatHandler for KeepLeaseHandler {
     async fn handle(
         &self,
         req: &HeartbeatRequest,
-        ctx: &Context,
+        ctx: &mut Context,
         _acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         if ctx.is_skip_all() {

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -69,10 +69,10 @@ impl Stat {
     }
 }
 
-impl TryFrom<&HeartbeatRequest> for Stat {
+impl TryFrom<HeartbeatRequest> for Stat {
     type Error = ();
 
-    fn try_from(value: &HeartbeatRequest) -> Result<Self, Self::Error> {
+    fn try_from(value: HeartbeatRequest) -> Result<Self, Self::Error> {
         let HeartbeatRequest {
             header,
             peer,
@@ -87,8 +87,8 @@ impl TryFrom<&HeartbeatRequest> for Stat {
                 timestamp_millis: time_util::current_time_millis(),
                 cluster_id: header.cluster_id,
                 id: peer.id,
-                addr: peer.addr.clone(),
-                is_leader: *is_leader,
+                addr: peer.addr,
+                is_leader,
                 rcus: node_stat.rcus,
                 wcus: node_stat.wcus,
                 table_num: node_stat.table_num,
@@ -97,15 +97,15 @@ impl TryFrom<&HeartbeatRequest> for Stat {
                 load: node_stat.load,
                 read_io_rate: node_stat.read_io_rate,
                 write_io_rate: node_stat.write_io_rate,
-                region_stats: region_stats.iter().map(RegionStat::from).collect(),
+                region_stats: region_stats.into_iter().map(RegionStat::from).collect(),
             }),
             _ => Err(()),
         }
     }
 }
 
-impl From<&api::v1::meta::RegionStat> for RegionStat {
-    fn from(value: &api::v1::meta::RegionStat) -> Self {
+impl From<api::v1::meta::RegionStat> for RegionStat {
+    fn from(value: api::v1::meta::RegionStat) -> Self {
         let table = value.table_name.as_ref();
         Self {
             id: value.region_id,

--- a/src/meta-srv/src/handler/on_leader_start.rs
+++ b/src/meta-srv/src/handler/on_leader_start.rs
@@ -12,37 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use api::v1::meta::HeartbeatRequest;
 
 use crate::error::Result;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
-use crate::service::store::memory::MemStore;
 
 #[derive(Default)]
-pub struct InitializeMemoryHandler {
-    in_memory: Arc<MemStore>,
-}
-
-impl InitializeMemoryHandler {
-    pub fn new(in_memory: Arc<MemStore>) -> Self {
-        Self { in_memory }
-    }
-}
+pub struct OnLeaderStartHandler;
 
 #[async_trait::async_trait]
-impl HeartbeatHandler for InitializeMemoryHandler {
+impl HeartbeatHandler for OnLeaderStartHandler {
     async fn handle(
         &self,
         _req: &HeartbeatRequest,
-        ctx: &Context,
+        ctx: &mut Context,
         _acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         if let Some(election) = &ctx.election {
             if election.in_infancy() {
-                self.in_memory.clear();
+                ctx.reset_in_memory();
             }
         }
         Ok(())

--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -43,7 +43,7 @@ impl HeartbeatHandler for PersistStatsHandler {
         // take stats from &mut acc.stats, avoid clone of vec
         let stats = std::mem::take(stats);
 
-        let val = &StatValue { stats };
+        let val = StatValue { stats };
 
         let put = PutRequest {
             key: key.into(),

--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -71,10 +71,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_datanode_stats() {
+        let in_memory = Arc::new(MemStore::new());
         let kv_store = Arc::new(MemStore::new());
         let ctx = Context {
             datanode_lease_secs: 30,
             server_addr: "127.0.0.1:0000".to_string(),
+            in_memory,
             kv_store,
             election: None,
             skip_all: Arc::new(AtomicBool::new(false)),

--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -27,7 +27,7 @@ impl HeartbeatHandler for PersistStatsHandler {
     async fn handle(
         &self,
         _req: &HeartbeatRequest,
-        ctx: &Context,
+        ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         if ctx.is_skip_all() || acc.stats.is_empty() {
@@ -73,7 +73,7 @@ mod tests {
     async fn test_handle_datanode_stats() {
         let in_memory = Arc::new(MemStore::new());
         let kv_store = Arc::new(MemStore::new());
-        let ctx = Context {
+        let mut ctx = Context {
             datanode_lease_secs: 30,
             server_addr: "127.0.0.1:0000".to_string(),
             in_memory,
@@ -94,7 +94,10 @@ mod tests {
         };
 
         let stats_handler = PersistStatsHandler;
-        stats_handler.handle(&req, &ctx, &mut acc).await.unwrap();
+        stats_handler
+            .handle(&req, &mut ctx, &mut acc)
+            .await
+            .unwrap();
 
         let key = StatKey {
             cluster_id: 3,

--- a/src/meta-srv/src/handler/response_header_handler.rs
+++ b/src/meta-srv/src/handler/response_header_handler.rs
@@ -53,10 +53,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_heartbeat_resp_header() {
+        let in_memory = Arc::new(MemStore::new());
         let kv_store = Arc::new(MemStore::new());
         let ctx = Context {
             datanode_lease_secs: 30,
             server_addr: "127.0.0.1:0000".to_string(),
+            in_memory,
             kv_store,
             election: None,
             skip_all: Arc::new(AtomicBool::new(false)),

--- a/src/meta-srv/src/handler/response_header_handler.rs
+++ b/src/meta-srv/src/handler/response_header_handler.rs
@@ -26,7 +26,7 @@ impl HeartbeatHandler for ResponseHeaderHandler {
     async fn handle(
         &self,
         req: &HeartbeatRequest,
-        _ctx: &Context,
+        _ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
         let HeartbeatRequest { header, .. } = req;
@@ -55,7 +55,7 @@ mod tests {
     async fn test_handle_heartbeat_resp_header() {
         let in_memory = Arc::new(MemStore::new());
         let kv_store = Arc::new(MemStore::new());
-        let ctx = Context {
+        let mut ctx = Context {
             datanode_lease_secs: 30,
             server_addr: "127.0.0.1:0000".to_string(),
             in_memory,
@@ -71,7 +71,10 @@ mod tests {
         let mut acc = HeartbeatAccumulator::default();
 
         let response_handler = ResponseHeaderHandler {};
-        response_handler.handle(&req, &ctx, &mut acc).await.unwrap();
+        response_handler
+            .handle(&req, &mut ctx, &mut acc)
+            .await
+            .unwrap();
         let header = std::mem::take(&mut acc.header);
         let res = HeartbeatResponse {
             header,

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -228,11 +228,11 @@ pub struct StatValue {
     pub stats: Vec<Stat>,
 }
 
-impl TryFrom<&StatValue> for Vec<u8> {
+impl TryFrom<StatValue> for Vec<u8> {
     type Error = error::Error;
 
-    fn try_from(stats: &StatValue) -> Result<Self> {
-        Ok(serde_json::to_string(stats)
+    fn try_from(stats: StatValue) -> Result<Self> {
+        Ok(serde_json::to_string(&stats)
             .context(crate::error::SerializeToJsonSnafu {
                 input: format!("{stats:?}"),
             })?
@@ -286,7 +286,7 @@ mod tests {
             ..Default::default()
         };
 
-        let stat_val = &StatValue { stats: vec![stat] };
+        let stat_val = StatValue { stats: vec![stat] };
 
         let bytes: Vec<u8> = stat_val.try_into().unwrap();
         let stat_val: StatValue = bytes.try_into().unwrap();

--- a/src/meta-srv/src/service/store/etcd.rs
+++ b/src/meta-srv/src/service/store/etcd.rs
@@ -29,7 +29,6 @@ use crate::error;
 use crate::error::Result;
 use crate::service::store::kv::{KvStore, KvStoreRef};
 
-#[derive(Clone)]
 pub struct EtcdStore {
     client: Client,
 }

--- a/src/meta-srv/src/service/store/kv.rs
+++ b/src/meta-srv/src/service/store/kv.rs
@@ -23,6 +23,7 @@ use api::v1::meta::{
 use crate::error::Result;
 
 pub type KvStoreRef = Arc<dyn KvStore>;
+pub type ResetableKvStoreRef = Arc<dyn ResetableKvStore>;
 
 #[async_trait::async_trait]
 pub trait KvStore: Send + Sync {
@@ -37,4 +38,8 @@ pub trait KvStore: Send + Sync {
     async fn delete_range(&self, req: DeleteRangeRequest) -> Result<DeleteRangeResponse>;
 
     async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse>;
+}
+
+pub trait ResetableKvStore: KvStore {
+    fn reset(&self);
 }

--- a/src/meta-srv/src/service/store/memory.rs
+++ b/src/meta-srv/src/service/store/memory.rs
@@ -43,7 +43,7 @@ impl MemStore {
         }
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         self.inner.write().clear();
     }
 }

--- a/src/meta-srv/src/service/store/memory.rs
+++ b/src/meta-srv/src/service/store/memory.rs
@@ -24,7 +24,7 @@ use api::v1::meta::{
 use parking_lot::RwLock;
 
 use crate::error::Result;
-use crate::service::store::kv::KvStore;
+use crate::service::store::kv::{KvStore, ResetableKvStore};
 
 pub struct MemStore {
     inner: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
@@ -42,8 +42,10 @@ impl MemStore {
             inner: RwLock::new(Default::default()),
         }
     }
+}
 
-    pub fn clear(&self) {
+impl ResetableKvStore for MemStore {
+    fn reset(&self) {
         self.inner.write().clear();
     }
 }

--- a/src/meta-srv/src/service/store/memory.rs
+++ b/src/meta-srv/src/service/store/memory.rs
@@ -15,7 +15,6 @@
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::ops::Range;
-use std::sync::Arc;
 
 use api::v1::meta::{
     BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
@@ -27,10 +26,8 @@ use parking_lot::RwLock;
 use crate::error::Result;
 use crate::service::store::kv::KvStore;
 
-/// Only for mock test
-#[derive(Clone)]
 pub struct MemStore {
-    inner: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
+    inner: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
 }
 
 impl Default for MemStore {
@@ -42,8 +39,12 @@ impl Default for MemStore {
 impl MemStore {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(Default::default())),
+            inner: RwLock::new(Default::default()),
         }
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.write().clear();
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Add in memory storage for meta leader, which can be used to temporarily store heartbeat data in the future. Followers and third parties can use the gRPC service to obtain the data.
- Optimize the election process to make the logs look clearer.
- Refactor some From/Into impl

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
