### PR TITLE
feat: prunine sst files according to time range in filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "arrow-schema",
  "common-base",
  "common-error",
+ "common-telemetry",
  "common-time",
  "datafusion-common",
  "enum_dispatch",
@@ -5404,6 +5405,7 @@ dependencies = [
  "stats-cli",
  "streaming-stats",
  "table",
+ "tempdir",
  "tokio",
  "tokio-stream",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ name = "common-time"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "common-error",
  "rand 0.8.5",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,7 +5405,6 @@ dependencies = [
  "stats-cli",
  "streaming-stats",
  "table",
- "tempdir",
  "tokio",
  "tokio-stream",
 ]

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { path = "../error" }
 chrono = "0.4"
+common-error = { path = "../error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+common-error = { path = "../error" }
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/common/time/src/error.rs
+++ b/src/common/time/src/error.rs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
+
 use chrono::ParseError;
-use snafu::{Backtrace, Snafu};
+use common_error::ext::ErrorExt;
+use common_error::prelude::StatusCode;
+use snafu::{Backtrace, ErrorCompat, Snafu};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -22,6 +26,24 @@ pub enum Error {
     ParseDateStr { raw: String, source: ParseError },
     #[snafu(display("Failed to parse a string into Timestamp, raw string: {}", raw))]
     ParseTimestamp { raw: String, backtrace: Backtrace },
+}
+
+impl ErrorExt for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::ParseDateStr { .. } | Error::ParseTimestamp { .. } => {
+                StatusCode::InvalidArguments
+            }
+        }
+    }
+
+    fn backtrace_opt(&self) -> Option<&Backtrace> {
+        ErrorCompat::backtrace(self)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -194,7 +194,7 @@ impl<T: PartialOrd> GenericRange<T> {
 pub type TimestampRange = GenericRange<Timestamp>;
 
 impl TimestampRange {
-    pub fn new_inclusive_unchecked(start: Option<Timestamp>, end: Option<Timestamp>) -> Self {
+    pub fn new_inclusive(start: Option<Timestamp>, end: Option<Timestamp>) -> Self {
         let end = if let Some(end) = end {
             end.value()
                 .checked_add(1)
@@ -228,7 +228,7 @@ impl TimestampRange {
     /// ### Notice
     /// Left-close right-open range cannot properly represent range with exclusive start like: `(start, ...)`.
     /// You may resort to `[start-1, ...)` instead.
-    pub fn from(start: Timestamp) -> Self {
+    pub fn from_start(start: Timestamp) -> Self {
         Self {
             start: Some(start),
             end: None,
@@ -239,7 +239,7 @@ impl TimestampRange {
     /// ### Notice
     /// Left-close right-open range cannot properly represent range with inclusive end like: `[..., END]`.
     /// If `inclusive` is true, this method returns `[-INF, end+1)` instead.
-    pub fn until(end: Timestamp, inclusive: bool) -> Self {
+    pub fn until_end(end: Timestamp, inclusive: bool) -> Self {
         let end = if inclusive {
             end.value()
                 .checked_add(1)

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -185,7 +185,7 @@ impl<T: PartialOrd> GenericRange<T> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         match (&self.start, &self.end) {
-            (Some(start), Some(end)) => start >= end,
+            (Some(start), Some(end)) => start == end,
             _ => false,
         }
     }

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -18,8 +18,9 @@ use crate::Timestamp;
 
 /// A half-open time range.
 ///
-/// The time range contains all timestamp `ts` that `ts >= start` and `ts < end`. It is
-/// empty if `start >= end`.
+/// The range contains values that `value >= start` and `val < end`.
+///
+/// The range is empty iff `start == end == "the default value of T"`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct GenericRange<T> {
     start: Option<T>,
@@ -28,8 +29,9 @@ pub struct GenericRange<T> {
 
 impl<T> GenericRange<T>
 where
-    T: Copy + PartialOrd,
+    T: Copy + PartialOrd + Default,
 {
+    /// Computes the AND'ed range with other.  
     pub fn and(&self, other: &GenericRange<T>) -> GenericRange<T> {
         let start = match (self.start(), other.start()) {
             (Some(l), Some(r)) => {
@@ -57,7 +59,7 @@ where
             (None, None) => None,
         };
 
-        Self { start, end }
+        Self::from_optional(start, end)
     }
 
     /// Compute the OR'ed range of two ranges.
@@ -98,17 +100,44 @@ where
             (None, None) => None,
         };
 
-        Self { start, end }
+        Self::from_optional(start, end)
     }
 
     /// Checks if current range intersect with target.
     pub fn intersects(&self, target: &GenericRange<T>) -> bool {
         !self.and(target).is_empty()
     }
+
+    /// Create an empty range.
+    pub fn empty() -> GenericRange<T> {
+        GenericRange {
+            start: Some(T::default()),
+            end: Some(T::default()),
+        }
+    }
+
+    /// Create GenericRange from optional start and end.
+    /// If the present value of start >= the present value of end, it will return an empty range
+    /// with the default value of `T`.
+    fn from_optional(start: Option<T>, end: Option<T>) -> GenericRange<T> {
+        match (start, end) {
+            (Some(start_val), Some(end_val)) => {
+                if start_val < end_val {
+                    Self {
+                        start: Some(start_val),
+                        end: Some(end_val),
+                    }
+                } else {
+                    Self::empty()
+                }
+            }
+            (s, e) => Self { start: s, end: e },
+        }
+    }
 }
 
 impl<T> GenericRange<T> {
-    /// Creates a new range that contains timestamp in `[start, end)`.
+    /// Creates a new range that contains values in `[start, end)`.
     ///
     /// Returns `None` if `start` > `end`.
     pub fn new<U: PartialOrd + Into<T>>(start: U, end: U) -> Option<GenericRange<T>> {
@@ -120,14 +149,7 @@ impl<T> GenericRange<T> {
         }
     }
 
-    /// Given a value, creates an empty time range that `start == end == value`.
-    pub fn empty_with_value<U: Clone + Into<T>>(value: U) -> GenericRange<T> {
-        GenericRange {
-            start: Some(value.clone().into()),
-            end: Some(value.into()),
-        }
-    }
-
+    /// Return a range containing all possible values.
     pub fn min_to_max() -> GenericRange<T> {
         Self {
             start: None,
@@ -180,24 +202,32 @@ impl TimestampRange {
         } else {
             None
         };
-        Self { start, end }
+        Self::from_optional(start, end)
     }
 
+    /// Shortcut method to create a timestamp range with given start/end value and time unit.
     pub fn with_unit(start: i64, end: i64, unit: TimeUnit) -> Option<Self> {
         let start = Timestamp::new(start, unit);
         let end = Timestamp::new(end, unit);
         Self::new(start, end)
     }
 
+    /// Create a range that containing only given `ts`.
+    /// ### Notice:
+    /// Left-close right-open range cannot properly represent range with a single value.
+    /// For simplicity, this implementation returns an approximate range `[ts, ts+1)` instead.
     pub fn single(ts: Timestamp) -> Self {
         let unit = ts.unit();
         let start = Some(ts);
         let end = ts.value().checked_add(1).map(|v| Timestamp::new(v, unit));
 
-        Self { start, end }
+        Self::from_optional(start, end)
     }
 
-    // we cannot represent exclusive start without missing any other value in a left-close range.
+    /// Create a range `[start, INF)`.
+    /// ### Notice
+    /// Left-close right-open range cannot properly represent range with exclusive start like: `(start, ...)`.
+    /// You may resort to `[start-1, ...)` instead.
     pub fn from(start: Timestamp) -> Self {
         Self {
             start: Some(start),
@@ -205,6 +235,10 @@ impl TimestampRange {
         }
     }
 
+    /// Create a range `[-INF, end)`.
+    /// ### Notice
+    /// Left-close right-open range cannot properly represent range with inclusive end like: `[..., END]`.
+    /// If `inclusive` is true, this method returns `[-INF, end+1)` instead.
     pub fn until(end: Timestamp, inclusive: bool) -> Self {
         let end = if inclusive {
             end.value()
@@ -241,9 +275,9 @@ mod tests {
 
         assert_eq!(None, RangeMillis::new(1, 0));
 
-        let range = RangeMillis::empty_with_value(1024);
+        let range = RangeMillis::empty();
         assert_eq!(range.start(), range.end());
-        assert_eq!(Some(TimestampMillis::new(1024)), *range.start());
+        assert_eq!(Some(TimestampMillis::new(0)), *range.start());
     }
 
     #[test]
@@ -339,9 +373,7 @@ mod tests {
             TimestampRange::min_to_max().or(&TimestampRange::min_to_max())
         );
 
-        let empty = TimestampRange::empty_with_value(Timestamp::new_millisecond(1)).or(
-            &TimestampRange::empty_with_value(Timestamp::new_millisecond(2)),
-        );
+        let empty = TimestampRange::empty().or(&TimestampRange::empty());
         assert!(empty.is_empty());
 
         let t1 = TimestampRange::with_unit(-10, 0, TimeUnit::Second).unwrap();
@@ -381,11 +413,11 @@ mod tests {
         assert!(t1.intersects(&t1));
 
         let t1 = TimestampRange::with_unit(0, 1, TimeUnit::Second).unwrap();
-        let t2 = TimestampRange::empty_with_value(Timestamp::new_millisecond(0));
+        let t2 = TimestampRange::empty();
         assert!(!t1.intersects(&t2));
 
         // empty range does not intersect with empty range
-        let empty = TimestampRange::empty_with_value(Timestamp::new_millisecond(0));
+        let empty = TimestampRange::empty();
         assert!(!empty.intersects(&empty));
 
         // full range intersects with full range

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -352,7 +352,7 @@ mod tests {
         }
     }
 
-    /// Generate timestamp less than or equal to `threshold`  
+    /// Generate timestamp less than or equal to `threshold`
     fn gen_ts_le(threshold: &Timestamp) -> Timestamp {
         let mut rng = rand::thread_rng();
         let timestamp = rng.gen_range(i64::MIN..=threshold.value);

--- a/src/common/time/src/timestamp_millis.rs
+++ b/src/common/time/src/timestamp_millis.rs
@@ -17,7 +17,7 @@ use std::cmp::Ordering;
 /// Unix timestamp in millisecond resolution.
 ///
 /// Negative timestamp is allowed, which represents timestamp before '1970-01-01T00:00:00'.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct TimestampMillis(i64);
 
 impl TimestampMillis {

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -14,6 +14,7 @@ arrow-schema.workspace = true
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
+common-telemetry = { path = "../common/telemetry" }
 datafusion-common.workspace = true
 enum_dispatch = "0.3"
 num = "0.4"

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -290,7 +290,7 @@ fn timestamp_to_scalar_value(unit: TimeUnit, val: Option<i64>) -> ScalarValue {
 }
 
 /// Convert [ScalarValue] to [Timestamp].
-/// Return `None` if
+/// Return `None` if given scalar value cannot be converted to a valid timestamp.
 pub fn scalar_value_to_timestamp(scalar: &ScalarValue) -> Option<Timestamp> {
     match scalar {
         ScalarValue::Int64(val) => val.map(Timestamp::new_millisecond),

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -297,7 +297,7 @@ pub fn scalar_value_to_timestamp(scalar: &ScalarValue) -> Option<Timestamp> {
         ScalarValue::Utf8(Some(s)) => match Timestamp::from_str(s) {
             Ok(t) => Some(t),
             Err(e) => {
-                logging::error!("Failed to convert string literal {s} to timestamp, error: {e:?}");
+                logging::error!(e;"Failed to convert string literal {s} to timestamp");
                 None
             }
         },

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -14,9 +14,11 @@
 
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use arrow::datatypes::{DataType as ArrowDataType, Field};
 use common_base::bytes::{Bytes, StringBytes};
+use common_telemetry::logging;
 use common_time::date::Date;
 use common_time::datetime::DateTime;
 use common_time::timestamp::{TimeUnit, Timestamp};
@@ -25,7 +27,8 @@ pub use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
-use crate::error::{self, Result};
+use crate::error;
+use crate::error::Result;
 use crate::prelude::*;
 use crate::type_id::LogicalTypeId;
 use crate::types::ListType;
@@ -283,6 +286,26 @@ fn timestamp_to_scalar_value(unit: TimeUnit, val: Option<i64>) -> ScalarValue {
         TimeUnit::Millisecond => ScalarValue::TimestampMillisecond(val, None),
         TimeUnit::Microsecond => ScalarValue::TimestampMicrosecond(val, None),
         TimeUnit::Nanosecond => ScalarValue::TimestampNanosecond(val, None),
+    }
+}
+
+/// Convert [ScalarValue] to [Timestamp].
+/// Return `None` if
+pub fn scalar_value_to_timestamp(scalar: &ScalarValue) -> Option<Timestamp> {
+    match scalar {
+        ScalarValue::Int64(val) => val.map(Timestamp::new_millisecond),
+        ScalarValue::Utf8(Some(s)) => match Timestamp::from_str(s) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                logging::error!("Failed to convert string literal {s} to timestamp, error: {e:?}");
+                None
+            }
+        },
+        ScalarValue::TimestampSecond(v, _) => v.map(Timestamp::new_second),
+        ScalarValue::TimestampMillisecond(v, _) => v.map(Timestamp::new_millisecond),
+        ScalarValue::TimestampMicrosecond(v, _) => v.map(Timestamp::new_microsecond),
+        ScalarValue::TimestampNanosecond(v, _) => v.map(Timestamp::new_nanosecond),
+        _ => None,
     }
 }
 

--- a/src/query/tests/time_range_filter_test.rs
+++ b/src/query/tests/time_range_filter_test.rs
@@ -230,5 +230,12 @@ async fn test_range_filter() {
             "select * from m where ts>='2023-01-16 17:01:57+08:00'",
             TimestampRange::from(Timestamp::new(1673859717000, TimeUnit::Millisecond)),
         )
-        .await
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts > 10 and ts < 9",
+            TimestampRange::empty(),
+        )
+        .await;
 }

--- a/src/query/tests/time_range_filter_test.rs
+++ b/src/query/tests/time_range_filter_test.rs
@@ -1,0 +1,234 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use catalog::local::{new_memory_catalog_list, MemoryCatalogProvider, MemorySchemaProvider};
+use catalog::{CatalogList, CatalogProvider, SchemaProvider};
+use common_query::physical_plan::PhysicalPlanRef;
+use common_query::prelude::Expr;
+use common_recordbatch::RecordBatch;
+use common_time::range::TimestampRange;
+use common_time::timestamp::TimeUnit;
+use common_time::Timestamp;
+use datatypes::data_type::ConcreteDataType;
+use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
+use datatypes::vectors::{Int64Vector, TimestampMillisecondVector};
+use query::QueryEngineRef;
+use session::context::QueryContext;
+use table::metadata::{FilterPushDownType, TableInfoRef};
+use table::predicate::TimeRangePredicateBuilder;
+use table::test_util::MemTable;
+use table::Table;
+use tokio::sync::RwLock;
+
+struct MemTableWrapper {
+    inner: MemTable,
+    filter: RwLock<Vec<Expr>>,
+}
+
+impl MemTableWrapper {
+    pub async fn get_filters(&self) -> Vec<Expr> {
+        self.filter.write().await.drain(..).collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for MemTableWrapper {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+
+    fn table_info(&self) -> TableInfoRef {
+        self.inner.table_info()
+    }
+
+    async fn scan(
+        &self,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> table::Result<PhysicalPlanRef> {
+        *self.filter.write().await = filters.to_vec();
+        self.inner.scan(projection, filters, limit).await
+    }
+
+    fn supports_filter_pushdown(&self, _filter: &Expr) -> table::Result<FilterPushDownType> {
+        Ok(FilterPushDownType::Exact)
+    }
+}
+
+fn create_test_engine() -> TimeRangeTester {
+    let schema = Schema::try_new(vec![
+        ColumnSchema::new("v".to_string(), ConcreteDataType::int64_datatype(), false),
+        ColumnSchema::new(
+            "ts".to_string(),
+            ConcreteDataType::timestamp_millisecond_datatype(),
+            false,
+        ),
+    ])
+    .unwrap();
+
+    let table = Arc::new(MemTableWrapper {
+        inner: MemTable::new(
+            "m",
+            RecordBatch::new(
+                Arc::new(schema),
+                vec![
+                    Arc::new(Int64Vector::from_slice((0..1000).collect::<Vec<i64>>())) as Arc<_>,
+                    Arc::new(TimestampMillisecondVector::from_slice(
+                        (0..1000).collect::<Vec<i64>>(),
+                    )) as Arc<_>,
+                ],
+            )
+            .unwrap(),
+        ),
+        filter: Default::default(),
+    });
+
+    let catalog_list = new_memory_catalog_list().unwrap();
+
+    let default_schema = Arc::new(MemorySchemaProvider::new());
+    MemorySchemaProvider::register_table(&default_schema, "m".to_string(), table.clone()).unwrap();
+
+    let default_catalog = Arc::new(MemoryCatalogProvider::new());
+    default_catalog
+        .register_schema("public".to_string(), default_schema)
+        .unwrap();
+    catalog_list
+        .register_catalog("greptime".to_string(), default_catalog)
+        .unwrap();
+
+    let engine = query::QueryEngineFactory::new(catalog_list).query_engine();
+    TimeRangeTester { engine, table }
+}
+
+struct TimeRangeTester {
+    engine: QueryEngineRef,
+    table: Arc<MemTableWrapper>,
+}
+
+impl TimeRangeTester {
+    async fn check(&self, sql: &str, expect: TimestampRange) {
+        let stmt = query::parser::QueryLanguageParser::parse_sql(sql).unwrap();
+        let _ = self
+            .engine
+            .execute(
+                &self
+                    .engine
+                    .statement_to_plan(stmt, Arc::new(QueryContext::new()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let filters = self.table.get_filters().await;
+
+        let range = TimeRangePredicateBuilder::new("ts", &filters).build();
+        assert_eq!(expect, range);
+    }
+}
+
+#[tokio::test]
+async fn test_range_filter() {
+    let tester = create_test_engine();
+    tester
+        .check(
+            "select * from m where ts >= 990;",
+            TimestampRange::from(Timestamp::new(990, TimeUnit::Millisecond)),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts <=1000;",
+            TimestampRange::until(Timestamp::new(1000, TimeUnit::Millisecond), true),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts > 1000;",
+            TimestampRange::from(Timestamp::new(1000, TimeUnit::Millisecond)),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts < 1000;",
+            TimestampRange::until(Timestamp::new(1000, TimeUnit::Millisecond), false),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts > 1000 and ts < 2000;",
+            TimestampRange::with_unit(1000, 2000, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts >= 1000 or ts < 0;",
+            TimestampRange::min_to_max(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where (ts >= 1000 and ts < 2000) or (ts>=3000 and ts<4000);",
+            TimestampRange::with_unit(1000, 4000, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    // sql's between is inclusive in both ends
+    tester
+        .check(
+            "select * from m where ts between 1000 and 2000",
+            TimestampRange::with_unit(1000, 2001, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts in (10, 20, 30, 40)",
+            TimestampRange::with_unit(10, 41, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts=1000",
+            TimestampRange::with_unit(1000, 1001, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts=1000 or ts=2000",
+            TimestampRange::with_unit(1000, 2001, TimeUnit::Millisecond).unwrap(),
+        )
+        .await;
+
+    tester
+        .check(
+            "select * from m where ts>='2023-01-16 17:01:57+08:00'",
+            TimestampRange::from(Timestamp::new(1673859717000, TimeUnit::Millisecond)),
+        )
+        .await
+}

--- a/src/query/tests/time_range_filter_test.rs
+++ b/src/query/tests/time_range_filter_test.rs
@@ -150,28 +150,28 @@ async fn test_range_filter() {
     tester
         .check(
             "select * from m where ts >= 990;",
-            TimestampRange::from(Timestamp::new(990, TimeUnit::Millisecond)),
+            TimestampRange::from_start(Timestamp::new(990, TimeUnit::Millisecond)),
         )
         .await;
 
     tester
         .check(
             "select * from m where ts <=1000;",
-            TimestampRange::until(Timestamp::new(1000, TimeUnit::Millisecond), true),
+            TimestampRange::until_end(Timestamp::new(1000, TimeUnit::Millisecond), true),
         )
         .await;
 
     tester
         .check(
             "select * from m where ts > 1000;",
-            TimestampRange::from(Timestamp::new(1000, TimeUnit::Millisecond)),
+            TimestampRange::from_start(Timestamp::new(1000, TimeUnit::Millisecond)),
         )
         .await;
 
     tester
         .check(
             "select * from m where ts < 1000;",
-            TimestampRange::until(Timestamp::new(1000, TimeUnit::Millisecond), false),
+            TimestampRange::until_end(Timestamp::new(1000, TimeUnit::Millisecond), false),
         )
         .await;
 
@@ -228,7 +228,7 @@ async fn test_range_filter() {
     tester
         .check(
             "select * from m where ts>='2023-01-16 17:01:57+08:00'",
-            TimestampRange::from(Timestamp::new(1673859717000, TimeUnit::Millisecond)),
+            TimestampRange::from_start(Timestamp::new(1673859717000, TimeUnit::Millisecond)),
         )
         .await;
 

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -128,6 +128,7 @@ impl ChunkReaderBuilder {
     }
 
     pub async fn build(mut self) -> Result<ChunkReaderImpl> {
+        let time_range_predicate = self.build_time_range_predicate();
         let schema = Arc::new(
             ProjectedSchema::new(self.schema, self.projection)
                 .context(error::InvalidProjectionSnafu)?,
@@ -142,8 +143,6 @@ impl ChunkReaderBuilder {
             let iter = mem.iter(&self.iter_ctx)?;
             reader_builder = reader_builder.push_batch_iter(iter);
         }
-
-        let time_range_predicate = self.build_time_range_predicate();
 
         let read_opts = ReadOptions {
             batch_size: self.iter_ctx.batch_size,

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -183,7 +183,7 @@ impl ChunkReaderBuilder {
     pub fn file_in_range(file: &FileHandle, predicate: TimestampRange) -> bool {
         // end_timestamp of sst file is inclusive.
         let file_ts_range =
-            TimestampRange::new_inclusive_unchecked(file.start_timestamp(), file.end_timestamp());
+            TimestampRange::new_inclusive(file.start_timestamp(), file.end_timestamp());
         file_ts_range.intersects(&predicate)
     }
 }

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use common_query::logical_plan::Expr;
 use snafu::ResultExt;
 use store_api::storage::{Chunk, ChunkReader, SchemaRef, SequenceNumber};
-use table::predicate::Predicate;
+use table::predicate::{Predicate, TimeRangePredicateBuilder};
 
 use crate::error::{self, Error, Result};
 use crate::memtable::{IterContext, MemtableRef};

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -152,10 +152,8 @@ impl ChunkReaderBuilder {
         for file in &self.files_to_read {
             if !Self::file_in_range(file, time_range_predicate) {
                 debug!(
-                    "Skip file, start: {:?}, end: {:?}, predicate: {:?}",
-                    file.start_timestamp(),
-                    file.end_timestamp(),
-                    time_range_predicate
+                    "Skip file {:?}, predicate: {:?}",
+                    file, time_range_predicate
                 );
                 continue;
             }
@@ -180,7 +178,11 @@ impl ChunkReaderBuilder {
     }
 
     /// Check if SST file's time range matches predicate.
-    pub fn file_in_range(file: &FileHandle, predicate: TimestampRange) -> bool {
+    #[inline]
+    fn file_in_range(file: &FileHandle, predicate: TimestampRange) -> bool {
+        if predicate == TimestampRange::min_to_max() {
+            return true;
+        }
         // end_timestamp of sst file is inclusive.
         let file_ts_range =
             TimestampRange::new_inclusive(file.start_timestamp(), file.end_timestamp());

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -161,13 +161,13 @@ impl FileHandle {
     /// Return the start timestamp of current SST file.
     #[inline]
     pub fn start_timestamp(&self) -> Option<Timestamp> {
-        self.inner.meta.start_timestamp.clone()
+        self.inner.meta.start_timestamp
     }
 
     /// Return the end timestamp of current SST file.
     #[inline]
     pub fn end_timestamp(&self) -> Option<Timestamp> {
-        self.inner.meta.start_timestamp.clone()
+        self.inner.meta.end_timestamp
     }
 }
 

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -157,6 +157,18 @@ impl FileHandle {
     pub fn file_name(&self) -> &str {
         &self.inner.meta.file_name
     }
+
+    /// Return the start timestamp of current SST file.
+    #[inline]
+    pub fn start_timestamp(&self) -> Option<Timestamp> {
+        self.inner.meta.start_timestamp.clone()
+    }
+
+    /// Return the end timestamp of current SST file.
+    #[inline]
+    pub fn end_timestamp(&self) -> Option<Timestamp> {
+        self.inner.meta.start_timestamp.clone()
+    }
 }
 
 /// Actually data of [FileHandle].

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -152,9 +152,8 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 Some(left.and(&right))
             }
             Operator::Or => {
-                let Some(left) = self
-                    .extract_time_range_from_expr(left) else { return None };
-                let Some(right) = self.extract_time_range_from_expr(right) else { return None };
+                let left = self.extract_time_range_from_expr(left)?;
+                let right = self.extract_time_range_from_expr(right)?;
                 Some(left.or(&right))
             }
             Operator::NotEq
@@ -240,11 +239,11 @@ impl<'a> TimeRangePredicateBuilder<'a> {
         if list.is_empty() {
             return Some(TimestampRange::empty());
         }
-        let mut init = TimestampRange::empty();
+        let mut init_range = TimestampRange::empty();
         for expr in list {
             if let DfExpr::Literal(scalar) = expr {
                 if let Some(timestamp) = scalar_value_to_timestamp(scalar) {
-                    init = init.or(&TimestampRange::single(timestamp))
+                    init_range = init_range.or(&TimestampRange::single(timestamp))
                 } else {
                     // TODO(hl): maybe we should raise an error here since cannot parse
                     // timestamp value from in list expr
@@ -252,7 +251,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
         }
-        Some(init)
+        Some(init_range)
     }
 }
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -70,7 +70,7 @@ impl Predicate {
     }
 }
 
-// tests for `TimeRangePredicateBuilder`locates in src/query/tests/time_range_filter_test.rs
+// tests for `TimeRangePredicateBuilder` locates in src/query/tests/time_range_filter_test.rs
 // since it requires query engine to convert sql to filters.
 pub struct TimeRangePredicateBuilder<'a> {
     ts_col_name: &'a str,
@@ -94,7 +94,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
         res
     }
 
-    fn extract_time_range_from_expr(&self, expr: &DfExpr) -> GenericRange<Timestamp> {
+    fn extract_time_range_from_expr(&self, expr: &DfExpr) -> TimestampRange {
         match expr {
             DfExpr::BinaryExpr(BinaryExpr { left, op, right }) => {
                 self.extract_from_binary_expr(left, op, right)
@@ -127,19 +127,19 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 .unwrap_or_else(TimestampRange::min_to_max),
             Operator::Lt => self
                 .get_timestamp_filter(left, right)
-                .map(|ts| TimestampRange::until(ts, false))
+                .map(|ts| TimestampRange::until_end(ts, false))
                 .unwrap_or_else(TimestampRange::min_to_max),
             Operator::LtEq => self
                 .get_timestamp_filter(left, right)
-                .map(|ts| TimestampRange::until(ts, true))
+                .map(|ts| TimestampRange::until_end(ts, true))
                 .unwrap_or_else(TimestampRange::min_to_max),
             Operator::Gt => self
                 .get_timestamp_filter(left, right)
-                .map(TimestampRange::from)
+                .map(TimestampRange::from_start)
                 .unwrap_or_else(TimestampRange::min_to_max),
             Operator::GtEq => self
                 .get_timestamp_filter(left, right)
-                .map(TimestampRange::from)
+                .map(TimestampRange::from_start)
                 .unwrap_or_else(TimestampRange::min_to_max),
             Operator::And => self
                 .extract_time_range_from_expr(left)
@@ -206,7 +206,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
             (DfExpr::Literal(low), DfExpr::Literal(high)) => {
                 let low_opt = scalar_value_to_timestamp(low);
                 let high_opt = scalar_value_to_timestamp(high);
-                TimestampRange::new_inclusive_unchecked(low_opt, high_opt)
+                TimestampRange::new_inclusive(low_opt, high_opt)
             }
             _ => TimestampRange::min_to_max(),
         }

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -227,10 +227,9 @@ impl<'a> TimeRangePredicateBuilder<'a> {
         }
 
         if list.is_empty() {
-            // TODO(hl): returning empty range with explicit value is weired.
-            return TimestampRange::empty_with_value(Timestamp::new_millisecond(0));
+            return TimestampRange::empty();
         }
-        let mut init = TimestampRange::empty_with_value(Timestamp::new_millisecond(0));
+        let mut init = TimestampRange::empty();
         for expr in list {
             if let DfExpr::Literal(scalar) = expr {
                 if let Some(timestamp) = scalar_value_to_timestamp(scalar) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
- Extract time range predicate from filters in SQL queries
- Prune SST files according to file time range and predicate

Future work: we may need to benchmark this feature against a large dataset.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#846 