### PR TITLE
feat: Store error in procedure state

### DIFF
--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_error::prelude::*;
 
@@ -81,6 +82,21 @@ pub enum Error {
         #[snafu(backtrace)]
         source: BoxedError,
     },
+
+    #[snafu(display("Procedure panics, procedure_id: {}", procedure_id))]
+    ProcedurePanic { procedure_id: ProcedureId },
+
+    #[snafu(display("Failed to wait watcher, source: {}", source))]
+    WaitWatcher {
+        source: tokio::sync::watch::error::RecvError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to execute procedure, source: {}", source))]
+    ProcedureExec {
+        source: Arc<Error>,
+        backtrace: Backtrace,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -95,10 +111,13 @@ impl ErrorExt for Error {
             | Error::ListState { .. }
             | Error::ReadState { .. }
             | Error::FromJson { .. }
-            | Error::RetryLater { .. } => StatusCode::Internal,
+            | Error::RetryLater { .. }
+            | Error::WaitWatcher { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }
+            Error::ProcedurePanic { .. } => StatusCode::Unexpected,
+            Error::ProcedureExec { source, .. } => source.status_code(),
         }
     }
 

--- a/src/common/procedure/src/lib.rs
+++ b/src/common/procedure/src/lib.rs
@@ -18,9 +18,11 @@ pub mod error;
 pub mod local;
 mod procedure;
 mod store;
+pub mod watcher;
 
 pub use crate::error::{Error, Result};
 pub use crate::procedure::{
     BoxedProcedure, Context, ContextProvider, LockKey, Procedure, ProcedureId, ProcedureManager,
-    ProcedureManagerRef, ProcedureState, ProcedureWithId, StateKind, Status, Watcher,
+    ProcedureManagerRef, ProcedureState, ProcedureWithId, Status,
 };
+pub use crate::watcher::Watcher;

--- a/src/common/procedure/src/lib.rs
+++ b/src/common/procedure/src/lib.rs
@@ -22,5 +22,5 @@ mod store;
 pub use crate::error::{Error, Result};
 pub use crate::procedure::{
     BoxedProcedure, Context, ContextProvider, LockKey, Procedure, ProcedureId, ProcedureManager,
-    ProcedureManagerRef, ProcedureState, ProcedureWithId, Status, Watcher,
+    ProcedureManagerRef, ProcedureState, ProcedureWithId, StateKind, Status, Watcher,
 };

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -334,7 +334,7 @@ impl LocalManager {
 
         common_runtime::spawn_bg(async move {
             // Run the root procedure.
-            let _ = runner.run().await;
+            runner.run().await;
         });
 
         Ok(watcher)

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -65,7 +65,7 @@ pub(crate) struct ProcedureMeta {
 
 impl ProcedureMeta {
     fn new(id: ProcedureId, parent_id: Option<ProcedureId>, lock_key: LockKey) -> ProcedureMeta {
-        let (state_sender, state_receiver) = watch::channel(ProcedureState::running());
+        let (state_sender, state_receiver) = watch::channel(ProcedureState::Running);
         ProcedureMeta {
             id,
             lock_notify: Notify::new(),
@@ -434,7 +434,7 @@ mod tests {
 
     use super::*;
     use crate::error::Error;
-    use crate::{Context, Procedure, StateKind, Status};
+    use crate::{Context, Procedure, Status};
 
     #[test]
     fn test_manager_context() {
@@ -447,9 +447,9 @@ mod tests {
         assert!(ctx.try_insert_procedure(meta.clone()));
         assert!(ctx.contains_procedure(meta.id));
 
-        assert_eq!(StateKind::Running, ctx.state(meta.id).unwrap().kind());
-        meta.set_state(ProcedureState::done());
-        assert_eq!(StateKind::Done, ctx.state(meta.id).unwrap().kind());
+        assert!(ctx.state(meta.id).unwrap().is_running());
+        meta.set_state(ProcedureState::Done);
+        assert!(ctx.state(meta.id).unwrap().is_done());
     }
 
     #[test]
@@ -634,7 +634,7 @@ mod tests {
         // Wait for the procedure done.
         let mut watcher = manager.procedure_watcher(procedure_id).unwrap();
         watcher.changed().await.unwrap();
-        assert_eq!(StateKind::Done, watcher.borrow().kind());
+        assert!(watcher.borrow().is_done());
 
         // Try to submit procedure with same id again.
         let err = manager
@@ -697,7 +697,7 @@ mod tests {
                     .unwrap();
                 // Wait for the notification.
                 watcher.changed().await.unwrap();
-                assert_eq!(StateKind::Failed, watcher.borrow().kind());
+                assert!(watcher.borrow().is_failed());
             }
         };
 

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use common_telemetry::logging;
 use tokio::time;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::local::{ManagerContext, ProcedureMeta, ProcedureMetaRef};
 use crate::store::ProcedureStore;
 use crate::{BoxedProcedure, Context, ProcedureId, ProcedureState, ProcedureWithId, Status};
@@ -30,7 +30,7 @@ enum ExecResult {
     Continue,
     Done,
     RetryLater,
-    Failed(Error),
+    Failed,
 }
 
 #[cfg(test)]
@@ -48,7 +48,7 @@ impl ExecResult {
     }
 
     fn is_failed(&self) -> bool {
-        matches!(self, ExecResult::Failed(_))
+        matches!(self, ExecResult::Failed)
     }
 }
 
@@ -83,7 +83,7 @@ impl Drop for ProcedureGuard {
             // Set state to failed. This is useful in test as runtime may not abort when the runner task panics.
             // See https://github.com/tokio-rs/tokio/issues/2002 .
             // We set set_panic_hook() in the application's main function. But our tests don't have this panic hook.
-            self.meta.set_state(ProcedureState::Failed);
+            self.meta.set_state(ProcedureState::failed());
         }
 
         // Notify parent procedure.
@@ -109,7 +109,7 @@ pub(crate) struct Runner {
 
 impl Runner {
     /// Run the procedure.
-    pub(crate) async fn run(mut self) -> Result<()> {
+    pub(crate) async fn run(mut self) {
         // Ensure we can update the procedure state.
         let guard = ProcedureGuard::new(self.meta.clone(), self.manager_ctx.clone());
 
@@ -129,12 +129,9 @@ impl Runner {
                 .await;
         }
 
-        let mut result = Ok(());
         // Execute the procedure. We need to release the lock whenever the the execution
         // is successful or fail.
-        if let Err(e) = self.execute_procedure_in_loop().await {
-            result = Err(e);
-        }
+        self.execute_procedure_in_loop().await;
 
         // We can't remove the metadata of the procedure now as users and its parent might
         // need to query its state.
@@ -155,11 +152,9 @@ impl Runner {
             self.procedure.type_name(),
             self.meta.id
         );
-
-        result
     }
 
-    async fn execute_procedure_in_loop(&mut self) -> Result<()> {
+    async fn execute_procedure_in_loop(&mut self) {
         let ctx = Context {
             procedure_id: self.meta.id,
             provider: self.manager_ctx.clone(),
@@ -168,11 +163,10 @@ impl Runner {
         loop {
             match self.execute_once(&ctx).await {
                 ExecResult::Continue => (),
-                ExecResult::Done => return Ok(()),
+                ExecResult::Done | ExecResult::Failed => return,
                 ExecResult::RetryLater => {
                     self.wait_on_err().await;
                 }
-                ExecResult::Failed(e) => return Err(e),
             }
         }
     }
@@ -222,14 +216,15 @@ impl Runner {
                     return ExecResult::RetryLater;
                 }
 
-                self.meta.set_state(ProcedureState::Failed);
+                self.meta
+                    .set_state(ProcedureState::failed().with_error(Arc::new(e)));
 
                 // Write rollback key so we can skip this procedure while recovering procedures.
                 if self.rollback_procedure().await.is_err() {
                     return ExecResult::RetryLater;
                 }
 
-                ExecResult::Failed(e)
+                ExecResult::Failed
             }
         }
     }
@@ -385,7 +380,7 @@ impl Runner {
         );
 
         // Mark the state of this procedure to done.
-        self.meta.set_state(ProcedureState::Done);
+        self.meta.set_state(ProcedureState::done());
     }
 }
 
@@ -404,7 +399,7 @@ mod tests {
 
     use super::*;
     use crate::local::test_util;
-    use crate::{ContextProvider, LockKey, Procedure};
+    use crate::{ContextProvider, Error, LockKey, Procedure, StateKind};
 
     const ROOT_ID: &str = "9f805a1f-05f7-490c-9f91-bd56e3cc54c1";
 
@@ -630,8 +625,13 @@ mod tests {
                     // Wait for subprocedures.
                     let mut all_child_done = true;
                     for id in children_ids {
-                        if ctx.provider.procedure_state(id).await.unwrap()
-                            != Some(ProcedureState::Done)
+                        if ctx
+                            .provider
+                            .procedure_state(id)
+                            .await
+                            .unwrap()
+                            .map(|s| s.kind())
+                            != Some(StateKind::Done)
                         {
                             all_child_done = false;
                         }
@@ -668,7 +668,7 @@ mod tests {
         // Replace the manager ctx.
         runner.manager_ctx = manager_ctx;
 
-        runner.run().await.unwrap();
+        runner.run().await;
 
         // Check files on store.
         for child_id in children_ids {
@@ -706,7 +706,7 @@ mod tests {
 
         let res = runner.execute_once(&ctx).await;
         assert!(res.is_failed(), "{res:?}");
-        assert_eq!(ProcedureState::Failed, meta.state());
+        assert_eq!(StateKind::Failed, meta.state().kind());
         check_files(&object_store, ctx.procedure_id, &["0000000000.rollback"]).await;
     }
 
@@ -779,7 +779,8 @@ mod tests {
                 } else {
                     // Wait for subprocedures.
                     let state = ctx.provider.procedure_state(child_id).await.unwrap();
-                    if state == Some(ProcedureState::Failed) {
+                    let is_failed = state.map(|s| s.is_failed()).unwrap_or(false);
+                    if is_failed {
                         // The parent procedure to abort itself if child procedure is failed.
                         Err(Error::from_error_ext(PlainError::new(
                             "subprocedure failed".to_string(),
@@ -811,12 +812,13 @@ mod tests {
 
         let manager_ctx = Arc::new(ManagerContext::new());
         // Manually add this procedure to the manager ctx.
-        assert!(manager_ctx.try_insert_procedure(meta));
+        assert!(manager_ctx.try_insert_procedure(meta.clone()));
         // Replace the manager ctx.
         runner.manager_ctx = manager_ctx;
 
         // Run the runer and execute the procedure.
-        let err = runner.run().await.unwrap_err();
-        assert!(err.to_string().contains("subprocedure failed"), "{err}");
+        runner.run().await;
+        let err = meta.state().error().unwrap().to_string();
+        assert!(err.contains("subprocedure failed"), "{err}");
     }
 }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -744,11 +744,11 @@ mod tests {
 
         let res = runner.execute_once(&ctx).await;
         assert!(res.is_retry_later(), "{res:?}");
-        assert_eq!(ProcedureState::Running, meta.state());
+        assert!(meta.state().is_running());
 
         let res = runner.execute_once(&ctx).await;
         assert!(res.is_done(), "{res:?}");
-        assert_eq!(ProcedureState::Done, meta.state());
+        assert!(meta.state().is_done());
         check_files(&object_store, ctx.procedure_id, &["0000000000.commit"]).await;
     }
 

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -1,0 +1,38 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use snafu::ResultExt;
+use tokio::sync::watch::Receiver;
+
+use crate::error::{ProcedureExecSnafu, Result, WaitWatcherSnafu};
+use crate::procedure::ProcedureState;
+
+/// Watcher to watch procedure state.
+pub type Watcher = Receiver<ProcedureState>;
+
+/// Wait the [Watcher] until the [ProcedureState] is done.
+pub async fn wait(watcher: &mut Watcher) -> Result<()> {
+    loop {
+        watcher.changed().await.context(WaitWatcherSnafu)?;
+        match &*watcher.borrow() {
+            ProcedureState::Running => (),
+            ProcedureState::Done => {
+                return Ok(());
+            }
+            ProcedureState::Failed { error } => {
+                return Err(error.clone()).context(ProcedureExecSnafu);
+            }
+        }
+    }
+}

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -408,23 +408,18 @@ pub enum Error {
         source: common_procedure::error::Error,
     },
 
-    #[snafu(display("Failed to submit procedure, source: {}", source))]
+    #[snafu(display("Failed to submit procedure {}, source: {}", procedure_id, source))]
     SubmitProcedure {
+        procedure_id: ProcedureId,
         #[snafu(backtrace)]
         source: common_procedure::error::Error,
     },
 
-    #[snafu(display("Failed to wait procedure done, source: {}", source))]
+    #[snafu(display("Failed to wait procedure {} done, source: {}", procedure_id, source))]
     WaitProcedure {
-        source: tokio::sync::watch::error::RecvError,
-        backtrace: Backtrace,
-    },
-
-    // TODO(yingwen): Use procedure's error.
-    #[snafu(display("Failed to execute procedure, procedure_id: {}", procedure_id))]
-    ProcedureExec {
         procedure_id: ProcedureId,
-        backtrace: Backtrace,
+        #[snafu(backtrace)]
+        source: common_procedure::error::Error,
     },
 }
 
@@ -507,7 +502,7 @@ impl ErrorExt for Error {
             RecoverProcedure { source, .. } | SubmitProcedure { source, .. } => {
                 source.status_code()
             }
-            WaitProcedure { .. } | ProcedureExec { .. } => StatusCode::Internal,
+            WaitProcedure { source, .. } => source.status_code(),
         }
     }
 

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -177,7 +177,6 @@ impl Instance {
         };
 
         let procedure_manager = create_procedure_manager(&opts.procedure).await?;
-        // Recover procedures.
         if let Some(procedure_manager) = &procedure_manager {
             table_engine.register_procedure_loaders(&**procedure_manager);
             table_procedure::register_procedure_loaders(
@@ -187,6 +186,7 @@ impl Instance {
                 &**procedure_manager,
             );
 
+            // Recover procedures.
             procedure_manager
                 .recover()
                 .await

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -423,7 +423,7 @@ pub(crate) async fn create_log_store(wal_config: &WalConfig) -> Result<RaftEngin
     Ok(logstore)
 }
 
-async fn create_procedure_manager(
+pub(crate) async fn create_procedure_manager(
     procedure_config: &Option<ProcedureConfig>,
 ) -> Result<Option<ProcedureManagerRef>> {
     let Some(procedure_config) = procedure_config else {

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -28,7 +28,7 @@ use table::engine::{EngineContext, TableEngineRef};
 use table::requests::{CreateTableRequest, TableOptions};
 use tempdir::TempDir;
 
-use crate::datanode::{DatanodeOptions, FileConfig, ProcedureConfig, ObjectStoreConfig, WalConfig};
+use crate::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, ProcedureConfig, WalConfig};
 use crate::error::{CreateTableSnafu, Result};
 use crate::instance::Instance;
 use crate::sql::SqlHandler;
@@ -46,7 +46,11 @@ impl MockInstance {
         let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
         instance.start().await.unwrap();
 
-        MockInstance { instance, _guard, procedure_dir: None }
+        MockInstance {
+            instance,
+            _guard,
+            procedure_dir: None,
+        }
     }
 
     pub(crate) async fn with_procedure_enabled(name: &str) -> Self {
@@ -61,7 +65,11 @@ impl MockInstance {
         let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
         instance.start().await.unwrap();
 
-        MockInstance { instance, _guard, procedure_dir: None }
+        MockInstance {
+            instance,
+            _guard,
+            procedure_dir: None,
+        }
     }
 
     pub(crate) fn inner(&self) -> &Instance {

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -36,7 +36,7 @@ use crate::sql::SqlHandler;
 pub(crate) struct MockInstance {
     instance: Instance,
     _guard: TestGuard,
-    procedure_dir: Option<TempDir>,
+    _procedure_dir: Option<TempDir>,
 }
 
 impl MockInstance {
@@ -49,7 +49,7 @@ impl MockInstance {
         MockInstance {
             instance,
             _guard,
-            procedure_dir: None,
+            _procedure_dir: None,
         }
     }
 
@@ -68,7 +68,7 @@ impl MockInstance {
         MockInstance {
             instance,
             _guard,
-            procedure_dir: None,
+            _procedure_dir: Some(procedure_dir),
         }
     }
 

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -28,7 +28,7 @@ use table::engine::{EngineContext, TableEngineRef};
 use table::requests::{CreateTableRequest, TableOptions};
 use tempdir::TempDir;
 
-use crate::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, WalConfig};
+use crate::datanode::{DatanodeOptions, FileConfig, ProcedureConfig, ObjectStoreConfig, WalConfig};
 use crate::error::{CreateTableSnafu, Result};
 use crate::instance::Instance;
 use crate::sql::SqlHandler;
@@ -36,6 +36,7 @@ use crate::sql::SqlHandler;
 pub(crate) struct MockInstance {
     instance: Instance,
     _guard: TestGuard,
+    procedure_dir: Option<TempDir>,
 }
 
 impl MockInstance {
@@ -45,7 +46,22 @@ impl MockInstance {
         let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
         instance.start().await.unwrap();
 
-        MockInstance { instance, _guard }
+        MockInstance { instance, _guard, procedure_dir: None }
+    }
+
+    pub(crate) async fn with_procedure_enabled(name: &str) -> Self {
+        let (mut opts, _guard) = create_tmp_dir_and_datanode_opts(name);
+        let procedure_dir = TempDir::new(&format!("gt_procedure_{name}")).unwrap();
+        opts.procedure = Some(ProcedureConfig {
+            store: ObjectStoreConfig::File(FileConfig {
+                data_dir: procedure_dir.path().to_str().unwrap().to_string(),
+            }),
+        });
+
+        let instance = Instance::with_mock_meta_client(&opts).await.unwrap();
+        instance.start().await.unwrap();
+
+        MockInstance { instance, _guard, procedure_dir: None }
     }
 
     pub(crate) fn inner(&self) -> &Instance {

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -58,7 +58,7 @@ mod procedure_test_util {
             &self,
             _procedure_id: ProcedureId,
         ) -> Result<Option<ProcedureState>> {
-            Ok(Some(ProcedureState::done()))
+            Ok(Some(ProcedureState::Done))
         }
     }
 

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -58,7 +58,7 @@ mod procedure_test_util {
             &self,
             _procedure_id: ProcedureId,
         ) -> Result<Option<ProcedureState>> {
-            Ok(Some(ProcedureState::Done))
+            Ok(Some(ProcedureState::done()))
         }
     }
 

--- a/src/table-procedure/src/create.rs
+++ b/src/table-procedure/src/create.rs
@@ -211,7 +211,7 @@ impl CreateTableProcedure {
                 self.data.state = CreateTableState::RegisterCatalog;
                 Ok(Status::executing(true))
             }
-            ProcedureState::Failed => {
+            ProcedureState::Failed { .. } => {
                 // Return error if the subprocedure is failed.
                 SubprocedureFailedSnafu {
                     subprocedure_id: sub_id,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR stores the procedure error in the `ProcedureState` so the watcher can use the error as source and expose the cause of failure to callers.
```rust
#[derive(Debug, Default, Clone)]
pub enum ProcedureState {
    /// The procedure is running.
    #[default]
    Running,
    /// The procedure is finished.
    Done,
    /// The procedure is failed and cannot proceed anymore.
    Failed { error: Arc<Error> },
}
```

Since the `ProcedureState` should be cloneable so we need to use `Arc<Error>` to share the error.

This PR also adds a `watcher` mod to provide a helper method `wait()` to wait for a procedure and simplify the usage of the watcher.
```rust
pub async fn wait(watcher: &mut Watcher) -> Result<()>;
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286