### PR TITLE
test: add api and doc http test

### DIFF
--- a/src/servers/tests/http/http_test.rs
+++ b/src/servers/tests/http/http_test.rs
@@ -12,60 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
-use async_trait::async_trait;
 use axum::Router;
 use axum_test_helper::TestClient;
-use common_query::Output;
-use datatypes::schema::Schema;
-use servers::error::{Error, Result};
 use servers::http::{HttpOptions, HttpServer};
-use servers::query_handler::sql::SqlQueryHandler;
-use session::context::QueryContextRef;
+use table::test_util::MemTable;
 
-pub struct DummyInstance {}
-
-#[async_trait]
-impl SqlQueryHandler for DummyInstance {
-    type Error = Error;
-
-    async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
-        unimplemented!()
-    }
-
-    async fn do_promql_query(
-        &self,
-        _: &str,
-        _: QueryContextRef,
-    ) -> Vec<std::result::Result<Output, Self::Error>> {
-        unimplemented!()
-    }
-
-    async fn do_statement_query(
-        &self,
-        _stmt: sql::statements::statement::Statement,
-        _query_ctx: QueryContextRef,
-    ) -> Result<Output> {
-        unimplemented!()
-    }
-
-    fn do_describe(
-        &self,
-        _stmt: sql::statements::statement::Statement,
-        _query_ctx: QueryContextRef,
-    ) -> Result<Option<Schema>> {
-        unimplemented!()
-    }
-
-    fn is_valid_schema(&self, _catalog: &str, _schema: &str) -> Result<bool> {
-        Ok(true)
-    }
-}
+use crate::create_testing_sql_query_handler;
 
 fn make_test_app() -> Router {
-    let instance = Arc::new(DummyInstance {});
-    let server = HttpServer::new(instance, HttpOptions::default());
+    let server = HttpServer::new(
+        create_testing_sql_query_handler(MemTable::default_numbers_table()),
+        HttpOptions::default(),
+    );
     server.make_app()
 }
 

--- a/src/servers/tests/http/http_test.rs
+++ b/src/servers/tests/http/http_test.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum_test_helper::TestClient;
+use common_query::Output;
+use datatypes::schema::Schema;
+use servers::error::{Error, Result};
+use servers::http::{HttpOptions, HttpServer};
+use servers::query_handler::sql::SqlQueryHandler;
+use session::context::QueryContextRef;
+
+pub struct DummyInstance {}
+
+#[async_trait]
+impl SqlQueryHandler for DummyInstance {
+    type Error = Error;
+
+    async fn do_query(&self, _: &str, _: QueryContextRef) -> Vec<Result<Output>> {
+        unimplemented!()
+    }
+
+    async fn do_promql_query(
+        &self,
+        _: &str,
+        _: QueryContextRef,
+    ) -> Vec<std::result::Result<Output, Self::Error>> {
+        unimplemented!()
+    }
+
+    async fn do_statement_query(
+        &self,
+        _stmt: sql::statements::statement::Statement,
+        _query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        unimplemented!()
+    }
+
+    fn do_describe(
+        &self,
+        _stmt: sql::statements::statement::Statement,
+        _query_ctx: QueryContextRef,
+    ) -> Result<Option<Schema>> {
+        unimplemented!()
+    }
+
+    fn is_valid_schema(&self, _catalog: &str, _schema: &str) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+fn make_test_app() -> Router {
+    let instance = Arc::new(DummyInstance {});
+    let server = HttpServer::new(instance, HttpOptions::default());
+    server.make_app()
+}
+
+#[tokio::test]
+async fn test_api_and_doc() {
+    let app = make_test_app();
+    let client = TestClient::new(app);
+    let result = client.get("/v1/private/api.json").send().await;
+    assert_eq!(result.status(), 200);
+    let result = client.get("/v1/private/docs").send().await;
+    assert_eq!(result.status(), 200);
+}

--- a/src/servers/tests/http/mod.rs
+++ b/src/servers/tests/http/mod.rs
@@ -14,6 +14,7 @@
 
 mod authorize;
 mod http_handler_test;
+mod http_test;
 mod influxdb_test;
 mod opentsdb_test;
 mod prometheus_test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add http's api and doc IT.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/983