### PR TITLE
feat: bind DataFrame API into python script

### DIFF
--- a/src/script/src/python.rs
+++ b/src/script/src/python.rs
@@ -18,6 +18,7 @@ mod builtins;
 pub(crate) mod coprocessor;
 mod engine;
 pub mod error;
+mod dataframe;
 #[cfg(test)]
 mod test;
 pub(crate) mod utils;

--- a/src/script/src/python.rs
+++ b/src/script/src/python.rs
@@ -16,9 +16,9 @@
 
 mod builtins;
 pub(crate) mod coprocessor;
+mod dataframe;
 mod engine;
 pub mod error;
-mod dataframe;
 #[cfg(test)]
 mod test;
 pub(crate) mod utils;

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -452,6 +452,7 @@ pub(crate) fn exec_with_cached_vm(
         let scope = vm.new_scope_with_builtins();
         set_items_in_scope(&scope, vm, &copr.deco_args.arg_names, args)?;
         crate::python::dataframe::data_frame::set_dataframe_in_scope(&scope, vm, "df", rb)?;
+
         if let Some(engine) = &copr.query_engine {
             let query_engine = PyQueryEngine {
                 inner: engine.clone(),
@@ -521,6 +522,8 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
                     PyVector::make_class(&vm.ctx);
                     vm.add_native_module("greptime", Box::new(greptime_builtin::make_module));
 
+                    data_frame::PyDataFrame::make_class(&vm.ctx);
+                    data_frame::PyExpr::make_class(&vm.ctx);
                     vm.add_native_module("data_frame", Box::new(data_frame::make_module));
                 }));
                 info!("Initialized Python interpreter.");

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -451,7 +451,7 @@ pub(crate) fn exec_with_cached_vm(
         // set arguments with given name and values
         let scope = vm.new_scope_with_builtins();
         set_items_in_scope(&scope, vm, &copr.deco_args.arg_names, args)?;
-        crate::python::dataframe::data_frame::set_dataframe_in_scope(&scope, vm, "df", rb)?;
+        crate::python::dataframe::data_frame::set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
 
         if let Some(engine) = &copr.query_engine {
             let query_engine = PyQueryEngine {

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -43,7 +43,7 @@ use vm::{pyclass, Interpreter, PyObjectRef, PyPayload, PyResult, VirtualMachine}
 
 use crate::python::builtins::greptime_builtin;
 use crate::python::coprocessor::parse::DecoratorArgs;
-use crate::python::dataframe::data_frame;
+use crate::python::dataframe::data_frame::{self, set_dataframe_in_scope};
 use crate::python::error::{
     ensure, ret_other_error_with, ArrowSnafu, NewRecordBatchSnafu, OtherSnafu, Result,
     TypeCastSnafu,
@@ -451,7 +451,7 @@ pub(crate) fn exec_with_cached_vm(
         // set arguments with given name and values
         let scope = vm.new_scope_with_builtins();
         set_items_in_scope(&scope, vm, &copr.deco_args.arg_names, args)?;
-        crate::python::dataframe::data_frame::set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
+        set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
 
         if let Some(engine) = &copr.query_engine {
             let query_engine = PyQueryEngine {

--- a/src/script/src/python/dataframe.rs
+++ b/src/script/src/python/dataframe.rs
@@ -217,17 +217,17 @@ pub(crate) mod data_frame {
         }
 
         #[pymethod]
-        /// collect `DataFrame` results into List[List[Vector]]
+        /// collect `DataFrame` results into `List[List[Vector]]`
         fn collect(&self, vm: &VirtualMachine) -> PyResult<PyListRef> {
             let inner = self.inner.clone();
             let res = block_on_async(async { inner.collect().await });
             let res = res
                 .map_err(|e| vm.new_runtime_error(format!("{e:?}")))?
                 .map_err(|e| vm.new_runtime_error(e.to_string()))?;
-            let outer_lst: Vec<_> = res
+            let outer_list: Vec<_> = res
                 .iter()
                 .map(|elem| -> PyResult<_> {
-                    let inner_lst: Vec<_> = elem
+                    let inner_list: Vec<_> = elem
                         .columns()
                         .iter()
                         .map(|arr| -> PyResult<_> {
@@ -237,11 +237,11 @@ pub(crate) mod data_frame {
                                 .map_err(|e| vm.new_runtime_error(e.to_string()))
                         })
                         .collect::<Result<_, _>>()?;
-                    let inner_lst = PyList::new_ref(inner_lst, vm.as_ref());
-                    Ok(inner_lst.into())
+                    let inner_list = PyList::new_ref(inner_list, vm.as_ref());
+                    Ok(inner_list.into())
                 })
                 .collect::<Result<_, _>>()?;
-            Ok(PyList::new_ref(outer_lst, vm.as_ref()))
+            Ok(PyList::new_ref(outer_list, vm.as_ref()))
         }
     }
 

--- a/src/script/src/python/dataframe.rs
+++ b/src/script/src/python/dataframe.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use rustpython_vm::pymodule as rspymodule;
 /// TODO: use given RecordBatch to register table in `SessionContext`
 /// with `register_batch`, and then wrap DataFrame API in it

--- a/src/script/src/python/dataframe.rs
+++ b/src/script/src/python/dataframe.rs
@@ -1,0 +1,115 @@
+use rustpython_vm::{
+    pyclass as rspyclass, pymodule as rspymodule, PyPayload, PyRef, PyResult, VirtualMachine,
+};
+/// TODO: use given RecordBatch to register table in `SessionContext`
+/// with `register_batch`, and then wrap DataFrame API in it
+/// TODO: wrap DataFrame&Expr
+#[rspymodule]
+mod data_frame {
+    use common_recordbatch::DfRecordBatch;
+    use datafusion::dataframe::DataFrame as DfDataFrame;
+    use datafusion_expr::Expr as DfExpr;
+    use rustpython_vm::{
+        pyclass as rspyclass, PyPayload, PyRef, PyResult,
+    };
+    #[rspyclass(module = "data_frame", name = "DataFrame")]
+    #[derive(PyPayload, Debug)]
+    pub struct PyDataFrame {
+        pub inner: DfDataFrame,
+    }
+
+    impl PyDataFrame {
+        /// TODO: error handling
+        fn from_record_batch(rb: &DfRecordBatch) -> Self {
+            let ctx = datafusion::execution::context::SessionContext::new();
+            let inner = ctx.read_batch(rb.clone()).unwrap();
+            Self { inner }
+        }
+    }
+
+    #[rspyclass(module = "data_frame", name = "expr")]
+    #[derive(PyPayload, Debug)]
+    pub struct PyExpr {
+        pub inner: DfExpr,
+    }
+
+    fn col(name: &str) -> PyExpr {
+        DfExpr::Column(datafusion_common::Column::from_name(name)).into()
+    }
+    fn cols<L>(names: L)
+    where
+        L: AsRef<[String]>,
+    {
+    }
+    fn lit(t: datafusion_common::ScalarValue) -> PyExpr {
+        DfExpr::Literal(t).into()
+    }
+
+    type PyExprRef = PyRef<PyExpr>;
+
+    impl From<datafusion_expr::Expr> for PyExpr {
+        fn from(value: DfExpr) -> Self {
+            Self { inner: value }
+        }
+    }
+
+    #[rspyclass]
+    impl PyExpr {
+        #[pymethod]
+        fn alias(&self, name: String) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().alias(name).into())
+        }
+
+        // bunch of binary op function(not use macro for macro expansion order doesn't support)
+        #[pymethod(magic)]
+        fn eq(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().eq(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn ne(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().not_eq(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn le(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().lt_eq(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn lt(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().lt(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn ge(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().gt_eq(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn gt(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().gt(other.inner.clone()).into())
+        }
+
+        #[pymethod(magic)]
+        fn and(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().and(other.inner.clone()).into())
+        }
+        #[pymethod(magic)]
+        fn or(&self, other: PyExprRef) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().and(other.inner.clone()).into())
+        }
+
+        /// `~` operator, return `!self`
+        #[pymethod(magic)]
+        fn invert(&self) -> PyResult<PyExpr> {
+            Ok(self.inner.clone().not().into())
+        }
+
+        /// sort ascending&nulls_first
+        #[pymethod]
+        fn sort(&self) -> PyExpr {
+            self.inner.clone().sort(true, true).into()
+        }
+    }
+}

--- a/src/script/src/python/dataframe.rs
+++ b/src/script/src/python/dataframe.rs
@@ -1,23 +1,38 @@
-use rustpython_vm::{
-    pyclass as rspyclass, pymodule as rspymodule, PyPayload, PyRef, PyResult, VirtualMachine,
-};
+use rustpython_vm::pymodule as rspymodule;
 /// TODO: use given RecordBatch to register table in `SessionContext`
 /// with `register_batch`, and then wrap DataFrame API in it
 /// TODO: wrap DataFrame&Expr
 #[rspymodule]
-mod data_frame {
-    use common_recordbatch::DfRecordBatch;
+pub(crate) mod data_frame {
+    use common_recordbatch::{DfRecordBatch, RecordBatch};
     use datafusion::dataframe::DataFrame as DfDataFrame;
     use datafusion_expr::Expr as DfExpr;
-    use rustpython_vm::{
-        pyclass as rspyclass, PyPayload, PyRef, PyResult,
-    };
+    use rustpython_vm::{pyclass as rspyclass, PyPayload, PyRef, PyResult, VirtualMachine};
     #[rspyclass(module = "data_frame", name = "DataFrame")]
     #[derive(PyPayload, Debug)]
     pub struct PyDataFrame {
         pub inner: DfDataFrame,
     }
 
+    impl From<DfDataFrame> for PyDataFrame {
+        fn from(inner: DfDataFrame) -> Self {
+            Self { inner }
+        }
+    }
+    /// set DataFrame instance into current scope with given name
+    pub fn set_dataframe_in_scope(
+        scope: &rustpython_vm::scope::Scope,
+        vm: &VirtualMachine,
+        name: &str,
+        rb: &RecordBatch,
+    ) -> crate::python::error::Result<()> {
+        let df = PyDataFrame::from_record_batch(rb.df_record_batch());
+        scope
+            .locals
+            .set_item(name, vm.new_pyobj(df), vm)
+            .map_err(|e| crate::python::utils::format_py_error(e, vm))
+    }
+    #[rspyclass]
     impl PyDataFrame {
         /// TODO: error handling
         fn from_record_batch(rb: &DfRecordBatch) -> Self {
@@ -25,25 +40,55 @@ mod data_frame {
             let inner = ctx.read_batch(rb.clone()).unwrap();
             Self { inner }
         }
+
+        #[pymethod]
+        fn filter(&self, predicate: PyExprRef, vm: &VirtualMachine) -> PyResult<Self> {
+            Ok(self
+                .inner
+                .clone()
+                .filter(predicate.inner.to_owned())
+                .map_err(|e| vm.new_runtime_error(e.to_string()))?
+                .into())
+        }
+
+        #[pymethod]
+        fn aggregate(
+            &self,
+            group_expr: Vec<PyExprRef>,
+            aggr_expr: Vec<PyExprRef>,
+            vm: &VirtualMachine,
+        ) -> PyResult<Self> {
+            let ret = self.inner.to_owned().aggregate(
+                group_expr.iter().map(|i| i.inner.to_owned()).collect(),
+                aggr_expr.iter().map(|i| i.inner.to_owned()).collect(),
+            );
+            Ok(ret.map_err(|e| vm.new_runtime_error(e.to_string()))?.into())
+        }
+
+        #[pymethod]
+        fn limit(&self, skip: usize, fetch: Option<usize>, vm: &VirtualMachine) -> PyResult<Self> {
+            Ok(self
+                .inner
+                .to_owned()
+                .limit(skip, fetch)
+                .map_err(|e| vm.new_runtime_error(e.to_string()))?
+                .into())
+        }
     }
 
-    #[rspyclass(module = "data_frame", name = "expr")]
+    #[rspyclass(module = "data_frame", name = "Expr")]
     #[derive(PyPayload, Debug)]
     pub struct PyExpr {
         pub inner: DfExpr,
     }
 
-    fn col(name: &str) -> PyExpr {
-        DfExpr::Column(datafusion_common::Column::from_name(name)).into()
+    #[pyfunction]
+    fn col(name: String, vm: &VirtualMachine) -> PyExprRef {
+        let expr: PyExpr = DfExpr::Column(datafusion_common::Column::from_name(name)).into();
+        expr.into_ref(vm)
     }
-    fn cols<L>(names: L)
-    where
-        L: AsRef<[String]>,
-    {
-    }
-    fn lit(t: datafusion_common::ScalarValue) -> PyExpr {
-        DfExpr::Literal(t).into()
-    }
+
+    // TODO: lit function that take PyObject and turn it into ScalarValue
 
     type PyExprRef = PyRef<PyExpr>;
 

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -347,7 +347,7 @@ from data_frame import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number)->vector[u32]:
-    return df.filter(col("number")==col("number")).collect()[0][0]
+    return dataframe.filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -320,7 +320,7 @@ import greptime as gt
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number)->vector[u32]:
-    return query.sql("select * from numbers")[0][0][1]
+    return query.sql("select * from numbers")[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())
@@ -347,7 +347,7 @@ from data_frame import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number)->vector[u32]:
-    return df.select([col("number")]).collect()[0][0][1]
+    return df.filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -326,10 +326,10 @@ def test(number)->vector[u32]:
             .compile(script, CompileContext::default())
             .await
             .unwrap();
-        let _output = script.execute(EvalContext::default()).await.unwrap();
-        let res = common_recordbatch::util::collect_batches(match _output {
+        let output = script.execute(EvalContext::default()).await.unwrap();
+        let res = common_recordbatch::util::collect_batches(match output {
             Output::Stream(s) => s,
-            _ => todo!(),
+            _ => unreachable!(),
         })
         .await
         .unwrap();

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -338,6 +338,33 @@ def test(number)->vector[u32]:
     }
 
     #[tokio::test]
+    async fn test_data_frame_in_py() {
+        let script_engine = sample_script_engine();
+
+        let script = r#"
+import greptime as gt
+from data_frame import col
+
+@copr(args=["number"], returns = ["number"], sql = "select * from numbers")
+def test(number)->vector[u32]:
+    return df.select([col("number")]).collect()[0][0][1]
+"#;
+        let script = script_engine
+            .compile(script, CompileContext::default())
+            .await
+            .unwrap();
+        let _output = script.execute(EvalContext::default()).await.unwrap();
+        let res = common_recordbatch::util::collect_batches(match _output {
+            Output::Stream(s) => s,
+            _ => todo!(),
+        })
+        .await
+        .unwrap();
+        let rb = res.iter().next().expect("One and only one recordbatch");
+        assert_eq!(rb.column(0).len(), 100);
+    }
+
+    #[tokio::test]
     async fn test_compile_execute() {
         let script_engine = sample_script_engine();
 

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -508,7 +508,7 @@ from data_frame import col
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    ret = df.select([col("cpu"), col("mem")]).collect()[0]
+    ret = dataframe.select([col("cpu"), col("mem")]).collect()[0]
     return ret[0], ret[1]
 "#,
         predicate: ExecIsOk(
@@ -542,7 +542,7 @@ from data_frame import col
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    ret = df.filter(col("cpu")>col("mem")).collect()[0]
+    ret = dataframe.filter(col("cpu")>col("mem")).collect()[0]
     return ret[0], ret[1]
 "#,
         predicate: ExecIsOk(

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -502,6 +502,74 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     ),
     (
         // constant column(int)
+        name: "test_data_frame",
+        code: r#"
+from data_frame import col
+@copr(args=["cpu", "mem"], returns=["perf", "what"])
+def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
+    vector[f32]):
+    ret = df.select([col("cpu"), col("mem")]).collect()[0]
+    return ret[0], ret[1]
+"#,
+        predicate: ExecIsOk(
+            fields: [
+                (
+                    datatype: Some(Float64(())),
+                    is_nullable: true
+                ),
+                (
+                    datatype: Some(Float32(())),
+                    is_nullable: false
+                ),
+            ],
+            columns: [
+                (
+                    ty: Float64,
+                    len: 4
+                ),
+                (
+                    ty: Float32,
+                    len: 4
+                )
+            ]
+        )
+    ),
+    (
+        // constant column(int)
+        name: "test_data_frame",
+        code: r#"
+from data_frame import col
+@copr(args=["cpu", "mem"], returns=["perf", "what"])
+def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
+    vector[f32]):
+    ret = df.filter(col("cpu")>col("mem")).collect()[0]
+    return ret[0], ret[1]
+"#,
+        predicate: ExecIsOk(
+            fields: [
+                (
+                    datatype: Some(Float64(())),
+                    is_nullable: true
+                ),
+                (
+                    datatype: Some(Float32(())),
+                    is_nullable: false
+                ),
+            ],
+            columns: [
+                (
+                    ty: Float64,
+                    len: 4
+                ),
+                (
+                    ty: Float32,
+                    len: 4
+                )
+            ]
+        )
+    ),
+    (
+        // constant column(int)
         name: "test_neg_import_stdlib",
         code: r#"
 @copr(args=["cpu", "mem"], returns=["perf", "what"])

--- a/src/script/src/python/utils.rs
+++ b/src/script/src/python/utils.rs
@@ -20,6 +20,7 @@ use datatypes::prelude::ScalarVector;
 use datatypes::vectors::{
     BooleanVector, Float64Vector, Helper, Int64Vector, NullVector, StringVector, VectorRef,
 };
+use futures::Future;
 use rustpython_vm::builtins::{PyBaseExceptionRef, PyBool, PyFloat, PyInt, PyList, PyStr};
 use rustpython_vm::{PyObjectRef, PyPayload, PyRef, VirtualMachine};
 use snafu::{Backtrace, GenerateImplicitData, OptionExt, ResultExt};
@@ -112,4 +113,17 @@ pub fn py_vec_obj_to_array(
     } else {
         ret_other_error_with(format!("Expect a vector or a constant, found {obj:?}")).fail()
     }
+}
+
+/// a terrible hack to call async from sync by:
+/// TODO(discord9): find a better way
+/// 1. spawn a new thread
+/// 2. create a new runtime in new thread and call `block_on` on it
+pub fn block_on_async<T, F>(f: F) -> std::thread::Result<T>
+where
+    F: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let rt = tokio::runtime::Runtime::new().map_err(|e| Box::new(e) as _)?;
+    std::thread::spawn(move || rt.block_on(f)).join()
 }

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -436,48 +436,6 @@ impl PyVector {
         }
     }
 
-    // it seems rustpython's richcompare support is not good
-    // The Comparable Trait only support normal cmp
-    // (yes there is a slot_richcompare function, but it is not used in anywhere)
-    // so use our own function
-    // TODO(discord9): test those function
-
-    #[pymethod(name = "eq")]
-    #[pymethod(magic)]
-    fn eq(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Eq, vm)
-    }
-
-    #[pymethod(name = "ne")]
-    #[pymethod(magic)]
-    fn ne(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Ne, vm)
-    }
-
-    #[pymethod(name = "gt")]
-    #[pymethod(magic)]
-    fn gt(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Gt, vm)
-    }
-
-    #[pymethod(name = "lt")]
-    #[pymethod(magic)]
-    fn lt(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Lt, vm)
-    }
-
-    #[pymethod(name = "ge")]
-    #[pymethod(magic)]
-    fn ge(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Ge, vm)
-    }
-
-    #[pymethod(name = "le")]
-    #[pymethod(magic)]
-    fn le(&self, other: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyVector> {
-        self.richcompare(other, PyComparisonOp::Le, vm)
-    }
-
     #[pymethod(magic)]
     fn and(&self, other: PyVectorRef, vm: &VirtualMachine) -> PyResult<PyVector> {
         let left = self.to_arrow_array();
@@ -516,7 +474,6 @@ impl PyVector {
 
     #[pymethod(magic)]
     fn invert(&self, vm: &VirtualMachine) -> PyResult<PyVector> {
-        dbg!();
         let left = self.to_arrow_array();
         let left = left
             .as_any()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bind `DataFrame` API in python script, example as below:
```python
from data_frame import col

def test(number)->vector[u32]:
    return df.filter((col("number")==col("number))).collect()[0][0]
```
this api is just a subset of DataFusion's `DataFrame` api.   `DataFrame` and `Expr` types are wrapped in corrseponding python types and exposed similiar api.

Sadly, the `collect()` is async, so this hack of calling from async to sync to async must be used again(Creating new thread and new runtime for blocking calls)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
