### PR TITLE
fix: use query_ctx in distributed inserts

### DIFF
--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -294,7 +294,10 @@ impl DistInstance {
                 explain(Box::new(stmt), self.query_engine.clone(), query_ctx).await
             }
             Statement::Insert(insert) => {
-                let (catalog, schema, table) = insert.full_table_name().context(ParseSqlSnafu)?;
+                let (catalog, schema, table) =
+                    table_idents_to_full_name(insert.table_name(), query_ctx)
+                        .map_err(BoxedError::new)
+                        .context(error::ExternalSnafu)?;
 
                 let table = self
                     .catalog_manager


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Resolves table name resolution for distributed writes

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
