### PR TITLE
docs: Document fields in the config examples

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -29,8 +29,8 @@ tcp_nodelay = true
 # WAL options, see `standalone.example.toml`.
 [wal]
 dir = "/tmp/greptimedb/wal"
-file_size = "1GiB"
-purge_threshold = "50GiB"
+file_size = "1GB"
+purge_threshold = "50GB"
 purge_interval = "10m"
 read_batch_size = 128
 sync_write = false

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -1,35 +1,52 @@
-node_id = 42
-mode = 'distributed'
-rpc_addr = '127.0.0.1:3001'
-rpc_hostname = '127.0.0.1'
-rpc_runtime_size = 8
-mysql_addr = '127.0.0.1:4406'
-mysql_runtime_size = 4
+# Node running mode, see `standalone.example.toml`.
+mode = "distributed"
+# Whether to use in-memory catalog, see `standalone.example.toml`.
 enable_memory_catalog = false
+# The datanode identifier, should be unique.
+node_id = 42
+# gRPC server address, "127.0.0.1:3001" by default.
+rpc_addr = "127.0.0.1:3001"
+# Hostname of this node.
+rpc_hostname = "127.0.0.1"
+# The number of gRPC server worker threads, 8 by default.
+rpc_runtime_size = 8
+# MySQL server address, "127.0.0.1:4406" by default.
+mysql_addr = "127.0.0.1:4406"
+# The number of MySQL server worker threads, 2 by default.
+mysql_runtime_size = 2
 
+# Metasrv client options.
+[meta_client_options]
+# Metasrv address list.
+metasrv_addrs = ["127.0.0.1:3002"]
+# Operation timeout in milliseconds, 3000 by default.
+timeout_millis = 3000
+# Connect server timeout in milliseconds, 5000 by default.
+connect_timeout_millis = 5000
+# `TCP_NODELAY` option for accepted connections, true by default.
+tcp_nodelay = true
+
+# WAL options, see `standalone.example.toml`.
 [wal]
 dir = "/tmp/greptimedb/wal"
-file_size = '1GB'
-purge_interval = '10m'
-purge_threshold = '50GB'
+file_size = "1GiB"
+purge_threshold = "50GiB"
+purge_interval = "10m"
 read_batch_size = 128
 sync_write = false
 
+# Storage options, see `standalone.example.toml`.
 [storage]
-type = 'File'
-data_dir = '/tmp/greptimedb/data/'
+type = "File"
+data_dir = "/tmp/greptimedb/data/"
 
-[meta_client_options]
-metasrv_addrs = ['127.0.0.1:3002']
-timeout_millis = 3000
-connect_timeout_millis = 5000
-tcp_nodelay = false
-
+# Compaction options, see `standalone.example.toml`.
 [compaction]
 max_inflight_tasks = 4
-max_files_in_level0 = 16
+max_files_in_level0 = 8
 max_purge_tasks = 32
 
-[procedure.store]
-type = 'File'
-data_dir = '/tmp/greptimedb/procedure/'
+# Procedure storage options, see `standalone.example.toml`.
+# [procedure.store]
+# type = 'File'
+# data_dir = '/tmp/greptimedb/procedure/'

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -1,12 +1,58 @@
-mode = 'distributed'
-datanode_rpc_addr = '127.0.0.1:3001'
+# Node running mode, see `standalone.example.toml`.
+mode = "distributed"
 
+# HTTP server options, see `standalone.example.toml`.
 [http_options]
-addr = '127.0.0.1:4000'
+addr = "127.0.0.1:4000"
 timeout = "30s"
 
