### PR TITLE
feat: supports passing user params into coprocessor

### DIFF
--- a/src/datanode/src/instance/script.rs
+++ b/src/datanode/src/instance/script.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use common_query::Output;
 use common_telemetry::timer;
@@ -34,8 +36,15 @@ impl ScriptHandler for Instance {
             .await
     }
 
-    async fn execute_script(&self, schema: &str, name: &str) -> servers::error::Result<Output> {
+    async fn execute_script(
+        &self,
+        schema: &str,
+        name: &str,
+        params: HashMap<String, String>,
+    ) -> servers::error::Result<Output> {
         let _timer = timer!(metric::METRIC_RUN_SCRIPT_ELAPSED);
-        self.script_executor.execute_script(schema, name).await
+        self.script_executor
+            .execute_script(schema, name, params)
+            .await
     }
 }

--- a/src/datanode/src/script.rs
+++ b/src/datanode/src/script.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use catalog::CatalogManagerRef;
 use common_query::Output;
 use query::QueryEngineRef;
@@ -34,13 +36,19 @@ mod dummy {
 
         pub async fn insert_script(
             &self,
+            _schema: &str,
             _name: &str,
             _script: &str,
         ) -> servers::error::Result<()> {
             servers::error::NotSupportedSnafu { feat: "script" }.fail()
         }
 
-        pub async fn execute_script(&self, _script: &str) -> servers::error::Result<Output> {
+        pub async fn execute_script(
+            &self,
+            _schema: &str,
+            _name: &str,
+            _params: HashMap<String, String>,
+        ) -> servers::error::Result<Output> {
             servers::error::NotSupportedSnafu { feat: "script" }.fail()
         }
     }
@@ -94,9 +102,10 @@ mod python {
             &self,
             schema: &str,
             name: &str,
+            params: HashMap<String, String>,
         ) -> servers::error::Result<Output> {
             self.script_manager
-                .execute(schema, name)
+                .execute(schema, name, params)
                 .await
                 .map_err(|e| {
                     error!(e; "Instance failed to execute script");

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -19,6 +19,7 @@ mod opentsdb;
 mod prometheus;
 mod standalone;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -508,9 +509,14 @@ impl ScriptHandler for Instance {
         }
     }
 
-    async fn execute_script(&self, schema: &str, script: &str) -> server_error::Result<Output> {
+    async fn execute_script(
+        &self,
+        schema: &str,
+        script: &str,
+        params: HashMap<String, String>,
+    ) -> server_error::Result<Output> {
         if let Some(handler) = &self.script_handler {
-            handler.execute_script(schema, script).await
+            handler.execute_script(schema, script, params).await
         } else {
             server_error::NotSupportedSnafu {
                 feat: "Script execution in Frontend",

--- a/src/script/src/engine.rs
+++ b/src/script/src/engine.rs
@@ -15,6 +15,7 @@
 //! Script engine
 
 use std::any::Any;
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use common_error::ext::ErrorExt;
@@ -30,7 +31,11 @@ pub trait Script {
     fn as_any(&self) -> &dyn Any;
 
     /// Execute the script and returns the output.
-    async fn execute(&self, ctx: EvalContext) -> std::result::Result<Output, Self::Error>;
+    async fn execute(
+        &self,
+        params: HashMap<String, String>,
+        ctx: EvalContext,
+    ) -> std::result::Result<Output, Self::Error>;
 }
 
 #[async_trait]

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -76,7 +76,12 @@ impl ScriptManager {
         Ok(compiled_script)
     }
 
-    pub async fn execute(&self, schema: &str, name: &str) -> Result<Output> {
+    pub async fn execute(
+        &self,
+        schema: &str,
+        name: &str,
+        params: HashMap<String, String>,
+    ) -> Result<Output> {
         let script = {
             let s = self.compiled.read().unwrap().get(name).cloned();
 
@@ -90,7 +95,7 @@ impl ScriptManager {
         let script = script.context(ScriptNotFoundSnafu { name })?;
 
         script
-            .execute(EvalContext::default())
+            .execute(params, EvalContext::default())
             .await
             .context(ExecutePythonSnafu { name })
     }

--- a/src/script/src/python/builtins.rs
+++ b/src/script/src/python/builtins.rs
@@ -97,7 +97,7 @@ pub fn try_into_columnar_value(obj: PyObjectRef, vm: &VirtualMachine) -> PyResul
             .borrow_vec()
             .iter()
             .map(|obj| -> PyResult<ScalarValue> {
-                let col = try_into_columnar_value(obj.to_owned(), vm)?;
+                let col = try_into_columnar_value(obj.clone(), vm)?;
                 match col {
                     DFColValue::Array(arr) => Err(vm.new_type_error(format!(
                         "Expect only scalar value in a list, found a vector of type {:?} nested in list", arr.data_type()
@@ -243,7 +243,7 @@ macro_rules! bind_aggr_fn {
                 $(
                     Arc::new(expressions::Column::new(stringify!($EXPR_ARGS), 0)) as _,
                 )*
-                    stringify!($AGGR_FUNC), $DATA_TYPE.to_owned()),
+                    stringify!($AGGR_FUNC), $DATA_TYPE.clone()),
             $ARGS, $VM)
     };
 }
@@ -597,7 +597,7 @@ pub(crate) mod greptime_builtin {
                     Arc::new(percent) as _,
                 ],
                 "ApproxPercentileCont",
-                (values.to_arrow_array().data_type()).to_owned(),
+                (values.to_arrow_array().data_type()).clone(),
             )
             .map_err(|err| from_df_err(err, vm))?,
             &[values.to_arrow_array()],
@@ -839,7 +839,7 @@ pub(crate) mod greptime_builtin {
             return Ok(ret.into());
         }
         let cur = cur.slice(0, cur.len() - 1); // except the last one that is
-        let fill = gen_none_array(cur.data_type().to_owned(), 1, vm)?;
+        let fill = gen_none_array(cur.data_type().clone(), 1, vm)?;
         let ret = compute::concat(&[&*fill, &*cur]).map_err(|err| {
             vm.new_runtime_error(format!("Can't concat array[0] with array[0:-1]!{err:#?}"))
         })?;
@@ -864,7 +864,7 @@ pub(crate) mod greptime_builtin {
             return Ok(ret.into());
         }
         let cur = cur.slice(1, cur.len() - 1); // except the last one that is
-        let fill = gen_none_array(cur.data_type().to_owned(), 1, vm)?;
+        let fill = gen_none_array(cur.data_type().clone(), 1, vm)?;
         let ret = compute::concat(&[&*cur, &*fill]).map_err(|err| {
             vm.new_runtime_error(format!("Can't concat array[0] with array[0:-1]!{err:#?}"))
         })?;
@@ -1048,7 +1048,7 @@ pub(crate) mod greptime_builtin {
             match (ch.is_ascii_digit(), &state) {
                 (true, State::Separator(_)) => {
                     let res = &input[prev..idx];
-                    let res = State::Separator(res.to_owned());
+                    let res = State::Separator(res.to_string());
                     parsed.push(res);
                     prev = idx;
                     state = State::Num(Default::default());
@@ -1073,7 +1073,7 @@ pub(crate) mod greptime_builtin {
             }
             State::Separator(_) => {
                 let res = &input[prev..];
-                State::Separator(res.to_owned())
+                State::Separator(res.to_string())
             }
         };
         parsed.push(last);

--- a/src/script/src/python/builtins/test.rs
+++ b/src/script/src/python/builtins/test.rs
@@ -240,10 +240,7 @@ impl PyValue {
                     .as_any()
                     .downcast_ref::<Float64Array>()
                     .ok_or(format!("Can't cast {vec_f64:#?} to Float64Array!"))?;
-                let ret = vec_f64
-                    .into_iter()
-                    .map(|v| v.map(|inner| inner.to_owned()))
-                    .collect::<Vec<_>>();
+                let ret = vec_f64.into_iter().collect::<Vec<_>>();
                 if ret.iter().all(|x| x.is_some()) {
                     Ok(Self::FloatVec(
                         ret.into_iter().map(|i| i.unwrap()).collect(),
@@ -266,7 +263,6 @@ impl PyValue {
                         v.ok_or(format!(
                             "No null element expected, found one in {idx} position"
                         ))
-                        .map(|v| v.to_owned())
                     })
                     .collect::<Result<_, String>>()?;
                 Ok(Self::IntVec(ret))
@@ -275,13 +271,13 @@ impl PyValue {
             }
         } else if is_instance::<PyInt>(obj, vm) {
             let res = obj
-                .to_owned()
+                .clone()
                 .try_into_value::<i64>(vm)
                 .map_err(|err| format_py_error(err, vm).to_string())?;
             Ok(Self::Int(res))
         } else if is_instance::<PyFloat>(obj, vm) {
             let res = obj
-                .to_owned()
+                .clone()
                 .try_into_value::<f64>(vm)
                 .map_err(|err| format_py_error(err, vm).to_string())?;
             Ok(Self::Float(res))
@@ -338,7 +334,7 @@ fn run_builtin_fn_testcases() {
                 .compile(
                     &case.script,
                     rustpython_compiler_core::Mode::BlockExpr,
-                    "<embedded>".to_owned(),
+                    "<embedded>".to_string(),
                 )
                 .map_err(|err| vm.new_syntax_error(&err))
                 .unwrap();
@@ -389,7 +385,7 @@ fn set_item_into_scope(
     scope
         .locals
         .as_object()
-        .set_item(&name.to_owned(), vm.new_pyobj(value), vm)
+        .set_item(&name.to_string(), vm.new_pyobj(value), vm)
         .map_err(|err| {
             format!(
                 "Error in setting var {name} in scope: \n{}",
@@ -408,7 +404,7 @@ fn set_lst_of_vecs_in_scope(
         scope
             .locals
             .as_object()
-            .set_item(name.to_owned(), vm.new_pyobj(vector), vm)
+            .set_item(&name.to_string(), vm.new_pyobj(vector), vm)
             .map_err(|err| {
                 format!(
                     "Error in setting var {name} in scope: \n{}",
@@ -447,7 +443,7 @@ fn test_vm() {
 from udf_builtins import *
 sin(values)"#,
                 rustpython_compiler_core::Mode::BlockExpr,
-                "<embedded>".to_owned(),
+                "<embedded>".to_string(),
             )
             .map_err(|err| vm.new_syntax_error(&err))
             .unwrap();

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -456,8 +456,9 @@ fn exec_with_cached_vm(
         PyVector::make_class(&vm.ctx);
         // set arguments with given name and values
         let scope = vm.new_scope_with_builtins();
-        set_items_in_scope(&scope, vm, &copr.deco_args.arg_names, args)?;
-        set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
+        if let Some(rb) = rb {
+            set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
+        }
 
         if let Some(arg_names) = &copr.deco_args.arg_names {
             assert_eq!(arg_names.len(), args.len());

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -16,7 +16,7 @@ pub mod compile;
 pub mod parse;
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
@@ -36,7 +36,7 @@ use rustpython_vm::AsObject;
 #[cfg(test)]
 use serde::Deserialize;
 use snafu::{OptionExt, ResultExt};
-use vm::builtins::{PyBaseExceptionRef, PyList, PyListRef, PyTuple};
+use vm::builtins::{PyBaseExceptionRef, PyDict, PyList, PyListRef, PyStr, PyTuple};
 use vm::convert::ToPyObject;
 use vm::scope::Scope;
 use vm::{pyclass, Interpreter, PyObjectRef, PyPayload, PyResult, VirtualMachine};
@@ -348,12 +348,12 @@ fn set_items_in_scope(
 /// You can return constant in python code like `return 1, 1.0, True`
 /// which create a constant array(with same value)(currently support int, float and bool) as column on return
 #[cfg(test)]
-pub fn exec_coprocessor(script: &str, rb: &RecordBatch) -> Result<RecordBatch> {
+pub fn exec_coprocessor(script: &str, rb: &Option<RecordBatch>) -> Result<RecordBatch> {
     // 1. parse the script and check if it's only a function with `@coprocessor` decorator, and get `args` and `returns`,
     // 2. also check for exist of `args` in `rb`, if not found, return error
     // TODO(discord9): cache the result of parse_copr
     let copr = parse::parse_and_compile_copr(script, None)?;
-    exec_parsed(&copr, rb)
+    exec_parsed(&copr, rb, &HashMap::new())
 }
 
 #[pyclass(module = false, name = "query_engine")]
@@ -445,10 +445,11 @@ fn set_query_engine_in_scope(
         .map_err(|e| format_py_error(e, vm))
 }
 
-pub(crate) fn exec_with_cached_vm(
+fn exec_with_cached_vm(
     copr: &Coprocessor,
-    rb: &RecordBatch,
+    rb: &Option<RecordBatch>,
     args: Vec<PyVector>,
+    params: &HashMap<String, String>,
     vm: &Arc<Interpreter>,
 ) -> Result<RecordBatch> {
     vm.enter(|vm| -> Result<RecordBatch> {
@@ -473,6 +474,19 @@ pub(crate) fn exec_with_cached_vm(
             set_query_engine_in_scope(&scope, vm, query_engine)?;
         }
 
+        if let Some(kwarg) = &copr.kwarg {
+            let dict = PyDict::new_ref(&vm.ctx);
+            for (k, v) in params {
+                dict.set_item(k, PyStr::from(v.clone()).into_pyobject(vm), vm)
+                    .map_err(|e| format_py_error(e, vm))?;
+            }
+            scope
+                .locals
+                .as_object()
+                .set_item(kwarg, vm.new_pyobj(dict), vm)
+                .map_err(|e| format_py_error(e, vm))?;
+        }
+
         // It's safe to unwrap code_object, it's already compiled before.
         let code_obj = vm.ctx.new_code(copr.code_obj.clone().unwrap());
         let ret = vm
@@ -480,21 +494,27 @@ pub(crate) fn exec_with_cached_vm(
             .map_err(|e| format_py_error(e, vm))?;
 
         // 5. get returns as either a PyVector or a PyTuple, and naming schema them according to `returns`
-        let col_len = rb.num_rows();
-        let mut cols = try_into_columns(&ret, vm, col_len)?;
-        ensure!(
-            cols.len() == copr.deco_args.ret_names.len(),
-            OtherSnafu {
-                reason: format!(
-                    "The number of return Vector is wrong, expect {}, found {}",
-                    copr.deco_args.ret_names.len(),
-                    cols.len()
-                )
-            }
-        );
+        let cols = if let Some(rb) = rb {
+            let col_len = rb.num_rows();
+            let mut cols = try_into_columns(&ret, vm, col_len)?;
+            ensure!(
+                cols.len() == copr.deco_args.ret_names.len(),
+                OtherSnafu {
+                    reason: format!(
+                        "The number of return Vector is wrong, expect {}, found {}",
+                        copr.deco_args.ret_names.len(),
+                        cols.len()
+                    )
+                }
+            );
 
-        // if cols and schema's data types is not match, try coerce it to given type(if annotated)(if error occur, return relevant error with question mark)
-        copr.check_and_cast_type(&mut cols)?;
+            // if cols and schema's data types is not match, try coerce it to given type(if annotated)(if error occur, return relevant error with question mark)
+            copr.check_and_cast_type(&mut cols)?;
+            cols
+        } else {
+            vec![]
+        };
+
         // 6. return a assembled DfRecordBatch
         let schema = copr.gen_schema(&cols)?;
         RecordBatch::new(schema, cols).context(NewRecordBatchSnafu)
@@ -544,14 +564,23 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
 }
 
 /// using a parsed `Coprocessor` struct as input to execute python code
-pub(crate) fn exec_parsed(copr: &Coprocessor, rb: &RecordBatch) -> Result<RecordBatch> {
+pub(crate) fn exec_parsed(
+    copr: &Coprocessor,
+    rb: &Option<RecordBatch>,
+    params: &HashMap<String, String>,
+) -> Result<RecordBatch> {
     // 3. get args from `rb`, and cast them into PyVector
-    let args: Vec<PyVector> =
-        select_from_rb(rb, copr.deco_args.arg_names.as_ref().unwrap_or(&vec![]))?;
-    check_args_anno_real_type(&args, copr, rb)?;
+    let args: Vec<PyVector> = if let Some(rb) = rb {
+        let args = select_from_rb(rb, copr.deco_args.arg_names.as_ref().unwrap_or(&vec![]))?;
+        check_args_anno_real_type(&args, copr, rb)?;
+        args
+    } else {
+        vec![]
+    };
+
     let interpreter = init_interpreter();
     // 4. then set args in scope and compile then run `CodeObject` which already append a new `Call` node
-    exec_with_cached_vm(copr, rb, args, &interpreter)
+    exec_with_cached_vm(copr, rb, args, params, &interpreter)
 }
 
 /// execute script just like [`exec_coprocessor`] do,
@@ -563,7 +592,7 @@ pub(crate) fn exec_parsed(copr: &Coprocessor, rb: &RecordBatch) -> Result<Record
 #[allow(dead_code)]
 pub fn exec_copr_print(
     script: &str,
-    rb: &RecordBatch,
+    rb: &Option<RecordBatch>,
     ln_offset: usize,
     filename: &str,
 ) -> StdResult<RecordBatch, String> {

--- a/src/script/src/python/coprocessor.rs
+++ b/src/script/src/python/coprocessor.rs
@@ -73,6 +73,8 @@ pub struct Coprocessor {
     pub arg_types: Vec<Option<AnnotationInfo>>,
     /// get from python function returns' annotation, first is type, second is is_nullable
     pub return_types: Vec<Option<AnnotationInfo>>,
+    /// kwargs in coprocessor function's signature
+    pub kwarg: Option<String>,
     /// store its corresponding script, also skip serde when in `cfg(test)` to reduce work in compare
     #[cfg_attr(test, serde(skip))]
     pub script: String,
@@ -582,7 +584,7 @@ def add(a, b):
     return a + b
 
 @copr(args=["a", "b", "c"], returns = ["r"], sql="select number as a,number as b,number as c from numbers limit 100")
-def test(a, b, c):
+def test(a, b, c, **params):
     import greptime as g
     return add(a, b) / g.sqrt(c)
 "#;
@@ -598,6 +600,7 @@ def test(a, b, c):
         assert_eq!(deco_args.arg_names.unwrap(), vec!["a", "b", "c"]);
         assert_eq!(copr.arg_types, vec![None, None, None]);
         assert_eq!(copr.return_types, vec![None]);
+        assert_eq!(copr.kwarg, Some("params".to_string()));
         assert_eq!(copr.script, script);
         assert!(copr.code_obj.is_some());
     }

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -156,7 +156,6 @@ pub fn compile_script(
         return fail_parse_error!(format!("Expect statement in script, found: {top:?}"), None);
     }
     // use `compile::Mode::BlockExpr` so it return the result of statement
-    println!("{:?}", top);
     compile_top(
         &top,
         "<embedded>".to_owned(),

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -37,17 +37,21 @@ fn gen_call(name: &str, deco_args: &DecoratorArgs, loc: &Location) -> ast::Stmt<
     // then the pretty print will point to the last line in code
     // instead of point to any of existing code written by user.
     loc.newline();
-    let args: Vec<Located<ast::ExprKind>> = deco_args
-        .arg_names
-        .iter()
-        .map(|v| {
-            let node = ast::ExprKind::Name {
-                id: v.to_owned(),
-                ctx: ast::ExprContext::Load,
-            };
-            create_located(node, loc)
-        })
-        .collect();
+    let args: Vec<Located<ast::ExprKind>> = if let Some(arg_names) = &deco_args.arg_names {
+        arg_names
+            .iter()
+            .map(|v| {
+                let node = ast::ExprKind::Name {
+                    id: v.to_owned(),
+                    ctx: ast::ExprContext::Load,
+                };
+                create_located(node, loc)
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
     let func = ast::ExprKind::Call {
         func: Box::new(create_located(
             ast::ExprKind::Name {

--- a/src/script/src/python/coprocessor/compile.rs
+++ b/src/script/src/python/coprocessor/compile.rs
@@ -37,7 +37,7 @@ fn gen_call(
     kwarg: &Option<String>,
     loc: &Location,
 ) -> ast::Stmt<()> {
-    let mut loc = loc.to_owned();
+    let mut loc = *loc;
     // adding a line to avoid confusing if any error occurs when calling the function
     // then the pretty print will point to the last line in code
     // instead of point to any of existing code written by user.
@@ -47,7 +47,7 @@ fn gen_call(
             .iter()
             .map(|v| {
                 let node = ast::ExprKind::Name {
-                    id: v.to_owned(),
+                    id: v.clone(),
                     ctx: ast::ExprContext::Load,
                 };
                 create_located(node, loc)
@@ -59,7 +59,7 @@ fn gen_call(
 
     if let Some(kwarg) = kwarg {
         let node = ast::ExprKind::Name {
-            id: kwarg.to_owned(),
+            id: kwarg.clone(),
             ctx: ast::ExprContext::Load,
         };
         args.push(create_located(node, loc));
@@ -116,7 +116,7 @@ pub fn compile_script(
                     if let Some(kwarg) = kwarg {
                         args.kwarg = None;
                         let node = ArgData {
-                            arg: kwarg.to_owned(),
+                            arg: kwarg.clone(),
                             annotation: None,
                             type_comment: Some("kwargs".to_string()),
                         };
@@ -158,7 +158,7 @@ pub fn compile_script(
     // use `compile::Mode::BlockExpr` so it return the result of statement
     compile_top(
         &top,
-        "<embedded>".to_owned(),
+        "<embedded>".to_string(),
         Mode::BlockExpr,
         CompileOpts { optimize: 0 },
     )

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -500,12 +500,14 @@ pub fn parse_and_compile_copr(
                         loc: None
                     }
                 );
+                let kwarg = fn_args.kwarg.as_ref().map(|arg| arg.node.arg.clone());
                 coprocessor = Some(Coprocessor {
-                    code_obj: Some(compile::compile_script(name, &deco_args, script)?),
+                    code_obj: Some(compile::compile_script(name, &deco_args, &kwarg, script)?),
                     name: name.to_string(),
                     deco_args,
                     arg_types,
                     return_types,
+                    kwarg,
                     script: script.to_owned(),
                     query_engine: query_engine.as_ref().map(|e| Arc::downgrade(e).into()),
                 });

--- a/src/script/src/python/coprocessor/parse.rs
+++ b/src/script/src/python/coprocessor/parse.rs
@@ -58,7 +58,7 @@ fn py_str_to_string(s: &ast::Expr<()>) -> Result<String> {
         kind: _,
     } = &s.node
     {
-        Ok(v.to_owned())
+        Ok(v.clone())
     } else {
         fail_parse_error!(
             format!(
@@ -100,10 +100,7 @@ fn try_into_datatype(ty: &str, loc: &Location) -> Result<Option<ConcreteDataType
         // for any datatype
         "_" => Ok(None),
         // note the different between "_" and _
-        _ => fail_parse_error!(
-            format!("Unknown datatype: {ty} at {loc:?}"),
-            Some(loc.to_owned())
-        ),
+        _ => fail_parse_error!(format!("Unknown datatype: {ty} at {loc:?}"), Some(*loc)),
     }
 }
 
@@ -508,7 +505,7 @@ pub fn parse_and_compile_copr(
                     arg_types,
                     return_types,
                     kwarg,
-                    script: script.to_owned(),
+                    script: script.to_string(),
                     query_engine: query_engine.as_ref().map(|e| Arc::downgrade(e).into()),
                 });
             }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -91,7 +91,7 @@ impl PyUDF {
         let col_sch: Vec<_> = columns
             .iter()
             .enumerate()
-            .map(|(i, col)| ColumnSchema::new(arg_names[i].to_owned(), col.data_type(), true))
+            .map(|(i, col)| ColumnSchema::new(arg_names[i].clone(), col.data_type(), true))
             .collect();
         let schema = datatypes::schema::Schema::new(col_sch);
         Arc::new(schema)
@@ -111,7 +111,7 @@ impl Function for PyUDF {
         match self.copr.return_types.get(0) {
             Some(Some(AnnotationInfo {
                 datatype: Some(ty), ..
-            })) => Ok(ty.to_owned()),
+            })) => Ok(ty.clone()),
             _ => PyUdfSnafu {
                 msg: "Can't found return type for python UDF {self}",
             }
@@ -127,7 +127,7 @@ impl Function for PyUDF {
             match ty {
                 Some(AnnotationInfo {
                     datatype: Some(ty), ..
-                }) => arg_types.push(ty.to_owned()),
+                }) => arg_types.push(ty.clone()),
                 _ => {
                     know_all_types = false;
                     break;
@@ -166,7 +166,7 @@ impl Function for PyUDF {
 
         // TODO(discord9): more error handling
         let res0 = res.column(0);
-        Ok(res0.to_owned())
+        Ok(res0.clone())
     }
 }
 
@@ -181,7 +181,7 @@ impl PyScript {
     pub fn register_udf(&self) {
         let udf = PyUDF::from_copr(self.copr.clone());
         PyUDF::register_as_udf(udf.clone());
-        PyUDF::register_to_query_engine(udf, self.query_engine.to_owned());
+        PyUDF::register_to_query_engine(udf, self.query_engine.clone());
     }
 }
 

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -345,7 +345,10 @@ def test(number)->vector[u32]:
             .compile(script, CompileContext::default())
             .await
             .unwrap();
-        let output = script.execute(EvalContext::default()).await.unwrap();
+        let output = script
+            .execute(HashMap::default(), EvalContext::default())
+            .await
+            .unwrap();
         let res = common_recordbatch::util::collect_batches(match output {
             Output::Stream(s) => s,
             _ => unreachable!(),

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -53,7 +53,12 @@ impl std::fmt::Display for PyUDF {
             f,
             "{}({})->",
             &self.copr.name,
-            &self.copr.deco_args.arg_names.join(",")
+            self.copr
+                .deco_args
+                .arg_names
+                .as_ref()
+                .unwrap_or(&vec![])
+                .join(",")
         )
     }
 }
@@ -73,7 +78,13 @@ impl PyUDF {
 
     /// Fake a schema, should only be used with dynamically eval a Python Udf
     fn fake_schema(&self, columns: &[VectorRef]) -> SchemaRef {
-        let arg_names = &self.copr.deco_args.arg_names;
+        let empty_args = vec![];
+        let arg_names = self
+            .copr
+            .deco_args
+            .arg_names
+            .as_ref()
+            .unwrap_or(&empty_args);
         let col_sch: Vec<_> = columns
             .iter()
             .enumerate()

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -216,7 +216,7 @@ pub fn visualize_loc(
 /// extract a reason for [`Error`] in string format, also return a location if possible
 pub fn get_error_reason_loc(err: &Error) -> (String, Option<Location>) {
     match err {
-        Error::CoprParse { reason, loc, .. } => (reason.clone(), loc.to_owned()),
+        Error::CoprParse { reason, loc, .. } => (reason.clone(), *loc),
         Error::Other { reason, .. } => (reason.clone(), None),
         Error::PyRuntime { msg, .. } => (msg.clone(), None),
         Error::PyParse { source, .. } => (source.error.to_string(), Some(source.location)),

--- a/src/script/src/python/test.rs
+++ b/src/script/src/python/test.rs
@@ -126,7 +126,7 @@ fn run_ron_testcases() {
             }
             Predicate::ExecIsOk { fields, columns } => {
                 let rb = create_sample_recordbatch();
-                let res = coprocessor::exec_coprocessor(&testcase.code, &rb).unwrap();
+                let res = coprocessor::exec_coprocessor(&testcase.code, &Some(rb)).unwrap();
                 fields
                     .iter()
                     .zip(res.schema.column_schemas())
@@ -152,7 +152,7 @@ fn run_ron_testcases() {
                 reason: part_reason,
             } => {
                 let rb = create_sample_recordbatch();
-                let res = coprocessor::exec_coprocessor(&testcase.code, &rb);
+                let res = coprocessor::exec_coprocessor(&testcase.code, &Some(rb));
                 assert!(res.is_err(), "{res:#?}\nExpect Err(...), actual Ok(...)");
                 if let Err(res) = res {
                     error!(
@@ -254,7 +254,7 @@ def calc_rvs(open_time, close):
         ],
     )
     .unwrap();
-    let ret = coprocessor::exec_coprocessor(python_source, &rb);
+    let ret = coprocessor::exec_coprocessor(python_source, &Some(rb));
     if let Err(Error::PyParse {
         backtrace: _,
         source,
@@ -304,7 +304,7 @@ def a(cpu, mem):
         ],
     )
     .unwrap();
-    let ret = coprocessor::exec_coprocessor(python_source, &rb);
+    let ret = coprocessor::exec_coprocessor(python_source, &Some(rb));
     if let Err(Error::PyParse {
         backtrace: _,
         source,

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -19,7 +19,7 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64], vector[f64|None], vecto
             result: (
                 name: "a",
                 deco_args: (
-                    arg_names: ["cpu", "mem"],
+                    arg_names: Some(["cpu", "mem"]),
                     ret_names: ["perf", "what", "how", "why"],
                 ),
                 arg_types: [
@@ -231,7 +231,7 @@ def a(cpu: vector[f64], mem: vector[f64])->(vector[f64|None], vector[into(f64)],
 "#,
         predicate: ParseIsErr(
             reason:
-            " keyword argument, found "
+            "Expect `returns` keyword"
         )
     ),
     (

--- a/src/script/src/python/testcases.ron
+++ b/src/script/src/python/testcases.ron
@@ -49,7 +49,62 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64], vector[f64|None], vecto
                         datatype: None,
                         is_nullable: true
                     )),
-                ]
+                ],
+                kwarg: None,
+            )
+        )
+    ),
+    (
+        name: "correct_parse_params",
+        code: r#"
+import greptime as gt
+from greptime import pow
+def add(a, b):
+    return a + b
+def sub(a, b):
+    return a - b
+@copr(args=["cpu", "mem"], returns=["perf", "what", "how", "why"])
+def a(cpu: vector[f32], mem: vector[f64], **params) -> (vector[f64], vector[f64|None], vector[_], vector[_ | None]):
+    for key, value in params.items():
+        print("%s == %s" % (key, value))
+    return add(cpu, mem), sub(cpu, mem), cpu * mem, cpu / mem
+        "#,
+        predicate: ParseIsOk(
+            result: (
+                name: "a",
+                deco_args: (
+                    arg_names: Some(["cpu", "mem"]),
+                    ret_names: ["perf", "what", "how", "why"],
+                ),
+                arg_types: [
+                    Some((
+                        datatype: Some(Float32(())),
+                        is_nullable: false
+                    )),
+                    Some((
+                        datatype: Some(Float64(())),
+                        is_nullable: false
+                    )),
+                ],
+                return_types: [
+                    Some((
+                        datatype: Some(Float64(())),
+                        is_nullable: false
+                    )),
+                    Some((
+                        datatype: Some(Float64(())),
+                        is_nullable: true
+                    )),
+                    Some((
+                        datatype: None,
+                        is_nullable: false
+                    )),
+                    Some((
+                        datatype: None,
+                        is_nullable: true
+                    )),
+                ],
+                kwarg: Some("params"),
             )
         )
     ),

--- a/src/script/src/python/vector.rs
+++ b/src/script/src/python/vector.rs
@@ -564,7 +564,7 @@ impl PyVector {
         // in the newest version of rustpython_vm, wrapped_at for isize is replace by wrap_index(i, len)
         let i = i
             .wrapped_at(self.len())
-            .ok_or_else(|| vm.new_index_error("PyVector index out of range".to_owned()))?;
+            .ok_or_else(|| vm.new_index_error("PyVector index out of range".to_string()))?;
         Ok(val_to_pyobj(self.as_vector_ref().get(i), vm))
     }
 
@@ -927,7 +927,7 @@ impl AsSequence for PyVector {
                 zelf.getitem_by_index(i, vm)
             }),
             ass_item: atomic_func!(|_seq, _i, _value, vm| {
-                Err(vm.new_type_error("PyVector object doesn't support item assigns".to_owned()))
+                Err(vm.new_type_error("PyVector object doesn't support item assigns".to_string()))
             }),
             ..PySequenceMethods::NOT_IMPLEMENTED
         });
@@ -1095,7 +1095,7 @@ pub mod tests {
                     .compile(
                         script,
                         rustpython_compiler_core::Mode::BlockExpr,
-                        "<embedded>".to_owned(),
+                        "<embedded>".to_string(),
                     )
                     .map_err(|err| vm.new_syntax_error(&err))?;
                 let ret = vm.run_code_obj(code_obj, scope);

--- a/src/servers/src/http/script.rs
+++ b/src/servers/src/http/script.rs
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+use std::collections::HashMap;
 use std::time::Instant;
 
 use axum::extract::{Json, Query, RawBody, State};
@@ -81,10 +81,12 @@ pub async fn scripts(
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Default)]
 pub struct ScriptQuery {
     pub schema: Option<String>,
     pub name: Option<String>,
+    #[serde(flatten)]
+    pub params: HashMap<String, String>,
 }
 
 /// Handler to execute script
@@ -110,7 +112,7 @@ pub async fn run_script(
         // TODO(sunng87): query_context and db name resolution
 
         let output = script_handler
-            .execute_script(schema.unwrap(), name.unwrap())
+            .execute_script(schema.unwrap(), name.unwrap(), params.params)
             .await;
         let resp = JsonResponse::from_output(vec![output]).await;
 

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -25,6 +25,7 @@
 pub mod grpc;
 pub mod sql;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use api::prometheus::remote::{ReadRequest, WriteRequest};
@@ -45,7 +46,12 @@ pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 #[async_trait]
 pub trait ScriptHandler {
     async fn insert_script(&self, schema: &str, name: &str, script: &str) -> Result<()>;
-    async fn execute_script(&self, schema: &str, name: &str) -> Result<Output>;
+    async fn execute_script(
+        &self,
+        schema: &str,
+        name: &str,
+        params: HashMap<String, String>,
+    ) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -156,6 +156,7 @@ fn create_script_query() -> Query<script_handler::ScriptQuery> {
     Query(script_handler::ScriptQuery {
         schema: Some("test".to_string()),
         name: Some("test".to_string()),
+        ..Default::default()
     })
 }
 
@@ -163,6 +164,7 @@ fn create_invalid_script_query() -> Query<script_handler::ScriptQuery> {
     Query(script_handler::ScriptQuery {
         schema: None,
         name: None,
+        ..Default::default()
     })
 }
 

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -120,12 +120,20 @@ impl ScriptHandler for DummyInstance {
         Ok(())
     }
 
-    async fn execute_script(&self, schema: &str, name: &str) -> Result<Output> {
+    async fn execute_script(
+        &self,
+        schema: &str,
+        name: &str,
+        params: HashMap<String, String>,
+    ) -> Result<Output> {
         let key = format!("{schema}_{name}");
 
         let py_script = self.scripts.read().unwrap().get(&key).unwrap().clone();
 
-        Ok(py_script.execute(EvalContext::default()).await.unwrap())
+        Ok(py_script
+            .execute(params, EvalContext::default())
+            .await
+            .unwrap())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:

1. Supports passing user params into scripts, for example:

```python
@copr(returns = ["number"])
def test(**params)->vector[i64]:
    return int(params['a']) + int(params['b'])
```

Or coprocessing with a query:

```python
@copr(sql='select uint32s as number from numbers limit 5', args=['number'], returns=['n'])
def test(n, **params)  -> vector[i64]:
    return n + int(params['a'])
```

As above, the `args` and `sql` in the `@coprocessor` annotation are both optional now. 

2. Let `/run-script` API accepts these params by URL params such as `run-script?name=test&a=1&b=1`. The params is in the form of `HashMap<String, String>`, and passed into python script as `KwArgs` such as `**params`.
3. Adds `concat` function to `PyVector` to merge the vectors.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
