### PR TITLE
feat: Support unary, paren, bool keyword and nonexistent metric/label in PromQL

### DIFF
--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 
 use common_error::prelude::*;
 use datafusion::error::DataFusionError;
-use promql_parser::label::Label;
 use promql_parser::parser::{Expr as PromExpr, TokenType};
 
 #[derive(Debug, Snafu)]
@@ -48,13 +47,6 @@ pub enum Error {
 
     #[snafu(display("Cannot find value columns in table {}", table))]
     ValueNotFound { table: String, backtrace: Backtrace },
-
-    #[snafu(display("Cannot find label {} in table {}", label, table,))]
-    LabelNotFound {
-        table: String,
-        label: Label,
-        backtrace: Backtrace,
-    },
 
     #[snafu(display("Cannot find the table {}", table))]
     TableNotFound {
@@ -116,8 +108,6 @@ impl ErrorExt for Error {
             | EmptyRange { .. } => StatusCode::Internal,
 
             TableNotFound { .. } | TableNameNotFound { .. } => StatusCode::TableNotFound,
-
-            LabelNotFound { .. } => StatusCode::TableColumnNotFound,
         }
     }
     fn backtrace_opt(&self) -> Option<&Backtrace> {

--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -107,15 +107,17 @@ impl ErrorExt for Error {
             | UnsupportedExpr { .. }
             | UnexpectedToken { .. }
             | MultipleVector { .. }
-            | LabelNotFound { .. }
             | ExpectExpr { .. } => StatusCode::InvalidArguments,
+
             UnknownTable { .. }
-            | TableNotFound { .. }
             | DataFusionPlanning { .. }
             | UnexpectedPlanExpr { .. }
             | IllegalRange { .. }
-            | EmptyRange { .. }
-            | TableNameNotFound { .. } => StatusCode::Internal,
+            | EmptyRange { .. } => StatusCode::Internal,
+
+            TableNotFound { .. } | TableNameNotFound { .. } => StatusCode::TableNotFound,
+
+            LabelNotFound { .. } => StatusCode::TableColumnNotFound,
         }
     }
     fn backtrace_opt(&self) -> Option<&Backtrace> {

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -767,15 +767,15 @@ impl<S: ContextProvider> PromPlanner<S> {
 
     /// Check if the given op is a [comparison operator](https://prometheus.io/docs/prometheus/latest/querying/operators/#comparison-binary-operators).
     fn is_token_a_comparison_op(token: TokenType) -> bool {
-        match token.id() {
+        matches!(
+            token.id(),
             token::T_EQLC
-            | token::T_NEQ
-            | token::T_GTR
-            | token::T_LSS
-            | token::T_GTE
-            | token::T_LTE => true,
-            _ => false,
-        }
+                | token::T_NEQ
+                | token::T_GTR
+                | token::T_LSS
+                | token::T_GTE
+                | token::T_LTE
+        )
     }
 
     /// Build a inner join on time index column and tag columns to concat two logical plans.

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -495,7 +495,7 @@ impl<S: ContextProvider> PromPlanner<S> {
         let table = self
             .schema_provider
             .get_table_provider(TableReference::Bare { table: &table_name })
-            .context(DataFusionPlanningSnafu)?
+            .context(TableNotFoundSnafu { table: &table_name })?
             .as_any()
             .downcast_ref::<DefaultTableSource>()
             .context(UnknownTableSnafu)?

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -202,10 +202,7 @@ impl<S: ContextProvider> PromPlanner<S> {
                     }
                 }
             }
-            PromExpr::Paren(ParenExpr { .. }) => UnsupportedExprSnafu {
-                name: "Prom Paren Expr",
-            }
-            .fail()?,
+            PromExpr::Paren(ParenExpr { expr }) => self.prom_expr_to_plan(*expr.clone())?,
             PromExpr::Subquery(SubqueryExpr { .. }) => UnsupportedExprSnafu {
                 name: "Prom Subquery",
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


- Support bool keyword (`some_metric > bool 1`)
- Support unary expr (`-some_metric`)
- Support paren expr (`(some_metric)`)
- Do not report error when querying a nonexistent label/metric.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Part of #1042