### PR TITLE
ci: simplify codecov commment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
 ignore:
   - "**/error*.rs" # ignore all error.rs files
   - "tests/runner/*.rs" # ignore integration test runner
+comment:                  # this is a top-level key
+  layout: "diff"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Remove some blocks from codecov's comment. It contains many (maybe useful) contents, but is toooo loooong that I can merely put them within one screen. And, in my experience, they are very very inaccurate. So removing them might be a good choice. 

It currently looks like this, and I'm going to only preserve the first **red-green** block
<img width="932" alt="image" src="https://user-images.githubusercontent.com/15380403/221088228-e2f4c27a-07b3-4699-b376-a2dd7da98341.png">



## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