+# gRPC server options, see `standalone.example.toml`.
+[grpc_options]
+addr = "127.0.0.1:4001"
+runtime_size = 8
+
+# MySQL server options, see `standalone.example.toml`.
+[mysql_options]
+addr = "127.0.0.1:4002"
+runtime_size = 2
+
+# MySQL server TLS options, see `standalone.example.toml`.
+[mysql_options.tls]
+mode = "disable"
+cert_path = ""
+key_path = ""
+
+# PostgresSQL server options, see `standalone.example.toml`.
+[postgres_options]
+addr = "127.0.0.1:4003"
+runtime_size = 2
+
+# PostgresSQL server TLS options, see `standalone.example.toml`.
+[postgres_options.tls]
+mode = "disable"
+cert_path = ""
+key_path = ""
+
+# OpenTSDB protocol options, see `standalone.example.toml`.
+[opentsdb_options]
+addr = "127.0.0.1:4242"
+runtime_size = 2
+
+# InfluxDB protocol options, see `standalone.example.toml`.
+[influxdb_options]
+enable = true
+
+# Prometheus protocol options, see `standalone.example.toml`.
+[prometheus_options]
+enable = true
+
+# PromQL protocol options, see `standalone.example.toml`.
+[promql_options]
+addr = "127.0.0.1:4004"
+
+# Metasrv client options, see `datanode.example.toml`.
 [meta_client_options]
-metasrv_addrs = ['127.0.0.1:3002']
+metasrv_addrs = ["127.0.0.1:3002"]
 timeout_millis = 3000
 connect_timeout_millis = 5000
-tcp_nodelay = false
+tcp_nodelay = true

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -9,6 +9,7 @@ datanode_lease_secs = 15
 # Datanode selector type.
 # - "LeaseBased" (default value).
 # - "LoadBased"
+# For details, please see "https://docs.greptime.com/developer-guide/meta/selector".
 selector = "LeaseBased"
 # Store data in memory, false by default.
 use_memory_store = false

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -1,6 +1,6 @@
 # The bind address of metasrv, "127.0.0.1:3002" by default.
 bind_addr = "127.0.0.1:3002"
-# The communication server address for frontend and datanode to connect metasrv,  "127.0.0.1:3002" by default for localhost.
+# The communication server address for frontend and datanode to connect to metasrv,  "127.0.0.1:3002" by default for localhost.
 server_addr = "127.0.0.1:3002"
 # Etcd server address, "127.0.0.1:2379" by default.
 store_addr = "127.0.0.1:2379"

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -1,6 +1,14 @@
-bind_addr = '127.0.0.1:3002'
-server_addr = '127.0.0.1:3002'
-store_addr = '127.0.0.1:2379'
+# The bind address of metasrv, "127.0.0.1:3002" by default.
+bind_addr = "127.0.0.1:3002"
+# The communication server address for frontend and datanode to connect metasrv,  "127.0.0.1:3002" by default for localhost.
+server_addr = "127.0.0.1:3002"
+# Etcd server address, "127.0.0.1:2379" by default.
+store_addr = "127.0.0.1:2379"
+# Datanode lease in seconds, 15 seconds by default.
 datanode_lease_secs = 15
-# selector: 'LeaseBased', 'LoadBased'
-selector = 'LeaseBased'
+# Datanode selector type.
+# - "LeaseBased" (default value).
+# - "LoadBased"
+selector = "LeaseBased"
+# Store data in memory, false by default.
+use_memory_store = false

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -1,47 +1,116 @@
-node_id = 0
-mode = 'standalone'
+# Node running mode, "standalone" or "distributed".
+mode = "standalone"
+# Whether to use in-memory catalog, `false` by default.
 enable_memory_catalog = false
 
+# HTTP server options.
 [http_options]
-addr = '127.0.0.1:4000'
+# Server address, "127.0.0.1:4000" by default.
+addr = "127.0.0.1:4000"
+# HTTP request timeout, 30s by default.
 timeout = "30s"
 
-[wal]
-dir = "/tmp/greptimedb/wal"
-file_size = '1GB'
-purge_interval = '10m'
-purge_threshold = '50GB'
-read_batch_size = 128
-sync_write = false
-
-[storage]
-type = 'File'
-data_dir = '/tmp/greptimedb/data/'
-
+# gRPC server options.
 [grpc_options]
-addr = '127.0.0.1:4001'
+# Server address, "127.0.0.1:4001" by default.
+addr = "127.0.0.1:4001"
+# The number of server worker threads, 8 by default.
 runtime_size = 8
 
