### PR TITLE
feat: handle "USE <catalog>-<schema>" in MySQL

### DIFF
--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -286,6 +286,9 @@ pub enum Error {
 
     #[snafu(display("Missing required field: {}", name))]
     MissingRequiredField { name: String, backtrace: Backtrace },
+
+    #[snafu(display("Cannot find requested database: {}-{}", catalog, schema))]
+    DatabaseNotFound { catalog: String, schema: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -328,7 +331,8 @@ impl ErrorExt for Error {
             | Error::SchemaNotFound { .. }
             | Error::ConstraintNotSupported { .. }
             | Error::SchemaExists { .. }
-            | Error::ParseTimestamp { .. } => StatusCode::InvalidArguments,
+            | Error::ParseTimestamp { .. }
+            | Error::DatabaseNotFound { .. } => StatusCode::InvalidArguments,
 
             // TODO(yingwen): Further categorize http error.
             Error::StartServer { .. }

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -213,10 +213,10 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to insert values to table, source: {}", source))]
-    Insert {
+    #[snafu(display("Failed to create AlterExpr from Alter statement, source: {}", source))]
+    AlterExprFromStmt {
         #[snafu(backtrace)]
-        source: client::Error,
+        source: sql::error::Error,
     },
 
     #[snafu(display("Failed to build CreateExpr on insertion: {}", source))]
@@ -318,10 +318,10 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to convert Arrow schema, source: {}", source))]
-    ConvertArrowSchema {
+    #[snafu(display("{source}"))]
+    InvokeDatanode {
         #[snafu(backtrace)]
-        source: datatypes::error::Error,
+        source: datanode::error::Error,
     },
 
     #[snafu(display("Missing meta_client_opts section in config"))]
@@ -369,6 +369,15 @@ pub enum Error {
         source: table::metadata::TableMetaBuilderError,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Not supported: {}", feat))]
+    NotSupported { feat: String },
+
+    #[snafu(display("Failed to find new columns on insertion: {}", source))]
+    FindNewColumnsOnInsertion {
+        #[snafu(backtrace)]
+        source: common_grpc_expr::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -383,19 +392,21 @@ impl ErrorExt for Error {
             | Error::InvalidInsertRequest { .. }
             | Error::FindPartitionColumn { .. }
             | Error::ColumnValuesNumberMismatch { .. }
-            | Error::RegionKeysSize { .. } => StatusCode::InvalidArguments,
+            | Error::RegionKeysSize { .. }
+            | Error::NotSupported { .. } => StatusCode::InvalidArguments,
 
             Error::RuntimeResource { source, .. } => source.status_code(),
 
             Error::StartServer { source, .. } => source.status_code(),
 
-            Error::ParseSql { source } => source.status_code(),
+            Error::ParseSql { source } | Error::AlterExprFromStmt { source } => {
+                source.status_code()
+            }
 
             Error::Table { source } => source.status_code(),
 
             Error::ConvertColumnDefaultConstraint { source, .. }
-            | Error::ConvertScalarValue { source, .. }
-            | Error::ConvertArrowSchema { source } => source.status_code(),
+            | Error::ConvertScalarValue { source, .. } => source.status_code(),
 
             Error::RequestDatanode { source } => source.status_code(),
 
@@ -431,9 +442,11 @@ impl ErrorExt for Error {
             }
             Error::SchemaNotFound { .. } => StatusCode::InvalidArguments,
             Error::CatalogNotFound { .. } => StatusCode::InvalidArguments,
-            Error::Insert { source, .. } => source.status_code(),
-            Error::BuildCreateExprOnInsertion { source, .. } => source.status_code(),
-            Error::ToTableInsertRequest { source, .. } => source.status_code(),
+
+            Error::BuildCreateExprOnInsertion { source }
+            | Error::ToTableInsertRequest { source }
+            | Error::FindNewColumnsOnInsertion { source } => source.status_code(),
+
             Error::PrimaryKeyNotFound { .. } => StatusCode::InvalidArguments,
             Error::ExecuteStatement { source, .. } => source.status_code(),
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
@@ -442,6 +455,7 @@ impl ErrorExt for Error {
             Error::TableAlreadyExist { .. } => StatusCode::TableAlreadyExists,
             Error::EncodeSubstraitLogicalPlan { source } => source.status_code(),
             Error::BuildVector { source, .. } => source.status_code(),
+            Error::InvokeDatanode { source } => source.status_code(),
         }
     }
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -392,8 +392,9 @@ impl ErrorExt for Error {
             | Error::InvalidInsertRequest { .. }
             | Error::FindPartitionColumn { .. }
             | Error::ColumnValuesNumberMismatch { .. }
-            | Error::RegionKeysSize { .. }
-            | Error::NotSupported { .. } => StatusCode::InvalidArguments,
+            | Error::RegionKeysSize { .. } => StatusCode::InvalidArguments,
+
+            Error::NotSupported { .. } => StatusCode::Unsupported,
 
             Error::RuntimeResource { source, .. } => source.status_code(),
 

--- a/src/frontend/src/instance/distributed/grpc.rs
+++ b/src/frontend/src/instance/distributed/grpc.rs
@@ -16,21 +16,23 @@ use api::v1::ddl_request::Expr as DdlExpr;
 use api::v1::greptime_request::Request;
 use api::v1::GreptimeRequest;
 use async_trait::async_trait;
-use common_error::prelude::BoxedError;
 use common_query::Output;
-use servers::query_handler::GrpcQueryHandler;
-use snafu::{OptionExt, ResultExt};
+use servers::query_handler::grpc::GrpcQueryHandler;
+use snafu::OptionExt;
 
 use crate::error::{self, Result};
 use crate::instance::distributed::DistInstance;
 
-impl DistInstance {
-    async fn handle_grpc_query(&self, query: GreptimeRequest) -> Result<Output> {
+#[async_trait]
+impl GrpcQueryHandler for DistInstance {
+    type Error = error::Error;
+
+    async fn do_query(&self, query: GreptimeRequest) -> Result<Output> {
         let request = query.request.context(error::IncompleteGrpcResultSnafu {
             err_msg: "Missing 'request' in GreptimeRequest",
         })?;
-        let output = match request {
-            Request::Insert(request) => self.handle_dist_insert(request).await?,
+        match request {
+            Request::Insert(request) => self.handle_dist_insert(request).await,
             Request::Query(_) => {
                 unreachable!("Query should have been handled directly in Frontend Instance!")
             }
@@ -39,13 +41,13 @@ impl DistInstance {
                     err_msg: "Missing 'expr' in DDL request",
                 })?;
                 match expr {
-                    DdlExpr::CreateDatabase(expr) => self.handle_create_database(expr).await?,
+                    DdlExpr::CreateDatabase(expr) => self.handle_create_database(expr).await,
                     DdlExpr::CreateTable(mut expr) => {
                         // TODO(LFC): Support creating distributed table through GRPC interface.
                         // Currently only SQL supports it; how to design the fields in CreateTableExpr?
-                        self.create_table(&mut expr, None).await?
+                        self.create_table(&mut expr, None).await
                     }
-                    DdlExpr::Alter(expr) => self.handle_alter_table(expr).await?,
+                    DdlExpr::Alter(expr) => self.handle_alter_table(expr).await,
                     DdlExpr::DropTable(_) => {
                         // TODO(LFC): Implement distributed drop table.
                         // Seems the whole "drop table through GRPC interface" feature is not implemented?
@@ -53,17 +55,6 @@ impl DistInstance {
                     }
                 }
             }
-        };
-        Ok(output)
-    }
-}
-
-#[async_trait]
-impl GrpcQueryHandler for DistInstance {
-    async fn do_query(&self, query: GreptimeRequest) -> servers::error::Result<Output> {
-        self.handle_grpc_query(query)
-            .await
-            .map_err(BoxedError::new)
-            .context(servers::error::ExecuteGrpcQuerySnafu)
+        }
     }
 }

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -42,7 +42,7 @@ mod tests {
     use common_query::Output;
     use common_recordbatch::RecordBatches;
     use itertools::Itertools;
-    use servers::query_handler::SqlQueryHandler;
+    use servers::query_handler::sql::SqlQueryHandler;
     use session::context::QueryContext;
 
     use super::*;

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use api::v1::GreptimeRequest;
+use async_trait::async_trait;
+use common_query::Output;
+use datanode::error::Error as DatanodeError;
+use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
+use servers::query_handler::sql::{SqlQueryHandler, SqlQueryHandlerRef};
+use session::context::QueryContextRef;
+use snafu::ResultExt;
+use sql::statements::statement::Statement;
+
+use crate::error::{self, Result};
+
+pub(crate) struct StandaloneSqlQueryHandler(SqlQueryHandlerRef<DatanodeError>);
+
+impl StandaloneSqlQueryHandler {
+    pub(crate) fn arc(handler: SqlQueryHandlerRef<DatanodeError>) -> Arc<Self> {
+        Arc::new(Self(handler))
+    }
+}
+
+#[async_trait]
+impl SqlQueryHandler for StandaloneSqlQueryHandler {
+    type Error = error::Error;
+
+    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
+        self.0
+            .do_query(query, query_ctx)
+            .await
+            .into_iter()
+            .map(|x| x.context(error::InvokeDatanodeSnafu))
+            .collect()
+    }
+
+    async fn do_statement_query(
+        &self,
+        stmt: Statement,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        self.0
+            .do_statement_query(stmt, query_ctx)
+            .await
+            .context(error::InvokeDatanodeSnafu)
+    }
+
+    fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool> {
+        self.0
+            .is_valid_schema(catalog, schema)
+            .context(error::InvokeDatanodeSnafu)
+    }
+}
+
+pub(crate) struct StandaloneGrpcQueryHandler(GrpcQueryHandlerRef<DatanodeError>);
+
+impl StandaloneGrpcQueryHandler {
+    pub(crate) fn arc(handler: GrpcQueryHandlerRef<DatanodeError>) -> Arc<Self> {
+        Arc::new(Self(handler))
+    }
+}
+
+#[async_trait]
+impl GrpcQueryHandler for StandaloneGrpcQueryHandler {
+    type Error = error::Error;
+
+    async fn do_query(&self, query: GreptimeRequest) -> Result<Output> {
+        self.0
+            .do_query(query)
+            .await
+            .context(error::InvokeDatanodeSnafu)
+    }
+}

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -29,6 +29,7 @@ use meta_srv::mocks::MockInfo;
 use meta_srv::service::store::kv::KvStoreRef;
 use meta_srv::service::store::memory::MemStore;
 use servers::grpc::GrpcServer;
+use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
 use servers::Mode;
 use tempdir::TempDir;
 use tonic::transport::Server;
@@ -110,7 +111,11 @@ pub(crate) async fn create_datanode_client(
 
     // create a mock datanode grpc service, see example here:
     // https://github.com/hyperium/tonic/blob/master/examples/src/mock/mock.rs
-    let datanode_service = GrpcServer::new(datanode_instance, runtime).create_service();
+    let datanode_service = GrpcServer::new(
+        ServerGrpcQueryHandlerAdaptor::arc(datanode_instance),
+        runtime,
+    )
+    .create_service();
     tokio::spawn(async move {
         Server::builder()
             .add_service(datanode_service)

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -30,17 +30,17 @@ use tokio_stream::wrappers::TcpListenerStream;
 
 use crate::error::{AlreadyStartedSnafu, Result, StartGrpcSnafu, TcpBindSnafu};
 use crate::grpc::flight::FlightHandler;
-use crate::query_handler::GrpcQueryHandlerRef;
+use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 use crate::server::Server;
 
 pub struct GrpcServer {
-    query_handler: GrpcQueryHandlerRef,
+    query_handler: ServerGrpcQueryHandlerRef,
     shutdown_tx: Mutex<Option<Sender<()>>>,
     runtime: Arc<Runtime>,
 }
 
 impl GrpcServer {
-    pub fn new(query_handler: GrpcQueryHandlerRef, runtime: Arc<Runtime>) -> Self {
+    pub fn new(query_handler: ServerGrpcQueryHandlerRef, runtime: Arc<Runtime>) -> Self {
         Self {
             query_handler,
             shutdown_tx: Mutex::new(None),

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -35,18 +35,18 @@ use tonic::{Request, Response, Status, Streaming};
 
 use crate::error;
 use crate::grpc::flight::stream::FlightRecordBatchStream;
-use crate::query_handler::GrpcQueryHandlerRef;
+use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 
 type TonicResult<T> = Result<T, Status>;
 type TonicStream<T> = Pin<Box<dyn Stream<Item = TonicResult<T>> + Send + Sync + 'static>>;
 
 pub(crate) struct FlightHandler {
-    handler: GrpcQueryHandlerRef,
+    handler: ServerGrpcQueryHandlerRef,
     runtime: Arc<Runtime>,
 }
 
 impl FlightHandler {
-    pub(crate) fn new(handler: GrpcQueryHandlerRef, runtime: Arc<Runtime>) -> Self {
+    pub(crate) fn new(handler: ServerGrpcQueryHandlerRef, runtime: Arc<Runtime>) -> Self {
         Self { handler, runtime }
     }
 }

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(assert_matches)]
 
+use common_catalog::consts::DEFAULT_CATALOG_NAME;
 use serde::{Deserialize, Serialize};
 
 pub mod auth;
@@ -56,33 +57,34 @@ pub enum Mode {
 /// schema name
 /// - if `[<catalog>-]` is provided, we split database name with `-` and use
 /// `<catalog>` and `<schema>`.
-pub(crate) fn parse_catalog_and_schema_from_client_database_name(db: &str) -> (Option<&str>, &str) {
+pub(crate) fn parse_catalog_and_schema_from_client_database_name(db: &str) -> (&str, &str) {
     let parts = db.splitn(2, '-').collect::<Vec<&str>>();
     if parts.len() == 2 {
-        (Some(parts[0]), parts[1])
+        (parts[0], parts[1])
     } else {
-        (None, db)
+        (DEFAULT_CATALOG_NAME, db)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     #[test]
-    fn test_parse_catalog_and_schema_from_client_database_name() {
+    fn test_parse_catalog_and_schema() {
         assert_eq!(
-            (None, "fullschema"),
-            super::parse_catalog_and_schema_from_client_database_name("fullschema")
+            (DEFAULT_CATALOG_NAME, "fullschema"),
+            parse_catalog_and_schema_from_client_database_name("fullschema")
         );
 
         assert_eq!(
-            (Some("catalog"), "schema"),
-            super::parse_catalog_and_schema_from_client_database_name("catalog-schema")
+            ("catalog", "schema"),
+            parse_catalog_and_schema_from_client_database_name("catalog-schema")
         );
 
         assert_eq!(
-            (Some("catalog"), "schema1-schema2"),
-            super::parse_catalog_and_schema_from_client_database_name("catalog-schema1-schema2")
+            ("catalog", "schema1-schema2"),
+            parse_catalog_and_schema_from_client_database_name("catalog-schema1-schema2")
         );
     }
 }

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -31,7 +31,7 @@ use tokio_rustls::rustls::ServerConfig;
 use crate::auth::UserProviderRef;
 use crate::error::{Error, Result};
 use crate::mysql::handler::MysqlInstanceShim;
-use crate::query_handler::SqlQueryHandlerRef;
+use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 use crate::server::{AbortableStream, BaseTcpServer, Server};
 use crate::tls::TlsOption;
 
@@ -40,14 +40,14 @@ const DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE: usize = 100 * 1024;
 
 pub struct MysqlServer {
     base_server: BaseTcpServer,
-    query_handler: SqlQueryHandlerRef,
+    query_handler: ServerSqlQueryHandlerRef,
     tls: TlsOption,
     user_provider: Option<UserProviderRef>,
 }
 
 impl MysqlServer {
     pub fn create_server(
-        query_handler: SqlQueryHandlerRef,
+        query_handler: ServerSqlQueryHandlerRef,
         io_runtime: Arc<Runtime>,
         tls: TlsOption,
         user_provider: Option<UserProviderRef>,
@@ -102,7 +102,7 @@ impl MysqlServer {
     async fn handle(
         stream: TcpStream,
         io_runtime: Arc<Runtime>,
-        query_handler: SqlQueryHandlerRef,
+        query_handler: ServerSqlQueryHandlerRef,
         tls_conf: Option<Arc<ServerConfig>>,
         force_tls: bool,
         user_provider: Option<UserProviderRef>,
@@ -122,7 +122,7 @@ impl MysqlServer {
 
     async fn do_handle(
         stream: TcpStream,
-        query_handler: SqlQueryHandlerRef,
+        query_handler: ServerSqlQueryHandlerRef,
         tls_conf: Option<Arc<ServerConfig>>,
         force_tls: bool,
         user_provider: Option<UserProviderRef>,

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -30,14 +30,14 @@ use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use session::context::QueryContext;
 
 use crate::error::{self, Error, Result};
-use crate::query_handler::SqlQueryHandlerRef;
+use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
 pub struct PostgresServerHandler {
-    query_handler: SqlQueryHandlerRef,
+    query_handler: ServerSqlQueryHandlerRef,
 }
 
 impl PostgresServerHandler {
-    pub fn new(query_handler: SqlQueryHandlerRef) -> Self {
+    pub fn new(query_handler: ServerSqlQueryHandlerRef) -> Self {
         PostgresServerHandler { query_handler }
     }
 }

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -29,7 +29,7 @@ use crate::auth::UserProviderRef;
 use crate::error::Result;
 use crate::postgres::auth_handler::PgAuthStartupHandler;
 use crate::postgres::handler::PostgresServerHandler;
-use crate::query_handler::SqlQueryHandlerRef;
+use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 use crate::server::{AbortableStream, BaseTcpServer, Server};
 use crate::tls::TlsOption;
 
@@ -43,7 +43,7 @@ pub struct PostgresServer {
 impl PostgresServer {
     /// Creates a new Postgres server with provided query_handler and async runtime
     pub fn new(
-        query_handler: SqlQueryHandlerRef,
+        query_handler: ServerSqlQueryHandlerRef,
         tls: TlsOption,
         io_runtime: Arc<Runtime>,
         user_provider: Option<UserProviderRef>,

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod grpc;
+pub mod sql;
+
 use std::sync::Arc;
 
 use api::prometheus::remote::{ReadRequest, WriteRequest};
-use api::v1::GreptimeRequest;
 use async_trait::async_trait;
 use common_query::Output;
-use session::context::QueryContextRef;
-use sql::statements::statement::Statement;
 
 use crate::error::Result;
 use crate::influxdb::InfluxdbRequest;
@@ -36,36 +36,15 @@ use crate::prometheus::Metrics;
 /// used as some kind of "convention", it's the "Q" in "SQL". So we might better stick to the
 /// word "query".
 
-pub type SqlQueryHandlerRef = Arc<dyn SqlQueryHandler + Send + Sync>;
-pub type GrpcQueryHandlerRef = Arc<dyn GrpcQueryHandler + Send + Sync>;
 pub type OpentsdbProtocolHandlerRef = Arc<dyn OpentsdbProtocolHandler + Send + Sync>;
 pub type InfluxdbLineProtocolHandlerRef = Arc<dyn InfluxdbLineProtocolHandler + Send + Sync>;
 pub type PrometheusProtocolHandlerRef = Arc<dyn PrometheusProtocolHandler + Send + Sync>;
 pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
-pub trait SqlQueryHandler {
-    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>>;
-
-    async fn do_statement_query(
-        &self,
-        stmt: Statement,
-        query_ctx: QueryContextRef,
-    ) -> Result<Output>;
-
-    /// check if schema is valid
-    fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool>;
-}
-
-#[async_trait]
 pub trait ScriptHandler {
     async fn insert_script(&self, name: &str, script: &str) -> Result<()>;
     async fn execute_script(&self, name: &str) -> Result<Output>;
-}
-
-#[async_trait]
-pub trait GrpcQueryHandler {
-    async fn do_query(&self, query: GreptimeRequest) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/src/query_handler/grpc.rs
+++ b/src/servers/src/query_handler/grpc.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use api::v1::GreptimeRequest;
+use async_trait::async_trait;
+use common_error::prelude::*;
+use common_query::Output;
+
+use crate::error::{self, Result};
+
+pub type GrpcQueryHandlerRef<E> = Arc<dyn GrpcQueryHandler<Error = E> + Send + Sync>;
+pub type ServerGrpcQueryHandlerRef = GrpcQueryHandlerRef<error::Error>;
+
+#[async_trait]
+pub trait GrpcQueryHandler {
+    type Error: ErrorExt;
+
+    async fn do_query(&self, query: GreptimeRequest) -> std::result::Result<Output, Self::Error>;
+}
+
+pub struct ServerGrpcQueryHandlerAdaptor<E>(GrpcQueryHandlerRef<E>);
+
+impl<E> ServerGrpcQueryHandlerAdaptor<E> {
+    pub fn arc(handler: GrpcQueryHandlerRef<E>) -> Arc<Self> {
+        Arc::new(Self(handler))
+    }
+}
+
+#[async_trait]
+impl<E> GrpcQueryHandler for ServerGrpcQueryHandlerAdaptor<E>
+where
+    E: ErrorExt + Send + Sync + 'static,
+{
+    type Error = error::Error;
+
+    async fn do_query(&self, query: GreptimeRequest) -> Result<Output> {
+        self.0
+            .do_query(query)
+            .await
+            .map_err(BoxedError::new)
+            .context(error::ExecuteGrpcQuerySnafu)
+    }
+}

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -1,0 +1,96 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_error::prelude::*;
+use common_query::Output;
+use session::context::QueryContextRef;
+use sql::statements::statement::Statement;
+
+use crate::error::{self, Result};
+
+pub type SqlQueryHandlerRef<E> = Arc<dyn SqlQueryHandler<Error = E> + Send + Sync>;
+pub type ServerSqlQueryHandlerRef = SqlQueryHandlerRef<error::Error>;
+
+#[async_trait]
+pub trait SqlQueryHandler {
+    type Error: ErrorExt;
+
+    async fn do_query(
+        &self,
+        query: &str,
+        query_ctx: QueryContextRef,
+    ) -> Vec<std::result::Result<Output, Self::Error>>;
+
+    async fn do_statement_query(
+        &self,
+        stmt: Statement,
+        query_ctx: QueryContextRef,
+    ) -> std::result::Result<Output, Self::Error>;
+
+    fn is_valid_schema(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> std::result::Result<bool, Self::Error>;
+}
+
+pub struct ServerSqlQueryHandlerAdaptor<E>(SqlQueryHandlerRef<E>);
+
+impl<E> ServerSqlQueryHandlerAdaptor<E> {
+    pub fn arc(handler: SqlQueryHandlerRef<E>) -> Arc<Self> {
+        Arc::new(Self(handler))
+    }
+}
+
+#[async_trait]
+impl<E> SqlQueryHandler for ServerSqlQueryHandlerAdaptor<E>
+where
+    E: ErrorExt + Send + Sync + 'static,
+{
+    type Error = error::Error;
+
+    async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
+        self.0
+            .do_query(query, query_ctx)
+            .await
+            .into_iter()
+            .map(|x| {
+                x.map_err(BoxedError::new)
+                    .context(error::ExecuteQuerySnafu { query })
+            })
+            .collect()
+    }
+
+    async fn do_statement_query(
+        &self,
+        stmt: Statement,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        self.0
+            .do_statement_query(stmt, query_ctx)
+            .await
+            .map_err(BoxedError::new)
+            .context(error::ExecuteStatementSnafu)
+    }
+
+    fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool> {
+        self.0
+            .is_valid_schema(catalog, schema)
+            .map_err(BoxedError::new)
+            .context(error::CheckDatabaseValiditySnafu)
+    }
+}

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -20,10 +20,11 @@ use axum::{http, Router};
 use axum_test_helper::TestClient;
 use common_query::Output;
 use servers::auth::user_provider::StaticUserProvider;
-use servers::error::Result;
+use servers::error::{Error, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
-use servers::query_handler::{InfluxdbLineProtocolHandler, SqlQueryHandler};
+use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::InfluxdbLineProtocolHandler;
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
@@ -46,6 +47,8 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
+    type Error = Error;
+
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -21,7 +21,8 @@ use common_query::Output;
 use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
-use servers::query_handler::{OpentsdbProtocolHandler, SqlQueryHandler};
+use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::OpentsdbProtocolHandler;
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
@@ -45,6 +46,8 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
+    type Error = error::Error;
+
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -22,11 +22,12 @@ use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
 use prost::Message;
-use servers::error::Result;
+use servers::error::{Error, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
-use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse, SqlQueryHandler};
+use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse};
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
 
@@ -70,6 +71,8 @@ impl PrometheusProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
+    type Error = Error;
+
     async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
         unimplemented!()
     }

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -15,13 +15,15 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
-use servers::error::Result;
+use servers::error::{self, Result};
 use servers::interceptor::SqlQueryInterceptor;
 use session::context::{QueryContext, QueryContextRef};
 
 pub struct NoopInterceptor;
 
 impl SqlQueryInterceptor for NoopInterceptor {
+    type Error = error::Error;
+
     fn pre_parsing<'a>(&self, query: &'a str, _query_ctx: QueryContextRef) -> Result<Cow<'a, str>> {
         let modified_query = format!("{query};");
         Ok(Cow::Owned(modified_query))

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -22,16 +22,15 @@ use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::Output;
 use query::parser::QueryLanguageParser;
 use query::{QueryEngineFactory, QueryEngineRef};
-use servers::error::Result;
-use servers::query_handler::{
-    ScriptHandler, ScriptHandlerRef, SqlQueryHandler, SqlQueryHandlerRef,
-};
+use servers::error::{Error, Result};
+use servers::query_handler::{ScriptHandler, ScriptHandlerRef};
 use table::test_util::MemTable;
 
 mod http;
 mod mysql;
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
+use servers::query_handler::sql::{ServerSqlQueryHandlerRef, SqlQueryHandler};
 use session::context::QueryContextRef;
 
 mod interceptor;
@@ -56,6 +55,8 @@ impl DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
+    type Error = Error;
+
     async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
         let stmt = QueryLanguageParser::parse_sql(query).unwrap();
         let plan = self
@@ -126,6 +127,6 @@ fn create_testing_script_handler(table: MemTable) -> ScriptHandlerRef {
     Arc::new(create_testing_instance(table)) as _
 }
 
-fn create_testing_sql_query_handler(table: MemTable) -> SqlQueryHandlerRef {
+fn create_testing_sql_query_handler(table: MemTable) -> ServerSqlQueryHandlerRef {
     Arc::new(create_testing_instance(table)) as _
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Handles `USE <catalog>-<schema>` in MySQL, as requested in #798 

Also do some refactors on SqlQueryHandler and GrpcQueryHandler, add associate types for implementors' errors, to get rid of the "map error to BoxedError then snafu context to server error" practice in implementors, gaining more coherence.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#670 