### PR TITLE
refactor: refactor execute_stream to non-async method

### DIFF
--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -119,14 +119,12 @@ impl QueryEngine for DatafusionQueryEngine {
         let physical_plan = self.create_physical_plan(&mut ctx, &logical_plan).await?;
         let physical_plan = self.optimize_physical_plan(&mut ctx, physical_plan)?;
 
-        Ok(Output::Stream(
-            self.execute_stream(&ctx, &physical_plan).await?,
-        ))
+        Ok(Output::Stream(self.execute_stream(&ctx, &physical_plan)?))
     }
 
     async fn execute_physical(&self, plan: &Arc<dyn PhysicalPlan>) -> Result<Output> {
         let ctx = QueryEngineContext::new(self.state.clone());
-        Ok(Output::Stream(self.execute_stream(&ctx, plan).await?))
+        Ok(Output::Stream(self.execute_stream(&ctx, plan)?))
     }
 
     fn register_udf(&self, udf: ScalarUdf) {
@@ -237,9 +235,8 @@ impl PhysicalOptimizer for DatafusionQueryEngine {
     }
 }
 
-#[async_trait::async_trait]
 impl QueryExecutor for DatafusionQueryEngine {
-    async fn execute_stream(
+    fn execute_stream(
         &self,
         ctx: &QueryEngineContext,
         plan: &Arc<dyn PhysicalPlan>,

--- a/src/query/src/executor.rs
+++ b/src/query/src/executor.rs
@@ -21,9 +21,8 @@ use crate::error::Result;
 use crate::query_engine::QueryEngineContext;
 
 /// Executor to run [ExecutionPlan].
-#[async_trait::async_trait]
 pub trait QueryExecutor {
-    async fn execute_stream(
+    fn execute_stream(
         &self,
         ctx: &QueryEngineContext,
         plan: &Arc<dyn PhysicalPlan>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

refactor execute_stream to non-async method

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#940 