### PR TITLE
feat: add --rpc-hostname option to datanode for a persist address to store in meta

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -1,6 +1,7 @@
 node_id = 42
 mode = 'distributed'
 rpc_addr = '127.0.0.1:3001'
+rpc_hostname = '127.0.0.1'
 rpc_runtime_size = 8
 mysql_addr = '127.0.0.1:4406'
 mysql_runtime_size = 4

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -97,7 +97,9 @@ impl TryFrom<StartCommand> for DatanodeOptions {
             opts.rpc_addr = addr;
         }
 
-        opts.rpc_hostname = cmd.rpc_hostname;
+        if cmd.rpc_hostname.is_some() {
+            opts.rpc_hostname = cmd.rpc_hostname;
+        }
 
         if let Some(addr) = cmd.mysql_addr {
             opts.mysql_addr = addr;

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -54,6 +54,8 @@ struct StartCommand {
     #[clap(long)]
     rpc_addr: Option<String>,
     #[clap(long)]
+    rpc_hostname: Option<String>,
+    #[clap(long)]
     mysql_addr: Option<String>,
     #[clap(long)]
     metasrv_addr: Option<String>,
@@ -94,6 +96,9 @@ impl TryFrom<StartCommand> for DatanodeOptions {
         if let Some(addr) = cmd.rpc_addr {
             opts.rpc_addr = addr;
         }
+
+        opts.rpc_hostname = cmd.rpc_hostname;
+
         if let Some(addr) = cmd.mysql_addr {
             opts.mysql_addr = addr;
         }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -84,6 +84,7 @@ impl Default for WalConfig {
 pub struct DatanodeOptions {
     pub node_id: Option<u64>,
     pub rpc_addr: String,
+    pub rpc_hostname: Option<String>,
     pub rpc_runtime_size: usize,
     pub mysql_addr: String,
     pub mysql_runtime_size: usize,
@@ -99,6 +100,7 @@ impl Default for DatanodeOptions {
         Self {
             node_id: None,
             rpc_addr: "127.0.0.1:3001".to_string(),
+            rpc_hostname: None,
             rpc_runtime_size: 8,
             mysql_addr: "127.0.0.1:4406".to_string(),
             mysql_runtime_size: 2,

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -157,7 +157,7 @@ fn resolve_addr(bind_addr: &str, hostname_addr: &Option<String>) -> String {
             } else {
                 // otherwise, resolve port from bind_addr
                 // should be safe to unwrap here because bind_addr is already validated
-                let port = &bind_addr.split(':').nth(1).unwrap();
+                let port = bind_addr.split(':').nth(1).unwrap();
                 format!("{hostname_addr}:{port}")
             }
         }
@@ -167,7 +167,6 @@ fn resolve_addr(bind_addr: &str, hostname_addr: &Option<String>) -> String {
 
 #[cfg(test)]
 mod tests {
-
     #[test]
     fn test_resolve_addr() {
         assert_eq!(

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -27,6 +27,7 @@ use crate::error::{MetaClientInitSnafu, Result};
 pub struct HeartbeatTask {
     node_id: u64,
     server_addr: String,
+    server_hostname: Option<String>,
     running: Arc<AtomicBool>,
     meta_client: Arc<MetaClient>,
     catalog_manager: CatalogManagerRef,
@@ -44,12 +45,14 @@ impl HeartbeatTask {
     pub fn new(
         node_id: u64,
         server_addr: String,
+        server_hostname: Option<String>,
         meta_client: Arc<MetaClient>,
         catalog_manager: CatalogManagerRef,
     ) -> Self {
         Self {
             node_id,
             server_addr,
+            server_hostname,
             running: Arc::new(AtomicBool::new(false)),
             meta_client,
             catalog_manager,
@@ -97,6 +100,7 @@ impl HeartbeatTask {
         let interval = self.interval;
         let node_id = self.node_id;
         let server_addr = self.server_addr.clone();
+        let server_hostname = self.server_hostname.clone();
         let meta_client = self.meta_client.clone();
 
         let catalog_manager_clone = self.catalog_manager.clone();
@@ -114,7 +118,7 @@ impl HeartbeatTask {
                 let req = HeartbeatRequest {
                     peer: Some(Peer {
                         id: node_id,
-                        addr: server_addr.clone(),
+                        addr: server_hostname.clone().unwrap_or(server_addr.clone()),
                     }),
                     node_stat: Some(NodeStat {
                         region_num,

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -160,6 +160,7 @@ impl Instance {
             Mode::Distributed => Some(HeartbeatTask::new(
                 opts.node_id.context(MissingNodeIdSnafu)?,
                 opts.rpc_addr.clone(),
+                opts.rpc_hostname.clone(),
                 meta_client.as_ref().unwrap().clone(),
                 catalog_manager.clone(),
             )),

--- a/src/datanode/src/mock.rs
+++ b/src/datanode/src/mock.rs
@@ -70,6 +70,7 @@ impl Instance {
         let heartbeat_task = HeartbeatTask::new(
             opts.node_id.unwrap_or(42),
             opts.rpc_addr.clone(),
+            None,
             meta_client.clone(),
             catalog_manager.clone(),
         );


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

At the moment, we stored datanode's grpc IP address in meta. However when this address changes, via a deployment in k8s for example, it's impossible for frontend to find that datanode again. This patch adds a new start option `--rpc-hostname` to `datanode` startup command and it will use value to report to meta.

- this option is optional and it fallback to `--rpc-addr`, this behaviour is completely same to current
- as its name suggests, you can configure hostname and it resolves port from `--rpc-addr`
- user has to guarantee that the `--rpc-hostname` resolves to `--rpc-addr` so that frontend can call datanode via this hostname. User can use `0.0.0.0` in `--rpc-addr` as an exception, if the environment permits


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
