### PR TITLE
feat: export the data from a table to parquet files

### DIFF
--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -382,7 +382,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Fail to write object into path: {}, source: {}", path, source))]
+    #[snafu(display("Failed to write object into path: {}, source: {}", path, source))]
     WriteObject {
         path: String,
         backtrace: Backtrace,

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -450,24 +450,19 @@ impl ErrorExt for Error {
             | MissingRequiredField { .. }
             | IncorrectInternalState { .. } => StatusCode::Internal,
 
-            Error::InitBackend { .. }
-            | Error::WriteParquet { .. }
-            | Error::PollStream { .. }
-            | Error::WriteObject { .. } => StatusCode::StorageUnavailable,
-            Error::OpenLogStore { source } => source.status_code(),
-            Error::StartScriptManager { source } => source.status_code(),
-            Error::OpenStorageEngine { source } => source.status_code(),
-            Error::RuntimeResource { .. } => StatusCode::RuntimeResourcesExhausted,
-            Error::MetaClientInit { source, .. } => source.status_code(),
-            Error::TableIdProviderNotFound { .. } => StatusCode::Unsupported,
-            Error::BumpTableId { source, .. } => source.status_code(),
-            Error::MissingNodeId { .. } => StatusCode::InvalidArguments,
-            Error::MissingMetasrvOpts { .. } => StatusCode::InvalidArguments,
-            Error::ColumnDefaultValue { source, .. } => source.status_code(),
-            Error::ColumnNoneDefaultValue { .. } => StatusCode::InvalidArguments,
-
-            Error::CopyTable { source, .. } => source.status_code(),
-            Error::TableScanExec { source, .. } => source.status_code(),
+            InitBackend { .. } | WriteParquet { .. } | PollStream { .. } | WriteObject { .. } => {
+                StatusCode::StorageUnavailable
+            }
+            OpenLogStore { source } => source.status_code(),
+            StartScriptManager { source } => source.status_code(),
+            OpenStorageEngine { source } => source.status_code(),
+            RuntimeResource { .. } => StatusCode::RuntimeResourcesExhausted,
+            MetaClientInit { source, .. } => source.status_code(),
+            TableIdProviderNotFound { .. } => StatusCode::Unsupported,
+            BumpTableId { source, .. } => source.status_code(),
+            ColumnDefaultValue { source, .. } => source.status_code(),
+            CopyTable { source, .. } => source.status_code(),
+            TableScanExec { source, .. } => source.status_code(),
         }
     }
 

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -16,6 +16,7 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use common_error::prelude::BoxedError;
+use common_grpc_expr::insert;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
 use common_telemetry::logging::info;
@@ -57,10 +58,10 @@ impl Instance {
                     .await
                     .context(ExecuteSqlSnafu)
             }
