### PR TITLE
build(ci): upload sqlness log files

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -127,7 +127,13 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run sqlness
-        run: cargo run --bin sqlness-runner
+        run: cargo run --bin sqlness-runner && ls /tmp
+      - name: Upload sqlness logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqlness-logs
+          path: /tmp/greptime-*.log
+          retention-days: 3
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Background: https://github.com/GreptimeTeam/greptimedb/pull/916#issuecomment-1408190700

It's hard to debug sqlness failure without those log files. This patch uploads log files after sqlness run is finished as CI artifacts. Those log files' TTL is set to 3 days, it might not be too large.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
