### PR TITLE
fix: continue if parsing err catalog

### DIFF
--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -27,7 +27,7 @@ use catalog::{
     RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
     SchemaProvider, SchemaProviderRef,
 };
-use common_telemetry::warn;
+use common_telemetry::error;
 use futures::StreamExt;
 use meta_client::rpc::TableName;
 use partition::manager::PartitionRuleManagerRef;
@@ -162,7 +162,7 @@ impl CatalogList for FrontendCatalogManager {
                     if let Ok(key) = CatalogKey::parse(catalog_key.as_ref()) {
                         res.insert(key.catalog_name);
                     } else {
-                        warn!("invalid catalog key: {:?}", catalog_key);
+                        error!("invalid catalog key: {:?}", catalog_key);
                     }
                 }
                 Ok(res.into_iter().collect())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Now `CatalogManager` loads and parses all catalog names while checking `is_valid_schema`. If any parse fails, the whole connections is aborted even if the failed one is not related to the current connection's catalog name.

This pr mainly adds warning to the above case instead of throwing an error and aborting the whole connection.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
