### PR TITLE
chore: alias sqlness subcommand

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[alias]
+sqlness = "run --bin sqlness-runner --"

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -138,7 +138,7 @@ jobs:
           sudo cp -a /tmp/etcd-download/etcd* /usr/local/bin/
           nohup etcd >/tmp/etcd.log 2>&1 &
       - name: Run sqlness
-        run: cargo run --bin sqlness-runner && ls /tmp
+        run: cargo sqlness && ls /tmp
       - name: Upload sqlness logs
         uses: actions/upload-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ integration-test: ## Run integation test.
 
 .PHONY: sqlness-test
 sqlness-test: ## Run sqlness test.
-	cargo run --bin sqlness-runner
+	cargo sqlness
 
 .PHONY: check
 check: ## Cargo check all the targets.

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,7 +31,7 @@ Sqlness walks through every file recursively and runs them.
 ## Run the test
 Unlike other tests, this harness is in a binary target form. You can run it with
 ```shell
-cargo run --bin sqlness-runner
+cargo sqlness
 ```
 It automatically finishes the following procedures: compile `GreptimeDB`, start it, grab tests and feed it to
 the server, then collect and compare the results. You only need to check whether there are new `.output` files.


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

simplify the sqlness command to `cargo sqlness`. But the previous `cargo run --bin sqlness-runner` is still avaliable

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
