### PR TITLE
feat: oss storage support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,9 @@
 GT_S3_BUCKET=S3 bucket
 GT_S3_ACCESS_KEY_ID=S3 access key id
 GT_S3_ACCESS_KEY=S3 secret access key
+
+# Settings for oss test
+GT_OSS_BUCKET=OSS bucket
+GT_OSS_ACCESS_KEY_ID=OSS access key id
+GT_OSS_ACCESS_KEY=OSS access key
+GT_OSS_ENDPOINT=OSS endpoint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,9 +681,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "benchmarks"
@@ -4401,20 +4401,21 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97541724cf371973b28f5a873404f2a2a4f7bb1efe7ca36a27836c13958781c2"
+checksum = "73829d3a057542556dc2c2d2b70700a44dda913cdb5483094c20ef9673ca283c"
 dependencies = [
  "anyhow",
  "async-compat",
  "async-trait",
  "backon",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bincode 2.0.0-rc.2",
  "bytes",
  "flagset",
  "futures",
  "http",
+ "hyper",
  "log",
  "md-5",
  "metrics",
@@ -5675,13 +5676,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c97ac0f771c78ddf4bcb73c8454c76565a7249780e7296767f7e89661b0e045"
+checksum = "3f446438814fde3785305a59a85a6d1b361ce2c9d29e58dd87c9103a242c40b6"
 dependencies = [
  "anyhow",
  "backon",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes",
  "dirs 4.0.0",
  "form_urlencoded",

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -14,7 +14,7 @@
 
 use clap::Parser;
 use common_telemetry::logging;
-use datanode::datanode::{Datanode, DatanodeOptions, ObjectStoreConfig};
+use datanode::datanode::{Datanode, DatanodeOptions, FileConfig, ObjectStoreConfig};
 use meta_client::MetaClientOpts;
 use servers::Mode;
 use snafu::ResultExt;
@@ -128,7 +128,7 @@ impl TryFrom<StartCommand> for DatanodeOptions {
         }
 
         if let Some(data_dir) = cmd.data_dir {
-            opts.storage = ObjectStoreConfig::File { data_dir };
+            opts.storage = ObjectStoreConfig::File(FileConfig { data_dir });
         }
 
         if let Some(wal_dir) = cmd.wal_dir {
@@ -175,7 +175,7 @@ mod tests {
         assert!(!tcp_nodelay);
 
         match options.storage {
-            ObjectStoreConfig::File { data_dir } => {
+            ObjectStoreConfig::File(FileConfig { data_dir }) => {
                 assert_eq!("/tmp/greptimedb/data/".to_string(), data_dir)
             }
             ObjectStoreConfig::S3 { .. } => unreachable!(),

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -179,7 +179,7 @@ mod tests {
                 assert_eq!("/tmp/greptimedb/data/".to_string(), data_dir)
             }
             ObjectStoreConfig::S3 { .. } => unreachable!(),
-            ObjectStoreConfig::OSS { .. } => unreachable!(),
+            ObjectStoreConfig::Oss { .. } => unreachable!(),
         };
     }
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -179,6 +179,7 @@ mod tests {
                 assert_eq!("/tmp/greptimedb/data/".to_string(), data_dir)
             }
             ObjectStoreConfig::S3 { .. } => unreachable!(),
+            ObjectStoreConfig::OSS { .. } => unreachable!(),
         };
     }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -45,7 +45,7 @@ pub enum ObjectStoreConfig {
         access_key_id: String,
         access_key_secret: String,
         endpoint: String,
-    }
+    },
 }
 
 impl Default for ObjectStoreConfig {

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -28,31 +28,43 @@ use crate::server::Services;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum ObjectStoreConfig {
-    File {
-        data_dir: String,
-    },
-    S3 {
-        bucket: String,
-        root: String,
-        access_key_id: String,
-        secret_access_key: String,
-        endpoint: Option<String>,
-        region: Option<String>,
-    },
-    Oss {
-        bucket: String,
-        root: String,
-        access_key_id: String,
-        access_key_secret: String,
-        endpoint: String,
-    },
+    File(FileConfig),
+    S3(S3Config),
+    Oss(OssConfig),
+}
+
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
+#[serde(default)]
+pub struct FileConfig {
+    pub data_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
+#[serde(default)]
+pub struct S3Config {
+    pub bucket: String,
+    pub root: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    pub endpoint: Option<String>,
+    pub region: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
+#[serde(default)]
+pub struct OssConfig {
+    pub bucket: String,
+    pub root: String,
+    pub access_key_id: String,
+    pub access_key_secret: String,
+    pub endpoint: String,
 }
 
 impl Default for ObjectStoreConfig {
     fn default() -> Self {
-        ObjectStoreConfig::File {
+        ObjectStoreConfig::File(FileConfig {
             data_dir: "/tmp/greptimedb/data/".to_string(),
-        }
+        })
     }
 }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -39,7 +39,7 @@ pub enum ObjectStoreConfig {
         endpoint: Option<String>,
         region: Option<String>,
     },
-    OSS {
+    Oss {
         bucket: String,
         root: String,
         access_key_id: String,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -39,6 +39,13 @@ pub enum ObjectStoreConfig {
         endpoint: Option<String>,
         region: Option<String>,
     },
+    OSS {
+        bucket: String,
+        root: String,
+        access_key_id: String,
+        access_key_secret: String,
+        endpoint: String,
+    }
 }
 
 impl Default for ObjectStoreConfig {

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -30,8 +30,8 @@ use mito::config::EngineConfig as TableEngineConfig;
 use mito::engine::MitoEngine;
 use object_store::layers::{LoggingLayer, MetricsLayer, RetryLayer, TracingLayer};
 use object_store::services::fs::Builder as FsBuilder;
-use object_store::services::s3::Builder as S3Builder;
 use object_store::services::oss::Builder as OSSBuilder;
+use object_store::services::s3::Builder as S3Builder;
 use object_store::{util, ObjectStore};
 use query::query_engine::{QueryEngineFactory, QueryEngineRef};
 use servers::Mode;
@@ -224,13 +224,7 @@ pub(crate) async fn new_oss_object_store(store_config: &ObjectStoreConfig) -> Re
             access_key_id,
             access_key_secret,
             endpoint,
-        } => (
-            root,
-            access_key_secret,
-            access_key_id,
-            bucket,
-            endpoint,
-        ),
+        } => (root, access_key_secret, access_key_id, bucket, endpoint),
         _ => unreachable!(),
     };
 

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -263,10 +263,10 @@ pub(crate) async fn new_s3_object_store(store_config: &ObjectStoreConfig) -> Res
         .secret_access_key(&s3_config.secret_access_key);
 
     if s3_config.endpoint.is_some() {
-        builder = builder.endpoint(&s3_config.endpoint.as_ref().unwrap());
+        builder = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
     }
     if s3_config.region.is_some() {
-        builder = builder.region(&s3_config.region.as_ref().unwrap());
+        builder = builder.region(s3_config.region.as_ref().unwrap());
     }
 
     let accessor = builder.build().with_context(|_| error::InitBackendSnafu {

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -204,7 +204,7 @@ pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result
     let object_store = match store_config {
         ObjectStoreConfig::File { data_dir } => new_fs_object_store(data_dir).await,
         ObjectStoreConfig::S3 { .. } => new_s3_object_store(store_config).await,
-        ObjectStoreConfig::OSS { .. } => new_oss_object_store(store_config).await,
+        ObjectStoreConfig::Oss { .. } => new_oss_object_store(store_config).await,
     };
 
     object_store.map(|object_store| {
@@ -218,7 +218,7 @@ pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result
 
 pub(crate) async fn new_oss_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
     let (root, secret_key, key_id, bucket, endpoint) = match store_config {
-        ObjectStoreConfig::OSS {
+        ObjectStoreConfig::Oss {
             bucket,
             root,
             access_key_id,

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -29,7 +29,7 @@ use table::engine::{EngineContext, TableEngineRef};
 use table::requests::CreateTableRequest;
 use tempdir::TempDir;
 
-use crate::datanode::{DatanodeOptions, ObjectStoreConfig, WalConfig};
+use crate::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, WalConfig};
 use crate::error::{CreateTableSnafu, Result};
 use crate::instance::Instance;
 use crate::sql::SqlHandler;
@@ -67,9 +67,9 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File {
+        storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
-        },
+        }),
         mode: Mode::Standalone,
         ..Default::default()
     };

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -20,7 +20,7 @@ use catalog::remote::MetaKvBackend;
 use client::Client;
 use common_grpc::channel_manager::ChannelManager;
 use common_runtime::Builder as RuntimeBuilder;
-use datanode::datanode::{DatanodeOptions, ObjectStoreConfig, WalConfig};
+use datanode::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, WalConfig};
 use datanode::instance::Instance as DatanodeInstance;
 use meta_client::client::MetaClientBuilder;
 use meta_client::rpc::Peer;
@@ -81,9 +81,9 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File {
+        storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
-        },
+        }),
         mode: Mode::Standalone,
         ..Default::default()
     };
@@ -167,9 +167,9 @@ async fn create_distributed_datanode(
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File {
+        storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
-        },
+        }),
         mode: Mode::Distributed,
         ..Default::default()
     };

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.24", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.25.1", features = ["layers-tracing", "layers-metrics"] }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -6,7 +6,10 @@ license.workspace = true
 
 [dependencies]
 futures = { version = "0.3" }
