### PR TITLE
fix: Sql Inline Primary Key definition

### DIFF
--- a/src/datanode/src/sql/create.rs
+++ b/src/datanode/src/sql/create.rs
@@ -147,11 +147,11 @@ impl SqlHandler {
                     })
             })
             .enumerate()
-            .map(|(_, col)| &col.name.value)
+            .map(|(_, col)| col.name.value.clone())
             .collect::<Vec<_>>();
 
         for pk in pk_map.iter() {
-            primary_keys.push(*col_map.get(pk.clone()).context(KeyColumnNotFoundSnafu {
+            primary_keys.push(*col_map.get(&pk.clone()).context(KeyColumnNotFoundSnafu {
                 name: pk.to_string(),
             })?);
         }

--- a/tests/cases/standalone/create/create.result
+++ b/tests/cases/standalone/create/create.result
@@ -110,6 +110,10 @@ CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STR
 
 Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found
 
+CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
+
+Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found
+
 CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);
 
 Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found

--- a/tests/cases/standalone/create/create.result
+++ b/tests/cases/standalone/create/create.result
@@ -88,3 +88,25 @@ DROP TABLE test2;
 
 Affected Rows: 1
 
+CREATE TABLE test_pk (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE);
+
+Affected Rows: 0
+
+DESC TABLE test_pk;
+
++-----------+---------+------+---------+---------------+
+| Field     | Type    | Null | Default | Semantic Type |
++-----------+---------+------+---------+---------------+
+| timestamp | Int64   | NO   |         | TIME INDEX    |
+| host      | String  | YES  |         | PRIMARY KEY   |
+| value     | Float64 | YES  |         | VALUE         |
++-----------+---------+------+---------+---------------+
+
+DROP TABLE test_pk;
+
+Affected Rows: 1
+
+CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));
+
+Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found
+

--- a/tests/cases/standalone/create/create.result
+++ b/tests/cases/standalone/create/create.result
@@ -110,3 +110,7 @@ CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STR
 
 Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found
 
+CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);
+
+Error: 1004(InvalidArguments), Invalid primary key: Multiple definitions of primary key found
+

--- a/tests/cases/standalone/create/create.sql
+++ b/tests/cases/standalone/create/create.sql
@@ -35,3 +35,11 @@ DROP TABLE times;
 DROP TABLE test1;
 
 DROP TABLE test2;
+
+CREATE TABLE test_pk (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE);
+
+DESC TABLE test_pk;
+
+DROP TABLE test_pk;
+
+CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));

--- a/tests/cases/standalone/create/create.sql
+++ b/tests/cases/standalone/create/create.sql
@@ -47,3 +47,4 @@ CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STR
 CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
 
 CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);
+

--- a/tests/cases/standalone/create/create.sql
+++ b/tests/cases/standalone/create/create.sql
@@ -44,4 +44,6 @@ DROP TABLE test_pk;
 
 CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));
 
+CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
+
 CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);

--- a/tests/cases/standalone/create/create.sql
+++ b/tests/cases/standalone/create/create.sql
@@ -43,3 +43,5 @@ DESC TABLE test_pk;
 DROP TABLE test_pk;
 
 CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));
+
+CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Loop through the Column Options for CreateTableRequest to find the inline primary key

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
[issues/923](https://github.com/GreptimeTeam/greptimedb/issues/923)