### PR TITLE
feat: add start, end and step to promql http api

### DIFF
--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -67,6 +67,9 @@ pub async fn sql(
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct PromqlQuery {
     pub query: String,
+    pub start: String,
+    pub end: String,
+    pub step: String,
 }
 
 /// Handler to execute promql


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The API looks like
```
http://localhost:4000/v1/promql?query=abs(foo{bar!="bar"})&start=0&end=100&step=5s
```

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/15380403/217997829-e31b5df4-fa33-48d3-99b5-cdea7e21846c.png">

All of these four params are required. It's derived from Prometheus' [range_query](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries) API, without the timeout param.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
