### PR TITLE
feat: support influxdb ping and health endpoint

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -50,7 +50,7 @@ use tower_http::auth::AsyncRequireAuthorizationLayer;
 use tower_http::trace::TraceLayer;
 
 use self::authorize::HttpAuth;
-use self::influxdb::{influxdb_ping, influxdb_write};
+use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write};
 use crate::auth::UserProviderRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
@@ -493,7 +493,7 @@ impl HttpServer {
         Router::new()
             .route("/write", routing::post(influxdb_write))
             .route("/ping", routing::get(influxdb_ping))
-            .route("/health", routing::get(influxdb_ping))
+            .route("/health", routing::get(influxdb_health))
             .with_state(influxdb_handler)
     }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -50,7 +50,7 @@ use tower_http::auth::AsyncRequireAuthorizationLayer;
 use tower_http::trace::TraceLayer;
 
 use self::authorize::HttpAuth;
-use self::influxdb::influxdb_write;
+use self::influxdb::{influxdb_ping, influxdb_write};
 use crate::auth::UserProviderRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
@@ -492,6 +492,8 @@ impl HttpServer {
     fn route_influxdb<S>(&self, influxdb_handler: InfluxdbLineProtocolHandlerRef) -> Router<S> {
         Router::new()
             .route("/write", routing::post(influxdb_write))
+            .route("/ping", routing::get(influxdb_ping))
+            .route("/health", routing::get(influxdb_ping))
             .with_state(influxdb_handler)
     }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -37,7 +37,6 @@ use common_recordbatch::{util, RecordBatch};
 use common_telemetry::logging::info;
 use datatypes::data_type::DataType;
 use futures::FutureExt;
-use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -89,8 +88,7 @@ pub(crate) fn query_context_from_db(
 pub const HTTP_API_VERSION: &str = "v1";
 pub const HTTP_API_PREFIX: &str = "/v1/";
 
-pub static PUBLIC_APIS: Lazy<Vec<&str>> =
-    Lazy::new(|| vec!["/v1/influxdb/ping", "/v1/influxdb/health"]);
+pub static PUBLIC_APIS: [&str; 2] = ["/v1/influxdb/ping", "/v1/influxdb/health"];
 
 pub struct HttpServer {
     sql_handler: ServerSqlQueryHandlerRef,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -37,6 +37,7 @@ use common_recordbatch::{util, RecordBatch};
 use common_telemetry::logging::info;
 use datatypes::data_type::DataType;
 use futures::FutureExt;
+use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -87,6 +88,9 @@ pub(crate) fn query_context_from_db(
 
 pub const HTTP_API_VERSION: &str = "v1";
 pub const HTTP_API_PREFIX: &str = "/v1/";
+
+pub static PUBLIC_APIS: Lazy<Vec<&str>> =
+    Lazy::new(|| vec!["/v1/influxdb/ping", "/v1/influxdb/health"]);
 
 pub struct HttpServer {
     sql_handler: ServerSqlQueryHandlerRef,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -88,6 +88,7 @@ pub(crate) fn query_context_from_db(
 pub const HTTP_API_VERSION: &str = "v1";
 pub const HTTP_API_PREFIX: &str = "/v1/";
 
+// TODO(fys): This is a temporary workaround, it will be improved later
 pub static PUBLIC_APIS: [&str; 2] = ["/v1/influxdb/ping", "/v1/influxdb/health"];
 
 pub struct HttpServer {

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -215,7 +215,7 @@ fn decode_basic(credential: Credential) -> Result<(Username, Password)> {
 fn need_auth<B>(req: &Request<B>) -> bool {
     let path = req.uri().path();
 
-    for api in &*PUBLIC_APIS {
+    for api in PUBLIC_APIS {
         if path.starts_with(api) {
             return false;
         }

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 // Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,8 @@ use std::collections::HashMap;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use axum::http::{self, Request, StatusCode};
@@ -23,6 +24,7 @@ use session::context::UserInfo;
 use snafu::{OptionExt, ResultExt};
 use tower_http::auth::AsyncAuthorizeRequest;
 
+use super::PUBLIC_APIS;
 use crate::auth::Error::IllegalParam;
 use crate::auth::{Identity, IllegalParamSnafu, InternalStateSnafu, UserProviderRef};
 use crate::error::{self, Result};
@@ -63,7 +65,8 @@ where
     fn authorize(&mut self, mut request: Request<B>) -> Self::Future {
         let user_provider = self.user_provider.clone();
         Box::pin(async move {
-            let need_auth = request.uri().path().starts_with(HTTP_API_PREFIX);
+            let need_auth = need_auth(&request);
+
             let user_provider = if let Some(user_provider) = user_provider.filter(|_| need_auth) {
                 user_provider
             } else {
@@ -209,9 +212,45 @@ fn decode_basic(credential: Credential) -> Result<(Username, Password)> {
     error::InvalidAuthorizationHeaderSnafu {}.fail()
 }
 
+fn need_auth<B>(req: &Request<B>) -> bool {
+    let path = req.uri().path();
+
+    for api in &*PUBLIC_APIS {
+        if path.starts_with(api) {
+            return false;
+        }
+    }
+
+    path.starts_with(HTTP_API_PREFIX)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_need_auth() {
+        let req = Request::builder()
+            .uri("http://127.0.0.1/v1/influxdb/ping")
+            .body(())
+            .unwrap();
+
+        assert!(!need_auth(&req));
+
+        let req = Request::builder()
+            .uri("http://127.0.0.1/v1/influxdb/health")
+            .body(())
+            .unwrap();
+
+        assert!(!need_auth(&req));
+
+        let req = Request::builder()
+            .uri("http://127.0.0.1/v1/influxdb/write")
+            .body(())
+            .unwrap();
+
+        assert!(need_auth(&req));
+    }
 
     #[test]
     fn test_decode_basic() {

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_grpc::writer::Precision;
 use session::context::QueryContext;
@@ -25,12 +26,24 @@ use crate::error::{Result, TimePrecisionSnafu};
 use crate::influxdb::InfluxdbRequest;
 use crate::query_handler::InfluxdbLineProtocolHandlerRef;
 
+// https://docs.influxdata.com/influxdb/v1.8/tools/api/#ping-http-endpoint
+#[axum_macros::debug_handler]
+pub async fn influxdb_ping() -> Result<impl IntoResponse> {
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// https://docs.influxdata.com/influxdb/v1.8/tools/api/#health-http-endpoint
+#[axum_macros::debug_handler]
+pub async fn influxdb_health() -> Result<impl IntoResponse> {
+    Ok(StatusCode::OK)
+}
+
 #[axum_macros::debug_handler]
 pub async fn influxdb_write(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
     lines: String,
-) -> Result<(StatusCode, ())> {
+) -> Result<impl IntoResponse> {
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -110,24 +110,10 @@ async fn test_influxdb_write() {
     let app = make_test_app(tx.clone(), None);
     let client = TestClient::new(app);
 
-    let result = client
-        .get("/v1/influxdb/health")
-        .header(
-            http::header::AUTHORIZATION,
-            "basic Z3JlcHRpbWU6Z3JlcHRpbWU=",
-        )
-        .send()
-        .await;
+    let result = client.get("/v1/influxdb/health").send().await;
     assert_eq!(result.status(), 200);
 
-    let result = client
-        .get("/v1/influxdb/ping")
-        .header(
-            http::header::AUTHORIZATION,
-            "basic Z3JlcHRpbWU6Z3JlcHRpbWU=",
-        )
-        .send()
-        .await;
+    let result = client.get("/v1/influxdb/ping").send().await;
     assert_eq!(result.status(), 204);
 
     // right request

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -110,6 +110,26 @@ async fn test_influxdb_write() {
     let app = make_test_app(tx.clone(), None);
     let client = TestClient::new(app);
 
+    let result = client
+        .get("/v1/influxdb/health")
+        .header(
+            http::header::AUTHORIZATION,
+            "basic Z3JlcHRpbWU6Z3JlcHRpbWU=",
+        )
+        .send()
+        .await;
+    assert_eq!(result.status(), 200);
+
+    let result = client
+        .get("/v1/influxdb/ping")
+        .header(
+            http::header::AUTHORIZATION,
+            "basic Z3JlcHRpbWU6Z3JlcHRpbWU=",
+        )
+        .send()
+        .await;
+    assert_eq!(result.status(), 204);
+
     // right request
     let result = client
         .post("/v1/influxdb/write?db=public")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This pr mainly simply support influxdb ping and health endpoint.  (Only status code as response.)

Related Links
  1. https://docs.influxdata.com/influxdb/v1.8/tools/api/#ping-http-endpoint
  2. https://docs.influxdata.com/influxdb/v1.8/tools/api/#health-http-endpoint


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
