### PR TITLE
feat: add FullTableName message in database.proto

### DIFF
--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -26,7 +26,9 @@ use arrow::datatypes::{DataType, Float64Type, Int64Type};
 use arrow::record_batch::RecordBatch;
 use clap::Parser;
 use client::api::v1::column::Values;
-use client::api::v1::{Column, ColumnDataType, ColumnDef, CreateTableExpr, InsertRequest, TableId};
+use client::api::v1::{
+    Column, ColumnDataType, ColumnDef, CreateTableExpr, FullTableName, InsertRequest, TableId,
+};
 use client::{Client, Database};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -100,8 +102,11 @@ async fn write_data(
         let record_batch = record_batch.unwrap();
         let (columns, row_count) = convert_record_batch(record_batch);
         let request = InsertRequest {
-            schema_name: "public".to_string(),
-            table_name: TABLE_NAME.to_string(),
+            full_tablename: Some(FullTableName {
+                catalog_name: "greptime".to_string(),
+                schema_name: "public".to_string(),
+                table_name: TABLE_NAME.to_string(),
+            }),
             region_number: 0,
             columns,
             row_count,

--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -103,8 +103,8 @@ async fn write_data(
         let (columns, row_count) = convert_record_batch(record_batch);
         let request = InsertRequest {
             full_tablename: Some(FullTableName {
-                catalog_name: "greptime".to_string(),
-                schema_name: "public".to_string(),
+                catalog_name: CATALOG_NAME.to_string(),
+                schema_name: SCHEMA_NAME.to_string(),
                 table_name: TABLE_NAME.to_string(),
             }),
             region_number: 0,

--- a/src/api/greptime/v1/database.proto
+++ b/src/api/greptime/v1/database.proto
@@ -21,21 +21,26 @@ message QueryRequest {
 }
 
 message InsertRequest {
-  string schema_name = 1;
-  string table_name = 2;
+  FullTableName full_tablename = 1;
 
   // Data is represented here.
-  repeated Column columns = 3;
+  repeated Column columns = 2;
 
   // The row_count of all columns, which include null and non-null values.
   //
   // Note: the row_count of all columns in a InsertRequest must be same.
-  uint32 row_count = 4;
+  uint32 row_count = 3;
 
   // The region number of current insert request.
-  uint32 region_number = 5;
+  uint32 region_number = 4;
 }
 
 message FlightDataExt {
   uint32 affected_rows = 1;
+}
+
+message FullTableName {
+  string catalog_name = 1;
+  string schema_name = 2;
+  string table_name = 3;
 }

--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -90,6 +90,9 @@ pub enum Error {
         #[snafu(backtrace)]
         source: api::error::Error,
     },
+
+    #[snafu(display("Empty full table name"))]
+    EmptyFullTableName { backtrace: Backtrace },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -104,6 +107,7 @@ impl ErrorExt for Error {
             Error::ColumnDataType { .. } => StatusCode::Internal,
             Error::CreateSchema { .. }
             | Error::DuplicatedTimestampColumn { .. }
+            | Error::EmptyFullTableName { .. }
             | Error::MissingTimestampColumn { .. } => StatusCode::InvalidArguments,
             Error::InvalidColumnProto { .. } => StatusCode::InvalidArguments,
             Error::CreateVector { .. } => StatusCode::InvalidArguments,

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -315,6 +315,9 @@ pub enum Error {
         column: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Empty full table name"))]
+    EmptyFullTableName { backtrace: Backtrace },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -358,6 +361,7 @@ impl ErrorExt for Error {
             | Error::ConstraintNotSupported { .. }
             | Error::SchemaExists { .. }
             | Error::ParseTimestamp { .. }
+            | Error::EmptyFullTableName { .. }
             | Error::DatabaseNotFound { .. } => StatusCode::InvalidArguments,
 
             // TODO(yingwen): Further categorize http error.

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -398,6 +398,9 @@ pub enum Error {
         column: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Empty full table name"))]
+    EmptyFullTableName { backtrace: Backtrace },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -412,6 +415,7 @@ impl ErrorExt for Error {
             | Error::InvalidInsertRequest { .. }
             | Error::FindPartitionColumn { .. }
             | Error::ColumnValuesNumberMismatch { .. }
+            | Error::EmptyFullTableName { .. }
             | Error::RegionKeysSize { .. } => StatusCode::InvalidArguments,
 
             Error::NotSupported { .. } => StatusCode::Unsupported,

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -81,7 +81,8 @@ mod test {
     use api::v1::ddl_request::Expr as DdlExpr;
     use api::v1::{
         alter_expr, AddColumn, AddColumns, AlterExpr, Column, ColumnDataType, ColumnDef,
-        CreateDatabaseExpr, CreateTableExpr, DdlRequest, InsertRequest, QueryRequest,
+        CreateDatabaseExpr, CreateTableExpr, DdlRequest, FullTableName, InsertRequest,
+        QueryRequest,
     };
     use catalog::helper::{TableGlobalKey, TableGlobalValue};
     use common_query::Output;
@@ -340,8 +341,11 @@ CREATE TABLE {table_name} (
 
     async fn test_insert_and_query_on_existing_table(instance: &Arc<Instance>, table_name: &str) {
         let insert = InsertRequest {
-            schema_name: "public".to_string(),
-            table_name: table_name.to_string(),
+            full_tablename: Some(FullTableName {
+                catalog_name: "greptime".to_string(),
+                schema_name: "public".to_string(),
+                table_name: table_name.to_string(),
+            }),
             columns: vec![
                 Column {
                     column_name: "a".to_string(),
@@ -461,8 +465,11 @@ CREATE TABLE {table_name} (
 
     async fn test_insert_and_query_on_auto_created_table(instance: &Arc<Instance>) {
         let insert = InsertRequest {
-            schema_name: "public".to_string(),
-            table_name: "auto_created_table".to_string(),
+            full_tablename: Some(FullTableName {
+                catalog_name: "greptime".to_string(),
+                schema_name: "public".to_string(),
+                table_name: "auto_created_table".to_string(),
+            }),
             columns: vec![
                 Column {
                     column_name: "a".to_string(),
@@ -499,8 +506,11 @@ CREATE TABLE {table_name} (
         assert!(matches!(output, Output::AffectedRows(3)));
 
         let insert = InsertRequest {
-            schema_name: "public".to_string(),
-            table_name: "auto_created_table".to_string(),
+            full_tablename: Some(FullTableName {
+                catalog_name: "greptime".to_string(),
+                schema_name: "public".to_string(),
+                table_name: "auto_created_table".to_string(),
+            }),
             columns: vec![
                 Column {
                     column_name: "b".to_string(),

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -68,6 +68,7 @@ monitor1,host=host1 cpu=66.6,memory=1024 1663840496100023100
 monitor1,host=host2 memory=1027 1663840496400340001";
         let request = InfluxdbRequest {
             precision: None,
+            tenant: "greptime".to_string(),
             db: "public".to_string(),
             lines: lines.to_string(),
         };

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -605,7 +605,7 @@ impl PartitionExec {
 #[cfg(test)]
 mod test {
     use api::v1::column::SemanticType;
-    use api::v1::{column, Column, ColumnDataType, InsertRequest};
+    use api::v1::{column, Column, ColumnDataType, FullTableName, InsertRequest};
     use catalog::error::Result;
     use catalog::remote::{KvBackend, ValueIter};
     use common_query::physical_plan::DfPhysicalPlanAdapter;
@@ -1158,8 +1158,11 @@ mod test {
             },
         ];
         let request = InsertRequest {
-            schema_name: table_name.schema_name.clone(),
-            table_name: table_name.table_name.clone(),
+            full_tablename: Some(FullTableName {
+                catalog_name: "greptime".to_string(),
+                schema_name: table_name.schema_name.clone(),
+                table_name: table_name.table_name.clone(),
+            }),
             columns,
             row_count,
             region_number: 0,

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
-use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_grpc::writer::Precision;
 
 use crate::error::{Result, TimePrecisionSnafu};
@@ -29,6 +29,9 @@ pub async fn influxdb_write(
     Query(mut params): Query<HashMap<String, String>>,
     lines: String,
 ) -> Result<(StatusCode, ())> {
+    let tenant = params
+        .remove("tenant")
+        .unwrap_or_else(|| DEFAULT_CATALOG_NAME.to_string());
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
@@ -38,6 +41,7 @@ pub async fn influxdb_write(
         .map(|val| parse_time_precision(val))
         .transpose()?;
     let request = InfluxdbRequest {
+        tenant,
         precision,
         lines,
         db,

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use api::v1::InsertRequest;
+use api::v1::{FullTableName, InsertRequest};
 use async_trait::async_trait;
 use axum::{http, Router};
 use axum_test_helper::TestClient;
@@ -39,7 +39,13 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
         let requests: Vec<InsertRequest> = request.try_into()?;
 
         for expr in requests {
-            let _ = self.tx.send((expr.schema_name, expr.table_name)).await;
+            let FullTableName {
+                schema_name,
+                table_name,
+                ..
+            } = expr.full_tablename.unwrap();
+
+            let _ = self.tx.send((schema_name, table_name)).await;
         }
 
         Ok(())

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -15,7 +15,7 @@ use api::v1::alter_expr::Kind;
 use api::v1::column::SemanticType;
 use api::v1::{
     column, AddColumn, AddColumns, AlterExpr, Column, ColumnDataType, ColumnDef, CreateTableExpr,
-    InsertRequest, TableId,
+    FullTableName, InsertRequest, TableId,
 };
 use client::{Client, Database};
 use common_catalog::consts::MIN_USER_TABLE_ID;
@@ -173,8 +173,11 @@ async fn insert_and_assert(db: &Database) {
     let (expected_host_col, expected_cpu_col, expected_mem_col, expected_ts_col) = expect_data();
 
     let request = InsertRequest {
-        schema_name: "public".to_string(),
-        table_name: "demo".to_string(),
+        full_tablename: Some(FullTableName {
+            catalog_name: "greptime".to_string(),
+            schema_name: "public".to_string(),
+            table_name: "demo".to_string(),
+        }),
         region_number: 0,
         columns: vec![
             expected_host_col.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly change:
1. Before this pr, the catalog information was missing in the `InsertRequest` message. In this pr,  add `full_tablename` field in `InsertRequest` message.
2. Add a optional param `tenant` in Influxdb line proto, which is used to distinguish different tenants when writing data.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#559 