### PR TITLE
refactor(storage): Simplify debug output of some structs

### DIFF
--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -14,6 +14,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{btree_map, BTreeMap};
+use std::fmt;
 use std::ops::Bound;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, RwLock};
@@ -37,7 +38,6 @@ type RwLockMap = RwLock<BTreeMap<InnerKey, RowValue>>;
 /// A simple memtable implementation based on std's [`BTreeMap`].
 ///
 /// Mainly for test purpose, don't use in production.
-#[derive(Debug)]
 pub struct BTreeMemtable {
     id: MemtableId,
     schema: RegionSchemaRef,
@@ -53,6 +53,20 @@ impl BTreeMemtable {
             map: Arc::new(RwLock::new(BTreeMap::new())),
             estimated_bytes: AtomicUsize::new(0),
         }
+    }
+}
+
+impl fmt::Debug for BTreeMemtable {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let len = self.map.read().unwrap().len();
+
+        f.debug_struct("BTreeMemtable")
+            .field("id", &self.id)
+            // Only show StoreSchema
+            .field("schema", &self.schema)
+            .field("rows", &len)
+            .field("estimated_bytes", &self.estimated_bytes)
+            .finish()
     }
 }
 

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -68,6 +68,12 @@ impl<S: LogStore> fmt::Debug for RegionImpl<S> {
         f.debug_struct("RegionImpl")
             .field("id", &self.inner.shared.id)
             .field("name", &self.inner.shared.name)
+            .field("wal", &self.inner.wal)
+            .field("flush_strategy", &self.inner.flush_strategy)
+            .field("flush_scheduler", &self.inner.flush_scheduler)
+            .field("compaction_scheduler", &self.inner.compaction_scheduler)
+            .field("sst_layer", &self.inner.sst_layer)
+            .field("manifest", &self.inner.manifest)
             .finish()
     }
 }

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -15,7 +15,9 @@
 #[cfg(test)]
 mod tests;
 mod writer;
+
 use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -49,7 +51,6 @@ use crate::wal::Wal;
 use crate::write_batch::WriteBatch;
 
 /// [Region] implementation.
-#[derive(Debug)]
 pub struct RegionImpl<S: LogStore> {
     inner: Arc<RegionInner<S>>,
 }
@@ -59,6 +60,15 @@ impl<S: LogStore> Clone for RegionImpl<S> {
         Self {
             inner: self.inner.clone(),
         }
+    }
+}
+
+impl<S: LogStore> fmt::Debug for RegionImpl<S> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("RegionImpl")
+            .field("id", &self.inner.shared.id)
+            .field("name", &self.inner.shared.name)
+            .finish()
     }
 }
 
@@ -440,7 +450,6 @@ impl SharedData {
 
 pub type SharedDataRef = Arc<SharedData>;
 
-#[derive(Debug)]
 struct RegionInner<S: LogStore> {
     shared: SharedDataRef,
     writer: RegionWriterRef,

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -271,10 +271,6 @@ async fn test_new_region() {
 
     assert_eq!(region_name, region.name());
     assert_eq!(expect_schema, *region.in_memory_metadata().schema());
-    assert_eq!(
-        r#"RegionImpl { id: 0, name: "region-0" }"#,
-        format!("{:?}", region)
-    );
 }
 
 #[tokio::test]

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -271,6 +271,10 @@ async fn test_new_region() {
 
     assert_eq!(region_name, region.name());
     assert_eq!(expect_schema, *region.in_memory_metadata().schema());
+    assert_eq!(
+        r#"RegionImpl { id: 0, name: "region-0" }"#,
+        format!("{:?}", region)
+    );
 }
 
 #[tokio::test]

--- a/src/storage/src/schema/region.rs
+++ b/src/storage/src/schema/region.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::sync::Arc;
 
 use common_error::prelude::*;
@@ -32,7 +33,7 @@ use crate::schema::{StoreSchema, StoreSchemaRef};
 ///
 /// The user schema is the schema that only contains columns that user could visit,
 /// as well as what the schema user created.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct RegionSchema {
     /// Schema that only contains columns that user defined, excluding internal columns
     /// that are reserved and used by the storage engine.
@@ -46,6 +47,14 @@ pub struct RegionSchema {
     store_schema: StoreSchemaRef,
     /// Metadata of columns.
     columns: ColumnsMetadataRef,
+}
+
+impl fmt::Debug for RegionSchema {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("RegionSchema")
+            .field("columns", &self.columns)
+            .finish()
+    }
 }
 
 impl RegionSchema {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Simplify debug output of some structs in storage crates
- RegionImpl
- BTreeMemtable
- RegionSchema

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
