### PR TITLE
feat: add retry logic for MetaPeerClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,6 +3895,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "dashmap",
+ "derive_builder 0.12.0",
  "etcd-client",
  "futures",
  "h2",

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -20,6 +20,7 @@ common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
 dashmap = "5.4"
+derive_builder = "0.12"
 etcd-client = "0.10"
 futures.workspace = true
 h2 = "0.3"

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -97,7 +97,7 @@ pub async fn make_meta_srv(opts: MetaSrvOptions) -> Result<MetaSrv> {
         .election(election.clone())
         .in_memory(in_memory.clone())
         .build()
-        // Safety: all required fields set at initializatio
+        // Safety: all required fields set at initialization
         .unwrap();
 
     let selector = match opts.selector {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -92,8 +92,7 @@ pub async fn make_meta_srv(opts: MetaSrvOptions) -> Result<MetaSrv> {
 
     let in_memory = Arc::new(MemStore::default()) as ResetableKvStoreRef;
 
-    let mut builder = MetaPeerClientBuilder::default();
-    let meta_peer_client = builder
+    let meta_peer_client = MetaPeerClientBuilder::default()
         .election(election.clone())
         .in_memory(in_memory.clone())
         .build()

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -25,7 +25,7 @@ use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::server::Router;
 
-use crate::cluster::MetaPeerClient;
+use crate::cluster::MetaPeerClientBuilder;
 use crate::election::etcd::EtcdElection;
 use crate::lock::etcd::EtcdLock;
 use crate::metasrv::builder::MetaSrvBuilder;
@@ -91,7 +91,14 @@ pub async fn make_meta_srv(opts: MetaSrvOptions) -> Result<MetaSrv> {
     };
 
     let in_memory = Arc::new(MemStore::default()) as ResetableKvStoreRef;
-    let meta_peer_client = MetaPeerClient::new(in_memory.clone(), election.clone());
+
+    let mut builder = MetaPeerClientBuilder::default();
+    let meta_peer_client = builder
+        .election(election.clone())
+        .in_memory(in_memory.clone())
+        .build()
+        // Safety: all required fields set at initializatio
+        .unwrap();
 
     let selector = match opts.selector {
         SelectorType::LoadBased => Arc::new(LoadBasedSelector {

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -38,9 +38,9 @@ pub struct MetaPeerClient {
     #[builder(default = "ChannelManager::default()")]
     channel_manager: ChannelManager,
     #[builder(default = "3")]
-    retry_num: usize,
+    max_retry_count: usize,
     #[builder(default = "1000")]
-    interval_ms: u64,
+    retry_interval_ms: u64,
 }
 
 impl MetaPeerClient {
@@ -75,8 +75,8 @@ impl MetaPeerClient {
             return self.in_memory.range(request).await.map(|resp| resp.kvs);
         }
 
-        let retry_num = self.retry_num;
-        let interval_mills = self.interval_ms;
+        let retry_num = self.max_retry_count;
+        let interval_mills = self.retry_interval_ms;
 
         for _ in 0..retry_num {
             match self.remote_range(key.clone(), range_end.clone()).await {
@@ -133,8 +133,8 @@ impl MetaPeerClient {
             return self.in_memory.batch_get(keys).await;
         }
 
-        let retry_num = self.retry_num;
-        let interval_mills = self.interval_ms;
+        let retry_num = self.max_retry_count;
+        let interval_mills = self.retry_interval_ms;
 
         for _ in 0..retry_num {
             match self.remote_batch_get(keys.clone()).await {

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use api::v1::meta::cluster_client::ClusterClient;
 use api::v1::meta::{
@@ -33,32 +34,74 @@ pub struct MetaPeerClient {
     election: Option<ElectionRef>,
     in_memory: ResetableKvStoreRef,
     channel_manager: ChannelManager,
+    retry_num: usize,
+    interval_mills: u64,
 }
 
 impl MetaPeerClient {
     pub fn new(in_mem: ResetableKvStoreRef, election: Option<ElectionRef>) -> Self {
+        let channel_manager = ChannelManager::default();
+
         Self {
             election,
             in_memory: in_mem,
-            channel_manager: ChannelManager::default(),
+            channel_manager,
+            retry_num: 3,
+            interval_mills: 500,
         }
     }
 
     // Get all datanode stat kvs from leader meta.
     pub async fn get_all_dn_stat_kvs(&self) -> Result<HashMap<StatKey, StatValue>> {
-        let stat_prefix = format!("{DN_STAT_PREFIX}-").into_bytes();
-        let range_end = util::get_prefix_end_key(&stat_prefix);
-        let req = RangeRequest {
-            key: stat_prefix.clone(),
-            range_end,
-            ..Default::default()
-        };
+        let key = format!("{DN_STAT_PREFIX}-").into_bytes();
+        let range_end = util::get_prefix_end_key(&key);
 
+        let kvs = self.range(key, range_end).await?;
+
+        to_stat_kv_map(kvs)
+    }
+
+    // Get datanode stat kvs from leader meta by input keys.
+    pub async fn get_dn_stat_kvs(&self, keys: Vec<StatKey>) -> Result<HashMap<StatKey, StatValue>> {
+        let stat_keys = keys.into_iter().map(|key| key.into()).collect();
+
+        let kvs = self.batch_get(stat_keys).await?;
+
+        to_stat_kv_map(kvs)
+    }
+
+    // Range kv information from the leader's in_mem kv store
+    pub async fn range(&self, key: Vec<u8>, range_end: Vec<u8>) -> Result<Vec<KeyValue>> {
         if self.is_leader() {
-            let kvs = self.in_memory.range(req).await?.kvs;
-            return to_stat_kv_map(kvs);
+            let request = RangeRequest {
+                key,
+                range_end,
+                ..Default::default()
+            };
+
+            return self.in_memory.range(request).await.map(|resp| resp.kvs);
         }
 
+        let retry_num = self.retry_num;
+        let interval_mills = self.interval_mills;
+
+        for _ in 0..retry_num {
+            match self.remote_range(key.clone(), range_end.clone()).await {
+                Ok(kvs) => return Ok(kvs),
+                Err(e) => {
+                    if need_retry(&e) {
+                        tokio::time::sleep(Duration::from_millis(interval_mills)).await;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        error::ExceededRetryLimitSnafu { retry_num }.fail()
+    }
+
+    async fn remote_range(&self, key: Vec<u8>, range_end: Vec<u8>) -> Result<Vec<KeyValue>> {
         // Safety: when self.is_leader() == false, election must not empty.
         let election = self.election.as_ref().unwrap();
 
@@ -69,39 +112,49 @@ impl MetaPeerClient {
             .get(&leader_addr)
             .context(error::CreateChannelSnafu)?;
 
-        let request = tonic::Request::new(req);
+        let request = tonic::Request::new(RangeRequest {
+            key,
+            range_end,
+            ..Default::default()
+        });
 
         let response: RangeResponse = ClusterClient::new(channel)
             .range(request)
             .await
-            .context(error::BatchGetSnafu)?
+            .context(error::RangeSnafu)?
             .into_inner();
 
         check_resp_header(&response.header, Context { addr: &leader_addr })?;
 
-        to_stat_kv_map(response.kvs)
-    }
-
-    // Get datanode stat kvs from leader meta by input keys.
-    pub async fn get_dn_stat_kvs(&self, keys: Vec<StatKey>) -> Result<HashMap<StatKey, StatValue>> {
-        let stat_keys = keys.into_iter().map(|key| key.into()).collect();
-        let stat_kvs = self.batch_get(stat_keys).await?;
-
-        let mut result = HashMap::with_capacity(stat_kvs.len());
-        for stat_kv in stat_kvs {
-            let stat_key = stat_kv.key.try_into()?;
-            let stat_val = stat_kv.value.try_into()?;
-            result.insert(stat_key, stat_val);
-        }
-        Ok(result)
+        Ok(response.kvs)
     }
 
     // Get kv information from the leader's in_mem kv store
-    async fn batch_get(&self, keys: Vec<Vec<u8>>) -> Result<Vec<KeyValue>> {
+    pub async fn batch_get(&self, keys: Vec<Vec<u8>>) -> Result<Vec<KeyValue>> {
         if self.is_leader() {
             return self.in_memory.batch_get(keys).await;
         }
 
+        let retry_num = self.retry_num;
+        let interval_mills = self.interval_mills;
+
+        for _ in 0..retry_num {
+            match self.remote_batch_get(keys.clone()).await {
+                Ok(kvs) => return Ok(kvs),
+                Err(e) => {
+                    if need_retry(&e) {
+                        tokio::time::sleep(Duration::from_millis(interval_mills)).await;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+
+        error::ExceededRetryLimitSnafu { retry_num }.fail()
+    }
+
+    async fn remote_batch_get(&self, keys: Vec<Vec<u8>>) -> Result<Vec<KeyValue>> {
         // Safety: when self.is_leader() == false, election must not empty.
         let election = self.election.as_ref().unwrap();
 
@@ -113,11 +166,11 @@ impl MetaPeerClient {
             .context(error::CreateChannelSnafu)?;
 
         let request = tonic::Request::new(BatchGetRequest {
-            keys: keys.clone(),
+            keys,
             ..Default::default()
         });
 
-        let response: BatchGetResponse = ClusterClient::new(channel.clone())
+        let response: BatchGetResponse = ClusterClient::new(channel)
             .batch_get(request)
             .await
             .context(error::BatchGetSnafu)?
@@ -163,6 +216,10 @@ fn check_resp_header(header: &Option<ResponseHeader>, ctx: Context) -> Result<()
     );
 
     Ok(())
+}
+
+fn need_retry(_error: &error::Error) -> bool {
+    unimplemented!()
 }
 
 #[cfg(test)]

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -212,7 +212,7 @@ fn check_resp_header(header: &Option<ResponseHeader>, ctx: Context) -> Result<()
 
 fn need_retry(error: &error::Error) -> bool {
     match error {
-        error::Error::NoLeader { .. } => true,
+        error::Error::IsNotLeader { .. } => true,
         error::Error::Range { source, .. } | error::Error::BatchGet { source, .. } => {
             match_for_io_error(source).is_some()
         }

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -39,7 +39,7 @@ pub struct MetaPeerClient {
     #[builder(default = "3")]
     retry_num: usize,
     #[builder(default = "1000")]
-    interval_mills: u64,
+    interval_ms: u64,
 }
 
 impl MetaPeerClient {
@@ -75,7 +75,7 @@ impl MetaPeerClient {
         }
 
         let retry_num = self.retry_num;
-        let interval_mills = self.interval_mills;
+        let interval_mills = self.interval_ms;
 
         for _ in 0..retry_num {
             match self.remote_range(key.clone(), range_end.clone()).await {
@@ -128,7 +128,7 @@ impl MetaPeerClient {
         }
 
         let retry_num = self.retry_num;
-        let interval_mills = self.interval_mills;
+        let interval_mills = self.interval_ms;
 
         for _ in 0..retry_num {
             match self.remote_batch_get(keys.clone()).await {

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -195,6 +195,15 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display(
+        "Failed to batch range KVs from leader's in_memory kv store, source: {}",
+        source
+    ))]
+    Range {
+        source: tonic::Status,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Response header not found"))]
     ResponseHeaderNotFound { backtrace: Backtrace },
 
@@ -210,6 +219,15 @@ pub enum Error {
     #[snafu(display("Invalid http body, source: {}", source))]
     InvalidHttpBody {
         source: http::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "The number of retries for the grpc call exceeded the limit, {}",
+        retry_num
+    ))]
+    ExceededRetryLimit {
+        retry_num: usize,
         backtrace: Backtrace,
     },
 
@@ -271,6 +289,7 @@ impl ErrorExt for Error {
             | Error::NoLeader { .. }
             | Error::CreateChannel { .. }
             | Error::BatchGet { .. }
+            | Error::Range { .. }
             | Error::ResponseHeaderNotFound { .. }
             | Error::IsNotLeader { .. }
             | Error::NoMetaPeerClient { .. }
@@ -279,6 +298,7 @@ impl ErrorExt for Error {
             | Error::Unlock { .. }
             | Error::LeaseGrant { .. }
             | Error::LockNotConfig { .. }
+            | Error::ExceededRetryLimit { .. }
             | Error::StartGrpc { .. } => StatusCode::Internal,
             Error::EmptyKey { .. }
             | Error::EmptyTableName { .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -223,10 +223,12 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "The number of retries for the grpc call exceeded the limit, {}",
+        "The number of retries for the grpc call {} exceeded the limit, {}",
+        func_name,
         retry_num
     ))]
     ExceededRetryLimit {
+        func_name: String,
         retry_num: usize,
         backtrace: Backtrace,
     },

--- a/src/meta-srv/src/service/cluster.rs
+++ b/src/meta-srv/src/service/cluster.rs
@@ -16,6 +16,7 @@ use api::v1::meta::{
     cluster_server, BatchGetRequest, BatchGetResponse, Error, RangeRequest, RangeResponse,
     ResponseHeader,
 };
+use common_telemetry::warn;
 use tonic::{Request, Response};
 
 use crate::metasrv::MetaSrv;
@@ -31,6 +32,8 @@ impl cluster_server::Cluster for MetaSrv {
                 header: Some(is_not_leader),
                 ..Default::default()
             };
+
+            warn!("The current meta is not leader, but a batch_get request have reached the meta.");
             return Ok(Response::new(resp));
         }
 
@@ -53,6 +56,8 @@ impl cluster_server::Cluster for MetaSrv {
                 header: Some(is_not_leader),
                 ..Default::default()
             };
+
+            warn!("The current meta is not leader, but a range request have reached the meta.");
             return Ok(Response::new(resp));
         }
 

--- a/src/meta-srv/src/service/cluster.rs
+++ b/src/meta-srv/src/service/cluster.rs
@@ -33,7 +33,7 @@ impl cluster_server::Cluster for MetaSrv {
                 ..Default::default()
             };
 
-            warn!("The current meta is not leader, but a batch_get request have reached the meta.");
+            warn!("The current meta is not leader, but a batch_get request have reached the meta. Detail: {:?}.", req);
             return Ok(Response::new(resp));
         }
 
@@ -57,7 +57,7 @@ impl cluster_server::Cluster for MetaSrv {
                 ..Default::default()
             };
 
-            warn!("The current meta is not leader, but a range request have reached the meta.");
+            warn!("The current meta is not leader, but a range request have reached the meta. Detail: {:?}.", req);
             return Ok(Response::new(resp));
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly change:  add retry logic for MetaPeerClient.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
