### PR TITLE
build(ci): disable release workflow for forked repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
             os: macos-latest
             file: greptime-darwin-amd64
     runs-on: ${{ matrix.os }}
+    if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -132,6 +133,7 @@ jobs:
     name: Release artifacts
     needs: [build]
     runs-on: ubuntu-latest
+    if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -174,6 +176,7 @@ jobs:
     name: Build docker image
     needs: [build]
     runs-on: ubuntu-latest
+    if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Prevent the release job from running on the forked repo by [adding conditions](https://github.com/orgs/community/discussions/26704), so that I don't need to receive the report email every time it's triggered.

<img width="533" alt="image" src="https://user-images.githubusercontent.com/15380403/217169598-d7f5f46a-eab0-4338-a9fe-f723b93d43a3.png">
 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