+# MySQL server options.
 [mysql_options]
-addr = '127.0.0.1:4002'
+# Server address, "127.0.0.1:4002" by default.
+addr = "127.0.0.1:4002"
+# The number of server worker threads, 2 by default.
 runtime_size = 2
 
-[influxdb_options]
-enable = true
+# MySQL server TLS options.
+[mysql_options.tls]
+# TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html
+# - "disable" (default value)
+# - "prefer"
+# - "require"
+# - "verify-ca"
+# - "verify-full"
+mode = "disable"
+# Certificate file path.
+cert_path = ""
+# Private key file path.
+key_path = ""
 
-[opentsdb_options]
-addr = '127.0.0.1:4242'
-enable = true
-runtime_size = 2
-
-[prometheus_options]
-enable = true
-
+# PostgresSQL server options.
 [postgres_options]
-addr = '127.0.0.1:4003'
+# Server address, "127.0.0.1:4003" by default.
+addr = "127.0.0.1:4003"
+# The number of server worker threads, 2 by default.
 runtime_size = 2
-check_pwd = false
 
-[procedure.store]
-type = 'File'
-data_dir = '/tmp/greptimedb/procedure/'
+# PostgresSQL server options.
+[postgres_options.tls]
+# TLS mode.
+mode = "disable"
+# certificate file path.
+cert_path = ""
+# private key file path.
+key_path = ""
+
+# OpenTSDB protocol options.
+[opentsdb_options]
+# OpenTSDB telnet API server address, "127.0.0.1:4242" by default.
+addr = "127.0.0.1:4242"
+# The number of server worker threads, 2 by default.
+runtime_size = 2
+
+# InfluxDB protocol options.
+[influxdb_options]
+# Whether to enable InfluxDB protocol in HTTP API, true by default.
+enable = true
+
+# Prometheus protocol options.
+[prometheus_options]
+# Whether to enable Prometheus remote write and read in HTTP API, true by default.
+enable = true
+
+# PromQL protocol options.
+[promql_options]
+# PromQL server address, "127.0.0.1:4004" by default.
+addr = "127.0.0.1:4004"
+
+# WAL options.
+[wal]
+# WAL data directory.
+dir = "/tmp/greptimedb/wal"
+# WAL file size in bytes.
+file_size = "1GiB"
+# WAL purge threshold in bytes.
+purge_threshold = "50GiB"
+# WAL purge interval in seconds.
+purge_interval = "10m"
+# WAL read batch size.
+read_batch_size = 128
+# Whether to sync log file after every write.
+sync_write = false
+
+# Storage options.
+[storage]
+# Storage type.
+type = "File"
+# Data directory, "/tmp/greptimedb/data" by default.
+data_dir = "/tmp/greptimedb/data/"
+
+# Compaction options.
+[compaction]
+# Max task number that can concurrently run.
+max_inflight_tasks = 4
+# Max files in level 0 to trigger compaction.
+max_files_in_level0 = 8
+# Max task number for SST purge task after compaction.
+max_purge_tasks = 32
+
+# Procedure storage options.
+# Uncomment to enable.
+# [procedure.store]
+# # Storage type.
+# type = "File"
+# # Procedure data path.
+# data_dir = "/tmp/greptimedb/procedure/"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -45,7 +45,7 @@ addr = "127.0.0.1:4003"
 # The number of server worker threads, 2 by default.
 runtime_size = 2
 
-# PostgresSQL server options.
+# PostgresSQL server TLS options, see `[mysql_options.tls]` section.
 [postgres_options.tls]
 # TLS mode.
 mode = "disable"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -81,9 +81,9 @@ addr = "127.0.0.1:4004"
 # WAL data directory.
 dir = "/tmp/greptimedb/wal"
 # WAL file size in bytes.
-file_size = "1GiB"
+file_size = "1GB"
 # WAL purge threshold in bytes.
-purge_threshold = "50GiB"
+purge_threshold = "50GB"
 # WAL purge interval in seconds.
 purge_interval = "10m"
 # WAL read batch size.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds comments to the config examples to document each option.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
