### PR TITLE
feat: initial changes for compaction_time_window field support

### DIFF
--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -407,6 +407,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                     .write_buffer_size
                     .map(|size| size.0 as usize),
                 ttl: request.table_options.ttl,
+                compaction_time_window: request.table_options.compaction_time_window,
             };
 
             let region = self
@@ -504,6 +505,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                     .write_buffer_size
                     .map(|s| s.0 as usize),
                 ttl: table_info.meta.options.ttl,
+                compaction_time_window: table_info.meta.options.compaction_time_window,
             };
 
             debug!(

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -394,6 +394,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
                 .id(region_id)
                 .name(&region_name)
                 .row_key(row_key.clone())
+                .compaction_time_window(request.table_options.compaction_time_window)
                 .default_cf(default_cf.clone())
                 .build()
                 .context(BuildRegionDescriptorSnafu {

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -219,6 +219,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
                 .name(region_name.clone())
                 .row_key(row_key.clone())
                 .default_cf(default_cf.clone())
+                .compaction_time_window(compaction_time_window)
                 .build()
                 .context(BuildRegionDescriptorSnafu {
                     table_name: &self.data.request.table_name,

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -163,15 +163,18 @@ impl<S: StorageEngine> CreateMitoTable<S> {
         let table_options = &self.data.request.table_options;
         let write_buffer_size = table_options.write_buffer_size.map(|size| size.0 as usize);
         let ttl = table_options.ttl;
+        let compaction_time_window = table_options.compaction_time_window;
         let open_opts = OpenOptions {
             parent_dir: table_dir.clone(),
             write_buffer_size,
             ttl,
+            compaction_time_window,
         };
         let create_opts = CreateOptions {
             parent_dir: table_dir,
             write_buffer_size,
             ttl,
+            compaction_time_window,
         };
 
         let primary_key_indices = &self.data.request.primary_key_indices;

--- a/src/storage/benches/memtable/util/regiondesc_util.rs
+++ b/src/storage/benches/memtable/util/regiondesc_util.rs
@@ -67,6 +67,7 @@ impl RegionDescBuilder {
             row_key: self.key_builder.build().unwrap(),
             default_cf: self.default_cf_builder.build().unwrap(),
             extra_cfs: Vec::new(),
+            compaction_time_window: None,
         }
     }
 

--- a/src/storage/src/compaction/noop.rs
+++ b/src/storage/src/compaction/noop.rs
@@ -17,8 +17,7 @@ use std::marker::PhantomData;
 
 use store_api::storage::RegionId;
 
-use crate::compaction::{CompactionTask, Picker, PickerContext};
-//use crate::compaction::{CompactionTask, Picker};
+use crate::compaction::{CompactionTask, Picker};
 use crate::error::Result;
 use crate::scheduler::{Request, Scheduler};
 
@@ -50,10 +49,7 @@ impl Picker for NoopCompactionPicker {
     type Request = NoopCompactionRequest;
     type Task = NoopCompactionTask;
 
-    fn pick(
-        &self,
-        _req: &Self::Request,
-    ) -> Result<Option<Self::Task>> {
+    fn pick(&self, _req: &Self::Request) -> Result<Option<Self::Task>> {
         Ok(None)
     }
 }

--- a/src/storage/src/compaction/noop.rs
+++ b/src/storage/src/compaction/noop.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use store_api::storage::RegionId;
 
 use crate::compaction::{CompactionTask, Picker, PickerContext};
+//use crate::compaction::{CompactionTask, Picker};
 use crate::error::Result;
 use crate::scheduler::{Request, Scheduler};
 
@@ -49,7 +50,10 @@ impl Picker for NoopCompactionPicker {
     type Request = NoopCompactionRequest;
     type Task = NoopCompactionTask;
 
-    fn pick(&self, _ctx: &PickerContext, _req: &Self::Request) -> Result<Option<Self::Task>> {
+    fn pick(
+        &self,
+        _req: &Self::Request,
+    ) -> Result<Option<Self::Task>> {
         Ok(None)
     }
 }

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -37,7 +37,6 @@ pub trait Picker: Send + 'static {
 
     fn pick(
         &self,
-        ctx: &PickerContext,
         req: &Self::Request,
     ) -> crate::error::Result<Option<Self::Task>>;
 }
@@ -103,7 +102,6 @@ impl<S: LogStore> Picker for SimplePicker<S> {
 
     fn pick(
         &self,
-        ctx: &PickerContext,
         req: &CompactionRequestImpl<S>,
     ) -> crate::error::Result<Option<CompactionTaskImpl<S>>> {
         let levels = &req.levels();
@@ -124,6 +122,7 @@ impl<S: LogStore> Picker for SimplePicker<S> {
             expired_ssts.iter().for_each(|f| f.mark_compacting(true));
         }
 
+        let ctx = &PickerContext::with(req.compaction_time_window);
         for level_num in 0..levels.level_num() {
             let level = levels.level(level_num as u8);
             let (compaction_time_window, outputs) = self.strategy.pick(ctx, level);

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -42,7 +42,21 @@ pub trait Picker: Send + 'static {
     ) -> crate::error::Result<Option<Self::Task>>;
 }
 
-pub struct PickerContext {}
+pub struct PickerContext {
+    compaction_time_window: Option<i64>,
+}
+
+impl PickerContext {
+    pub fn with(compaction_time_window: Option<i64>) -> Self {
+        Self {
+            compaction_time_window,
+        }
+    }
+
+    pub fn compaction_time_window(&self) -> Option<i64> {
+        self.compaction_time_window
+    }
+}
 
 /// L0 -> L1 compaction based on time windows.
 pub struct SimplePicker<S> {
@@ -112,7 +126,7 @@ impl<S: LogStore> Picker for SimplePicker<S> {
 
         for level_num in 0..levels.level_num() {
             let level = levels.level(level_num as u8);
-            let outputs = self.strategy.pick(ctx, level);
+            let (compaction_time_window, outputs) = self.strategy.pick(ctx, level);
 
             if outputs.is_empty() {
                 debug!("No SST file can be compacted at level {}", level_num);
@@ -133,6 +147,7 @@ impl<S: LogStore> Picker for SimplePicker<S> {
                 manifest: req.manifest.clone(),
                 expired_ssts,
                 sst_write_buffer_size: req.sst_write_buffer_size,
+                compaction_time_window,
             }));
         }
 

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -35,10 +35,7 @@ pub trait Picker: Send + 'static {
     type Request: Request;
     type Task: CompactionTask;
 
-    fn pick(
-        &self,
-        req: &Self::Request,
-    ) -> crate::error::Result<Option<Self::Task>>;
+    fn pick(&self, req: &Self::Request) -> crate::error::Result<Option<Self::Task>>;
 }
 
 pub struct PickerContext {

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -22,7 +22,7 @@ use store_api::storage::RegionId;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::Notify;
 
-use crate::compaction::picker::{Picker, PickerContext};
+use crate::compaction::picker::Picker;
 use crate::compaction::task::CompactionTask;
 use crate::error::Result;
 use crate::manifest::region::RegionManifest;
@@ -102,8 +102,7 @@ where
         finish_notifier: Arc<Notify>,
     ) -> Result<()> {
         let region_id = req.key();
-        // TODO check if it's None
-        let Some(task) = self.picker.pick(&PickerContext::with(None), &req)? else {
+        let Some(task) = self.picker.pick(&req)? else {
             info!("No file needs compaction in region: {:?}", region_id);
             req.complete(Ok(()));
             return Ok(());

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -59,6 +59,7 @@ pub struct CompactionRequestImpl<S: LogStore> {
     pub manifest: RegionManifest,
     pub wal: Wal<S>,
     pub ttl: Option<Duration>,
+    pub compaction_time_window: Option<i64>,
     /// Compaction result sender.
     pub sender: Option<Sender<Result<()>>>,
 
@@ -101,7 +102,8 @@ where
         finish_notifier: Arc<Notify>,
     ) -> Result<()> {
         let region_id = req.key();
-        let Some(task) = self.picker.pick(&PickerContext {}, &req)? else {
+        // TODO check if it's None
+        let Some(task) = self.picker.pick(&PickerContext::with(None), &req)? else {
             info!("No file needs compaction in region: {:?}", region_id);
             req.complete(Ok(()));
             return Ok(());

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -37,7 +37,7 @@ pub type StrategyRef = Arc<dyn Strategy + Send + Sync>;
 pub struct SimpleTimeWindowStrategy {}
 
 impl Strategy for SimpleTimeWindowStrategy {
-    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> (Option<i64>, Vec<CompactionOutput>) {        
+    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> (Option<i64>, Vec<CompactionOutput>) {
         // SimpleTimeWindowStrategy only handles level 0 to level 1 compaction.
         if level.level() != 0 {
             return (None, vec![]);
@@ -47,19 +47,23 @@ impl Strategy for SimpleTimeWindowStrategy {
         if files.is_empty() {
             return (None, vec![]);
         }
-        let time_bucket = ctx.compaction_time_window().unwrap_or_else(|| infer_time_bucket(&files));
+        let time_bucket = ctx
+            .compaction_time_window()
+            .unwrap_or_else(|| infer_time_bucket(&files));
         let buckets = calculate_time_buckets(time_bucket, &files);
         debug!("File bucket:{}, file groups: {:?}", time_bucket, buckets);
-        (Some(time_bucket),
-         buckets
-          .into_iter()
-          .map(|(bound, files)| CompactionOutput {
-              output_level: 1,
-              bucket_bound: bound,
-              bucket: time_bucket,
-              inputs: files,
-          })
-          .collect())
+        (
+            Some(time_bucket),
+            buckets
+                .into_iter()
+                .map(|(bound, files)| CompactionOutput {
+                    output_level: 1,
+                    bucket_bound: bound,
+                    bucket: time_bucket,
+                    inputs: files,
+                })
+                .collect(),
+        )
     }
 }
 

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -26,7 +26,7 @@ use crate::sst::{FileHandle, LevelMeta};
 
 /// Compaction strategy that defines which SSTs need to be compacted at given level.
 pub trait Strategy {
-    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> Vec<CompactionOutput>;
+    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> (Option<i64>, Vec<CompactionOutput>);
 }
 
 pub type StrategyRef = Arc<dyn Strategy + Send + Sync>;
@@ -37,29 +37,29 @@ pub type StrategyRef = Arc<dyn Strategy + Send + Sync>;
 pub struct SimpleTimeWindowStrategy {}
 
 impl Strategy for SimpleTimeWindowStrategy {
-    fn pick(&self, _ctx: &PickerContext, level: &LevelMeta) -> Vec<CompactionOutput> {
+    fn pick(&self, ctx: &PickerContext, level: &LevelMeta) -> (Option<i64>, Vec<CompactionOutput>) {        
         // SimpleTimeWindowStrategy only handles level 0 to level 1 compaction.
         if level.level() != 0 {
-            return vec![];
+            return (None, vec![]);
         }
         let files = find_compactable_files(level);
         debug!("Compactable files found: {:?}", files);
         if files.is_empty() {
-            return vec![];
+            return (None, vec![]);
         }
-
-        let time_bucket = infer_time_bucket(&files);
+        let time_bucket = ctx.compaction_time_window().unwrap_or_else(|| infer_time_bucket(&files));
         let buckets = calculate_time_buckets(time_bucket, &files);
         debug!("File bucket:{}, file groups: {:?}", time_bucket, buckets);
-        buckets
-            .into_iter()
-            .map(|(bound, files)| CompactionOutput {
-                output_level: 1,
-                bucket_bound: bound,
-                bucket: time_bucket,
-                inputs: files,
-            })
-            .collect()
+        (Some(time_bucket),
+         buckets
+          .into_iter()
+          .map(|(bound, files)| CompactionOutput {
+              output_level: 1,
+              bucket_bound: bound,
+              bucket: time_bucket,
+              inputs: files,
+          })
+          .collect())
     }
 }
 

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -48,6 +48,7 @@ pub struct CompactionTaskImpl<S: LogStore> {
     pub manifest: RegionManifest,
     pub expired_ssts: Vec<FileHandle>,
     pub sst_write_buffer_size: ReadableSize,
+    pub compaction_time_window: Option<i64>,
 }
 
 impl<S: LogStore> Debug for CompactionTaskImpl<S> {

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -102,6 +102,7 @@ impl<S: LogStore> CompactionTaskImpl<S> {
     }
 
     /// Writes updated SST info into manifest.
+    // TODO(etolbakov): we are not persisting inferred compaction_time_window (#1083)[https://github.com/GreptimeTeam/greptimedb/pull/1083]
     async fn write_manifest_and_apply(
         &self,
         output: HashSet<FileMeta>,

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -298,6 +298,7 @@ impl<S: LogStore> EngineInner<S> {
                 name,
                 &self.config,
                 opts.ttl,
+                opts.compaction_time_window,
             )
             .await?;
 
@@ -336,6 +337,7 @@ impl<S: LogStore> EngineInner<S> {
                 &region_name,
                 &self.config,
                 opts.ttl,
+                opts.compaction_time_window,
             )
             .await?;
 
@@ -360,6 +362,7 @@ impl<S: LogStore> EngineInner<S> {
         region_name: &str,
         config: &EngineConfig,
         ttl: Option<Duration>,
+        compaction_time_window: Option<i64>,
     ) -> Result<StoreConfig<S>> {
         let parent_dir = util::normalize_dir(parent_dir);
 
@@ -389,6 +392,7 @@ impl<S: LogStore> EngineInner<S> {
             engine_config: self.config.clone(),
             file_purger: self.file_purger.clone(),
             ttl,
+            compaction_time_window,
         })
     }
 }

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -38,6 +38,8 @@ pub struct RawRegionMetadata {
     pub columns: RawColumnsMetadata,
     pub column_families: RawColumnFamiliesMetadata,
     pub version: VersionNumber,
+    /// Time window for compaction
+    pub compaction_time_window: Option<i64>
 }
 
 /// Minimal data that could be used to persist and recover [ColumnsMetadata](crate::metadata::ColumnsMetadata).

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -39,7 +39,7 @@ pub struct RawRegionMetadata {
     pub column_families: RawColumnFamiliesMetadata,
     pub version: VersionNumber,
     /// Time window for compaction
-    pub compaction_time_window: Option<i64>
+    pub compaction_time_window: Option<i64>,
 }
 
 /// Minimal data that could be used to persist and recover [ColumnsMetadata](crate::metadata::ColumnsMetadata).

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -199,7 +199,7 @@ pub struct RegionMetadata {
     column_families: ColumnFamiliesMetadata,
     version: VersionNumber,
     /// Time window for compaction
-    compaction_time_window: Option<i64>
+    compaction_time_window: Option<i64>,
 }
 
 impl RegionMetadata {
@@ -324,7 +324,8 @@ impl RegionMetadata {
         let mut builder = RegionDescriptorBuilder::default()
             .id(self.id)
             .name(&self.name)
-            .row_key(row_key);
+            .row_key(row_key)
+            .compaction_time_window(self.compaction_time_window);
 
         for (cf_id, cf) in &self.column_families.id_to_cfs {
             let mut cf_builder = ColumnFamilyDescriptorBuilder::default()
@@ -644,7 +645,7 @@ impl TryFrom<RegionDescriptor> for RegionMetadataBuilder {
             .name(desc.name)
             .id(desc.id)
             .row_key(desc.row_key)?
-            .compaction_time_window(None) // TODO should I update `RegionDescriptor` as well?
+            .compaction_time_window(desc.compaction_time_window)
             .add_column_family(desc.default_cf)?;
         for cf in desc.extra_cfs {
             builder = builder.add_column_family(cf)?;
@@ -878,7 +879,7 @@ impl RegionMetadataBuilder {
             columns,
             column_families: self.cfs_meta_builder.build(),
             version: self.version,
-            compaction_time_window: self.compaction_time_window
+            compaction_time_window: self.compaction_time_window,
         })
     }
 }

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -309,8 +309,9 @@ impl<S: LogStore> RegionImpl<S> {
             name,
             version_control,
         });
-
-        let compaction_time_window = store_config.compaction_time_window.or(opts.compaction_time_window);
+        let compaction_time_window = store_config
+            .compaction_time_window
+            .or(opts.compaction_time_window);
         let writer = Arc::new(RegionWriter::new(
             store_config.memtable_builder,
             store_config.engine_config.clone(),

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -693,6 +693,7 @@ impl WriterInner {
             manifest: writer_ctx.manifest.clone(),
             wal: writer_ctx.wal.clone(),
             ttl: self.ttl,
+            compaction_time_window: self.compaction_time_window,
             sender: None,
             sst_write_buffer_size,
         };
@@ -751,7 +752,7 @@ impl WriterInner {
             manifest: ctx.manifest.clone(),
             wal: ctx.wal.clone(),
             ttl,
-            compaction_time_window
+            compaction_time_window,
             sender: None,
             sst_write_buffer_size: config.sst_write_buffer_size,
         };

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -71,7 +71,12 @@ impl RegionWriter {
         compaction_time_window: Option<i64>,
     ) -> RegionWriter {
         RegionWriter {
-            inner: Mutex::new(WriterInner::new(memtable_builder, config, ttl, compaction_time_window)),
+            inner: Mutex::new(WriterInner::new(
+                memtable_builder,
+                config,
+                ttl,
+                compaction_time_window,
+            )),
             version_mutex: Mutex::new(()),
         }
     }
@@ -642,7 +647,13 @@ impl WriterInner {
             return Ok(());
         }
 
-        let cb = Self::build_flush_callback(&current_version, ctx, &self.engine_config, self.ttl, self.compaction_time_window);
+        let cb = Self::build_flush_callback(
+            &current_version,
+            ctx,
+            &self.engine_config,
+            self.ttl,
+            self.compaction_time_window,
+        );
 
         let flush_req = FlushJob {
             max_memtable_id: max_memtable_id.unwrap(),

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -362,7 +362,7 @@ struct WriterInner {
     closed: bool,
     engine_config: Arc<EngineConfig>,
     ttl: Option<Duration>,
-    compaction_time_window: Option<i64>, // TODO never used
+    compaction_time_window: Option<i64>,
 }
 
 impl WriterInner {

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -68,9 +68,10 @@ impl RegionWriter {
         memtable_builder: MemtableBuilderRef,
         config: Arc<EngineConfig>,
         ttl: Option<Duration>,
+        compaction_time_window: Option<i64>,
     ) -> RegionWriter {
         RegionWriter {
-            inner: Mutex::new(WriterInner::new(memtable_builder, config, ttl)),
+            inner: Mutex::new(WriterInner::new(memtable_builder, config, ttl, compaction_time_window)),
             version_mutex: Mutex::new(()),
         }
     }
@@ -361,6 +362,7 @@ struct WriterInner {
     closed: bool,
     engine_config: Arc<EngineConfig>,
     ttl: Option<Duration>,
+    compaction_time_window: Option<i64>, // TODO never used
 }
 
 impl WriterInner {
@@ -368,6 +370,7 @@ impl WriterInner {
         memtable_builder: MemtableBuilderRef,
         engine_config: Arc<EngineConfig>,
         ttl: Option<Duration>,
+        compaction_time_window: Option<i64>,
     ) -> WriterInner {
         WriterInner {
             memtable_builder,
@@ -375,6 +378,7 @@ impl WriterInner {
             engine_config,
             closed: false,
             ttl,
+            compaction_time_window,
         }
     }
 
@@ -638,7 +642,7 @@ impl WriterInner {
             return Ok(());
         }
 
-        let cb = Self::build_flush_callback(&current_version, ctx, &self.engine_config, self.ttl);
+        let cb = Self::build_flush_callback(&current_version, ctx, &self.engine_config, self.ttl, self.compaction_time_window);
 
         let flush_req = FlushJob {
             max_memtable_id: max_memtable_id.unwrap(),
@@ -725,6 +729,7 @@ impl WriterInner {
         ctx: &WriterContext<S>,
         config: &Arc<EngineConfig>,
         ttl: Option<Duration>,
+        compaction_time_window: Option<i64>,
     ) -> Option<FlushCallback> {
         let region_id = version.metadata().id();
         let compaction_request = CompactionRequestImpl {
@@ -735,6 +740,7 @@ impl WriterInner {
             manifest: ctx.manifest.clone(),
             wal: ctx.wal.clone(),
             ttl,
+            compaction_time_window
             sender: None,
             sst_write_buffer_size: config.sst_write_buffer_size,
         };

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -83,5 +83,6 @@ pub async fn new_store_config_with_object_store(
         engine_config: Default::default(),
         file_purger,
         ttl: None,
+        compaction_time_window: None,
     }
 }

--- a/src/storage/src/test_util/descriptor_util.rs
+++ b/src/storage/src/test_util/descriptor_util.rs
@@ -94,6 +94,7 @@ impl RegionDescBuilder {
             row_key: self.key_builder.build().unwrap(),
             default_cf: self.default_cf_builder.build().unwrap(),
             extra_cfs: Vec::new(),
+            compaction_time_window: None, // TODO should we it to "RegionDescBuilder"
         }
     }
 

--- a/src/storage/src/test_util/descriptor_util.rs
+++ b/src/storage/src/test_util/descriptor_util.rs
@@ -94,7 +94,7 @@ impl RegionDescBuilder {
             row_key: self.key_builder.build().unwrap(),
             default_cf: self.default_cf_builder.build().unwrap(),
             extra_cfs: Vec::new(),
-            compaction_time_window: None, // TODO should we it to "RegionDescBuilder"
+            compaction_time_window: None,
         }
     }
 

--- a/src/store-api/src/storage/descriptors.rs
+++ b/src/store-api/src/storage/descriptors.rs
@@ -149,6 +149,8 @@ pub struct RegionDescriptor {
     /// Extra column families defined by user.
     #[builder(default, setter(each(name = "push_extra_column_family")))]
     pub extra_cfs: Vec<ColumnFamilyDescriptor>,
+    /// Time window for compaction
+    pub compaction_time_window: Option<i64>,
 }
 
 impl RowKeyDescriptorBuilder {

--- a/src/store-api/src/storage/engine.rs
+++ b/src/store-api/src/storage/engine.rs
@@ -88,6 +88,7 @@ pub struct CreateOptions {
     pub write_buffer_size: Option<usize>,
     /// Region SST files TTL
     pub ttl: Option<Duration>,
+    pub compaction_time_window: Option<i64>,
 }
 
 /// Options to open a region.
@@ -99,4 +100,5 @@ pub struct OpenOptions {
     pub write_buffer_size: Option<usize>,
     /// Region SST files TTL
     pub ttl: Option<Duration>,
+    pub compaction_time_window: Option<i64>,
 }

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -162,6 +162,7 @@ mod tests {
             .name("test")
             .row_key(row_key)
             .default_cf(default_cf)
+            .compaction_time_window(Some(1677652502))
             .build()
             .unwrap()
     }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -97,16 +97,16 @@ impl TryFrom<&HashMap<String, String>> for TableOptions {
             options.ttl = Some(ttl_value);
         }
         if let Some(compaction_time_window) = value.get(COMPACTION_TIME_WINDOW_KEY) {
-            options.compaction_time_window = compaction_time_window
-                .parse::<i64>()
-                .map_err(|_| {
-                    ParseTableOptionSnafu {
+            options.compaction_time_window = match compaction_time_window.parse::<i64>() {
+                Ok(t) => Some(t),
+                Err(_) => {
+                    return ParseTableOptionSnafu {
                         key: COMPACTION_TIME_WINDOW_KEY,
                         value: compaction_time_window,
                     }
-                    .build()
-                })
-                .ok();
+                    .fail()
+                }
+            };
         }
         options.extra_options = HashMap::from_iter(value.iter().filter_map(|(k, v)| {
             if k != WRITE_BUFFER_SIZE_KEY && k != TTL_KEY && k != COMPACTION_TIME_WINDOW_KEY {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
 - add a field `compaction_time_window` in `TableOptions`.
 -  persist the inferred time window to table manifest to avoid calculating it everytime.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Related issue link
https://github.com/GreptimeTeam/greptimedb/issues/1055
