### PR TITLE
feat: Query using sql inside python script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,12 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -15,7 +15,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use datatypes::arrow::datatypes::DataType;
+use datatypes::prelude::ConcreteDataType;
 use query::QueryEngineRef;
 use rustpython_parser::ast::{Arguments, Location};
 use rustpython_parser::{ast, parser};

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -425,7 +425,10 @@ fn get_return_annotations(rets: &ast::Expr<()>) -> Result<Vec<Option<AnnotationI
 }
 
 /// parse script and return `Coprocessor` struct with info extract from ast
-pub fn parse_and_compile_copr(script: &str, query_engine: Option<QueryEngineRef>) -> Result<Coprocessor> {
+pub fn parse_and_compile_copr(
+    script: &str,
+    query_engine: Option<QueryEngineRef>,
+) -> Result<Coprocessor> {
     let python_ast = parser::parse_program(script, "<embedded>").context(PyParseSnafu)?;
 
     let mut coprocessor = None;
@@ -502,7 +505,7 @@ pub fn parse_and_compile_copr(script: &str, query_engine: Option<QueryEngineRef>
                     arg_types,
                     return_types,
                     script: script.to_owned(),
-                    query_engine: query_engine.as_ref().map(|e|Arc::downgrade(e).into())
+                    query_engine: query_engine.as_ref().map(|e| Arc::downgrade(e).into()),
                 });
             }
         } else if matches!(

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
-use datatypes::prelude::ConcreteDataType;
+use datatypes::arrow::datatypes::DataType;
+use query::QueryEngineRef;
 use rustpython_parser::ast::{Arguments, Location};
 use rustpython_parser::{ast, parser};
 #[cfg(test)]
@@ -423,7 +425,7 @@ fn get_return_annotations(rets: &ast::Expr<()>) -> Result<Vec<Option<AnnotationI
 }
 
 /// parse script and return `Coprocessor` struct with info extract from ast
