### PR TITLE
fix: remove incorrect `table_idents_to_full_name`

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -37,6 +37,7 @@ use common_recordbatch::RecordBatches;
 use common_telemetry::logging::{debug, info};
 use datafusion::sql::sqlparser::ast::ObjectName;
 use datafusion_common::TableReference;
+use datanode::instance::sql::table_idents_to_full_name;
 use datanode::instance::InstanceRef as DnInstanceRef;
 use datatypes::schema::Schema;
 use distributed::DistInstance;
@@ -63,8 +64,8 @@ use sql::statements::statement::Statement;
 use crate::catalog::FrontendCatalogManager;
 use crate::datanode::DatanodeClients;
 use crate::error::{
-    self, Error, ExecutePromqlSnafu, MissingMetasrvOptsSnafu, NotSupportedSnafu, ParseSqlSnafu,
-    Result, SqlExecInterceptedSnafu,
+    self, Error, ExecutePromqlSnafu, ExternalSnafu, MissingMetasrvOptsSnafu, NotSupportedSnafu,
+    ParseSqlSnafu, Result, SqlExecInterceptedSnafu,
 };
 use crate::expr_factory::{CreateExprFactoryRef, DefaultCreateExprFactory};
 use crate::frontend::FrontendOptions;
@@ -557,7 +558,11 @@ pub fn check_permission(
         Statement::ShowCreateTable(_) | Statement::Alter(_) => {}
 
         Statement::Insert(insert) => {
-            let (catalog, schema, _) = insert.full_table_name().context(ParseSqlSnafu)?;
+            let (catalog, schema, _) =
+                table_idents_to_full_name(insert.table_name(), query_ctx.clone())
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)?;
+
             validate_param(&catalog, &schema, query_ctx)?;
         }
         Statement::CreateTable(stmt) => {

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -295,7 +295,7 @@ impl DistInstance {
             }
             Statement::Insert(insert) => {
                 let (catalog, schema, table) =
-                    table_idents_to_full_name(insert.table_name(), query_ctx)
+                    table_idents_to_full_name(insert.table_name(), query_ctx.clone())
                         .map_err(BoxedError::new)
                         .context(error::ExternalSnafu)?;
 
@@ -305,7 +305,7 @@ impl DistInstance {
                     .context(CatalogSnafu)?
                     .context(TableNotFoundSnafu { table_name: table })?;
 
-                let insert_request = insert_to_request(&table, *insert)?;
+                let insert_request = insert_to_request(&table, *insert, query_ctx)?;
 
                 return Ok(Output::AffectedRows(
                     table.insert(insert_request).await.context(TableSnafu)?,

--- a/src/query/src/query_engine/options.rs
+++ b/src/query/src/query_engine/options.rs
@@ -18,7 +18,7 @@ use snafu::ensure;
 
 use crate::error::{QueryAccessDeniedSnafu, Result};
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct QueryOptions {
     pub disallow_cross_schema_query: bool,
 }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -25,7 +25,6 @@ use std::str::FromStr;
 
 use api::helper::ColumnDataTypeWrapper;
 use common_base::bytes::Bytes;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_time::Timestamp;
 use datatypes::data_type::DataType;
 use datatypes::prelude::ConcreteDataType;
@@ -35,44 +34,13 @@ use datatypes::value::Value;
 use snafu::{ensure, OptionExt, ResultExt};
 
 use crate::ast::{
-    ColumnDef, ColumnOption, ColumnOptionDef, DataType as SqlDataType, Expr, ObjectName,
-    Value as SqlValue,
+    ColumnDef, ColumnOption, ColumnOptionDef, DataType as SqlDataType, Expr, Value as SqlValue,
 };
 use crate::error::{
     self, ColumnTypeMismatchSnafu, ConvertToGrpcDataTypeSnafu, InvalidSqlValueSnafu,
     ParseSqlValueSnafu, Result, SerializeColumnDefaultConstraintSnafu, TimestampOverflowSnafu,
     UnsupportedDefaultValueSnafu,
 };
-
-// TODO(LFC): Get rid of this function, use session context aware version of "table_idents_to_full_name" instead.
-// Current obstacles remain in some usage in Frontend, and other SQLs like "describe", "drop" etc.
-/// Converts maybe fully-qualified table name (`<catalog>.<schema>.<table>` or `<table>` when
-/// catalog and schema are default) to tuple.
-pub fn table_idents_to_full_name(obj_name: &ObjectName) -> Result<(String, String, String)> {
-    match &obj_name.0[..] {
-        [table] => Ok((
-            DEFAULT_CATALOG_NAME.to_string(),
-            DEFAULT_SCHEMA_NAME.to_string(),
-            table.value.clone(),
-        )),
-        [schema, table] => Ok((
-            DEFAULT_CATALOG_NAME.to_string(),
-            schema.value.clone(),
-            table.value.clone(),
-        )),
-        [catalog, schema, table] => Ok((
-            catalog.value.clone(),
-            schema.value.clone(),
-            table.value.clone(),
-        )),
-        _ => error::InvalidSqlSnafu {
-            msg: format!(
-                "expect table name to be <catalog>.<schema>.<table>, <schema>.<table> or <table>, actual: {obj_name}",
-            ),
-        }
-        .fail(),
-    }
-}
 
 fn parse_string_to_value(
     column_name: &str,
@@ -368,6 +336,7 @@ mod tests {
     use common_time::timestamp::TimeUnit;
     use datatypes::types::BooleanType;
     use datatypes::value::OrderedFloat;
+    use sqlparser::ast::ObjectName;
 
     use super::*;
     use crate::ast::{Ident, TimezoneInfo};

--- a/src/sql/src/statements/insert.rs
+++ b/src/sql/src/statements/insert.rs
@@ -17,7 +17,6 @@ use sqlparser::parser::ParserError;
 
 use crate::ast::{Expr, Value};
 use crate::error::{self, Result};
-use crate::statements::table_idents_to_full_name;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Insert {
@@ -26,13 +25,6 @@ pub struct Insert {
 }
 
 impl Insert {
-    pub fn full_table_name(&self) -> Result<(String, String, String)> {
-        match &self.inner {
-            Statement::Insert { table_name, .. } => table_idents_to_full_name(table_name),
-            _ => unreachable!(),
-        }
-    }
-
     pub fn table_name(&self) -> &ObjectName {
         match &self.inner {
             Statement::Insert { table_name, .. } => table_name,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly removes the incorrect `table_idents_to_full_name` function and change usage to the right one using `query_ctx`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
