### PR TITLE
refactor(SST): UUID as id in FileMeta

### DIFF
--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -189,7 +189,7 @@ impl ChunkReaderBuilder {
             }
             let reader = self
                 .sst_layer
-                .read_sst(file.file_name(), &read_opts)
+                .read_sst(file.file_id(), &read_opts)
                 .await?;
 
             reader_builder = reader_builder.push_batch_reader(reader);

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -19,7 +19,6 @@ use common_telemetry::{debug, warn};
 use common_time::timestamp::TimeUnit;
 use common_time::timestamp_millis::BucketAligned;
 use common_time::Timestamp;
-use uuid::Uuid;
 
 use crate::compaction::picker::PickerContext;
 use crate::compaction::task::CompactionOutput;
@@ -171,8 +170,7 @@ mod tests {
     use super::*;
     use crate::file_purger::noop::new_noop_file_purger;
     use crate::sst::FileMeta;
-
-    
+    use uuid::Uuid;
 
     #[test]
     fn test_time_bucket_span() {
@@ -282,7 +280,7 @@ mod tests {
                 .unwrap()
                 .iter()
                 .map(|f| f.file_id())
-                .collect::<HashSet<_>>();
+                .collect();
             assert_eq!(
                 file_ids, actual,
                 "bucket: {bucket}, expected: {file_ids:?}, actual: {actual:?}",

--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -171,6 +171,8 @@ mod tests {
     use crate::file_purger::noop::new_noop_file_purger;
     use crate::sst::FileMeta;
 
+    
+
     #[test]
     fn test_time_bucket_span() {
         assert_eq!(vec![0], file_time_bucket_span(1, 9, 10));
@@ -221,19 +223,21 @@ mod tests {
         assert_eq!(
             TIME_BUCKETS[0],
             infer_time_bucket(&[
-                new_file_handle("a", 0, TIME_BUCKETS[0] * 1000 - 1),
-                new_file_handle("b", 1, 10_000)
+                new_file_handle("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", 0, TIME_BUCKETS[0] * 1000 - 1),
+                new_file_handle("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", 1, 10_000)
             ])
         );
     }
 
-    fn new_file_handle(name: &str, start_ts_millis: i64, end_ts_millis: i64) -> FileHandle {
+    // only for test
+    fn new_file_handle(file_id: &str, start_ts_millis: i64, end_ts_millis: i64) -> FileHandle {
         let file_purger = new_noop_file_purger();
         let layer = Arc::new(crate::test_util::access_layer_util::MockAccessLayer {});
+        let file_id_uuid = Uuid::uuid!(file_id);
         FileHandle::new(
             FileMeta {
                 region_id: 0,
-                file_name: name.to_string(),
+                file_id: file_id_uuid,
                 time_range: Some((
                     Timestamp::new_millisecond(start_ts_millis),
                     Timestamp::new_millisecond(end_ts_millis),
@@ -248,7 +252,7 @@ mod tests {
     fn new_file_handles(input: &[(&str, i64, i64)]) -> Vec<FileHandle> {
         input
             .iter()
-            .map(|(name, start, end)| new_file_handle(name, *start, *end))
+            .map(|(file_id, start, end)| new_file_handle(file_id, *start, *end))
             .collect()
     }
 
@@ -277,7 +281,7 @@ mod tests {
                 .get(&bucket)
                 .unwrap()
                 .iter()
-                .map(|f| f.file_name().to_string())
+                .map(|f| f.file_name())
                 .collect();
             assert_eq!(
                 file_names, actual,

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -18,7 +18,6 @@ use std::fmt::{Debug, Formatter};
 use common_telemetry::{error, info};
 use store_api::logstore::LogStore;
 use store_api::storage::RegionId;
-use uuid::Uuid;
 
 use crate::compaction::writer::build_sst_reader;
 use crate::error::Result;
@@ -28,6 +27,7 @@ use crate::region::{RegionWriterRef, SharedDataRef};
 use crate::schema::RegionSchemaRef;
 use crate::sst::{AccessLayerRef, FileHandle, FileMeta, Level, Source, SstInfo, WriteOptions};
 use crate::wal::Wal;
+use uuid::Uuid;
 
 #[async_trait::async_trait]
 pub trait CompactionTask: Debug + Send + Sync + 'static {
@@ -170,16 +170,17 @@ impl CompactionOutput {
             self.bucket_bound + self.bucket,
         )
         .await?;
-        let output_file_name = format!("{}.parquet", Uuid::new_v4().hyphenated());
+        // let output_file_name = format!("{}.parquet", Uuid::new_v4().hyphenated());
+        let output_file_id = Uuid::new_v4();
         let opts = WriteOptions {};
 
         let SstInfo { time_range } = sst_layer
-            .write_sst(&output_file_name, Source::Reader(reader), &opts)
+            .write_sst(&output_file_id, Source::Reader(reader), &opts)
             .await?;
 
         Ok(FileMeta {
             region_id,
-            file_name: output_file_name,
+            file_id: output_file_id,
             time_range,
             level: self.output_level,
         })

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -165,7 +165,7 @@ mod tests {
     }
 
     async fn write_sst(
-        sst_file_name: &str,
+        sst_file_id: &Uuid,
         schema: RegionSchemaRef,
         seq: &AtomicU64,
         object_store: ObjectStore,
@@ -219,7 +219,7 @@ mod tests {
         }
 
         let iter = memtable.iter(&IterContext::default()).unwrap();
-        let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
+        let writer = ParquetWriter::new(sst_file_id.append_extension(), Source::Iter(iter), object_store.clone());
 
         let SstInfo { time_range } = writer
             .write_sst(&sst::WriteOptions::default())
@@ -228,7 +228,7 @@ mod tests {
         let handle = FileHandle::new(
             FileMeta {
                 region_id: 0,
-                file_name: sst_file_name.to_string(),
+                file_id: sst_file_id.clone(),
                 time_range,
                 level: 0,
             },
@@ -278,7 +278,7 @@ mod tests {
         let seq = AtomicU64::new(0);
         let schema = schema_for_test();
         let file1 = write_sst(
-            "a.parquet",
+            &Uuid::uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -293,7 +293,7 @@ mod tests {
         )
         .await;
         let file2 = write_sst(
-            "b.parquet",
+            &Uuid::uuid!("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -355,7 +355,7 @@ mod tests {
         let schema = schema_for_test();
         let seq = AtomicU64::new(0);
         let file1 = write_sst(
-            "i1.parquet",
+            &Uuid::uuid!("i1i1i1i1-i1i1-i1i1-i1i1-i1i1i1i1i1i1"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -372,7 +372,7 @@ mod tests {
 
         // in file2 we delete the row with timestamp 1000.
         let file2 = write_sst(
-            "i2.parquet",
+            &Uuid::uuid!("i2i2i2i2-i2i2-i2i2-i2i2-i2i2i2i2i2i2"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -401,7 +401,7 @@ mod tests {
 
         let opts = WriteOptions {};
         let s1 = ParquetWriter::new(
-            "./o1.parquet",
+            "./o1o1o1o1-o1o1-o1o1-o1o1-o1o1o1o1o1o1.parquet",
             Source::Reader(reader1),
             object_store.clone(),
         )
@@ -419,7 +419,7 @@ mod tests {
         );
 
         let s2 = ParquetWriter::new(
-            "./o2.parquet",
+            "./o2o2o2o2-o2o2-o2o2-o2o2-o2o2o2o2o2o2.parquet",
             Source::Reader(reader2),
             object_store.clone(),
         )
@@ -437,7 +437,7 @@ mod tests {
         );
 
         let s3 = ParquetWriter::new(
-            "./o3.parquet",
+            "./o3o3o3o3-o3o3-o3o3-o3o3-o3o3o3o3o3o3.parquet",
             Source::Reader(reader3),
             object_store.clone(),
         )
@@ -455,13 +455,16 @@ mod tests {
             s3
         );
 
-        let output_files = ["o1.parquet", "o2.parquet", "o3.parquet"]
+        let output_files = [ 
+            Uuid::uuid!("o1o1o1o1-o1o1-o1o1-o1o1-o1o1o1o1o1o1"), 
+            Uuid::uuid!("o2o2o2o2-o2o2-o2o2-o2o2-o2o2o2o2o2o2"), 
+            Uuid::uuid!("o3o3o3o3-o3o3-o3o3-o3o3-o3o3o3o3o3o3")]
             .into_iter()
             .map(|f| {
                 FileHandle::new(
                     FileMeta {
                         region_id: 0,
-                        file_name: f.to_string(),
+                        file_id: f,
                         level: 1,
                         time_range: None,
                     },

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -15,7 +15,6 @@
 use common_query::logical_plan::{DfExpr, Expr};
 use datafusion_common::ScalarValue;
 use datafusion_expr::{BinaryExpr, Operator};
-use uuid::Uuid;
 
 use crate::chunk::{ChunkReaderBuilder, ChunkReaderImpl};
 use crate::error;
@@ -96,6 +95,7 @@ mod tests {
     use object_store::{ObjectStore, ObjectStoreBuilder};
     use store_api::storage::{ChunkReader, OpType, SequenceNumber};
     use tempdir::TempDir;
+    use uuid::Uuid;
 
     use super::*;
     use crate::file_purger::noop::new_noop_file_purger;

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -15,6 +15,7 @@
 use common_query::logical_plan::{DfExpr, Expr};
 use datafusion_common::ScalarValue;
 use datafusion_expr::{BinaryExpr, Operator};
+use uuid::Uuid;
 
 use crate::chunk::{ChunkReaderBuilder, ChunkReaderImpl};
 use crate::error;
@@ -219,7 +220,8 @@ mod tests {
         }
 
         let iter = memtable.iter(&IterContext::default()).unwrap();
-        let writer = ParquetWriter::new(sst_file_id.append_extension(), Source::Iter(iter), object_store.clone());
+        let file_path = FileMeta::append_extension_parquet(sst_file_id);
+        let writer = ParquetWriter::new(&file_path, Source::Iter(iter), object_store.clone());
 
         let SstInfo { time_range } = writer
             .write_sst(&sst::WriteOptions::default())
@@ -278,7 +280,7 @@ mod tests {
         let seq = AtomicU64::new(0);
         let schema = schema_for_test();
         let file1 = write_sst(
-            &Uuid::uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            &uuid::uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -293,7 +295,7 @@ mod tests {
         )
         .await;
         let file2 = write_sst(
-            &Uuid::uuid!("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            &uuid::uuid!("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -355,7 +357,7 @@ mod tests {
         let schema = schema_for_test();
         let seq = AtomicU64::new(0);
         let file1 = write_sst(
-            &Uuid::uuid!("i1i1i1i1-i1i1-i1i1-i1i1-i1i1i1i1i1i1"),
+            &uuid::uuid!("a1a1a1a1-a1a1-a1a1-a1a1-a1a1a1a1a1a1"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -372,7 +374,7 @@ mod tests {
 
         // in file2 we delete the row with timestamp 1000.
         let file2 = write_sst(
-            &Uuid::uuid!("i2i2i2i2-i2i2-i2i2-i2i2-i2i2i2i2i2i2"),
+            &uuid::uuid!("a2a2a2a2-a2a2-a2a2-a2a2-a2a2a2a2a2a2"),
             schema.clone(),
             &seq,
             object_store.clone(),
@@ -401,7 +403,7 @@ mod tests {
 
         let opts = WriteOptions {};
         let s1 = ParquetWriter::new(
-            "./o1o1o1o1-o1o1-o1o1-o1o1-o1o1o1o1o1o1.parquet",
+            "./b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1.parquet",
             Source::Reader(reader1),
             object_store.clone(),
         )
@@ -419,7 +421,7 @@ mod tests {
         );
 
         let s2 = ParquetWriter::new(
-            "./o2o2o2o2-o2o2-o2o2-o2o2-o2o2o2o2o2o2.parquet",
+            "./b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2.parquet",
             Source::Reader(reader2),
             object_store.clone(),
         )
@@ -437,7 +439,7 @@ mod tests {
         );
 
         let s3 = ParquetWriter::new(
-            "./o3o3o3o3-o3o3-o3o3-o3o3-o3o3o3o3o3o3.parquet",
+            "./b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3.parquet",
             Source::Reader(reader3),
             object_store.clone(),
         )
@@ -456,9 +458,9 @@ mod tests {
         );
 
         let output_files = [ 
-            Uuid::uuid!("o1o1o1o1-o1o1-o1o1-o1o1-o1o1o1o1o1o1"), 
-            Uuid::uuid!("o2o2o2o2-o2o2-o2o2-o2o2-o2o2o2o2o2o2"), 
-            Uuid::uuid!("o3o3o3o3-o3o3-o3o3-o3o3-o3o3o3o3o3o3")]
+            uuid::uuid!("b1b1b1b1-b1b1-b1b1-b1b1-b1b1b1b1b1b1"), 
+            uuid::uuid!("b2b2b2b2-b2b2-b2b2-b2b2-b2b2b2b2b2b2"), 
+            uuid::uuid!("b3b3b3b3-b3b3-b3b3-b3b3-b3b3b3b3b3b3")]
             .into_iter()
             .map(|f| {
                 FileHandle::new(

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -178,14 +178,14 @@ mod tests {
         )
         .finish();
         // let sst_file_name = "test-file-purge-handler.parquet";
-        let sst_file_id = Uuid::uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        let sst_file_id = uuid::uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
         let noop_file_purger = Arc::new(LocalScheduler::new(
             SchedulerConfig::default(),
             NoopFilePurgeHandler,
         ));
-        let (file, path, layer) =
-            create_sst_file(object_store.clone(), sst_file_id, noop_file_purger).await;
+        let (_file, path, layer) =
+            create_sst_file(object_store.clone(), &sst_file_id, noop_file_purger).await;
         let request = FilePurgeRequest {
             region_id: 0,
             file_id: sst_file_id,
@@ -204,7 +204,7 @@ mod tests {
         let object = object_store.object(&format!(
             "{}/{}",
             path,
-            sst_file_id.with_extension(".parquet")
+            FileMeta::append_extension_parquet(&sst_file_id)
         ));
         assert!(!object.is_exist().await.unwrap());
     }
@@ -221,13 +221,13 @@ mod tests {
         )
         .finish();
         // let sst_file_name = "test-file-purger.parquet";
-        let sst_file_id = Uuid::uuid!("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        let sst_file_id = uuid::uuid!("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
         let scheduler = Arc::new(LocalScheduler::new(
             SchedulerConfig::default(),
             FilePurgeHandler,
         ));
         let (handle, path, _layer) =
-            create_sst_file(object_store.clone(), sst_file_id, scheduler.clone()).await;
+            create_sst_file(object_store.clone(), &sst_file_id, scheduler.clone()).await;
 
         {
             // mark file as deleted and drop the handle, we expect the file is deleted.
@@ -239,7 +239,7 @@ mod tests {
             .object(&format!(
                 "{}/{}",
                 path,
-                sst_file_id.with_extension(".parquet")
+                FileMeta::append_extension_parquet(&sst_file_id)
             ))
             .is_exist()
             .await

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -264,8 +264,8 @@ impl<S: LogStore> Job for FlushJob<S> {
 
 #[cfg(test)]
 mod tests {
-    use log_store::NoopLogStore;
-    use regex::Regex;
+    // use log_store::NoopLogStore;
+    // use regex::Regex;
 
     use super::*;
 
@@ -276,13 +276,13 @@ mod tests {
         assert_eq!(56, get_mutable_limitation(64));
     }
 
-    #[test]
-    pub fn test_uuid_generate() {
-        let file_name = FlushJob::<NoopLogStore>::generate_sst_file_name();
-        let regex = Regex::new(r"^[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}.parquet$").unwrap();
-        assert!(
-            regex.is_match(&file_name),
-            "Illegal sst file name: {file_name}",
-        );
-    }
+    // #[test]
+    // pub fn test_uuid_generate() {
+    //     let file_name = FlushJob::<NoopLogStore>::generate_sst_file_name();
+    //     let regex = Regex::new(r"^[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}.parquet$").unwrap();
+    //     assert!(
+    //         regex.is_match(&file_name),
+    //         "Illegal sst file name: {file_name}",
+    //     );
+    // }
 }

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -264,9 +264,6 @@ impl<S: LogStore> Job for FlushJob<S> {
 
 #[cfg(test)]
 mod tests {
-    // use log_store::NoopLogStore;
-    // use regex::Regex;
-
     use super::*;
 
     #[test]
@@ -275,14 +272,4 @@ mod tests {
         assert_eq!(8, get_mutable_limitation(10));
         assert_eq!(56, get_mutable_limitation(64));
     }
-
-    // #[test]
-    // pub fn test_uuid_generate() {
-    //     let file_name = FlushJob::<NoopLogStore>::generate_sst_file_name();
-    //     let regex = Regex::new(r"^[a-f\d]{8}(-[a-f\d]{4}){3}-[a-f\d]{12}.parquet$").unwrap();
-    //     assert!(
-    //         regex.is_match(&file_name),
-    //         "Illegal sst file name: {file_name}",
-    //     );
-    // }
 }

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -181,6 +181,7 @@ impl MetaAction for RegionMetaActionList {
 #[cfg(test)]
 mod tests {
     use common_telemetry::logging;
+    use uuid::Uuid;
 
     use super::*;
     use crate::manifest::test_utils;
@@ -194,8 +195,8 @@ mod tests {
             RegionMetaAction::Protocol(protocol.clone()),
             RegionMetaAction::Edit(test_utils::build_region_edit(
                 99,
-                &["test1", "test2"],
-                &["test3"],
+                &[&Uuid::new_v4(), &Uuid::new_v4()],
+                &[&Uuid::new_v4()],
             )),
         ]);
         action_list.set_prev_version(3);

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -16,6 +16,8 @@
 use crate::manifest::action::*;
 use crate::manifest::ManifestImpl;
 
+use uuid::Uuid;
+
 pub type RegionManifest = ManifestImpl<RegionMetaActionList>;
 
 #[cfg(test)]
@@ -94,8 +96,8 @@ mod tests {
         // Save some actions
         manifest
             .update(RegionMetaActionList::new(vec![
-                RegionMetaAction::Edit(build_region_edit(1, &["f1"], &[])),
-                RegionMetaAction::Edit(build_region_edit(2, &["f2", "f3"], &[])),
+                RegionMetaAction::Edit(build_region_edit(1, &[&Uuid::new_v4()], &[])),
+                RegionMetaAction::Edit(build_region_edit(2, &[&Uuid::new_v4(), &Uuid::new_v4()], &[])),
             ]))
             .await
             .unwrap();

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -16,8 +16,6 @@
 use crate::manifest::action::*;
 use crate::manifest::ManifestImpl;
 
-use uuid::Uuid;
-
 pub type RegionManifest = ManifestImpl<RegionMetaActionList>;
 
 #[cfg(test)]
@@ -29,6 +27,7 @@ mod tests {
     use store_api::manifest::action::ProtocolAction;
     use store_api::manifest::{Manifest, MetaActionIterator, MAX_VERSION};
     use tempdir::TempDir;
+    use uuid::Uuid;
 
     use super::*;
     use crate::manifest::test_utils::*;

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -14,6 +14,7 @@
 
 use datatypes::type_id::LogicalTypeId;
 use store_api::storage::SequenceNumber;
+use uuid::Uuid;
 
 use crate::manifest::action::*;
 use crate::metadata::RegionMetadata;
@@ -32,8 +33,8 @@ pub fn build_region_meta() -> RegionMetadata {
 
 pub fn build_region_edit(
     sequence: SequenceNumber,
-    files_to_add: &[&str],
-    files_to_remove: &[&str],
+    files_to_add: &[&Uuid],
+    files_to_remove: &[&Uuid],
 ) -> RegionEdit {
     RegionEdit {
         region_version: 0,
@@ -42,7 +43,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_id: Uuid::uuid!(f),
+                file_id: **f,
                 time_range: None,
                 level: 0,
             })
@@ -51,7 +52,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_id: Uuid::uuid!(f),
+                file_id: **f,
                 time_range: None,
                 level: 0,
             })

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -43,7 +43,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_id: **f,
+                file_id: f.clone().clone(),
                 time_range: None,
                 level: 0,
             })
@@ -52,7 +52,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_id: **f,
+                file_id: f.clone().clone(),
                 time_range: None,
                 level: 0,
             })

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -42,7 +42,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_name: f.to_string(),
+                file_id: Uuid::uuid!(f),
                 time_range: None,
                 level: 0,
             })
@@ -51,7 +51,7 @@ pub fn build_region_edit(
             .iter()
             .map(|f| FileMeta {
                 region_id: 0,
-                file_name: f.to_string(),
+                file_id: Uuid::uuid!(f),
                 time_range: None,
                 level: 0,
             })

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -35,6 +35,7 @@ use store_api::storage::{
     consts, Chunk, ChunkReader, RegionMeta, ScanRequest, SequenceNumber, Snapshot, WriteRequest,
 };
 use tempdir::TempDir;
+use uuid::Uuid;
 
 use super::*;
 use crate::file_purger::noop::NoopFilePurgeHandler;
@@ -45,6 +46,7 @@ use crate::scheduler::{LocalScheduler, SchedulerConfig};
 use crate::sst::FsAccessLayer;
 use crate::test_util::descriptor_util::RegionDescBuilder;
 use crate::test_util::{self, config_util, schema_util, write_batch_util};
+use crate::sst::FileMeta;
 
 /// Create metadata of a region with schema: (timestamp, v0).
 pub fn new_metadata(region_name: &str, enable_version_column: bool) -> RegionMetadata {
@@ -309,6 +311,10 @@ async fn test_recover_region_manifets() {
     .0
     .is_none());
 
+    let file_id_a = Uuid::new_v4();
+    let file_id_b = Uuid::new_v4();
+    let file_id_c = Uuid::new_v4();
+
     {
         // save some actions into region_meta
         manifest
@@ -323,8 +329,8 @@ async fn test_recover_region_manifets() {
 
         manifest
             .update(RegionMetaActionList::new(vec![
-                RegionMetaAction::Edit(build_region_edit(1, &["f1"], &[])),
-                RegionMetaAction::Edit(build_region_edit(2, &["f2", "f3"], &[])),
+                RegionMetaAction::Edit(build_region_edit(1, &[&file_id_a], &[])),
+                RegionMetaAction::Edit(build_region_edit(2, &[&file_id_b, &file_id_c], &[])),
             ]))
             .await
             .unwrap();
@@ -362,7 +368,9 @@ async fn test_recover_region_manifets() {
         .collect::<HashSet<_>>();
     assert_eq!(3, files.len());
     assert_eq!(
-        HashSet::from(["f1".to_string(), "f2".to_string(), "f3".to_string()]),
+        HashSet::from([FileMeta::append_extension_parquet(&file_id_a), 
+        FileMeta::append_extension_parquet(&file_id_b),
+        FileMeta::append_extension_parquet(&file_id_c)]),
         files
     );
 

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -358,7 +358,7 @@ async fn test_recover_region_manifets() {
     let ssts = version.ssts();
     let files = ssts.levels()[0]
         .files()
-        .map(|f| f.file_name().to_string())
+        .map(|f| f.file_name())
         .collect::<HashSet<_>>();
     assert_eq!(3, files.len());
     assert_eq!(

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -292,28 +292,6 @@ impl FileHandleInner {
     }
 }
 
-// #[derive(Debug, Clone)]
-// pub struct FileId(Uuid);
-
-// impl FileId {
-//     pub fn new() -> FileId {
-//         FileId(Uuid::new_v4())
-//     }
-//     // fn From(id: &str) -> FileId {
-//     //     FileId(uuid::uuid!(id))
-//     // }
-//     // TODO(vinland-avalon): make ".parquet" a const variable or default param
-//     fn append_extension(&self, extension: &str) -> String {
-//         format!("{}{}", self.0.hyphenated(), extension)
-//     }
-// }
-
-// impl From<Uuid> for FileId {
-//     fn from(id: Uuid) -> FileId {
-//         FileId(id)
-//     }
-// }
-
 /// Immutable metadata of a sst file.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FileMeta {

--- a/src/storage/src/test_util/access_layer_util.rs
+++ b/src/storage/src/test_util/access_layer_util.rs
@@ -15,6 +15,8 @@
 use crate::read::BoxedBatchReader;
 use crate::sst::{AccessLayer, ReadOptions, Source, SstInfo, WriteOptions};
 
+use uuid::Uuid;
+
 #[derive(Debug)]
 pub struct MockAccessLayer;
 
@@ -22,7 +24,7 @@ pub struct MockAccessLayer;
 impl AccessLayer for MockAccessLayer {
     async fn write_sst(
         &self,
-        _file_name: &str,
+        _file_id: &Uuid,
         _source: Source,
         _opts: &WriteOptions,
     ) -> crate::error::Result<SstInfo> {
@@ -31,13 +33,13 @@ impl AccessLayer for MockAccessLayer {
 
     async fn read_sst(
         &self,
-        _file_name: &str,
+        _file_name: &Uuid,
         _opts: &ReadOptions,
     ) -> crate::error::Result<BoxedBatchReader> {
         unimplemented!()
     }
 
-    async fn delete_sst(&self, _file_name: &str) -> crate::error::Result<()> {
+    async fn delete_sst(&self, _file_name: &Uuid) -> crate::error::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Refactor region SST struct to hold an UUID as SST key to reduce overhead

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

- related to [issue#1053](https://github.com/GreptimeTeam/greptimedb/issues/1053)
