### PR TITLE
chore: add an opaque error type in meta

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -159,6 +159,12 @@ pub enum Error {
         selector_type: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("An error occurred in Meta, source: {}", source))]
+    MetaBoxedError {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -207,6 +213,7 @@ impl ErrorExt for Error {
             | Error::InvalidTxnResult { .. } => StatusCode::Unexpected,
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
+            Error::MetaBoxedError { source } => source.status_code(),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly add an opaque error type in meta, to facilitate error handling in extension modules

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
