### PR TITLE
feat: implement flush method for mito table

### DIFF
--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -196,6 +196,10 @@ impl Region for MockRegion {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    async fn flush(&self) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 impl MockRegionInner {

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -125,6 +125,10 @@ impl<S: LogStore> Region for RegionImpl<S> {
     async fn close(&self) -> Result<()> {
         self.inner.close().await
     }
+
+    async fn flush(&self) -> Result<()> {
+        self.inner.flush().await
+    }
 }
 
 /// Storage related config for region.
@@ -549,5 +553,19 @@ impl<S: LogStore> RegionInner<S> {
 
     async fn close(&self) -> Result<()> {
         self.writer.close().await
+    }
+
+    async fn flush(&self) -> Result<()> {
+        let writer_ctx = WriterContext {
+            shared: &self.shared,
+            flush_strategy: &self.flush_strategy,
+            flush_scheduler: &self.flush_scheduler,
+            compaction_scheduler: &self.compaction_scheduler,
+            sst_layer: &self.sst_layer,
+            wal: &self.wal,
+            writer: &self.writer,
+            manifest: &self.manifest,
+        };
+        self.writer.flush(writer_ctx).await
     }
 }

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -260,6 +260,15 @@ impl RegionWriter {
         Ok(())
     }
 
+    /// Flush task manually  
+    pub async fn flush<S: LogStore>(&self, writer_ctx: WriterContext<'_, S>) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+
+        ensure!(!inner.is_closed(), error::ClosedRegionSnafu);
+
+        inner.manual_flush(writer_ctx).await
+    }
+
     /// Cancel flush task if any
     async fn cancel_flush(&self) -> Result<()> {
         let mut inner = self.inner.lock().await;
@@ -680,6 +689,13 @@ impl WriterInner {
         Some(schedule_compaction_cb)
     }
 
+    async fn manual_flush<S: LogStore>(
+        &mut self,
+        writer_ctx: WriterContext<'_, S>,
+    ) -> Result<()> {
+        self.trigger_flush(&writer_ctx).await?;
+        Ok(())
+    }
     #[inline]
     fn is_closed(&self) -> bool {
         self.closed

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -74,6 +74,8 @@ pub trait Region: Send + Sync + Clone + std::fmt::Debug + 'static {
     async fn alter(&self, request: AlterRequest) -> Result<(), Self::Error>;
 
     async fn close(&self) -> Result<(), Self::Error>;
+
+    async fn flush(&self) -> Result<(), Self::Error>;
 }
 
 /// Context for write operations.

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -93,6 +93,11 @@ pub trait Table: Send + Sync {
         }
         .fail()?
     }
+
+    /// Flush table.
+    async fn flush(&self) -> Result<()> {
+        UnsupportedSnafu { operation: "FLUSH" }.fail()?
+    }
 }
 
 pub type TableRef = Arc<dyn Table>;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Implement flush method for mito table

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#1087