### PR TITLE
fix: an error occurred when requesting the http doc api

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -417,7 +417,7 @@ impl HttpServer {
                 script_handler: self.script_handler.clone(),
             })
             .finish_api(&mut api)
-            .layer(Extension(Arc::new(api)));
+            .layer(Extension(api));
 
         let mut router = Router::new().nest(&format!("/{HTTP_API_VERSION}"), sql_router);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr fix: an error occurred when requesting the http doc api

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#983 