### PR TITLE
chore: add custom log level support for `common_telemetry::init_default_ut_logging()`

### DIFF
--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -45,7 +45,8 @@ pub fn init_default_ut_logging() {
         let dir =
             env::var("UNITTEST_LOG_DIR").unwrap_or_else(|_| "/tmp/__unittest_logs".to_string());
 
-        *g = Some(init_global_logging("unittest", &dir, "DEBUG", false));
+        let level = env::var("UNITTEST_LOG_LEVEL").unwrap_or_else(|_| "DEBUG".to_string());
+        *g = Some(init_global_logging("unittest", &dir, &level, false));
 
         info!("logs dir = {}", dir);
     });


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add custom log level support for `common_telemetry::init_default_ut_logging()`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
