### PR TITLE
fix: fix panic when the root is not specified

### DIFF
--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -190,6 +190,12 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Failed to build backend, source: {}", source))]
+    BuildBackend {
+        source: object_store::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Runtime resource error, source: {}", source))]
     RuntimeResource {
         #[snafu(backtrace)]
@@ -482,9 +488,11 @@ impl ErrorExt for Error {
             | MissingRequiredField { .. }
             | IncorrectInternalState { .. } => StatusCode::Internal,
 
-            InitBackend { .. } | WriteParquet { .. } | PollStream { .. } | WriteObject { .. } => {
-                StatusCode::StorageUnavailable
-            }
+            BuildBackend { .. }
+            | InitBackend { .. }
+            | WriteParquet { .. }
+            | PollStream { .. }
+            | WriteObject { .. } => StatusCode::StorageUnavailable,
             OpenLogStore { source } => source.status_code(),
             StartScriptManager { source } => source.status_code(),
             OpenStorageEngine { source } => source.status_code(),

--- a/src/datanode/src/sql/copy_table.rs
+++ b/src/datanode/src/sql/copy_table.rs
@@ -52,7 +52,10 @@ impl SqlHandler {
             .context(error::TableScanExecSnafu)?;
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(stream));
 
-        let accessor = Builder::default().build().unwrap();
+        let accessor = Builder::default()
+            .root("/")
+            .build()
+            .context(error::BuildBackendSnafu)?;
         let object_store = ObjectStore::new(accessor).finish();
 
         let mut parquet_writer = ParquetWriter::new(req.file_name, stream, object_store);

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -51,6 +51,10 @@ impl MockInstance {
     pub(crate) fn inner(&self) -> &Instance {
         &self.instance
     }
+
+    pub(crate) fn data_tmp_dir(&self) -> &TempDir {
+        &self._guard._data_tmp_dir
+    }
 }
 
 struct TestGuard {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

After the OpenDAL was [bumped to v0.27](https://github.com/GreptimeTeam/greptimedb/commit/98ef74bff4507b730369b5a15ba69a31d3206903) , the fs backend builder [will panic if the root is not specified](https://github.com/datafuselabs/opendal/blob/91eebebee1b683659073f9cc751e25293a0fd974/src/services/fs/backend.rs#L147-L153).



## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
