### PR TITLE
feat: add `authorize` to `UserProvider` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6633,6 +6633,7 @@ dependencies = [
  "script",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "session",
  "sha1",
  "snafu",

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -287,7 +287,7 @@ mod tests {
 
         let provider = provider.unwrap();
         let result = provider
-            .auth(Identity::UserId("test", None), Password::PlainText("test"))
+            .authenticate(Identity::UserId("test", None), Password::PlainText("test"))
             .await;
         assert!(result.is_ok());
     }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -350,7 +350,7 @@ mod tests {
         assert!(provider.is_some());
         let provider = provider.unwrap();
         let result = provider
-            .auth(Identity::UserId("test", None), Password::PlainText("test"))
+            .authenticate(Identity::UserId("test", None), Password::PlainText("test"))
             .await;
         assert!(result.is_ok());
     }

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -77,6 +77,8 @@ pub enum StatusCode {
     AuthHeaderNotFound = 7003,
     /// Invalid http authorization header
     InvalidAuthHeader = 7004,
+    /// Illegal request to connect catalog-schema
+    AccessDenied = 7005,
     // ====== End of auth related status code =====
 }
 

--- a/src/datanode/src/server.rs
+++ b/src/datanode/src/server.rs
@@ -66,7 +66,6 @@ impl Services {
                     mysql_io_runtime,
                     Default::default(),
                     None,
-                    None,
                 ))
             }
         };

--- a/src/datanode/src/server.rs
+++ b/src/datanode/src/server.rs
@@ -66,6 +66,7 @@ impl Services {
                     mysql_io_runtime,
                     Default::default(),
                     None,
+                    None,
                 ))
             }
         };

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use meta_client::MetaClientOpts;
 use serde::{Deserialize, Serialize};
-use servers::auth::UserProviderRef;
 use servers::http::HttpOptions;
 use servers::Mode;
 use snafu::prelude::*;
@@ -92,8 +91,6 @@ impl<T: FrontendInstance> Frontend<T> {
         let instance = Arc::new(instance);
 
         // TODO(sunng87): merge this into instance
-        let provider = self.plugins.get::<UserProviderRef>().cloned();
-
-        Services::start(&self.opts, instance, provider).await
+        Services::start(&self.opts, instance, self.plugins.clone()).await
     }
 }

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -112,6 +112,7 @@ impl Services {
                 opts.tls.clone(),
                 pg_io_runtime,
                 user_provider.clone(),
+                schema_validator.clone(),
             )) as Box<dyn Server>;
 
             Some((pg_server, pg_addr))
