### PR TITLE
chore: add interceptor err in `frontend::error::Error`

### DIFF
--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -399,7 +399,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("SQL execution intercepted: {}", source))]
+    #[snafu(display("SQL execution intercepted, source: {}", source))]
     SqlExecIntercepted {
         #[snafu(backtrace)]
         source: BoxedError,

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -399,8 +399,8 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("SQL intercepted: {}", source))]
-    Interceptor {
+    #[snafu(display("SQL execution intercepted: {}", source))]
+    SqlExecIntercepted {
         #[snafu(backtrace)]
         source: BoxedError,
     },
@@ -425,7 +425,7 @@ impl ErrorExt for Error {
             Error::RuntimeResource { source, .. } => source.status_code(),
 
             Error::StartServer { source, .. } => source.status_code(),
-            Error::Interceptor { source, .. } => source.status_code(),
+            Error::SqlExecIntercepted { source, .. } => source.status_code(),
 
             Error::ParseSql { source } | Error::AlterExprFromStmt { source } => {
                 source.status_code()

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -398,6 +398,12 @@ pub enum Error {
         column: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("SQL intercepted: {}", source))]
+    Interceptor {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -419,6 +425,7 @@ impl ErrorExt for Error {
             Error::RuntimeResource { source, .. } => source.status_code(),
 
             Error::StartServer { source, .. } => source.status_code(),
+            Error::Interceptor { source, .. } => source.status_code(),
 
             Error::ParseSql { source } | Error::AlterExprFromStmt { source } => {
                 source.status_code()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Since the `SqlQueryHandler` implementation uses `frontend::error::Error` in [`do_query`](https://github.com/GreptimeTeam/greptimedb/blob/a7dc86ffe5c7be47e65c399b124c33222431aade/src/frontend/src/instance.rs#L421) and `do_statement_query`, error returned by interceptor should be able to convert to frontend error.

This pr adds `SqlExecIntercepted` snafu in `frontend::error::Error` to enable conversion.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
