### PR TITLE
fix: rename `schema` to `db` in http param

### DIFF
--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -63,13 +63,13 @@ pub async fn sql(
     Json(resp.with_execution_time(start.elapsed().as_millis()))
 }
 
-// TODO(ruihang): add db param and form data support
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct PromqlQuery {
     pub query: String,
     pub start: String,
     pub end: String,
     pub step: String,
+    pub db: Option<String>,
 }
 
 /// Handler to execute promql
@@ -82,7 +82,7 @@ pub async fn promql(
 ) -> Json<JsonResponse> {
     let sql_handler = &state.sql_handler;
     let start = Instant::now();
-    let resp = match super::query_context_from_db(sql_handler.clone(), None) {
+    let resp = match super::query_context_from_db(sql_handler.clone(), params.db) {
         Ok(query_ctx) => {
             JsonResponse::from_output(sql_handler.do_promql_query(&params.query, query_ctx).await)
                 .await

--- a/src/servers/src/http/script.rs
+++ b/src/servers/src/http/script.rs
@@ -51,7 +51,7 @@ pub async fn scripts(
     RawBody(body): RawBody,
 ) -> Json<JsonResponse> {
     if let Some(script_handler) = &state.script_handler {
-        let schema = params.schema.as_ref();
+        let schema = params.db.as_ref();
 
         if schema.is_none() || schema.unwrap().is_empty() {
             json_err!("invalid schema")
@@ -83,7 +83,7 @@ pub async fn scripts(
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ScriptQuery {
-    pub schema: Option<String>,
+    pub db: Option<String>,
     pub name: Option<String>,
 }
 
@@ -95,7 +95,7 @@ pub async fn run_script(
 ) -> Json<JsonResponse> {
     if let Some(script_handler) = &state.script_handler {
         let start = Instant::now();
-        let schema = params.schema.as_ref();
+        let schema = params.db.as_ref();
 
         if schema.is_none() || schema.unwrap().is_empty() {
             json_err!("invalid schema")

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -154,14 +154,14 @@ def test(n):
 
 fn create_script_query() -> Query<script_handler::ScriptQuery> {
     Query(script_handler::ScriptQuery {
-        schema: Some("test".to_string()),
+        db: Some("test".to_string()),
         name: Some("test".to_string()),
     })
 }
 
 fn create_invalid_script_query() -> Query<script_handler::ScriptQuery> {
     Query(script_handler::ScriptQuery {
-        schema: None,
+        db: None,
         name: None,
     })
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -317,7 +317,7 @@ pub async fn test_scripts_api(store_type: StorageType) {
     let client = TestClient::new(app);
 
     let res = client
-        .post("/v1/scripts?schema=schema_test&name=test")
+        .post("/v1/scripts?db=schema_test&name=test")
         .body(
             r#"
 @copr(sql='select number from numbers limit 10', args=['number'], returns=['n'])
@@ -335,7 +335,7 @@ def test(n):
 
     // call script
     let res = client
-        .post("/v1/run-script?schema=schema_test&name=test")
+        .post("/v1/run-script?db=schema_test&name=test")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

unify http handler db param name to `db` instead of `schema` to fit auth procedure
- change param name from `schema` to `db` in script handler
- add `db: Option<String>` in promql handler

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
