### PR TITLE
fix: aarch64 apple darwin build

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-12-20"
+channel = "nightly-2023-01-27"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix Mac M1 greptimedb build error

Please explain IN DETAIL what the changes are in this PR and why they are needed:

**Error:**
```
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the 'nightly-2022-12-20-aarch64-apple-darwin' toolchain
```

fix error by updating rust version

**Note:** 

```
warning: the following packages contain code that will be rejected by a future version of Rust: lalrpop v0.19.8, nalgebra v0.27.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 3`
```

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
