### PR TITLE
feat: mysql prepare replacing sql placeholder to param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6947,6 +6947,7 @@ dependencies = [
  "once_cell",
  "openmetrics-parser",
  "opensrv-mysql",
+ "parking_lot",
  "pgwire",
  "pin-project",
  "postgres-types",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -43,6 +43,7 @@ num_cpus = "1.13"
 once_cell = "1.16"
 openmetrics-parser = "0.4"
 opensrv-mysql = { git = "https://github.com/sunng87/opensrv", branch = "fix/buffer-overread" }
+parking_lot = "0.12"
 pgwire = "0.10"
 pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -263,8 +263,8 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_mem_prof::error::Error,
     },
-    #[snafu(display("Prepare statement failed: {}", err_msg))]
-    PrepareStatementFailed { err_msg: String },
+    #[snafu(display("Invalid prepare statement: {}", err_msg))]
+    InvalidPrepareStatement { err_msg: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -304,7 +304,7 @@ impl ErrorExt for Error {
             | DecompressPromRemoteRequest { .. }
             | InvalidPromRemoteRequest { .. }
             | InvalidFlightTicket { .. }
-            | PrepareStatementFailed { .. }
+            | InvalidPrepareStatement { .. }
             | TimePrecision { .. } => StatusCode::InvalidArguments,
 
             InfluxdbLinesWrite { source, .. } | ConvertFlightMessage { source } => {

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -263,6 +263,8 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_mem_prof::error::Error,
     },
+    #[snafu(display("Prepare statement failed: {}", err_msg))]
+    PrepareStatementFailed { err_msg: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -302,6 +304,7 @@ impl ErrorExt for Error {
             | DecompressPromRemoteRequest { .. }
             | InvalidPromRemoteRequest { .. }
             | InvalidFlightTicket { .. }
+            | PrepareStatementFailed { .. }
             | TimePrecision { .. } => StatusCode::InvalidArguments,
 
             InfluxdbLinesWrite { source, .. } | ConvertFlightMessage { source } => {

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -171,9 +171,8 @@ fn create_mysql_column(column_schema: &ColumnSchema) -> Result<Column> {
         ConcreteDataType::Int64(_) | ConcreteDataType::UInt64(_) => {
             Ok(ColumnType::MYSQL_TYPE_LONGLONG)
         }
-        ConcreteDataType::Float32(_) | ConcreteDataType::Float64(_) => {
-            Ok(ColumnType::MYSQL_TYPE_FLOAT)
-        }
+        ConcreteDataType::Float32(_) => Ok(ColumnType::MYSQL_TYPE_FLOAT),
+        ConcreteDataType::Float64(_) => Ok(ColumnType::MYSQL_TYPE_DOUBLE),
         ConcreteDataType::Binary(_) | ConcreteDataType::String(_) => {
             Ok(ColumnType::MYSQL_TYPE_VARCHAR)
         }

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -186,6 +186,14 @@ fn create_mysql_column(column_schema: &ColumnSchema) -> Result<Column> {
         }
         .fail(),
     };
+    let mut colflags = ColumnFlags::empty();
+    match column_schema.data_type {
+        ConcreteDataType::UInt16(_)
+        | ConcreteDataType::UInt8(_)
+        | ConcreteDataType::UInt32(_)
+        | ConcreteDataType::UInt64(_) => colflags |= ColumnFlags::UNSIGNED_FLAG,
+        _ => {}
+    };
     column_type.map(|column_type| Column {
         column: column_schema.name.clone(),
         coltype: column_type,
@@ -193,7 +201,7 @@ fn create_mysql_column(column_schema: &ColumnSchema) -> Result<Column> {
         // TODO(LFC): Currently "table" and "colflags" are not relevant in MySQL server
         //   implementation, will revisit them again in the future.
         table: "".to_string(),
-        colflags: ColumnFlags::empty(),
+        colflags,
     })
 }
 

--- a/src/servers/tests/mysql/mod.rs
+++ b/src/servers/tests/mysql/mod.rs
@@ -119,7 +119,7 @@ pub fn all_datatype_testing_data() -> TestingData {
         ColumnType::MYSQL_TYPE_LONG,
         ColumnType::MYSQL_TYPE_LONGLONG,
         ColumnType::MYSQL_TYPE_FLOAT,
-        ColumnType::MYSQL_TYPE_FLOAT,
+        ColumnType::MYSQL_TYPE_DOUBLE,
         ColumnType::MYSQL_TYPE_VARCHAR,
         ColumnType::MYSQL_TYPE_VARCHAR,
     ];

--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -19,9 +19,11 @@ use std::time::Duration;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_recordbatch::RecordBatch;
 use common_runtime::Builder as RuntimeBuilder;
-use datatypes::schema::Schema;
+use datatypes::prelude::VectorRef;
+use datatypes::schema::{ColumnSchema, Schema};
+use datatypes::value::Value;
 use mysql_async::prelude::*;
-use mysql_async::{Row, SslOpts};
+use mysql_async::{Conn, Row, SslOpts};
 use rand::rngs::StdRng;
 use rand::Rng;
 use servers::error::Result;
@@ -454,30 +456,90 @@ async fn test_query_concurrently() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_query_prepared() -> Result<()> {
     common_telemetry::init_default_ut_logging();
+    let TestingData {
+        column_schemas,
+        mysql_columns_def: _,
+        columns,
+        mysql_text_output_rows: _,
+    } = all_datatype_testing_data();
+    let schema = Arc::new(Schema::new(column_schemas.clone()));
+    let recordbatch = RecordBatch::new(schema, columns.clone()).unwrap();
+    let table = MemTable::new("all_datatypes", recordbatch);
 
-    let table = MemTable::default_numbers_table();
+    let mysql_server = create_mysql_server(
+        table,
+        MysqlOpts {
+            ..Default::default()
+        },
+    )?;
 
-    let mysql_server = create_mysql_server(table, Default::default())?;
     let listening = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     let server_addr = mysql_server.start(listening).await.unwrap();
-    let server_port = server_addr.port();
-    let mut connection = create_connection_default_db_name(server_port, false)
+
+    let mut connection = create_connection_default_db_name(server_addr.port(), false)
         .await
         .unwrap();
-    let statement = connection
-        .prep(format!("SELECT uint32s FROM numbers WHERE uint32s = ?"))
-        .await;
-    let statement = statement.unwrap();
-    let stmt_id = statement.id();
 
-    assert_eq!(stmt_id, 1);
+    test_prepare_all_type(column_schemas, columns, &mut connection).await;
 
-    let output: std::result::Result<Vec<Row>, mysql_async::Error> = connection
-        .exec(statement, vec![mysql_async::Value::UInt(10)])
-        .await;
-
-    assert!(output.is_ok());
     Ok(())
+}
+
+async fn test_prepare_all_type(
+    column_schemas: Vec<ColumnSchema>,
+    columns: Vec<VectorRef>,
+    connection: &mut Conn,
+) {
+    let mut column_index = 0;
+    let mut stmt_id = 1;
+    for schema in column_schemas {
+        let query = format!(
+            "SELECT {} FROM all_datatypes WHERE {} = ?",
+            schema.name, schema.name
+        );
+        let statement = connection.prep(query).await;
+        let statement = statement.unwrap();
+        assert_eq!(stmt_id, statement.id());
+        stmt_id += 1;
+
+        let vector_ref = columns.get(column_index).unwrap();
+        for vector_index in 0..vector_ref.len() {
+            let v = vector_ref.get(vector_index);
+            let v = if let Some(v) = prepare_convert_type(v) {
+                v
+            } else {
+                continue;
+            };
+
+            let output: std::result::Result<Vec<Row>, mysql_async::Error> =
+                connection.exec(statement.clone(), vec![v]).await;
+
+            assert!(output.is_ok());
+
+            let rows = output.unwrap();
+            assert!(!rows.is_empty());
+        }
+        column_index += 1;
+    }
+}
+
+fn prepare_convert_type(item: Value) -> Option<mysql_async::Value> {
+    let v = match item {
+        Value::UInt8(u) => mysql_async::Value::UInt(u as u64),
+        Value::UInt16(u) => mysql_async::Value::UInt(u as u64),
+        Value::UInt32(u) => mysql_async::Value::UInt(u as u64),
+        Value::UInt64(u) => mysql_async::Value::UInt(u),
+        Value::Int8(i) => mysql_async::Value::Int(i as i64),
+        Value::Int16(i) => mysql_async::Value::Int(i as i64),
+        Value::Int32(i) => mysql_async::Value::Int(i as i64),
+        Value::Int64(i) => mysql_async::Value::Int(i),
+        Value::Float32(f) => mysql_async::Value::Float(f.into()),
+        Value::Float64(f) => mysql_async::Value::Double(f.into()),
+        Value::String(s) => mysql_async::Value::Bytes(s.as_utf8().as_bytes().to_vec()),
+        Value::Binary(b) => mysql_async::Value::Bytes(b.to_vec()),
+        _ => return None,
+    };
+    Some(v)
 }
 
 async fn create_connection_default_db_name(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

support mysql prepared statement

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- this initial version just cache sql for simplicity in `COM_STMT_PREPARE` 
- replace "?" placeholder with param in `COM_STMT_EXECUTE`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/470