@@ -146,6 +147,10 @@ impl Services {
             );
             if let Some(user_provider) = user_provider {
                 http_server.set_user_provider(user_provider);
+            }
+
+            if let Some(schema_validator) = schema_validator {
+                http_server.set_schema_validator(schema_validator);
             }
 
             if opentsdb_server_and_addr.is_some() {

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use common_runtime::Builder as RuntimeBuilder;
 use common_telemetry::info;
-use servers::auth::{SchemaValidatorRef, UserProviderRef};
+use servers::auth::UserProviderRef;
 use servers::grpc::GrpcServer;
 use servers::http::HttpServer;
 use servers::mysql::server::MysqlServer;
@@ -49,7 +49,6 @@ impl Services {
     {
         info!("Starting frontend servers");
         let user_provider = plugins.get::<UserProviderRef>().cloned();
-        let schema_validator = plugins.get::<SchemaValidatorRef>().cloned();
 
         let grpc_server_and_addr = if let Some(opts) = &opts.grpc_options {
             let grpc_addr = parse_addr(&opts.addr)?;
@@ -88,7 +87,6 @@ impl Services {
                 mysql_io_runtime,
                 opts.tls.clone(),
                 user_provider.clone(),
-                schema_validator.clone(),
             );
 
             Some((mysql_server, mysql_addr))
@@ -112,7 +110,6 @@ impl Services {
                 opts.tls.clone(),
                 pg_io_runtime,
                 user_provider.clone(),
-                schema_validator.clone(),
             )) as Box<dyn Server>;
 
             Some((pg_server, pg_addr))
@@ -147,10 +144,6 @@ impl Services {
             );
             if let Some(user_provider) = user_provider {
                 http_server.set_user_provider(user_provider);
-            }
-
-            if let Some(schema_validator) = schema_validator {
-                http_server.set_schema_validator(schema_validator);
             }
 
             if opentsdb_server_and_addr.is_some() {

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -48,6 +48,7 @@ rustls-pemfile = "1.0"
 schemars = "0.8"
 serde.workspace = true
 serde_json = "1.0"
+serde_urlencoded = "0.7"
 session = { path = "../session" }
 sha1 = "0.10"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -85,6 +85,9 @@ pub enum Error {
     #[snafu(display("Illegal runtime param: {}", msg))]
     IllegalParam { msg: String },
 
+    #[snafu(display("Internal state error: {}", msg))]
+    InternalState { msg: String },
+
     #[snafu(display("IO error, source: {}", source))]
     Io {
         source: std::io::Error,
@@ -124,6 +127,7 @@ impl ErrorExt for Error {
         match self {
             Error::InvalidConfig { .. } => StatusCode::InvalidArguments,
             Error::IllegalParam { .. } => StatusCode::InvalidArguments,
+            Error::InternalState { .. } => StatusCode::Unexpected,
             Error::Io { .. } => StatusCode::Internal,
             Error::AuthBackend { .. } => StatusCode::Internal,
 

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -28,7 +28,13 @@ pub mod user_provider;
 pub trait UserProvider: Send + Sync {
     fn name(&self) -> &str;
 
-    async fn auth(&self, id: Identity<'_>, password: Password<'_>) -> Result<UserInfo>;
+    /// [`authenticate`] checks whether a user is valid and allowed to access the database.
+    async fn authenticate(&self, id: Identity<'_>, password: Password<'_>) -> Result<UserInfo>;
+
+    /// [`authorize`] checks whether a connection request
+    /// from a certain user to a certain catalog/schema is legal.
+    /// This method should be called after [`authenticate`].
+    async fn authorize(&self, catalog: &str, schema: &str, user_info: &UserInfo) -> Result<()>;
 }
 
 pub type UserProviderRef = Arc<dyn UserProvider>;
@@ -69,17 +75,6 @@ pub fn user_provider_from_option(opt: &String) -> Result<UserProviderRef> {
         .fail(),
     }
 }
-
-/// [`SchemaValidator`] validates whether a connection request
-/// from a certain user to a certain catalog/schema is legal.
-/// This authorization is performed after a user is authenticated,
-/// so that the user's [`UserInfo`] should be already stored in the session.
-#[async_trait::async_trait]
-pub trait SchemaValidator: Send + Sync {
-    async fn validate(&self, catalog: &str, schema: &str, user_info: &UserInfo) -> Result<()>;
-}
-
-pub type SchemaValidatorRef = Arc<dyn SchemaValidator>;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -149,185 +144,3 @@ impl ErrorExt for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-#[cfg(test)]
-pub mod test_mock_user_provider {
-    use super::{Identity, Password, UserInfo, UserProvider};
-
-    pub struct MockUserProvider {}
-
-    #[async_trait::async_trait]
-    impl UserProvider for MockUserProvider {
-        fn name(&self) -> &str {
-            "mock_user_provider"
-        }
-
-        async fn auth(
-            &self,
-            id: Identity<'_>,
-            password: Password<'_>,
-        ) -> Result<UserInfo, super::Error> {
-            match id {
-                Identity::UserId(username, _host) => match password {
-                    Password::PlainText(password) => {
-                        if username == "greptime" {
-                            if password == "greptime" {
-                                return Ok(UserInfo::new("greptime"));
-                            } else {
-                                return super::UserPasswordMismatchSnafu {
-                                    username: username.to_string(),
-                                }
-                                .fail();
-                            }
-                        } else {
-                            return super::UserNotFoundSnafu {
-                                username: username.to_string(),
-                            }
-                            .fail();
-                        }
-                    }
-                    _ => super::UnsupportedPasswordTypeSnafu {
-                        password_type: "mysql_native_password",
-                    }
-                    .fail(),
-                },
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-pub mod test_mock_schema_validator {
-
-    use session::context::UserInfo;
-
-    use super::SchemaValidator;
-    use crate::auth::AccessDeniedSnafu;
-
-    pub struct MockSchemaValidator {
-        catalog: String,
-        schema: String,
-        username: String,
-    }
-
-    impl MockSchemaValidator {
-        pub fn new(catalog: &str, schema: &str, username: &str) -> Self {
-            Self {
-                catalog: catalog.to_string(),
-                schema: schema.to_string(),
-                username: username.to_string(),
-            }
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl SchemaValidator for MockSchemaValidator {
-        async fn validate(
-            &self,
-            catalog: &str,
-            schema: &str,
-            user_info: &UserInfo,
-        ) -> Result<(), super::Error> {
-            if catalog == self.catalog
-                && schema == self.schema
-                && user_info.username() == self.username
-            {
-                Ok(())
-            } else {
-                AccessDeniedSnafu {
-                    catalog: catalog.to_string(),
-                    schema: schema.to_string(),
-                    username: user_info.username().to_string(),
-                }
-                .fail()
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use session::context::UserInfo;
-
-    use super::test_mock_user_provider::MockUserProvider;
-    use super::{Identity, Password, UserProvider};
-    use crate::auth;
-    use crate::auth::test_mock_schema_validator::MockSchemaValidator;
-    use crate::auth::SchemaValidator;
-
-    #[tokio::test]
-    async fn test_auth_by_plain_text() {
-        let user_provider = MockUserProvider {};
-        assert_eq!("mock_user_provider", user_provider.name());
-
-        // auth success
-        let auth_result = user_provider
-            .auth(
-                Identity::UserId("greptime", None),
-                Password::PlainText("greptime"),
-            )
-            .await;
-        assert!(auth_result.is_ok());
-        assert_eq!("greptime", auth_result.unwrap().username());
-
-        // auth failed, unsupported password type
-        let auth_result = user_provider
-            .auth(
-                Identity::UserId("greptime", None),
-                Password::MysqlNativePassword(b"hashed_value", b"salt"),
-            )
-            .await;
-        assert!(auth_result.is_err());
-        matches!(
-            auth_result.err().unwrap(),
-            auth::Error::UnsupportedPasswordType { .. }
-        );
-
-        // auth failed, err: user not exist.
-        let auth_result = user_provider
-            .auth(
-                Identity::UserId("not_exist_username", None),
-                Password::PlainText("greptime"),
-            )
-            .await;
-        assert!(auth_result.is_err());
-        matches!(auth_result.err().unwrap(), auth::Error::UserNotFound { .. });
-
-        // auth failed, err: wrong password
-        let auth_result = user_provider
-            .auth(
-                Identity::UserId("greptime", None),
-                Password::PlainText("wrong_password"),
-            )
-            .await;
-        assert!(auth_result.is_err());
-        matches!(
-            auth_result.err().unwrap(),
-            auth::Error::UserPasswordMismatch { .. }
-        );
-    }
-
-    #[tokio::test]
-    async fn test_schema_validate() {
-        let validator = MockSchemaValidator::new("greptime", "public", "test_user");
-        let right_user = UserInfo::new("test_user");
-        let wrong_user = UserInfo::default();
-
-        // check catalog
-        let re = validator
-            .validate("greptime_wrong", "public", &right_user)
-            .await;
-        assert!(re.is_err());
-        // check schema
-        let re = validator
-            .validate("greptime", "public_wrong", &right_user)
-            .await;
-        assert!(re.is_err());
-        // check username
-        let re = validator.validate("greptime", "public", &wrong_user).await;
-        assert!(re.is_err());
-        // check ok
-        let re = validator.validate("greptime", "public", &right_user).await;
-        assert!(re.is_ok());
-    }
-}

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -87,6 +87,9 @@ pub enum Error {
     #[snafu(display("Invalid config value: {}, {}", value, msg))]
     InvalidConfig { value: String, msg: String },
 
+    #[snafu(display("Illegal runtime param: {}", msg))]
+    IllegalParam { msg: String },
+
     #[snafu(display("IO error, source: {}", source))]
     Io {
         source: std::io::Error,
@@ -125,6 +128,7 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Error::InvalidConfig { .. } => StatusCode::InvalidArguments,
+            Error::IllegalParam { .. } => StatusCode::InvalidArguments,
             Error::Io { .. } => StatusCode::Internal,
             Error::AuthBackend { .. } => StatusCode::Internal,
 

--- a/src/servers/src/auth/user_provider.rs
+++ b/src/servers/src/auth/user_provider.rs
@@ -99,7 +99,11 @@ impl UserProvider for StaticUserProvider {
         STATIC_USER_PROVIDER
     }
 
-    async fn auth(&self, input_id: Identity<'_>, input_pwd: Password<'_>) -> Result<UserInfo> {
+    async fn authenticate(
+        &self,
+        input_id: Identity<'_>,
+        input_pwd: Password<'_>,
+    ) -> Result<UserInfo> {
         match input_id {
             Identity::UserId(username, _) => {
                 let save_pwd = self.users.get(username).context(UserNotFoundSnafu {
@@ -128,6 +132,11 @@ impl UserProvider for StaticUserProvider {
                 }
             }
         }
+    }
+
+    async fn authorize(&self, _catalog: &str, _schema: &str, _user_info: &UserInfo) -> Result<()> {
+        // default allow all
+        Ok(())
     }
 }
 
@@ -209,7 +218,7 @@ pub mod test {
 
     async fn test_auth(provider: &dyn UserProvider, username: &str, password: &str) {
         let re = provider
-            .auth(
+            .authenticate(
                 Identity::UserId(username, None),
                 Password::PlainText(password),
             )

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -353,6 +353,12 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<auth::Error> for Error {
+    fn from(e: auth::Error) -> Self {
+        Error::Auth { source: e }
+    }
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -24,7 +24,7 @@ use snafu::{OptionExt, ResultExt};
 use tower_http::auth::AsyncAuthorizeRequest;
 
 use crate::auth::Error::IllegalParam;
-use crate::auth::{Identity, IllegalParamSnafu, UserProviderRef};
+use crate::auth::{Identity, IllegalParamSnafu, InternalStateSnafu, UserProviderRef};
 use crate::error::{self, Result};
 use crate::http::HTTP_API_PREFIX;
 
@@ -118,10 +118,8 @@ async fn authorize<B: Send + Sync + 'static>(
     let user_info = request
         .extensions()
         .get::<UserInfo>()
-        .context(IllegalParamSnafu {
-            // should not happen
-            // since authorize should happen after authenticate
-            msg: "fail to get user info from request",
+        .context(InternalStateSnafu {
+            msg: "no user info provided while authorizing",
         })?;
 
     user_provider.authorize(catalog, database, user_info).await

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -114,7 +114,7 @@ async fn authorize<B: Send + Sync + 'static>(
             msg: "fail to get valid database from http query",
         })?,
         Err(e) => IllegalParamSnafu {
-            msg: format!("fail to parse http query: {}", e),
+            msg: format!("fail to parse http query: {e}"),
         }
         .fail()?,
     };
@@ -147,13 +147,13 @@ async fn authenticate<B: Send + Sync + 'static>(
     };
 
     let (scheme, credential) = auth_header(request).map_err(|e| IllegalParam {
-        msg: format!("failed to get http authorize header, err: {:?}", e),
+        msg: format!("failed to get http authorize header, err: {e:?}"),
     })?;
 
     match scheme {
         AuthScheme::Basic => {
             let (username, password) = decode_basic(credential).map_err(|e| IllegalParam {
-                msg: format!("failed to decode basic authorize, err: {:?}", e),
+                msg: format!("failed to decode basic authorize, err: {e:?}"),
             })?;
 
             Ok(user_provider

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -23,19 +23,24 @@ use session::context::UserInfo;
 use snafu::{OptionExt, ResultExt};
 use tower_http::auth::AsyncAuthorizeRequest;
 
-use crate::auth::{Identity, UserProviderRef};
+use crate::auth::{Identity, SchemaValidatorRef, UserProviderRef};
 use crate::error::{self, Result};
 use crate::http::HTTP_API_PREFIX;
 
 pub struct HttpAuth<RespBody> {
     user_provider: Option<UserProviderRef>,
+    schema_validator: Option<SchemaValidatorRef>,
     _ty: PhantomData<RespBody>,
 }
 
 impl<RespBody> HttpAuth<RespBody> {
-    pub fn new(user_provider: Option<UserProviderRef>) -> Self {
+    pub fn new(
+        user_provider: Option<UserProviderRef>,
+        schema_validator: Option<SchemaValidatorRef>,
+    ) -> Self {
         Self {
             user_provider,
+            schema_validator,
             _ty: PhantomData,
         }
     }
@@ -45,6 +50,7 @@ impl<RespBody> Clone for HttpAuth<RespBody> {
     fn clone(&self) -> Self {
         Self {
             user_provider: self.user_provider.clone(),
+            schema_validator: self.schema_validator.clone(),
             _ty: PhantomData,
         }
     }
@@ -190,6 +196,7 @@ mod tests {
     async fn test_http_auth() {
         let mut http_auth: HttpAuth<BoxBody> = HttpAuth {
             user_provider: None,
+            schema_validator: None,
             _ty: PhantomData,
         };
 
@@ -204,6 +211,7 @@ mod tests {
         let mock_user_provider = Some(Arc::new(MockUserProvider {}) as Arc<dyn UserProvider>);
         let mut http_auth: HttpAuth<BoxBody> = HttpAuth {
             user_provider: mock_user_provider,
+            schema_validator: None,
             _ty: PhantomData,
         };
 
@@ -230,6 +238,7 @@ mod tests {
         let mock_user_provider = Some(Arc::new(MockUserProvider {}) as Arc<dyn UserProvider>);
         let mut http_auth: HttpAuth<BoxBody> = HttpAuth {
             user_provider: mock_user_provider,
+            schema_validator: None,
             _ty: PhantomData,
         };
 

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -181,7 +181,7 @@ mod tests {
     use tower_http::auth::AsyncAuthorizeRequest;
 
     use super::{auth_header, decode_basic, AuthScheme, HttpAuth};
-    use crate::auth::test::MockUserProvider;
+    use crate::auth::test_mock_user_provider::MockUserProvider;
     use crate::auth::UserProvider;
     use crate::error;
     use crate::error::Result;

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -28,7 +28,7 @@ use crate::http::{ApiState, JsonResponse};
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SqlQuery {
-    pub database: Option<String>,
+    pub db: Option<String>,
     pub sql: Option<String>,
 }
 
@@ -43,7 +43,7 @@ pub async fn sql(
     let sql_handler = &state.sql_handler;
     let start = Instant::now();
     let resp = if let Some(sql) = &params.sql {
-        match super::query_context_from_db(sql_handler.clone(), params.database) {
+        match super::query_context_from_db(sql_handler.clone(), params.db) {
             Ok(query_ctx) => {
                 JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
             }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -195,7 +195,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
 
         if let Some(schema_validator) = &self.schema_validator {
             schema_validator
-                .validate(catalog, schema, self.session.clone())
+                .validate(catalog, schema, &self.session.user_info())
                 .await?;
         }
 

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -28,7 +28,7 @@ use tokio::io::BufWriter;
 use tokio::net::TcpStream;
 use tokio_rustls::rustls::ServerConfig;
 
-use crate::auth::{SchemaValidatorRef, UserProviderRef};
+use crate::auth::UserProviderRef;
 use crate::error::{Error, Result};
 use crate::mysql::handler::MysqlInstanceShim;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
@@ -43,7 +43,6 @@ struct MysqlRuntimeOption {
     tls_conf: Option<Arc<ServerConfig>>,
     force_tls: bool,
     user_provider: Option<UserProviderRef>,
-    schema_validator: Option<SchemaValidatorRef>,
 }
 
 type MysqlRuntimeOptionRef = Arc<MysqlRuntimeOption>;
@@ -53,7 +52,6 @@ pub struct MysqlServer {
     query_handler: ServerSqlQueryHandlerRef,
     tls: TlsOption,
     user_provider: Option<UserProviderRef>,
-    schema_validator: Option<SchemaValidatorRef>,
 }
 
 impl MysqlServer {
@@ -62,14 +60,12 @@ impl MysqlServer {
         io_runtime: Arc<Runtime>,
         tls: TlsOption,
         user_provider: Option<UserProviderRef>,
-        schema_validator: Option<SchemaValidatorRef>,
     ) -> Box<dyn Server> {
         Box::new(MysqlServer {
             base_server: BaseTcpServer::create_server("MySQL", io_runtime),
             query_handler,
             tls,
             user_provider,
-            schema_validator,
         })
     }
 
@@ -81,7 +77,6 @@ impl MysqlServer {
     ) -> impl Future<Output = ()> {
         let query_handler = self.query_handler.clone();
         let user_provider = self.user_provider.clone();
-        let schema_validator = self.schema_validator.clone();
 
         let force_tls = self.tls.should_force_tls();
 
@@ -89,7 +84,6 @@ impl MysqlServer {
             let io_runtime = io_runtime.clone();
             let query_handler = query_handler.clone();
             let user_provider = user_provider.clone();
-            let schema_validator = schema_validator.clone();
             let tls_conf = tls_conf.clone();
 
             let mysql_runtime_option = Arc::new(MysqlRuntimeOption {
@@ -97,7 +91,6 @@ impl MysqlServer {
                 tls_conf,
                 force_tls,
                 user_provider,
-                schema_validator,
             });
 
             async move {
@@ -138,7 +131,6 @@ impl MysqlServer {
             runtime_opts.query_handler.clone(),
             stream.peer_addr()?,
             runtime_opts.user_provider.clone(),
-            runtime_opts.schema_validator.clone(),
         );
         let (mut r, w) = stream.into_split();
         let mut w = BufWriter::with_capacity(DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE, w);

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -209,18 +209,9 @@ impl StartupHandler for PgAuthStartupHandler {
                 } else {
                     // no user is provided, use default user
                     // and still do authorization
-                    let login_info = LoginInfo {
-                        user: Some(DEFAULT_USERNAME.to_string()),
-                        catalog: client
-                            .metadata()
-                            .get(super::METADATA_CATALOG)
-                            .map(Into::into),
-                        database: client
-                            .metadata()
-                            .get(super::METADATA_SCHEMA)
-                            .map(Into::into),
-                        host: client.socket_addr().ip().to_string(),
-                    };
+                    let mut login_info = LoginInfo::from_client_info(client);
+                    login_info.user = Some(DEFAULT_USERNAME.to_string());
+
                     let authorize_result = self.verifier.authorize(&login_info).await;
                     if !matches!(authorize_result, Ok(true)) {
                         return send_error(

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -39,7 +39,7 @@ struct PgLoginVerifier {
 struct LoginInfo {
     user: Option<String>,
     catalog: Option<String>,
-    database: Option<String>,
+    schema: Option<String>,
     host: String,
 }
 
@@ -54,9 +54,9 @@ impl LoginInfo {
                 .metadata()
                 .get(super::METADATA_CATALOG)
                 .map(Into::into),
-            database: client
+            schema: client
                 .metadata()
-                .get(super::METADATA_DATABASE)
+                .get(super::METADATA_SCHEMA)
                 .map(Into::into),
             host: client.socket_addr().ip().to_string(),
         }
@@ -95,7 +95,7 @@ impl PgLoginVerifier {
                 Some(name) => name,
                 None => return Ok(false),
             };
-            let schema = match &login.database {
+            let schema = match &login.schema {
                 Some(name) => name,
                 None => return Ok(false),
             };

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -86,7 +86,7 @@ impl PgLoginVerifier {
 
     async fn authorize(&self, login: &LoginInfo) -> Result<bool> {
         // at this time, username in login info should be valid
-        // todo(shuiyisong): change to use actually user_info from session
+        // TODO(shuiyisong): change to use actually user_info from session
         if let Some(schema_validator) = &self.schema_validator {
             let user_name = match &login.user {
                 Some(name) => name,

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -23,20 +23,23 @@ use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use pgwire::messages::response::ErrorResponse;
 use pgwire::messages::startup::Authentication;
 use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
+use session::context::UserInfo;
 use snafu::ResultExt;
 
-use crate::auth::{Identity, Password, UserProviderRef};
+use crate::auth::{Identity, Password, SchemaValidatorRef, UserProviderRef};
 use crate::error;
 use crate::error::Result;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
-struct PgPwdVerifier {
+struct PgLoginVerifier {
     user_provider: Option<UserProviderRef>,
+    schema_validator: Option<SchemaValidatorRef>,
 }
 
 #[allow(dead_code)]
 struct LoginInfo {
     user: Option<String>,
+    catalog: Option<String>,
     database: Option<String>,
     host: String,
 }
@@ -48,6 +51,10 @@ impl LoginInfo {
     {
         LoginInfo {
             user: client.metadata().get(super::METADATA_USER).map(Into::into),
+            catalog: client
+                .metadata()
+                .get(super::METADATA_CATALOG)
+                .map(Into::into),
             database: client
                 .metadata()
                 .get(super::METADATA_DATABASE)
@@ -57,10 +64,10 @@ impl LoginInfo {
     }
 }
 
-impl PgPwdVerifier {
-    async fn verify_pwd(&self, password: &str, login: LoginInfo) -> Result<bool> {
+impl PgLoginVerifier {
+    async fn verify_pwd(&self, password: &str, login: &LoginInfo) -> Result<bool> {
         if let Some(user_provider) = &self.user_provider {
-            let user_name = match login.user {
+            let user_name = match &login.user {
                 Some(name) => name,
                 None => return Ok(false),
             };
@@ -68,11 +75,34 @@ impl PgPwdVerifier {
             // TODO(fys): pass user_info to context
             let _user_info = user_provider
                 .auth(
-                    Identity::UserId(&user_name, None),
+                    Identity::UserId(user_name, None),
                     Password::PlainText(password),
                 )
                 .await
                 .context(error::AuthSnafu)?;
+        }
+        Ok(true)
+    }
+
+    async fn authorize(&self, login: &LoginInfo) -> Result<bool> {
+        // at this time, username in login info should be valid
+        // todo(shuiyisong): change to use actually user_info from session
+        if let Some(schema_validator) = &self.schema_validator {
+            let user_name = match &login.user {
+                Some(name) => name,
+                None => return Ok(false),
+            };
+            let catalog = match &login.catalog {
+                Some(name) => name,
+                None => return Ok(false),
+            };
+            let schema = match &login.database {
+                Some(name) => name,
+                None => return Ok(false),
+            };
+            schema_validator
+                .validate(catalog, schema, &UserInfo::new(user_name))
+                .await?;
         }
         Ok(true)
     }
@@ -106,7 +136,7 @@ impl ServerParameterProvider for GreptimeDBStartupParameters {
 }
 
 pub struct PgAuthStartupHandler {
-    verifier: PgPwdVerifier,
+    verifier: PgLoginVerifier,
     param_provider: GreptimeDBStartupParameters,
     force_tls: bool,
     query_handler: ServerSqlQueryHandlerRef,
@@ -115,11 +145,15 @@ pub struct PgAuthStartupHandler {
 impl PgAuthStartupHandler {
     pub fn new(
         user_provider: Option<UserProviderRef>,
+        schema_validator: Option<SchemaValidatorRef>,
         force_tls: bool,
         query_handler: ServerSqlQueryHandlerRef,
     ) -> Self {
         PgAuthStartupHandler {
-            verifier: PgPwdVerifier { user_provider },
+            verifier: PgLoginVerifier {
+                user_provider,
+                schema_validator,
+            },
             param_provider: GreptimeDBStartupParameters::new(),
             force_tls,
             query_handler,
@@ -178,17 +212,30 @@ impl StartupHandler for PgAuthStartupHandler {
             }
             PgWireFrontendMessage::Password(ref pwd) => {
                 let login_info = LoginInfo::from_client_info(client);
-                if let Ok(true) = self.verifier.verify_pwd(pwd.password(), login_info).await {
-                    auth::finish_authentication(client, &self.param_provider).await
-                } else {
-                    send_error(
+                // do authenticate
+                let authenticate_result =
+                    self.verifier.verify_pwd(pwd.password(), &login_info).await;
+                if authenticate_result.is_err() || !authenticate_result.unwrap() {
+                    return send_error(
                         client,
                         "FATAL",
                         "28P01",
-                        "Password authentication failed".to_owned(),
+                        "password authentication failed".to_owned(),
                     )
-                    .await?;
+                    .await;
                 }
+                // do authorize
+                let authorize_result = self.verifier.authorize(&login_info).await;
+                if authorize_result.is_err() || !authorize_result.unwrap() {
+                    return send_error(
+                        client,
+                        "FATAL",
+                        "28P01",
+                        "password authentication failed".to_owned(),
+                    )
+                    .await;
+                }
+                auth::finish_authentication(client, &self.param_provider).await;
             }
             _ => {}
         }

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -222,7 +222,7 @@ impl StartupHandler for PgAuthStartupHandler {
                         host: client.socket_addr().ip().to_string(),
                     };
                     let authorize_result = self.verifier.authorize(&login_info).await;
-                    if authorize_result.is_err() || !authorize_result.unwrap() {
+                    if !matches!(authorize_result, Ok(true)) {
                         return send_error(
                             client,
                             "FATAL",
@@ -239,7 +239,7 @@ impl StartupHandler for PgAuthStartupHandler {
                 // do authenticate
                 let authenticate_result =
                     self.verifier.verify_pwd(pwd.password(), &login_info).await;
-                if authenticate_result.is_err() || !authenticate_result.unwrap() {
+                if !matches!(authenticate_result, Ok(true)) {
                     return send_error(
                         client,
                         "FATAL",
@@ -250,7 +250,7 @@ impl StartupHandler for PgAuthStartupHandler {
                 }
                 // do authorize
                 let authorize_result = self.verifier.authorize(&login_info).await;
-                if authorize_result.is_err() || !authorize_result.unwrap() {
+                if !matches!(authorize_result, Ok(true)) {
                     return send_error(
                         client,
                         "FATAL",

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -25,7 +25,7 @@ use pgwire::tokio::process_socket;
 use tokio;
 use tokio_rustls::TlsAcceptor;
 
-use crate::auth::{SchemaValidatorRef, UserProviderRef};
+use crate::auth::UserProviderRef;
 use crate::error::Result;
 use crate::postgres::auth_handler::PgAuthStartupHandler;
 use crate::postgres::handler::PostgresServerHandler;
@@ -47,12 +47,10 @@ impl PostgresServer {
         tls: TlsOption,
         io_runtime: Arc<Runtime>,
         user_provider: Option<UserProviderRef>,
-        schema_validator: Option<SchemaValidatorRef>,
     ) -> PostgresServer {
         let postgres_handler = Arc::new(PostgresServerHandler::new(query_handler.clone()));
         let startup_handler = Arc::new(PgAuthStartupHandler::new(
             user_provider,
-            schema_validator,
             tls.should_force_tls(),
             query_handler,
         ));

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -25,7 +25,7 @@ use pgwire::tokio::process_socket;
 use tokio;
 use tokio_rustls::TlsAcceptor;
 
-use crate::auth::UserProviderRef;
+use crate::auth::{SchemaValidatorRef, UserProviderRef};
 use crate::error::Result;
 use crate::postgres::auth_handler::PgAuthStartupHandler;
 use crate::postgres::handler::PostgresServerHandler;
@@ -47,10 +47,12 @@ impl PostgresServer {
         tls: TlsOption,
         io_runtime: Arc<Runtime>,
         user_provider: Option<UserProviderRef>,
+        schema_validator: Option<SchemaValidatorRef>,
     ) -> PostgresServer {
         let postgres_handler = Arc::new(PostgresServerHandler::new(query_handler.clone()));
         let startup_handler = Arc::new(PgAuthStartupHandler::new(
             user_provider,
+            schema_validator,
             tls.should_force_tls(),
             query_handler,
         ));

--- a/src/servers/tests/auth.rs
+++ b/src/servers/tests/auth.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use servers::auth::user_provider::auth_mysql;
 use servers::auth::{
     AccessDeniedSnafu, Identity, Password, UnsupportedPasswordTypeSnafu, UserNotFoundSnafu,

--- a/src/servers/tests/auth.rs
+++ b/src/servers/tests/auth.rs
@@ -1,0 +1,183 @@
+use servers::auth::user_provider::auth_mysql;
+use servers::auth::{
+    AccessDeniedSnafu, Identity, Password, UnsupportedPasswordTypeSnafu, UserNotFoundSnafu,
+    UserPasswordMismatchSnafu, UserProvider,
+};
+use session::context::UserInfo;
+
+pub struct DatabaseAuthInfo<'a> {
+    pub catalog: &'a str,
+    pub schema: &'a str,
+    pub username: &'a str,
+}
+
+pub struct MockUserProvider {
+    pub catalog: String,
+    pub schema: String,
+    pub username: String,
+}
+
+impl Default for MockUserProvider {
+    fn default() -> Self {
+        MockUserProvider {
+            catalog: "greptime".to_owned(),
+            schema: "public".to_owned(),
+            username: "greptime".to_owned(),
+        }
+    }
+}
+
+impl MockUserProvider {
+    pub fn set_authorization_info(&mut self, info: DatabaseAuthInfo) {
+        self.catalog = info.catalog.to_owned();
+        self.schema = info.schema.to_owned();
+        self.username = info.username.to_owned();
+    }
+}
+
+#[async_trait::async_trait]
+impl UserProvider for MockUserProvider {
+    fn name(&self) -> &str {
+        "mock_user_provider"
+    }
+
+    async fn authenticate(
+        &self,
+        id: Identity<'_>,
+        password: Password<'_>,
+    ) -> servers::auth::Result<UserInfo> {
+        match id {
+            Identity::UserId(username, _host) => match password {
+                Password::PlainText(password) => {
+                    if username == "greptime" {
+                        if password == "greptime" {
+                            Ok(UserInfo::new("greptime"))
+                        } else {
+                            UserPasswordMismatchSnafu {
+                                username: username.to_string(),
+                            }
+                            .fail()
+                        }
+                    } else {
+                        UserNotFoundSnafu {
+                            username: username.to_string(),
+                        }
+                        .fail()
+                    }
+                }
+                Password::MysqlNativePassword(auth_data, salt) => {
+                    auth_mysql(auth_data, salt, username, "greptime".as_bytes())
+                        .map(|_| UserInfo::new(username))
+                }
+                _ => UnsupportedPasswordTypeSnafu {
+                    password_type: "mysql_native_password",
+                }
+                .fail(),
+            },
+        }
+    }
+
+    async fn authorize(
+        &self,
+        catalog: &str,
+        schema: &str,
+        user_info: &UserInfo,
+    ) -> servers::auth::Result<()> {
+        if catalog == self.catalog && schema == self.schema && user_info.username() == self.username
+        {
+            Ok(())
+        } else {
+            AccessDeniedSnafu {
+                catalog: catalog.to_string(),
+                schema: schema.to_string(),
+                username: user_info.username().to_string(),
+            }
+            .fail()
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_auth_by_plain_text() {
+    let user_provider = MockUserProvider::default();
+    assert_eq!("mock_user_provider", user_provider.name());
+
+    // auth success
+    let auth_result = user_provider
+        .authenticate(
+            Identity::UserId("greptime", None),
+            Password::PlainText("greptime"),
+        )
+        .await;
+    assert!(auth_result.is_ok());
+    assert_eq!("greptime", auth_result.unwrap().username());
+
+    // auth failed, unsupported password type
+    let auth_result = user_provider
+        .authenticate(
+            Identity::UserId("greptime", None),
+            Password::PgMD5(b"hashed_value", b"salt"),
+        )
+        .await;
+    assert!(auth_result.is_err());
+    matches!(
+        auth_result.err().unwrap(),
+        servers::auth::Error::UnsupportedPasswordType { .. }
+    );
+
+    // auth failed, err: user not exist.
+    let auth_result = user_provider
+        .authenticate(
+            Identity::UserId("not_exist_username", None),
+            Password::PlainText("greptime"),
+        )
+        .await;
+    assert!(auth_result.is_err());
+    matches!(
+        auth_result.err().unwrap(),
+        servers::auth::Error::UserNotFound { .. }
+    );
+
+    // auth failed, err: wrong password
+    let auth_result = user_provider
+        .authenticate(
+            Identity::UserId("greptime", None),
+            Password::PlainText("wrong_password"),
+        )
+        .await;
+    assert!(auth_result.is_err());
+    matches!(
+        auth_result.err().unwrap(),
+        servers::auth::Error::UserPasswordMismatch { .. }
+    );
+}
+
+#[tokio::test]
+async fn test_schema_validate() {
+    let mut validator = MockUserProvider::default();
+    validator.set_authorization_info(DatabaseAuthInfo {
+        catalog: "greptime",
+        schema: "public",
+        username: "test_user",
+    });
+
+    let right_user = UserInfo::new("test_user");
+    let wrong_user = UserInfo::default();
+
+    // check catalog
+    let re = validator
+        .authorize("greptime_wrong", "public", &right_user)
+        .await;
+    assert!(re.is_err());
+    // check schema
+    let re = validator
+        .authorize("greptime", "public_wrong", &right_user)
+        .await;
+    assert!(re.is_err());
+    // check username
+    let re = validator.authorize("greptime", "public", &wrong_user).await;
+    assert!(re.is_err());
+    // check ok
+    let re = validator.authorize("greptime", "public", &right_user).await;
+    assert!(re.is_ok());
+}

--- a/src/servers/tests/http/authorize.rs
+++ b/src/servers/tests/http/authorize.rs
@@ -64,11 +64,11 @@ async fn test_schema_validating() {
     let mut http_auth: HttpAuth<BoxBody> = HttpAuth::new(mock_user_provider);
 
     // base64encode("greptime:greptime") == "Z3JlcHRpbWU6Z3JlcHRpbWU="
-    // http://localhost/{http_api_version}/sql?database=greptime
+    // http://localhost/{http_api_version}/sql?db=greptime
     let version = servers::http::HTTP_API_VERSION;
     let req = mock_http_request(
         Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="),
-        Some(format!("http://localhost/{version}/sql?database=public").as_str()),
+        Some(format!("http://localhost/{version}/sql?db=public").as_str()),
     )
     .unwrap();
     let req = http_auth.authorize(req).await.unwrap();
@@ -79,7 +79,7 @@ async fn test_schema_validating() {
     // wrong database
     let req = mock_http_request(
         Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="),
-        Some(format!("http://localhost/{version}/sql?database=wrong").as_str()),
+        Some(format!("http://localhost/{version}/sql?db=wrong").as_str()),
     )
     .unwrap();
     let result = http_auth.authorize(req).await;
@@ -110,9 +110,8 @@ fn mock_http_request(
     uri: Option<&str>,
 ) -> servers::error::Result<Request<()>> {
     let http_api_version = servers::http::HTTP_API_VERSION;
-    let mut req = Request::builder().uri(
-        uri.unwrap_or(format!("http://localhost/{http_api_version}/sql?database=public").as_str()),
-    );
+    let mut req = Request::builder()
+        .uri(uri.unwrap_or(format!("http://localhost/{http_api_version}/sql?db=public").as_str()));
     if let Some(auth_header) = auth_header {
         req = req.header(http::header::AUTHORIZATION, auth_header);
     }

--- a/src/servers/tests/http/authorize.rs
+++ b/src/servers/tests/http/authorize.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use axum::body::BoxBody;
+use axum::http;
+use hyper::Request;
+use servers::auth::UserProvider;
+use servers::http::authorize::HttpAuth;
+use session::context::UserInfo;
+use tower_http::auth::AsyncAuthorizeRequest;
+
+use crate::auth::MockUserProvider;
+
+#[tokio::test]
+async fn test_http_auth() {
+    let mut http_auth: HttpAuth<BoxBody> = HttpAuth::new(None);
+
+    // base64encode("username:password") == "dXNlcm5hbWU6cGFzc3dvcmQ="
+    let req = mock_http_request(Some("Basic dXNlcm5hbWU6cGFzc3dvcmQ="), None).unwrap();
+    let auth_res = http_auth.authorize(req).await.unwrap();
+    let user_info: &UserInfo = auth_res.extensions().get().unwrap();
+    let default = UserInfo::default();
+    assert_eq!(default.username(), user_info.username());
+
+    // In mock user provider, right username:password == "greptime:greptime"
+    let mock_user_provider = Some(Arc::new(MockUserProvider::default()) as Arc<dyn UserProvider>);
+    let mut http_auth: HttpAuth<BoxBody> = HttpAuth::new(mock_user_provider);
+
+    // base64encode("greptime:greptime") == "Z3JlcHRpbWU6Z3JlcHRpbWU="
+    let req = mock_http_request(Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="), None).unwrap();
+    let req = http_auth.authorize(req).await.unwrap();
+    let user_info: &UserInfo = req.extensions().get().unwrap();
+    let default = UserInfo::default();
+    assert_eq!(default.username(), user_info.username());
+
+    let req = mock_http_request(None, None).unwrap();
+    let auth_res = http_auth.authorize(req).await;
+    assert!(auth_res.is_err());
+
+    // base64encode("username:password") == "dXNlcm5hbWU6cGFzc3dvcmQ="
+    let wrong_req = mock_http_request(Some("Basic dXNlcm5hbWU6cGFzc3dvcmQ="), None).unwrap();
+    let auth_res = http_auth.authorize(wrong_req).await;
+    assert!(auth_res.is_err());
+}
+
+#[tokio::test]
+async fn test_schema_validating() {
+    // In mock user provider, right username:password == "greptime:greptime"
+    let provider = MockUserProvider::default();
+    let mock_user_provider = Some(Arc::new(provider) as Arc<dyn UserProvider>);
+    let mut http_auth: HttpAuth<BoxBody> = HttpAuth::new(mock_user_provider);
+
+    // base64encode("greptime:greptime") == "Z3JlcHRpbWU6Z3JlcHRpbWU="
+    // http://localhost/{http_api_version}/sql?database=greptime
+    let version = servers::http::HTTP_API_VERSION;
+    let req = mock_http_request(
+        Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="),
+        Some(format!("http://localhost/{version}/sql?database=public").as_str()),
+    )
+    .unwrap();
+    let req = http_auth.authorize(req).await.unwrap();
+    let user_info: &UserInfo = req.extensions().get().unwrap();
+    let default = UserInfo::default();
+    assert_eq!(default.username(), user_info.username());
+
+    // wrong database
+    let req = mock_http_request(
+        Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="),
+        Some(format!("http://localhost/{version}/sql?database=wrong").as_str()),
+    )
+    .unwrap();
+    let result = http_auth.authorize(req).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_whitelist_no_auth() {
+    // In mock user provider, right username:password == "greptime:greptime"
+    let mock_user_provider = Some(Arc::new(MockUserProvider::default()) as Arc<dyn UserProvider>);
+    let mut http_auth: HttpAuth<BoxBody> = HttpAuth::new(mock_user_provider);
+
+    // base64encode("greptime:greptime") == "Z3JlcHRpbWU6Z3JlcHRpbWU="
+    // try auth path first
+    let req = mock_http_request(None, None).unwrap();
+    let req = http_auth.authorize(req).await;
+    assert!(req.is_err());
+
+    // try whitelist path
+    let req = mock_http_request(None, Some("http://localhost/health")).unwrap();
+    let req = http_auth.authorize(req).await;
+    assert!(req.is_ok());
+}
+
+// copy from http::authorize
+fn mock_http_request(
+    auth_header: Option<&str>,
+    uri: Option<&str>,
+) -> servers::error::Result<Request<()>> {
+    let http_api_version = servers::http::HTTP_API_VERSION;
+    let mut req = Request::builder().uri(
+        uri.unwrap_or(format!("http://localhost/{http_api_version}/sql?database=public").as_str()),
+    );
+    if let Some(auth_header) = auth_header {
+        req = req.header(http::header::AUTHORIZATION, auth_header);
+    }
+
+    Ok(req.body(()).unwrap())
+}

--- a/src/servers/tests/http/authorize.rs
+++ b/src/servers/tests/http/authorize.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::Arc;
 
 use axum::body::BoxBody;

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -135,7 +135,7 @@ fn create_invalid_script_query() -> Query<script_handler::ScriptQuery> {
 fn create_query() -> Query<http_handler::SqlQuery> {
     Query(http_handler::SqlQuery {
         sql: Some("select sum(uint32s) from numbers limit 20".to_string()),
-        database: None,
+        db: None,
     })
 }
 

--- a/src/servers/tests/http/mod.rs
+++ b/src/servers/tests/http/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod authorize;
 mod http_handler_test;
 mod influxdb_test;
 mod opentsdb_test;

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -163,7 +163,6 @@ pub mod test_mock_schema_validator {
             schema: &str,
             user_info: &UserInfo,
         ) -> Result<(), servers::auth::Error> {
-            println!("entering validator");
             if catalog == self.catalog
                 && schema == self.schema
                 && user_info.username() == self.username

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -51,6 +51,7 @@ fn create_mysql_server(table: MemTable, tls: TlsOption) -> Result<Box<dyn Server
         io_runtime,
         tls,
         Some(Arc::new(provider)),
+        None,
     ))
 }
 

--- a/src/servers/tests/postgres/mod.rs
+++ b/src/servers/tests/postgres/mod.rs
@@ -59,6 +59,7 @@ fn create_postgres_server(
         tls,
         io_runtime,
         user_provider,
+        None,
     )))
 }
 

--- a/src/servers/tests/postgres/mod.rs
+++ b/src/servers/tests/postgres/mod.rs
@@ -23,7 +23,7 @@ use rand::Rng;
 use rustls::client::{ServerCertVerified, ServerCertVerifier};
 use rustls::{Certificate, Error, ServerName};
 use servers::auth::user_provider::StaticUserProvider;
-use servers::auth::UserProviderRef;
+use servers::auth::{SchemaValidatorRef, UserProviderRef};
 use servers::error::Result;
 use servers::postgres::PostgresServer;
 use servers::server::Server;
@@ -32,11 +32,13 @@ use table::test_util::MemTable;
 use tokio_postgres::{Client, Error as PgError, NoTls, SimpleQueryMessage};
 
 use crate::create_testing_instance;
+use crate::test_mock_schema_validator::MockSchemaValidator;
 
 fn create_postgres_server(
     table: MemTable,
     check_pwd: bool,
     tls: TlsOption,
+    schema_validator: Option<SchemaValidatorRef>,
 ) -> Result<Box<dyn Server>> {
     let instance = Arc::new(create_testing_instance(table));
     let io_runtime = Arc::new(
@@ -59,7 +61,7 @@ fn create_postgres_server(
         tls,
         io_runtime,
         user_provider,
-        None,
+        schema_validator,
     )))
 }
 
@@ -67,7 +69,7 @@ fn create_postgres_server(
 pub async fn test_start_postgres_server() -> Result<()> {
     let table = MemTable::default_numbers_table();
 
-    let pg_server = create_postgres_server(table, false, Default::default())?;
+    let pg_server = create_postgres_server(table, false, Default::default(), None)?;
     let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     let result = pg_server.start(listening).await;
     assert!(result.is_ok());
@@ -87,12 +89,48 @@ async fn test_shutdown_pg_server_range() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_schema_validating() -> Result<()> {
+    async fn generate_server(validator: SchemaValidatorRef) -> Result<(Box<dyn Server>, u16)> {
+        let table = MemTable::default_numbers_table();
+        let postgres_server =
+            create_postgres_server(table, false, Default::default(), Some(validator))?;
+        let listening = "127.0.0.1:5432".parse::<SocketAddr>().unwrap();
+        let server_addr = postgres_server.start(listening).await.unwrap();
+        let server_port = server_addr.port();
+        Ok((postgres_server, server_port))
+    }
+
+    common_telemetry::init_default_ut_logging();
+    let validator = Arc::new(MockSchemaValidator::new("greptime", "public", "greptime"));
+    let (pg_server, server_port) = generate_server(validator).await?;
+
+    let pass = create_plain_connection(server_port, false).await;
+    assert!(pass.is_ok());
+    let result = pg_server.shutdown().await;
+    assert!(result.is_ok());
+
+    let validator = Arc::new(MockSchemaValidator::new(
+        "greptime",
+        "public",
+        "no_right_user",
+    ));
+    let (pg_server, server_port) = generate_server(validator).await?;
+
+    let fail = create_plain_connection(server_port, false).await;
+    assert!(fail.is_err());
+    let result = pg_server.shutdown().await;
+    assert!(result.is_ok());
+
+    Ok(())
+}
+
 // #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shutdown_pg_server(with_pwd: bool) -> Result<()> {
     common_telemetry::init_default_ut_logging();
 
     let table = MemTable::default_numbers_table();
-    let postgres_server = create_postgres_server(table, with_pwd, Default::default())?;
+    let postgres_server = create_postgres_server(table, with_pwd, Default::default(), None)?;
     let result = postgres_server.shutdown().await;
     assert!(result
         .unwrap_err()
@@ -274,7 +312,7 @@ async fn test_using_db() -> Result<()> {
 async fn start_test_server(server_tls: TlsOption) -> Result<u16> {
     common_telemetry::init_default_ut_logging();
     let table = MemTable::default_numbers_table();
-    let pg_server = create_postgres_server(table, false, server_tls)?;
+    let pg_server = create_postgres_server(table, false, server_tls, None)?;
     let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     let server_addr = pg_server.start(listening).await.unwrap();
     Ok(server_addr.port())

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -195,7 +195,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test database given
     let res = client
-        .get("/v1/sql?database=public&sql=select cpu, ts from demo limit 1")
+        .get("/v1/sql?db=public&sql=select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -214,7 +214,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test database not found
     let res = client
-        .get("/v1/sql?database=notfound&sql=select cpu, ts from demo limit 1")
+        .get("/v1/sql?db=notfound&sql=select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -223,7 +223,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test catalog-schema given
     let res = client
-        .get("/v1/sql?database=greptime-public&sql=select cpu, ts from demo limit 1")
+        .get("/v1/sql?db=greptime-public&sql=select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -242,7 +242,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test invalid catalog
     let res = client
-        .get("/v1/sql?database=notfound2-schema&sql=select cpu, ts from demo limit 1")
+        .get("/v1/sql?db=notfound2-schema&sql=select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
@@ -251,7 +251,7 @@ pub async fn test_sql_api(store_type: StorageType) {
 
     // test invalid schema
     let res = client
-        .get("/v1/sql?database=greptime-schema&sql=select cpu, ts from demo limit 1")
+        .get("/v1/sql?db=greptime-schema&sql=select cpu, ts from demo limit 1")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- change method name from `auth` to `authenticate` in `UserProvider`
- add `authorize` method to `UserProvider ` to check user request's access permission to database(framework logic, no implementation yet)
- extract `MysqlRuntimeOption` to aggregate mysql pass-through options
- **BREAK**: rename `database` to `db` in http's `SqlQuery` to better align with InfluxDB and promethues
- add and modify necessary unit test

todo
- [ ] rename `UserProvider`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