-            QueryStatement::Sql(Statement::Insert(i)) => {
+            QueryStatement::Sql(Statement::Insert(insert)) => {
                 let requests = self
                     .sql_handler
-                    .insert_to_requests(self.catalog_manager.clone(), *i, query_ctx.clone())
+                    .insert_to_requests(self.catalog_manager.clone(), *insert, query_ctx.clone())
                     .await?;
 
                 match requests {
@@ -86,14 +87,14 @@ impl Instance {
                     }
                 }
             }
-            QueryStatement::Sql(Statement::Delete(d)) => {
-                let request = SqlRequest::Delete(*d);
+            QueryStatement::Sql(Statement::Delete(delete)) => {
+                let request = SqlRequest::Delete(*delete);
                 self.sql_handler.execute(request, query_ctx).await
             }
-            QueryStatement::Sql(Statement::CreateDatabase(c)) => {
+            QueryStatement::Sql(Statement::CreateDatabase(create_database)) => {
                 let request = CreateDatabaseRequest {
-                    db_name: c.name.to_string(),
-                    create_if_not_exists: c.if_not_exists,
+                    db_name: create_database.name.to_string(),
+                    create_if_not_exists: create_database.if_not_exists,
                 };
 
                 info!("Creating a new database: {}", request.db_name);
@@ -103,7 +104,7 @@ impl Instance {
                     .await
             }
 
-            QueryStatement::Sql(Statement::CreateTable(c)) => {
+            QueryStatement::Sql(Statement::CreateTable(create_table)) => {
                 let table_id = self
                     .table_id_provider
                     .as_ref()
@@ -111,15 +112,15 @@ impl Instance {
                     .next_table_id()
                     .await
                     .context(BumpTableIdSnafu)?;
-                let _engine_name = c.engine.clone();
+                let _engine_name = create_table.engine.clone();
                 // TODO(hl): Select table engine by engine_name
 
-                let name = c.name.clone();
+                let name = create_table.name.clone();
                 let (catalog, schema, table) = table_idents_to_full_name(&name, query_ctx.clone())?;
                 let table_ref = TableReference::full(&catalog, &schema, &table);
-                let request = self
-                    .sql_handler
-                    .create_to_request(table_id, c, &table_ref)?;
+                let request =
+                    self.sql_handler
+                        .create_to_request(table_id, create_table, &table_ref)?;
                 let table_id = request.id;
                 info!("Creating table: {table_ref}, table id = {table_id}",);
 
@@ -148,27 +149,27 @@ impl Instance {
                     .execute(SqlRequest::DropTable(req), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::ShowDatabases(stmt)) => {
+            QueryStatement::Sql(Statement::ShowDatabases(show_databases)) => {
                 self.sql_handler
-                    .execute(SqlRequest::ShowDatabases(stmt), query_ctx)
+                    .execute(SqlRequest::ShowDatabases(show_databases), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::ShowTables(stmt)) => {
+            QueryStatement::Sql(Statement::ShowTables(show_tables)) => {
                 self.sql_handler
-                    .execute(SqlRequest::ShowTables(stmt), query_ctx)
+                    .execute(SqlRequest::ShowTables(show_tables), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::Explain(stmt)) => {
+            QueryStatement::Sql(Statement::Explain(explain)) => {
                 self.sql_handler
-                    .execute(SqlRequest::Explain(Box::new(stmt)), query_ctx)
+                    .execute(SqlRequest::Explain(Box::new(explain)), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::DescribeTable(stmt)) => {
+            QueryStatement::Sql(Statement::DescribeTable(describe_table)) => {
                 self.sql_handler
-                    .execute(SqlRequest::DescribeTable(stmt), query_ctx)
+                    .execute(SqlRequest::DescribeTable(describe_table), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::ShowCreateTable(_stmt)) => {
+            QueryStatement::Sql(Statement::ShowCreateTable(_show_create_table)) => {
                 unimplemented!("SHOW CREATE TABLE is unimplemented yet");
             }
             QueryStatement::Sql(Statement::Use(ref schema)) => {

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -16,7 +16,6 @@ use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use common_error::prelude::BoxedError;
-use common_grpc_expr::insert;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
 use common_telemetry::logging::info;

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -182,6 +182,9 @@ impl Instance {
 
                 Ok(Output::RecordBatches(RecordBatches::empty()))
             }
+            QueryStatement::Sql(Statement::Copy(stmt)) => {
+                todo!()
+            }
         }
     }
 

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -31,6 +31,7 @@ use crate::error::{self, ExecuteSqlSnafu, GetTableSnafu, Result, TableNotFoundSn
 use crate::instance::sql::table_idents_to_full_name;
 
 mod alter;
+mod copy_table;
 mod create;
 mod delete;
 mod drop_table;
@@ -48,6 +49,7 @@ pub enum SqlRequest {
     DescribeTable(DescribeTable),
     Explain(Box<Explain>),
     Delete(Delete),
+    CopyTable(CopyTableRequest),
 }
 
 // Handler to execute SQL except query
@@ -82,6 +84,7 @@ impl SqlHandler {
             SqlRequest::Alter(req) => self.alter(req).await,
             SqlRequest::DropTable(req) => self.drop_table(req).await,
             SqlRequest::Delete(stmt) => self.delete(query_ctx.clone(), stmt).await,
+            SqlRequest::CopyTable(req) => self.copy_table(req).await,
             SqlRequest::ShowDatabases(stmt) => {
                 show_databases(stmt, self.catalog_manager.clone()).context(ExecuteSqlSnafu)
             }

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -65,7 +65,6 @@ impl SqlHandler {
         let object_store = ObjectStore::new(accessor);
 
         let mut parquet_writer = ParquetWriter::new(req.file_name, stream, object_store);
-
         let rows = parquet_writer.flush().await?;
 
         Ok(Output::AffectedRows(rows))

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -83,9 +83,9 @@ impl ParquetWriter {
             file_name,
             stream,
             object_store,
-            // TODO(jiachun): make these configurable
+            // TODO(jiachun): make these configurable: WITH (max_row_group_size=xxx, max_rows_in_segment=xxx)
             max_row_group_size: 4096,
-            max_rows_in_segment: 1000000,
+            max_rows_in_segment: 5000000, // default 5M rows per segment
         }
     }
 

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -56,6 +56,11 @@ impl SqlHandler {
         let object_store = ObjectStore::new(accessor);
 
         let mut parquet_writer = ParquetWriter::new(req.file_name, stream, object_store);
+        // TODO(jiachun):
+        // For now, COPY is implemented synchronously.
+        // When copying large table, it will be blocked for a long time.
+        // Maybe we should make "copy" runs in background?
+        // Like pg: https://www.postgresql.org/docs/current/sql-copy.html
         let rows = parquet_writer.flush().await?;
 
         Ok(Output::AffectedRows(rows))

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -24,8 +24,8 @@ use datafusion::physical_plan::RecordBatchStream;
 use futures::TryStreamExt;
 use object_store::services::fs::Builder;
 use object_store::ObjectStore;
-use snafu::{OptionExt, ResultExt};
-use table::engine::{EngineContext, TableReference};
+use snafu::ResultExt;
+use table::engine::TableReference;
 use table::requests::CopyTableRequest;
 
 use crate::error::{self, Result};
@@ -38,16 +38,7 @@ impl SqlHandler {
             schema: &req.schema_name.to_string(),
             table: &req.table_name.to_string(),
         };
-
-        let table = self
-            .table_engine()
-            .get_table(&EngineContext::default(), &table_ref)
-            .context(error::GetTableSnafu {
-                table_name: table_ref.to_string(),
-            })?
-            .context(error::TableNotFoundSnafu {
-                table_name: table_ref.to_string(),
-            })?;
+        let table = self.get_table(&table_ref)?;
 
         let stream = table
             .scan(None, &[], None)

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -128,7 +128,7 @@ impl ParquetWriter {
             total_rows += rows;
             arrow_writer.close().context(error::WriteParquetSnafu)?;
 
-            // if rows == 0, we just end up with a empty file.
+            // if rows == 0, we just end up with an empty file.
             //
             // file_name like:
             // "file_name_1_1000000"        (row num: 1 ~ 1000000),

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -60,7 +60,7 @@ impl SqlHandler {
         // For now, COPY is implemented synchronously.
         // When copying large table, it will be blocked for a long time.
         // Maybe we should make "copy" runs in background?
-        // Like pg: https://www.postgresql.org/docs/current/sql-copy.html
+        // Like PG: https://www.postgresql.org/docs/current/sql-copy.html
         let rows = parquet_writer.flush().await?;
 
         Ok(Output::AffectedRows(rows))
@@ -131,9 +131,9 @@ impl ParquetWriter {
             // if rows == 0, we just end up with a empty file.
             //
             // file_name like:
-            // "file_name_1"            (row num: 1 ~ 1000000),
-            // "file_name_1000001"      (row num: 1000001 ~ max_row_num)
-            let file_name = format!("{}_{}", self.file_name, start_row_num);
+            // "file_name_1_1000000"        (row num: 1 ~ 1000000),
+            // "file_name_1000001_xxx"      (row num: 1000001 ~ xxx)
+            let file_name = format!("{}_{}_{}", self.file_name, start_row_num, total_rows);
             let object = self.object_store.object(&file_name);
             object.write(buf).await.context(error::WriteObjectSnafu {
                 path: object.path(),

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -1,0 +1,145 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::pin::Pin;
+
+use common_query::physical_plan::SessionContext;
+use common_query::Output;
+use common_recordbatch::adapter::DfRecordBatchStreamAdapter;
+use datafusion::parquet::arrow::ArrowWriter;
+use datafusion::parquet::basic::{Compression, Encoding};
+use datafusion::parquet::file::properties::WriterProperties;
+use datafusion::physical_plan::RecordBatchStream;
+use futures::TryStreamExt;
+use object_store::services::fs::Builder;
+use object_store::ObjectStore;
+use snafu::ResultExt;
+use table::engine::TableReference;
+use table::requests::CopyTableRequest;
+
+use crate::error::{self, Result};
+use crate::sql::SqlHandler;
+
+impl SqlHandler {
+    pub(crate) async fn copy_table(&self, req: CopyTableRequest) -> Result<Output> {
+        let table_ref = TableReference {
+            catalog: &req.catalog_name.to_string(),
+            schema: &req.schema_name.to_string(),
+            table: &req.table_name.to_string(),
+        };
+
+        let table = self.get_table(&table_ref)?;
+
+        let stream = table
+            .scan(None, &[], None)
+            .await
+            .with_context(|_| error::CopyTableSnafu {
+                table_name: table_ref.to_string(),
+            })?;
+
+        let session_ctx = SessionContext::new();
+        let stream = stream
+            .execute(0, session_ctx.task_ctx())
+            .context(error::TableScanExecSnafu)?;
+        let stream = Box::pin(DfRecordBatchStreamAdapter::new(stream));
+
+        // TODO(jiachun): make this configurable
+        let accessor = Builder::default().root(".").build().unwrap();
+        let object_store = ObjectStore::new(accessor);
+
+        let mut parquet_writer = ParquetWriter::new(req.file_name, stream, object_store);
+
+        let rows = parquet_writer.flush().await?;
+
+        Ok(Output::AffectedRows(rows))
+    }
+}
+
+type DfRecordBatchStream = Pin<Box<DfRecordBatchStreamAdapter>>;
+
+struct ParquetWriter {
+    file_name: String,
+    stream: DfRecordBatchStream,
+    object_store: ObjectStore,
+    max_row_group_size: usize,
+    max_rows_in_segment: usize,
+}
+
+impl ParquetWriter {
+    pub fn new(file_name: String, stream: DfRecordBatchStream, object_store: ObjectStore) -> Self {
+        Self {
+            file_name,
+            stream,
+            object_store,
+            // TODO(jiachun): make these configurable
+            max_row_group_size: 4096,
+            max_rows_in_segment: 100000,
+        }
+    }
+
+    pub async fn flush(&mut self) -> Result<usize> {
+        let schema = self.stream.as_ref().schema();
+        let writer_props = WriterProperties::builder()
+            .set_compression(Compression::ZSTD)
+            .set_encoding(Encoding::PLAIN)
+            .set_max_row_group_size(self.max_row_group_size)
+            .build();
+        let mut total_rows = 0;
+        let mut seq = 0;
+        loop {
+            let mut buf = vec![];
+            let mut arrow_writer =
+                ArrowWriter::try_new(&mut buf, schema.clone(), Some(writer_props.clone()))
+                    .context(error::WriteParquetSnafu)?;
+            let file_name = format!("{}_{}", self.file_name, seq);
+            seq += 1;
+            let object = self.object_store.object(&file_name);
+            let mut rows = 0;
+            let mut end_loop = true;
+
+            // TODO(hl & jiachun): Since OpenDAL's writer is async and ArrowWriter requires a `std::io::Write`,
+            // here we use a Vec<u8> to buffer all parquet bytes in memory and write to object store
+            // at a time. Maybe we should find a better way to brige ArrowWriter and OpenDAL's object.
+            while let Some(batch) = self
+                .stream
+                .try_next()
+                .await
+                .context(error::PollStreamSnafu)?
+            {
+                arrow_writer
+                    .write(&batch)
+                    .context(error::WriteParquetSnafu)?;
+                rows += batch.num_rows();
+                if rows >= self.max_rows_in_segment {
+                    end_loop = false;
+                    break;
+                }
+            }
+
+            if rows == 0 {
+                return Ok(total_rows);
+            }
+
+            total_rows += rows;
+            arrow_writer.close().context(error::WriteParquetSnafu)?;
+            object.write(buf).await.context(error::WriteObjectSnafu {
+                path: object.path(),
+            })?;
+
+            if end_loop {
+                return Ok(total_rows);
+            }
+        }
+    }
+}

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -129,7 +129,7 @@ impl ParquetWriter {
             arrow_writer.close().context(error::WriteParquetSnafu)?;
 
             // if rows == 0, we just end up with a empty file.
-            // 
+            //
             // file_name like:
             // "file_name_1"            (row num: 1 ~ 1000000),
             // "file_name_1000001"      (row num: 1000001 ~ max_row_num)

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -34,9 +34,9 @@ use crate::sql::SqlHandler;
 impl SqlHandler {
     pub(crate) async fn copy_table(&self, req: CopyTableRequest) -> Result<Output> {
         let table_ref = TableReference {
-            catalog: &req.catalog_name.to_string(),
-            schema: &req.schema_name.to_string(),
-            table: &req.table_name.to_string(),
+            catalog: &req.catalog_name,
+            schema: &req.schema_name,
+            table: &req.table_name,
         };
         let table = self.get_table(&table_ref)?;
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -396,7 +396,8 @@ impl Instance {
             | Statement::Insert(_)
             | Statement::Delete(_)
             | Statement::Alter(_)
-            | Statement::DropTable(_) => self.sql_handler.do_statement_query(stmt, query_ctx).await,
+            | Statement::DropTable(_)
+            | Statement::Copy(_) => self.sql_handler.do_statement_query(stmt, query_ctx).await,
             Statement::Use(db) => self.handle_use(db, query_ctx),
             Statement::ShowCreateTable(_) => NotSupportedSnafu {
                 feat: format!("{stmt:?}"),

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -589,6 +589,9 @@ pub fn check_permission(
         Statement::Delete(delete) => {
             validate_param(delete.table_name(), query_ctx)?;
         }
+        Statement::Copy(stmd) => {
+            validate_param(stmd.table_name(), query_ctx)?;
+        }
     }
     Ok(())
 }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -103,7 +103,8 @@ where
             | Statement::Alter(_)
             | Statement::Insert(_)
             | Statement::DropTable(_)
-            | Statement::Use(_) => unreachable!(),
+            | Statement::Use(_)
+            | Statement::Copy(_) => unreachable!(),
         }
     }
 }

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -135,6 +135,9 @@ pub enum Error {
         timestamp: Timestamp,
         target_unit: TimeUnit,
     },
+
+    #[snafu(display("Unsupported format: {}", name))]
+    UnsupportedFormat { name: String },
 }
 
 impl ErrorExt for Error {
@@ -156,12 +159,14 @@ impl ErrorExt for Error {
             InvalidColumnOption { .. }
             | InvalidDatabaseName { .. }
             | ColumnTypeMismatch { .. }
-            | InvalidTableName { .. } => StatusCode::InvalidArguments,
+            | InvalidTableName { .. }
+            | InvalidSqlValue { .. }
+            | TimestampOverflow { .. }
+            | UnsupportedFormat { .. } => StatusCode::InvalidArguments,
+
             UnsupportedAlterTableStatement { .. } => StatusCode::InvalidSyntax,
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),
             ConvertToGrpcDataType { source, .. } => source.status_code(),
-            InvalidSqlValue { .. } => StatusCode::InvalidArguments,
-            TimestampOverflow { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -136,8 +136,8 @@ pub enum Error {
         target_unit: TimeUnit,
     },
 
-    #[snafu(display("Unsupported format: {}", name))]
-    UnsupportedFormat { name: String },
+    #[snafu(display("Unsupported format option: {}", name))]
+    UnsupportedCopyFormatOption { name: String },
 }
 
 impl ErrorExt for Error {
@@ -162,7 +162,7 @@ impl ErrorExt for Error {
             | InvalidTableName { .. }
             | InvalidSqlValue { .. }
             | TimestampOverflow { .. }
-            | UnsupportedFormat { .. } => StatusCode::InvalidArguments,
+            | UnsupportedCopyFormatOption { .. } => StatusCode::InvalidArguments,
 
             UnsupportedAlterTableStatement { .. } => StatusCode::InvalidSyntax,
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -117,6 +117,8 @@ impl<'a> ParserContext<'a> {
                         Ok(Statement::Use(database_name.value))
                     }
 
+                    Keyword::COPY => self.parse_copy(),
+
                     // todo(hl) support more statements.
                     _ => self.unsupported(self.peek_token_as_string()),
                 }

--- a/src/sql/src/parsers.rs
+++ b/src/sql/src/parsers.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod alter_parser;
+pub(crate) mod copy_parser;
 pub(crate) mod create_parser;
 pub(crate) mod delete_parser;
 pub(crate) mod insert_parser;

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -126,7 +126,7 @@ mod tests {
         assert!(result.is_err());
         assert_matches!(
             result.err().unwrap(),
-            error::Error::UnsupportedFormat { .. }
+            error::Error::UnsupportedCopyFormatOption { .. }
         );
     }
 }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -1,0 +1,83 @@
+use snafu::ResultExt;
+use sqlparser::keywords::Keyword;
+
+use crate::error::{self, Result};
+use crate::parser::ParserContext;
+use crate::statements::copy::CopyTable;
+use crate::statements::statement::Statement;
+
+// COPY tbl TO 'output.parquet';
+impl<'a> ParserContext<'a> {
+    pub(crate) fn parse_copy(&mut self) -> Result<Statement> {
+        self.parser.next_token();
+        let copy_table = self.parse_copy_table()?;
+        Ok(Statement::Copy(copy_table))
+    }
+
+    fn parse_copy_table(&mut self) -> Result<CopyTable> {
+        let table_name =
+            self.parser
+                .parse_object_name()
+                .with_context(|_| error::UnexpectedSnafu {
+                    sql: self.sql,
+                    expected: "a table name",
+                    actual: self.peek_token_as_string(),
+                })?;
+
+        self.parser
+            .expect_keyword(Keyword::TO)
+            .context(error::SyntaxSnafu { sql: self.sql })?;
+
+        let file_name =
+            self.parser
+                .parse_literal_string()
+                .with_context(|_| error::UnexpectedSnafu {
+                    sql: self.sql,
+                    expected: "a file name",
+                    actual: self.peek_token_as_string(),
+                })?;
+
+        Ok(CopyTable::new(table_name, file_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+
+    use sqlparser::dialect::GenericDialect;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_copy_table() {
+        let sql = "COPY catalog0.schema0.tbl TO 'tbl_file.parquet'";
+        let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
+        assert_eq!(1, result.len());
+
+        let statement = result.remove(0);
+        assert_matches!(statement, Statement::Copy { .. });
+        match statement {
+            Statement::Copy(copy_table) => {
+                let (catalog, schema, table) =
+                    if let [catalog, schema, table] = &copy_table.table_name().0[..] {
+                        (
+                            catalog.value.clone(),
+                            schema.value.clone(),
+                            table.value.clone(),
+                        )
+                    } else {
+                        unreachable!()
+                    };
+
+                assert_eq!("catalog0", catalog);
+                assert_eq!("schema0", schema);
+                assert_eq!("tbl", table);
+
+                let file_name = copy_table.file_name();
+                assert_eq!("tbl_file.parquet", file_name);
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use snafu::ResultExt;
 use sqlparser::keywords::Keyword;
 

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod alter;
+pub mod copy;
 pub mod create;
 pub mod delete;
 pub mod describe;

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -56,7 +56,7 @@ impl TryFrom<String> for Format {
     fn try_from(name: String) -> Result<Self> {
         match name.to_uppercase().as_str() {
             "PARQUET" => Ok(Format::Parquet),
-            _ => error::UnsupportedFormatSnafu { name }.fail(),
+            _ => error::UnsupportedCopyFormatOptionSnafu { name }.fail(),
         }
     }
 }

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -1,0 +1,24 @@
+use sqlparser::ast::ObjectName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CopyTable {
+    table_name: ObjectName,
+    file_name: String,
+}
+
+impl CopyTable {
+    pub(crate) fn new(table_name: ObjectName, file_name: String) -> Self {
+        Self {
+            table_name,
+            file_name,
+        }
+    }
+
+    pub fn table_name(&self) -> &ObjectName {
+        &self.table_name
+    }
+
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+}

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -14,17 +14,21 @@
 
 use sqlparser::ast::ObjectName;
 
+use crate::error::{self, Result};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyTable {
     table_name: ObjectName,
     file_name: String,
+    format: Format,
 }
 
 impl CopyTable {
-    pub(crate) fn new(table_name: ObjectName, file_name: String) -> Self {
+    pub(crate) fn new(table_name: ObjectName, file_name: String, format: Format) -> Self {
         Self {
             table_name,
             file_name,
+            format,
         }
     }
 
@@ -34,5 +38,25 @@ impl CopyTable {
 
     pub fn file_name(&self) -> &str {
         &self.file_name
+    }
+
+    pub fn format(&self) -> &Format {
+        &self.format
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Format {
+    Parquet,
+}
+
+impl TryFrom<String> for Format {
+    type Error = error::Error;
+
+    fn try_from(name: String) -> Result<Self> {
+        match name.to_uppercase().as_str() {
+            "PARQUET" => Ok(Format::Parquet),
+            _ => error::UnsupportedFormatSnafu { name }.fail(),
+        }
     }
 }

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use sqlparser::ast::ObjectName;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::copy::CopyTable;
 use crate::statements::alter::AlterTable;
 use crate::statements::create::{CreateDatabase, CreateTable};
 use crate::statements::delete::Delete;
@@ -51,6 +52,8 @@ pub enum Statement {
     // EXPLAIN QUERY
     Explain(Explain),
     Use(String),
+    // COPY
+    Copy(CopyTable),
 }
 
 /// Comment hints from SQL.

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::copy::CopyTable;
 use crate::statements::alter::AlterTable;
+use crate::statements::copy::CopyTable;
 use crate::statements::create::{CreateDatabase, CreateTable};
 use crate::statements::delete::Delete;
 use crate::statements::describe::DescribeTable;

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -106,3 +106,12 @@ pub struct DeleteRequest {
     /// The key is the column name, and the value is the column value.
     pub key_column_values: HashMap<String, VectorRef>,
 }
+
+/// Copy table request
+#[derive(Debug)]
+pub struct CopyTableRequest {
+    pub catalog_name: String,
+    pub schema_name: String,
+    pub table_name: String,
+    pub file_name: String,
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

To export the data from a table to a Parquet file, use the COPY statement.
```
COPY tbl TO '/xxx/xxx/output.parquet' WITH (FORMAT = 'parquet');
```

If the data is too large, it will be automatically split into multiple files, one file per 5 million rows.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
