### PR TITLE
chore: return `authorize` err msg to mysql client

### DIFF
--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -110,7 +110,7 @@ pub enum Error {
     UserPasswordMismatch { username: String },
 
     #[snafu(display(
-        "User {} is not allowed to access catalog {} and schema {}",
+        "Access denied for user '{}' to database '{}-{}'",
         username,
         catalog,
         schema


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly adds human-friendly return msg to mysql client if `authorize` method fails.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
