### PR TITLE
feat: Execute procedure in LocalManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "futures",
+ "futures-util",
  "object-store",
  "serde",
  "serde_json",

--- a/docs/rfcs/2023-01-03-procedure-framework.md
+++ b/docs/rfcs/2023-01-03-procedure-framework.md
@@ -140,8 +140,6 @@ Rollback is complicated to implement so some procedures might not support rollba
 ## Locking
 The `ProcedureManager` can provide a locking mechanism that gives a procedure read/write access to a database object such as a table so other procedures are unable to modify the same table while the current one is executing.
 
-Sub-procedures always inherit their parents' locks. The `ProcedureManager` only acquires locks for a procedure if its parent doesn't hold the lock.
-
 # Drawbacks
 The `Procedure` framework introduces additional complexity and overhead to our database.
 - To execute a `Procedure`, we need to write to the `ProcedureStore` multiple times, which may slow down the server

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -18,4 +18,5 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+futures-util.workspace = true
 tempdir = "0.3"

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -208,13 +208,16 @@ impl ManagerContext {
     }
 
     /// Returns all procedures in the tree (including given `root` procedure).
+    ///
+    /// If callers need a consistent view of the tree, they must ensure no new
+    /// procedure is added to the tree during using this method.
     fn procedures_in_tree(&self, root: &ProcedureMetaRef) -> Vec<ProcedureId> {
         let sub_num = root.num_children();
         // Reserve capacity for the root procedure and its children.
         let mut procedures = Vec::with_capacity(1 + sub_num);
 
-        // Push the root procedure to the queue.
         let mut queue = VecDeque::with_capacity(1 + sub_num);
+        // Push the root procedure to the queue.
         queue.push_back(root.clone());
 
         let mut children_ids = Vec::with_capacity(sub_num);

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -38,12 +38,15 @@ use crate::{
 struct ExecMeta {
     /// Current procedure state.
     state: ProcedureState,
+    /// Id of subprocedures.
+    subprocedures: Vec<ProcedureId>,
 }
 
 impl Default for ExecMeta {
     fn default() -> ExecMeta {
         ExecMeta {
             state: ProcedureState::Running,
+            subprocedures: Vec::new(),
         }
     }
 }
@@ -100,6 +103,12 @@ impl ProcedureMeta {
     fn set_state(&self, state: ProcedureState) {
         let mut meta = self.exec_meta.lock().unwrap();
         meta.state = state;
+    }
+
+    /// Push `procedure_id` of the subprocedure to the metadata.
+    fn push_subprocedure(&self, procedure_id: ProcedureId) {
+        let mut meta = self.exec_meta.lock().unwrap();
+        meta.subprocedures.push(procedure_id);
     }
 }
 

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -233,10 +233,12 @@ impl ManagerContext {
         while let Some(meta) = queue.pop_front() {
             procedures.push(meta.id);
 
+            // Find metadatas of children.
             children_ids.clear();
             meta.list_children(&mut children_ids);
             self.find_procedures(&children_ids, &mut children);
 
+            // Traverse children later.
             for child in children.drain(..) {
                 queue.push_back(child);
             }
@@ -311,7 +313,7 @@ impl LocalManager {
 
         common_runtime::spawn_bg(async move {
             // Run the root procedure.
-            runner.run().await
+            let _ = runner.run().await;
         });
     }
 }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -218,15 +218,15 @@ impl ManagerContext {
         })
     }
 
-    /// Returns all procedures in the tree (including given procedure).
-    fn procedures_in_tree(&self, meta: &ProcedureMetaRef) -> Vec<ProcedureId> {
-        let sub_num = meta.num_children();
+    /// Returns all procedures in the tree (including given `root` procedure).
+    fn procedures_in_tree(&self, root: &ProcedureMetaRef) -> Vec<ProcedureId> {
+        let sub_num = root.num_children();
         // Reserve capacity for the root procedure and its children.
         let mut procedures = Vec::with_capacity(1 + sub_num);
 
         // Push the root procedure to the queue.
         let mut queue = VecDeque::with_capacity(1 + sub_num);
-        queue.push_back(meta.clone());
+        queue.push_back(root.clone());
 
         let mut children_ids = Vec::with_capacity(sub_num);
         let mut children = Vec::with_capacity(sub_num);

--- a/src/common/procedure/src/local/lock.rs
+++ b/src/common/procedure/src/local/lock.rs
@@ -142,11 +142,11 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::local;
+    use crate::local::test_util;
 
     #[test]
     fn test_lock_no_waiter() {
-        let meta = Arc::new(local::procedure_meta_for_test());
+        let meta = Arc::new(test_util::procedure_meta_for_test());
         let mut lock = Lock::from_owner(meta);
 
         assert!(!lock.switch_owner());
@@ -154,10 +154,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_lock_with_waiter() {
-        let owner = Arc::new(local::procedure_meta_for_test());
+        let owner = Arc::new(test_util::procedure_meta_for_test());
         let mut lock = Lock::from_owner(owner);
 
-        let waiter = Arc::new(local::procedure_meta_for_test());
+        let waiter = Arc::new(test_util::procedure_meta_for_test());
         lock.waiters.push_back(waiter.clone());
 
         assert!(lock.switch_owner());
@@ -171,11 +171,11 @@ mod tests {
     async fn test_lock_map() {
         let key = "hello";
 
-        let owner = Arc::new(local::procedure_meta_for_test());
+        let owner = Arc::new(test_util::procedure_meta_for_test());
         let lock_map = Arc::new(LockMap::new());
         lock_map.acquire_lock(key, owner.clone()).await;
 
-        let waiter = Arc::new(local::procedure_meta_for_test());
+        let waiter = Arc::new(test_util::procedure_meta_for_test());
         let waiter_id = waiter.id;
 
         // Waiter release the lock, this should not take effect.

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use common_telemetry::logging;
+use tokio::sync::Notify;
+use tokio::time;
 
-use crate::local::{ManagerContext, ProcedureMetaRef};
+use crate::error::Result;
+use crate::local::{ExecMeta, ManagerContext, ProcedureMeta, ProcedureMetaRef};
 use crate::store::ProcedureStore;
-use crate::BoxedProcedure;
+use crate::{BoxedProcedure, Context, ProcedureId, ProcedureState, ProcedureWithId, Status};
+
+const ERR_WAIT_DURATION: Duration = Duration::from_secs(30);
 
 pub(crate) struct Runner {
     pub(crate) meta: ProcedureMetaRef,
@@ -30,7 +36,7 @@ pub(crate) struct Runner {
 
 impl Runner {
     /// Run the procedure.
-    pub(crate) async fn run(self) {
+    pub(crate) async fn run(mut self) {
         logging::info!(
             "Runner {}-{} starts",
             self.procedure.type_name(),
@@ -49,7 +55,14 @@ impl Runner {
                 .await;
         }
 
-        // TODO(yingwen): Execute the procedure.
+        // Execute the procedure.
+        if let Err(e) = self.execute_procedure().await {
+            logging::error!(
+                e; "Failed to execute procedure {}-{}",
+                self.procedure.type_name(),
+                self.meta.id
+            );
+        }
 
         if let Some(key) = &lock_key {
             self.manager_ctx
@@ -66,5 +79,171 @@ impl Runner {
             self.procedure.type_name(),
             self.meta.id
         );
+    }
+
+    async fn execute_procedure(&mut self) -> Result<()> {
+        let ctx = Context {
+            procedure_id: self.meta.id,
+        };
+
+        loop {
+            match self.procedure.execute(&ctx).await {
+                Ok(status) => {
+                    if status.need_persist() {
+                        if let Err(e) = self.persist_procedure().await {
+                            logging::error!(
+                                e; "Failed to persist procedure {}-{}",
+                                self.procedure.type_name(),
+                                self.meta.id
+                            );
+
+                            time::sleep(ERR_WAIT_DURATION).await;
+                            continue;
+                        }
+                    }
+
+                    match status {
+                        Status::Executing { .. } => (),
+                        Status::Suspended { subprocedures, .. } => {
+                            self.on_suspended(subprocedures).await;
+                        }
+                        Status::Done => {
+                            if let Err(e) = self.commit_procedure().await {
+                                logging::error!(
+                                    e; "Failed to commit procedure {}-{}",
+                                    self.procedure.type_name(),
+                                    self.meta.id
+                                );
+
+                                time::sleep(ERR_WAIT_DURATION).await;
+                                continue;
+                            }
+
+                            self.done();
+                            return Ok(());
+                        }
+                    }
+                }
+                Err(e) => {
+                    logging::error!(e; "Failed to execute procedure {}-{}", self.procedure.type_name(), self.meta.id);
+
+                    // TODO(yingwen): Write rollback key.
+
+                    self.meta.set_state(ProcedureState::Failed);
+                    // TODO(yingwen): Retry and rollback if it can't proceed.
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    /// Submit a subprocedure.
+    fn submit_subprocedure(&self, procedure_id: ProcedureId, mut procedure: BoxedProcedure) {
+        if let Some(procedure_and_parent) = self.manager_ctx.load_one_procedure(procedure_id) {
+            // Try to load procedure state from the message to avoid re-run the subprocedure
+            // from initial state.
+            assert_eq!(self.meta.id, procedure_and_parent.1.unwrap());
+
+            // Use the dumped procedure from the procedure store.
+            procedure = procedure_and_parent.0;
+        }
+
+        if self.manager_ctx.contains_procedure(procedure_id) {
+            // If the parent has already submitted this procedure, don't submit it again.
+            return;
+        }
+
+        // Inherit locks from the parent procedure. This procedure can submit a subprocedure,
+        // which indicates the procedure already owns the locks and is executing now.
+        let parent_locks = self.meta.locks_needed();
+        let mut child_lock = procedure.lock_key();
+        if let Some(lock) = &child_lock {
+            if parent_locks.contains(lock) {
+                // If the parent procedure already holds this lock, we set this lock to None
+                // so the subprocedure don't need to acquire lock again.
+                child_lock = None;
+            }
+        }
+
+        let meta = Arc::new(ProcedureMeta {
+            id: procedure_id,
+            lock_notify: Notify::new(),
+            parent_id: Some(self.meta.id),
+            child_notify: Notify::new(),
+            parent_locks,
+            lock_key: child_lock,
+            exec_meta: Mutex::new(ExecMeta::default()),
+        });
+        let runner = Runner {
+            meta: meta.clone(),
+            procedure,
+            manager_ctx: self.manager_ctx.clone(),
+            step: 0,
+            store: self.store.clone(),
+        };
+
+        self.manager_ctx.insert_procedure(meta);
+
+        common_runtime::spawn_bg(async move {
+            // Run the root procedure.
+            runner.run().await
+        });
+    }
+
+    async fn on_suspended(&self, subprocedures: Vec<ProcedureWithId>) {
+        for subprocedure in subprocedures {
+            self.submit_subprocedure(subprocedure.id, subprocedure.procedure);
+        }
+
+        logging::info!(
+            "Procedure {}-{} is waiting for subprocedures",
+            self.procedure.type_name(),
+            self.meta.id,
+        );
+
+        // Wait for subprocedures.
+        self.meta.child_notify.notified().await;
+
+        logging::info!(
+            "Procedure {}-{} is waked up",
+            self.procedure.type_name(),
+            self.meta.id,
+        );
+    }
+
+    async fn persist_procedure(&mut self) -> Result<()> {
+        self.store
+            .store_procedure(
+                self.meta.id,
+                self.step,
+                &self.procedure,
+                self.meta.parent_id,
+            )
+            .await?;
+        self.step += 1;
+        Ok(())
+    }
+
+    async fn commit_procedure(&mut self) -> Result<()> {
+        self.store.commit_procedure(self.meta.id, self.step).await?;
+        self.step += 1;
+        Ok(())
+    }
+
+    fn done(&self) {
+        // TODO(yingwen): Add files to remove list.
+        logging::info!(
+            "Procedure {}-{} done",
+            self.procedure.type_name(),
+            self.meta.id
+        );
+
+        // Mark the state of this procedure to done.
+        self.meta.set_state(ProcedureState::Done);
+
+        // Notify parent procedure.
+        if let Some(parent_id) = self.meta.parent_id {
+            self.manager_ctx.notify_by_subprocedure(parent_id);
+        }
     }
 }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -567,7 +567,7 @@ mod tests {
                         .iter()
                         .all(|id| ctx_in_future.state(*id) == Some(ProcedureState::Done));
                     if all_child_done {
-                        return Ok(Status::Done);
+                        Ok(Status::Done)
                     } else {
                         // Return suspended to wait for notify.
                         Ok(Status::Suspended {

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -19,12 +19,39 @@ use common_telemetry::logging;
 use tokio::sync::Notify;
 use tokio::time;
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::local::{ExecMeta, ManagerContext, ProcedureMeta, ProcedureMetaRef};
 use crate::store::ProcedureStore;
 use crate::{BoxedProcedure, Context, ProcedureId, ProcedureState, ProcedureWithId, Status};
 
 const ERR_WAIT_DURATION: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+enum ExecResult {
+    Continue,
+    Done,
+    RetryLater,
+    Failed(Error),
+}
+
+#[cfg(test)]
+impl ExecResult {
+    fn is_continue(&self) -> bool {
+        matches!(self, ExecResult::Continue)
+    }
+
+    fn is_done(&self) -> bool {
+        matches!(self, ExecResult::Done)
+    }
+
+    fn is_retry_later(&self) -> bool {
+        matches!(self, ExecResult::RetryLater)
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, ExecResult::Failed(_))
+    }
+}
 
 // TODO(yingwen): Support cancellation.
 pub(crate) struct Runner {
@@ -59,7 +86,7 @@ impl Runner {
         let mut result = Ok(());
         // Execute the procedure. We need to release the lock whenever the the execution
         // is successful or fail.
-        if let Err(e) = self.execute_procedure().await {
+        if let Err(e) = self.execute_procedure_in_loop().await {
             logging::error!(
                 e; "Failed to execute procedure {}-{}",
                 self.procedure.type_name(),
@@ -94,55 +121,63 @@ impl Runner {
         result
     }
 
-    async fn execute_procedure(&mut self) -> Result<()> {
+    async fn execute_procedure_in_loop(&mut self) -> Result<()> {
         let ctx = Context {
             procedure_id: self.meta.id,
         };
 
         loop {
-            match self.procedure.execute(&ctx).await {
-                Ok(status) => {
-                    if status.need_persist() {
-                        if self.persist_procedure().await.is_err() {
-                            self.wait_on_err().await;
-                            continue;
-                        }
+            match self.execute_once(&ctx).await {
+                ExecResult::Continue => (),
+                ExecResult::Done => return Ok(()),
+                ExecResult::RetryLater => {
+                    self.wait_on_err().await;
+                }
+                ExecResult::Failed(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn execute_once(&mut self, ctx: &Context) -> ExecResult {
+        match self.procedure.execute(ctx).await {
+            Ok(status) => {
+                if status.need_persist() && self.persist_procedure().await.is_err() {
+                    return ExecResult::RetryLater;
+                }
+
+                match status {
+                    Status::Executing { .. } => (),
+                    Status::Suspended { subprocedures, .. } => {
+                        self.on_suspended(subprocedures).await;
                     }
-
-                    match status {
-                        Status::Executing { .. } => (),
-                        Status::Suspended { subprocedures, .. } => {
-                            self.on_suspended(subprocedures).await;
+                    Status::Done => {
+                        if self.commit_procedure().await.is_err() {
+                            return ExecResult::RetryLater;
                         }
-                        Status::Done => {
-                            if self.commit_procedure().await.is_err() {
-                                self.wait_on_err().await;
-                                continue;
-                            }
 
-                            self.done();
-                            return Ok(());
-                        }
+                        self.done();
+                        return ExecResult::Done;
                     }
                 }
-                Err(e) => {
-                    logging::error!(
-                        e;
-                        "Failed to execute procedure {}-{}",
-                        self.procedure.type_name(),
-                        self.meta.id
-                    );
 
-                    self.meta.set_state(ProcedureState::Failed);
+                ExecResult::Continue
+            }
+            Err(e) => {
+                logging::error!(
+                    e;
+                    "Failed to execute procedure {}-{}",
+                    self.procedure.type_name(),
+                    self.meta.id
+                );
 
-                    // Write rollback key so we can skip this procedure while recovering procedures.
-                    if self.rollback_procedure().await.is_err() {
-                        self.wait_on_err().await;
-                        continue;
-                    }
+                self.meta.set_state(ProcedureState::Failed);
 
-                    return Err(e);
+                // Write rollback key so we can skip this procedure while recovering procedures.
+                if self.rollback_procedure().await.is_err() {
+                    return ExecResult::RetryLater;
                 }
+
+                ExecResult::Failed(e)
             }
         }
     }
@@ -210,7 +245,16 @@ impl Runner {
     }
 
     async fn on_suspended(&self, subprocedures: Vec<ProcedureWithId>) {
+        let has_child = !subprocedures.is_empty();
         for subprocedure in subprocedures {
+            logging::info!(
+                "Procedure {}-{} submit subprocedure {}-{}",
+                self.procedure.type_name(),
+                self.meta.id,
+                subprocedure.procedure.type_name(),
+                subprocedure.id
+            );
+
             self.submit_subprocedure(subprocedure.id, subprocedure.procedure);
         }
 
@@ -221,13 +265,15 @@ impl Runner {
         );
 
         // Wait for subprocedures.
-        self.meta.child_notify.notified().await;
+        if has_child {
+            self.meta.child_notify.notified().await;
 
-        logging::info!(
-            "Procedure {}-{} is waked up",
-            self.procedure.type_name(),
-            self.meta.id,
-        );
+            logging::info!(
+                "Procedure {}-{} is waked up",
+                self.procedure.type_name(),
+                self.meta.id,
+            );
+        }
     }
 
     async fn persist_procedure(&mut self) -> Result<()> {
@@ -294,9 +340,309 @@ impl Runner {
         // Mark the state of this procedure to done.
         self.meta.set_state(ProcedureState::Done);
 
-        // Notify parent procedure.
+        // Notify parent procedure, remember to update state first.
         if let Some(parent_id) = self.meta.parent_id {
             self.manager_ctx.notify_by_subprocedure(parent_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use common_error::mock::MockError;
+    use common_error::prelude::StatusCode;
+    use futures_util::future::BoxFuture;
+    use futures_util::{FutureExt, TryStreamExt};
+    use object_store::ObjectStore;
+    use tempdir::TempDir;
+
+    use super::*;
+    use crate::local::test_util;
+    use crate::store::ObjectStateStore;
+    use crate::{LockKey, Procedure};
+
+    const ROOT_ID: &str = "9f805a1f-05f7-490c-9f91-bd56e3cc54c1";
+
+    fn new_runner(
+        meta: ProcedureMetaRef,
+        procedure: BoxedProcedure,
+        store: ProcedureStore,
+    ) -> Runner {
+        Runner {
+            meta,
+            procedure,
+            manager_ctx: Arc::new(ManagerContext::new()),
+            step: 0,
+            store,
+        }
+    }
+
+    fn new_procedure_store(object_store: ObjectStore) -> ProcedureStore {
+        let state_store = ObjectStateStore::new(object_store);
+
+        ProcedureStore::new(Arc::new(state_store))
+    }
+
+    async fn check_files(object_store: &ObjectStore, procedure_id: ProcedureId, files: &[&str]) {
+        let dir = format!("{procedure_id}/");
+        let object = object_store.object(&dir);
+        let lister = object.list().await.unwrap();
+        let mut files_in_dir: Vec<_> = lister
+            .map_ok(|de| de.name().to_string())
+            .try_collect()
+            .await
+            .unwrap();
+        files_in_dir.sort_unstable();
+        assert_eq!(files, files_in_dir);
+    }
+
+    #[derive(Debug)]
+    struct ProcedureAdapter<F> {
+        data: String,
+        lock_key: Option<LockKey>,
+        exec_fn: F,
+    }
+
+    impl<F> ProcedureAdapter<F> {
+        fn new_meta(&self, uuid: &str) -> ProcedureMetaRef {
+            let mut meta = test_util::procedure_meta_for_test();
+            meta.id = ProcedureId::parse_str(uuid).unwrap();
+            meta.lock_key = self.lock_key.clone();
+
+            Arc::new(meta)
+        }
+    }
+
+    #[async_trait]
+    impl<F> Procedure for ProcedureAdapter<F>
+    where
+        F: FnMut() -> BoxFuture<'static, Result<Status>> + Send + Sync,
+    {
+        fn type_name(&self) -> &str {
+            "ProcedureAdapter"
+        }
+
+        async fn execute(&mut self, _ctx: &Context) -> Result<Status> {
+            let f = (self.exec_fn)();
+            f.await
+        }
+
+        fn dump(&self) -> Result<String> {
+            Ok(self.data.clone())
+        }
+
+        fn lock_key(&self) -> Option<LockKey> {
+            self.lock_key.clone()
+        }
+    }
+
+    async fn execute_once_normal(persist: bool, first_files: &[&str], second_files: &[&str]) {
+        let mut times = 0;
+        let exec_fn = move || {
+            times += 1;
+            async move {
+                if times == 1 {
+                    Ok(Status::Executing { persist })
+                } else {
+                    Ok(Status::Done)
+                }
+            }
+            .boxed()
+        };
+        let normal = ProcedureAdapter {
+            data: "normal".to_string(),
+            lock_key: Some(LockKey::new("catalog.schema.table")),
+            exec_fn,
+        };
+
+        let dir = TempDir::new("normal").unwrap();
+        let meta = normal.new_meta(ROOT_ID);
+        let ctx = Context {
+            procedure_id: meta.id,
+        };
+        let object_store = test_util::new_object_store(&dir);
+        let procedure_store = new_procedure_store(object_store.clone());
+        let mut runner = new_runner(meta, Box::new(normal), procedure_store);
+
+        let res = runner.execute_once(&ctx).await;
+        assert!(res.is_continue(), "{res:?}");
+        check_files(&object_store, ctx.procedure_id, first_files).await;
+
+        let res = runner.execute_once(&ctx).await;
+        assert!(res.is_done(), "{res:?}");
+        check_files(&object_store, ctx.procedure_id, second_files).await;
+    }
+
+    #[tokio::test]
+    async fn test_execute_once_normal() {
+        execute_once_normal(
+            true,
+            &["0000000000.step"],
+            &["0000000000.step", "0000000001.commit"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_execute_once_normal_skip_persist() {
+        execute_once_normal(false, &[], &["0000000000.commit"]).await;
+    }
+
+    #[tokio::test]
+    async fn test_on_suspend_empty() {
+        let exec_fn = move || {
+            async move {
+                Ok(Status::Suspended {
+                    subprocedures: Vec::new(),
+                    persist: false,
+                })
+            }
+            .boxed()
+        };
+        let suspend = ProcedureAdapter {
+            data: "suspend".to_string(),
+            lock_key: Some(LockKey::new("catalog.schema.table")),
+            exec_fn,
+        };
+
+        let dir = TempDir::new("suspend").unwrap();
+        let meta = suspend.new_meta(ROOT_ID);
+        let ctx = Context {
+            procedure_id: meta.id,
+        };
+        let object_store = test_util::new_object_store(&dir);
+        let procedure_store = new_procedure_store(object_store.clone());
+        let mut runner = new_runner(meta, Box::new(suspend), procedure_store);
+
+        let res = runner.execute_once(&ctx).await;
+        assert!(res.is_continue(), "{res:?}");
+    }
+
+    fn new_child_procedure(procedure_id: ProcedureId) -> ProcedureWithId {
+        let mut times = 0;
+        let exec_fn = move || {
+            times += 1;
+            async move {
+                if times == 1 {
+                    time::sleep(Duration::from_millis(200)).await;
+                    Ok(Status::Executing { persist: true })
+                } else {
+                    Ok(Status::Done)
+                }
+            }
+            .boxed()
+        };
+        let child = ProcedureAdapter {
+            data: "child".to_string(),
+            // Acquire the same lock as parent's.
+            lock_key: Some(LockKey::new("catalog.schema.table")),
+            exec_fn,
+        };
+
+        ProcedureWithId {
+            id: procedure_id,
+            procedure: Box::new(child),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_on_suspend_by_subprocedures() {
+        let mut times = 0;
+        let children_ids = [ProcedureId::random(), ProcedureId::random()];
+        let manager_ctx = Arc::new(ManagerContext::new());
+
+        let ctx_in_fn = manager_ctx.clone();
+        let exec_fn = move || {
+            times += 1;
+            let ctx_in_future = ctx_in_fn.clone();
+
+            async move {
+                if times == 1 {
+                    // Submit subprocedures.
+                    Ok(Status::Suspended {
+                        subprocedures: children_ids.into_iter().map(new_child_procedure).collect(),
+                        persist: true,
+                    })
+                } else {
+                    // Wait for subprocedures.
+                    let all_child_done = children_ids
+                        .iter()
+                        .all(|id| ctx_in_future.state(*id) == Some(ProcedureState::Done));
+                    if all_child_done {
+                        return Ok(Status::Done);
+                    } else {
+                        // Return suspended to wait for notify.
+                        Ok(Status::Suspended {
+                            subprocedures: Vec::new(),
+                            persist: false,
+                        })
+                    }
+                }
+            }
+            .boxed()
+        };
+        let parent = ProcedureAdapter {
+            data: "parent".to_string(),
+            lock_key: Some(LockKey::new("catalog.schema.table")),
+            exec_fn,
+        };
+
+        let dir = TempDir::new("parent").unwrap();
+        let meta = parent.new_meta(ROOT_ID);
+        let procedure_id = meta.id;
+        // Manually add this procedure to the manager ctx.
+        manager_ctx.insert_procedure(meta.clone());
+
+        let object_store = test_util::new_object_store(&dir);
+        let procedure_store = new_procedure_store(object_store.clone());
+        let mut runner = new_runner(meta, Box::new(parent), procedure_store);
+        // Replace the manager ctx.
+        runner.manager_ctx = manager_ctx;
+
+        runner.run().await.unwrap();
+
+        // Check files on store.
+        for child_id in children_ids {
+            check_files(
+                &object_store,
+                child_id,
+                &["0000000000.step", "0000000001.commit"],
+            )
+            .await;
+        }
+        check_files(
+            &object_store,
+            procedure_id,
+            &["0000000000.step", "0000000001.commit"],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_execute_on_error() {
+        let exec_fn =
+            || async { Err(Error::external(MockError::new(StatusCode::Unexpected))) }.boxed();
+        let fail = ProcedureAdapter {
+            data: "fail".to_string(),
+            lock_key: Some(LockKey::new("catalog.schema.table")),
+            exec_fn,
+        };
+
+        let dir = TempDir::new("fail").unwrap();
+        let meta = fail.new_meta(ROOT_ID);
+        let ctx = Context {
+            procedure_id: meta.id,
+        };
+        let object_store = test_util::new_object_store(&dir);
+        let procedure_store = new_procedure_store(object_store.clone());
+        let mut runner = new_runner(meta.clone(), Box::new(fail), procedure_store);
+
+        let res = runner.execute_once(&ctx).await;
+        assert!(res.is_failed(), "{res:?}");
+        assert_eq!(ProcedureState::Failed, meta.state());
+        check_files(&object_store, ctx.procedure_id, &["0000000000.rollback"]).await;
     }
 }

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use crate::error::Result;
 
 /// Procedure execution status.
+#[derive(Debug)]
 pub enum Status {
     /// The procedure is still executing.
     Executing {
@@ -118,6 +119,12 @@ impl ProcedureWithId {
             id: ProcedureId::random(),
             procedure,
         }
+    }
+}
+
+impl fmt::Debug for ProcedureWithId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}-{}", self.procedure.type_name(), self.id)
     }
 }
 

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -36,6 +36,8 @@ pub struct ProcedureMessage {
     pub data: String,
     /// Parent procedure id.
     pub parent_id: Option<ProcedureId>,
+    /// Current step.
+    pub step: u32,
 }
 
 /// Procedure storage layer.
@@ -63,6 +65,7 @@ impl ProcedureStore {
             type_name: type_name.to_string(),
             data,
             parent_id,
+            step,
         };
         let key = ParsedKey {
             procedure_id,
@@ -306,12 +309,13 @@ mod tests {
             type_name: "TestMessage".to_string(),
             data: "no parent id".to_string(),
             parent_id: None,
+            step: 4,
         };
 
         let json = serde_json::to_string(&message).unwrap();
         assert_eq!(
             json,
-            r#"{"type_name":"TestMessage","data":"no parent id","parent_id":null}"#
+            r#"{"type_name":"TestMessage","data":"no parent id","parent_id":null,"step":4}"#
         );
 
         let procedure_id = ProcedureId::parse_str("9f805a1f-05f7-490c-9f91-bd56e3cc54c1").unwrap();
@@ -381,6 +385,7 @@ mod tests {
             type_name: "MockProcedure".to_string(),
             data: "test store procedure".to_string(),
             parent_id: None,
+            step: 0,
         };
         assert_eq!(expect, *msg);
     }

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -49,7 +49,7 @@ impl ProcedureStore {
     }
 
     /// Dump the `procedure` to the storage.
-    async fn store_procedure(
+    pub(crate) async fn store_procedure(
         &self,
         procedure_id: ProcedureId,
         step: u32,
@@ -78,7 +78,11 @@ impl ProcedureStore {
     }
 
     /// Write commit flag to the storage.
-    async fn commit_procedure(&self, procedure_id: ProcedureId, step: u32) -> Result<()> {
+    pub(crate) async fn commit_procedure(
+        &self,
+        procedure_id: ProcedureId,
+        step: u32,
+    ) -> Result<()> {
         let key = ParsedKey {
             procedure_id,
             step,

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -323,7 +323,7 @@ mod tests {
         let json = serde_json::to_string(&message).unwrap();
         assert_eq!(
             json,
-            r#"{"type_name":"TestMessage","data":"no parent id","parent_id":"9f805a1f-05f7-490c-9f91-bd56e3cc54c1"}"#
+            r#"{"type_name":"TestMessage","data":"no parent id","parent_id":"9f805a1f-05f7-490c-9f91-bd56e3cc54c1","step":4}"#
         );
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

LocalManager now actually executes procedures submitted to it.

The Runner executes the procedure in the `execute_procedure_in_loop` method
```rust
loop {
    match self.execute_once(&ctx).await {
        ExecResult::Continue => (),
        ExecResult::Done => return Ok(()),
        ExecResult::RetryLater => {
            self.wait_on_err().await;
        }
        ExecResult::Failed(e) => return Err(e),
    }
}
```

The Runner now supports subprocedures:
- Procedure can return `Status::Suspended` to submit subprocedures
- The Runner submits the subprocedures in `Runner::submit_subprocedure`
  - It inherits parent_locks from the parent procedure
  - It setups the parent_id of the subprocedure's metadata and push the child to its parent's children list
  - It uses another runner to execute the subprocedure
- The parent procedure waits for notification from subprocedures. When a subprocedure is done, it notifies its parent via `notify_by_subprocedure()` method

It adds a `children` field to the `ExecMeta` to store children of the current procedure
```rust
#[derive(Debug)]
struct ExecMeta {
    state: ProcedureState,
    children: Vec<ProcedureId>,
}
```

`ManagerContext` provides a `procedures_in_tree()` method to collect all procedures in the procedure tree
```rust
fn procedures_in_tree(&self, root: &ProcedureMetaRef) -> Vec<ProcedureId> {}
```

### Design Changes
A deadlock happens if a subprocedure acquires the same lock key as its parent.

The main concern is if the subprocedure directly inherits its parent's lock, then how should we behave when multiple subprocedures acquire this same lock? Each procedure may assume it has unique access to the same object but it actually shares the resource with others.

Now subprocedures need to use different keys to lock objects, which is reasonable. For example:
- A parent procedure wants to create a table so it locks the table with a key like `catalog.schema.table`
- Subprocedures create regions for the table so they lock the regions with keys `catalog.schema.table.region-0 ~ catalog.schema.table.region-n`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 
