### PR TITLE
fix: use query_range http endpoint

### DIFF
--- a/src/servers/src/promql.rs
+++ b/src/servers/src/promql.rs
@@ -74,7 +74,7 @@ impl PromqlServer {
 
         let router = Router::new()
             .route("/query", routing::post(instant_query).get(instant_query))
-            .route("/range_query", routing::post(range_query).get(range_query))
+            .route("/query_range", routing::post(range_query).get(range_query))
             .with_state(self.query_handler.clone());
 
         Router::new()
@@ -233,7 +233,7 @@ pub async fn instant_query(
 ) -> Json<PromqlJsonResponse> {
     PromqlJsonResponse::error(
         "not implemented",
-        "instant query api `/query` is not implemented. Use `/range_query` instead.",
+        "instant query api `/query` is not implemented. Use `/query_range` instead.",
     )
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -296,12 +296,12 @@ pub async fn test_promql_http_api(store_type: StorageType) {
     assert_eq!(res.status(), StatusCode::OK);
 
     let res = client
-        .get("/v1/range_query?query=up&start=1&end=100&step=5")
+        .get("/v1/query_range?query=up&start=1&end=100&step=5")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);
     let res = client
-        .post("/v1/range_query?query=up&start=1&end=100&step=5")
+        .post("/v1/query_range?query=up&start=1&end=100&step=5")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

use the same `query_range` endpoint with [prometheus range queries](https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries)

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.