### PR TITLE
feat: Implement ProcedureStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,12 @@ dependencies = [
  "common-error",
  "common-runtime",
  "common-telemetry",
+ "futures",
+ "object-store",
  "serde",
  "serde_json",
  "snafu",
+ "tempdir",
  "tokio",
  "uuid",
 ]

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -9,8 +9,13 @@ async-trait.workspace = true
 common-error = { path = "../error" }
 common-runtime = { path = "../runtime" }
 common-telemetry = { path = "../telemetry" }
+futures.workspace = true
+object-store = { path = "../../object-store" }
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true
 tokio.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tempdir = "0.3"

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -45,6 +45,30 @@ pub enum Error {
         procedure_id: ProcedureId,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Failed to put {}, source: {}", key, source))]
+    PutState {
+        key: String,
+        source: object_store::Error,
+    },
+
+    #[snafu(display("Failed to delete {}, source: {}", key, source))]
+    DeleteState {
+        key: String,
+        source: object_store::Error,
+    },
+
+    #[snafu(display("Failed to list {}, source: {}", path, source))]
+    ListState {
+        path: String,
+        source: object_store::Error,
+    },
+
+    #[snafu(display("Failed to read {}, source: {}", key, source))]
+    ReadState {
+        key: String,
+        source: object_store::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -53,7 +77,11 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
             Error::External { source } => source.status_code(),
-            Error::ToJson { .. } => StatusCode::Internal,
+            Error::ToJson { .. }
+            | Error::PutState { .. }
+            | Error::DeleteState { .. }
+            | Error::ListState { .. }
+            | Error::ReadState { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/lib.rs
+++ b/src/common/procedure/src/lib.rs
@@ -16,6 +16,8 @@
 
 pub mod error;
 mod procedure;
+// TODO(yingwen): Remove this attribute once ProcedureManager is implemented.
+#[allow(dead_code)]
 mod store;
 
 pub use crate::error::{Error, Result};

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -252,5 +252,17 @@ mod tests {
 
         let parsed = ProcedureId::parse_str(&uuid_str).unwrap();
         assert_eq!(id, parsed);
+        let parsed = uuid_str.parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn test_procedure_id_serialization() {
+        let id = ProcedureId::random();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(format!("\"{}\"", id.to_string()), json);
+
+        let parsed = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, parsed);
     }
 }

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -248,7 +248,7 @@ mod tests {
     fn test_procedure_id_serialization() {
         let id = ProcedureId::random();
         let json = serde_json::to_string(&id).unwrap();
-        assert_eq!(format!("\"{}\"", id.to_string()), json);
+        assert_eq!(format!("\"{id}\""), json);
 
         let parsed = serde_json::from_str(&json).unwrap();
         assert_eq!(id, parsed);

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -197,18 +197,6 @@ pub trait ProcedureManager: Send + Sync + 'static {
 /// Ref-counted pointer to the [ProcedureManager].
 pub type ProcedureManagerRef = Arc<dyn ProcedureManager>;
 
-/// Serialized data of a procedure.
-#[derive(Debug, Serialize, Deserialize)]
-struct ProcedureMessage {
-    /// Type name of the procedure. The procedure framework also use the type name to
-    /// find a loader to load the procedure.
-    type_name: String,
-    /// The data of the procedure.
-    data: String,
-    /// Parent procedure id.
-    parent_id: Option<ProcedureId>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -202,7 +202,7 @@ mod tests {
             step: 2,
             is_committed: false,
         };
-        assert_eq!(format!("{}/0000000002.step", procedure_id), key.to_string());
+        assert_eq!(format!("{procedure_id}/0000000002.step"), key.to_string());
         assert_eq!(key, ParsedKey::parse_str(&key.to_string()).unwrap());
 
         let key = ParsedKey {
@@ -210,10 +210,7 @@ mod tests {
             step: 2,
             is_committed: true,
         };
-        assert_eq!(
-            format!("{}/0000000002.commit", procedure_id),
-            key.to_string()
-        );
+        assert_eq!(format!("{procedure_id}/0000000002.commit"), key.to_string());
         assert_eq!(key, ParsedKey::parse_str(&key.to_string()).unwrap());
     }
 
@@ -222,24 +219,24 @@ mod tests {
         assert!(ParsedKey::parse_str("").is_none());
 
         let procedure_id = ProcedureId::random();
-        let input = format!("{}", procedure_id);
+        let input = format!("{procedure_id}");
         assert!(ParsedKey::parse_str(&input).is_none());
 
-        let input = format!("{}/", procedure_id);
+        let input = format!("{procedure_id}/");
         assert!(ParsedKey::parse_str(&input).is_none());
 
-        let input = format!("{}/0000000003", procedure_id);
+        let input = format!("{procedure_id}/0000000003");
         assert!(ParsedKey::parse_str(&input).is_none());
 
-        let input = format!("{}/0000000003.", procedure_id);
+        let input = format!("{procedure_id}/0000000003.");
         assert!(ParsedKey::parse_str(&input).is_none());
 
-        let input = format!("{}/0000000003.other", procedure_id);
+        let input = format!("{procedure_id}/0000000003.other");
         assert!(ParsedKey::parse_str(&input).is_none());
 
         assert!(ParsedKey::parse_str("12345/0000000003.step").is_none());
 
-        let input = format!("{}-0000000003.commit", procedure_id);
+        let input = format!("{procedure_id}-0000000003.commit");
         assert!(ParsedKey::parse_str(&input).is_none());
     }
 

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Common traits and structures for the procedure framework.
+use serde::{Deserialize, Serialize};
 
-pub mod error;
-mod procedure;
-mod store;
+use crate::ProcedureId;
 
-pub use crate::error::{Error, Result};
-pub use crate::procedure::{
-    BoxedProcedure, Context, LockKey, Procedure, ProcedureId, ProcedureManager,
-    ProcedureManagerRef, ProcedureState, ProcedureWithId, Status,
-};
+mod state_store;
+
+/// Serialized data of a procedure.
+#[derive(Debug, Serialize, Deserialize)]
+struct ProcedureMessage {
+    /// Type name of the procedure. The procedure framework also use the type name to
+    /// find a loader to load the procedure.
+    type_name: String,
+    /// The data of the procedure.
+    data: String,
+    /// Parent procedure id.
+    parent_id: Option<ProcedureId>,
+}

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -92,7 +92,7 @@ impl ProcedureStore {
         let mut procedure_key_value = None;
 
         // Scan all procedures.
-        let mut key_values = self.0.list("/").await?;
+        let mut key_values = self.0.walk_top_down("/").await?;
         while let Some((key, value)) = key_values.try_next().await? {
             let Some(curr_key) = ParsedKey::parse_str(&key) else {
                 logging::info!("Unknown key while loading procedures, key: {}", key);

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -95,7 +95,7 @@ impl ProcedureStore {
         let mut key_values = self.0.walk_top_down("/").await?;
         while let Some((key, value)) = key_values.try_next().await? {
             let Some(curr_key) = ParsedKey::parse_str(&key) else {
-                logging::info!("Unknown key while loading procedures, key: {}", key);
+                logging::warn!("Unknown key while loading procedures, key: {}", key);
                 continue;
             };
 

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -12,9 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fmt;
 
-use crate::ProcedureId;
+use common_telemetry::logging;
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{Result, ToJsonSnafu};
+use crate::store::state_store::StateStoreRef;
+use crate::{BoxedProcedure, ProcedureId};
 
 mod state_store;
 
@@ -28,4 +36,157 @@ struct ProcedureMessage {
     data: String,
     /// Parent procedure id.
     parent_id: Option<ProcedureId>,
+}
+
+/// Procedure storage layer.
+#[derive(Clone)]
+struct ProcedureStore(StateStoreRef);
+
+impl ProcedureStore {
+    /// Dump the `procedure` to the storage.
+    async fn store_procedure(
+        &self,
+        procedure_id: ProcedureId,
+        step: u32,
+        procedure: &BoxedProcedure,
+        parent_id: Option<ProcedureId>,
+    ) -> Result<()> {
+        let type_name = procedure.type_name();
+        let data = procedure.dump()?;
+
+        let message = ProcedureMessage {
+            type_name: type_name.to_string(),
+            data,
+            parent_id,
+        };
+        let key = ParsedKey {
+            procedure_id,
+            step,
+            is_committed: false,
+        }
+        .to_string();
+        let value = serde_json::to_string(&message).context(ToJsonSnafu)?;
+
+        self.0.put(&key, value.into_bytes()).await?;
+
+        Ok(())
+    }
+
+    /// Write commit flag to the storage.
+    async fn commit_procedure(&self, procedure_id: ProcedureId, step: u32) -> Result<()> {
+        let key = ParsedKey {
+            procedure_id,
+            step,
+            is_committed: true,
+        }
+        .to_string();
+        self.0.put(&key, Vec::new()).await?;
+
+        Ok(())
+    }
+
+    /// Load uncommitted procedures from the storage.
+    async fn load_messages(&self) -> Result<HashMap<ProcedureId, ProcedureMessage>> {
+        let mut messages = HashMap::new();
+        // Tracks the last key-value pair of an uncommitted procedure.
+        let mut procedure_key_value = None;
+
+        // Scan all procedures.
+        let mut key_values = self.0.list("/").await?;
+        while let Some((key, value)) = key_values.try_next().await? {
+            let Some(curr_key) = ParsedKey::parse_str(&key) else {
+                logging::info!("Unknown key while loading procedures, key: {}", key);
+                continue;
+            };
+            let Some((prev_key, prev_value)) = &procedure_key_value else {
+                // This is new procedure. We stores the key-value pair and check next
+                // key-value pair.
+                procedure_key_value = Some((curr_key, value));
+                continue;
+            };
+            if prev_key.procedure_id == curr_key.procedure_id && !curr_key.is_committed {
+                // The same procedure, update its value.
+                procedure_key_value = Some((curr_key, value));
+            } else if prev_key.procedure_id == curr_key.procedure_id {
+                // Skips the procedure if it is committed.
+                procedure_key_value = None;
+            } else {
+                // A new procedure, now we can load previous procedure.
+                let Some(message) = self.load_one_message(prev_key, prev_value) else {
+                    // We don't abort the loading process and just ignore errors to ensure all remaining
+                    // procedures are loaded.
+                    continue;
+                };
+                messages.insert(prev_key.procedure_id, message);
+
+                procedure_key_value = Some((curr_key, value));
+            }
+        }
+
+        // Load last procedure.
+        if let Some((last_key, last_value)) = &procedure_key_value {
+            if let Some(message) = self.load_one_message(last_key, last_value) {
+                messages.insert(last_key.procedure_id, message);
+            }
+        }
+
+        Ok(messages)
+    }
+
+    fn load_one_message(&self, key: &ParsedKey, value: &[u8]) -> Option<ProcedureMessage> {
+        serde_json::from_slice(value)
+            .map_err(|e| {
+                // `e` doesn't impl ErrorExt so we print it as normal error.
+                logging::error!("Failed to parse value, key: {:?}, source: {}", key, e);
+                e
+            })
+            .ok()
+    }
+}
+
+/// Key to refer the procedure in the [ProcedureStore].
+#[derive(Debug)]
+struct ParsedKey {
+    procedure_id: ProcedureId,
+    step: u32,
+    is_committed: bool,
+}
+
+impl fmt::Display for ParsedKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}.{}",
+            self.procedure_id,
+            self.step,
+            if self.is_committed { "commit" } else { "step" }
+        )
+    }
+}
+
+impl ParsedKey {
+    /// Try to parse the key from specific `input`.
+    fn parse_str(input: &str) -> Option<ParsedKey> {
+        let mut iter = input.rsplit('/');
+        let name = iter.next()?;
+        let id_str = iter.next()?;
+
+        let procedure_id = ProcedureId::parse_str(id_str).ok()?;
+
+        let mut parts = name.split('.');
+        let step_str = parts.next()?;
+        let suffix = parts.next()?;
+        let is_committed = match suffix {
+            "commit" => true,
+            "step" => false,
+            _ => return None,
+        };
+        let step = step_str.parse().ok()?;
+
+        Some(ParsedKey {
+            procedure_id,
+            step,
+            is_committed,
+        })
+    }
 }

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -32,7 +32,7 @@ type KeyValueStream = Pin<Box<dyn Stream<Item = Result<KeyValue>> + Send>>;
 
 /// Storage layer for persisting key-value pairs.
 #[async_trait]
-trait StateStore: Send + Sync {
+pub(crate) trait StateStore: Send + Sync {
     /// Puts `key` and `value` into the store.
     async fn put(&self, key: &str, value: Vec<u8>) -> Result<()>;
 
@@ -46,7 +46,7 @@ trait StateStore: Send + Sync {
 }
 
 /// Reference counted pointer to [StateStore].
-type StateStoreRef = Arc<dyn StateStore>;
+pub(crate) type StateStoreRef = Arc<dyn StateStore>;
 
 /// [StateStore] based on [ObjectStore].
 #[derive(Debug)]

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -73,6 +73,9 @@ impl StateStore for ObjectStateStore {
     async fn walk_top_down(&self, path: &str) -> Result<KeyValueStream> {
         let path_string = path.to_string();
         let op = self.store.batch();
+        // Note that there is no guarantee about the order between files and dirs
+        // at the same level.
+        // See https://docs.rs/opendal/0.25.2/opendal/raw/struct.TopDownWalker.html#note
         let stream = op
             .walk_top_down(path)
             .context(ListStateSnafu { path })?

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -1,0 +1,180 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::{Stream, TryStreamExt};
+use object_store::{ObjectMode, ObjectStore};
+use snafu::ResultExt;
+
+use crate::error::{
+    DeleteStateSnafu, Error, ListStateSnafu, PutStateSnafu, ReadStateSnafu, Result,
+};
+
+/// Key value from state store.
+type KeyValue = (String, Vec<u8>);
+
+/// Stream that yields [KeyValue].
+type KeyValueStream = Pin<Box<dyn Stream<Item = Result<KeyValue>> + Send>>;
+
+/// Storage layer for persisting key-value pairs.
+#[async_trait]
+trait StateStore: Send + Sync {
+    /// Puts `key` and `value` into the store.
+    async fn put(&self, key: &str, value: Vec<u8>) -> Result<()>;
+
+    /// Returns the key-value pairs that have the same key `path`.
+    ///
+    /// The `path` must ends with `/`.
+    async fn list(&self, path: &str) -> Result<KeyValueStream>;
+
+    /// Deletes key-value pairs by `keys`.
+    async fn delete(&self, keys: &[String]) -> Result<()>;
+}
+
+/// Reference counted pointer to [StateStore].
+type StateStoreRef = Arc<dyn StateStore>;
+
+/// [StateStore] based on [ObjectStore].
+#[derive(Debug)]
+struct ObjectStateStore {
+    store: ObjectStore,
+}
+
+impl ObjectStateStore {
+    /// Returns a new [ObjectStateStore] with specific `store`.
+    fn new(store: ObjectStore) -> ObjectStateStore {
+        ObjectStateStore { store }
+    }
+}
+
+#[async_trait]
+impl StateStore for ObjectStateStore {
+    async fn put(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        let object = self.store.object(key);
+        object.write(value).await.context(PutStateSnafu { key })
+    }
+
+    async fn list(&self, path: &str) -> Result<KeyValueStream> {
+        let path_string = path.to_string();
+        let op = self.store.batch();
+        let stream = op
+            .walk_top_down(path)
+            .context(ListStateSnafu { path })?
+            .map_err(move |e| Error::ListState {
+                path: path_string.clone(),
+                source: e,
+            })
+            .try_filter_map(|entry| async move {
+                let key = entry.path();
+                let key_value = match entry.mode().await.context(ReadStateSnafu { key })? {
+                    ObjectMode::FILE => {
+                        let value = entry.read().await.context(ReadStateSnafu { key })?;
+
+                        Some((key.to_string(), value))
+                    }
+                    ObjectMode::DIR | ObjectMode::Unknown => None,
+                };
+
+                Ok(key_value)
+            });
+
+        Ok(Box::pin(stream))
+    }
+
+    async fn delete(&self, keys: &[String]) -> Result<()> {
+        for key in keys {
+            let object = self.store.object(key);
+            object.delete().await.context(DeleteStateSnafu { key })?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use object_store::services::fs::Builder;
+    use tempdir::TempDir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_object_state_store() {
+        let dir = TempDir::new("state_store").unwrap();
+        let store_dir = dir.path().to_str().unwrap();
+        let accessor = Builder::default().root(store_dir).build().unwrap();
+        let object_store = ObjectStore::new(accessor);
+        let state_store = ObjectStateStore::new(object_store);
+
+        let data: Vec<_> = state_store
+            .list("/")
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert!(data.is_empty());
+
+        state_store.put("a/1", b"v1".to_vec()).await.unwrap();
+        state_store.put("a/2", b"v2".to_vec()).await.unwrap();
+        state_store.put("b/1", b"v3".to_vec()).await.unwrap();
+
+        let data: Vec<_> = state_store
+            .list("/")
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            vec![
+                ("a/1".to_string(), b"v1".to_vec()),
+                ("a/2".to_string(), b"v2".to_vec()),
+                ("b/1".to_string(), b"v3".to_vec())
+            ],
+            data
+        );
+
+        let data: Vec<_> = state_store
+            .list("a/")
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            vec![
+                ("a/1".to_string(), b"v1".to_vec()),
+                ("a/2".to_string(), b"v2".to_vec()),
+            ],
+            data
+        );
+
+        state_store
+            .delete(&["a/2".to_string(), "b/1".to_string()])
+            .await
+            .unwrap();
+        let data: Vec<_> = state_store
+            .list("a/")
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        assert_eq!(vec![("a/1".to_string(), b"v1".to_vec()),], data);
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements the storage layer for the procedure framework.

The `ProcedureStore` stores procedures on the object store, using the following directory structure

```
/path/to/procedures/{PROCEDURE_ID}/0000000000.step
/path/to/procedures/{PROCEDURE_ID}/0000000001.step
/path/to/procedures/{PROCEDURE_ID}/0000000002.commit
```

The content of the `step` file is a JSON object serialized from `ProcedureMessage`
```rust
struct ProcedureMessage {
    type_name: String,
    data: String,
    parent_id: Option<ProcedureId>,
}
```

e.g.
```json
{
    "type_name":"TestMessage",
    "data":"no parent id",
    "parent_id":"9f805a1f-05f7-490c-9f91-bd56e3cc54c1"
}
```

The `StateStore` trait is an abstraction for persistent storage like ObjectStore. We can implement this trait if we want to store procedure states in meta or etcd.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 