### PR TITLE
ci: use ubuntu 2004 to build weekly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
         # The file format is greptime-<os>-<arch>
         include:
           - arch: x86_64-unknown-linux-gnu
-            os: ubuntu-latest-16-cores
+            os: ubuntu-2004-16-cores
             file: greptime-linux-amd64
           - arch: aarch64-unknown-linux-gnu
-            os: ubuntu-latest-16-cores
+            os: ubuntu-2004-16-cores
             file: greptime-linux-arm64
           - arch: aarch64-apple-darwin
             os: macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,6 @@ debug = true
 [profile.weekly]
 inherits = "release"
 strip = true
-lto = true
+lto = "thin"
 debug = false
 incremental = false


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch fixes #893 by assigning our ubuntu 20.04 runners to release tasks. We also changed `lto` to `thin`  to speed up binary building.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
