### PR TITLE
fix: impl total order for Timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ name = "common-time"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "snafu",
@@ -7223,6 +7224,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "common-telemetry",
+ "common-time",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -9,3 +9,6 @@ chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
+
+[dev-dependencies]
+rand = "0.8"

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -20,7 +20,7 @@ use crate::Timestamp;
 ///
 /// The time range contains all timestamp `ts` that `ts >= start` and `ts < end`. It is
 /// empty if `start >= end`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GenericRange<T> {
     start: Option<T>,
     end: Option<T>,
@@ -123,7 +123,7 @@ impl<T> GenericRange<T> {
         }
     }
 
-    pub fn all() -> GenericRange<T> {
+    pub fn min_to_max() -> GenericRange<T> {
         Self {
             start: None,
             end: None,
@@ -256,7 +256,7 @@ mod tests {
         assert!(empty.is_empty());
 
         // whatever AND'ed with empty shall return empty
-        let empty_and_all = empty.and(&TimestampRange::all());
+        let empty_and_all = empty.and(&TimestampRange::min_to_max());
         assert!(empty_and_all.is_empty());
         assert!(empty.and(&empty).is_empty());
         assert!(empty
@@ -291,8 +291,8 @@ mod tests {
         );
 
         assert_eq!(
-            TimestampRange::all(),
-            TimestampRange::all().or(&TimestampRange::all())
+            TimestampRange::min_to_max(),
+            TimestampRange::min_to_max().or(&TimestampRange::min_to_max())
         );
 
         let empty = TimestampRange::empty_with_value(Timestamp::new_millisecond(1)).or(

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -66,11 +66,11 @@ where
     /// instead of `[1, 2) ∪ [4, 5)`
     pub fn or(&self, other: &GenericRange<T>) -> GenericRange<T> {
         if self.is_empty() {
-            return other.clone();
+            return *other;
         }
 
         if other.is_empty() {
-            return self.clone();
+            return *self;
         }
         let start = match (self.start(), other.start()) {
             (Some(l), Some(r)) => {

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -223,6 +223,25 @@ mod tests {
     }
 
     #[test]
+    fn test_range_with_diff_unit() {
+        let r1 = TimestampRange::with_unit(1, 2, TimeUnit::Second).unwrap();
+        let r2 = TimestampRange::with_unit(1000, 2000, TimeUnit::Millisecond).unwrap();
+        assert_eq!(r2, r1);
+
+        let r3 = TimestampRange::with_unit(0, 0, TimeUnit::Second).unwrap();
+        let r4 = TimestampRange::with_unit(0, 0, TimeUnit::Millisecond).unwrap();
+        assert_eq!(r3, r4);
+
+        let r5 = TimestampRange::with_unit(0, 0, TimeUnit::Millisecond).unwrap();
+        let r6 = TimestampRange::with_unit(0, 0, TimeUnit::Microsecond).unwrap();
+        assert_eq!(r5, r6);
+
+        let r5 = TimestampRange::with_unit(-1, 1, TimeUnit::Second).unwrap();
+        let r6 = TimestampRange::with_unit(-1000, 1000, TimeUnit::Millisecond).unwrap();
+        assert_eq!(r5, r6);
+    }
+
+    #[test]
     fn test_range_and() {
         assert_eq!(
             TimestampRange::with_unit(5, 10, TimeUnit::Millisecond).unwrap(),

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -255,6 +255,11 @@ impl PartialOrd for Timestamp {
 /// total order.
 impl Ord for Timestamp {
     fn cmp(&self, other: &Self) -> Ordering {
+        // fast path: most comparisons use the same unit.
+        if self.unit == other.unit {
+            return self.value.cmp(&other.value);
+        }
+
         let (s_sec, s_nsec) = self.split();
         let (o_sec, o_nsec) = other.split();
         match s_sec.cmp(&o_sec) {

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -343,7 +343,7 @@ mod tests {
     fn test_timestamp_reflexivity() {
         for _ in 0..1000 {
             let ts = gen_random_ts();
-            assert!(ts >= ts, "ts: {:?}", ts);
+            assert!(ts >= ts, "ts: {ts:?}");
         }
     }
 
@@ -359,25 +359,25 @@ mod tests {
         let t0 = Timestamp::new_millisecond(100);
         let t1 = gen_ts_le(&t0);
         let t2 = gen_ts_le(&t1);
-        assert!(t0 >= t1, "t0: {:?}, t1: {:?}", t0, t1);
-        assert!(t1 >= t2, "t1: {:?}, t2: {:?}", t1, t2);
-        assert!(t0 >= t2, "t0: {:?}, t2: {:?}", t0, t2);
+        assert!(t0 >= t1, "t0: {t0:?}, t1: {t1:?}");
+        assert!(t1 >= t2, "t1: {t1:?}, t2: {t2:?}");
+        assert!(t0 >= t2, "t0: {t0:?}, t2: {t2:?}");
 
         let t0 = Timestamp::new_millisecond(-100);
         let t1 = gen_ts_le(&t0); // t0 >= t1
         let t2 = gen_ts_le(&t1); // t1 >= t2
-        assert!(t0 >= t1, "t0: {:?}, t1: {:?}", t0, t1);
-        assert!(t1 >= t2, "t1: {:?}, t2: {:?}", t1, t2);
-        assert!(t0 >= t2, "t0: {:?}, t2: {:?}", t0, t2); // check if t0 >= t2
+        assert!(t0 >= t1, "t0: {t0:?}, t1: {t1:?}");
+        assert!(t1 >= t2, "t1: {t1:?}, t2: {t2:?}");
+        assert!(t0 >= t2, "t0: {t0:?}, t2: {t2:?}"); // check if t0 >= t2
     }
 
     #[test]
     fn test_antisymmetry() {
         let t0 = Timestamp::new(1, TimeUnit::Second);
         let t1 = Timestamp::new(1000, TimeUnit::Millisecond);
-        assert!(t0 >= t1, "t0: {:?}, t1: {:?}", t0, t1);
-        assert!(t1 >= t0, "t0: {:?}, t1: {:?}", t0, t1);
-        assert_eq!(t1, t0, "t0: {:?}, t1: {:?}", t0, t1);
+        assert!(t0 >= t1, "t0: {t0:?}, t1: {t1:?}");
+        assert!(t1 >= t0, "t0: {t0:?}, t1: {t1:?}");
+        assert_eq!(t1, t0, "t0: {t0:?}, t1: {t1:?}");
     }
 
     #[test]
@@ -389,7 +389,7 @@ mod tests {
 
         for l in &values {
             for r in &values {
-                assert!(l >= r || l <= r, "l: {:?}, r: {:?}", l, r);
+                assert!(l >= r || l <= r, "l: {l:?}, r: {r:?}");
             }
         }
     }
@@ -416,11 +416,11 @@ mod tests {
         let t2 = Timestamp::new(i64::MAX / 1000, TimeUnit::Second);
         assert!(t2 < t1);
 
-        let t1 = Timestamp::new(100 * 1000_1, TimeUnit::Millisecond);
+        let t1 = Timestamp::new(10_010_001, TimeUnit::Millisecond);
         let t2 = Timestamp::new(100, TimeUnit::Second);
         assert!(t1 > t2);
 
-        let t1 = Timestamp::new(-100 * 1000_1, TimeUnit::Millisecond);
+        let t1 = Timestamp::new(-100 * 10_001, TimeUnit::Millisecond);
         let t2 = Timestamp::new(-100, TimeUnit::Second);
         assert!(t2 > t1);
 
@@ -463,11 +463,11 @@ mod tests {
             Timestamp::new(1, TimeUnit::Second),
         );
         check_hash_eq(
-            Timestamp::new(1000_000, TimeUnit::Microsecond),
+            Timestamp::new(1_000_000, TimeUnit::Microsecond),
             Timestamp::new(1, TimeUnit::Second),
         );
         check_hash_eq(
-            Timestamp::new(1000_000_000, TimeUnit::Nanosecond),
+            Timestamp::new(1_000_000_000, TimeUnit::Nanosecond),
             Timestamp::new(1, TimeUnit::Second),
         );
     }
@@ -634,17 +634,17 @@ mod tests {
             ts.convert_to(TimeUnit::Millisecond).unwrap()
         );
         assert_eq!(
-            Timestamp::new(1000_000, TimeUnit::Microsecond),
+            Timestamp::new(1_000_000, TimeUnit::Microsecond),
             ts.convert_to(TimeUnit::Microsecond).unwrap()
         );
         assert_eq!(
-            Timestamp::new(1000_000_000, TimeUnit::Nanosecond),
+            Timestamp::new(1_000_000_000, TimeUnit::Nanosecond),
             ts.convert_to(TimeUnit::Nanosecond).unwrap()
         );
 
-        let ts = Timestamp::new(1000_100_100, TimeUnit::Nanosecond);
+        let ts = Timestamp::new(1_000_100_100, TimeUnit::Nanosecond);
         assert_eq!(
-            Timestamp::new(1000_100, TimeUnit::Microsecond),
+            Timestamp::new(1_000_100, TimeUnit::Microsecond),
             ts.convert_to(TimeUnit::Microsecond).unwrap()
         );
         assert_eq!(
@@ -656,13 +656,13 @@ mod tests {
             ts.convert_to(TimeUnit::Second).unwrap()
         );
 
-        let ts = Timestamp::new(1000_100_100, TimeUnit::Nanosecond);
+        let ts = Timestamp::new(1_000_100_100, TimeUnit::Nanosecond);
         assert_eq!(ts, ts.convert_to(TimeUnit::Nanosecond).unwrap());
-        let ts = Timestamp::new(1000_100_100, TimeUnit::Microsecond);
+        let ts = Timestamp::new(1_000_100_100, TimeUnit::Microsecond);
         assert_eq!(ts, ts.convert_to(TimeUnit::Microsecond).unwrap());
-        let ts = Timestamp::new(1000_100_100, TimeUnit::Millisecond);
+        let ts = Timestamp::new(1_000_100_100, TimeUnit::Millisecond);
         assert_eq!(ts, ts.convert_to(TimeUnit::Millisecond).unwrap());
-        let ts = Timestamp::new(1000_100_100, TimeUnit::Second);
+        let ts = Timestamp::new(1_000_100_100, TimeUnit::Second);
         assert_eq!(ts, ts.convert_to(TimeUnit::Second).unwrap());
 
         // -9223372036854775808 in milliseconds should be rounded up to -9223372036854776 in seconds

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -126,8 +126,10 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                     Value::Binary(v) => row_writer.write_col(v.deref())?,
                     Value::Date(v) => row_writer.write_col(v.val())?,
                     Value::DateTime(v) => row_writer.write_col(v.val())?,
-                    Value::Timestamp(v) => row_writer
-                        .write_col(DateTime::new(v.convert_to(TimeUnit::Second)).to_string())?,
+                    Value::Timestamp(v) => row_writer.write_col(
+                        // safety: converting timestamp with whatever unit to second will not cause overflow
+                        DateTime::new(v.convert_to(TimeUnit::Second).unwrap().value()).to_string(),
+                    )?,
                     Value::List(_) => {
                         return Err(Error::Internal {
                             err_msg: format!(

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -15,6 +15,8 @@
 use std::any::Any;
 
 use common_error::prelude::*;
+use common_time::timestamp::TimeUnit;
+use common_time::Timestamp;
 use datatypes::prelude::ConcreteDataType;
 use sqlparser::parser::ParserError;
 use sqlparser::tokenizer::TokenizerError;
@@ -134,6 +136,17 @@ pub enum Error {
 
     #[snafu(display("Invalid sql value: {}", value))]
     InvalidSqlValue { value: String, backtrace: Backtrace },
+
+    #[snafu(display(
+        "Converting timestamp {:?} to unit {:?} overflow",
+        timestamp,
+        target_unit
+    ))]
+    TimestampOverflow {
+        timestamp: Timestamp,
+        target_unit: TimeUnit,
+        backtrace: Backtrace,
+    },
 }
 
 impl ErrorExt for Error {
@@ -160,6 +173,7 @@ impl ErrorExt for Error {
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),
             ConvertToGrpcDataType { source, .. } => source.status_code(),
             InvalidSqlValue { .. } => StatusCode::InvalidArguments,
+            TimestampOverflow { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -13,6 +13,7 @@ common-error = { path = "../common/error" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry" }
+common-time = { path = "../common/time" }
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
- Reimplement total order for `Timestamp`
- Fix overflow and rounding issue for `Timestamp`
- Rename `TimeRange` to `GenericRange`, and add `and`/`or` methods for `GenericRange`

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
This is the prerequisite of #846 