### PR TITLE
feat(procedure): Support multi-lock keys and querying procedure state from context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "object-store",
  "serde",
  "serde_json",
+ "smallvec",
  "snafu",
  "tempdir",
  "tokio",

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -13,6 +13,7 @@ futures.workspace = true
 object-store = { path = "../../object-store" }
 serde.workspace = true
 serde_json = "1.0"
+smallvec = "1"
 snafu.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/src/common/procedure/src/lib.rs
+++ b/src/common/procedure/src/lib.rs
@@ -24,6 +24,6 @@ mod store;
 
 pub use crate::error::{Error, Result};
 pub use crate::procedure::{
-    BoxedProcedure, Context, LockKey, Procedure, ProcedureId, ProcedureManager,
+    BoxedProcedure, Context, ContextProvider, LockKey, Procedure, ProcedureId, ProcedureManager,
     ProcedureManagerRef, ProcedureState, ProcedureWithId, Status,
 };

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -30,7 +30,8 @@ use crate::local::runner::Runner;
 use crate::procedure::BoxedProcedureLoader;
 use crate::store::{ObjectStateStore, ProcedureMessage, ProcedureStore, StateStoreRef};
 use crate::{
-    BoxedProcedure, LockKey, ProcedureId, ProcedureManager, ProcedureState, ProcedureWithId,
+    BoxedProcedure, ContextProvider, LockKey, ProcedureId, ProcedureManager, ProcedureState,
+    ProcedureWithId,
 };
 
 /// Mutable metadata of a procedure during execution.
@@ -126,6 +127,13 @@ pub(crate) struct ManagerContext {
     // should be able to remove the its message and all its child messages.
     /// Messages loaded from the procedure store.
     messages: Mutex<HashMap<ProcedureId, ProcedureMessage>>,
+}
+
+#[async_trait]
+impl ContextProvider for ManagerContext {
+    async fn procedure_state(&self, procedure_id: ProcedureId) -> Result<Option<ProcedureState>> {
+        Ok(self.state(procedure_id))
+    }
 }
 
 impl ManagerContext {

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -71,7 +71,7 @@ pub(crate) struct ProcedureMeta {
     /// Notify to wait for subprocedures.
     child_notify: Notify,
     /// Lock required by this procedure.
-    lock_key: Option<LockKey>,
+    lock_key: LockKey,
     /// Mutable status during execution.
     exec_meta: Mutex<ExecMeta>,
 }
@@ -417,7 +417,7 @@ mod test_util {
             lock_notify: Notify::new(),
             parent_id: None,
             child_notify: Notify::new(),
-            lock_key: None,
+            lock_key: LockKey::default(),
             exec_meta: Mutex::new(ExecMeta::default()),
         }
     }
@@ -516,8 +516,8 @@ mod tests {
             Ok(self.content.clone())
         }
 
-        fn lock_key(&self) -> Option<LockKey> {
-            None
+        fn lock_key(&self) -> LockKey {
+            LockKey::default()
         }
     }
 
@@ -625,8 +625,8 @@ mod tests {
                 unimplemented!()
             }
 
-            fn lock_key(&self) -> Option<LockKey> {
-                Some(LockKey::new("test.submit"))
+            fn lock_key(&self) -> LockKey {
+                LockKey::single("test.submit")
             }
         }
 

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -73,7 +73,7 @@ impl Runner {
 
         // TODO(yingwen): Detect recursive locking (and deadlock) if possible. Maybe we could detect
         // recursive locking by adding a root procedure id to the meta.
-        for key in self.meta.lock_key.keys() {
+        for key in self.meta.lock_key.keys_to_lock() {
             // Acquire lock for each key.
             self.manager_ctx
                 .lock_map
@@ -94,7 +94,7 @@ impl Runner {
         }
 
         // Release lock in reverse order.
-        for key in self.meta.lock_key.keys().iter().rev() {
+        for key in self.meta.lock_key.keys_to_unlock() {
             self.manager_ctx.lock_map.release_lock(key, self.meta.id);
         }
 

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -58,11 +58,23 @@ impl Status {
     }
 }
 
+/// [ContextProvider] provides information about procedures in the [ProcedureManager].
+#[async_trait]
+pub trait ContextProvider: Send + Sync {
+    /// Query the procedure state.
+    async fn procedure_state(&self, procedure_id: ProcedureId) -> Result<Option<ProcedureState>>;
+}
+
+/// Reference-counted pointer to [ContextProvider].
+pub type ContextProviderRef = Arc<dyn ContextProvider>;
+
 /// Procedure execution context.
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct Context {
     /// Id of the procedure.
     pub procedure_id: ProcedureId,
+    /// [ProcedureManager] context provider.
+    pub provider: ContextProviderRef,
 }
 
 /// A `Procedure` represents an operation or a set of operations to be performed step-by-step.

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -365,8 +365,8 @@ mod tests {
             Ok(self.data.clone())
         }
 
-        fn lock_key(&self) -> Option<LockKey> {
-            None
+        fn lock_key(&self) -> LockKey {
+            LockKey::default()
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds two minor features to the procedure framework:
- Allow procedures to acquire multiple locks.
- Allow procedures to query procedure's state via the `ContexProvider` in the `Context`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 