### PR TITLE
refactor(SST): take Uuid as SST key

### DIFF
--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -170,16 +170,17 @@ impl CompactionOutput {
             self.bucket_bound + self.bucket,
         )
         .await?;
-        let output_file_name = format!("{}.parquet", Uuid::new_v4().hyphenated());
+        let output_file_name = SST_file_id::new();
         let opts = WriteOptions {};
 
         let SstInfo { time_range } = sst_layer
-            .write_sst(&output_file_name, Source::Reader(reader), &opts)
+            .write_sst(&output_file_name
+            , Source::Reader(reader), &opts)
             .await?;
 
         Ok(FileMeta {
             region_id,
-            file_name: output_file_name,
+            file_id: output_file_name,
             time_range,
             level: self.output_level,
         })

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -178,6 +178,7 @@ pub struct FlushJob<S: LogStore> {
 }
 
 impl<S: LogStore> FlushJob<S> {
+    // wbh attention
     async fn write_memtables_to_layer(&mut self, ctx: &Context) -> Result<Vec<FileMeta>> {
         if ctx.is_cancelled() {
             return CancelledSnafu {}.fail();
@@ -197,7 +198,8 @@ impl<S: LogStore> FlushJob<S> {
                 continue;
             }
 
-            let file_name = Self::generate_sst_file_name();
+            // WBH here's the sst_table
+            let file_id = Self::generate_sst_file_name();
             // TODO(hl): Check if random file name already exists in meta.
             let iter = m.iter(&iter_ctx)?;
             let sst_layer = self.sst_layer.clone();
@@ -209,7 +211,7 @@ impl<S: LogStore> FlushJob<S> {
 
                 Ok(FileMeta {
                     region_id,
-                    file_name,
+                    file_id,
                     time_range,
                     level: 0,
                 })
@@ -248,8 +250,10 @@ impl<S: LogStore> FlushJob<S> {
     }
 
     /// Generates random SST file name in format: `^[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}.parquet$`
-    fn generate_sst_file_name() -> String {
-        format!("{}.parquet", Uuid::new_v4().hyphenated())
+    fn generate_sst_file_name() -> SST_file_id {
+        SST_file_id::new()
+        // Uuid::new_v4()
+        // format!("{}.parquet", Uuid::new_v4().hyphenated())
     }
 }
 

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -32,8 +32,8 @@ pub fn build_region_meta() -> RegionMetadata {
 
 pub fn build_region_edit(
     sequence: SequenceNumber,
-    files_to_add: &[&str],
-    files_to_remove: &[&str],
+    files_to_add: &[SST_file_id],
+    files_to_remove: &[SST_file_id],
 ) -> RegionEdit {
     RegionEdit {
         region_version: 0,
@@ -42,7 +42,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_name: f.to_string(),
+                file_id: f,
                 time_range: None,
                 level: 0,
             })
@@ -51,7 +51,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_name: f.to_string(),
+                file_id: f,
                 time_range: None,
                 level: 0,
             })

--- a/src/storage/src/test_util/access_layer_util.rs
+++ b/src/storage/src/test_util/access_layer_util.rs
@@ -22,7 +22,7 @@ pub struct MockAccessLayer;
 impl AccessLayer for MockAccessLayer {
     async fn write_sst(
         &self,
-        _file_name: &str,
+        _file_name: &Uuid,
         _source: Source,
         _opts: &WriteOptions,
     ) -> crate::error::Result<SstInfo> {
@@ -31,7 +31,7 @@ impl AccessLayer for MockAccessLayer {
 
     async fn read_sst(
         &self,
-        _file_name: &str,
+        _file_name: &Uuid,
         _opts: &ReadOptions,
     ) -> crate::error::Result<BoxedBatchReader> {
         unimplemented!()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Refactor region SST struct to hold an UUID as SST key to reduce overhead

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

- related to [issue](https://github.com/GreptimeTeam/greptimedb/issues/1053)
