### PR TITLE
refactor: move partition related code to partition manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,22 +680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
-name = "base64ct"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
-
-[[package]]
-name = "bcder"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dfb7dc0d4aee3f8c723c43553b55662badf692b541ff8e4426df75dae8da9a"
-dependencies = [
- "bytes",
- "smallvec",
-]
-
-[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
@@ -1511,21 +1495,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common-procedure"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "common-error",
- "common-runtime",
- "common-telemetry",
- "serde",
- "serde_json",
- "snafu",
- "tokio",
- "uuid",
-]
-
-[[package]]
 name = "common-query"
 version = "0.1.0"
 dependencies = [
@@ -1664,12 +1633,6 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "const-random"
@@ -2232,15 +2195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2257,16 +2211,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro 0.11.2",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
-dependencies = [
- "derive_builder_macro 0.12.0",
+ "derive_builder_macro",
 ]
 
 [[package]]
@@ -2282,34 +2227,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder_core"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core 0.11.2",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
-dependencies = [
- "derive_builder_core 0.12.0",
+ "derive_builder_core",
  "syn",
 ]
 
@@ -4818,28 +4741,25 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.8.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6594056c6fc1c40b203ce6647d55bda25f249bc2b06bffaad3a4032a6d110e88"
+checksum = "ab6d8c74bed581ab4a5ae0393ae05dc50e6b097d6298bcf97c5c58246b74aee6"
 dependencies = [
  "async-trait",
- "base64 0.21.0",
  "bytes",
  "derive-new",
  "futures",
  "getset",
+ "hex",
  "log",
  "md5",
  "postgres-types",
  "rand 0.8.5",
- "ring",
- "stringprep",
  "thiserror",
  "time 0.3.17",
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "x509-certificate",
 ]
 
 [[package]]
@@ -6643,7 +6563,6 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datatypes",
- "derive_builder 0.12.0",
  "digest",
  "futures",
  "hex",
@@ -6763,12 +6682,6 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "signature"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 
 [[package]]
 name = "simba"
@@ -6905,16 +6818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "sql"
 version = "0.1.0"
 dependencies = [
@@ -6940,7 +6843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa69a2ae10018ec72a3cb7574e3a33a3fc322ed03740f6e435fd7f0c1db4a7"
 dependencies = [
  "async-trait",
- "derive_builder 0.11.2",
+ "derive_builder",
  "prettydiff",
  "serde",
  "thiserror",
@@ -7067,7 +6970,7 @@ dependencies = [
  "common-query",
  "common-time",
  "datatypes",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "serde",
  "serde_json",
@@ -7283,7 +7186,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datatypes",
- "derive_builder 0.11.2",
+ "derive_builder",
  "futures",
  "parquet",
  "parquet-format-async-temp",
@@ -8633,24 +8536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-certificate"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ae06cd45e681e1ae216e2e668e30ce1c4f02db026374bde8c0644684af1721"
-dependencies = [
- "bcder",
- "bytes",
- "chrono",
- "der",
- "hex",
- "pem",
- "ring",
- "signature",
- "spki",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,6 +2687,7 @@ dependencies = [
  "meta-srv",
  "moka",
  "openmetrics-parser",
+ "partition",
  "prost 0.11.6",
  "query",
  "rustls",
@@ -4713,6 +4714,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "partition"
+version = "0.1.0"
+dependencies = [
+ "common-error",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
+ "datatypes",
+ "meta-client",
+ "moka",
+ "serde",
+ "serde_json",
+ "snafu",
+ "store-api",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
+name = "bcder"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69dfb7dc0d4aee3f8c723c43553b55662badf692b541ff8e4426df75dae8da9a"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "benchmarks"
 version = "0.1.0"
 dependencies = [
@@ -1495,6 +1511,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-procedure"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "common-error",
+ "common-runtime",
+ "common-telemetry",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "common-query"
 version = "0.1.0"
 dependencies = [
@@ -1633,6 +1664,12 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "const-random"
@@ -2195,6 +2232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,7 +2257,16 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.11.2",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
 ]
 
 [[package]]
@@ -2227,12 +2282,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder_macro"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.11.2",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
  "syn",
 ]
 
@@ -4741,25 +4818,28 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6d8c74bed581ab4a5ae0393ae05dc50e6b097d6298bcf97c5c58246b74aee6"
+checksum = "6594056c6fc1c40b203ce6647d55bda25f249bc2b06bffaad3a4032a6d110e88"
 dependencies = [
  "async-trait",
+ "base64 0.21.0",
  "bytes",
  "derive-new",
  "futures",
  "getset",
- "hex",
  "log",
  "md5",
  "postgres-types",
  "rand 0.8.5",
+ "ring",
+ "stringprep",
  "thiserror",
  "time 0.3.17",
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -6563,6 +6643,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "datatypes",
+ "derive_builder 0.12.0",
  "digest",
  "futures",
  "hex",
@@ -6682,6 +6763,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 
 [[package]]
 name = "simba"
@@ -6818,6 +6905,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sql"
 version = "0.1.0"
 dependencies = [
@@ -6843,7 +6940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa69a2ae10018ec72a3cb7574e3a33a3fc322ed03740f6e435fd7f0c1db4a7"
 dependencies = [
  "async-trait",
- "derive_builder",
+ "derive_builder 0.11.2",
  "prettydiff",
  "serde",
  "thiserror",
@@ -6970,7 +7067,7 @@ dependencies = [
  "common-query",
  "common-time",
  "datatypes",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "serde",
  "serde_json",
@@ -7186,7 +7283,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr",
  "datatypes",
- "derive_builder",
+ "derive_builder 0.11.2",
  "futures",
  "parquet",
  "parquet-format-async-temp",
@@ -8536,6 +8633,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ae06cd45e681e1ae216e2e668e30ce1c4f02db026374bde8c0644684af1721"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4731,6 +4731,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "store-api",
+ "table",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4721,6 +4721,7 @@ name = "partition"
 version = "0.1.0"
 dependencies = [
  "common-error",
+ "common-query",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "src/meta-srv",
     "src/mito",
     "src/object-store",
+    "src/partition",
     "src/promql",
     "src/query",
     "src/script",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -32,6 +32,7 @@ itertools = "0.10"
 meta-client = { path = "../meta-client" }
 moka = { version = "0.9", features = ["future"] }
 openmetrics-parser = "0.4"
+partition = { path = "../partition" }
 prost.workspace = true
 query = { path = "../query" }
 rustls = "0.20"

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -29,11 +29,11 @@ use catalog::{
 };
 use futures::StreamExt;
 use meta_client::rpc::TableName;
+use partition::route::TableRoutes;
 use snafu::prelude::*;
 use table::TableRef;
 
 use crate::datanode::DatanodeClients;
-use crate::table::route::TableRoutes;
 use crate::table::DistTable;
 
 #[derive(Clone)]

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -405,8 +405,9 @@ impl ErrorExt for Error {
             Error::InvokeDatanode { source } => source.status_code(),
             Error::ColumnDefaultValue { source, .. } => source.status_code(),
             Error::ColumnNoneDefaultValue { .. } => StatusCode::InvalidArguments,
-            Error::DeserializePartition { source, .. } => source.status_code(),
-            Error::FindTableRoute { source, .. } => source.status_code(),
+            Error::DeserializePartition { source, .. } | Error::FindTableRoute { source, .. } => {
+                source.status_code()
+            }
         }
     }
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -181,10 +181,17 @@ pub enum Error {
         source: meta_client::error::Error,
     },
 
-    #[snafu(display("Failed to find table routes for table {}", table_name))]
-    FindTableRoutes {
+    #[snafu(display("Failed to create table routes for table {}", table_name))]
+    CreateTableRoutes {
         table_name: String,
         backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to find table routes for table {}", table_name))]
+    FindTableRoute {
+        table_name: String,
+        #[snafu(backtrace)]
+        source: partition::error::Error,
     },
 
     #[snafu(display("Failed to create AlterExpr from Alter statement, source: {}", source))]
@@ -401,7 +408,7 @@ impl ErrorExt for Error {
             }
 
             Error::FindDatanode { .. }
-            | Error::FindTableRoutes { .. }
+            | Error::CreateTableRoutes { .. }
             | Error::FindRegionRoutes { .. }
             | Error::FindLeaderPeer { .. }
             | Error::FindRegionPartition { .. }
@@ -440,9 +447,9 @@ impl ErrorExt for Error {
             Error::InvokeDatanode { source } => source.status_code(),
             Error::ColumnDefaultValue { source, .. } => source.status_code(),
             Error::ColumnNoneDefaultValue { .. } => StatusCode::InvalidArguments,
-            Error::DeserializePartition { source, .. } | Error::FindPartition { source, .. } => {
-                source.status_code()
-            }
+            Error::FindPartition { source, .. } => source.status_code(),
+            Error::DeserializePartition { source, .. } => source.status_code(),
+            Error::FindTableRoute { source, .. } => source.status_code(),
         }
     }
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -110,12 +110,6 @@ pub enum Error {
         source: datatypes::error::Error,
     },
 
-    #[snafu(display("Failed to find partition column: {}", column_name))]
-    FindPartitionColumn {
-        column_name: String,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Failed to find region, reason: {}", reason))]
     FindRegion {
         reason: String,
@@ -425,7 +419,6 @@ impl ErrorExt for Error {
             | Error::FindRegion { .. }
             | Error::FindRegions { .. }
             | Error::InvalidInsertRequest { .. }
-            | Error::FindPartitionColumn { .. }
             | Error::ColumnValuesNumberMismatch { .. }
             | Error::RegionKeysSize { .. } => StatusCode::InvalidArguments,
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -330,9 +330,6 @@ pub enum Error {
         #[snafu(backtrace)]
         source: partition::error::Error,
     },
-
-    #[snafu(display("Failed to deserialize partition in meta to partition def",))]
-    DeserializePartition { source: partition::error::Error },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -349,9 +346,8 @@ impl ErrorExt for Error {
 
             Error::RuntimeResource { source, .. } => source.status_code(),
 
-            Error::SqlExecIntercepted { source, .. } | Error::StartServer { source, .. } => {
-                source.status_code()
-            }
+            Error::SqlExecIntercepted { source, .. } => source.status_code(),
+            Error::StartServer { source, .. } => source.status_code(),
 
             Error::ParseSql { source } | Error::AlterExprFromStmt { source } => {
                 source.status_code()

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -40,6 +40,7 @@ use datanode::instance::InstanceRef as DnInstanceRef;
 use distributed::DistInstance;
 use meta_client::client::{MetaClient, MetaClientBuilder};
 use meta_client::MetaClientOpts;
+use partition::manager::PartitionRuleManager;
 use partition::route::TableRoutes;
 use servers::error as server_error;
 use servers::interceptor::{SqlQueryInterceptor, SqlQueryInterceptorRef};
@@ -104,10 +105,12 @@ impl Instance {
             client: meta_client.clone(),
         });
         let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
+        let partition_manager = Arc::new(PartitionRuleManager::new(table_routes.clone()));
         let datanode_clients = Arc::new(DatanodeClients::new());
+
         let catalog_manager = Arc::new(FrontendCatalogManager::new(
             meta_backend,
-            table_routes,
+            partition_manager,
             datanode_clients.clone(),
         ));
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -105,7 +105,7 @@ impl Instance {
             client: meta_client.clone(),
         });
         let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
-        let partition_manager = Arc::new(PartitionRuleManager::new(table_routes.clone()));
+        let partition_manager = Arc::new(PartitionRuleManager::new(table_routes));
         let datanode_clients = Arc::new(DatanodeClients::new());
 
         let catalog_manager = Arc::new(FrontendCatalogManager::new(

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -40,6 +40,7 @@ use datanode::instance::InstanceRef as DnInstanceRef;
 use distributed::DistInstance;
 use meta_client::client::{MetaClient, MetaClientBuilder};
 use meta_client::MetaClientOpts;
+use partition::route::TableRoutes;
 use servers::error as server_error;
 use servers::interceptor::{SqlQueryInterceptor, SqlQueryInterceptorRef};
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
@@ -60,7 +61,6 @@ use crate::error::{self, Error, MissingMetasrvOptsSnafu, Result};
 use crate::expr_factory::{CreateExprFactoryRef, DefaultCreateExprFactory};
 use crate::frontend::FrontendOptions;
 use crate::instance::standalone::{StandaloneGrpcQueryHandler, StandaloneSqlQueryHandler};
-use crate::table::route::TableRoutes;
 use crate::Plugins;
 
 #[async_trait]

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -92,7 +92,7 @@ impl DistInstance {
         let table_routes = response.table_routes;
         ensure!(
             table_routes.len() == 1,
-            error::FindTableRoutesSnafu {
+            error::CreateTableRoutesSnafu {
                 table_name: create_table.table_name.to_string()
             }
         );

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -92,7 +92,7 @@ impl DistInstance {
         let table_routes = response.table_routes;
         ensure!(
             table_routes.len() == 1,
-            error::CreateTableRoutesSnafu {
+            error::CreateTableRouteSnafu {
                 table_name: create_table.table_name.to_string()
             }
         );
@@ -107,7 +107,7 @@ impl DistInstance {
         let region_routes = &table_route.region_routes;
         ensure!(
             !region_routes.is_empty(),
-            error::FindRegionRoutesSnafu {
+            error::FindRegionRouteSnafu {
                 table_name: create_table.table_name.to_string()
             }
         );
@@ -509,11 +509,9 @@ fn parse_partitions(
 
     partition_entries
         .into_iter()
-        .map(|x| {
-            MetaPartition::try_from(PartitionDef::new(partition_columns.clone(), x))
-                .context(DeserializePartitionSnafu)
-        })
-        .collect::<Result<Vec<MetaPartition>>>()
+        .map(|x| MetaPartition::try_from(PartitionDef::new(partition_columns.clone(), x)))
+        .collect::<std::result::Result<_, _>>()
+        .context(DeserializePartitionSnafu)
 }
 
 fn find_partition_entries(

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -34,6 +34,7 @@ use meta_client::rpc::{
     CreateRequest as MetaCreateRequest, Partition as MetaPartition, PutRequest, RouteResponse,
     TableName, TableRoute,
 };
+use partition::partition::{PartitionBound, PartitionDef};
 use query::parser::QueryStatement;
 use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
@@ -51,13 +52,12 @@ use crate::catalog::FrontendCatalogManager;
 use crate::datanode::DatanodeClients;
 use crate::error::{
     self, AlterExprToRequestSnafu, CatalogEntrySerdeSnafu, CatalogNotFoundSnafu, CatalogSnafu,
-    ColumnDataTypeSnafu, ParseSqlSnafu, PrimaryKeyNotFoundSnafu, RequestDatanodeSnafu,
-    RequestMetaSnafu, Result, SchemaNotFoundSnafu, StartMetaClientSnafu, TableNotFoundSnafu,
-    TableSnafu, ToTableInsertRequestSnafu,
+    ColumnDataTypeSnafu, DeserializePartitionSnafu, ParseSqlSnafu, PrimaryKeyNotFoundSnafu,
+    RequestDatanodeSnafu, RequestMetaSnafu, Result, SchemaNotFoundSnafu, StartMetaClientSnafu,
+    TableNotFoundSnafu, TableSnafu, ToTableInsertRequestSnafu,
 };
 use crate::expr_factory::{CreateExprFactory, DefaultCreateExprFactory};
 use crate::instance::parse_stmt;
-use crate::partitioning::{PartitionBound, PartitionDef};
 use crate::sql::insert_to_request;
 
 #[derive(Clone)]
@@ -509,7 +509,10 @@ fn parse_partitions(
 
     partition_entries
         .into_iter()
-        .map(|x| PartitionDef::new(partition_columns.clone(), x).try_into())
+        .map(|x| {
+            MetaPartition::try_from(PartitionDef::new(partition_columns.clone(), x))
+                .context(DeserializePartitionSnafu)
+        })
         .collect::<Result<Vec<MetaPartition>>>()
 }
 

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -29,7 +29,6 @@ pub mod opentsdb;
 pub mod postgres;
 pub mod prometheus;
 mod server;
-pub mod spliter;
 mod sql;
 mod table;
 #[cfg(test)]

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -44,7 +44,7 @@ use partition::columns::RangeColumnsPartitionRule;
 use partition::partition::{PartitionBound, PartitionDef, PartitionExpr};
 use partition::range::RangePartitionRule;
 use partition::route::TableRoutes;
-use partition::splitter::RequestSplitter;
+use partition::splitter::WriteSplitter;
 use partition::PartitionRuleRef;
 use snafu::prelude::*;
 use store_api::storage::RegionNumber;
@@ -96,7 +96,7 @@ impl Table for DistTable {
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 
-        let spliter = RequestSplitter::with_partition_rule(partition_rule);
+        let spliter = WriteSplitter::with_partition_rule(partition_rule);
         let inserts = spliter
             .split_insert(request)
             .map_err(BoxedError::new)

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use api::v1::AlterExpr;
@@ -35,19 +34,10 @@ use datafusion::physical_plan::{
     Partitioning, SendableRecordBatchStream as DfSendableRecordBatchStream,
 };
 use datafusion_common::DataFusionError;
-use datafusion_expr::expr::Expr as DfExpr;
-use datafusion_expr::{BinaryExpr, Operator};
-use datatypes::prelude::Value;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
-use meta_client::rpc::{Peer, TableName};
-use partition::columns::RangeColumnsPartitionRule;
-use partition::partition::{PartitionBound, PartitionDef, PartitionExpr};
-use partition::range::RangePartitionRule;
-use partition::route::TableRoutes;
-use partition::splitter::WriteSplitter;
-use partition::PartitionRuleRef;
+use meta_client::rpc::TableName;
+use partition::manager::PartitionRuleManagerRef;
 use snafu::prelude::*;
-use store_api::storage::RegionNumber;
 use table::error::TableOperationSnafu;
 use table::metadata::{FilterPushDownType, TableInfo, TableInfoRef};
 use table::requests::{AlterTableRequest, InsertRequest};
@@ -56,11 +46,7 @@ use table::Table;
 use tokio::sync::RwLock;
 
 use crate::datanode::DatanodeClients;
-use crate::error::{
-    self, BuildTableMetaSnafu, CatalogEntrySerdeSnafu, CatalogSnafu, ContextValueNotFoundSnafu,
-    DeserializePartitionSnafu, FindPartitionSnafu, LeaderNotFoundSnafu, RequestDatanodeSnafu,
-    Result, TableNotFoundSnafu, TableSnafu,
-};
+use crate::error::{self, Result};
 use crate::table::scan::{DatanodeInstance, TableScanPlan};
 
 pub mod insert;
@@ -70,7 +56,7 @@ pub(crate) mod scan;
 pub struct DistTable {
     table_name: TableName,
     table_info: TableInfoRef,
-    table_routes: Arc<TableRoutes>,
+    partition_manager: PartitionRuleManagerRef,
     datanode_clients: Arc<DatanodeClients>,
     backend: KvBackendRef,
 }
@@ -90,20 +76,15 @@ impl Table for DistTable {
     }
 
     async fn insert(&self, request: InsertRequest) -> table::Result<usize> {
-        let partition_rule = self
-            .find_partition_rule()
+        let split = self
+            .partition_manager
+            .split_insert_request(&self.table_name, request)
             .await
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 
-        let spliter = WriteSplitter::with_partition_rule(partition_rule);
-        let inserts = spliter
-            .split_insert(request)
-            .map_err(BoxedError::new)
-            .context(TableOperationSnafu)?;
-
         let output = self
-            .dist_insert(inserts)
+            .dist_insert(split)
             .await
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
@@ -118,17 +99,20 @@ impl Table for DistTable {
         limit: Option<usize>,
     ) -> table::Result<PhysicalPlanRef> {
         let partition_rule = self
-            .find_partition_rule()
+            .partition_manager
+            .find_table_partition_rule(&self.table_name)
             .await
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 
         let regions = self
-            .find_regions(partition_rule, filters)
+            .partition_manager
+            .find_regions_by_filters(partition_rule, filters)
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
         let datanodes = self
-            .find_datanodes(regions)
+            .partition_manager
+            .find_region_datanodes(&self.table_name, regions)
             .await
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
@@ -173,239 +157,17 @@ impl DistTable {
     pub(crate) fn new(
         table_name: TableName,
         table_info: TableInfoRef,
-        table_routes: Arc<TableRoutes>,
+        partition_manager: PartitionRuleManagerRef,
         datanode_clients: Arc<DatanodeClients>,
         backend: KvBackendRef,
     ) -> Self {
         Self {
             table_name,
             table_info,
-            table_routes,
+            partition_manager,
             datanode_clients,
             backend,
         }
-    }
-
-    // TODO(LFC): Finding regions now seems less efficient, should be further looked into.
-    fn find_regions(
-        &self,
-        partition_rule: PartitionRuleRef,
-        filters: &[Expr],
-    ) -> Result<Vec<RegionNumber>> {
-        let regions = if let Some((first, rest)) = filters.split_first() {
-            let mut target = self.find_regions0(partition_rule.clone(), first)?;
-            for filter in rest {
-                let regions = self.find_regions0(partition_rule.clone(), filter)?;
-
-                // When all filters are provided as a collection, it often implicitly states that
-                // "all filters must be satisfied". So we join all the results here.
-                target.retain(|x| regions.contains(x));
-
-                // Failed fast, empty collection join any is empty.
-                if target.is_empty() {
-                    break;
-                }
-            }
-            target.into_iter().collect::<Vec<_>>()
-        } else {
-            partition_rule
-                .find_regions(&[])
-                .with_context(|_| FindPartitionSnafu {
-                    table: self.table_name.to_string(),
-                })?
-        };
-        ensure!(
-            !regions.is_empty(),
-            error::FindRegionsSnafu {
-                filters: filters.to_vec()
-            }
-        );
-        Ok(regions)
-    }
-
-    // TODO(LFC): Support other types of filter expr:
-    //   - BETWEEN and IN (maybe more)
-    //   - expr with arithmetic like "a + 1 < 10" (should have been optimized in logic plan?)
-    //   - not comparison or neither "AND" nor "OR" operations, for example, "a LIKE x"
-    fn find_regions0(
-        &self,
-        partition_rule: PartitionRuleRef,
-        filter: &Expr,
-    ) -> Result<HashSet<RegionNumber>> {
-        let expr = filter.df_expr();
-        match expr {
-            DfExpr::BinaryExpr(BinaryExpr { left, op, right }) if is_compare_op(op) => {
-                let column_op_value = match (left.as_ref(), right.as_ref()) {
-                    (DfExpr::Column(c), DfExpr::Literal(v)) => Some((&c.name, *op, v)),
-                    (DfExpr::Literal(v), DfExpr::Column(c)) => {
-                        Some((&c.name, reverse_operator(op), v))
-                    }
-                    _ => None,
-                };
-                if let Some((column, op, sv)) = column_op_value {
-                    let value = sv
-                        .clone()
-                        .try_into()
-                        .with_context(|_| error::ConvertScalarValueSnafu { value: sv.clone() })?;
-                    return Ok(partition_rule
-                        .find_regions(&[PartitionExpr::new(column, op, value)])
-                        .with_context(|_| FindPartitionSnafu {
-                            table: self.table_name.to_string(),
-                        })?
-                        .into_iter()
-                        .collect::<HashSet<RegionNumber>>());
-                }
-            }
-            DfExpr::BinaryExpr(BinaryExpr { left, op, right })
-                if matches!(op, Operator::And | Operator::Or) =>
-            {
-                let left_regions =
-                    self.find_regions0(partition_rule.clone(), &(*left.clone()).into())?;
-                let right_regions =
-                    self.find_regions0(partition_rule.clone(), &(*right.clone()).into())?;
-                let regions = match op {
-                    Operator::And => left_regions
-                        .intersection(&right_regions)
-                        .cloned()
-                        .collect::<HashSet<RegionNumber>>(),
-                    Operator::Or => left_regions
-                        .union(&right_regions)
-                        .cloned()
-                        .collect::<HashSet<RegionNumber>>(),
-                    _ => unreachable!(),
-                };
-                return Ok(regions);
-            }
-            _ => (),
-        }
-
-        // Returns all regions for not supported partition expr as a safety hatch.
-        Ok(partition_rule
-            .find_regions(&[])
-            .with_context(|_| FindPartitionSnafu {
-                table: self.table_name.to_string(),
-            })?
-            .into_iter()
-            .collect::<HashSet<RegionNumber>>())
-    }
-
-    async fn find_datanodes(
-        &self,
-        regions: Vec<RegionNumber>,
-    ) -> Result<HashMap<Peer, Vec<RegionNumber>>> {
-        let route = self
-            .table_routes
-            .get_route(&self.table_name)
-            .await
-            .with_context(|_| FindPartitionSnafu {
-                table: self.table_name.to_string(),
-            })?;
-
-        let mut datanodes = HashMap::new();
-        for region in regions.iter() {
-            let datanode = route
-                .region_routes
-                .iter()
-                .find_map(|x| {
-                    if x.region.id == *region as u64 {
-                        x.leader_peer.clone()
-                    } else {
-                        None
-                    }
-                })
-                .context(error::FindDatanodeSnafu { region: *region })?;
-            datanodes
-                .entry(datanode)
-                .or_insert_with(Vec::new)
-                .push(*region);
-        }
-        Ok(datanodes)
-    }
-
-    async fn find_partition_rule(&self) -> Result<PartitionRuleRef> {
-        let route = self
-            .table_routes
-            .get_route(&self.table_name)
-            .await
-            .with_context(|_| FindPartitionSnafu {
-                table: self.table_name.to_string(),
-            })?;
-        ensure!(
-            !route.region_routes.is_empty(),
-            error::FindRegionRoutesSnafu {
-                table_name: self.table_name.to_string()
-            }
-        );
-
-        let mut partitions = Vec::with_capacity(route.region_routes.len());
-        for r in route.region_routes.iter() {
-            let partition =
-                r.region
-                    .partition
-                    .clone()
-                    .context(error::FindRegionPartitionSnafu {
-                        region: r.region.id,
-                        table_name: self.table_name.to_string(),
-                    })?;
-            let partition_def =
-                PartitionDef::try_from(partition).context(DeserializePartitionSnafu)?;
-            partitions.push((r.region.id, partition_def));
-        }
-        partitions.sort_by(|a, b| a.1.partition_bounds().cmp(b.1.partition_bounds()));
-
-        ensure!(
-            partitions
-                .windows(2)
-                .all(|w| w[0].1.partition_columns() == w[1].1.partition_columns()),
-            error::IllegalTableRoutesDataSnafu {
-                table_name: self.table_name.to_string(),
-                err_msg: "partition columns of all regions are not the same"
-            }
-        );
-        let partition_columns = partitions[0].1.partition_columns();
-        ensure!(
-            !partition_columns.is_empty(),
-            error::IllegalTableRoutesDataSnafu {
-                table_name: self.table_name.to_string(),
-                err_msg: "no partition columns found"
-            }
-        );
-
-        let regions = partitions
-            .iter()
-            .map(|x| x.0 as u32)
-            .collect::<Vec<RegionNumber>>();
-
-        // TODO(LFC): Serializing and deserializing partition rule is ugly, must find a much more elegant way.
-        let partition_rule: PartitionRuleRef = match partition_columns.len() {
-            1 => {
-                // Omit the last "MAXVALUE".
-                let bounds = partitions
-                    .iter()
-                    .filter_map(|(_, p)| match &p.partition_bounds()[0] {
-                        PartitionBound::Value(v) => Some(v.clone()),
-                        PartitionBound::MaxValue => None,
-                    })
-                    .collect::<Vec<Value>>();
-                Arc::new(RangePartitionRule::new(
-                    partition_columns[0].clone(),
-                    bounds,
-                    regions,
-                )) as _
-            }
-            _ => {
-                let bounds = partitions
-                    .iter()
-                    .map(|x| x.1.partition_bounds().clone())
-                    .collect::<Vec<Vec<PartitionBound>>>();
-                Arc::new(RangeColumnsPartitionRule::new(
-                    partition_columns.clone(),
-                    bounds,
-                    regions,
-                )) as _
-            }
-        };
-        Ok(partition_rule)
     }
 
     pub(crate) async fn table_global_value(
@@ -416,9 +178,9 @@ impl DistTable {
             .backend
             .get(key.to_string().as_bytes())
             .await
-            .context(CatalogSnafu)?;
+            .context(error::CatalogSnafu)?;
         Ok(if let Some(raw) = raw {
-            Some(TableGlobalValue::from_bytes(raw.1).context(CatalogEntrySerdeSnafu)?)
+            Some(TableGlobalValue::from_bytes(raw.1).context(error::CatalogEntrySerdeSnafu)?)
         } else {
             None
         })
@@ -429,17 +191,17 @@ impl DistTable {
         key: TableGlobalKey,
         value: TableGlobalValue,
     ) -> Result<()> {
-        let value = value.as_bytes().context(CatalogEntrySerdeSnafu)?;
+        let value = value.as_bytes().context(error::CatalogEntrySerdeSnafu)?;
         self.backend
             .set(key.to_string().as_bytes(), &value)
             .await
-            .context(CatalogSnafu)
+            .context(error::CatalogSnafu)
     }
 
     async fn handle_alter(&self, context: AlterContext, request: &AlterTableRequest) -> Result<()> {
         let alter_expr = context
             .get::<AlterExpr>()
-            .context(ContextValueNotFoundSnafu { key: "AlterExpr" })?;
+            .context(error::ContextValueNotFoundSnafu { key: "AlterExpr" })?;
 
         self.alter_by_expr(alter_expr).await?;
 
@@ -448,9 +210,9 @@ impl DistTable {
         let new_meta = table_info
             .meta
             .builder_with_alter_kind(table_name, &request.alter_kind)
-            .context(TableSnafu)?
+            .context(error::TableSnafu)?
             .build()
-            .context(BuildTableMetaSnafu {
+            .context(error::BuildTableMetaSnafu {
                 table_name: table_name.clone(),
             })?;
 
@@ -463,12 +225,12 @@ impl DistTable {
             schema_name: alter_expr.schema_name.clone(),
             table_name: alter_expr.table_name.clone(),
         };
-        let mut value = self
-            .table_global_value(&key)
-            .await?
-            .context(TableNotFoundSnafu {
-                table_name: alter_expr.table_name.clone(),
-            })?;
+        let mut value =
+            self.table_global_value(&key)
+                .await?
+                .context(error::TableNotFoundSnafu {
+                    table_name: alter_expr.table_name.clone(),
+                })?;
 
         value.table_info = new_info.into();
 
@@ -479,16 +241,16 @@ impl DistTable {
     /// [`table::requests::AlterTableRequest`] and [`AlterExpr`].
     async fn alter_by_expr(&self, expr: &AlterExpr) -> Result<()> {
         let table_routes = self
-            .table_routes
-            .get_route(&self.table_name)
+            .partition_manager
+            .find_table_route(&self.table_name)
             .await
-            .with_context(|_| FindPartitionSnafu {
-                table: self.table_name.to_string(),
+            .with_context(|_| error::FindTableRouteSnafu {
+                table_name: self.table_name.to_string(),
             })?;
         let leaders = table_routes.find_leaders();
         ensure!(
             !leaders.is_empty(),
-            LeaderNotFoundSnafu {
+            error::LeaderNotFoundSnafu {
                 table: format!(
                     "{:?}.{:?}.{}",
                     expr.catalog_name, expr.schema_name, expr.table_name
@@ -501,7 +263,10 @@ impl DistTable {
                 self.datanode_clients.get_client(&datanode).await,
             );
             debug!("Sending {:?} to {:?}", expr, db);
-            let result = db.alter(expr.clone()).await.context(RequestDatanodeSnafu)?;
+            let result = db
+                .alter(expr.clone())
+                .await
+                .context(error::RequestDatanodeSnafu)?;
             debug!("Alter table result: {:?}", result);
             // TODO(hl): We should further check and track alter result in some global DDL task tracker
         }
@@ -519,28 +284,6 @@ fn project_schema(table_schema: SchemaRef, projection: Option<&Vec<usize>>) -> S
         Arc::new(Schema::new(projected))
     } else {
         table_schema
-    }
-}
-
-fn is_compare_op(op: &Operator) -> bool {
-    matches!(
-        *op,
-        Operator::Eq
-            | Operator::NotEq
-            | Operator::Lt
-            | Operator::LtEq
-            | Operator::Gt
-            | Operator::GtEq
-    )
-}
-
-fn reverse_operator(op: &Operator) -> Operator {
-    match *op {
-        Operator::Lt => Operator::Gt,
-        Operator::Gt => Operator::Lt,
-        Operator::LtEq => Operator::GtEq,
-        Operator::GtEq => Operator::LtEq,
-        _ => *op,
     }
 }
 
@@ -632,6 +375,8 @@ impl PartitionExec {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use api::v1::column::SemanticType;
     use api::v1::{column, Column, ColumnDataType, InsertRequest};
     use catalog::error::Result;
@@ -655,9 +400,14 @@ mod test {
     use meta_client::rpc::router::RegionRoute;
     use meta_client::rpc::{Region, Table, TableRoute};
     use partition::columns::RangeColumnsPartitionRule;
-    use partition::partition::PartitionDef;
+    use partition::manager::PartitionRuleManager;
+    use partition::partition::{PartitionBound, PartitionDef};
+    use partition::range::RangePartitionRule;
+    use partition::route::TableRoutes;
+    use partition::PartitionRuleRef;
     use sql::parser::ParserContext;
     use sql::statements::statement::Statement;
+    use store_api::storage::RegionNumber;
     use table::metadata::{TableInfoBuilder, TableMetaBuilder};
     use table::TableRef;
 
@@ -696,33 +446,8 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_find_partition_rule() {
         let table_name = TableName::new("greptime", "public", "foo");
-
-        let column_schemas = vec![
-            ColumnSchema::new("ts", ConcreteDataType::uint64_datatype(), false),
-            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), true),
-            ColumnSchema::new("b", ConcreteDataType::string_datatype(), true),
-        ];
-        let schema = Arc::new(Schema::new(column_schemas.clone()));
-        let meta = TableMetaBuilder::default()
-            .schema(schema)
-            .primary_key_indices(vec![])
-            .next_column_id(1)
-            .build()
-            .unwrap();
-        let table_info = TableInfoBuilder::default()
-            .name(&table_name.table_name)
-            .meta(meta)
-            .build()
-            .unwrap();
-
         let table_routes = Arc::new(TableRoutes::new(Arc::new(MetaClient::default())));
-        let table = DistTable {
-            table_name: table_name.clone(),
-            table_info: Arc::new(table_info),
-            table_routes: table_routes.clone(),
-            datanode_clients: Arc::new(DatanodeClients::new()),
-            backend: Arc::new(DummyKvBackend),
-        };
+        let partition_manager = Arc::new(PartitionRuleManager::new(table_routes.clone()));
 
         let table_route = TableRoute {
             table: Table {
@@ -788,7 +513,10 @@ mod test {
             .insert_table_route(table_name.clone(), Arc::new(table_route))
             .await;
 
-        let partition_rule = table.find_partition_rule().await.unwrap();
+        let partition_rule = partition_manager
+            .find_table_partition_rule(&table_name)
+            .await
+            .unwrap();
         let range_rule = partition_rule
             .as_any()
             .downcast_ref::<RangePartitionRule>()
@@ -867,7 +595,10 @@ mod test {
             .insert_table_route(table_name.clone(), Arc::new(table_route))
             .await;
 
-        let partition_rule = table.find_partition_rule().await.unwrap();
+        let partition_rule = partition_manager
+            .find_table_partition_rule(&table_name)
+            .await
+            .unwrap();
         let range_columns_rule = partition_rule
             .as_any()
             .downcast_ref::<RangeColumnsPartitionRule>()
@@ -1064,7 +795,7 @@ mod test {
         let datanode_instances = instance.datanodes;
 
         let catalog_manager = dist_instance.catalog_manager();
-        let table_routes = catalog_manager.table_routes();
+        let partition_manager = catalog_manager.partition_manager();
         let datanode_clients = catalog_manager.datanode_clients();
 
         let table_name = TableName::new("greptime", "public", "dist_numbers");
@@ -1103,7 +834,10 @@ mod test {
             .await
             .unwrap();
 
-        let table_route = table_routes.get_route(&table_name).await.unwrap();
+        let table_route = partition_manager
+            .find_table_route(&table_name)
+            .await
+            .unwrap();
 
         let mut region_to_datanode_mapping = HashMap::new();
         for region_route in table_route.region_routes.iter() {
@@ -1143,7 +877,7 @@ mod test {
         DistTable {
             table_name,
             table_info: Arc::new(table_info),
-            table_routes,
+            partition_manager,
             datanode_clients,
             backend: catalog_manager.backend(),
         }
@@ -1198,30 +932,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_find_regions() {
-        let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
-            "a",
-            ConcreteDataType::int32_datatype(),
-            true,
-        )]));
-        let table_name = TableName::new("greptime", "public", "foo");
-        let meta = TableMetaBuilder::default()
-            .schema(schema)
-            .primary_key_indices(vec![])
-            .next_column_id(1)
-            .build()
-            .unwrap();
-        let table_info = TableInfoBuilder::default()
-            .name(&table_name.table_name)
-            .meta(meta)
-            .build()
-            .unwrap();
-        let table = DistTable {
-            table_name,
-            table_info: Arc::new(table_info),
-            table_routes: Arc::new(TableRoutes::new(Arc::new(MetaClient::default()))),
-            datanode_clients: Arc::new(DatanodeClients::new()),
-            backend: Arc::new(DummyKvBackend),
-        };
+        let partition_manager = Arc::new(PartitionRuleManager::new(Arc::new(TableRoutes::new(
+            Arc::new(MetaClient::default()),
+        ))));
 
         // PARTITION BY RANGE (a) (
         //   PARTITION r1 VALUES LESS THAN (10),
@@ -1235,12 +948,12 @@ mod test {
             vec![0_u32, 1, 2, 3],
         )) as _;
 
+        let partition_rule_clone = partition_rule.clone();
         let test = |filters: Vec<Expr>, expect_regions: Vec<RegionNumber>| {
-            let mut regions = table
-                .find_regions(partition_rule.clone(), filters.as_slice())
+            let mut regions = partition_manager
+                .find_regions_by_filters(partition_rule_clone.clone(), filters.as_slice())
                 .unwrap();
             regions.sort();
-
             assert_eq!(regions, expect_regions);
         };
 
@@ -1327,7 +1040,7 @@ mod test {
         );
 
         // test failed to find regions by contradictory filters
-        let regions = table.find_regions(
+        let regions = partition_manager.find_regions_by_filters(
             partition_rule,
             vec![and(
                 binary_expr(col("a"), Operator::Lt, lit(20)),
@@ -1338,7 +1051,7 @@ mod test {
         ); // a < 20 AND a >= 20
         assert!(matches!(
             regions.unwrap_err(),
-            error::Error::FindRegions { .. }
+            partition::error::Error::FindRegions { .. }
         ));
     }
 }

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -44,6 +44,7 @@ use partition::columns::RangeColumnsPartitionRule;
 use partition::partition::{PartitionBound, PartitionDef, PartitionExpr};
 use partition::range::RangePartitionRule;
 use partition::route::TableRoutes;
+use partition::splitter::WriteSplitter;
 use partition::PartitionRuleRef;
 use snafu::prelude::*;
 use store_api::storage::RegionNumber;
@@ -60,7 +61,6 @@ use crate::error::{
     DeserializePartitionSnafu, FindPartitionSnafu, LeaderNotFoundSnafu, RequestDatanodeSnafu,
     Result, TableNotFoundSnafu, TableSnafu,
 };
-use crate::spliter::WriteSpliter;
 use crate::table::scan::{DatanodeInstance, TableScanPlan};
 
 pub mod insert;
@@ -96,7 +96,7 @@ impl Table for DistTable {
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 
-        let spliter = WriteSpliter::with_partition_rule(partition_rule);
+        let spliter = WriteSplitter::with_partition_rule(partition_rule);
         let inserts = spliter
             .split(request)
             .map_err(BoxedError::new)

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -44,7 +44,7 @@ use partition::columns::RangeColumnsPartitionRule;
 use partition::partition::{PartitionBound, PartitionDef, PartitionExpr};
 use partition::range::RangePartitionRule;
 use partition::route::TableRoutes;
-use partition::splitter::WriteSplitter;
+use partition::splitter::RequestSplitter;
 use partition::PartitionRuleRef;
 use snafu::prelude::*;
 use store_api::storage::RegionNumber;
@@ -96,9 +96,9 @@ impl Table for DistTable {
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 
-        let spliter = WriteSplitter::with_partition_rule(partition_rule);
+        let spliter = RequestSplitter::with_partition_rule(partition_rule);
         let inserts = spliter
-            .split(request)
+            .split_insert(request)
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;
 

--- a/src/frontend/src/table/insert.rs
+++ b/src/frontend/src/table/insert.rs
@@ -27,7 +27,7 @@ use table::requests::InsertRequest;
 
 use super::DistTable;
 use crate::error;
-use crate::error::{FindPartitionSnafu, Result};
+use crate::error::{FindTableRouteSnafu, Result};
 use crate::table::scan::DatanodeInstance;
 
 impl DistTable {
@@ -36,13 +36,12 @@ impl DistTable {
         inserts: HashMap<RegionNumber, InsertRequest>,
     ) -> Result<Output> {
         let route = self
-            .table_routes
-            .get_route(&self.table_name)
+            .partition_manager
+            .find_table_route(&self.table_name)
             .await
-            .with_context(|_| FindPartitionSnafu {
-                table: self.table_name.to_string(),
+            .with_context(|_| FindTableRouteSnafu {
+                table_name: self.table_name.to_string(),
             })?;
-
         let mut joins = Vec::with_capacity(inserts.len());
         for (region_id, insert) in inserts {
             let datanode = route

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -28,6 +28,7 @@ use meta_srv::metasrv::MetaSrvOptions;
 use meta_srv::mocks::MockInfo;
 use meta_srv::service::store::kv::KvStoreRef;
 use meta_srv::service::store::memory::MemStore;
+use partition::route::TableRoutes;
 use servers::grpc::GrpcServer;
 use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
 use servers::Mode;
@@ -39,7 +40,6 @@ use crate::catalog::FrontendCatalogManager;
 use crate::datanode::DatanodeClients;
 use crate::instance::distributed::DistInstance;
 use crate::instance::Instance;
-use crate::table::route::TableRoutes;
 
 /// Guard against the `TempDir`s that used in unit tests.
 /// (The `TempDir` will be deleted once it goes out of scope.)

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -28,6 +28,7 @@ use meta_srv::metasrv::MetaSrvOptions;
 use meta_srv::mocks::MockInfo;
 use meta_srv::service::store::kv::KvStoreRef;
 use meta_srv::service::store::memory::MemStore;
+use partition::manager::PartitionRuleManager;
 use partition::route::TableRoutes;
 use servers::grpc::GrpcServer;
 use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
@@ -241,10 +242,12 @@ pub(crate) async fn create_distributed_instance(test_name: &str) -> MockDistribu
     let meta_backend = Arc::new(MetaKvBackend {
         client: meta_client.clone(),
     });
-    let table_routes = Arc::new(TableRoutes::new(meta_client.clone()));
+    let partition_manager = Arc::new(PartitionRuleManager::new(Arc::new(TableRoutes::new(
+        meta_client.clone(),
+    ))));
     let catalog_manager = Arc::new(FrontendCatalogManager::new(
         meta_backend,
-        table_routes.clone(),
+        partition_manager,
         datanode_clients.clone(),
     ));
 

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 
 [dependencies]
 common-error = {path = "../common/error"}
+common-query = {path = "../common/query"}
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-common-error = {path = "../common/error"}
-common-query = {path = "../common/query"}
+common-error = { path = "../common/error" }
+common-query = { path = "../common/query" }
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
@@ -16,7 +16,7 @@ datatypes = { path = "../datatypes" }
 meta-client = { path = "../meta-client" }
 moka = { version = "0.9", features = ["future"] }
 snafu = { version = "0.7", features = ["backtraces"] }
-store-api = {path = "../store-api"}
+store-api = { path = "../store-api" }
 serde = "1.0"
 serde_json = "1.0"
-table = {path = "../table"}
+table = { path = "../table" }

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -18,3 +18,4 @@ snafu = { version = "0.7", features = ["backtraces"] }
 store-api = {path = "../store-api"}
 serde = "1.0"
 serde_json = "1.0"
+table = {path = "../table"}

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "partition"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+common-error = {path = "../common/error"}
+datafusion.workspace = true
+datafusion-common.workspace = true
+datafusion-expr.workspace = true
+datatypes = { path = "../datatypes" }
+meta-client = { path = "../meta-client" }
+moka = { version = "0.9", features = ["future"] }
+snafu = { version = "0.7", features = ["backtraces"] }
+store-api = {path = "../store-api"}
+serde = "1.0"
+serde_json = "1.0"

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -15,8 +15,8 @@ datafusion-expr.workspace = true
 datatypes = { path = "../datatypes" }
 meta-client = { path = "../meta-client" }
 moka = { version = "0.9", features = ["future"] }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 store-api = { path = "../store-api" }
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 table = { path = "../table" }

--- a/src/partition/src/columns.rs
+++ b/src/partition/src/columns.rs
@@ -137,8 +137,6 @@ impl RangeColumnsPartitionRule {
 }
 
 impl PartitionRule for RangeColumnsPartitionRule {
-    type Error = Error;
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -147,7 +145,7 @@ impl PartitionRule for RangeColumnsPartitionRule {
         self.column_list.clone()
     }
 
-    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Self::Error> {
+    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Error> {
         ensure!(
             values.len() == self.column_list.len(),
             error::RegionKeysSizeSnafu {
@@ -168,7 +166,7 @@ impl PartitionRule for RangeColumnsPartitionRule {
         })
     }
 
-    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Self::Error> {
+    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Error> {
         let regions = if exprs.iter().all(|x| self.column_list.contains(&x.column)) {
             let PartitionExpr {
                 column: _,

--- a/src/partition/src/columns.rs
+++ b/src/partition/src/columns.rs
@@ -123,17 +123,14 @@ impl RangeColumnsPartitionRule {
         }
     }
 
-    // #[cfg(test)]
     pub fn column_list(&self) -> &Vec<String> {
         &self.column_list
     }
 
-    // #[cfg(test)]
     pub fn value_lists(&self) -> &Vec<Vec<PartitionBound>> {
         &self.value_lists
     }
 
-    // #[cfg(test)]
     pub fn regions(&self) -> &Vec<RegionNumber> {
         &self.regions
     }

--- a/src/partition/src/columns.rs
+++ b/src/partition/src/columns.rs
@@ -20,7 +20,7 @@ use snafu::ensure;
 use store_api::storage::RegionNumber;
 
 use crate::error::{self, Error};
-use crate::partitioning::{PartitionBound, PartitionExpr, PartitionRule};
+use crate::partition::{PartitionBound, PartitionExpr, PartitionRule};
 
 /// A [RangeColumnsPartitionRule] is very similar to [RangePartitionRule] except that it allows
 /// partitioning by multiple columns.
@@ -77,7 +77,7 @@ pub struct RangeColumnsPartitionRule {
 impl RangeColumnsPartitionRule {
     // It's assured that input arguments are valid because they are checked in SQL parsing stage.
     // So we can skip validating them.
-    pub(crate) fn new(
+    pub fn new(
         column_list: Vec<String>,
         value_lists: Vec<Vec<PartitionBound>>,
         regions: Vec<RegionNumber>,
@@ -123,18 +123,18 @@ impl RangeColumnsPartitionRule {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn column_list(&self) -> &Vec<String> {
+    // #[cfg(test)]
+    pub fn column_list(&self) -> &Vec<String> {
         &self.column_list
     }
 
-    #[cfg(test)]
-    pub(crate) fn value_lists(&self) -> &Vec<Vec<PartitionBound>> {
+    // #[cfg(test)]
+    pub fn value_lists(&self) -> &Vec<Vec<PartitionBound>> {
         &self.value_lists
     }
 
-    #[cfg(test)]
-    pub(crate) fn regions(&self) -> &Vec<RegionNumber> {
+    // #[cfg(test)]
+    pub fn regions(&self) -> &Vec<RegionNumber> {
         &self.regions
     }
 }
@@ -220,6 +220,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     use super::*;
+    use crate::partition::{PartitionBound, PartitionExpr};
 
     #[test]
     fn test_find_regions() {

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -1,0 +1,95 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_error::prelude::*;
+use datafusion_expr::Expr;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Failed to get cache, error: {}", err_msg))]
+    GetCache {
+        err_msg: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to request Meta, source: {}", source))]
+    RequestMeta {
+        #[snafu(backtrace)]
+        source: meta_client::error::Error,
+    },
+
+    #[snafu(display("Failed to find table routes for table {}", table_name))]
+    FindTableRoutes {
+        table_name: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to serialize value to json, source: {}", source))]
+    SerializeJson {
+        source: serde_json::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to deserialize value from json, source: {}", source))]
+    DeserializeJson {
+        source: serde_json::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Expect {} region keys, actual {}", expect, actual))]
+    RegionKeysSize {
+        expect: usize,
+        actual: usize,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to find region, reason: {}", reason))]
+    FindRegion {
+        reason: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to find regions by filters: {:?}", filters))]
+    FindRegions {
+        filters: Vec<Expr>,
+        backtrace: Backtrace,
+    },
+}
+
+impl ErrorExt for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::GetCache { .. } => StatusCode::StorageUnavailable,
+            Error::RequestMeta { source, .. } => source.status_code(),
+            Error::FindRegion { .. }
+            | Error::FindRegions { .. }
+            | Error::RegionKeysSize { .. }
+            | Error::FindTableRoutes { .. } => StatusCode::InvalidArguments,
+            Error::SerializeJson { .. } | Error::DeserializeJson { .. } => StatusCode::Internal,
+        }
+    }
+    fn backtrace_opt(&self) -> Option<&Backtrace> {
+        ErrorCompat::backtrace(self)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -69,6 +69,18 @@ pub enum Error {
         filters: Vec<Expr>,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Failed to find partition column: {}", column_name))]
+    FindPartitionColumn {
+        column_name: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Invalid InsertRequest, reason: {}", reason))]
+    InvalidInsertRequest {
+        reason: String,
+        backtrace: Backtrace,
+    },
 }
 
 impl ErrorExt for Error {
@@ -79,7 +91,9 @@ impl ErrorExt for Error {
             Error::FindRegion { .. }
             | Error::FindRegions { .. }
             | Error::RegionKeysSize { .. }
-            | Error::FindTableRoutes { .. } => StatusCode::InvalidArguments,
+            | Error::FindTableRoutes { .. }
+            | Error::InvalidInsertRequest { .. }
+            | Error::FindPartitionColumn { .. } => StatusCode::InvalidArguments,
             Error::SerializeJson { .. } | Error::DeserializeJson { .. } => StatusCode::Internal,
         }
     }

--- a/src/partition/src/lib.rs
+++ b/src/partition/src/lib.rs
@@ -10,5 +10,6 @@ pub mod manager;
 pub mod partition;
 pub mod range;
 pub mod route;
+pub mod splitter;
 
 pub type PartitionRuleRef = Arc<dyn PartitionRule<Error = error::Error>>;

--- a/src/partition/src/lib.rs
+++ b/src/partition/src/lib.rs
@@ -1,0 +1,14 @@
+#![feature(assert_matches)]
+
+use std::sync::Arc;
+
+use crate::partition::PartitionRule;
+
+pub mod columns;
+pub mod error;
+pub mod manager;
+pub mod partition;
+pub mod range;
+pub mod route;
+
+pub type PartitionRuleRef = Arc<dyn PartitionRule<Error = error::Error>>;

--- a/src/partition/src/lib.rs
+++ b/src/partition/src/lib.rs
@@ -14,10 +14,6 @@
 
 #![feature(assert_matches)]
 
-use std::sync::Arc;
-
-use crate::partition::PartitionRule;
-
 pub mod columns;
 pub mod error;
 pub mod manager;
@@ -26,4 +22,4 @@ pub mod range;
 pub mod route;
 pub mod splitter;
 
-pub type PartitionRuleRef = Arc<dyn PartitionRule<Error = error::Error>>;
+pub use crate::partition::{PartitionRule, PartitionRuleRef};

--- a/src/partition/src/lib.rs
+++ b/src/partition/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![feature(assert_matches)]
 
 use std::sync::Arc;

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -33,13 +33,14 @@ use crate::{error, PartitionRuleRef};
 
 pub type PartitionRuleManagerRef = Arc<PartitionRuleManager>;
 
+/// PartitionRuleManager manages the table routes and partition rules.
+/// It provides methods to find regions by:
+/// - values (in case of insertion)
+/// - filters (in case of select, deletion and update)
 pub struct PartitionRuleManager {
     table_routes: Arc<TableRoutes>,
 }
 
-/// Provides methods to find regions by:
-/// - values (in case of insertion)
-/// - filters (in case of select, deletion and update)
 impl PartitionRuleManager {
     pub fn new(table_routes: Arc<TableRoutes>) -> Self {
         Self { table_routes }

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -29,6 +29,7 @@ use crate::range::RangePartitionRule;
 use crate::route::TableRoutes;
 use crate::{error, PartitionRuleRef};
 
+// TODO(hl): maybe rename to partition rule manager?
 pub struct PartitionManager {
     table_routes: TableRoutes,
 }

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -12,25 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
+use meta_client::rpc::TableName;
 
-pub type Plugins = anymap::Map<dyn core::any::Any + Send + Sync>;
+use crate::error::Result;
+use crate::route::TableRoutes;
+use crate::PartitionRuleRef;
 
-mod catalog;
-mod datanode;
-pub mod error;
-mod expr_factory;
-pub mod frontend;
-pub mod grpc;
-pub mod influxdb;
-pub mod instance;
-pub mod mysql;
-pub mod opentsdb;
-pub mod postgres;
-pub mod prometheus;
-mod server;
-pub mod spliter;
-mod sql;
-mod table;
-#[cfg(test)]
-mod tests;
+pub struct PartitionManager {
+    table_routes: TableRoutes,
+}
+
+impl PartitionManager {
+    pub async fn find_partition(&self, _table: TableName) -> Result<Option<PartitionRuleRef>> {
+        todo!()
+    }
+}

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -45,10 +45,12 @@ impl PartitionRuleManager {
         Self { table_routes }
     }
 
+    /// Find table route of given table name.
     pub async fn find_table_route(&self, table: &TableName) -> Result<Arc<TableRoute>> {
         self.table_routes.get_route(table).await
     }
 
+    /// Find datanodes of corresponding regions of given table.
     pub async fn find_region_datanodes(
         &self,
         table: &TableName,
@@ -159,6 +161,7 @@ impl PartitionRuleManager {
         Ok(partition_rule)
     }
 
+    /// Find regions in partition rule by filters.
     pub fn find_regions_by_filters(
         &self,
         partition_rule: PartitionRuleRef,

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -57,7 +57,7 @@ impl PartitionRuleManager {
         regions: Vec<RegionNumber>,
     ) -> Result<HashMap<Peer, Vec<RegionNumber>>> {
         let route = self.table_routes.get_route(table).await?;
-        let mut datanodes = HashMap::new();
+        let mut datanodes = HashMap::with_capacity(regions.len());
         for region in regions.iter() {
             let datanode = route
                 .region_routes

--- a/src/partition/src/partition.rs
+++ b/src/partition/src/partition.rs
@@ -14,6 +14,7 @@
 
 use std::any::Any;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use datafusion_expr::Operator;
 use datatypes::prelude::Value;
@@ -24,18 +25,18 @@ use store_api::storage::RegionNumber;
 
 use crate::error::{self, Error};
 
-pub trait PartitionRule: Sync + Send {
-    type Error: Debug;
+pub type PartitionRuleRef = Arc<dyn PartitionRule>;
 
+pub trait PartitionRule: Sync + Send {
     fn as_any(&self) -> &dyn Any;
 
     fn partition_columns(&self) -> Vec<String>;
 
     // TODO(LFC): Unify `find_region` and `find_regions` methods when distributed read and write features are both merged into develop.
     // Or find better names since one is mainly for writes and the other is for reads.
-    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Self::Error>;
+    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Error>;
 
-    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Self::Error>;
+    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Error>;
 }
 
 /// The right bound(exclusive) of partition range.

--- a/src/partition/src/partition.rs
+++ b/src/partition/src/partition.rs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) mod columns;
-pub(crate) mod range;
-
 use std::any::Any;
 use std::fmt::Debug;
-use std::sync::Arc;
 
-pub use datafusion_expr::Operator;
+use datafusion_expr::Operator;
 use datatypes::prelude::Value;
 use meta_client::rpc::Partition as MetaPartition;
 use serde::{Deserialize, Serialize};
@@ -27,8 +23,6 @@ use snafu::ResultExt;
 use store_api::storage::RegionNumber;
 
 use crate::error::{self, Error};
-
-pub(crate) type PartitionRuleRef<E> = Arc<dyn PartitionRule<Error = E>>;
 
 pub trait PartitionRule: Sync + Send {
     type Error: Debug;
@@ -46,33 +40,30 @@ pub trait PartitionRule: Sync + Send {
 
 /// The right bound(exclusive) of partition range.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub(crate) enum PartitionBound {
+pub enum PartitionBound {
     Value(Value),
     MaxValue,
 }
 
 #[derive(Debug)]
-pub(crate) struct PartitionDef {
+pub struct PartitionDef {
     partition_columns: Vec<String>,
     partition_bounds: Vec<PartitionBound>,
 }
 
 impl PartitionDef {
-    pub(crate) fn new(
-        partition_columns: Vec<String>,
-        partition_bounds: Vec<PartitionBound>,
-    ) -> Self {
+    pub fn new(partition_columns: Vec<String>, partition_bounds: Vec<PartitionBound>) -> Self {
         Self {
             partition_columns,
             partition_bounds,
         }
     }
 
-    pub(crate) fn partition_columns(&self) -> &Vec<String> {
+    pub fn partition_columns(&self) -> &Vec<String> {
         &self.partition_columns
     }
 
-    pub(crate) fn partition_bounds(&self) -> &Vec<PartitionBound> {
+    pub fn partition_bounds(&self) -> &Vec<PartitionBound> {
         &self.partition_bounds
     }
 }
@@ -133,13 +124,13 @@ impl TryFrom<PartitionDef> for MetaPartition {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct PartitionExpr {
-    column: String,
-    op: Operator,
-    value: Value,
+    pub column: String,
+    pub op: Operator,
+    pub value: Value,
 }
 
 impl PartitionExpr {
-    pub(crate) fn new(column: impl Into<String>, op: Operator, value: Value) -> Self {
+    pub fn new(column: impl Into<String>, op: Operator, value: Value) -> Self {
         Self {
             column: column.into(),
             op,

--- a/src/partition/src/range.rs
+++ b/src/partition/src/range.rs
@@ -91,7 +91,6 @@ impl RangePartitionRule {
         &self.regions
     }
 
-    // #[cfg(test)]
     pub fn bounds(&self) -> &Vec<Value> {
         &self.bounds
     }

--- a/src/partition/src/range.rs
+++ b/src/partition/src/range.rs
@@ -97,8 +97,6 @@ impl RangePartitionRule {
 }
 
 impl PartitionRule for RangePartitionRule {
-    type Error = Error;
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -107,7 +105,7 @@ impl PartitionRule for RangePartitionRule {
         vec![self.column_name().to_string()]
     }
 
-    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Self::Error> {
+    fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Error> {
         debug_assert_eq!(
             values.len(),
             1,
@@ -122,7 +120,7 @@ impl PartitionRule for RangePartitionRule {
         })
     }
 
-    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Self::Error> {
+    fn find_regions(&self, exprs: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Error> {
         if exprs.is_empty() {
             return Ok(self.regions.clone());
         }

--- a/src/partition/src/range.rs
+++ b/src/partition/src/range.rs
@@ -14,13 +14,14 @@
 
 use std::any::Any;
 
+use datafusion_expr::Operator;
 use datatypes::prelude::*;
 use serde::{Deserialize, Serialize};
 use snafu::OptionExt;
 use store_api::storage::RegionNumber;
 
 use crate::error::{self, Error};
-use crate::partitioning::{Operator, PartitionExpr, PartitionRule};
+use crate::partition::{PartitionExpr, PartitionRule};
 
 /// [RangePartitionRule] manages the distribution of partitions partitioning by some column's value
 /// range. It's generated from create table request, using MySQL's syntax:
@@ -70,7 +71,7 @@ pub struct RangePartitionRule {
 }
 
 impl RangePartitionRule {
-    pub(crate) fn new(
+    pub fn new(
         column_name: impl Into<String>,
         bounds: Vec<Value>,
         regions: Vec<RegionNumber>,
@@ -82,16 +83,16 @@ impl RangePartitionRule {
         }
     }
 
-    pub(crate) fn column_name(&self) -> &String {
+    pub fn column_name(&self) -> &String {
         &self.column_name
     }
 
-    pub(crate) fn all_regions(&self) -> &Vec<RegionNumber> {
+    pub fn all_regions(&self) -> &Vec<RegionNumber> {
         &self.regions
     }
 
-    #[cfg(test)]
-    pub(crate) fn bounds(&self) -> &Vec<Value> {
+    // #[cfg(test)]
+    pub fn bounds(&self) -> &Vec<Value> {
         &self.bounds
     }
 }
@@ -173,7 +174,10 @@ impl PartitionRule for RangePartitionRule {
 
 #[cfg(test)]
 mod test {
+    use datafusion_expr::Operator;
+
     use super::*;
+    use crate::partition::PartitionExpr;
 
     #[test]
     fn test_find_regions() {

--- a/src/partition/src/route.rs
+++ b/src/partition/src/route.rs
@@ -22,13 +22,14 @@ use snafu::{ensure, ResultExt};
 
 use crate::error::{self, Result};
 
-pub(crate) struct TableRoutes {
+pub struct TableRoutes {
     meta_client: Arc<MetaClient>,
     cache: Cache<TableName, Arc<TableRoute>>,
 }
 
+// TODO(hl): maybe periodically refresh table route cache?
 impl TableRoutes {
-    pub(crate) fn new(meta_client: Arc<MetaClient>) -> Self {
+    pub fn new(meta_client: Arc<MetaClient>) -> Self {
         Self {
             meta_client,
             cache: CacheBuilder::new(1024)
@@ -38,7 +39,7 @@ impl TableRoutes {
         }
     }
 
-    pub(crate) async fn get_route(&self, table_name: &TableName) -> Result<Arc<TableRoute>> {
+    pub async fn get_route(&self, table_name: &TableName) -> Result<Arc<TableRoute>> {
         self.cache
             .try_get_with_by_ref(table_name, self.get_from_meta(table_name))
             .await
@@ -68,12 +69,7 @@ impl TableRoutes {
         Ok(Arc::new(route))
     }
 
-    #[cfg(test)]
-    pub(crate) async fn insert_table_route(
-        &self,
-        table_name: TableName,
-        table_route: Arc<TableRoute>,
-    ) {
+    pub async fn insert_table_route(&self, table_name: TableName, table_route: Arc<TableRoute>) {
         self.cache.insert(table_name, table_route).await
     }
 }

--- a/src/partition/src/splitter.rs
+++ b/src/partition/src/splitter.rs
@@ -28,11 +28,11 @@ use crate::PartitionRuleRef;
 pub type InsertRequestSplit = HashMap<RegionNumber, InsertRequest>;
 pub type DeleteRequestSplit = HashMap<RegionNumber, DeleteRequest>;
 
-pub struct RequestSplitter {
+pub struct WriteSplitter {
     partition_rule: PartitionRuleRef,
 }
 
-impl RequestSplitter {
+impl WriteSplitter {
     pub fn with_partition_rule(rule: PartitionRuleRef) -> Self {
         Self {
             partition_rule: rule,
@@ -192,8 +192,7 @@ mod tests {
     use table::requests::InsertRequest;
 
     use super::{
-        check_req, find_partitioning_values, partition_values, split_insert_request,
-        RequestSplitter,
+        check_req, find_partitioning_values, partition_values, split_insert_request, WriteSplitter,
     };
     use crate::error::Error;
     use crate::partition::{PartitionExpr, PartitionRule};
@@ -214,7 +213,7 @@ mod tests {
     fn test_writer_spliter() {
         let insert = mock_insert_request();
         let rule = Arc::new(MockPartitionRule) as PartitionRuleRef;
-        let spliter = RequestSplitter::with_partition_rule(rule);
+        let spliter = WriteSplitter::with_partition_rule(rule);
         let ret = spliter.split_insert(insert).unwrap();
 
         assert_eq!(2, ret.len());

--- a/src/partition/src/splitter.rs
+++ b/src/partition/src/splitter.rs
@@ -438,8 +438,6 @@ mod tests {
     //     PARTITION r1 VALUES IN(2, 3),
     // );
     impl PartitionRule for MockPartitionRule {
-        type Error = Error;
-
         fn as_any(&self) -> &dyn Any {
             self
         }
@@ -448,7 +446,7 @@ mod tests {
             vec!["id".to_string()]
         }
 
-        fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Self::Error> {
+        fn find_region(&self, values: &[Value]) -> Result<RegionNumber, Error> {
             let val = values.get(0).unwrap().to_owned();
             let id_1: Value = 1_i16.into();
             let id_2: Value = 2_i16.into();
@@ -462,7 +460,7 @@ mod tests {
             unreachable!()
         }
 
-        fn find_regions(&self, _: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Self::Error> {
+        fn find_regions(&self, _: &[PartitionExpr]) -> Result<Vec<RegionNumber>, Error> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Move partition rule related code to partition manager.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#901
