### PR TITLE
test: fix datanode::test_read_from_config_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ dependencies = [
  "snafu",
  "substrait 0.1.0",
  "tempdir",
+ "tempfile",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.30"
+tempfile = "3"
 tokio = { version = "1.24.2", features = ["full"] }
 tokio-util = "0.7"
 tonic = { version = "0.8", features = ["tls"] }

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -43,6 +43,7 @@ toml = "0.5"
 rexpect = "0.5"
 serde.workspace = true
 tempdir = "0.3"
+tempfile.workspace = true
 
 [build-dependencies]
 build-data = "0.1.3"

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -150,27 +150,68 @@ impl TryFrom<StartCommand> for DatanodeOptions {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::io::Write;
     use std::time::Duration;
 
     use datanode::datanode::{CompactionConfig, ObjectStoreConfig};
     use servers::Mode;
+    use tempfile::NamedTempFile;
 
     use super::*;
 
     #[test]
     fn test_read_from_config_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        let toml_str = r#"
+            mode = "distributed"
+            enable_memory_catalog = false
+            node_id = 42
+            rpc_addr = "127.0.0.1:3001"
+            rpc_hostname = "127.0.0.1"
+            rpc_runtime_size = 8
+            mysql_addr = "127.0.0.1:4406"
+            mysql_runtime_size = 2
+
+            [meta_client_options]
+            metasrv_addrs = ["127.0.0.1:3002"]
+            timeout_millis = 3000
+            connect_timeout_millis = 5000
+            tcp_nodelay = true
+
+            [wal]
+            dir = "/tmp/greptimedb/wal"
+            file_size = "1GB"
+            purge_threshold = "50GB"
+            purge_interval = "10m"
+            read_batch_size = 128
+            sync_write = false
+
+            [storage]
+            type = "File"
+            data_dir = "/tmp/greptimedb/data/"
+
+            [compaction]
+            max_inflight_tasks = 4
+            max_files_in_level0 = 8
+            max_purge_tasks = 32
+        "#;
+        write!(file, "{}", toml_str).unwrap();
+
         let cmd = StartCommand {
-            config_file: Some(format!(
-                "{}/../../config/datanode.example.toml",
-                std::env::current_dir().unwrap().as_path().to_str().unwrap()
-            )),
+            config_file: Some(file.path().to_str().unwrap().to_string()),
             ..Default::default()
         };
         let options: DatanodeOptions = cmd.try_into().unwrap();
         assert_eq!("127.0.0.1:3001".to_string(), options.rpc_addr);
-        assert_eq!("/tmp/greptimedb/wal".to_string(), options.wal.dir);
         assert_eq!("127.0.0.1:4406".to_string(), options.mysql_addr);
-        assert_eq!(4, options.mysql_runtime_size);
+        assert_eq!(2, options.mysql_runtime_size);
+        assert_eq!(Some(42), options.node_id);
+
+        assert_eq!(Duration::from_secs(600), options.wal.purge_interval);
+        assert_eq!(1024 * 1024 * 1024, options.wal.file_size.0);
+        assert_eq!(1024 * 1024 * 1024 * 50, options.wal.purge_threshold.0);
+        assert!(!options.wal.sync_write);
+
         let MetaClientOptions {
             metasrv_addrs: metasrv_addr,
             timeout_millis,
@@ -181,7 +222,7 @@ mod tests {
         assert_eq!(vec!["127.0.0.1:3002".to_string()], metasrv_addr);
         assert_eq!(5000, connect_timeout_millis);
         assert_eq!(3000, timeout_millis);
-        assert!(!tcp_nodelay);
+        assert!(tcp_nodelay);
 
         match options.storage {
             ObjectStoreConfig::File(FileConfig { data_dir }) => {
@@ -194,7 +235,7 @@ mod tests {
         assert_eq!(
             CompactionConfig {
                 max_inflight_tasks: 4,
-                max_files_in_level0: 16,
+                max_files_in_level0: 8,
                 max_purge_tasks: 32,
             },
             options.compaction
@@ -231,33 +272,5 @@ mod tests {
             ..Default::default()
         })
         .unwrap();
-    }
-
-    #[test]
-    fn test_merge_config() {
-        let dn_opts = DatanodeOptions::try_from(StartCommand {
-            config_file: Some(format!(
-                "{}/../../config/datanode.example.toml",
-                std::env::current_dir().unwrap().as_path().to_str().unwrap()
-            )),
-            ..Default::default()
-        })
-        .unwrap();
-        assert_eq!("/tmp/greptimedb/wal", dn_opts.wal.dir);
-        assert_eq!(Duration::from_secs(600), dn_opts.wal.purge_interval);
-        assert_eq!(1024 * 1024 * 1024, dn_opts.wal.file_size.0);
-        assert_eq!(1024 * 1024 * 1024 * 50, dn_opts.wal.purge_threshold.0);
-        assert!(!dn_opts.wal.sync_write);
-        assert_eq!(Some(42), dn_opts.node_id);
-        let MetaClientOptions {
-            metasrv_addrs: metasrv_addr,
-            timeout_millis,
-            connect_timeout_millis,
-            tcp_nodelay,
-        } = dn_opts.meta_client_options.unwrap();
-        assert_eq!(vec!["127.0.0.1:3002".to_string()], metasrv_addr);
-        assert_eq!(3000, timeout_millis);
-        assert_eq!(5000, connect_timeout_millis);
-        assert!(!tcp_nodelay);
     }
 }

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -173,9 +173,11 @@ impl TryFrom<StartCommand> for FrontendOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::time::Duration;
 
     use servers::auth::{Identity, Password, UserProviderRef};
+    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -231,6 +233,16 @@ mod tests {
 
     #[test]
     fn test_read_from_config_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        let toml_str = r#"
+            mode = "distributed"
+
+            [http_options]
+            addr = "127.0.0.1:4000"
+            timeout = "30s"
+        "#;
+        write!(file, "{}", toml_str).unwrap();
+
         let command = StartCommand {
             http_addr: None,
             grpc_addr: None,
@@ -238,10 +250,7 @@ mod tests {
             postgres_addr: None,
             opentsdb_addr: None,
             influxdb_enable: None,
-            config_file: Some(format!(
-                "{}/../../config/frontend.example.toml",
-                std::env::current_dir().unwrap().as_path().to_str().unwrap()
-            )),
+            config_file: Some(file.path().to_str().unwrap().to_string()),
             metasrv_addr: None,
             tls_mode: None,
             tls_cert_path: None,

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -113,7 +113,10 @@ impl TryFrom<StartCommand> for MetaSrvOptions {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use meta_srv::selector::SelectorType;
+    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -136,15 +139,23 @@ mod tests {
 
     #[test]
     fn test_read_from_config_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        let toml_str = r#"
+            bind_addr = "127.0.0.1:3002"
+            server_addr = "127.0.0.1:3002"
+            store_addr = "127.0.0.1:2379"
+            datanode_lease_secs = 15
+            selector = "LeaseBased"
+            use_memory_store = false
+        "#;
+        write!(file, "{}", toml_str).unwrap();
+
         let cmd = StartCommand {
             bind_addr: None,
             server_addr: None,
             store_addr: None,
             selector: None,
-            config_file: Some(format!(
-                "{}/../../config/metasrv.example.toml",
-                std::env::current_dir().unwrap().as_path().to_str().unwrap()
-            )),
+            config_file: Some(file.path().to_str().unwrap().to_string()),
             use_memory_store: false,
         };
         let options: MetaSrvOptions = cmd.try_into().unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix test datanode::test_read_from_config_file, which depends on the example config file.

Also modify frontend and metasrv tests to construct toml file instead of read from example.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
