### PR TITLE
ci: update breaking-change labeler

### DIFF
--- a/.github/pr-title-breaking-change-label-config.json
+++ b/.github/pr-title-breaking-change-label-config.json
@@ -4,9 +4,10 @@
         "color": "D93F0B"
     },
     "CHECKS": {
-        "regexp": "^.*\\!:.*",
+        "regexp": "^(?:(?!!:).)*$",
         "ignoreLabels": [
             "ignore-title"
-        ]
+        ],
+        "alwaysPassCI": true
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- change the regex to match all strings that DO NOT match `!:`
<img width="497" alt="image" src="https://user-images.githubusercontent.com/15380403/222120166-f669c79e-0123-47f0-8bcf-9f41c19fedf6.png">

- never fails the CI for breaking-change label


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
