### PR TITLE
feat: add close method for the region trait

### DIFF
--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -192,6 +192,10 @@ impl Region for MockRegion {
 
         Ok(())
     }
+
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl MockRegionInner {
@@ -279,8 +283,8 @@ impl StorageEngine for MockEngine {
         return Ok(None);
     }
 
-    async fn close_region(&self, _ctx: &EngineContext, _region: MockRegion) -> Result<()> {
-        unimplemented!()
+    async fn close_region(&self, _ctx: &EngineContext, region: MockRegion) -> Result<()> {
+        region.close().await
     }
 
     async fn create_region(

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -21,7 +21,7 @@ use object_store::{util, ObjectStore};
 use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::storage::{
-    CreateOptions, EngineContext, OpenOptions, RegionDescriptor, StorageEngine,
+    CreateOptions, EngineContext, OpenOptions, Region, RegionDescriptor, StorageEngine,
 };
 
 use crate::background::JobPoolImpl;
@@ -62,8 +62,8 @@ impl<S: LogStore> StorageEngine for EngineImpl<S> {
         self.inner.open_region(name, opts).await
     }
 
-    async fn close_region(&self, _ctx: &EngineContext, _region: Self::Region) -> Result<()> {
-        unimplemented!()
+    async fn close_region(&self, _ctx: &EngineContext, region: Self::Region) -> Result<()> {
+        region.close().await
     }
 
     async fn create_region(

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -141,6 +141,12 @@ pub enum Error {
     #[snafu(display("Task already cancelled"))]
     Cancelled { backtrace: Backtrace },
 
+    #[snafu(display("Failed to cancel flush, source: {}", source))]
+    CancelFlush {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
+
     #[snafu(display(
         "Manifest protocol forbid to read, min_version: {}, supported_version: {}",
         min_version,
@@ -231,6 +237,9 @@ pub enum Error {
         #[snafu(backtrace)]
         source: MetadataError,
     },
+
+    #[snafu(display("Try to write the closed region"))]
+    ClosedRegion { backtrace: Backtrace },
 
     #[snafu(display("Invalid projection, source: {}", source))]
     InvalidProjection {
@@ -443,12 +452,14 @@ impl ErrorExt for Error {
             | DecodeJson { .. }
             | JoinTask { .. }
             | Cancelled { .. }
+            | CancelFlush { .. }
             | DecodeMetaActionList { .. }
             | Readline { .. }
             | WalDataCorrupted { .. }
             | SequenceNotMonotonic { .. }
             | ConvertStoreSchema { .. }
             | InvalidRawRegion { .. }
+            | ClosedRegion { .. }
             | FilterColumn { .. }
             | AlterMetadata { .. }
             | CompatRead { .. }

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -103,6 +103,10 @@ impl<S: LogStore> Region for RegionImpl<S> {
     async fn alter(&self, request: AlterRequest) -> Result<()> {
         self.inner.alter(request).await
     }
+
+    async fn close(&self) -> Result<()> {
+        self.inner.close().await
+    }
 }
 
 /// Storage related config for region.
@@ -508,5 +512,9 @@ impl<S: LogStore> RegionInner<S> {
         };
 
         self.writer.alter(alter_ctx, request).await
+    }
+
+    async fn close(&self) -> Result<()> {
+        self.writer.close().await
     }
 }

--- a/src/storage/src/region/tests/close.rs
+++ b/src/storage/src/region/tests/close.rs
@@ -1,0 +1,147 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region close tests.
+
+use std::sync::Arc;
+
+use log_store::raft_engine::log_store::RaftEngineLogStore;
+use store_api::storage::{AlterOperation, AlterRequest, Region, RegionMeta, WriteResponse};
+use tempdir::TempDir;
+
+use crate::engine;
+use crate::error::Error;
+use crate::flush::FlushStrategyRef;
+use crate::region::tests::{self, FileTesterBase};
+use crate::region::RegionImpl;
+use crate::test_util::config_util;
+use crate::test_util::flush_switch::{has_parquet_file, FlushSwitch};
+
+const REGION_NAME: &str = "region-close-0";
+
+/// Tester for region close
+struct CloseTester {
+    base: Option<FileTesterBase>,
+}
+
+/// Create a new region for flush test
+async fn create_region_for_close(
+    store_dir: &str,
+    enable_version_column: bool,
+    flush_strategy: FlushStrategyRef,
+) -> RegionImpl<RaftEngineLogStore> {
+    let metadata = tests::new_metadata(REGION_NAME, enable_version_column);
+
+    let mut store_config = config_util::new_store_config(REGION_NAME, store_dir).await;
+    store_config.flush_strategy = flush_strategy;
+
+    RegionImpl::create(metadata, store_config).await.unwrap()
+}
+
+impl CloseTester {
+    async fn new(store_dir: &str, flush_strategy: FlushStrategyRef) -> CloseTester {
+        let region = create_region_for_close(store_dir, false, flush_strategy.clone()).await;
+
+        CloseTester {
+            base: Some(FileTesterBase::with_region(region)),
+        }
+    }
+
+    #[inline]
+    fn base(&self) -> &FileTesterBase {
+        self.base.as_ref().unwrap()
+    }
+
+    async fn put(&self, data: &[(i64, Option<i64>)]) -> WriteResponse {
+        self.base().put(data).await
+    }
+
+    async fn try_put(&self, data: &[(i64, Option<i64>)]) -> Result<WriteResponse, Error> {
+        self.base().try_put(data).await
+    }
+
+    async fn try_alter(&self, mut req: AlterRequest) -> Result<(), Error> {
+        let version = self.version();
+        req.version = version;
+
+        self.base().region.alter(req).await
+    }
+
+    fn version(&self) -> u32 {
+        let metadata = self.base().region.in_memory_metadata();
+        metadata.version()
+    }
+}
+
+#[tokio::test]
+async fn test_close_basic() {
+    common_telemetry::init_default_ut_logging();
+    let dir = TempDir::new("close-basic").unwrap();
+    let store_dir = dir.path().to_str().unwrap();
+
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let tester = CloseTester::new(store_dir, flush_switch).await;
+
+    tester.base().region.close().await.unwrap();
+
+    let data = [(1000, Some(100))];
+
+    let closed_region_error = "Try to write the closed region".to_string();
+    // Put one element should return ClosedRegion error
+    assert_eq!(
+        tester.try_put(&data).await.unwrap_err().to_string(),
+        closed_region_error
+    );
+
+    // Alter table should return ClosedRegion error
+    assert_eq!(
+        tester
+            .try_alter(AlterRequest {
+                operation: AlterOperation::AddColumns {
+                    columns: Vec::new(),
+                },
+                version: 0,
+            })
+            .await
+            .unwrap_err()
+            .to_string(),
+        closed_region_error
+    );
+}
+
+#[tokio::test]
+async fn test_close_wait_flush_done() {
+    common_telemetry::init_default_ut_logging();
+    let dir = TempDir::new("close-basic").unwrap();
+    let store_dir = dir.path().to_str().unwrap();
+
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let tester = CloseTester::new(store_dir, flush_switch.clone()).await;
+
+    let data = [(1000, Some(100))];
+
+    // Now set should flush to true to trigger flush.
+    flush_switch.set_should_flush(true);
+
+    // Put one element so we have content to flush.
+    tester.put(&data).await;
+
+    let sst_dir = format!("{}/{}", store_dir, engine::region_sst_dir("", REGION_NAME));
+    assert!(!has_parquet_file(&sst_dir));
+
+    // Close should cancel the flush.
+    tester.base().region.close().await.unwrap();
+
+    assert!(!has_parquet_file(&sst_dir));
+}

--- a/src/storage/src/test_util.rs
+++ b/src/storage/src/test_util.rs
@@ -14,6 +14,7 @@
 
 pub mod config_util;
 pub mod descriptor_util;
+pub mod flush_switch;
 pub mod read_util;
 pub mod schema_util;
 pub mod write_batch_util;

--- a/src/storage/src/test_util/flush_switch.rs
+++ b/src/storage/src/test_util/flush_switch.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::flush::FlushStrategy;
+use crate::region::SharedDataRef;
+
+#[derive(Debug, Default)]
+pub struct FlushSwitch {
+    should_flush: AtomicBool,
+}
+
+impl FlushSwitch {
+    pub fn set_should_flush(&self, should_flush: bool) {
+        self.should_flush.store(should_flush, Ordering::Relaxed);
+    }
+}
+
+impl FlushStrategy for FlushSwitch {
+    fn should_flush(
+        &self,
+        _shared: &SharedDataRef,
+        _bytes_mutable: usize,
+        _bytes_total: usize,
+    ) -> bool {
+        self.should_flush.load(Ordering::Relaxed)
+    }
+}
+
+pub fn has_parquet_file(sst_dir: &str) -> bool {
+    for entry in std::fs::read_dir(sst_dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if !path.is_dir() {
+            assert_eq!("parquet", path.extension().unwrap());
+            return true;
+        }
+    }
+
+    false
+}

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -72,6 +72,8 @@ pub trait Region: Send + Sync + Clone + std::fmt::Debug + 'static {
     fn write_request(&self) -> Self::WriteRequest;
 
     async fn alter(&self, request: AlterRequest) -> Result<(), Self::Error>;
+
+    async fn close(&self) -> Result<(), Self::Error>;
 }
 
 /// Context for write operations.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Adds `close` method for `Region` trait and implements the`close` method for the corresponding structs. Therefore, the upper(e.g. `EngineInner`) can call the `close` method to release the region resources when closing or dropping regions.

Based on my understanding, in order to close a region,

1. (Frontend) The frontend sets a CLOSING flag for the target region in metasrv. After that, it will reject future writing / altering requests.
2. (Frontend) Sends the close request to datanode leader(s).
 - [x] (Datanode-leader) Leader acquires the write lock.
- [x] (Datanode-leader) Sets a memory flag to reject any potential(due to network delay) writing.
- [x] (Datanode-leader) Waits for the pending flush task.
- [ ] (Datanode-leader) Cancels compaction task (TODO #930 )
3. (Frontend) The frontend sets a CLOSED flag for the target region in metasrv.


![Untitled Diagram (5)](https://user-images.githubusercontent.com/32535939/218388390-8aa1fe26-f01d-497b-aeb3-4fbd023a9a5c.jpg)
(rejecting the write requests due to network delay)



## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#832 