### PR TITLE
feat: compaction scheduler and rate limiter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7058,6 +7058,7 @@ dependencies = [
  "table",
  "tempdir",
  "tokio",
+ "tokio-util",
  "tonic",
  "tonic-build",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ serde = { version = "1.0", features = ["derive"] }
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.28"
 tokio = { version = "1.24.2", features = ["full"] }
+tokio-util = "0.7"
 tonic = "0.8"
 uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
 

--- a/docs/rfcs/2023-02-01-table-compaction.md
+++ b/docs/rfcs/2023-02-01-table-compaction.md
@@ -82,7 +82,7 @@ We can first group SSTs in level n into buckets according to some predefined tim
 SSTs are compacted in a size-tired manner (find SSTs with similar size and compact them to level n+1). 
 SSTs from different time windows are neven compacted together.
 That strategy guarantees SSTs in each level are mainly sorted in timestamp order which boosts queries with 
-explict timestamp condition, while size-tired compaction minimizes the impact to foreground writes. 
+explicit timestamp condition, while size-tired compaction minimizes the impact to foreground writes. 
 
 ### Alternatives
 

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -30,7 +30,7 @@ snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
 tempdir = "0.3"
 tokio.workspace = true
-tokio-util = "0.7"
+tokio-util.workspace = true
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,6 +34,7 @@ snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
 table = { path = "../table" }
 tokio.workspace = true
+tokio-util.workspace = true
 tonic.workspace = true
 uuid.workspace = true
 

--- a/src/storage/src/compaction.rs
+++ b/src/storage/src/compaction.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod dedup_deque;
+mod picker;
 mod rate_limit;
 mod scheduler;
 mod task;

--- a/src/storage/src/compaction.rs
+++ b/src/storage/src/compaction.rs
@@ -12,30 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Storage engine implementation.
-
-mod background;
-mod chunk;
-pub mod codec;
-mod compaction;
-pub mod config;
-mod engine;
-pub mod error;
-mod flush;
-pub mod manifest;
-pub mod memtable;
-pub mod metadata;
-pub mod proto;
-pub mod read;
-pub mod region;
-pub mod schema;
-mod snapshot;
-mod sst;
-mod sync;
-#[cfg(test)]
-mod test_util;
-mod version;
-mod wal;
-pub mod write_batch;
-
-pub use engine::EngineImpl;
+mod dedup_deque;
+mod rate_limit;
+mod scheduler;
+mod task;

--- a/src/storage/src/compaction/dedup_deque.rs
+++ b/src/storage/src/compaction/dedup_deque.rs
@@ -58,8 +58,7 @@ impl<K: Eq + Hash + Clone, V> DedupDeque<K, V> {
         Some((key, value))
     }
 
-    #[cfg(test)]
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         debug_assert_eq!(self.deque.len(), self.existing.len());
         self.deque.len()
     }

