### PR TITLE
refactor: add schema column to the scripts table

### DIFF
--- a/src/datanode/src/instance/script.rs
+++ b/src/datanode/src/instance/script.rs
@@ -22,13 +22,20 @@ use crate::metric;
 
 #[async_trait]
 impl ScriptHandler for Instance {
-    async fn insert_script(&self, name: &str, script: &str) -> servers::error::Result<()> {
+    async fn insert_script(
+        &self,
+        schema: &str,
+        name: &str,
+        script: &str,
+    ) -> servers::error::Result<()> {
         let _timer = timer!(metric::METRIC_HANDLE_SCRIPTS_ELAPSED);
-        self.script_executor.insert_script(name, script).await
+        self.script_executor
+            .insert_script(schema, name, script)
+            .await
     }
 
-    async fn execute_script(&self, name: &str) -> servers::error::Result<Output> {
+    async fn execute_script(&self, schema: &str, name: &str) -> servers::error::Result<Output> {
         let _timer = timer!(metric::METRIC_RUN_SCRIPT_ELAPSED);
-        self.script_executor.execute_script(name).await
+        self.script_executor.execute_script(schema, name).await
     }
 }

--- a/src/datanode/src/script.rs
+++ b/src/datanode/src/script.rs
@@ -71,10 +71,15 @@ mod python {
             })
         }
 
