### PR TITLE
feat: Add procedure manager LocalManager

### DIFF
--- a/src/common/procedure/src/local/lock.rs
+++ b/src/common/procedure/src/local/lock.rs
@@ -54,13 +54,13 @@ impl Lock {
 }
 
 /// Manages lock entries for procedures.
-struct LockMap {
+pub(crate) struct LockMap {
     locks: RwLock<HashMap<String, Lock>>,
 }
 
 impl LockMap {
     /// Returns a new [LockMap].
-    fn new() -> LockMap {
+    pub(crate) fn new() -> LockMap {
         LockMap {
             locks: RwLock::new(HashMap::new()),
         }
@@ -73,7 +73,7 @@ impl LockMap {
     ///
     /// # Panics
     /// Panics if the procedure acquires the lock recursively.
-    async fn acquire_lock(&self, key: &str, meta: ProcedureMetaRef) {
+    pub(crate) async fn acquire_lock(&self, key: &str, meta: ProcedureMetaRef) {
         assert!(!self.hold_lock(key, meta.id));
 
         {
@@ -101,7 +101,7 @@ impl LockMap {
     }
 
     /// Release lock by `key`.
-    fn release_lock(&self, key: &str, procedure_id: ProcedureId) {
+    pub(crate) fn release_lock(&self, key: &str, procedure_id: ProcedureId) {
         let mut locks = self.locks.write().unwrap();
         if let Some(lock) = locks.get_mut(key) {
             if lock.owner.id != procedure_id {

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -1,0 +1,70 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_telemetry::logging;
+
+use crate::local::{ManagerContext, ProcedureMetaRef};
+use crate::store::ProcedureStore;
+use crate::BoxedProcedure;
+
+pub(crate) struct Runner {
+    pub(crate) meta: ProcedureMetaRef,
+    pub(crate) procedure: BoxedProcedure,
+    pub(crate) manager_ctx: Arc<ManagerContext>,
+    pub(crate) step: u32,
+    pub(crate) store: ProcedureStore,
+}
+
+impl Runner {
+    /// Run the procedure.
+    pub(crate) async fn run(self) {
+        logging::info!(
+            "Runner {}-{} starts",
+            self.procedure.type_name(),
+            self.meta.id
+        );
+        // We use the lock key in ProcedureMeta as it considers locks inherited from
+        // its parent.
+        let lock_key = self.meta.lock_key.clone();
+
+        // TODO(yingwen): Support multiple lock keys.
+        // Acquire lock if necessary.
+        if let Some(key) = &lock_key {
+            self.manager_ctx
+                .lock_map
+                .acquire_lock(key.key(), self.meta.clone())
+                .await;
+        }
+
+        // TODO(yingwen): Execute the procedure.
+
+        if let Some(key) = &lock_key {
+            self.manager_ctx
+                .lock_map
+                .release_lock(key.key(), self.meta.id);
+        }
+        // We can't remove the metadata of the procedure now as users and its parent might
+        // need to query its state.
+        // TODO(yingwen): 1. Add TTL to the metadata; 2. Only keep state in the procedure store
+        // so we don't need to always store the metadata in memory after the procedure is done.
+
+        logging::info!(
+            "Runner {}-{} exits",
+            self.procedure.type_name(),
+            self.meta.id
+        );
+    }
+}

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -163,7 +163,7 @@ pub type BoxedProcedureLoader = Box<dyn Fn(&str) -> Result<BoxedProcedure> + Sen
 
 // TODO(yingwen): Find a way to return the error message if the procedure is failed.
 /// State of a submitted procedure.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProcedureState {
     /// The procedure is running.
     Running,

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -163,7 +163,7 @@ pub type BoxedProcedureLoader = Box<dyn Fn(&str) -> Result<BoxedProcedure> + Sen
 
 // TODO(yingwen): Find a way to return the error message if the procedure is failed.
 /// State of a submitted procedure.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProcedureState {
     /// The procedure is running.
     Running,

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -332,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_commit_procedure() {
-        let dir = TempDir::new("store_procedure").unwrap();
+        let dir = TempDir::new("commit_procedure").unwrap();
         let store = new_procedure_store(&dir);
 
         let procedure_id = ProcedureId::random();
@@ -350,7 +350,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_load_messages() {
-        let dir = TempDir::new("store_procedure").unwrap();
+        let dir = TempDir::new("load_messages").unwrap();
         let store = new_procedure_store(&dir);
 
         // store 3 steps

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -21,28 +21,33 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use crate::error::{Result, ToJsonSnafu};
-use crate::store::state_store::StateStoreRef;
+pub(crate) use crate::store::state_store::{ObjectStateStore, StateStoreRef};
 use crate::{BoxedProcedure, ProcedureId};
 
 mod state_store;
 
 /// Serialized data of a procedure.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-struct ProcedureMessage {
+pub struct ProcedureMessage {
     /// Type name of the procedure. The procedure framework also use the type name to
     /// find a loader to load the procedure.
-    type_name: String,
+    pub type_name: String,
     /// The data of the procedure.
-    data: String,
+    pub data: String,
     /// Parent procedure id.
-    parent_id: Option<ProcedureId>,
+    pub parent_id: Option<ProcedureId>,
 }
 
 /// Procedure storage layer.
 #[derive(Clone)]
-struct ProcedureStore(StateStoreRef);
+pub(crate) struct ProcedureStore(StateStoreRef);
 
 impl ProcedureStore {
+    /// Creates a new [ProcedureStore] from specific [StateStoreRef].
+    pub(crate) fn new(state_store: StateStoreRef) -> ProcedureStore {
+        ProcedureStore(state_store)
+    }
+
     /// Dump the `procedure` to the storage.
     async fn store_procedure(
         &self,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a procedure manager and implements its skeleton
- The manager runs a procedure in a dedicated Runner
- The runner acquires and releases lock for the procedure
- ManagerContext tracks all loaders, locks and procedures

### Unimplemented Features
- Recover
- Subprocedures
- Inherit locks from parent

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 