--- a/src/storage/src/compaction/dedup_deque.rs
+++ b/src/storage/src/compaction/dedup_deque.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
@@ -29,8 +30,8 @@ impl<K: Eq + Hash + Clone, V> DedupDeque<K, V> {
     /// returns false.
     pub fn push_back(&mut self, key: K, value: V) -> bool {
         debug_assert_eq!(self.deque.len(), self.existing.len());
-        if !self.existing.contains_key(&key) {
-            self.existing.insert(key.clone(), value);
+        if let Entry::Vacant(entry) = self.existing.entry(key.clone()) {
+            entry.insert(value);
             self.deque.push_back(key);
             return true;
         }
@@ -41,9 +42,8 @@ impl<K: Eq + Hash + Clone, V> DedupDeque<K, V> {
     /// Returns true if the deque does not already contain value with the same key, otherwise
     /// returns false.
     pub fn push_front(&mut self, key: K, value: V) -> bool {
-        debug_assert_eq!(self.deque.len(), self.existing.len());
-        if !self.existing.contains_key(&key) {
-            self.existing.insert(key.clone(), value);
+        if let Entry::Vacant(entry) = self.existing.entry(key.clone()) {
+            entry.insert(value);
             self.deque.push_front(key);
             return true;
         }

--- a/src/storage/src/compaction/dedup_deque.rs
+++ b/src/storage/src/compaction/dedup_deque.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::{HashMap, VecDeque};
+use std::fmt::{Debug, Formatter};
+use std::hash::Hash;
+
+/// Deque with key deduplication.
+#[derive(Default)]
+pub struct DedupDeque<K, V> {
+    deque: VecDeque<K>,
+    existing: HashMap<K, V>,
+}
+
+impl<K: Eq + Hash + Clone, V> DedupDeque<K, V> {
+    /// Pushes a key value to the back of deque.
+    /// Returns true if the deque does not already contain value with the same key, otherwise
+    /// returns false.
+    pub fn push_back(&mut self, key: K, value: V) -> bool {
+        debug_assert_eq!(self.deque.len(), self.existing.len());
+        if !self.existing.contains_key(&key) {
+            self.existing.insert(key.clone(), value);
+            self.deque.push_back(key);
+            return true;
+        }
+        false
+    }
+
+    /// Pushes a key value to the front of deque.
+    /// Returns true if the deque does not already contain value with the same key, otherwise
+    /// returns false.
+    pub fn push_front(&mut self, key: K, value: V) -> bool {
+        debug_assert_eq!(self.deque.len(), self.existing.len());
+        if !self.existing.contains_key(&key) {
+            self.existing.insert(key.clone(), value);
+            self.deque.push_front(key);
+            return true;
+        }
+        false
+    }
+
+    /// Pops a pair from the back of deque. Returns [None] if the deque is empty.
+    pub fn pop_front(&mut self) -> Option<(K, V)> {
+        debug_assert_eq!(self.deque.len(), self.existing.len());
+        let key = self.deque.pop_front()?;
+        let value = self.existing.remove(&key)?;
+        Some((key, value))
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        debug_assert_eq!(self.deque.len(), self.existing.len());
+        self.deque.len()
+    }
+}
+
+impl<K, V> Debug for DedupDeque<K, V>
+where
+    K: Debug,
+    V: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DedupDeque")
+            .field("deque", &self.deque)
+            .field("existing", &self.existing)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dedup_deque() {
+        let mut deque = DedupDeque::default();
+        assert!(deque.push_back(1, "hello".to_string()));
+        assert_eq!(1, deque.len());
+        assert!(deque.push_back(2, "world".to_string()));
+        assert_eq!(2, deque.len());
+        assert_eq!((1, "hello".to_string()), deque.pop_front().unwrap());
+        assert_eq!(1, deque.len());
+        assert_eq!((2, "world".to_string()), deque.pop_front().unwrap());
+        assert_eq!(0, deque.len());
+
+        // insert duplicated item
+        assert!(deque.push_back(1, "hello".to_string()));
+        assert!(!deque.push_back(1, "world".to_string()));
+        assert_eq!((1, "hello".to_string()), deque.pop_front().unwrap());
+    }
+}

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::compaction::scheduler::CompactionRequest;
+use crate::compaction::task::{CompactionTask, CompactionTaskImpl};
+
+/// Picker picks input SST files and build the compaction task.
+/// Different compaction strategy may implement different pickers.
+pub(crate) trait Picker<R, T: CompactionTask>: 'static {
+    fn pick(&self, req: &R) -> crate::error::Result<T>;
+}
+
+/// L0 -> L1 all-to-all compaction based on time windows.
+pub(crate) struct SimplePicker {}
+
+impl SimplePicker {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Picker<CompactionRequest, CompactionTaskImpl> for SimplePicker {
+    fn pick(&self, _req: &CompactionRequest) -> crate::error::Result<CompactionTaskImpl> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::compaction::task::tests::{CallbackRef, NoopCompactionTask};
+
+    pub(crate) struct MockPicker {
+        pub cbs: Vec<CallbackRef>,
+    }
+
+    impl Picker<CompactionRequest, NoopCompactionTask> for MockPicker {
+        fn pick(&self, _req: &CompactionRequest) -> crate::error::Result<NoopCompactionTask> {
+            Ok(NoopCompactionTask::new(self.cbs.clone()))
+        }
+    }
+}

--- a/src/storage/src/compaction/rate_limit.rs
+++ b/src/storage/src/compaction/rate_limit.rs
@@ -68,7 +68,11 @@ impl<R> RateLimiter for MaxInflightTaskLimiter<R> {
         if self.inflight_task.fetch_add(1, Ordering::Relaxed) >= self.max_inflight_task {
             self.inflight_task.fetch_sub(1, Ordering::Relaxed);
             return CompactionRateLimitedSnafu {
-                msg: "Max inflight task num exceeds",
+                msg: format!(
+                    "Max inflight task num exceeds, current: {}, max: {}",
+                    self.inflight_task.load(Ordering::Relaxed),
+                    self.max_inflight_task
+                ),
             }
             .fail();
         }

--- a/src/storage/src/compaction/rate_limit.rs
+++ b/src/storage/src/compaction/rate_limit.rs
@@ -1,0 +1,171 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::marker::PhantomData;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use common_error::ext::ErrorExt;
+
+use crate::error::CompactionRateLimitedSnafu;
+
+pub trait RateLimitToken {
+    /// Releases the token.
+    /// ### Note
+    /// Implementation should guarantee the idempotency.
+    fn try_release(&self);
+}
+
+pub type RateLimitTokenPtr = Box<dyn RateLimitToken + Send + Sync>;
+
+impl<T: RateLimitToken + ?Sized> RateLimitToken for Box<T> {
+    fn try_release(&self) {
+        (**self).try_release()
+    }
+}
+
+/// Rate limiter
+pub trait RateLimiter {
+    type Error: ErrorExt;
+    type Request;
+
+    /// Acquires a token from rate limiter. Returns `Err` on failure.  
+    fn acquire_token(&self, req: &Self::Request) -> Result<RateLimitTokenPtr, Self::Error>;
+}
+
+pub type RateLimiterPtr<R, E> = Box<dyn RateLimiter<Error = E, Request = R> + Send + Sync>;
+
+/// Limits max inflight tasks number.
+pub struct MaxInflightTaskLimiter<R> {
+    max_inflight_task: usize,
+    inflight_task: Arc<AtomicUsize>,
+    _phantom_data: PhantomData<R>,
+}
+
+#[allow(unused)]
+impl<R> MaxInflightTaskLimiter<R> {
+    pub fn new(max_inflight_task: usize) -> Self {
+        Self {
+            max_inflight_task,
+            inflight_task: Arc::new(AtomicUsize::new(0)),
+            _phantom_data: Default::default(),
+        }
+    }
+}
+
+impl<R> RateLimiter for MaxInflightTaskLimiter<R> {
+    type Error = crate::error::Error;
+    type Request = R;
+
+    fn acquire_token(&self, _: &Self::Request) -> Result<RateLimitTokenPtr, Self::Error> {
+        if self.inflight_task.fetch_add(1, Ordering::Relaxed) >= self.max_inflight_task {
+            self.inflight_task.fetch_sub(1, Ordering::Relaxed);
+            return CompactionRateLimitedSnafu {
+                msg: "Max inflight task num exceeds",
+            }
+            .fail();
+        }
+
+        return Ok(Box::new(MaxInflightLimiterToken {
+            counter: self.inflight_task.clone(),
+        }));
+    }
+}
+
+pub struct MaxInflightLimiterToken {
+    counter: Arc<AtomicUsize>,
+}
+
+impl RateLimitToken for MaxInflightLimiterToken {
+    fn try_release(&self) {
+        self.counter.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// A composite rate limiter that allows token acquisition only when all internal limiters allow.
+pub struct CascadeRateLimiter<T> {
+    limits: Vec<RateLimiterPtr<T, crate::error::Error>>,
+}
+
+impl<T> CascadeRateLimiter<T> {
+    pub fn new(limits: Vec<RateLimiterPtr<T, crate::error::Error>>) -> Self {
+        Self { limits }
+    }
+}
+
+impl<T> RateLimiter for CascadeRateLimiter<T> {
+    type Error = crate::error::Error;
+    type Request = T;
+
+    fn acquire_token(&self, req: &Self::Request) -> Result<RateLimitTokenPtr, Self::Error> {
+        let mut res = vec![];
+        for limit in &self.limits {
+            match limit.acquire_token(req) {
+                Ok(token) => {
+                    res.push(token);
+                }
+                Err(e) => {
+                    res.iter().for_each(RateLimitToken::try_release);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(Box::new(CompositeToken { tokens: res }))
+    }
+}
+
+/// Composite token that releases all acquired token when released.
+pub struct CompositeToken {
+    tokens: Vec<RateLimitTokenPtr>,
+}
+
+impl RateLimitToken for CompositeToken {
+    fn try_release(&self) {
+        for token in &self.tokens {
+            token.try_release();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_max_inflight_limiter() {
+        let limiter = MaxInflightTaskLimiter::new(3);
+        let t1 = limiter.acquire_token(&1).unwrap();
+        assert_eq!(1, limiter.inflight_task.load(Ordering::Relaxed));
+        let _t2 = limiter.acquire_token(&1).unwrap();
+        assert_eq!(2, limiter.inflight_task.load(Ordering::Relaxed));
+        let _t3 = limiter.acquire_token(&1).unwrap();
+        assert_eq!(3, limiter.inflight_task.load(Ordering::Relaxed));
+        assert!(limiter.acquire_token(&1).is_err());
+        t1.try_release();
+        assert_eq!(2, limiter.inflight_task.load(Ordering::Relaxed));
+        let _t4 = limiter.acquire_token(&1).unwrap();
+    }
+
+    #[test]
+    fn test_cascade_limiter() {
+        let limiter: CascadeRateLimiter<usize> =
+            CascadeRateLimiter::new(vec![Box::new(MaxInflightTaskLimiter::new(3))]);
+        let t1 = limiter.acquire_token(&1).unwrap();
+        let _t2 = limiter.acquire_token(&1).unwrap();
+        let _t3 = limiter.acquire_token(&1).unwrap();
+        assert!(limiter.acquire_token(&1).is_err());
+        t1.try_release();
+        let _t4 = limiter.acquire_token(&1).unwrap();
+    }
+}

--- a/src/storage/src/compaction/rate_limit.rs
+++ b/src/storage/src/compaction/rate_limit.rs
@@ -77,9 +77,9 @@ impl<R> RateLimiter for MaxInflightTaskLimiter<R> {
             .fail();
         }
 
-        return Ok(Box::new(MaxInflightLimiterToken {
+        Ok(Box::new(MaxInflightLimiterToken {
             counter: self.inflight_task.clone(),
-        }));
+        }))
     }
 }
 

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -1,0 +1,175 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_telemetry::info;
+use table::metadata::TableId;
+use tokio::sync::{Notify, RwLock};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::compaction::dedup_deque::DedupDeque;
+use crate::compaction::rate_limit::{
+    CascadeRateLimiter, RateLimitToken, RateLimitTokenPtr, RateLimiter,
+};
+use crate::compaction::task::CompactionTask;
+use crate::error::Result;
+
+/// Table compaction request.
+#[derive(Default)]
+pub struct CompactionRequest {
+    table_id: TableId,
+}
+
+impl CompactionRequest {
+    #[inline]
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+}
+
+/// CompactionScheduler defines a set of API to schedule compaction tasks.
+#[async_trait]
+pub trait CompactionScheduler {
+    /// Schedules a compaction request.
+    async fn schedule(&self, request: CompactionRequest) -> Result<()>;
+
+    /// Stops compaction scheduler.
+    async fn stop(&self) -> Result<()>;
+}
+
+/// Compaction task scheduler based on local state.
+#[allow(unused)]
+pub struct LocalCompactionScheduler {
+    request_queue: Arc<RwLock<DedupDeque<TableId, CompactionRequest>>>,
+    cancel_token: CancellationToken,
+    task_notifier: Arc<Notify>,
+    join_handle: JoinHandle<()>,
+}
+
+#[async_trait]
+impl CompactionScheduler for LocalCompactionScheduler {
+    async fn schedule(&self, request: CompactionRequest) -> Result<()> {
+        let mut queue = self.request_queue.write().await;
+        queue.push_back(request.table_id(), request);
+        self.task_notifier.notify_one();
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[allow(unused)]
+impl LocalCompactionScheduler {
+    pub fn new() -> Self {
+        let request_queue: Arc<RwLock<DedupDeque<TableId, CompactionRequest>>> =
+            Arc::new(RwLock::new(DedupDeque::default()));
+        let cancel_token = CancellationToken::new();
+        let task_notifier = Arc::new(Notify::new());
+        let handler = CompactionHandler {
+            task_notifier: task_notifier.clone(),
+            req_queue: request_queue.clone(),
+            cancel_token: cancel_token.child_token(),
+            limiter: Arc::new(CascadeRateLimiter::new(vec![])),
+        };
+        let join_handle: JoinHandle<()> =
+            common_runtime::spawn_bg(async move { handler.run().await });
+        Self {
+            join_handle,
+            request_queue,
+            cancel_token,
+            task_notifier,
+        }
+    }
+}
+
+#[allow(unused)]
+struct CompactionHandler {
+    req_queue: Arc<RwLock<DedupDeque<TableId, CompactionRequest>>>,
+    cancel_token: CancellationToken,
+    task_notifier: Arc<Notify>,
+    limiter: Arc<CascadeRateLimiter<CompactionRequest>>,
+}
+
+#[allow(unused)]
+impl CompactionHandler {
+    /// Runs table compaction requests dispatch loop.
+    pub async fn run(self) {
+        let task_notifier = self.task_notifier.clone();
+        let limiter = self.limiter.clone();
+        loop {
+            tokio::select! {
+                _ = task_notifier.notified() => {
+                    // poll requests as many as possible until rate limited, and then wait for
+                    // notification (some task's finished).
+                    while let Some((table_id,  req)) = self.poll_task().await {
+                        if let Ok(token) = limiter.acquire_token(&req) {
+                            self.handle_compaction_request(req, token).await;
+                        } else {
+                            // compaction rate limited, put back to req queue to wait for next
+                            // schedule
+                            self.put_back_req(table_id, req).await;
+                            break;
+                        }
+                    }
+                }
+                _ = self.cancel_token.cancelled() => {
+                    info!("Compaction tasks scheduler stopped.");
+                    return;
+                }
+            }
+        }
+    }
+
+    #[inline]
+    async fn poll_task(&self) -> Option<(TableId, CompactionRequest)> {
+        let mut queue = self.req_queue.write().await;
+        queue.pop_front()
+    }
+
+    /// Puts request back to the front of request queue.
+    #[inline]
+    async fn put_back_req(&self, table_id: TableId, req: CompactionRequest) {
+        let mut queue = self.req_queue.write().await;
+        queue.push_front(table_id, req);
+    }
+
+    // Handles compaction request, submit task to bg runtime.
+    async fn handle_compaction_request(
+        &self,
+        mut req: CompactionRequest,
+        token: RateLimitTokenPtr,
+    ) {
+        let cloned_notify = self.task_notifier.clone();
+        let task = self.build_compaction_task(req).await;
+
+        common_runtime::spawn_bg(async move {
+            task.run();
+            // releases rate limit token
+            token.try_release();
+            // notify scheduler to schedule next task when current task finishes.
+            cloned_notify.notify_one();
+        });
+    }
+
+    // TODO(hl): generate compaction task(find SSTs to compact along with the output of compaction)
+    async fn build_compaction_task(&self, req: CompactionRequest) -> CompactionTask {
+        todo!()
+    }
+}

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -42,17 +42,12 @@ pub(crate) struct CompactionInput {
 
 #[cfg(test)]
 pub mod tests {
-    use std::future::Future;
-    use std::pin::Pin;
     use std::sync::Arc;
-
-    use common_telemetry::debug;
 
     use super::*;
     use crate::compaction::task::CompactionTask;
 
-    pub type CallbackRef =
-        Arc<dyn Fn() -> Pin<Box<dyn Future<Output = ()> + Send + Sync>> + Send + Sync>;
+    pub type CallbackRef = Arc<dyn Fn() + Send + Sync>;
     pub struct NoopCompactionTask {
         pub cbs: Vec<CallbackRef>,
     }
@@ -66,11 +61,8 @@ pub mod tests {
     #[async_trait::async_trait]
     impl CompactionTask for NoopCompactionTask {
         async fn run(&self) -> Result<()> {
-            debug!("Running NoopCompactionTask");
             for cb in &self.cbs {
-                debug!("Running callback");
-                let f = cb();
-                f.await;
+                cb()
             }
             Ok(())
         }

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -12,30 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Storage engine implementation.
+use crate::error::Result;
+use crate::sst::FileHandle;
 
-mod background;
-mod chunk;
-pub mod codec;
-mod compaction;
-pub mod config;
-mod engine;
-pub mod error;
-mod flush;
-pub mod manifest;
-pub mod memtable;
-pub mod metadata;
-pub mod proto;
-pub mod read;
-pub mod region;
-pub mod schema;
-mod snapshot;
-mod sst;
-mod sync;
-#[cfg(test)]
-mod test_util;
-mod version;
-mod wal;
-pub mod write_batch;
+#[allow(unused)]
+pub(crate) struct CompactionTask {
+    inputs: Vec<CompactionInput>,
+}
 
-pub use engine::EngineImpl;
+#[allow(unused)]
+impl CompactionTask {
+    // TODO(hl): Actual SST compaction tasks
+    pub async fn run(self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[allow(unused)]
+pub(crate) struct CompactionInput {
+    input_level: u8,
+    output_level: u8,
+    file: FileHandle,
+}

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -16,7 +16,7 @@ use crate::error::Result;
 use crate::sst::FileHandle;
 
 #[async_trait::async_trait]
-pub(crate) trait CompactionTask: Send + Sync + 'static {
+pub trait CompactionTask: Send + Sync + 'static {
     async fn run(&self) -> Result<()>;
 }
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -412,6 +412,9 @@ pub enum Error {
 
     #[snafu(display("Failed to decode parquet file time range, msg: {}", msg))]
     DecodeParquetTimeRange { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Compaction rate limited, msg: {}", msg))]
+    CompactionRateLimited { msg: String, backtrace: Backtrace },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -481,6 +484,7 @@ impl ErrorExt for Error {
             ConvertChunk { source, .. } => source.status_code(),
             MarkWalObsolete { source, .. } => source.status_code(),
             DecodeParquetTimeRange { .. } => StatusCode::Unexpected,
+            CompactionRateLimited { .. } => StatusCode::Internal,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This is the first part of work towards table compaction which contains:
- table compaction scheduler that polls and executes table compaction requests in a FIFO manner
- rate limiter framework to limit the resources used by compaction tasks;
   - currently it only limits the max concurrently running tasks number
- compaction strategy (`Picker`) part is still working, but the tests involves the trait so a primitive trait is defined, but it's not the final trait definition.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
