### PR TITLE
refactor: query handler

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,12 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[build]
+rustflags = [
+    # lints
+    # TODO: use lint configuration in cargo https://github.com/rust-lang/cargo/issues/5034
+    "-Wclippy::print_stdout",
+    "-Wclippy::print_stderr",
+    # false positive: https://github.com/rust-lang/rust/issues/51443#issuecomment-1374847313
+    "-Awhere_clauses_object_safety",
+]

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   coverage:
     if: github.event.pull_request.draft == false

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ check: ## Cargo check all the targets.
 
 .PHONY: clippy
 clippy: ## Check clippy rules.
-	cargo clippy --workspace --all-targets -- -D warnings -D clippy::print_stdout -D clippy::print_stderr
+	cargo clippy --workspace --all-targets -- -D warnings
 
 .PHONY: fmt-check
 fmt-check: ## Check code format.

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -252,6 +252,12 @@ pub enum Error {
         source: catalog::error::Error,
     },
 
+    #[snafu(display("Failed to find catalog, source: {}", source))]
+    FindCatalog {
+        #[snafu(backtrace)]
+        source: servers::error::Error,
+    },
+
     #[snafu(display("Failed to find table {} from catalog, source: {}", table_name, source))]
     FindTable {
         table_name: String,
@@ -333,6 +339,7 @@ impl ErrorExt for Error {
             | Error::GetTable { source, .. }
             | Error::AlterTable { source, .. } => source.status_code(),
             Error::DropTable { source, .. } => source.status_code(),
+            Error::FindCatalog { source } => source.status_code(),
 
             Error::Insert { source, .. } => source.status_code(),
 

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -18,7 +18,7 @@ use api::v1::query_request::Query;
 use api::v1::{CreateDatabaseExpr, DdlRequest, InsertRequest};
 use async_trait::async_trait;
 use common_query::Output;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::plan::LogicalPlan;
 use servers::query_handler::grpc::GrpcQueryHandler;
 use session::context::QueryContextRef;
@@ -52,7 +52,8 @@ impl Instance {
     async fn handle_query(&self, query: Query, ctx: QueryContextRef) -> Result<Output> {
         Ok(match query {
             Query::Sql(sql) => {
-                let stmt = QueryLanguageParser::parse_sql(&sql).context(ExecuteSqlSnafu)?;
+                let stmt =
+                    QueryLanguageParser::parse(QueryLanguage::Sql(sql)).context(ExecuteSqlSnafu)?;
                 self.execute_stmt(stmt, ctx).await?
             }
             Query::LogicalPlan(plan) => self.execute_logical(plan).await?,

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -18,7 +18,7 @@ use common_query::Output;
 use common_recordbatch::RecordBatches;
 use common_telemetry::logging::info;
 use common_telemetry::timer;
-use query::parser::{QueryLanguageParser, QueryStatement};
+use query::parser::{QueryLanguage, QueryLanguageParser, QueryStatement};
 use servers::error as server_error;
 use servers::promql::PromqlHandler;
 use servers::query_handler::sql::SqlQueryHandler;
@@ -160,12 +160,14 @@ impl Instance {
     }
 
     pub async fn execute_sql(&self, sql: &str, query_ctx: QueryContextRef) -> Result<Output> {
-        let stmt = QueryLanguageParser::parse_sql(sql).context(ExecuteSqlSnafu)?;
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql.to_owned()))
+            .context(ExecuteSqlSnafu)?;
         self.execute_stmt(stmt, query_ctx).await
     }
 
     pub async fn execute_promql(&self, sql: &str, query_ctx: QueryContextRef) -> Result<Output> {
-        let stmt = QueryLanguageParser::parse_promql(sql).context(ExecuteSqlSnafu)?;
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Promql(sql.to_owned()))
+            .context(ExecuteSqlSnafu)?;
         self.execute_stmt(stmt, query_ctx).await
     }
 }

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -208,34 +208,6 @@ pub fn table_idents_to_full_name(
 
 #[async_trait]
 impl SqlQueryHandler for Instance {
-    type Error = server_error::Error;
-
-    async fn do_query(
-        &self,
-        query: &str,
-        query_ctx: QueryContextRef,
-    ) -> Vec<server_error::Result<Output>> {
-        let _timer = timer!(metric::METRIC_HANDLE_SQL_ELAPSED);
-        // we assume sql string has only 1 statement in datanode
-        let result = self
-            .execute_sql(query, query_ctx)
-            .await
-            .map_err(BoxedError::new)
-            .context(server_error::ExecuteQueryStatementSnafu);
-        vec![result]
-    }
-
-    async fn do_promql_query(
-        &self,
-        query: &str,
-        query_ctx: QueryContextRef,
-    ) -> Vec<server_error::Result<Output>> {
-        // let _timer = timer!(metric::METRIC_HANDLE_PROMQL_ELAPSED);
-        // let result = self.execute_promql(query, query_ctx).await;
-        // vec![result]
-        todo!()
-    }
-
     async fn statement_query(
         &self,
         stmt: QueryStatement,

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -224,14 +224,13 @@ impl SqlQueryHandler for Instance {
         vec![result]
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        stmt: Statement,
+        stmt: QueryStatement,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         let _timer = timer!(metric::METRIC_HANDLE_SQL_ELAPSED);
-        self.execute_stmt(QueryStatement::Sql(stmt), query_ctx)
-            .await
+        self.execute_stmt(stmt, query_ctx).await
     }
 
     fn is_valid_schema(&self, catalog: &str, schema: &str) -> Result<bool> {

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -21,7 +21,7 @@ use common_telemetry::timer;
 use query::parser::{QueryLanguage, QueryLanguageParser, QueryStatement};
 use servers::error as server_error;
 use servers::promql::PromqlHandler;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use session::context::{QueryContext, QueryContextRef};
 use snafu::prelude::*;
 use sql::ast::ObjectName;
@@ -207,7 +207,7 @@ pub fn table_idents_to_full_name(
 }
 
 #[async_trait]
-impl SqlQueryHandler for Instance {
+impl QueryHandler for Instance {
     async fn statement_query(
         &self,
         stmt: QueryStatement,

--- a/src/datanode/src/server.rs
+++ b/src/datanode/src/server.rs
@@ -22,7 +22,7 @@ use servers::error::Error::InternalIo;
 use servers::grpc::GrpcServer;
 use servers::mysql::server::{MysqlServer, MysqlSpawnConfig, MysqlSpawnRef};
 use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
-use servers::query_handler::sql::ServerSqlQueryHandlerAdaptor;
+use servers::query_handler::sql::ServerQueryHandlerAdaptor;
 use servers::server::Server;
 use servers::tls::TlsOption;
 use servers::Mode;
@@ -70,7 +70,7 @@ impl Services {
                 Some(MysqlServer::create_server(
                     mysql_io_runtime,
                     Arc::new(MysqlSpawnRef::new(
-                        ServerSqlQueryHandlerAdaptor::arc(instance.clone()),
+                        ServerQueryHandlerAdaptor::arc(instance.clone()),
                         None,
                     )),
                     Arc::new(MysqlSpawnConfig::new(

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -143,7 +143,7 @@ mod tests {
     use mito::engine::MitoEngine;
     use object_store::services::fs::Builder;
     use object_store::ObjectStore;
-    use query::parser::{QueryLanguageParser, QueryStatement};
+    use query::parser::{QueryLanguage, QueryLanguageParser, QueryStatement};
     use query::QueryEngineFactory;
     use sql::statements::statement::Statement;
     use storage::config::EngineConfig as StorageEngineConfig;
@@ -241,7 +241,7 @@ mod tests {
         let query_engine = factory.query_engine();
         let sql_handler = SqlHandler::new(table_engine, catalog_list.clone(), query_engine.clone());
 
-        let stmt = match QueryLanguageParser::parse_sql(sql).unwrap() {
+        let stmt = match QueryLanguageParser::parse(QueryLanguage::Sql(sql.to_owned())).unwrap() {
             QueryStatement::Sql(Statement::Insert(i)) => i,
             _ => {
                 unreachable!()

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -56,6 +56,12 @@ pub enum Error {
         source: sql::error::Error,
     },
 
+    #[snafu(display("Failed to parse query, source: {}", source))]
+    ParseQuery {
+        #[snafu(backtrace)]
+        source: query::error::Error,
+    },
+
     #[snafu(display("Column datatype error, source: {}", source))]
     ColumnDataType {
         #[snafu(backtrace)]
@@ -407,7 +413,9 @@ impl ErrorExt for Error {
             | Error::FindNewColumnsOnInsertion { source } => source.status_code(),
 
             Error::PrimaryKeyNotFound { .. } => StatusCode::InvalidArguments,
-            Error::ExecuteStatement { source, .. } => source.status_code(),
+            Error::ExecuteStatement { source, .. } | Error::ParseQuery { source } => {
+                source.status_code()
+            }
             Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
             Error::AlterExprToRequest { source, .. } => source.status_code(),
             Error::LeaderNotFound { .. } => StatusCode::StorageUnavailable,

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -344,11 +344,17 @@ pub enum Error {
     },
 
     // TODO(ruihang): merge all query execution error kinds
-    #[snafu(display("failed to execute PromQL query {}, source: {}", query, source))]
+    #[snafu(display("Failed to execute PromQL query {}, source: {}", query, source))]
     ExecutePromql {
         query: String,
         #[snafu(backtrace)]
         source: servers::error::Error,
+    },
+
+    #[snafu(display("Failed to execute query statement, source: {}", source))]
+    ExecuteQueryStatement {
+        #[snafu(backtrace)]
+        source: BoxedError,
     },
 }
 
@@ -424,7 +430,9 @@ impl ErrorExt for Error {
             Error::InvokeDatanode { source } => source.status_code(),
             Error::ColumnDefaultValue { source, .. } => source.status_code(),
             Error::ColumnNoneDefaultValue { .. } => StatusCode::InvalidArguments,
-            Error::External { source } => source.status_code(),
+            Error::External { source } | Error::ExecuteQueryStatement { source } => {
+                source.status_code()
+            }
             Error::DeserializePartition { source, .. } | Error::FindTableRoute { source, .. } => {
                 source.status_code()
             }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -46,7 +46,7 @@ use servers::error as server_error;
 use servers::interceptor::{SqlQueryInterceptor, SqlQueryInterceptorRef};
 use servers::promql::{PromqlHandler, PromqlHandlerRef};
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
-use servers::query_handler::sql::{SqlQueryHandler, SqlQueryHandlerRef};
+use servers::query_handler::sql::{QueryHandler, QueryHandlerRef};
 use servers::query_handler::{
     InfluxdbLineProtocolHandler, OpentsdbProtocolHandler, PrometheusProtocolHandler, ScriptHandler,
     ScriptHandlerRef,
@@ -66,7 +66,7 @@ use crate::Plugins;
 #[async_trait]
 pub trait FrontendInstance:
     GrpcQueryHandler<Error = Error>
-    + SqlQueryHandler
+    + QueryHandler
     + OpentsdbProtocolHandler
     + InfluxdbLineProtocolHandler
     + PrometheusProtocolHandler
@@ -87,7 +87,7 @@ pub struct Instance {
 
     /// Script handler is None in distributed mode, only works on standalone mode.
     script_handler: Option<ScriptHandlerRef>,
-    sql_handler: SqlQueryHandlerRef,
+    sql_handler: QueryHandlerRef,
     grpc_query_handler: GrpcQueryHandlerRef<Error>,
     promql_handler: Option<PromqlHandlerRef>,
 
@@ -445,7 +445,7 @@ impl Instance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for Instance {
+impl QueryHandler for Instance {
     async fn query(
         &self,
         query: QueryLanguage,

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -509,8 +509,12 @@ impl QueryHandler for Instance {
             .context(server_error::CheckDatabaseValiditySnafu)
     }
 
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
-        self.sql_handler.do_describe(stmt, query_ctx)
+    fn describe(
+        &self,
+        stmt: QueryStatement,
+        query_ctx: QueryContextRef,
+    ) -> server_error::Result<Option<Schema>> {
+        self.sql_handler.describe(stmt, query_ctx)
     }
 }
 

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -403,12 +403,17 @@ impl QueryHandler for DistInstance {
             .context(server_error::CheckDatabaseValiditySnafu)
     }
 
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
-        if let Statement::Query(_) = stmt {
+    fn describe(
+        &self,
+        stmt: QueryStatement,
+        query_ctx: QueryContextRef,
+    ) -> server_error::Result<Option<Schema>> {
+        if let QueryStatement::Sql(Statement::Query(_)) = stmt {
             self.query_engine
-                .describe(QueryStatement::Sql(stmt), query_ctx)
+                .describe(stmt, query_ctx)
                 .map(Some)
-                .context(error::DescribeStatementSnafu)
+                .map_err(BoxedError::new)
+                .context(server_error::DescribeStatementSnafu)
         } else {
             Ok(None)
         }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -41,7 +41,7 @@ use query::parser::QueryStatement;
 use query::sql::{describe_table, explain, show_databases, show_tables};
 use query::{QueryEngineFactory, QueryEngineRef};
 use servers::error as server_error;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::ast::Value as SqlValue;
@@ -380,7 +380,7 @@ impl DistInstance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for DistInstance {
+impl QueryHandler for DistInstance {
     async fn statement_query(
         &self,
         stmt: QueryStatement,
@@ -596,7 +596,7 @@ fn find_partition_columns(
 mod test {
     use itertools::Itertools;
     use query::parser::QueryLanguage;
-    use servers::query_handler::sql::SqlQueryHandlerRef;
+    use servers::query_handler::sql::QueryHandlerRef;
     use session::context::QueryContext;
     use sql::dialect::GenericDialect;
     use sql::parser::ParserContext;
@@ -719,7 +719,7 @@ ENGINE=mito",
         );
         dist_instance.query(sql, QueryContext::arc()).await.unwrap();
 
-        async fn assert_show_tables(instance: SqlQueryHandlerRef) {
+        async fn assert_show_tables(instance: QueryHandlerRef) {
             let query = QueryLanguage::Sql("show tables in test_show_tables".to_string());
             let output = instance.query(query, QueryContext::arc()).await.unwrap();
             match output {

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -19,7 +19,7 @@ use common_error::prelude::BoxedError;
 use common_query::Output;
 use query::parser::QueryLanguage;
 use servers::query_handler::grpc::GrpcQueryHandler;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
 
@@ -40,7 +40,7 @@ impl GrpcQueryHandler for Instance {
                         err_msg: "Missing field 'QueryRequest.query'",
                     })?;
                 match query {
-                    Query::Sql(sql) => SqlQueryHandler::query(self, QueryLanguage::Sql(sql), ctx)
+                    Query::Sql(sql) => QueryHandler::query(self, QueryLanguage::Sql(sql), ctx)
                         .await
                         .map_err(BoxedError::new)
                         .context(error::ExecuteQueryStatementSnafu)?,

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -43,6 +43,7 @@ mod test {
 
     use common_query::Output;
     use common_recordbatch::RecordBatches;
+    use query::parser::QueryLanguage;
     use servers::query_handler::sql::SqlQueryHandler;
     use session::context::QueryContext;
 
@@ -77,13 +78,15 @@ monitor1,host=host2 memory=1027 1663840496400340001";
         };
         instance.exec(&request, QueryContext::arc()).await.unwrap();
 
-        let mut output = instance
-            .do_query(
-                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+        let output = instance
+            .query(
+                QueryLanguage::Sql(
+                    "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts".to_string(),
+                ),
                 QueryContext::arc(),
             )
-            .await;
-        let output = output.remove(0).unwrap();
+            .await
+            .unwrap();
         let Output::Stream(stream) = output else { unreachable!() };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
         assert_eq!(

--- a/src/frontend/src/instance/influxdb.rs
+++ b/src/frontend/src/instance/influxdb.rs
@@ -44,7 +44,7 @@ mod test {
     use common_query::Output;
     use common_recordbatch::RecordBatches;
     use query::parser::QueryLanguage;
-    use servers::query_handler::sql::SqlQueryHandler;
+    use servers::query_handler::sql::QueryHandler;
     use session::context::QueryContext;
 
     use super::*;

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -44,7 +44,7 @@ mod tests {
     use common_recordbatch::RecordBatches;
     use itertools::Itertools;
     use query::parser::QueryLanguage;
-    use servers::query_handler::sql::SqlQueryHandler;
+    use servers::query_handler::sql::QueryHandler;
     use session::context::QueryContext;
 
     use super::*;

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -43,6 +43,7 @@ mod tests {
     use common_query::Output;
     use common_recordbatch::RecordBatches;
     use itertools::Itertools;
+    use query::parser::QueryLanguage;
     use servers::query_handler::sql::SqlQueryHandler;
     use session::context::QueryContext;
 
@@ -98,12 +99,13 @@ mod tests {
         assert!(result.is_ok());
 
         let output = instance
-            .do_query(
-                "select * from my_metric_1 order by greptime_timestamp",
+            .query(
+                QueryLanguage::Sql(
+                    "select * from my_metric_1 order by greptime_timestamp".to_string(),
+                ),
                 Arc::new(QueryContext::new()),
             )
             .await
-            .remove(0)
             .unwrap();
         match output {
             Output::Stream(stream) => {

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -162,7 +162,7 @@ mod tests {
     use api::prometheus::remote::{Label, LabelMatcher, Sample};
     use common_catalog::consts::DEFAULT_CATALOG_NAME;
     use query::parser::QueryLanguage;
-    use servers::query_handler::sql::SqlQueryHandler;
+    use servers::query_handler::sql::QueryHandler;
     use session::context::QueryContext;
 
     use super::*;

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -161,6 +161,7 @@ mod tests {
     use api::prometheus::remote::label_matcher::Type as MatcherType;
     use api::prometheus::remote::{Label, LabelMatcher, Sample};
     use common_catalog::consts::DEFAULT_CATALOG_NAME;
+    use query::parser::QueryLanguage;
     use servers::query_handler::sql::SqlQueryHandler;
     use session::context::QueryContext;
 
@@ -194,15 +195,14 @@ mod tests {
         let db = "prometheus";
         let ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, db));
 
-        assert!(SqlQueryHandler::do_query(
-            instance.as_ref(),
-            "CREATE DATABASE IF NOT EXISTS prometheus",
-            ctx.clone(),
-        )
-        .await
-        .get(0)
-        .unwrap()
-        .is_ok());
+        let _ = instance
+            .as_ref()
+            .query(
+                QueryLanguage::Sql("CREATE DATABASE IF NOT EXISTS prometheus".to_string()),
+                ctx.clone(),
+            )
+            .await
+            .unwrap();
 
         instance.write(write_request, ctx.clone()).await.unwrap();
 

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -18,11 +18,11 @@ use api::v1::greptime_request::Request as GreptimeRequest;
 use async_trait::async_trait;
 use common_query::Output;
 use datanode::error::Error as DatanodeError;
+use query::parser::QueryStatement;
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
 use servers::query_handler::sql::{SqlQueryHandler, SqlQueryHandlerRef};
 use session::context::QueryContextRef;
 use snafu::ResultExt;
-use sql::statements::statement::Statement;
 
 use crate::error::{self, Result};
 
@@ -55,13 +55,13 @@ impl SqlQueryHandler for StandaloneSqlQueryHandler {
         unimplemented!()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        stmt: Statement,
+        stmt: QueryStatement,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         self.0
-            .do_statement_query(stmt, query_ctx)
+            .statement_query(stmt, query_ctx)
             .await
             .context(error::InvokeDatanodeSnafu)
     }

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -49,10 +49,12 @@ impl QueryHandler for StandaloneSqlQueryHandler {
         self.0.is_valid_schema(catalog, schema)
     }
 
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
-        self.0
-            .do_describe(stmt, query_ctx)
-            .context(error::InvokeDatanodeSnafu)
+    fn describe(
+        &self,
+        stmt: QueryStatement,
+        query_ctx: QueryContextRef,
+    ) -> server_error::Result<Option<Schema>> {
+        self.0.describe(stmt, query_ctx)
     }
 }
 

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -22,16 +22,16 @@ use datanode::error::Error as DatanodeError;
 use query::parser::QueryStatement;
 use servers::error as server_error;
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
-use servers::query_handler::sql::{SqlQueryHandler, SqlQueryHandlerRef};
+use servers::query_handler::sql::{QueryHandler, QueryHandlerRef};
 use session::context::QueryContextRef;
 use snafu::ResultExt;
 
 use crate::error::{self, Result};
 
-pub(crate) struct StandaloneSqlQueryHandler(SqlQueryHandlerRef);
+pub(crate) struct StandaloneSqlQueryHandler(QueryHandlerRef);
 
 #[async_trait]
-impl SqlQueryHandler for StandaloneSqlQueryHandler {
+impl QueryHandler for StandaloneSqlQueryHandler {
     async fn statement_query(
         &self,
         stmt: QueryStatement,

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -26,7 +26,7 @@ use servers::opentsdb::OpentsdbServer;
 use servers::postgres::PostgresServer;
 use servers::promql::PromqlServer;
 use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
-use servers::query_handler::sql::ServerSqlQueryHandlerAdaptor;
+use servers::query_handler::sql::ServerQueryHandlerAdaptor;
 use servers::server::Server;
 use snafu::ResultExt;
 use tokio::try_join;
@@ -87,7 +87,7 @@ impl Services {
             let mysql_server = MysqlServer::create_server(
                 mysql_io_runtime,
                 Arc::new(MysqlSpawnRef::new(
-                    ServerSqlQueryHandlerAdaptor::arc(instance.clone()),
+                    ServerQueryHandlerAdaptor::arc(instance.clone()),
                     user_provider.clone(),
                 )),
                 Arc::new(MysqlSpawnConfig::new(
@@ -119,7 +119,7 @@ impl Services {
             );
 
             let pg_server = Box::new(PostgresServer::new(
-                ServerSqlQueryHandlerAdaptor::arc(instance.clone()),
+                ServerQueryHandlerAdaptor::arc(instance.clone()),
                 opts.tls.clone(),
                 pg_io_runtime,
                 user_provider.clone(),
@@ -152,7 +152,7 @@ impl Services {
             let http_addr = parse_addr(&http_options.addr)?;
 
             let mut http_server = HttpServer::new(
-                ServerSqlQueryHandlerAdaptor::arc(instance.clone()),
+                ServerQueryHandlerAdaptor::arc(instance.clone()),
                 http_options.clone(),
             );
             if let Some(user_provider) = user_provider.clone() {

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -277,7 +277,7 @@ mod tests {
     use session::context::QueryContext;
     use table::table::numbers::NumbersTable;
 
-    use crate::parser::QueryLanguageParser;
+    use crate::parser::{QueryLanguage, QueryLanguageParser};
     use crate::query_engine::{QueryEngineFactory, QueryEngineRef};
 
     fn create_test_engine() -> QueryEngineRef {
@@ -301,9 +301,9 @@ mod tests {
     #[test]
     fn test_sql_to_plan() {
         let engine = create_test_engine();
-        let sql = "select sum(number) from numbers limit 20";
+        let sql = "select sum(number) from numbers limit 20".to_string();
 
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
         let plan = engine
             .statement_to_plan(stmt, Arc::new(QueryContext::new()))
             .unwrap();
@@ -321,9 +321,9 @@ mod tests {
     #[tokio::test]
     async fn test_execute() {
         let engine = create_test_engine();
-        let sql = "select sum(number) from numbers limit 20";
+        let sql = "select sum(number) from numbers limit 20".to_string();
 
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
         let plan = engine
             .statement_to_plan(stmt, Arc::new(QueryContext::new()))
             .unwrap();

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -369,9 +369,8 @@ mod tests {
     #[test]
     fn test_describe() {
         let engine = create_test_engine();
-        let sql = "select sum(number) from numbers limit 20";
-
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let sql = QueryLanguage::Sql("select sum(number) from numbers limit 20".to_string());
+        let stmt = QueryLanguageParser::parse(sql).unwrap();
 
         let schema = engine
             .describe(stmt, Arc::new(QueryContext::new()))

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -78,7 +78,7 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            QueryParse { .. } | MultipleStatements { .. } => StatusCode::InvalidSyntax,
+            MultipleStatements { .. } => StatusCode::InvalidSyntax,
             UnsupportedExpr { .. }
             | CatalogNotFound { .. }
             | SchemaNotFound { .. }
@@ -87,7 +87,9 @@ impl ErrorExt for Error {
             VectorComputation { source } => source.status_code(),
             CreateRecordBatch { source } => source.status_code(),
             Datatype { source } => source.status_code(),
-            QueryExecution { source } | QueryPlan { source } => source.status_code(),
+            QueryExecution { source } | QueryPlan { source } | QueryParse { source, .. } => {
+                source.status_code()
+            }
         }
     }
 

--- a/src/query/tests/argmax_test.rs
+++ b/src/query/tests/argmax_test.rs
@@ -23,7 +23,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -84,7 +84,7 @@ async fn execute_argmax<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select ARGMAX({column_name}) as argmax from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/argmin_test.rs
+++ b/src/query/tests/argmin_test.rs
@@ -23,7 +23,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -84,7 +84,7 @@ async fn execute_argmin<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select argmin({column_name}) as argmin from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/function.rs
+++ b/src/query/tests/function.rs
@@ -26,7 +26,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::types::WrapperType;
 use datatypes::vectors::Helper;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::query_engine::QueryEngineFactory;
 use query::QueryEngine;
 use rand::Rng;
@@ -83,7 +83,7 @@ where
     T: WrapperType,
 {
     let sql = format!("SELECT {column_name} FROM {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/mean_test.rs
+++ b/src/query/tests/mean_test.rs
@@ -26,7 +26,7 @@ use datatypes::value::OrderedFloat;
 use format_num::NumberFormat;
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -80,7 +80,7 @@ async fn execute_mean<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select MEAN({column_name}) as mean from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/my_sum_udaf_example.rs
+++ b/src/query/tests/my_sum_udaf_example.rs
@@ -33,7 +33,7 @@ use datatypes::vectors::Helper;
 use datatypes::with_match_primitive_type_id;
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngineFactory;
 use session::context::QueryContext;
 use table::test_util::MemTable;
@@ -219,7 +219,7 @@ where
     )));
 
     let sql = format!("select MY_SUM({column_name}) as my_sum from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/percentile_test.rs
+++ b/src/query/tests/percentile_test.rs
@@ -27,7 +27,7 @@ use datatypes::vectors::Int32Vector;
 use function::{create_query_engine, get_numbers_from_table};
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::{QueryEngine, QueryEngineFactory};
 use session::context::QueryContext;
 use table::test_util::MemTable;
@@ -53,7 +53,7 @@ async fn test_percentile_aggregator() -> Result<()> {
 async fn test_percentile_correctness() -> Result<()> {
     let engine = create_correctness_engine();
     let sql = String::from("select PERCENTILE(corr_number,88.0) as percentile from corr_numbers");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();
@@ -98,7 +98,7 @@ async fn execute_percentile<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select PERCENTILE({column_name},50.0) as percentile from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/polyval_test.rs
+++ b/src/query/tests/polyval_test.rs
@@ -23,7 +23,7 @@ use datatypes::prelude::*;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 
@@ -80,7 +80,7 @@ async fn execute_polyval<'a>(
     engine: Arc<dyn QueryEngine>,
 ) -> RecordResult<Vec<RecordBatch>> {
     let sql = format!("select POLYVAL({column_name}, 0) as polyval from {table_name}");
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/query_engine_test.rs
+++ b/src/query/tests/query_engine_test.rs
@@ -34,7 +34,7 @@ use datatypes::prelude::*;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::UInt32Vector;
 use query::error::{QueryExecutionSnafu, Result};
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::plan::LogicalPlan;
 use query::query_engine::QueryEngineFactory;
 use session::context::QueryContext;
@@ -145,9 +145,10 @@ async fn test_udf() -> Result<()> {
 
     engine.register_udf(udf);
 
-    let stmt =
-        QueryLanguageParser::parse_sql("select my_pow(number, number) as p from numbers limit 10")
-            .unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(
+        "select my_pow(number, number) as p from numbers limit 10".to_string(),
+    ))
+    .unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/scipy_stats_norm_cdf_test.rs
+++ b/src/query/tests/scipy_stats_norm_cdf_test.rs
@@ -22,7 +22,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 use statrs::distribution::{ContinuousCDF, Normal};
@@ -79,7 +79,7 @@ async fn execute_scipy_stats_norm_cdf<'a>(
     let sql = format!(
         "select SCIPYSTATSNORMCDF({column_name},2.0) as scipy_stats_norm_cdf from {table_name}",
     );
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/scipy_stats_norm_pdf.rs
+++ b/src/query/tests/scipy_stats_norm_pdf.rs
@@ -22,7 +22,7 @@ use datatypes::for_all_primitive_types;
 use datatypes::types::WrapperType;
 use num_traits::AsPrimitive;
 use query::error::Result;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use session::context::QueryContext;
 use statrs::distribution::{Continuous, Normal};
@@ -79,7 +79,7 @@ async fn execute_scipy_stats_norm_pdf<'a>(
     let sql = format!(
         "select SCIPYSTATSNORMPDF({column_name},2.0) as scipy_stats_norm_pdf from {table_name}"
     );
-    let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+    let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
     let plan = engine
         .statement_to_plan(stmt, Arc::new(QueryContext::new()))
         .unwrap();

--- a/src/query/tests/time_range_filter_test.rs
+++ b/src/query/tests/time_range_filter_test.rs
@@ -26,6 +26,7 @@ use common_time::Timestamp;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{Int64Vector, TimestampMillisecondVector};
+use query::parser::QueryLanguage;
 use query::QueryEngineRef;
 use session::context::QueryContext;
 use table::metadata::{FilterPushDownType, TableInfoRef};
@@ -126,7 +127,8 @@ struct TimeRangeTester {
 
 impl TimeRangeTester {
     async fn check(&self, sql: &str, expect: TimestampRange) {
-        let stmt = query::parser::QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt =
+            query::parser::QueryLanguageParser::parse(QueryLanguage::Sql(sql.to_owned())).unwrap();
         let _ = self
             .engine
             .execute(

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -27,7 +27,7 @@ use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{Helper, VectorRef};
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngine;
 use rustpython_compiler_core::CodeObject;
 use rustpython_vm as vm;
@@ -290,7 +290,7 @@ fn set_items_in_scope(
 }
 
 /// The coprocessor function accept a python script and a Record Batch:
-/// ## What it does
+/// # What it does
 /// 1. it take a python script and a [`RecordBatch`], extract columns and annotation info according to `args` given in decorator in python script
 /// 2. execute python code and return a vector or a tuple of vector,
 /// 3. the returning vector(s) is assembled into a new [`RecordBatch`] according to `returns` in python decorator and return to caller
@@ -369,7 +369,8 @@ impl PyQueryEngine {
         let query = self.inner.0.upgrade();
         let thread_handle = std::thread::spawn(move || -> std::result::Result<_, String> {
             if let Some(engine) = query {
-                let stmt = QueryLanguageParser::parse_sql(s.as_str()).map_err(|e| e.to_string())?;
+                let stmt =
+                    QueryLanguageParser::parse(QueryLanguage::Sql(s)).map_err(|e| e.to_string())?;
                 let plan = engine
                     .statement_to_plan(stmt, Default::default())
                     .map_err(|e| e.to_string())?;

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -30,7 +30,7 @@ use datafusion_expr::Volatility;
 use datatypes::schema::{ColumnSchema, SchemaRef};
 use datatypes::vectors::VectorRef;
 use futures::Stream;
-use query::parser::{QueryLanguageParser, QueryStatement};
+use query::parser::{QueryLanguage, QueryLanguageParser, QueryStatement};
 use query::QueryEngineRef;
 use session::context::QueryContext;
 use snafu::{ensure, ResultExt};
@@ -220,7 +220,7 @@ impl Script for PyScript {
 
     async fn execute(&self, _ctx: EvalContext) -> Result<Output> {
         if let Some(sql) = &self.copr.deco_args.sql {
-            let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+            let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql.clone())).unwrap();
             ensure!(
                 matches!(stmt, QueryStatement::Sql(Statement::Query { .. })),
                 error::UnsupportedSqlSnafu { sql }

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -25,7 +25,7 @@ use common_time::util;
 use datatypes::prelude::{ConcreteDataType, ScalarVector};
 use datatypes::schema::{ColumnSchema, Schema, SchemaBuilder};
 use datatypes::vectors::{StringVector, TimestampMillisecondVector, Vector, VectorRef};
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::QueryEngineRef;
 use session::context::QueryContext;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -145,7 +145,7 @@ impl ScriptsTable {
         // TODO(dennis): we use sql to find the script, the better way is use a function
         //               such as `find_record_by_primary_key` in table_engine.
         let sql = format!("select script from {} where name='{}'", self.name(), name);
-        let stmt = QueryLanguageParser::parse_sql(&sql).unwrap();
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(sql)).unwrap();
         let plan = self
             .query_engine
             .statement_to_plan(stmt, Arc::new(QueryContext::new()))

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -82,6 +82,12 @@ pub enum Error {
         source: BoxedError,
     },
 
+    #[snafu(display("Failed to parse query, source: {}", source))]
+    ParseQuery {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
+
     #[snafu(display("{source}"))]
     ExecuteGrpcQuery {
         #[snafu(backtrace)]
@@ -90,6 +96,12 @@ pub enum Error {
 
     #[snafu(display("Failed to execute sql statement, source: {}", source))]
     ExecuteStatement {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
+
+    #[snafu(display("Failed to execute query statement, source: {}", source))]
+    ExecuteQueryStatement {
         #[snafu(backtrace)]
         source: BoxedError,
     },
@@ -285,7 +297,9 @@ impl ErrorExt for Error {
             | ExecuteStatement { source, .. }
             | CheckDatabaseValidity { source, .. }
             | ExecuteAlter { source, .. }
-            | PutOpentsdbDataPoint { source, .. } => source.status_code(),
+            | PutOpentsdbDataPoint { source, .. }
+            | ParseQuery { source }
+            | ExecuteQueryStatement { source } => source.status_code(),
 
             NotSupported { .. }
             | InvalidQuery { .. }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -590,9 +590,9 @@ mod test {
             unimplemented!()
         }
 
-        async fn do_statement_query(
+        async fn statement_query(
             &self,
-            _stmt: sql::statements::statement::Statement,
+            _stmt: query::parser::QueryStatement,
             _query_ctx: QueryContextRef,
         ) -> Result<Output> {
             unimplemented!()

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -563,6 +563,7 @@ mod test {
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
     use datatypes::vectors::{StringVector, UInt32Vector};
+    use query::parser::QueryStatement;
     use session::context::QueryContextRef;
     use tokio::sync::mpsc;
 
@@ -577,15 +578,15 @@ mod test {
     impl QueryHandler for DummyInstance {
         async fn statement_query(
             &self,
-            _stmt: query::parser::QueryStatement,
+            _stmt: QueryStatement,
             _query_ctx: QueryContextRef,
         ) -> Result<Output> {
             unimplemented!()
         }
 
-        fn do_describe(
+        fn describe(
             &self,
-            _stmt: sql::statements::statement::Statement,
+            _stmt: QueryStatement,
             _query_ctx: QueryContextRef,
         ) -> Result<Option<Schema>> {
             unimplemented!()

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -567,7 +567,6 @@ mod test {
     use tokio::sync::mpsc;
 
     use super::*;
-    use crate::error::Error;
     use crate::query_handler::sql::{ServerSqlQueryHandlerAdaptor, SqlQueryHandler};
 
     struct DummyInstance {
@@ -576,20 +575,6 @@ mod test {
 
     #[async_trait]
     impl SqlQueryHandler for DummyInstance {
-        type Error = Error;
-
-        async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
-            unimplemented!()
-        }
-
-        async fn do_promql_query(
-            &self,
-            _: &str,
-            _: QueryContextRef,
-        ) -> Vec<std::result::Result<Output, Self::Error>> {
-            unimplemented!()
-        }
-
         async fn statement_query(
             &self,
             _stmt: query::parser::QueryStatement,

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -41,13 +41,13 @@ pub async fn sql(
     // TODO(fys): pass _user_info into query context
     _user_info: Extension<UserInfo>,
 ) -> Json<JsonResponse> {
-    let sql_handler = &state.sql_handler;
+    let query_handler = &state.query_handler;
     let start = Instant::now();
     let resp = if let Some(sql) = &params.sql {
-        match super::query_context_from_db(sql_handler.clone(), params.db) {
+        match super::query_context_from_db(query_handler.clone(), params.db) {
             Ok(query_ctx) => {
                 JsonResponse::from_output(
-                    sql_handler
+                    query_handler
                         .query_multiple(QueryLanguage::Sql(sql.clone()), query_ctx)
                         .await,
                 )
@@ -78,12 +78,12 @@ pub async fn promql(
     // TODO(fys): pass _user_info into query context
     _user_info: Extension<UserInfo>,
 ) -> Json<JsonResponse> {
-    let sql_handler = &state.sql_handler;
+    let query_handler = &state.query_handler;
     let start = Instant::now();
-    let resp = match super::query_context_from_db(sql_handler.clone(), None) {
+    let resp = match super::query_context_from_db(query_handler.clone(), None) {
         Ok(query_ctx) => {
             JsonResponse::from_output(
-                sql_handler
+                query_handler
                     .query_multiple(QueryLanguage::Promql(params.query), query_ctx)
                     .await,
             )

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -27,7 +27,7 @@ pub trait SqlQueryInterceptor {
 
     /// Called before a query is parsed into statement.
     /// The implementation is allowed to change the query if needed.
-    fn pre_parsing<'a>(
+    fn pre_parsing(
         &self,
         query: QueryLanguage,
         _query_ctx: QueryContextRef,

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -32,11 +32,11 @@ use tokio::io::AsyncWrite;
 use crate::auth::{Identity, Password, UserProviderRef};
 use crate::error::{self, Result};
 use crate::mysql::writer::MysqlResultWriter;
-use crate::query_handler::sql::ServerSqlQueryHandlerRef;
+use crate::query_handler::sql::ServerQueryHandlerRef;
 
 // An intermediate shim for executing MySQL queries.
 pub struct MysqlInstanceShim {
-    query_handler: ServerSqlQueryHandlerRef,
+    query_handler: ServerQueryHandlerRef,
     salt: [u8; 20],
     session: Arc<Session>,
     user_provider: Option<UserProviderRef>,
@@ -44,7 +44,7 @@ pub struct MysqlInstanceShim {
 
 impl MysqlInstanceShim {
     pub fn create(
-        query_handler: ServerSqlQueryHandlerRef,
+        query_handler: ServerQueryHandlerRef,
         user_provider: Option<UserProviderRef>,
         client_addr: SocketAddr,
     ) -> MysqlInstanceShim {

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -22,6 +22,7 @@ use common_telemetry::{error, trace};
 use opensrv_mysql::{
     AsyncMysqlShim, ErrorKind, InitWriter, ParamParser, QueryResultWriter, StatementMetaWriter,
 };
+use query::parser::QueryLanguage;
 use rand::RngCore;
 use session::context::Channel;
 use session::Session;
@@ -80,7 +81,10 @@ impl MysqlInstanceShim {
                 vec![Ok(output)]
             } else {
                 self.query_handler
-                    .do_query(query, self.session.context())
+                    .query_multiple(
+                        QueryLanguage::Sql(query.to_string()),
+                        self.session.context(),
+                    )
                     .await
             };
 

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -31,7 +31,7 @@ use tokio_rustls::rustls::ServerConfig;
 use crate::auth::UserProviderRef;
 use crate::error::{Error, Result};
 use crate::mysql::handler::MysqlInstanceShim;
-use crate::query_handler::sql::ServerSqlQueryHandlerRef;
+use crate::query_handler::sql::ServerQueryHandlerRef;
 use crate::server::{AbortableStream, BaseTcpServer, Server};
 
 // Default size of ResultSet write buffer: 100KB
@@ -40,13 +40,13 @@ const DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE: usize = 100 * 1024;
 /// [`MysqlSpawnRef`] stores arc refs
 /// that should be passed to new [`MysqlInstanceShim`]s.
 pub struct MysqlSpawnRef {
-    query_handler: ServerSqlQueryHandlerRef,
+    query_handler: ServerQueryHandlerRef,
     user_provider: Option<UserProviderRef>,
 }
 
 impl MysqlSpawnRef {
     pub fn new(
-        query_handler: ServerSqlQueryHandlerRef,
+        query_handler: ServerQueryHandlerRef,
         user_provider: Option<UserProviderRef>,
     ) -> MysqlSpawnRef {
         MysqlSpawnRef {
@@ -55,7 +55,7 @@ impl MysqlSpawnRef {
         }
     }
 
-    fn query_handler(&self) -> ServerSqlQueryHandlerRef {
+    fn query_handler(&self) -> ServerQueryHandlerRef {
         self.query_handler.clone()
     }
     fn user_provider(&self) -> Option<UserProviderRef> {

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -36,7 +36,7 @@ use session::context::{QueryContext, QueryContextRef};
 
 use self::auth_handler::PgLoginVerifier;
 use crate::auth::UserProviderRef;
-use crate::query_handler::sql::ServerSqlQueryHandlerRef;
+use crate::query_handler::sql::ServerQueryHandlerRef;
 
 pub(crate) struct GreptimeDBStartupParameters {
     version: &'static str,
@@ -66,7 +66,7 @@ impl ServerParameterProvider for GreptimeDBStartupParameters {
 }
 
 pub struct PostgresServerHandler {
-    query_handler: ServerSqlQueryHandlerRef,
+    query_handler: ServerQueryHandlerRef,
     login_verifier: PgLoginVerifier,
     force_tls: bool,
     param_provider: Arc<GreptimeDBStartupParameters>,
@@ -78,7 +78,7 @@ pub struct PostgresServerHandler {
 
 #[derive(Builder)]
 pub(crate) struct MakePostgresServerHandler {
-    query_handler: ServerSqlQueryHandlerRef,
+    query_handler: ServerQueryHandlerRef,
     user_provider: Option<UserProviderRef>,
     #[builder(default = "Arc::new(GreptimeDBStartupParameters::new())")]
     param_provider: Arc<GreptimeDBStartupParameters>,

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -29,7 +29,7 @@ use super::PostgresServerHandler;
 use crate::auth::{Identity, Password, UserProviderRef};
 use crate::error;
 use crate::error::Result;
-use crate::query_handler::sql::ServerSqlQueryHandlerRef;
+use crate::query_handler::sql::ServerQueryHandlerRef;
 
 pub(crate) struct PgLoginVerifier {
     user_provider: Option<UserProviderRef>,
@@ -238,7 +238,7 @@ enum DbResolution {
 /// A function extracted to resolve lifetime and readability issues:
 fn resolve_db_info<C>(
     client: &mut C,
-    query_handler: ServerSqlQueryHandlerRef,
+    query_handler: ServerQueryHandlerRef,
 ) -> PgWireResult<DbResolution>
 where
     C: ClientInfo + Unpin + Send,

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -34,7 +34,7 @@ use pgwire::api::stmt::{QueryParser, StoredStatement};
 use pgwire::api::store::MemPortalStore;
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
-use query::parser::QueryLanguage;
+use query::parser::{QueryLanguage, QueryStatement};
 use sql::dialect::GenericDialect;
 use sql::parser::ParserContext;
 use sql::statements::statement::Statement;
@@ -376,9 +376,8 @@ impl ExtendedQueryHandler for PostgresServerHandler {
 
         let output = self
             .query_handler
-            .do_query(&sql, self.query_ctx.clone())
-            .await
-            .remove(0);
+            .query(QueryLanguage::Sql(sql), self.query_ctx.clone())
+            .await;
 
         output_to_query_response(output, false)
     }
@@ -394,7 +393,7 @@ impl ExtendedQueryHandler for PostgresServerHandler {
         let (stmt, _) = statement.statement();
         if let Some(schema) = self
             .query_handler
-            .do_describe(stmt.clone(), self.query_ctx.clone())
+            .describe(QueryStatement::Sql(stmt.clone()), self.query_ctx.clone())
             .map_err(|e| PgWireError::ApiError(Box::new(e)))?
         {
             schema_to_pg(&schema).map_err(|e| PgWireError::ApiError(Box::new(e)))

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -29,6 +29,7 @@ use pgwire::api::stmt::NoopQueryParser;
 use pgwire::api::store::MemPortalStore;
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use query::parser::QueryLanguage;
 
 use super::PostgresServerHandler;
 use crate::error::{self, Error, Result};
@@ -41,7 +42,10 @@ impl SimpleQueryHandler for PostgresServerHandler {
     {
         let outputs = self
             .query_handler
-            .do_query(query, self.query_ctx.clone())
+            .query_multiple(
+                QueryLanguage::Sql(query.to_string()),
+                self.query_ctx.clone(),
+            )
             .await;
 
         let mut results = Vec::with_capacity(outputs.len());

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -28,7 +28,7 @@ use tokio_rustls::TlsAcceptor;
 use super::{MakePostgresServerHandler, MakePostgresServerHandlerBuilder};
 use crate::auth::UserProviderRef;
 use crate::error::Result;
-use crate::query_handler::sql::ServerSqlQueryHandlerRef;
+use crate::query_handler::sql::ServerQueryHandlerRef;
 use crate::server::{AbortableStream, BaseTcpServer, Server};
 use crate::tls::TlsOption;
 
@@ -41,7 +41,7 @@ pub struct PostgresServer {
 impl PostgresServer {
     /// Creates a new Postgres server with provided query_handler and async runtime
     pub fn new(
-        query_handler: ServerSqlQueryHandlerRef,
+        query_handler: ServerQueryHandlerRef,
         tls: TlsOption,
         io_runtime: Arc<Runtime>,
         user_provider: Option<UserProviderRef>,

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -52,6 +52,11 @@ pub trait SqlQueryHandler {
         catalog: &str,
         schema: &str,
     ) -> std::result::Result<bool, Self::Error>;
+
+    async fn foo(&self) -> std::result::Result<(), Self::Error> {
+        println!("");
+        unimplemented!()
+    }
 }
 
 pub struct ServerSqlQueryHandlerAdaptor<E>(SqlQueryHandlerRef<E>);

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_error::prelude::*;
 use common_query::Output;
+use query::parser::QueryStatement;
 use session::context::QueryContextRef;
-use sql::statements::statement::Statement;
 
 use crate::error::{self, Result};
 
@@ -41,9 +41,9 @@ pub trait SqlQueryHandler {
         query_ctx: QueryContextRef,
     ) -> Vec<std::result::Result<Output, Self::Error>>;
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        stmt: Statement,
+        stmt: QueryStatement,
         query_ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error>;
 
@@ -52,11 +52,6 @@ pub trait SqlQueryHandler {
         catalog: &str,
         schema: &str,
     ) -> std::result::Result<bool, Self::Error>;
-
-    async fn foo(&self) -> std::result::Result<(), Self::Error> {
-        println!("");
-        unimplemented!()
-    }
 }
 
 pub struct ServerSqlQueryHandlerAdaptor<E>(SqlQueryHandlerRef<E>);
@@ -102,13 +97,13 @@ where
             .collect()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        stmt: Statement,
+        stmt: QueryStatement,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         self.0
-            .do_statement_query(stmt, query_ctx)
+            .statement_query(stmt, query_ctx)
             .await
             .map_err(BoxedError::new)
             .context(error::ExecuteStatementSnafu)

--- a/src/servers/src/query_handler/sql.rs
+++ b/src/servers/src/query_handler/sql.rs
@@ -49,7 +49,8 @@ pub trait QueryHandler {
     }
 
     // TODO(LFC): revisit this for mysql prepared statement
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>>;
+    /// Retrieve query schema without execute it.
+    fn describe(&self, stmt: QueryStatement, query_ctx: QueryContextRef) -> Result<Option<Schema>>;
 
     /// Execute a [QueryLanguage] that may return multiple [Output]s.
     async fn query_multiple(
@@ -106,9 +107,9 @@ impl QueryHandler for ServerQueryHandlerAdaptor {
             .context(error::ExecuteStatementSnafu)
     }
 
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
+    fn describe(&self, stmt: QueryStatement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
         self.0
-            .do_describe(stmt, query_ctx)
+            .describe(stmt, query_ctx)
             .map_err(BoxedError::new)
             .context(error::DescribeStatementSnafu)
     }

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -26,10 +26,10 @@ use crate::{create_testing_script_handler, create_testing_sql_query_handler};
 
 #[tokio::test]
 async fn test_sql_not_provided() {
-    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
     let Json(json) = http_handler::sql(
         State(ApiState {
-            sql_handler,
+            query_handler,
             script_handler: None,
         }),
         Query(http_handler::SqlQuery::default()),
@@ -49,11 +49,11 @@ async fn test_sql_output_rows() {
     common_telemetry::init_default_ut_logging();
 
     let query = create_query();
-    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
     let Json(json) = http_handler::sql(
         State(ApiState {
-            sql_handler,
+            query_handler,
             script_handler: None,
         }),
         query,
@@ -90,13 +90,13 @@ def test(n):
     return n;
 "#
     .to_string();
-    let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let query_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
     let script_handler = create_testing_script_handler(MemTable::default_numbers_table());
     let body = RawBody(Body::from(script.clone()));
     let invalid_query = create_invalid_script_query();
     let Json(json) = script_handler::scripts(
         State(ApiState {
-            sql_handler: sql_handler.clone(),
+            query_handler: query_handler.clone(),
             script_handler: Some(script_handler.clone()),
         }),
         invalid_query,
@@ -110,7 +110,7 @@ def test(n):
     let exec = create_script_query();
     let Json(json) = script_handler::scripts(
         State(ApiState {
-            sql_handler,
+            query_handler,
             script_handler: Some(script_handler),
         }),
         exec,

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -62,9 +62,9 @@ impl SqlQueryHandler for DummyInstance {
         unimplemented!()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: query::parser::QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use axum::{http, Router};
 use axum_test_helper::TestClient;
 use common_query::Output;
-use servers::error::{Error, Result};
+use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::sql::SqlQueryHandler;
@@ -48,20 +48,6 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = Error;
-
-    async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
-        unimplemented!()
-    }
-
-    async fn do_promql_query(
-        &self,
-        _: &str,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
-        unimplemented!()
-    }
-
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -22,7 +22,7 @@ use common_query::Output;
 use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use servers::query_handler::InfluxdbLineProtocolHandler;
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
@@ -47,7 +47,7 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for DummyInstance {
+impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -20,7 +20,8 @@ use axum::{http, Router};
 use axum_test_helper::TestClient;
 use common_query::Output;
 use datatypes::schema::Schema;
-use servers::error::{Error, Result};
+use query::parser::QueryStatement;
+use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::influxdb::InfluxdbRequest;
 use servers::query_handler::sql::QueryHandler;
@@ -51,15 +52,15 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
 impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
-        _stmt: query::parser::QueryStatement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()
     }
 
-    fn do_describe(
+    fn describe(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Option<Schema>> {
         unimplemented!()

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -21,7 +21,7 @@ use common_query::Output;
 use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use servers::query_handler::OpentsdbProtocolHandler;
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
@@ -45,7 +45,7 @@ impl OpentsdbProtocolHandler for DummyInstance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for DummyInstance {
+impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -60,9 +60,9 @@ impl SqlQueryHandler for DummyInstance {
         unimplemented!()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: query::parser::QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -19,6 +19,7 @@ use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
 use datatypes::schema::Schema;
+use query::parser::QueryStatement;
 use servers::error::{self, Result};
 use servers::http::{HttpOptions, HttpServer};
 use servers::opentsdb::codec::DataPoint;
@@ -49,15 +50,15 @@ impl OpentsdbProtocolHandler for DummyInstance {
 impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
-        _stmt: query::parser::QueryStatement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()
     }
 
-    fn do_describe(
+    fn describe(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Option<Schema>> {
         unimplemented!()

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -46,20 +46,6 @@ impl OpentsdbProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = error::Error;
-
-    async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
-        unimplemented!()
-    }
-
-    async fn do_promql_query(
-        &self,
-        _: &str,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
-        unimplemented!()
-    }
-
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -22,7 +22,7 @@ use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
 use prost::Message;
-use servers::error::{Error, Result};
+use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
@@ -71,20 +71,6 @@ impl PrometheusProtocolHandler for DummyInstance {
 
 #[async_trait]
 impl SqlQueryHandler for DummyInstance {
-    type Error = Error;
-
-    async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
-        unimplemented!()
-    }
-
-    async fn do_promql_query(
-        &self,
-        _: &str,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
-        unimplemented!()
-    }
-
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -26,7 +26,7 @@ use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
 use servers::prometheus::{snappy_compress, Metrics};
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use servers::query_handler::{PrometheusProtocolHandler, PrometheusResponse};
 use session::context::QueryContextRef;
 use tokio::sync::mpsc;
@@ -70,7 +70,7 @@ impl PrometheusProtocolHandler for DummyInstance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for DummyInstance {
+impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
         _stmt: query::parser::QueryStatement,

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -23,6 +23,7 @@ use axum_test_helper::TestClient;
 use common_query::Output;
 use datatypes::schema::Schema;
 use prost::Message;
+use query::parser::QueryStatement;
 use servers::error::Result;
 use servers::http::{HttpOptions, HttpServer};
 use servers::prometheus;
@@ -74,15 +75,15 @@ impl PrometheusProtocolHandler for DummyInstance {
 impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
-        _stmt: query::parser::QueryStatement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()
     }
 
-    fn do_describe(
+    fn describe(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Option<Schema>> {
         unimplemented!()

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -85,9 +85,9 @@ impl SqlQueryHandler for DummyInstance {
         unimplemented!()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: query::parser::QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -20,7 +20,7 @@ use catalog::local::{MemoryCatalogManager, MemoryCatalogProvider, MemorySchemaPr
 use catalog::{CatalogList, CatalogProvider, SchemaProvider};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::Output;
-use query::parser::QueryLanguageParser;
+use query::parser::{QueryLanguage, QueryLanguageParser};
 use query::{QueryEngineFactory, QueryEngineRef};
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
@@ -59,7 +59,7 @@ impl SqlQueryHandler for DummyInstance {
     type Error = Error;
 
     async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
-        let stmt = QueryLanguageParser::parse_sql(query).unwrap();
+        let stmt = QueryLanguageParser::parse(QueryLanguage::Sql(query.to_owned())).unwrap();
         let plan = self
             .query_engine
             .statement_to_plan(stmt, query_ctx)

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -25,7 +25,7 @@ use query::{QueryEngineFactory, QueryEngineRef};
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
 use servers::error::Result;
-use servers::query_handler::sql::{ServerSqlQueryHandlerRef, SqlQueryHandler};
+use servers::query_handler::sql::{QueryHandler, ServerQueryHandlerRef};
 use servers::query_handler::{ScriptHandler, ScriptHandlerRef};
 use session::context::QueryContextRef;
 use table::test_util::MemTable;
@@ -55,7 +55,7 @@ impl DummyInstance {
 }
 
 #[async_trait]
-impl SqlQueryHandler for DummyInstance {
+impl QueryHandler for DummyInstance {
     async fn statement_query(
         &self,
         stmt: QueryStatement,
@@ -121,6 +121,6 @@ fn create_testing_script_handler(table: MemTable) -> ScriptHandlerRef {
     Arc::new(create_testing_instance(table)) as _
 }
 
-fn create_testing_sql_query_handler(table: MemTable) -> ServerSqlQueryHandlerRef {
+fn create_testing_sql_query_handler(table: MemTable) -> ServerQueryHandlerRef {
     Arc::new(create_testing_instance(table)) as _
 }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -21,7 +21,7 @@ use catalog::{CatalogList, CatalogProvider, SchemaProvider};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::Output;
 use datatypes::schema::Schema;
-use query::parser::{QueryLanguageParser, QueryStatement};
+use query::parser::QueryStatement;
 use query::{QueryEngineFactory, QueryEngineRef};
 use script::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use script::python::{PyEngine, PyScript};
@@ -70,12 +70,9 @@ impl QueryHandler for DummyInstance {
         Ok(self.query_engine.execute(&plan).await.unwrap())
     }
 
-    fn do_describe(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
-        if let Statement::Query(_) = stmt {
-            let schema = self
-                .query_engine
-                .describe(QueryStatement::Sql(stmt), query_ctx)
-                .unwrap();
+    fn describe(&self, stmt: QueryStatement, query_ctx: QueryContextRef) -> Result<Option<Schema>> {
+        if let QueryStatement::Sql(Statement::Query(_)) = stmt {
+            let schema = self.query_engine.describe(stmt, query_ctx).unwrap();
             Ok(Some(schema))
         } else {
             Ok(None)

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -76,9 +76,9 @@ impl SqlQueryHandler for DummyInstance {
         unimplemented!()
     }
 
-    async fn do_statement_query(
+    async fn statement_query(
         &self,
-        _stmt: sql::statements::statement::Statement,
+        _stmt: query::parser::QueryStatement,
         _query_ctx: QueryContextRef,
     ) -> Result<Output> {
         unimplemented!()

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use query::parser::QueryLanguage;
 use servers::error::Result;
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::ScriptHandler;
@@ -35,9 +36,11 @@ def double_that(col)->vector[u32]:
     "#;
     instance.insert_script("double_that", src).await?;
     let res = instance
-        .do_query("select double_that(uint32s) from numbers", query_ctx)
+        .query(
+            QueryLanguage::Sql("select double_that(uint32s) from numbers".to_string()),
+            query_ctx,
+        )
         .await
-        .remove(0)
         .unwrap();
     match res {
         common_query::Output::AffectedRows(_) => (),

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use query::parser::QueryLanguage;
 use servers::error::Result;
-use servers::query_handler::sql::SqlQueryHandler;
+use servers::query_handler::sql::QueryHandler;
 use servers::query_handler::ScriptHandler;
 use session::context::QueryContext;
 use table::test_util::MemTable;

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -42,7 +42,7 @@ use servers::grpc::GrpcServer;
 use servers::http::{HttpOptions, HttpServer};
 use servers::promql::PromqlServer;
 use servers::query_handler::grpc::ServerGrpcQueryHandlerAdaptor;
-use servers::query_handler::sql::ServerSqlQueryHandlerAdaptor;
+use servers::query_handler::sql::ServerQueryHandlerAdaptor;
 use servers::server::Server;
 use servers::Mode;
 use snafu::ResultExt;
@@ -278,7 +278,7 @@ pub async fn setup_test_http_app(store_type: StorageType, name: &str) -> (Router
     .await
     .unwrap();
     let http_server = HttpServer::new(
-        ServerSqlQueryHandlerAdaptor::arc(instance),
+        ServerQueryHandlerAdaptor::arc(instance),
         HttpOptions::default(),
     );
     (http_server.make_app(), guard)
@@ -300,7 +300,7 @@ pub async fn setup_test_http_app_with_frontend(
     .await
     .unwrap();
     let mut http_server = HttpServer::new(
-        ServerSqlQueryHandlerAdaptor::arc(Arc::new(frontend)),
+        ServerQueryHandlerAdaptor::arc(Arc::new(frontend)),
         HttpOptions::default(),
     );
     http_server.set_script_handler(instance.clone());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR refactors the `SqlQueryHandler` trait, and serval changes around it. In detail, it
- Change `SqlQueryHandler` to `QueryHandler`. Because promql is also handled by it.
- Add `QueryLanguage` enum, to represent both SQL and PromQL
- use rustlint flag to config lints. It now contains clippy denied warnings and overrides a false positive rustc warning.
- Change `do_xxx` in `SqlQueryHandler` to `xxx`, to align the naming rule with other places (`do_xxx` is often left for implementation's inner method).
- `statement_query` now accepts `QueryStatement` rather than `Statement`, which is only for SQL.
- `SqlQueryInterceptor` now accepts `QueryLanguage`/`QueryStatement`, for the same reason. cc @sunng87 
- Split the single query and multiple query methods. Like `parse`&`parse_multiple`, `query`/`query_multiple`. To reduce the redundant multiple statements handle logic, and only limit this behavior in the implementation of `QueryHandler`. cc @sunng87 
- Remove the type parameter `Error` in `QueryHandler`. Now it only returns `servers::error`, in which sub-crate the `QueryHandler` is defined. This place might not be appropriate, we may need to think about moving `QueryHandler` to another place. cc @MichaelScofield 
- Provide default implementations for methods `query` and `query_multiple`. Now the only two required methods for `QueryHandler` are `statement_query` and `is_schema_valid`. BTW, I doubt if `QueryHandler` is a good place for `is_schema_valid`?

The commits are organized by content. It might be easier to review by commits.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Follows #924