### PR TITLE
fix: TimestampRange::new_inclusive and  strum dependency 

### DIFF
--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -5,5 +5,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-strum = "0.24.1"
+strum = { version = "0.24", features = ["std", "derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
- Fix `TimestampRange::new_inclusive`, add emptiness check.
- Add `std` and `derive` feature to strum dep in common-error crate.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
