### PR TITLE
feat: enhance sizeBasedFlushStrategy by judging WAL disk usage

### DIFF
--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -111,6 +111,10 @@ impl LogStore for NoopLogStore {
         let _ = id;
         Ok(())
     }
+
+    fn get_disk_size(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -319,6 +319,10 @@ impl LogStore for RaftEngineLogStore {
         );
         Ok(())
     }
+
+    fn get_disk_size(&self) -> Option<usize> {
+        Some(self.engine.get_used_size())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -113,6 +113,7 @@ impl FlushStrategy for FlushSwitch {
         _shared: &SharedDataRef,
         _bytes_mutable: usize,
         _bytes_total: usize,
+        _wal_disk_usage: Option<usize>,
     ) -> bool {
         self.should_flush.load(Ordering::Relaxed)
     }

--- a/src/storage/src/wal.rs
+++ b/src/storage/src/wal.rs
@@ -73,6 +73,10 @@ impl<S: LogStore> Wal<S> {
             })
     }
 
+    pub fn get_store(&self) -> Arc<S> {
+        self.store.clone()
+    }
+
     #[inline]
     pub fn region_id(&self) -> RegionId {
         self.region_id

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -73,6 +73,9 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     /// the log files if all entries inside are obsolete. This method may not delete log
     /// files immediately.
     async fn obsolete(&self, namespace: Self::Namespace, id: Id) -> Result<(), Self::Error>;
+
+    /// Get wal disk usage size.
+    fn get_disk_size(&self) -> Option<usize>;
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR links this issue,  #842 WAL disk usage based flush strategy

- If WAL takes up too much disk space, the recovery process may take a long time to finish. So, to fix the issue, I enhance `SizeBasedFlushStrategy` by judging WAL disk usage. If the disk usage exceeds the threshold, the data in memtable should be flushed. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#842 