### PR TITLE
feat: remove backtrace from sql::error::Error

### DIFF
--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -56,7 +56,6 @@ pub enum Error {
     UnsupportedDefaultValue {
         column_name: String,
         expr: Expr,
-        backtrace: Backtrace,
     },
 
     // Syntax error from sql parser.
@@ -67,29 +66,27 @@ pub enum Error {
     Tokenizer { sql: String, source: TokenizerError },
 
     #[snafu(display("Missing time index constraint"))]
-    MissingTimeIndex { backtrace: Backtrace },
+    MissingTimeIndex {},
 
     #[snafu(display("Invalid time index: {}", msg))]
-    InvalidTimeIndex { msg: String, backtrace: Backtrace },
+    InvalidTimeIndex { msg: String },
 
     #[snafu(display("Invalid SQL, error: {}", msg))]
-    InvalidSql { msg: String, backtrace: Backtrace },
+    InvalidSql { msg: String },
 
     #[snafu(display("Invalid column option, column name: {}, error: {}", name, msg))]
     InvalidColumnOption {
         name: String,
         msg: String,
-        backtrace: Backtrace,
     },
 
     #[snafu(display("SQL data type not supported yet: {:?}", t))]
     SqlTypeNotSupported {
         t: crate::ast::DataType,
-        backtrace: Backtrace,
     },
 
     #[snafu(display("Failed to parse value: {}", msg))]
-    ParseSqlValue { msg: String, backtrace: Backtrace },
+    ParseSqlValue { msg: String },
 
     #[snafu(display(
         "Column {} expect type: {:?}, actual: {:?}",
@@ -104,10 +101,10 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid database name: {}", name))]
-    InvalidDatabaseName { name: String, backtrace: Backtrace },
+    InvalidDatabaseName { name: String },
 
     #[snafu(display("Invalid table name: {}", name))]
-    InvalidTableName { name: String, backtrace: Backtrace },
+    InvalidTableName { name: String },
 
     #[snafu(display("Invalid default constraint, column: {}, source: {}", column, source))]
     InvalidDefault {
@@ -117,7 +114,7 @@ pub enum Error {
     },
 
     #[snafu(display("Unsupported ALTER TABLE statement: {}", msg))]
-    UnsupportedAlterTableStatement { msg: String, backtrace: Backtrace },
+    UnsupportedAlterTableStatement { msg: String },
 
     #[snafu(display("Failed to serialize column default constraint, source: {}", source))]
     SerializeColumnDefaultConstraint {
@@ -135,7 +132,7 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid sql value: {}", value))]
-    InvalidSqlValue { value: String, backtrace: Backtrace },
+    InvalidSqlValue { value: String },
 
     #[snafu(display(
         "Converting timestamp {:?} to unit {:?} overflow",
@@ -145,7 +142,6 @@ pub enum Error {
     TimestampOverflow {
         timestamp: Timestamp,
         target_unit: TimeUnit,
-        backtrace: Backtrace,
     },
 }
 

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -53,10 +53,7 @@ pub enum Error {
         expr,
         column_name
     ))]
-    UnsupportedDefaultValue {
-        column_name: String,
-        expr: Expr,
-    },
+    UnsupportedDefaultValue { column_name: String, expr: Expr },
 
     // Syntax error from sql parser.
     #[snafu(display("Syntax error, sql: {}, source: {}", sql, source))]
@@ -75,15 +72,10 @@ pub enum Error {
     InvalidSql { msg: String },
 
     #[snafu(display("Invalid column option, column name: {}, error: {}", name, msg))]
-    InvalidColumnOption {
-        name: String,
-        msg: String,
-    },
+    InvalidColumnOption { name: String, msg: String },
 
     #[snafu(display("SQL data type not supported yet: {:?}", t))]
-    SqlTypeNotSupported {
-        t: crate::ast::DataType,
-    },
+    SqlTypeNotSupported { t: crate::ast::DataType },
 
     #[snafu(display("Failed to parse value: {}", msg))]
     ParseSqlValue { msg: String },


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Removed `backtrace` from `Error` enum.

Please explain IN DETAIL what the changes are in this PR and why they are needed:
 - this is a cleanup task. As per https://github.com/GreptimeTeam/greptimedb/issues/855 most backtraces in `sql::error::Error` are unnecessary and might hurt performance since the parser would always return them while parsing an invalid SQL.


## Checklist

- Docs are not needed in this case
- Need a bit of a steer with the necessary unit tests and integration tests.

## Refer to a related PR or issue link
https://github.com/GreptimeTeam/greptimedb/issues/855