### PR TITLE
fix: remove incorrect continue

### DIFF
--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -115,7 +115,6 @@ impl RemoteCatalogManager {
                     yield Ok(key)
                 } else {
                     error!("Invalid catalog key: {:?}", catalog_key);
-                    continue;
                 }
             }
         }))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly removes incorrect `continue;` while datanode is initializing and pulling catalogs from remote meta srv.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
