### PR TITLE
refactor: move the batch_get to KvStore trait

### DIFF
--- a/src/meta-client/src/rpc.rs
+++ b/src/meta-client/src/rpc.rs
@@ -28,9 +28,9 @@ pub use router::{
 };
 use serde::{Deserialize, Serialize};
 pub use store::{
-    BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
-    DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest,
-    PutResponse, RangeRequest, RangeResponse,
+    BatchGetRequest, BatchGetResponse, BatchPutRequest, BatchPutResponse, CompareAndPutRequest,
+    CompareAndPutResponse, DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest,
+    MoveValueResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
 };
 
 #[derive(Debug, Clone)]

--- a/src/meta-srv/src/sequence.rs
+++ b/src/meta-srv/src/sequence.rs
@@ -150,6 +150,8 @@ impl Inner {
 mod tests {
     use std::sync::Arc;
 
+    use api::v1::meta::{BatchGetRequest, BatchGetResponse};
+
     use super::*;
     use crate::service::store::kv::KvStore;
     use crate::service::store::memory::MemStore;
@@ -189,6 +191,10 @@ mod tests {
                 &self,
                 _: api::v1::meta::BatchPutRequest,
             ) -> Result<api::v1::meta::BatchPutResponse> {
+                unreachable!()
+            }
+
+            async fn batch_get(&self, _: BatchGetRequest) -> Result<BatchGetResponse> {
                 unreachable!()
             }
 

--- a/src/meta-srv/src/service/cluster.rs
+++ b/src/meta-srv/src/service/cluster.rs
@@ -20,7 +20,6 @@ use common_telemetry::warn;
 use tonic::{Request, Response};
 
 use crate::metasrv::MetaSrv;
-use crate::service::store::ext::KvStoreExt;
 use crate::service::GrpcResult;
 
 #[async_trait::async_trait]
@@ -37,8 +36,8 @@ impl cluster_server::Cluster for MetaSrv {
             return Ok(Response::new(resp));
         }
 
-        let req = req.into_inner();
-        let kvs = self.in_memory().batch_get(req.keys).await?;
+        let kvs = self.in_memory().batch_get(req.into_inner()).await?.kvs;
+
         let success = ResponseHeader::success(0);
 
         let get_resp = BatchGetResponse {

--- a/src/meta-srv/src/service/store/etcd.rs
+++ b/src/meta-srv/src/service/store/etcd.rs
@@ -596,6 +596,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_batch_get() {
+        let req = BatchGetRequest {
+            keys: vec![b"k1".to_vec(), b"k2".to_vec(), b"k3".to_vec()],
+            ..Default::default()
+        };
+
+        let batch_get: BatchGet = req.try_into().unwrap();
+        let keys = batch_get.keys;
+
+        assert_eq!(b"k1".to_vec(), keys.get(0).unwrap().to_vec());
+        assert_eq!(b"k2".to_vec(), keys.get(1).unwrap().to_vec());
+        assert_eq!(b"k3".to_vec(), keys.get(2).unwrap().to_vec());
+    }
+
+    #[test]
     fn test_parse_batch_put() {
         let req = BatchPutRequest {
             kvs: vec![KeyValue {

--- a/src/meta-srv/src/service/store/kv.rs
+++ b/src/meta-srv/src/service/store/kv.rs
@@ -15,9 +15,9 @@
 use std::sync::Arc;
 
 use api::v1::meta::{
-    BatchPutRequest, BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse,
-    DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest,
-    PutResponse, RangeRequest, RangeResponse,
+    BatchGetRequest, BatchGetResponse, BatchPutRequest, BatchPutResponse, CompareAndPutRequest,
+    CompareAndPutResponse, DeleteRangeRequest, DeleteRangeResponse, MoveValueRequest,
+    MoveValueResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
 };
 
 use crate::error::Result;
@@ -30,6 +30,8 @@ pub trait KvStore: Send + Sync {
     async fn range(&self, req: RangeRequest) -> Result<RangeResponse>;
 
     async fn put(&self, req: PutRequest) -> Result<PutResponse>;
+
+    async fn batch_get(&self, req: BatchGetRequest) -> Result<BatchGetResponse>;
 
     async fn batch_put(&self, req: BatchPutRequest) -> Result<BatchPutResponse>;
 

--- a/src/meta-srv/src/service/store/memory.rs
+++ b/src/meta-srv/src/service/store/memory.rs
@@ -271,8 +271,8 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::meta::{
-        BatchPutRequest, CompareAndPutRequest, DeleteRangeRequest, KeyValue, MoveValueRequest,
-        PutRequest, RangeRequest,
+        BatchGetRequest, BatchPutRequest, CompareAndPutRequest, DeleteRangeRequest, KeyValue,
+        MoveValueRequest, PutRequest, RangeRequest,
     };
 
     use super::MemStore;
@@ -344,8 +344,8 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(b"key11".to_vec(), resp.prev_kv.as_ref().unwrap().key);
-        assert_eq!(b"val12".to_vec(), resp.prev_kv.as_ref().unwrap().value);
+        assert_eq!(b"key11".as_slice(), resp.prev_kv.as_ref().unwrap().key);
+        assert_eq!(b"val12".as_slice(), resp.prev_kv.as_ref().unwrap().value);
     }
 
     #[tokio::test]
@@ -367,10 +367,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(2, resp.kvs.len());
-        assert_eq!(b"key1".to_vec(), resp.kvs[0].key);
-        assert_eq!(b"val1".to_vec(), resp.kvs[0].value);
-        assert_eq!(b"key11".to_vec(), resp.kvs[1].key);
-        assert_eq!(b"val11".to_vec(), resp.kvs[1].value);
+        assert_eq!(b"key1".as_slice(), resp.kvs[0].key);
+        assert_eq!(b"val1".as_slice(), resp.kvs[0].value);
+        assert_eq!(b"key11".as_slice(), resp.kvs[1].key);
+        assert_eq!(b"val11".as_slice(), resp.kvs[1].value);
 
         let resp = kv_store
             .range(RangeRequest {
@@ -384,10 +384,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(2, resp.kvs.len());
-        assert_eq!(b"key1".to_vec(), resp.kvs[0].key);
-        assert_eq!(b"".to_vec(), resp.kvs[0].value);
-        assert_eq!(b"key11".to_vec(), resp.kvs[1].key);
-        assert_eq!(b"".to_vec(), resp.kvs[1].value);
+        assert_eq!(b"key1".as_slice(), resp.kvs[0].key);
+        assert_eq!(b"".as_slice(), resp.kvs[0].value);
+        assert_eq!(b"key11".as_slice(), resp.kvs[1].key);
+        assert_eq!(b"".as_slice(), resp.kvs[1].value);
 
         let resp = kv_store
             .range(RangeRequest {
@@ -400,8 +400,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, resp.kvs.len());
-        assert_eq!(b"key1".to_vec(), resp.kvs[0].key);
-        assert_eq!(b"val1".to_vec(), resp.kvs[0].value);
+        assert_eq!(b"key1".as_slice(), resp.kvs[0].key);
+        assert_eq!(b"val1".as_slice(), resp.kvs[0].value);
 
         let resp = kv_store
             .range(RangeRequest {
@@ -415,8 +415,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(1, resp.kvs.len());
-        assert_eq!(b"key1".to_vec(), resp.kvs[0].key);
-        assert_eq!(b"val1".to_vec(), resp.kvs[0].value);
+        assert_eq!(b"key1".as_slice(), resp.kvs[0].key);
+        assert_eq!(b"val1".as_slice(), resp.kvs[0].value);
     }
 
     #[tokio::test]
@@ -425,7 +425,7 @@ mod tests {
 
         let keys = vec![];
         let batch_resp = kv_store
-            .batch_get(api::v1::meta::BatchGetRequest {
+            .batch_get(BatchGetRequest {
                 keys,
                 ..Default::default()
             })
@@ -436,7 +436,7 @@ mod tests {
 
         let keys = vec![b"key10".to_vec()];
         let batch_resp = kv_store
-            .batch_get(api::v1::meta::BatchGetRequest {
+            .batch_get(BatchGetRequest {
                 keys,
                 ..Default::default()
             })
@@ -447,7 +447,7 @@ mod tests {
 
         let keys = vec![b"key1".to_vec(), b"key3".to_vec(), b"key4".to_vec()];
         let batch_resp = kv_store
-            .batch_get(api::v1::meta::BatchGetRequest {
+            .batch_get(BatchGetRequest {
                 keys,
                 ..Default::default()
             })
@@ -455,10 +455,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(2, batch_resp.kvs.len());
-        assert_eq!(b"key1".to_vec(), batch_resp.kvs[0].key);
-        assert_eq!(b"val1".to_vec(), batch_resp.kvs[0].value);
-        assert_eq!(b"key3".to_vec(), batch_resp.kvs[1].key);
-        assert_eq!(b"val3".to_vec(), batch_resp.kvs[1].value);
+        assert_eq!(b"key1".as_slice(), batch_resp.kvs[0].key);
+        assert_eq!(b"val1".as_slice(), batch_resp.kvs[0].value);
+        assert_eq!(b"key3".as_slice(), batch_resp.kvs[1].key);
+        assert_eq!(b"val3".as_slice(), batch_resp.kvs[1].value);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -505,8 +505,8 @@ mod tests {
 
         let resp = kv_store.delete_range(req).await.unwrap();
         assert_eq!(1, resp.prev_kvs.len());
-        assert_eq!(b"key3".to_vec(), resp.prev_kvs[0].key);
-        assert_eq!(b"val3".to_vec(), resp.prev_kvs[0].value);
+        assert_eq!(b"key3".as_slice(), resp.prev_kvs[0].key);
+        assert_eq!(b"val3".as_slice(), resp.prev_kvs[0].value);
 
         let get_resp = kv_store.get(b"key3".to_vec()).await.unwrap();
         assert!(get_resp.is_none());
@@ -556,8 +556,8 @@ mod tests {
         };
 
         let resp = kv_store.move_value(req).await.unwrap();
-        assert_eq!(b"key1".to_vec(), resp.kv.as_ref().unwrap().key);
-        assert_eq!(b"val1".to_vec(), resp.kv.as_ref().unwrap().value);
+        assert_eq!(b"key1".as_slice(), resp.kv.as_ref().unwrap().key);
+        assert_eq!(b"val1".as_slice(), resp.kv.as_ref().unwrap().value);
 
         let kv_store = mock_mem_store_with_data().await;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This pr mainly change:
1. move the batch_get method to KvStore trait.
2. add some unit tests.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1015 