-        pub async fn insert_script(&self, name: &str, script: &str) -> servers::error::Result<()> {
+        pub async fn insert_script(
+            &self,
+            schema: &str,
+            name: &str,
+            script: &str,
+        ) -> servers::error::Result<()> {
             let _s = self
                 .script_manager
-                .insert_and_compile(name, script)
+                .insert_and_compile(schema, name, script)
                 .await
                 .map_err(|e| {
                     error!(e; "Instance failed to insert script");
@@ -85,9 +90,13 @@ mod python {
             Ok(())
         }
 
-        pub async fn execute_script(&self, name: &str) -> servers::error::Result<Output> {
+        pub async fn execute_script(
+            &self,
+            schema: &str,
+            name: &str,
+        ) -> servers::error::Result<Output> {
             self.script_manager
-                .execute(name)
+                .execute(schema, name)
                 .await
                 .map_err(|e| {
                     error!(e; "Instance failed to execute script");

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -483,9 +483,14 @@ impl SqlQueryHandler for Instance {
 
 #[async_trait]
 impl ScriptHandler for Instance {
-    async fn insert_script(&self, name: &str, script: &str) -> server_error::Result<()> {
+    async fn insert_script(
+        &self,
+        schema: &str,
+        name: &str,
+        script: &str,
+    ) -> server_error::Result<()> {
         if let Some(handler) = &self.script_handler {
-            handler.insert_script(name, script).await
+            handler.insert_script(schema, name, script).await
         } else {
             server_error::NotSupportedSnafu {
                 feat: "Script execution in Frontend",
@@ -494,9 +499,9 @@ impl ScriptHandler for Instance {
         }
     }
 
-    async fn execute_script(&self, script: &str) -> server_error::Result<Output> {
+    async fn execute_script(&self, schema: &str, script: &str) -> server_error::Result<Output> {
         if let Some(handler) = &self.script_handler {
-            handler.execute_script(script).await
+            handler.execute_script(schema, script).await
         } else {
             server_error::NotSupportedSnafu {
                 feat: "Script execution in Frontend",

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -60,8 +60,8 @@ impl ScriptsTable {
             desc: Some("Scripts table".to_string()),
             schema,
             region_numbers: vec![0],
-            // name as primary key
-            primary_key_indices: vec![0],
+            //schema and name as primary key
+            primary_key_indices: vec![0, 1],
             create_if_not_exists: true,
             table_options: HashMap::default(),
         };
@@ -85,8 +85,12 @@ impl ScriptsTable {
         })
     }
 
-    pub async fn insert(&self, name: &str, script: &str) -> Result<()> {
-        let mut columns_values: HashMap<String, VectorRef> = HashMap::with_capacity(7);
+    pub async fn insert(&self, schema: &str, name: &str, script: &str) -> Result<()> {
+        let mut columns_values: HashMap<String, VectorRef> = HashMap::with_capacity(8);
+        columns_values.insert(
+            "schema".to_string(),
+            Arc::new(StringVector::from(vec![schema])) as _,
+        );
         columns_values.insert(
             "name".to_string(),
             Arc::new(StringVector::from(vec![name])) as _,
@@ -114,7 +118,6 @@ impl ScriptsTable {
             "gmt_modified".to_string(),
             Arc::new(TimestampMillisecondVector::from_slice(&[now])) as _,
         );
-
         let table = self
             .catalog_manager
             .table(
@@ -140,12 +143,18 @@ impl ScriptsTable {
         Ok(())
     }
 
-    pub async fn find_script_by_name(&self, name: &str) -> Result<String> {
+    pub async fn find_script_by_name(&self, schema: &str, name: &str) -> Result<String> {
         // FIXME(dennis): SQL injection
         // TODO(dennis): we use sql to find the script, the better way is use a function
         //               such as `find_record_by_primary_key` in table_engine.
-        let sql = format!("select script from {} where name='{}'", self.name(), name);
+        let sql = format!(
+            "select script from {} where schema='{}' and name='{}'",
+            self.name(),
+            schema,
+            name
+        );
         let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+
         let plan = self
             .query_engine
             .statement_to_plan(stmt, Arc::new(QueryContext::new()))
@@ -193,6 +202,11 @@ impl ScriptsTable {
 /// Build scripts table
 fn build_scripts_schema() -> Schema {
     let cols = vec![
+        ColumnSchema::new(
+            "schema".to_string(),
+            ConcreteDataType::string_datatype(),
+            false,
+        ),
         ColumnSchema::new(
             "name".to_string(),
             ConcreteDataType::string_datatype(),

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -43,8 +43,8 @@ pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
 pub trait ScriptHandler {
-    async fn insert_script(&self, name: &str, script: &str) -> Result<()>;
-    async fn execute_script(&self, name: &str) -> Result<Output>;
+    async fn insert_script(&self, schema: &str, name: &str, script: &str) -> Result<()>;
+    async fn execute_script(&self, schema: &str, name: &str) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -104,7 +104,7 @@ def test(n):
     )
     .await;
     assert!(!json.success(), "{json:?}");
-    assert_eq!(json.error().unwrap(), "Invalid argument: invalid name");
+    assert_eq!(json.error().unwrap(), "Invalid argument: invalid schema");
 
     let body = RawBody(Body::from(script));
     let exec = create_script_query();
@@ -124,12 +124,16 @@ def test(n):
 
 fn create_script_query() -> Query<script_handler::ScriptQuery> {
     Query(script_handler::ScriptQuery {
+        schema: Some("test".to_string()),
         name: Some("test".to_string()),
     })
 }
 
 fn create_invalid_script_query() -> Query<script_handler::ScriptQuery> {
-    Query(script_handler::ScriptQuery { name: None })
+    Query(script_handler::ScriptQuery {
+        schema: None,
+        name: None,
+    })
 }
 
 fn create_query() -> Query<http_handler::SqlQuery> {

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -83,7 +83,7 @@ impl SqlQueryHandler for DummyInstance {
 
 #[async_trait]
 impl ScriptHandler for DummyInstance {
-    async fn insert_script(&self, name: &str, script: &str) -> Result<()> {
+    async fn insert_script(&self, schema: &str, name: &str, script: &str) -> Result<()> {
         let script = self
             .py_engine
             .compile(script, CompileContext::default())
@@ -93,13 +93,15 @@ impl ScriptHandler for DummyInstance {
         self.scripts
             .write()
             .unwrap()
-            .insert(name.to_string(), Arc::new(script));
+            .insert(format!("{schema}_{name}"), Arc::new(script));
 
         Ok(())
     }
 
-    async fn execute_script(&self, name: &str) -> Result<Output> {
-        let py_script = self.scripts.read().unwrap().get(name).unwrap().clone();
+    async fn execute_script(&self, schema: &str, name: &str) -> Result<Output> {
+        let key = format!("{schema}_{name}");
+
+        let py_script = self.scripts.read().unwrap().get(&key).unwrap().clone();
 
         Ok(py_script.execute(EvalContext::default()).await.unwrap())
     }

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -33,7 +33,9 @@ async fn test_insert_py_udf_and_query() -> Result<()> {
 def double_that(col)->vector[u32]:
     return col*2
     "#;
-    instance.insert_script("double_that", src).await?;
+    instance
+        .insert_script("schema_test", "double_that", src)
+        .await?;
     let res = instance
         .do_query("select double_that(uint32s) from numbers", query_ctx)
         .await

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -288,7 +288,7 @@ pub async fn test_scripts_api(store_type: StorageType) {
     let client = TestClient::new(app);
 
     let res = client
-        .post("/v1/scripts?name=test")
+        .post("/v1/scripts?schema=schema_test&name=test")
         .body(
             r#"
 @copr(sql='select number from numbers limit 10', args=['number'], returns=['n'])
@@ -305,7 +305,10 @@ def test(n):
     assert!(body.output().is_none());
 
     // call script
-    let res = client.post("/v1/run-script?name=test").send().await;
+    let res = client
+        .post("/v1/run-script?schema=schema_test&name=test")
+        .send()
+        .await;
     assert_eq!(res.status(), StatusCode::OK);
     let body = serde_json::from_str::<JsonResponse>(&res.text().await).unwrap();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

#665 Scripts table should be created for each database/schema

- To fix this issue, we decided to add `schema column` to scripts table. Then all scripts can insert to  scripts table and use `schema column` to specify which schema the script belongs to.

- Currently, I still put scripts table in the default catalog. We will create another issue for supporting `show scripts`  sql command and support http access, this is a proper time to move the `scripts table to system catalog. If I move scripts table to the system catalog in this issue, the scripts isn't visible to users.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#665 