-opendal = { version = "0.25.1", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.25.1", features = [
+    "layers-tracing",
+    "layers-metrics",
+] }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -15,6 +15,7 @@
 use std::env;
 
 use anyhow::Result;
+use opendal::services::oss;
 use common_telemetry::logging;
 use object_store::backend::{fs, s3};
 use object_store::test_util::TempFolder;
@@ -117,6 +118,34 @@ async fn test_s3_backend() -> Result<()> {
                 .root(&root)
                 .access_key_id(&env::var("GT_S3_ACCESS_KEY_ID")?)
                 .secret_access_key(&env::var("GT_S3_ACCESS_KEY")?)
+                .bucket(&bucket)
+                .build()?;
+
+            let store = ObjectStore::new(accessor);
+
+            let mut guard = TempFolder::new(&store, "/");
+            test_object_crud(&store).await?;
+            test_object_list(&store).await?;
+            guard.remove_all().await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_oss_backend() -> Result<()> {
+    logging::init_default_ut_logging();
+    if let Ok(bucket) = env::var("GT_OSS_BUCKET") {
+        if !bucket.is_empty() {
+            logging::info!("Running oss test.");
+
+            let root = uuid::Uuid::new_v4().to_string();
+
+            let accessor = oss::Builder::default()
+                .root(&root)
+                .access_key_id(&env::var("GT_OSS_ACCESS_KEY_ID")?)
+                .access_key_secret(&env::var("GT_OSS_ACCESS_KEY")?)
                 .bucket(&bucket)
                 .build()?;
 

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -15,11 +15,11 @@
 use std::env;
 
 use anyhow::Result;
-use opendal::services::oss;
 use common_telemetry::logging;
 use object_store::backend::{fs, s3};
 use object_store::test_util::TempFolder;
 use object_store::{util, Object, ObjectLister, ObjectMode, ObjectStore};
+use opendal::services::oss;
 use tempdir::TempDir;
 
 async fn test_object_crud(store: &ObjectStore) -> Result<()> {

--- a/tests-integration/README.md
+++ b/tests-integration/README.md
@@ -11,6 +11,7 @@ GT_S3_ACCESS_KEY_ID=S3 access key id
 GT_S3_ACCESS_KEY=S3 secret access key
 ```
 
+
 ## Run
 
 Execute the following command in the project root folder:
@@ -23,4 +24,10 @@ Test s3 storage:
 
 ```
 cargo test s3
+```
+
+Test oss storage:
+
+```
+cargo test oss
 ```

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -60,7 +60,7 @@ fn get_port() -> usize {
 pub enum StorageType {
     S3,
     File,
-    OSS,
+    Oss,
 }
 
 impl StorageType {
@@ -76,7 +76,7 @@ impl StorageType {
                     false
                 }
             }
-            StorageType::OSS => {
+            StorageType::Oss => {
                 if let Ok(b) = env::var("GT_OSS_BUCKET") {
                     !b.is_empty()
                 } else {
@@ -94,7 +94,7 @@ fn get_test_store_config(
     let _ = dotenv::dotenv();
 
     match store_type {
-        StorageType::OSS => {
+        StorageType::Oss => {
             let oss_config = OssConfig {
                 root: uuid::Uuid::new_v4().to_string(),
                 access_key_id: env::var("GT_OSS_ACCESS_KEY_ID").unwrap(),

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -108,7 +108,7 @@ fn get_test_store_config(
                 .build()
                 .unwrap();
 
-            let config = ObjectStoreConfig::OSS {
+            let config = ObjectStoreConfig::Oss {
                 root,
                 bucket,
                 access_key_id: key_id,

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -17,5 +17,5 @@ mod grpc;
 #[macro_use]
 mod http;
 
-grpc_tests!(File, S3, OSS);
-http_tests!(File, S3, OSS);
+grpc_tests!(File, S3, Oss);
+http_tests!(File, S3, Oss);

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -17,5 +17,5 @@ mod grpc;
 #[macro_use]
 mod http;
 
-grpc_tests!(File, S3);
-http_tests!(File, S3);
+grpc_tests!(File, S3, OSS);
+http_tests!(File, S3, OSS);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Adds ObjectStoreConfig::OSS for OSS object storage configurations.
- Create oss object-store instance in the datanode when configured.
- Introduced Config Structs for ObjectStoreConfig

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Added support for OSS storage according to this issue GreptimeTeam/greptimedb/issues/823

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
GreptimeTeam/greptimedb/issues/823
