### PR TITLE
build(deps): bump tokio to 1.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7538,9 +7538,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ prost = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.28"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.24.2", features = ["full"] }
 tonic = "0.8"
 
 [profile.release]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -24,7 +24,7 @@ meta-srv = { path = "../meta-srv" }
 serde.workspace = true
 servers = { path = "../servers" }
 snafu.workspace = true
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true
 toml = "0.5"
 
 [dev-dependencies]

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -18,4 +18,4 @@ snafu = { version = "0.7", features = ["backtraces"] }
 [dev-dependencies]
 chrono = "0.4"
 tempdir = "0.3"
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -18,4 +18,4 @@ statrs = "0.15"
 
 [dev-dependencies]
 common-base = { path = "../base" }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -16,4 +16,4 @@ snafu = { version = "0.7", features = ["backtraces"] }
 
 [dev-dependencies]
 serde_json = "1.0"
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true

--- a/src/common/substrait/Cargo.toml
+++ b/src/common/substrait/Cargo.toml
@@ -25,4 +25,4 @@ version = "0.2"
 [dev-dependencies]
 datatypes = { path = "../../datatypes" }
 table = { path = "../../table" }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -29,7 +29,7 @@ raft-engine = "0.3"
 snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
 tempdir = "0.3"
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true
 tokio-util = "0.7"
 
 [dev-dependencies]

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -33,8 +33,7 @@ storage = { path = "../storage" }
 store-api = { path = "../store-api" }
 table = { path = "../table" }
 tempdir = { version = "0.3", optional = true }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true
 
 [dev-dependencies]
 tempdir = { version = "0.3" }
-tokio = { version = "1.18", features = ["full"] }

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -19,5 +19,5 @@ snafu = { version = "0.7", features = ["backtraces"] }
 table = { path = "../table" }
 
 [dev-dependencies]
-tokio = { version = "1.23", features = ["full"] }
+tokio.workspace = true
 query = { path = "../query" }

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -34,7 +34,7 @@ session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }
-tokio = "1.0"
+tokio.workspace = true
 
 [dev-dependencies]
 approx_eq = "0.1"
@@ -47,5 +47,4 @@ rand = "0.8"
 statrs = "0.15"
 stats-cli = "3.0"
 streaming-stats = "0.2"
-tokio = { version = "1.0", features = ["full"] }
 tokio-stream = "0.1"

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -62,7 +62,7 @@ session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
 table = { path = "../table" }
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true
 
 [dev-dependencies]
 log-store = { path = "../log-store" }
@@ -72,5 +72,4 @@ serde = { version = "1.0", features = ["derive"] }
 storage = { path = "../storage" }
 store-api = { path = "../store-api" }
 tempdir = "0.3"
-tokio = { version = "1.18", features = ["full"] }
 tokio-test = "0.4"

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -20,4 +20,4 @@ snafu.workspace = true
 [dev-dependencies]
 async-stream.workspace = true
 serde_json = "1.0"
-tokio = { version = "1.0", features = ["full"] }
+tokio.workspace = true

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -25,7 +25,7 @@ paste = "1.0"
 serde = "1.0.136"
 snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
-tokio = { version = "1.18", features = ["full"] }
+tokio.workspace = true
 
 [dev-dependencies]
 parquet = { workspace = true, features = ["async"] }


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Bump tokio to `1.24.2` to resolve a [dependabot alert](https://github.com/GreptimeTeam/greptimedb/security/dependabot/5) (which won't be triggered in our project). And migrate some `Cargo.toml` files to workspace dependence style (only on for tokio).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes #899