### PR TITLE
ci: allow ci pass when codecov can't upload data

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -223,5 +223,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
           flags: rust
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
According to the [arguments](https://github.com/codecov/codecov-action#arguments)

> Specify if CI pipeline should fail when Codecov runs into errors during upload

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
