### PR TITLE
feat: admin http api

### DIFF
--- a/src/catalog/src/helper.rs
+++ b/src/catalog/src/helper.rs
@@ -24,10 +24,10 @@ use serde::{Deserialize, Serialize, Serializer};
 use snafu::{ensure, OptionExt, ResultExt};
 use table::metadata::{RawTableInfo, TableId, TableVersion};
 
-const CATALOG_KEY_PREFIX: &str = "__c";
-const SCHEMA_KEY_PREFIX: &str = "__s";
-const TABLE_GLOBAL_KEY_PREFIX: &str = "__tg";
-const TABLE_REGIONAL_KEY_PREFIX: &str = "__tr";
+pub const CATALOG_KEY_PREFIX: &str = "__c";
+pub const SCHEMA_KEY_PREFIX: &str = "__s";
+pub const TABLE_GLOBAL_KEY_PREFIX: &str = "__tg";
+pub const TABLE_REGIONAL_KEY_PREFIX: &str = "__tr";
 
 const ALPHANUMERICS_NAME_PATTERN: &str = "[a-zA-Z_][a-zA-Z0-9_]*";
 

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -267,6 +267,9 @@ pub enum Error {
         source: FromUtf8Error,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Missing required parameter, msg: {:?}", msg))]
+    MissingRequiredParameter { msg: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -311,6 +314,7 @@ impl ErrorExt for Error {
             | Error::ExceededRetryLimit { .. }
             | Error::StartGrpc { .. } => StatusCode::Internal,
             Error::EmptyKey { .. }
+            | Error::MissingRequiredParameter {..}
             | Error::EmptyTableName { .. }
             | Error::InvalidLeaseKey { .. }
             | Error::InvalidStatKey { .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -314,7 +314,7 @@ impl ErrorExt for Error {
             | Error::ExceededRetryLimit { .. }
             | Error::StartGrpc { .. } => StatusCode::Internal,
             Error::EmptyKey { .. }
-            | Error::MissingRequiredParameter {..}
+            | Error::MissingRequiredParameter { .. }
             | Error::EmptyTableName { .. }
             | Error::InvalidLeaseKey { .. }
             | Error::InvalidStatKey { .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::string::FromUtf8Error;
+
 use common_error::prelude::*;
 use tonic::codegen::http;
 use tonic::{Code, Status};
@@ -259,6 +261,12 @@ pub enum Error {
 
     #[snafu(display("Distributed lock is not configured"))]
     LockNotConfig { backtrace: Backtrace },
+
+    #[snafu(display("Invalid utf-8 value, source: {:?}", source))]
+    InvalidUtf8Value {
+        source: FromUtf8Error,
+        backtrace: Backtrace,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -319,6 +327,7 @@ impl ErrorExt for Error {
             | Error::MoveValue { .. }
             | Error::InvalidKvsLength { .. }
             | Error::InvalidTxnResult { .. }
+            | Error::InvalidUtf8Value { .. }
             | Error::Unexpected { .. } => StatusCode::Unexpected,
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidCatalogValue { source, .. } => source.status_code(),

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -268,8 +268,8 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Missing required parameter, msg: {:?}", msg))]
-    MissingRequiredParameter { msg: String },
+    #[snafu(display("Missing required parameter, param: {:?}", param))]
+    MissingRequiredParameter { param: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -38,8 +38,29 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     );
 
     let router = router.route(
-        "/catalog",
-        meta::CatalogHandler {
+        "/catalogs",
+        meta::CatalogsHandler {
+            kv_store: meta_srv.kv_store(),
+        },
+    );
+
+    let router = router.route(
+        "/schemas",
+        meta::SchemasHandler {
+            kv_store: meta_srv.kv_store(),
+        },
+    );
+
+    let router = router.route(
+        "/tables",
+        meta::TablesHandler {
+            kv_store: meta_srv.kv_store(),
+        },
+    );
+
+    let router = router.route(
+        "/table",
+        meta::TableHandler {
             kv_store: meta_srv.kv_store(),
         },
     );

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -14,6 +14,7 @@
 
 mod health;
 mod heartbeat;
+mod leader;
 mod meta;
 
 use std::collections::HashMap;
@@ -62,6 +63,13 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         "/table",
         meta::TableHandler {
             kv_store: meta_srv.kv_store(),
+        },
+    );
+
+    let router = router.route(
+        "/leader",
+        leader::LeaderHandler {
+            election: meta_srv.election(),
         },
     );
 

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -14,6 +14,7 @@
 
 mod health;
 mod heartbeat;
+mod meta;
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -33,6 +34,13 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         "/heartbeat",
         heartbeat::HeartBeatHandler {
             meta_peer_client: meta_srv.meta_peer_client(),
+        },
+    );
+
+    let router = router.route(
+        "/catalog",
+        meta::CatalogHandler {
+            kv_store: meta_srv.kv_store(),
         },
     );
 

--- a/src/meta-srv/src/service/admin/heartbeat.rs
+++ b/src/meta-srv/src/service/admin/heartbeat.rs
@@ -32,7 +32,7 @@ impl HttpHandler for HeartBeatHandler {
     async fn handle(
         &self,
         _: &str,
-        map: &HashMap<String, String>,
+        params: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
         let meta_peer_client = self
             .meta_peer_client
@@ -42,13 +42,13 @@ impl HttpHandler for HeartBeatHandler {
         let stat_kvs = meta_peer_client.get_all_dn_stat_kvs().await?;
         let mut stat_vals: Vec<StatValue> = stat_kvs.into_values().collect();
 
-        if let Some(addr) = map.get("addr") {
+        if let Some(addr) = params.get("addr") {
             stat_vals.retain(|stat_val| {
-                if let Some(stat) = stat_val.stats.get(0) {
-                    stat.addr == addr.clone()
-                } else {
-                    false
-                }
+                stat_val
+                    .stats
+                    .get(0)
+                    .map(|stat| &stat.addr == addr)
+                    .unwrap_or(false)
             });
         }
         let result = StatValues { stat_vals }.try_into()?;

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -29,15 +29,14 @@ impl HttpHandler for LeaderHandler {
     async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
         if let Some(election) = &self.election {
             let leader_addr = election.leader().await?.0;
-            http::Response::builder()
+            return http::Response::builder()
                 .status(http::StatusCode::OK)
                 .body(leader_addr)
-                .context(error::InvalidHttpBodySnafu)
-        } else {
-            http::Response::builder()
-                .status(http::StatusCode::OK)
-                .body("election info is None".to_string())
-                .context(error::InvalidHttpBodySnafu)
+                .context(error::InvalidHttpBodySnafu);
         }
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body("election info is None".to_string())
+            .context(error::InvalidHttpBodySnafu)
     }
 }

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -1,11 +1,3 @@
-use std::collections::HashMap;
-
-use tonic::codegen::http;
-
-use crate::error::Result;
-use crate::metasrv::ElectionRef;
-use crate::service::admin::HttpHandler;
-
 // Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +11,14 @@ use crate::service::admin::HttpHandler;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use std::collections::HashMap;
+
+use tonic::codegen::http;
+
+use crate::error::Result;
+use crate::metasrv::ElectionRef;
+use crate::service::admin::HttpHandler;
+
 pub struct LeaderHandler {
     pub election: Option<ElectionRef>,
 }

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -27,18 +27,17 @@ pub struct LeaderHandler {
 #[async_trait::async_trait]
 impl HttpHandler for LeaderHandler {
     async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
-        match &self.election {
-            Some(election) => {
-                let leader_addr = election.leader().await?.0;
-                http::Response::builder()
-                    .status(http::StatusCode::OK)
-                    .body(leader_addr)
-                    .context(error::InvalidHttpBodySnafu)
-            }
-            None => http::Response::builder()
+        if let Some(election) = &self.election {
+            let leader_addr = election.leader().await?.0;
+            http::Response::builder()
+                .status(http::StatusCode::OK)
+                .body(leader_addr)
+                .context(error::InvalidHttpBodySnafu)
+        } else {
+            http::Response::builder()
                 .status(http::StatusCode::OK)
                 .body("election info is None".to_string())
-                .context(error::InvalidHttpBodySnafu),
+                .context(error::InvalidHttpBodySnafu)
         }
     }
 }

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -13,9 +13,10 @@
 // limitations under the License.
 use std::collections::HashMap;
 
+use snafu::ResultExt;
 use tonic::codegen::http;
 
-use crate::error::Result;
+use crate::error::{self, Result};
 use crate::metasrv::ElectionRef;
 use crate::service::admin::HttpHandler;
 
@@ -29,15 +30,15 @@ impl HttpHandler for LeaderHandler {
         match &self.election {
             Some(election) => {
                 let leader_addr = election.leader().await?.0;
-                Ok(http::Response::builder()
+                http::Response::builder()
                     .status(http::StatusCode::OK)
                     .body(leader_addr)
-                    .unwrap())
+                    .context(error::InvalidHttpBodySnafu)
             }
-            None => Ok(http::Response::builder()
+            None => http::Response::builder()
                 .status(http::StatusCode::OK)
                 .body("election info is None".to_string())
-                .unwrap()),
+                .context(error::InvalidHttpBodySnafu),
         }
     }
 }

--- a/src/meta-srv/src/service/admin/leader.rs
+++ b/src/meta-srv/src/service/admin/leader.rs
@@ -1,0 +1,43 @@
+use std::collections::HashMap;
+
+use tonic::codegen::http;
+
+use crate::error::Result;
+use crate::metasrv::ElectionRef;
+use crate::service::admin::HttpHandler;
+
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pub struct LeaderHandler {
+    pub election: Option<ElectionRef>,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for LeaderHandler {
+    async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
+        match &self.election {
+            Some(election) => {
+                let leader_addr = election.leader().await?.0;
+                Ok(http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .body(leader_addr)
+                    .unwrap())
+            }
+            None => Ok(http::Response::builder()
+                .status(http::StatusCode::OK)
+                .body("election info is None".to_string())
+                .unwrap()),
+        }
+    }
+}

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -130,10 +130,10 @@ impl HttpHandler for TableHandler {
         if let Some(key_value) = response {
             value = String::from_utf8(key_value.value).context(error::InvalidUtf8ValueSnafu)?;
         }
-        Ok(http::Response::builder()
+        http::Response::builder()
             .status(http::StatusCode::OK)
             .body(value)
-            .unwrap())
+            .context(error::InvalidHttpBodySnafu)
     }
 }
 
@@ -147,10 +147,10 @@ async fn get_key_list_response_by_prefix_key(
         input: format!("{keys:?}"),
     })?;
 
-    Ok(http::Response::builder()
+    http::Response::builder()
         .status(http::StatusCode::OK)
         .body(body)
-        .unwrap())
+        .context(error::InvalidHttpBodySnafu)
 }
 
 /// Get kv_store's key list by prefix key

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -19,79 +19,146 @@ use snafu::ResultExt;
 use tonic::codegen::http;
 
 use crate::error::Result;
+use crate::error;
+use crate::util;
 use crate::service::admin::HttpHandler;
 use crate::service::store::kv::KvStoreRef;
-use crate::{error, util};
 
-pub struct CatalogHandler {
+pub struct CatalogsHandler {
     pub kv_store: KvStoreRef,
 }
 
-pub struct SchemaHandler {
+pub struct SchemasHandler {
+    pub kv_store: KvStoreRef,
+}
+
+pub struct TablesHandler {
+    pub kv_store: KvStoreRef,
+}
+
+pub struct TableHandler {
     pub kv_store: KvStoreRef,
 }
 
 const CATALOG_KEY_PREFIX: &str = "__c-";
 const SCHEMA_KEY_PREFIX: &str = "__s-";
+const TABLE_KEY_PREFIX: &str = "__tg-";
 
 #[async_trait::async_trait]
-impl HttpHandler for CatalogHandler {
+impl HttpHandler for CatalogsHandler {
     async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
-        let key = String::from(CATALOG_KEY_PREFIX).into_bytes();
-        let range_end = util::get_prefix_end_key(&key);
-        let req = RangeRequest {
-            key,
-            range_end,
-            ..Default::default()
-        };
-
-        let response: RangeResponse = self.kv_store.range(req).await?;
-
-        let kvs = response.kvs;
-        let mut catalog_list = vec![];
-        for kv in kvs {
-            let catalog = String::from_utf8(kv.key).context(error::InvalidUtf8ValueSnafu)?;
-            let split_catalog = catalog.split(CATALOG_KEY_PREFIX).collect::<Vec<&str>>()[1];
-            catalog_list.push(split_catalog.to_string());
-        }
-        let r = serde_json::to_string(&catalog_list).context(error::SerializeToJsonSnafu {
-            input: format!("{catalog_list:?}"),
-        })?;
-
-        Ok(http::Response::builder()
-            .status(http::StatusCode::OK)
-            .body(r)
-            .unwrap())
+        get_key_list_response_by_prefix_key(&String::from(CATALOG_KEY_PREFIX), &self.kv_store).await
     }
 }
 
 #[async_trait::async_trait]
-impl HttpHandler for SchemaHandler{
-    async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
-        let key = String::from(SCHEMA_KEY_PREFIX).into_bytes();
-        let range_end = util::get_prefix_end_key(&key);
+impl HttpHandler for SchemasHandler {
+    async fn handle(&self, _: &str, map: &HashMap<String, String>) -> Result<http::Response<String>> {
+        let mut schema_key_prefix = String::from(SCHEMA_KEY_PREFIX);
+        match map.get("catalog_name") {
+            Some(catalog_value) => {
+                schema_key_prefix = schema_key_prefix + catalog_value + "-"
+            }
+            None => {
+                return error::MissingRequiredParameterSnafu {
+                    msg: "catalog_name parameter is required".to_string(),
+                }.fail();
+            }
+        }
+        get_key_list_response_by_prefix_key(&schema_key_prefix, &self.kv_store).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for TablesHandler {
+    async fn handle(&self, _: &str, map: &HashMap<String, String>) -> Result<http::Response<String>> {
+        let mut table_key_prefix = String::from(TABLE_KEY_PREFIX);
+        match map.get("catalog_name") {
+            Some(catalog_value) => {
+                table_key_prefix = table_key_prefix + catalog_value + "-"
+            }
+            None => {
+                return error::MissingRequiredParameterSnafu {
+                    msg: "catalog_name parameter is required".to_string(),
+                }.fail();
+            }
+        }
+
+        match map.get("schema_name") {
+            Some(schema_value) => {
+                table_key_prefix = table_key_prefix + schema_value + "-"
+            }
+            None => {
+                return error::MissingRequiredParameterSnafu {
+                    msg: "schema_name parameter is required".to_string(),
+                }.fail();
+            }
+        }
+        get_key_list_response_by_prefix_key(&table_key_prefix, &self.kv_store).await
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for TableHandler {
+    async fn handle(&self, _: &str, map: &HashMap<String, String>) -> Result<http::Response<String>> {
+        let mut table_key_prefix = String::from(TABLE_KEY_PREFIX);
+        match map.get("full_table_name") {
+            Some(full_table_name) => {
+                let replace_name = full_table_name.replace('.', "-");
+                table_key_prefix = table_key_prefix + &replace_name
+            }
+            None => {
+                return error::MissingRequiredParameterSnafu {
+                    msg: "full_table_name parameter is required".to_string(),
+                }.fail();
+            }
+        }
+
         let req = RangeRequest {
-            key,
-            range_end,
+            key: table_key_prefix.into_bytes(),
             ..Default::default()
         };
 
         let response: RangeResponse = self.kv_store.range(req).await?;
 
         let kvs = response.kvs;
-        let mut catalog_list = vec![];
-        for kv in kvs {
-            let catalog = String::from_utf8(kv.key).context(error::InvalidUtf8ValueSnafu)?;
-            let split_catalog = catalog.split(CATALOG_KEY_PREFIX).collect::<Vec<&str>>()[1];
-            catalog_list.push(split_catalog.to_string());
-        }
-        let r = serde_json::to_string(&catalog_list).context(error::SerializeToJsonSnafu {
-            input: format!("{catalog_list:?}"),
-        })?;
-
+        let value = String::from_utf8(kvs.get_mut(0)).context(error::InvalidUtf8ValueSnafu)?;
         Ok(http::Response::builder()
             .status(http::StatusCode::OK)
-            .body(r)
+            .body(value)
             .unwrap())
     }
+}
+
+async fn get_key_list_response_by_prefix_key(key_prefix: &String, kv_store: &KvStoreRef) -> Result<http::Response<String>> {
+    let keys = get_key_list_by_prefix_key(key_prefix, kv_store).await?;
+    let body = serde_json::to_string(&keys).context(error::SerializeToJsonSnafu {
+        input: format!("{keys:?}"),
+    })?;
+
+    Ok(http::Response::builder()
+        .status(http::StatusCode::OK)
+        .body(body)
+        .unwrap())
+}
+
+async fn get_key_list_by_prefix_key(key_prefix: &String, kv_store: &KvStoreRef) -> Result<Vec<String>> {
+    let key_prefix_u8 = key_prefix.clone().into_bytes();
+    let range_end = util::get_prefix_end_key(&key_prefix_u8);
+    let req = RangeRequest {
+        key: key_prefix_u8,
+        range_end,
+        ..Default::default()
+    };
+
+    let response: RangeResponse = kv_store.range(req).await?;
+
+    let kvs = response.kvs;
+    let mut values = vec![];
+    for kv in kvs {
+        let value = String::from_utf8(kv.key).context(error::InvalidUtf8ValueSnafu)?;
+        let split_value = value.split(key_prefix).collect::<Vec<&str>>()[1];
+        values.push(split_value.to_string());
+    }
+    Ok(values)
 }

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use api::v1::meta::{RangeRequest, RangeResponse};
+use snafu::ResultExt;
+use tonic::codegen::http;
+
+use crate::error::Result;
+use crate::service::admin::HttpHandler;
+use crate::service::store::kv::KvStoreRef;
+use crate::{error, util};
+
+pub struct CatalogHandler {
+    pub kv_store: KvStoreRef,
+}
+
+const CATALOG_KEY_PREFIX: &str = "__c-";
+
+#[async_trait::async_trait]
+impl HttpHandler for CatalogHandler {
+    async fn handle(&self, _: &str, _: &HashMap<String, String>) -> Result<http::Response<String>> {
+        let key = String::from(CATALOG_KEY_PREFIX).into_bytes();
+        let range_end = util::get_prefix_end_key(&key);
+        let req = RangeRequest {
+            key,
+            range_end,
+            ..Default::default()
+        };
+
+        let response: RangeResponse = self.kv_store.range(req).await?;
+
+        let kvs = response.kvs;
+        let mut catalog_list = vec![];
+        for kv in kvs {
+            let catalog = String::from_utf8(kv.key).context(error::InvalidUtf8ValueSnafu)?;
+            let split_catalog = catalog.split(CATALOG_KEY_PREFIX).collect::<Vec<&str>>()[1];
+            catalog_list.push(split_catalog.to_string());
+        }
+        let r = serde_json::to_string(&catalog_list).context(error::SerializeToJsonSnafu {
+            input: format!("{catalog_list:?}"),
+        })?;
+
+        Ok(http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(r)
+            .unwrap())
+    }
+}

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -59,7 +59,7 @@ impl HttpHandler for SchemasHandler {
             Some(catalog) => catalog,
             None => {
                 return error::MissingRequiredParameterSnafu {
-                    msg: "catalog_name parameter is required".to_string(),
+                    param: "catalog_name",
                 }
                 .fail();
             }
@@ -80,7 +80,7 @@ impl HttpHandler for TablesHandler {
             Some(catalog) => catalog,
             None => {
                 return error::MissingRequiredParameterSnafu {
-                    msg: "catalog_name parameter is required".to_string(),
+                    param: "catalog_name",
                 }
                 .fail();
             }
@@ -90,7 +90,7 @@ impl HttpHandler for TablesHandler {
             Some(schema) => schema,
             None => {
                 return error::MissingRequiredParameterSnafu {
-                    msg: "schema_name parameter is required".to_string(),
+                    param: "schema_name",
                 }
                 .fail();
             }
@@ -111,7 +111,7 @@ impl HttpHandler for TableHandler {
             Some(full_table_name) => full_table_name.replace('.', "-"),
             None => {
                 return error::MissingRequiredParameterSnafu {
-                    msg: "full_table_name parameter is required".to_string(),
+                    param: "full_table_name",
                 }
                 .fail();
             }

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -40,9 +40,10 @@ pub struct TableHandler {
     pub kv_store: KvStoreRef,
 }
 
-const CATALOG_KEY_PREFIX: &str = "__c-";
-const SCHEMA_KEY_PREFIX: &str = "__s-";
-const TABLE_KEY_PREFIX: &str = "__tg-";
+const CATALOG_KEY_PREFIX: &str = "__c";
+const SCHEMA_KEY_PREFIX: &str = "__s";
+const TABLE_KEY_PREFIX: &str = "__tg";
+const SEPARATOR: &str = "-";
 
 #[async_trait::async_trait]
 impl HttpHandler for CatalogsHandler {
@@ -58,9 +59,9 @@ impl HttpHandler for SchemasHandler {
         _: &str,
         map: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
-        let mut schema_key_prefix = String::from(SCHEMA_KEY_PREFIX);
+        let mut key_prefix = String::from(SCHEMA_KEY_PREFIX) + SEPARATOR;
         match map.get("catalog_name") {
-            Some(catalog_value) => schema_key_prefix = schema_key_prefix + catalog_value + "-",
+            Some(catalog_value) => key_prefix = key_prefix + catalog_value + SEPARATOR,
             None => {
                 return error::MissingRequiredParameterSnafu {
                     msg: "catalog_name parameter is required".to_string(),
@@ -68,7 +69,7 @@ impl HttpHandler for SchemasHandler {
                 .fail();
             }
         }
-        get_key_list_response_by_prefix_key(&schema_key_prefix, &self.kv_store).await
+        get_key_list_response_by_prefix_key(&key_prefix, &self.kv_store).await
     }
 }
 
@@ -79,9 +80,9 @@ impl HttpHandler for TablesHandler {
         _: &str,
         map: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
-        let mut table_key_prefix = String::from(TABLE_KEY_PREFIX);
+        let mut key_prefix = String::from(TABLE_KEY_PREFIX) + SEPARATOR;
         match map.get("catalog_name") {
-            Some(catalog_value) => table_key_prefix = table_key_prefix + catalog_value + "-",
+            Some(catalog_value) => key_prefix = key_prefix + catalog_value + SEPARATOR,
             None => {
                 return error::MissingRequiredParameterSnafu {
                     msg: "catalog_name parameter is required".to_string(),
@@ -91,7 +92,7 @@ impl HttpHandler for TablesHandler {
         }
 
         match map.get("schema_name") {
-            Some(schema_value) => table_key_prefix = table_key_prefix + schema_value + "-",
+            Some(schema_value) => key_prefix = key_prefix + schema_value + SEPARATOR,
             None => {
                 return error::MissingRequiredParameterSnafu {
                     msg: "schema_name parameter is required".to_string(),
@@ -99,7 +100,7 @@ impl HttpHandler for TablesHandler {
                 .fail();
             }
         }
-        get_key_list_response_by_prefix_key(&table_key_prefix, &self.kv_store).await
+        get_key_list_response_by_prefix_key(&key_prefix, &self.kv_store).await
     }
 }
 
@@ -110,10 +111,10 @@ impl HttpHandler for TableHandler {
         _: &str,
         map: &HashMap<String, String>,
     ) -> Result<http::Response<String>> {
-        let mut table_key_prefix = String::from(TABLE_KEY_PREFIX);
+        let mut table_key_prefix = String::from(TABLE_KEY_PREFIX) + SEPARATOR;
         match map.get("full_table_name") {
             Some(full_table_name) => {
-                let replace_name = full_table_name.replace('.', "-");
+                let replace_name = full_table_name.replace('.', SEPARATOR);
                 table_key_prefix = table_key_prefix + &replace_name
             }
             None => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

support admin meta http api.

### feature
1. Query the catalog list. 
2. Query the schema list by catalog name. 
3. Query the table list by catalog name and schema name.
4. Query table info by full table name.
5. Query the information of the meta leader node.
6. Query heartbeat by ip.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
