### PR TITLE
fix: apply ttl and write_buffer_size options when a table is created via procedure

### DIFF
--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -151,15 +151,18 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             &self.data.request.schema_name,
             self.data.request.id,
         );
+        let table_options = &mut self.data.request.table_options;
+        let write_buffer_size = table_options.write_buffer_size.map(|size| size.0 as usize);
+        let ttl = table_options.ttl;
         let open_opts = OpenOptions {
             parent_dir: table_dir.clone(),
-            write_buffer_size: None,
-            ttl: None,
+            write_buffer_size,
+            ttl,
         };
         let create_opts = CreateOptions {
             parent_dir: table_dir,
-            write_buffer_size: None,
-            ttl: None,
+            write_buffer_size,
+            ttl,
         };
 
         let table_schema =

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -151,7 +151,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             &self.data.request.schema_name,
             self.data.request.id,
         );
-        let table_options = &mut self.data.request.table_options;
+        let table_options = self.data.request.table_options;
         let write_buffer_size = table_options.write_buffer_size.map(|size| size.0 as usize);
         let ttl = table_options.ttl;
         let open_opts = OpenOptions {

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -151,7 +151,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             &self.data.request.schema_name,
             self.data.request.id,
         );
-        let table_options = self.data.request.table_options;
+        let table_options = &self.data.request.table_options;
         let write_buffer_size = table_options.write_buffer_size.map(|size| size.0 as usize);
         let ttl = table_options.ttl;
         let open_opts = OpenOptions {


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
When creating a table using the Procedure framework, `ttl` and `write_buffer_size` options were not applied. The current PR improves that

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/1112