### PR TITLE
fix: use catalog from connection

### DIFF
--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -49,7 +49,6 @@ pub async fn influxdb_write(
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
     let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
-
     let ctx = Arc::new(QueryContext::with(catalog, schema));
 
     let precision = params

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -18,12 +18,13 @@ use std::sync::Arc;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_grpc::writer::Precision;
 use session::context::QueryContext;
 
 use crate::error::{Result, TimePrecisionSnafu};
 use crate::influxdb::InfluxdbRequest;
+use crate::parse_catalog_and_schema_from_client_database_name;
 use crate::query_handler::InfluxdbLineProtocolHandlerRef;
 
 // https://docs.influxdata.com/influxdb/v1.8/tools/api/#ping-http-endpoint
@@ -47,7 +48,9 @@ pub async fn influxdb_write(
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
-    let ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, &db));
+    let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
+
+    let ctx = Arc::new(QueryContext::with(catalog, schema));
 
     let precision = params
         .get("precision")

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -19,7 +19,6 @@ use axum::extract::{Query, RawBody, State};
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
-use common_telemetry::error;
 use hyper::Body;
 use prost::Message;
 use schemars::JsonSchema;

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -60,14 +60,8 @@ pub async fn remote_write(
         QueryContext::arc()
     };
 
-    // TODO debug log
-    // handler.write(request, ctx).await?;
-    let re = handler.write(request, ctx).await;
-    if re.is_err() {
-        error!("prom write error: {:#?}", re.as_ref().err().unwrap());
-    }
-    re?;
-
+    // TODO(shuiyisong): add more error log
+    handler.write(request, ctx).await?;
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -99,13 +93,8 @@ pub async fn remote_read(
         QueryContext::arc()
     };
 
-    // TODO debug log
-    // handler.read(request, ctx).await
-    let re = handler.read(request, ctx).await;
-    if re.is_err() {
-        error!("prom read error: {:#?}", re.as_ref().err().unwrap());
-    }
-    re
+    // TODO(shuiyisong): add more error log
+    handler.read(request, ctx).await
 }
 
 async fn decode_remote_write_request(body: Body) -> Result<WriteRequest> {

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -19,6 +19,7 @@ use axum::extract::{Query, RawBody, State};
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use common_telemetry::error;
 use hyper::Body;
 use prost::Message;
 use schemars::JsonSchema;
@@ -59,7 +60,14 @@ pub async fn remote_write(
         QueryContext::arc()
     };
 
-    handler.write(request, ctx).await?;
+    // TODO debug log
+    // handler.write(request, ctx).await?;
+    let re = handler.write(request, ctx).await;
+    if re.is_err() {
+        error!("prom write error: {:#?}", re.as_ref().err().unwrap());
+    }
+    re?;
+
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -91,7 +99,13 @@ pub async fn remote_read(
         QueryContext::arc()
     };
 
-    handler.read(request, ctx).await
+    // TODO debug log
+    // handler.read(request, ctx).await
+    let re = handler.read(request, ctx).await;
+    if re.is_err() {
+        error!("prom read error: {:#?}", re.as_ref().err().unwrap());
+    }
+    re
 }
 
 async fn decode_remote_write_request(body: Body) -> Result<WriteRequest> {

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -18,7 +18,7 @@ use api::prometheus::remote::{ReadRequest, WriteRequest};
 use axum::extract::{Query, RawBody, State};
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use hyper::Body;
 use prost::Message;
 use schemars::JsonSchema;
@@ -85,7 +85,8 @@ pub async fn remote_read(
     let request = decode_remote_read_request(body).await?;
 
     let ctx = if let Some(db) = params.db {
-        Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, &db))
+        let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
+        Arc::new(QueryContext::with(catalog, schema))
     } else {
         QueryContext::arc()
     };

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -27,6 +27,7 @@ use session::context::QueryContext;
 use snafu::prelude::*;
 
 use crate::error::{self, Result};
+use crate::parse_catalog_and_schema_from_client_database_name;
 use crate::prometheus::snappy_decompress;
 use crate::query_handler::{PrometheusProtocolHandlerRef, PrometheusResponse};
 
@@ -52,7 +53,8 @@ pub async fn remote_write(
     let request = decode_remote_write_request(body).await?;
 
     let ctx = if let Some(db) = params.db {
-        Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, &db))
+        let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
+        Arc::new(QueryContext::with(catalog, schema))
     } else {
         QueryContext::arc()
     };

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -206,7 +206,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
 
         let context = self.session.context();
         context.set_current_catalog(catalog);
-        context.set_current_schema(database);
+        context.set_current_schema(schema);
 
         w.ok().await.map_err(|e| e.into())
     }

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -65,7 +65,7 @@ pub trait InfluxdbLineProtocolHandler {
 pub trait OpentsdbProtocolHandler {
     /// A successful request will not return a response.
     /// Only on error will the socket return a line of data.
-    async fn exec(&self, data_point: &DataPoint) -> Result<()>;
+    async fn exec(&self, data_point: &DataPoint, ctx: QueryContextRef) -> Result<()>;
 }
 
 pub struct PrometheusResponse {

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -34,7 +34,7 @@ struct DummyInstance {
 
 #[async_trait]
 impl OpentsdbProtocolHandler for DummyInstance {
-    async fn exec(&self, data_point: &DataPoint) -> Result<()> {
+    async fn exec(&self, data_point: &DataPoint, _ctx: QueryContextRef) -> Result<()> {
         if data_point.metric() == "should_failed" {
             return error::InternalSnafu {
                 err_msg: "expected",

--- a/src/servers/tests/opentsdb.rs
+++ b/src/servers/tests/opentsdb.rs
@@ -27,6 +27,7 @@ use servers::opentsdb::connection::Connection;
 use servers::opentsdb::OpentsdbServer;
 use servers::query_handler::OpentsdbProtocolHandler;
 use servers::server::Server;
+use session::context::QueryContextRef;
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, Notify};
 
@@ -36,7 +37,7 @@ struct DummyOpentsdbInstance {
 
 #[async_trait]
 impl OpentsdbProtocolHandler for DummyOpentsdbInstance {
-    async fn exec(&self, data_point: &DataPoint) -> Result<()> {
+    async fn exec(&self, data_point: &DataPoint, _ctx: QueryContextRef) -> Result<()> {
         let metric = data_point.metric();
         if metric == "should_failed" {
             return server_error::InternalSnafu {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly uses `catalog` from connection parameters instead of using the default `greptime` catalog
see #909 

Some client protocols have been tested with `show tables`, `select from` and `insert` sql queries
1. MySQL
2. PostgreSQL
3. GRPC
4. HTTP api
5. influxdb line protocol

Further works and todos
1. openTSDB should be working but has not been tested yet
2. Prometheus remote config is working, but more thorough tests should be conducted
3. `scripts` interface will be refactored to accept `QueryContext`. This would be done in a separate patch refactoring `scripts` as a whole
4. add more unit test and integration test for custom catalog situation

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#909 