### PR TITLE
feat: L0 to L1 compaction strategy

### DIFF
--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -184,8 +184,8 @@ impl ChunkReaderBuilder {
             return true;
         }
         // end_timestamp of sst file is inclusive.
-        let file_ts_range =
-            TimestampRange::new_inclusive(file.start_timestamp(), file.end_timestamp());
+        let Some((start, end)) = file.time_range().clone() else { return true; };
+        let file_ts_range = TimestampRange::new_inclusive(Some(start), Some(end));
         file_ts_range.intersects(&predicate)
     }
 }

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -184,7 +184,7 @@ impl ChunkReaderBuilder {
             return true;
         }
         // end_timestamp of sst file is inclusive.
-        let Some((start, end)) = file.time_range().clone() else { return true; };
+        let Some((start, end)) = *file.time_range() else { return true; };
         let file_ts_range = TimestampRange::new_inclusive(Some(start), Some(end));
         file_ts_range.intersects(&predicate)
     }

--- a/src/storage/src/compaction.rs
+++ b/src/storage/src/compaction.rs
@@ -16,4 +16,5 @@ mod dedup_deque;
 mod picker;
 mod rate_limit;
 mod scheduler;
+mod strategy;
 mod task;

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -12,28 +12,59 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::time::Duration;
+
+use common_telemetry::debug;
+
 use crate::compaction::scheduler::CompactionRequestImpl;
+use crate::compaction::strategy::StrategyRef;
 use crate::compaction::task::{CompactionTask, CompactionTaskImpl};
 
-/// Picker picks input SST files and build the compaction task.
+/// Picker picks input SST files and builds the compaction task.
 /// Different compaction strategy may implement different pickers.
 pub trait Picker<R, T: CompactionTask>: Send + 'static {
-    fn pick(&self, req: &R) -> crate::error::Result<T>;
+    fn pick(&self, ctx: &PickerContext, req: &R) -> crate::error::Result<Option<T>>;
+}
+
+pub struct PickerContext {
+    pub time_bucket_duration: Duration,
 }
 
 /// L0 -> L1 all-to-all compaction based on time windows.
-pub(crate) struct SimplePicker {}
+pub(crate) struct SimplePicker {
+    strategy: StrategyRef,
+}
 
 #[allow(unused)]
 impl SimplePicker {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(strategy: StrategyRef) -> Self {
+        Self { strategy }
     }
 }
 
 impl Picker<CompactionRequestImpl, CompactionTaskImpl> for SimplePicker {
-    fn pick(&self, _req: &CompactionRequestImpl) -> crate::error::Result<CompactionTaskImpl> {
-        todo!()
+    fn pick(
+        &self,
+        ctx: &PickerContext,
+        req: &CompactionRequestImpl,
+    ) -> crate::error::Result<Option<CompactionTaskImpl>> {
+        let levels = req.levels();
+
+        for level_num in 0..levels.level_num() {
+            let level = levels.level(level_num as u8);
+            let outputs = self.strategy.pick(ctx, level);
+
+            if outputs.is_empty() {
+                debug!("No SST file can be compacted at level {}", level_num);
+                return Ok(None);
+            }
+
+            debug!("Found SST files to compact {:?}", outputs);
+            // TODO(hl): build compaction task
+            return Ok(None);
+        }
+
+        Ok(None)
     }
 }
 
@@ -60,8 +91,12 @@ pub mod tests {
     }
 
     impl<R: CompactionRequest> Picker<R, NoopCompactionTask> for MockPicker<R> {
-        fn pick(&self, _req: &R) -> crate::error::Result<NoopCompactionTask> {
-            Ok(NoopCompactionTask::new(self.cbs.clone()))
+        fn pick(
+            &self,
+            _ctx: &PickerContext,
+            _req: &R,
+        ) -> crate::error::Result<Option<NoopCompactionTask>> {
+            Ok(Some(NoopCompactionTask::new(self.cbs.clone())))
         }
     }
 }

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
-
 use common_telemetry::debug;
 
 use crate::compaction::scheduler::CompactionRequestImpl;
@@ -26,9 +24,7 @@ pub trait Picker<R, T: CompactionTask>: Send + 'static {
     fn pick(&self, ctx: &PickerContext, req: &R) -> crate::error::Result<Option<T>>;
 }
 
