### PR TITLE
fix: create table after rename table

### DIFF
--- a/src/datanode/src/tests/instance_test.rs
+++ b/src/datanode/src/tests/instance_test.rs
@@ -343,6 +343,7 @@ pub async fn test_execute_create() {
 }
 
 #[tokio::test]
+#[should_panic]
 async fn test_rename_table() {
     let instance = MockInstance::new("test_rename_table_local").await;
 
@@ -392,6 +393,58 @@ async fn test_rename_table() {
 "
     .to_string();
     check_output_stream(output, expected).await;
+
+    execute_sql_in_db(&instance, "select * from demo", "db").await;
+}
+
+#[tokio::test]
+async fn test_create_table_after_rename_table() {
+    let instance = MockInstance::new("test_rename_table_local").await;
+
+    let output = execute_sql(&instance, "create database db").await;
+    assert!(matches!(output, Output::AffectedRows(1)));
+
+    // create test table
+    let table_name = "demo";
+    let output = execute_sql_in_db(
+        &instance,
+        &format!("create table {table_name}(host string, cpu double, memory double, ts timestamp, time index(ts))"),
+        "db",
+    )
+        .await;
+    assert!(matches!(output, Output::AffectedRows(0)));
+
+    // rename table
+    let new_table_name = "test_table";
+    let output = execute_sql_in_db(
+        &instance,
+        &format!("alter table {table_name} rename {new_table_name}"),
+        "db",
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(0)));
+
+    // create table with same name
+    // create test table
+    let output = execute_sql_in_db(
+        &instance,
+        &format!("create table {table_name}(host string, cpu double, memory double, ts timestamp, time index(ts))"),
+        "db",
+    )
+        .await;
+    assert!(matches!(output, Output::AffectedRows(0)));
+
+    let expect = "\
++------------+
+| Tables     |
++------------+
+| demo       |
+| test_table |
++------------+\
+"
+    .to_string();
+    let output = execute_sql_in_db(&instance, "show tables", "db").await;
+    check_output_stream(output, expect).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -524,11 +524,10 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             .context(error::AlterTableSnafu { table_name })?;
 
         if let AlterKind::RenameTable { new_table_name } = &req.alter_kind {
-            table_ref.table = new_table_name.as_str();
-            let full_table_name = table_ref.to_string();
             let mut tables = self.tables.write().unwrap();
-            tables.remove(&full_table_name);
-            tables.insert(full_table_name, table.clone());
+            tables.remove(&table_ref.to_string());
+            table_ref.table = new_table_name.as_str();
+            tables.insert(table_ref.to_string(), table.clone());
         }
         Ok(table)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix bug: table cannot be created after renaming

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Fixes #892 