### PR TITLE
fix: update mysql server library to fix tls corrupt messsage issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.3.0"
-source = "git+https://github.com/datafuselabs/opensrv?rev=b44c9d1360da297b305abf33aecfa94888e1554c#b44c9d1360da297b305abf33aecfa94888e1554c"
+source = "git+https://github.com/sunng87/opensrv?branch=fix/buffer-overread#d5c24b25543ba48b69c3c4fe97f71e499819bd99"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -38,7 +38,7 @@ metrics = "0.20"
 num_cpus = "1.13"
 once_cell = "1.16"
 openmetrics-parser = "0.4"
-opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "b44c9d1360da297b305abf33aecfa94888e1554c" }
+opensrv-mysql = { git = "https://github.com/sunng87/opensrv", branch = "fix/buffer-overread" }
 pgwire = "0.10"
 pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

A bug in upstream opensrv-mysql cause occasional tls corrupt message error on tls handshake. 

Upstream fix: https://github.com/datafuselabs/opensrv/pull/39

cc @SSebo 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Fixes #677 