### PR TITLE
fix: can not find catalog when create table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "meta-client",
  "mito",
  "object-store",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-time",
+ "dashmap",
  "datafusion",
  "datatypes",
  "futures",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 futures-util.workspace = true
 lazy_static = "1.4"
 meta-client = { path = "../meta-client" }
+parking_lot = "0.12"
 regex = "1.6"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -18,6 +18,7 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+dashmap = "5.4"
 datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures = "0.3"

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -549,7 +549,7 @@ impl CatalogList for RemoteCatalogManager {
         let backend = self.backend.clone();
 
         let catalogs: Vec<String> = std::thread::spawn(|| {
-            common_runtime::block_on_write(async move {
+            common_runtime::block_on_read(async move {
                 let mut stream = backend.range(CATALOG_KEY_PREFIX.as_bytes());
                 let mut catalogs = Vec::new();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr simply fix:

### Issue Description:
In the GreptimeDB Cloud, when creating a table under a non-default catalog, an error is reported. As follows:
```
2023-03-02T09:16:22.951100Z ERROR servers::mysql::server: Internal error occurred during query exec, server actively close the channel to let client try next time. err.msg=Failed to collect recordbatch, source: Failed to poll stream, source: External error: Failed to init Recordbatch stream, source: External error: Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu err.code=Internal err.source=Failed to poll stream, source: External error: Failed to init Recordbatch stream, source: External error: Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu err.source.sources=[External error: Failed to init Recordbatch stream, source: External error: Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu, Failed to init Recordbatch stream, source: External error: Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu, External error: Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu, Failed to request Datanode, source: Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu, Failed to do Flight get, addr: greptimedb-datanode-0.greptimedb-datanode.greptimedb:4001, code: Internal error, source: Cannot find catalog by name: lyek6r2lmzmu, Cannot find catalog by name: lyek6r2lmzmu] err.backtrace=
```
### Reason

`RemoteCatalogmanager` for datanode only pulls metadata under the default catalog.

### Solution

When getting the catalog by name, if it is not found in the local cache, then the full amount of metadata will be re-pulled from the meta and cached.

Note: This is a temporary solution, which will be optimized later.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
