### PR TITLE
feat: update promql-parser to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,8 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "promql-parser"
-version = "0.0.1"
-source = "git+https://github.com/GreptimeTeam/promql-parser.git?rev=fa186978a1234baf5a3e372da03aa663d859cdd2#fa186978a1234baf5a3e372da03aa663d859cdd2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24766dbb98852e704a98fc2c003d2b3ffa48317ab09b4ae184925f0e60385764"
 dependencies = [
  "cfgrammar",
  "lazy_static",

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -13,7 +13,7 @@ common-catalog = { path = "../common/catalog" }
 datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures = "0.3"
-promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", rev = "fa186978a1234baf5a3e372da03aa663d859cdd2" }
+promql-parser = "0.1.0"
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 table = { path = "../table" }

--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     #[snafu(display("Unsupported expr type: {}", name))]
     UnsupportedExpr { name: String, backtrace: Backtrace },
 
-    #[snafu(display("Unexpected token: {}", token))]
+    #[snafu(display("Unexpected token: {:?}", token))]
     UnexpectedToken {
         token: TokenType,
         backtrace: Backtrace,

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -28,7 +28,7 @@ futures-util.workspace = true
 metrics = "0.20"
 once_cell = "1.10"
 promql = { path = "../promql" }
-promql-parser = { git = "https://github.com/GreptimeTeam/promql-parser.git", rev = "fa186978a1234baf5a3e372da03aa663d859cdd2" }
+promql-parser = "0.1.0"
 serde.workspace = true
 serde_json = "1.0"
 session = { path = "../session" }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

update [promql-parser](https://crates.io/crates/promql-parser) to v0.1.0

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.