### PR TITLE
feat: support InfluxDB auth protocol

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -219,6 +219,9 @@ pub enum Error {
     #[snafu(display("Not found http authorization header"))]
     NotFoundAuthHeader {},
 
+    #[snafu(display("Not found influx http authorization info"))]
+    NotFoundInfluxAuth {},
+
     #[snafu(display("Invalid visibility ASCII chars, source: {}", source))]
     InvisibleASCII {
         source: ToStrError,
@@ -305,7 +308,7 @@ impl ErrorExt for Error {
             Auth { source, .. } => source.status_code(),
             DescribeStatement { source } => source.status_code(),
 
-            NotFoundAuthHeader { .. } => StatusCode::AuthHeaderNotFound,
+            NotFoundAuthHeader { .. } | NotFoundInfluxAuth { .. } => StatusCode::AuthHeaderNotFound,
             InvisibleASCII { .. }
             | UnsupportedAuthScheme { .. }
             | InvalidAuthorizationHeader { .. }

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -159,7 +159,7 @@ fn get_influxdb_credentials<B: Send + Sync + 'static>(
             return Ok(None);
         }
         // TODO(shuiyisong): remove this for performance optimization
-        // authorize would deserialize agian
+        // `authorize` would deserialize query from urlencoded again
         let query = match serde_urlencoded::from_str::<HashMap<String, String>>(query_str.unwrap())
         {
             Ok(query_map) => query_map,

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -21,13 +21,16 @@ use common_telemetry::error;
 use futures::future::BoxFuture;
 use http_body::Body;
 use session::context::UserInfo;
-use snafu::{OptionExt, ResultExt};
+use snafu::{ensure, OptionExt, ResultExt};
 use tower_http::auth::AsyncAuthorizeRequest;
 
 use super::PUBLIC_APIS;
 use crate::auth::Error::IllegalParam;
 use crate::auth::{Identity, IllegalParamSnafu, InternalStateSnafu, UserProviderRef};
-use crate::error::{self, Result};
+use crate::error::{
+    self, InvalidAuthorizationHeaderSnafu, InvisibleASCIISnafu, NotFoundInfluxAuthSnafu, Result,
+    UnsupportedAuthSchemeSnafu,
+};
 use crate::http::HTTP_API_PREFIX;
 
 pub struct HttpAuth<RespBody> {
@@ -128,26 +131,87 @@ async fn authorize<B: Send + Sync + 'static>(
     user_provider.authorize(catalog, database, user_info).await
 }
 
+fn get_influxdb_credentials<B: Send + Sync + 'static>(
+    request: &Request<B>,
+) -> Result<Option<(String, String)>> {
+    // compat with influxdb v2 and v1
+    if let Some(header) = request.headers().get(http::header::AUTHORIZATION) {
+        // try v2 first
+        let (auth_scheme, credential) = header
+            .to_str()
+            .context(InvisibleASCIISnafu)?
+            .split_once(' ')
+            .context(InvalidAuthorizationHeaderSnafu)?;
+        ensure!(
+            auth_scheme.to_lowercase() == "token",
+            UnsupportedAuthSchemeSnafu { name: auth_scheme }
+        );
+
+        let (username, password) = credential
+            .split_once(':')
+            .context(InvalidAuthorizationHeaderSnafu)?;
+
+        Ok(Some((username.to_string(), password.to_string())))
+    } else {
+        // try v1
+        let query_str = request.uri().query();
+        if query_str.is_none() {
+            return Ok(None);
+        }
+        // TODO(shuiyisong): remove this for performance optimization
+        // authorize would deserialize agian
+        let query = match serde_urlencoded::from_str::<HashMap<String, String>>(query_str.unwrap())
+        {
+            Ok(query_map) => query_map,
+            Err(e) => IllegalParamSnafu {
+                msg: format!("fail to parse http query: {e}"),
+            }
+            .fail()?,
+        };
+
+        let username = query.get("u");
+        let password = query.get("p");
+        if username.is_none() && password.is_none() {
+            Ok(None)
+        } else if username.is_some() && password.is_some() {
+            Ok(Some((username.unwrap().clone(), password.unwrap().clone())))
+        } else {
+            IllegalParamSnafu {
+                msg: "influxdb v1 auth: username and password must be provided together",
+            }
+            .fail()?
+        }
+    }
+}
+
 async fn authenticate<B: Send + Sync + 'static>(
     user_provider: &UserProviderRef,
     request: &Request<B>,
-) -> crate::auth::Result<UserInfo> {
-    let (scheme, credential) = auth_header(request).map_err(|e| IllegalParam {
-        msg: format!("failed to get http authorize header, err: {e:?}"),
-    })?;
+) -> Result<UserInfo> {
+    if request.uri().path().contains("influxdb") {
+        let (username, password) =
+            get_influxdb_credentials(request)?.context(NotFoundInfluxAuthSnafu)?;
 
-    match scheme {
-        AuthScheme::Basic => {
-            let (username, password) = decode_basic(credential).map_err(|e| IllegalParam {
-                msg: format!("failed to decode basic authorize, err: {e:?}"),
-            })?;
+        Ok(user_provider
+            .authenticate(
+                Identity::UserId(&username, None),
+                crate::auth::Password::PlainText(&password),
+            )
+            .await?)
+    } else {
+        // normal http auth
+        let (scheme, credential) = auth_header(request)?;
+        match scheme {
+            AuthScheme::Basic => {
+                let (username, password) = decode_basic(credential)?;
 
-            Ok(user_provider
-                .authenticate(
-                    Identity::UserId(&username, None),
-                    crate::auth::Password::PlainText(&password),
-                )
-                .await?)
+                Ok(user_provider
+                    .authenticate(
+                        Identity::UserId(&username, None),
+                        crate::auth::Password::PlainText(&password),
+                    )
+                    .await?)
+            }
         }
     }
 }
@@ -172,7 +236,7 @@ impl TryFrom<&str> for AuthScheme {
     fn try_from(value: &str) -> Result<Self> {
         match value.to_lowercase().as_str() {
             "basic" => Ok(AuthScheme::Basic),
-            other => error::UnsupportedAuthSchemeSnafu { name: other }.fail(),
+            other => UnsupportedAuthSchemeSnafu { name: other }.fail(),
         }
     }
 }
@@ -185,14 +249,14 @@ fn auth_header<B>(req: &Request<B>) -> Result<(AuthScheme, Credential)> {
         .get(http::header::AUTHORIZATION)
         .context(error::NotFoundAuthHeaderSnafu)?
         .to_str()
-        .context(error::InvisibleASCIISnafu)?;
+        .context(InvisibleASCIISnafu)?;
 
     let (auth_scheme, encoded_credentials) = auth_header
         .split_once(' ')
-        .context(error::InvalidAuthorizationHeaderSnafu)?;
+        .context(InvalidAuthorizationHeaderSnafu)?;
 
     if encoded_credentials.contains(' ') {
-        return error::InvalidAuthorizationHeaderSnafu {}.fail();
+        return InvalidAuthorizationHeaderSnafu {}.fail();
     }
 
     Ok((auth_scheme.try_into()?, encoded_credentials))
@@ -209,7 +273,7 @@ fn decode_basic(credential: Credential) -> Result<(Username, Password)> {
         return Ok((user_id.to_string(), password.to_string()));
     }
 
-    error::InvalidAuthorizationHeaderSnafu {}.fail()
+    InvalidAuthorizationHeaderSnafu {}.fail()
 }
 
 fn need_auth<B>(req: &Request<B>) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly supports InfluxDB specific auth protocol as #1032 mentioned. 

Discussion: 
1. should we support basic auth fallback if InfluxDB specified auth failed or not found
2. using v1 auth would try to parse http query string twice, should we optimize that in this patch

@sunng87 @Fengys123 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1032 