### PR TITLE
docs: add dashboard to resources in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ You can always cleanup test database by removing `/tmp/greptimedb`.
 - GreptimeDB [Developer
   Guide](https://docs.greptime.com/developer-guide/overview.html)
 
+### Dashboard
+- [The dashboard UI for GreptimeDB](https://github.com/GreptimeTeam/dashboard)
+
 ### SDK
 
 - [GreptimeDB Java


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Adds dashboard repo link to resources section in README.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