-pub struct PickerContext {
-    pub time_bucket_duration: Duration,
-}
+pub struct PickerContext {}
 
 /// L0 -> L1 all-to-all compaction based on time windows.
 pub(crate) struct SimplePicker {
@@ -61,7 +57,6 @@ impl Picker<CompactionRequestImpl, CompactionTaskImpl> for SimplePicker {
 
             debug!("Found SST files to compact {:?}", outputs);
             // TODO(hl): build compaction task
-            return Ok(None);
         }
 
         Ok(None)

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -224,7 +224,7 @@ impl<R: CompactionRequest, T: CompactionTask, P: Picker<R, T>> CompactionHandler
         let cloned_notify = self.task_notifier.clone();
         let table_id = req.table_id();
         let Some(task) = self.build_compaction_task(req).await? else {
-            info!("No files need to compaction in table: {}", table_id);
+            info!("No file needs compaction in table: {}", table_id);
             return Ok(());
         };
 

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -24,17 +24,25 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::compaction::dedup_deque::DedupDeque;
-use crate::compaction::picker::Picker;
+use crate::compaction::picker::{Picker, PickerContext};
 use crate::compaction::rate_limit::{
     BoxedRateLimitToken, CascadeRateLimiter, MaxInflightTaskLimiter, RateLimitToken, RateLimiter,
 };
 use crate::compaction::task::CompactionTask;
 use crate::error::{Result, StopCompactionSchedulerSnafu};
+use crate::version::LevelMetasRef;
 
 /// Table compaction request.
 #[derive(Default)]
 pub struct CompactionRequestImpl {
     table_id: TableId,
+    levels: LevelMetasRef,
+}
+
+impl CompactionRequestImpl {
+    pub fn levels(&self) -> &LevelMetasRef {
+        &self.levels
+    }
 }
 
 impl CompactionRequest for CompactionRequestImpl {
@@ -162,7 +170,7 @@ struct CompactionHandler<R, T: CompactionTask, P: Picker<R, T>> {
 }
 
 #[allow(unused)]
-impl<R, T: CompactionTask, P: Picker<R, T>> CompactionHandler<R, T, P> {
+impl<R: CompactionRequest, T: CompactionTask, P: Picker<R, T>> CompactionHandler<R, T, P> {
     /// Runs table compaction requests dispatch loop.
     pub async fn run(&self) {
         let task_notifier = self.task_notifier.clone();
@@ -214,7 +222,11 @@ impl<R, T: CompactionTask, P: Picker<R, T>> CompactionHandler<R, T, P> {
         token: BoxedRateLimitToken,
     ) -> Result<()> {
         let cloned_notify = self.task_notifier.clone();
-        let task = self.build_compaction_task(req).await?;
+        let table_id = req.table_id();
+        let Some(task) = self.build_compaction_task(req).await? else {
+            info!("No files need to compaction in table: {}", table_id);
+            return Ok(());
+        };
 
         // TODO(hl): we need to keep a track of task handle here to allow task cancellation.
         common_runtime::spawn_bg(async move {
@@ -230,8 +242,9 @@ impl<R, T: CompactionTask, P: Picker<R, T>> CompactionHandler<R, T, P> {
     }
 
     // TODO(hl): generate compaction task(find SSTs to compact along with the output of compaction)
-    async fn build_compaction_task(&self, req: R) -> crate::error::Result<T> {
-        self.picker.pick(&req)
+    async fn build_compaction_task(&self, req: R) -> crate::error::Result<Option<T>> {
+        let ctx = PickerContext {};
+        self.picker.pick(&ctx, &req)
     }
 }
 

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -148,7 +148,7 @@ fn infer_time_bucket(files: &[FileHandle]) -> i64 {
     max_sec
         .checked_sub(min_sec)
         .map(fit_time_bucket) // return the max bucket on subtraction overflow.
-        .unwrap_or_else(|| *TIME_BUCKETS.last().unwrap()) // // safety: TIME_BUCKETS cannot be empty.
+        .unwrap_or_else(|| *TIME_BUCKETS.last().unwrap()) // safety: TIME_BUCKETS cannot be empty.
 }
 
 /// A set of predefined time buckets.

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -1,0 +1,377 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_telemetry::debug;
+use common_time::timestamp::TimeUnit;
+use common_time::timestamp_millis::BucketAligned;
+use common_time::Timestamp;
+
+use crate::compaction::picker::PickerContext;
+use crate::compaction::task::CompactionOutput;
+use crate::sst::{FileHandle, LevelMeta};
+
+/// Compaction strategy that defines which SSTs need to be compacted at given level.
+pub trait Strategy {
+    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> Vec<CompactionOutput>;
+}
+
+pub type StrategyRef = Arc<dyn Strategy + Send + Sync>;
+
+/// SimpleTimeWindowStrategy only handles level 0 to level 1 compaction in a time-window tiered
+/// manner. It picks all SSTs in level 0 and writes rows in these SSTs to a new file partitioned
+/// by a predefined time bucket in level 1.
+/// After compaction, level 1 may contains more than one sorted run within the same time bucket.
+pub struct SimpleTimeWindowStrategy {}
+
+impl Strategy for SimpleTimeWindowStrategy {
+    fn pick(&self, _ctx: &PickerContext, level: &LevelMeta) -> Vec<CompactionOutput> {
+        // SimpleTimeWindowStrategy only handles level 0 to level 1 compaction.
+        if level.level() != 0 {
+            return vec![];
+        }
+        let files = find_compactable_files(level);
+        if files.is_empty() {
+            return vec![];
+        }
+
+        let time_bucket = infer_time_bucket(&files);
+        let buckets = calculate_time_buckets(time_bucket.to_secs(), &files);
+        debug!("File buckets: {:?}", buckets);
+        buckets
+            .into_iter()
+            .map(|(bound, files)| CompactionOutput {
+                output_level: 1,
+                bucket_bound: bound,
+                bucket: time_bucket,
+                inputs: files,
+            })
+            .collect()
+    }
+}
+
+/// Finds files that can be compacted in given level.
+/// Currently they're files that is not currently under compaction.
+#[inline]
+fn find_compactable_files(level: &LevelMeta) -> Vec<FileHandle> {
+    level
+        .files()
+        .iter()
+        .filter(|f| !f.compacting())
+        .cloned()
+        .collect()
+}
+
+fn calculate_time_buckets(bucket_sec: i64, files: &[FileHandle]) -> HashMap<i64, Vec<FileHandle>> {
+    let mut buckets = HashMap::new();
+
+    for file in files {
+        if let Some((start, end)) = file.time_range().clone() {
+            let bounds = file_time_bucket_span(
+                start.convert_to(TimeUnit::Second).unwrap().value(),
+                end.convert_to(TimeUnit::Second).unwrap().value(),
+                bucket_sec,
+            );
+            for bound in bounds {
+                buckets
+                    .entry(bound)
+                    .or_insert_with(Vec::new)
+                    .push(file.clone());
+            }
+        } else {
+            // Files without timestamp range is assign to a special bucket `i64::MAX`,
+            // so that they can be compacted together.
+            buckets
+                .entry(i64::MAX)
+                .or_insert_with(Vec::new)
+                .push(file.clone());
+        }
+    }
+    buckets
+}
+
+/// Calculates timestamp span between start and end timestamp.
+fn file_time_bucket_span(start_sec: i64, end_sec: i64, bucket_sec: i64) -> Vec<i64> {
+    assert!(start_sec <= end_sec);
+
+    // if timestamp is between `[i64::MIN, i64::MIN.align_by_bucket(bucket)]`, which cannot
+    // be aligned to a valid i64 bound, simply return `i64::MIN` rather than just underflow.
+    let mut start_aligned = start_sec.align_by_bucket(bucket_sec).unwrap_or(i64::MIN);
+    let end_aligned = end_sec.align_by_bucket(bucket_sec).unwrap_or(i64::MIN);
+
+    let mut res = Vec::with_capacity(((end_aligned - start_aligned) / bucket_sec + 1) as usize);
+    while start_aligned < end_aligned {
+        res.push(start_aligned);
+        start_aligned += bucket_sec;
+    }
+    res.push(end_aligned);
+    res
+}
+
+/// Infers the suitable time bucket duration.
+/// Now it simply find the max and min timestamp across all SSTs in level and fit the time span
+/// into `TimeBucket`.
+fn infer_time_bucket(files: &[FileHandle]) -> TimeBucket {
+    let mut max_ts = &Timestamp::new(i64::MIN, TimeUnit::Second);
+    let mut min_ts = &Timestamp::new(i64::MAX, TimeUnit::Second);
+
+    for f in files {
+        if let Some((start, end)) = f.time_range() {
+            min_ts = min_ts.min(start);
+            max_ts = max_ts.max(end);
+        } else {
+            return TimeBucket::MAX;
+        }
+    }
+
+    // safety: Convert whatever timestamp into seconds will not cause overflow.
+    let min_sec = min_ts.convert_to(TimeUnit::Second).unwrap().value();
+    let max_sec = max_ts.convert_to(TimeUnit::Second).unwrap().value();
+    TimeBucket::fit(max_sec - min_sec)
+}
+
+/// A set of predefined time bucket used to align timestamp.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TimeBucket {
+    OneHour,
+    TwoHours,
+    TwelveHours,
+    OneDay,
+    OneWeek,
+}
+
+impl TimeBucket {
+    const ONE_HOUR_SECS: i64 = 60 * 60;
+    const TWO_HOUR_SECS: i64 = 2 * Self::ONE_HOUR_SECS;
+    const TWELVE_HOUR_SECS: i64 = 12 * Self::ONE_HOUR_SECS;
+    const ONE_DAY_SECS: i64 = 24 * Self::ONE_HOUR_SECS;
+    const ONE_WEEK_SECS: i64 = 7 * Self::ONE_DAY_SECS;
+
+    const BUCKETS: [TimeBucket; 5] = [
+        Self::OneHour,
+        Self::TwoHours,
+        Self::TwelveHours,
+        Self::OneDay,
+        Self::OneWeek,
+    ];
+
+    pub const MAX: TimeBucket = Self::OneWeek;
+
+    /// Converts time bucket to seconds.
+    pub fn to_secs(&self) -> i64 {
+        match self {
+            Self::OneHour => Self::ONE_HOUR_SECS,
+            Self::TwoHours => Self::TWO_HOUR_SECS,
+            Self::TwelveHours => Self::TWELVE_HOUR_SECS,
+            Self::OneDay => Self::ONE_DAY_SECS,
+            Self::OneWeek => Self::ONE_WEEK_SECS,
+        }
+    }
+
+    /// Fits a given time span into time bucket by find the minimum bucket that can cover the span.
+    /// Returns `TimeBucket::MAX` if no such bucket can be found.
+    pub fn fit(span_sec: i64) -> Self {
+        assert!(span_sec >= 0);
+        for b in Self::BUCKETS {
+            if b.to_secs() >= span_sec {
+                return b;
+            }
+        }
+        return Self::MAX;
+    }
+}
+
+impl PartialOrd for TimeBucket {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.to_secs().cmp(&other.to_secs()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::sst::FileMeta;
+
+    #[test]
+    fn test_time_bucket_span() {
+        assert_eq!(vec![0], file_time_bucket_span(1, 9, 10));
+
+        assert_eq!(vec![0, 10], file_time_bucket_span(1, 10, 10));
+
+        assert_eq!(vec![-10], file_time_bucket_span(-10, -1, 10));
+
+        assert_eq!(vec![-10, 0], file_time_bucket_span(-10, 0, 10));
+    }
+
+    #[test]
+    fn test_time_bucket_span_large() {
+        assert_eq!(
+            vec![
+                (i64::MAX - 10).align_by_bucket(10).unwrap(),
+                i64::MAX.align_by_bucket(10).unwrap(),
+            ],
+            file_time_bucket_span(i64::MAX - 10, i64::MAX, 10)
+        );
+
+        // magic hmmm?
+        for bucket in 1..100 {
+            assert_eq!(
+                vec![
+                    i64::MIN,
+                    (i64::MIN + bucket).align_by_bucket(bucket).unwrap()
+                ],
+                file_time_bucket_span(i64::MIN, i64::MIN + bucket, bucket)
+            );
+        }
+    }
+
+    #[test]
+    fn test_time_bucket() {
+        assert_eq!(
+            TimeBucket::MAX,
+            TimeBucket::BUCKETS.last().copied().unwrap()
+        );
+
+        assert_eq!(TimeBucket::OneHour, TimeBucket::fit(1));
+        assert_eq!(TimeBucket::OneHour, TimeBucket::fit(60 * 60));
+        assert_eq!(TimeBucket::TwoHours, TimeBucket::fit(60 * 60 + 1));
+
+        assert_eq!(
+            TimeBucket::TwelveHours,
+            TimeBucket::fit(TimeBucket::TwelveHours.to_secs() - 1)
+        );
+        assert_eq!(
+            TimeBucket::TwelveHours,
+            TimeBucket::fit(TimeBucket::TwelveHours.to_secs())
+        );
+        assert_eq!(
+            TimeBucket::OneDay,
+            TimeBucket::fit(TimeBucket::OneDay.to_secs() - 1)
+        );
+        assert_eq!(TimeBucket::OneWeek, TimeBucket::fit(i64::MAX));
+    }
+
+    #[test]
+    fn test_infer_time_buckets() {
+        assert_eq!(
+            TimeBucket::OneHour,
+            infer_time_bucket(&[
+                new_file_handle("a", 0, TimeBucket::OneHour.to_secs() * 1000 - 1),
+                new_file_handle("b", 1, 10_000)
+            ])
+        );
+    }
+
+    fn new_file_handle(name: &str, start_ts_millis: i64, end_ts_millis: i64) -> FileHandle {
+        FileHandle::new(FileMeta {
+            file_name: name.to_string(),
+            time_range: Some((
+                Timestamp::new_millisecond(start_ts_millis),
+                Timestamp::new_millisecond(end_ts_millis),
+            )),
+            level: 0,
+        })
+    }
+
+    fn new_file_handles(input: &[(&str, i64, i64)]) -> Vec<FileHandle> {
+        input
+            .iter()
+            .map(|(name, start, end)| new_file_handle(name, *start, *end))
+            .collect()
+    }
+
+    fn check_bucket_calculation(
+        bucket_sec: i64,
+        files: Vec<FileHandle>,
+        expected: &[(i64, &[&str])],
+    ) {
+        let res = calculate_time_buckets(bucket_sec, &files);
+
+        let expected = expected
+            .iter()
+            .map(|(bucket, file_names)| {
+                (
+                    *bucket,
+                    file_names
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<HashSet<_>>(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        for (bucket, file_names) in expected {
+            let actual = res
+                .get(&bucket)
+                .unwrap()
+                .iter()
+                .map(|f| f.file_name().to_string())
+                .collect();
+            assert_eq!(
+                file_names, actual,
+                "bucket: {bucket}, expected: {file_names:?}, actual: {actual:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_calculate_time_buckets() {
+        // simple case, files with disjoint
+        check_bucket_calculation(
+            10,
+            new_file_handles(&[("a", 0, 9000), ("b", 10000, 19000)]),
+            &[(0, &["a"]), (10, &["b"])],
+        );
+
+        // files across buckets
+        check_bucket_calculation(
+            10,
+            new_file_handles(&[("a", 0, 10001), ("b", 10000, 19000)]),
+            &[(0, &["a"]), (10, &["a", "b"])],
+        );
+        check_bucket_calculation(
+            10,
+            new_file_handles(&[("a", 0, 10000)]),
+            &[(0, &["a"]), (10, &["a"])],
+        );
+
+        // files without timestamp are align to a special bucket: i64::MAX
+        check_bucket_calculation(
+            10,
+            vec![FileHandle::new(FileMeta {
+                file_name: "a".to_string(),
+                time_range: None,
+                level: 0,
+            })],
+            &[(i64::MAX, &["a"])],
+        );
+
+        // file with an large time range
+
+        let expected = (0..(TimeBucket::ONE_WEEK_SECS / TimeBucket::ONE_HOUR_SECS))
+            .into_iter()
+            .map(|b| (b * TimeBucket::ONE_HOUR_SECS, &["a"] as _))
+            .collect::<Vec<_>>();
+        check_bucket_calculation(
+            TimeBucket::OneHour.to_secs(),
+            new_file_handles(&[("a", 0, TimeBucket::ONE_WEEK_SECS * 1000)]),
+            &expected,
+        );
+    }
+}

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::compaction::strategy::TimeBucket;
 use crate::error::Result;
 use crate::sst::{FileHandle, Level};
 
@@ -46,9 +45,13 @@ pub(crate) struct CompactionInput {
 #[derive(Debug)]
 #[allow(unused)]
 pub struct CompactionOutput {
+    /// Compaction output file level.
     pub(crate) output_level: Level,
+    /// The left bound of time bucket.
     pub(crate) bucket_bound: i64,
-    pub(crate) bucket: TimeBucket,
+    /// Bucket duration in seconds.
+    pub(crate) bucket: i64,
+    /// Compaction input files.
     pub(crate) inputs: Vec<FileHandle>,
 }
 

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::compaction::strategy::TimeBucket;
 use crate::error::Result;
-use crate::sst::FileHandle;
+use crate::sst::{FileHandle, Level};
 
 #[async_trait::async_trait]
 pub trait CompactionTask: Send + Sync + 'static {
@@ -38,6 +39,17 @@ pub(crate) struct CompactionInput {
     input_level: u8,
     output_level: u8,
     file: FileHandle,
+}
+
+/// Many-to-many compaction can be decomposed to a many-to-one compaction from level n to level n+1
+/// and a many-to-one compaction from level n+1 to level n+1.
+#[derive(Debug)]
+#[allow(unused)]
+pub struct CompactionOutput {
+    pub(crate) output_level: Level,
+    pub(crate) bucket_bound: i64,
+    pub(crate) bucket: TimeBucket,
+    pub(crate) inputs: Vec<FileHandle>,
 }
 
 #[cfg(test)]

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -185,18 +185,14 @@ impl<S: LogStore> FlushJob<S> {
             // TODO(hl): Check if random file name already exists in meta.
             let iter = m.iter(&iter_ctx)?;
             futures.push(async move {
-                let SstInfo {
-                    start_timestamp,
-                    end_timestamp,
-                } = self
+                let SstInfo { time_range } = self
                     .sst_layer
                     .write_sst(&file_name, iter, &WriteOptions::default())
                     .await?;
 
                 Ok(FileMeta {
                     file_name,
-                    start_timestamp,
-                    end_timestamp,
+                    time_range,
                     level: 0,
                 })
             });

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -30,6 +30,7 @@ pub fn build_region_meta() -> RegionMetadata {
     desc.try_into().unwrap()
 }
 
+// TODO(hl): region edit should contain the time range of added files
 pub fn build_region_edit(
     sequence: SequenceNumber,
     files_to_add: &[&str],
@@ -42,8 +43,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 file_name: f.to_string(),
-                start_timestamp: None,
-                end_timestamp: None,
+                time_range: None,
                 level: 0,
             })
             .collect(),
@@ -51,8 +51,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 file_name: f.to_string(),
-                start_timestamp: None,
-                end_timestamp: None,
+                time_range: None,
                 level: 0,
             })
             .collect(),

--- a/src/storage/src/version.rs
+++ b/src/storage/src/version.rs
@@ -137,7 +137,7 @@ pub struct VersionEdit {
 pub type VersionControlRef = Arc<VersionControl>;
 pub type VersionRef = Arc<Version>;
 type MemtableVersionRef = Arc<MemtableVersion>;
-type LevelMetasRef = Arc<LevelMetas>;
+pub type LevelMetasRef = Arc<LevelMetas>;
 
 /// Version contains metadata and state of region.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Implement a simple compaction strategy that compacts SSTs in leve 0 to level 1. 

The strategy iterates all compactable files in level 0, finds the time span of these files and fits the span to a set of predefine time bucket (`TimeBucket`). 

According to this time bucket duration, those files are assigned to multiple buckets. For example, given a bucket of 10, a file with time range 1~15 is assigned with bucket 0 and 10. If a file does not contain time range, it will be assigned by a special bucket `i64::MAX` so that all files without time range can be compacted together.

The compaction strategy generates a set of `CompactionOutput`. Each `CompactionOutput` will scan its input files, filter rows within its bucket, write these rows into a new SST in level 1.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
