### PR TITLE
fix: setting postgres query context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
- "lru",
+ "lru 0.8.1",
  "mio",
  "mysql_common",
  "once_cell",
@@ -4834,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c2d164b7e92ef8f93e4e4588097804dd7aa275465b29e169b0fb2d36270890a"
+checksum = "e340551bf363d84f7f25be77eedf85d1fd40f7894de252647486049a781f9c4e"
 dependencies = [
  "async-trait",
  "base64 0.21.0",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -38,7 +38,7 @@ num_cpus = "1.13"
 once_cell = "1.16"
 openmetrics-parser = "0.4"
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "b44c9d1360da297b305abf33aecfa94888e1554c" }
-pgwire = "0.9.1"
+pgwire = "0.10"
 pin-project = "1.0"
 prost.workspace = true
 query = { path = "../query" }

--- a/src/servers/src/postgres/server.rs
+++ b/src/servers/src/postgres/server.rs
@@ -21,6 +21,7 @@ use common_runtime::Runtime;
 use common_telemetry::logging::error;
 use common_telemetry::{debug, warn};
 use futures::StreamExt;
+use pgwire::api::MakeHandler;
 use pgwire::tokio::process_socket;
 use tokio;
 use tokio_rustls::TlsAcceptor;
@@ -71,7 +72,7 @@ impl PostgresServer {
         accepting_stream.for_each(move |tcp_stream| {
             let io_runtime = io_runtime.clone();
             let tls_acceptor = tls_acceptor.clone();
-            let handler = handler.clone();
+            let handler = handler.make();
 
             async move {
                 match tcp_stream {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -23,6 +23,7 @@ use common_telemetry::debug;
 pub type QueryContextRef = Arc<QueryContext>;
 pub type ConnInfoRef = Arc<ConnInfo>;
 
+#[derive(Debug)]
 pub struct QueryContext {
     current_catalog: ArcSwap<String>,
     current_schema: ArcSwap<String>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This is a design issue introduced in #914 and recent version of pgwire. In order to share state (reuse query context) between authenticator and query processors, we must ensure it's the same instance. The previous implementation recreate instance for each authenticator and query processor, causing the issue that it always uses default query context when processing query.

Content of this patch are mostly APIs changes in pgwire 0.9 -> 0.10. Key changes happen in:

- https://github.com/sunng87/pgwire/pull/51/files
- https://github.com/GreptimeTeam/greptimedb/pull/958/files#diff-e9848216200f785abc4e7134221158d9026b87896d50908b12aa407d6e973f48

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