-pub fn parse_and_compile_copr(script: &str) -> Result<Coprocessor> {
+pub fn parse_and_compile_copr(script: &str, query_engine: Option<QueryEngineRef>) -> Result<Coprocessor> {
     let python_ast = parser::parse_program(script, "<embedded>").context(PyParseSnafu)?;
 
     let mut coprocessor = None;
@@ -500,6 +502,7 @@ pub fn parse_and_compile_copr(script: &str) -> Result<Coprocessor> {
                     arg_types,
                     return_types,
                     script: script.to_owned(),
+                    query_engine: query_engine.as_ref().map(|e|Arc::downgrade(e).into())
                 });
             }
         } else if matches!(

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -265,7 +265,10 @@ impl ScriptEngine for PyEngine {
     }
 
     async fn compile(&self, script: &str, _ctx: CompileContext) -> Result<PyScript> {
-        let copr = Arc::new(parse::parse_and_compile_copr(script, None)?);
+        let copr = Arc::new(parse::parse_and_compile_copr(
+            script,
+            Some(self.query_engine.clone()),
+        )?);
 
         Ok(PyScript {
             copr,
@@ -287,8 +290,7 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_compile_execute() {
+    fn sample_script_engine() -> PyEngine {
         let catalog_list = catalog::local::new_memory_catalog_list().unwrap();
 
         let default_schema = Arc::new(MemorySchemaProvider::new());
@@ -306,7 +308,30 @@ mod tests {
         let factory = QueryEngineFactory::new(catalog_list);
         let query_engine = factory.query_engine();
 
-        let script_engine = PyEngine::new(query_engine.clone());
+        PyEngine::new(query_engine.clone())
+    }
+
+    #[tokio::test]
+    async fn test_sql_in_py() {
+        let script_engine = sample_script_engine();
+
+        let script = r#"
+import greptime as gt
+
+@copr(args=["a"], returns = ["r"], sql = "select * from numbers")
+def test(a):
+    return query.sql("select * from numbers")[0][0][1]
+"#;
+        let script = script_engine
+            .compile(script, CompileContext::default())
+            .await
+            .unwrap();
+        let _output = script.execute(EvalContext::default()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_compile_execute() {
+        let script_engine = sample_script_engine();
 
         // To avoid divide by zero, the script divides `add(a, b)` by `g.sqrt(c + 1)` instead of `g.sqrt(c)`
         let script = r#"
@@ -351,7 +376,8 @@ import greptime as gt
 
 @copr(args=["number"], returns = ["r"], sql="select number from numbers limit 100")
 def test(a):
-   return gt.vector([x for x in a if x % 2 == 0])
+    print(query.sql("select * from numbers")[0][0][1])
+    return gt.vector([x for x in a if x % 2 == 0])
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -265,7 +265,7 @@ impl ScriptEngine for PyEngine {
     }
 
     async fn compile(&self, script: &str, _ctx: CompileContext) -> Result<PyScript> {
-        let copr = Arc::new(parse::parse_and_compile_copr(script)?);
+        let copr = Arc::new(parse::parse_and_compile_copr(script, None)?);
 
         Ok(PyScript {
             copr,

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -384,7 +384,6 @@ import greptime as gt
 
 @copr(args=["number"], returns = ["r"], sql="select number from numbers limit 100")
 def test(a):
-    print(query.sql("select * from numbers")[0][0][1])
     return gt.vector([x for x in a if x % 2 == 0])
 "#;
         let script = script_engine

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -318,8 +318,8 @@ mod tests {
         let script = r#"
 import greptime as gt
 
-@copr(args=["a"], returns = ["r"], sql = "select * from numbers")
-def test(a):
+@copr(args=["number"], returns = ["number"], sql = "select * from numbers")
+def test(number)->vector[u32]:
     return query.sql("select * from numbers")[0][0][1]
 "#;
         let script = script_engine
@@ -327,6 +327,14 @@ def test(a):
             .await
             .unwrap();
         let _output = script.execute(EvalContext::default()).await.unwrap();
+        let res = common_recordbatch::util::collect_batches(match _output {
+            Output::Stream(s) => s,
+            _ => todo!(),
+        })
+        .await
+        .unwrap();
+        let rb = res.iter().next().expect("One and only one recordbatch");
+        assert_eq!(rb.column(0).len(), 100);
     }
 
     #[tokio::test]

--- a/src/script/src/python/test.rs
+++ b/src/script/src/python/test.rs
@@ -103,13 +103,13 @@ fn run_ron_testcases() {
         info!(".ron test {}", testcase.name);
         match testcase.predicate {
             Predicate::ParseIsOk { result } => {
-                let copr = parse_and_compile_copr(&testcase.code);
+                let copr = parse_and_compile_copr(&testcase.code, None);
                 let mut copr = copr.unwrap();
                 copr.script = "".into();
                 assert_eq!(copr, *result);
             }
             Predicate::ParseIsErr { reason } => {
-                let copr = parse_and_compile_copr(&testcase.code);
+                let copr = parse_and_compile_copr(&testcase.code, None);
                 assert!(copr.is_err(), "Expect to be err, actual {copr:#?}");
 
                 let res = &copr.unwrap_err();
@@ -183,7 +183,7 @@ def a(cpu, mem: vector[f64])->(vector[f64|None], vector[f64], vector[_], vector[
     return cpu + mem, cpu - mem, cpu * mem, cpu / mem
 "#;
     let pyast = parser::parse(python_source, parser::Mode::Interactive, "<embedded>").unwrap();
-    let copr = parse_and_compile_copr(python_source);
+    let copr = parse_and_compile_copr(python_source, None);
     dbg!(copr);
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

Allow query with sql in python coprocessor, just like this:
```python
def test(a):
    return query.sql("select * from numbers")[0][0][1]
```
`sql` call return a Python List, a List[List[PyVector]] to be exactly, where the inner `List[PyVector]` corrseponding to the `RecordBatch`, the outer List corrseponding to `RecordBatches`

- How does this PR work? 
Because RustPython is sync, we have to spawn a thread and a new tokio Runtime everytime `sql` is called, for not knowing if being called in a async context(call stack could be like async -> sync -> async or just sync->async)
- Describe any limitations of the current code
Calling `sql` block current task, might create a new tokio Runtime if is called first time in a sync context

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

