### PR TITLE
chore(deps): bump sqlness to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7131,8 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "sqlness"
-version = "0.3.0"
-source = "git+https://github.com/CeresDB/sqlness.git?rev=e6d602ed7d894ffb806580f17f4a6f1283abbf1f#e6d602ed7d894ffb806580f17f4a6f1283abbf1f"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc90b1d2e46d618148d3118ec25c3cb4c18563fef8589095fc21389952c54864"
 dependencies = [
  "async-trait",
  "derive_builder 0.11.2",

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,20 +6,12 @@
 Sqlness has three types of file
 - `.sql`: test input, SQL only
 - `.result`: expected test output, SQL and its results
-- `.output`: different output, SQL and its results
 
-Both `.result` and `.output` are output (execution result) files. The difference is that `.result` is the
-the standard (expected) output, and `.output` is the error output. Therefore, if you see `.output` files generated,
+`.result` is the output (execution result) file. If you see `.result` files is changed,
 it means this test gets a different result and indicates it fails. You should
 check change logs to solve the problem.  
 
-You only need to write test SQL in `.sql` file, and run the test. On the first run it produces
-an `.output` file because there is no `.result` to compare with. If you can make sure the content in
-`.output` is correct, you can rename it to `.result`, which means it is the expected output.
-
-And at any time there should only be two file types, `.sql` and `.result` -- otherwise, an existing `.output`
-file means your test fails. That's why we should not ignore `.output` file type in `.gitignore`, instead, track
-it and make sure it doesn't exist.
+You only need to write test SQL in `.sql` file, and run the test.
 
 ### Case organization
 The root dir of input cases is `tests/cases`. It contains several sub-directories stand for different test
@@ -34,5 +26,5 @@ Unlike other tests, this harness is in a binary target form. You can run it with
 cargo sqlness
 ```
 It automatically finishes the following procedures: compile `GreptimeDB`, start it, grab tests and feed it to
-the server, then collect and compare the results. You only need to check whether there are new `.output` files.
+the server, then collect and compare the results. You only need to check if the `.result` files are changed.
 If not, congratulations, the test is passed 🥳!

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -13,6 +13,6 @@ common-grpc = { path = "../../src/common/grpc" }
 common-query = { path = "../../src/common/query" }
 common-time = { path = "../../src/common/time" }
 serde.workspace = true
-sqlness = { git = "https://github.com/CeresDB/sqlness.git", rev = "e6d602ed7d894ffb806580f17f4a6f1283abbf1f" }
+sqlness = "0.4"
 tinytemplate = "1.2"
 tokio.workspace = true

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -26,7 +26,7 @@ use common_error::ext::ErrorExt;
 use common_error::snafu::ErrorCompat;
 use common_query::Output;
 use serde::Serialize;
-use sqlness::{Database, EnvController};
+use sqlness::{Database, EnvController, QueryContext};
 use tinytemplate::TinyTemplate;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
@@ -269,7 +269,7 @@ pub struct GreptimeDB {
 
 #[async_trait]
 impl Database for GreptimeDB {
-    async fn query(&self, query: String) -> Box<dyn Display> {
+    async fn query(&self, _ctx: QueryContext, query: String) -> Box<dyn Display> {
         let mut client = self.client.lock().await;
         if query.trim().starts_with("USE ") {
             let database = query


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Upgrade `sqlness` to [0.4](https://github.com/CeresDB/sqlness/releases).

From this PR, sqlness runner won't generate `.output` file to indicate errors. It would overwrite the result file directly. So you should check the git status to make sure everything works fine.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
