### PR TITLE
test: add Integrated Test for Coprocessor& fix minor bugs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -211,7 +211,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-          cache: 'pip' 
       - name: Install PyArrow Package
         run: pip install pyarrow
       - name: Install cargo-llvm-cov

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -207,6 +207,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip' 
+      - name: Install PyArrow Package
+        run: pip install pyarrow
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Collect coverage data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "comfy-table",
+ "pyo3",
 ]
 
 [[package]]
@@ -390,6 +391,7 @@ version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb327717d87eb94be5eff3b0cb8987f54059d343ee5235abf7f143c85f54cfc8"
 dependencies = [
+ "bitflags",
  "serde",
 ]
 
@@ -6655,6 +6657,7 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 name = "script"
 version = "0.1.0"
 dependencies = [
+ "arrow",
  "async-trait",
  "catalog",
  "common-catalog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-arrow = "33.0"
+arrow = { version = "33.0", features = ["pyarrow"] }
 arrow-array = "33.0"
 arrow-flight = "33.0"
 arrow-schema = { version = "33.0", features = ["serde"] }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     pkg-config \
-    python3-dev
+    python3 \
+    python3-dev \
+    && pip install pyarrow
 
 # Install Rust.
 SHELL ["/bin/bash", "-c"]

--- a/src/common/function/src/scalars/udf.rs
+++ b/src/common/function/src/scalars/udf.rs
@@ -54,15 +54,18 @@ pub fn create_udf(func: FunctionRef) -> ScalarUdf {
             .collect();
 
         let result = func_cloned.eval(func_ctx, &args.context(FromScalarValueSnafu)?);
+        // FIXME(discord9): just use `Vector` to convert to `ColumnarValue`
+        let udf = result.map(ColumnarValue::Vector)?;
+        /*
 
-        let udf = if len.is_some() {
-            result.map(ColumnarValue::Vector)?
-        } else {
-            ScalarValue::try_from_array(&result?.to_arrow_array(), 0)
-                .map(ColumnarValue::Scalar)
-                .context(ExecuteFunctionSnafu)?
-        };
-
+                let udf = if len.is_some() {
+                    result.map(ColumnarValue::Vector)?
+                } else {
+                    ScalarValue::try_from_array(&result?.to_arrow_array(), 0)
+                        .map(ColumnarValue::Scalar)
+                        .context(ExecuteFunctionSnafu)?
+                };
+        */
         Ok(udf)
     });
 

--- a/src/common/function/src/scalars/udf.rs
+++ b/src/common/function/src/scalars/udf.rs
@@ -14,9 +14,9 @@
 
 use std::sync::Arc;
 
-use common_query::error::{ExecuteFunctionSnafu, FromScalarValueSnafu};
+use common_query::error::FromScalarValueSnafu;
 use common_query::prelude::{
-    ColumnarValue, ReturnTypeFunction, ScalarFunctionImplementation, ScalarUdf, ScalarValue,
+    ColumnarValue, ReturnTypeFunction, ScalarFunctionImplementation, ScalarUdf,
 };
 use datatypes::error::Error as DataTypeError;
 use datatypes::prelude::*;

--- a/src/common/function/src/scalars/udf.rs
+++ b/src/common/function/src/scalars/udf.rs
@@ -54,9 +54,8 @@ pub fn create_udf(func: FunctionRef) -> ScalarUdf {
             .collect();
 
         let result = func_cloned.eval(func_ctx, &args.context(FromScalarValueSnafu)?);
-        // FIXME(discord9): just use `Vector` to convert to `ColumnarValue`
-        let udf = result.map(ColumnarValue::Vector)?;
-        Ok(udf)
+        let udf_result = result.map(ColumnarValue::Vector)?;
+        Ok(udf_result)
     });
 
     ScalarUdf::new(func.name(), &func.signature(), &return_type, &fun)

--- a/src/common/function/src/scalars/udf.rs
+++ b/src/common/function/src/scalars/udf.rs
@@ -56,16 +56,6 @@ pub fn create_udf(func: FunctionRef) -> ScalarUdf {
         let result = func_cloned.eval(func_ctx, &args.context(FromScalarValueSnafu)?);
         // FIXME(discord9): just use `Vector` to convert to `ColumnarValue`
         let udf = result.map(ColumnarValue::Vector)?;
-        /*
-
-                let udf = if len.is_some() {
-                    result.map(ColumnarValue::Vector)?
-                } else {
-                    ScalarValue::try_from_array(&result?.to_arrow_array(), 0)
-                        .map(ColumnarValue::Scalar)
-                        .context(ExecuteFunctionSnafu)?
-                };
-        */
         Ok(udf)
     });
 

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -24,6 +24,7 @@ python = [
 ]
 
 [dependencies]
+arrow.workspace = true
 async-trait.workspace = true
 catalog = { path = "../catalog" }
 common-catalog = { path = "../common/catalog" }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -85,8 +85,8 @@ impl PyUDF {
         // for Coprocessor
         let args = self.copr.deco_args.arg_names.clone();
         let try_get_name = |i: usize| {
-            if let Some(args) = args.as_ref() {
-                args[i].clone()
+            if let Some(arg_name) = args.as_ref().and_then(|args| args.get(i)) {
+                arg_name.clone()
             } else {
                 format!("name_{i}")
             }
@@ -149,7 +149,6 @@ impl Function for PyUDF {
         _func_ctx: common_function::scalars::function::FunctionContext,
         columns: &[datatypes::vectors::VectorRef],
     ) -> common_query::error::Result<datatypes::vectors::VectorRef> {
-        // FIXME(discord9): the returned vector will be truncated if no args is provided
         // FIXME(discord9): exec_parsed require a RecordBatch(basically a Vector+Schema), where schema can't pop out from nowhere, right?
         let schema = self.fake_schema(columns);
         let columns = columns.to_vec();
@@ -378,7 +377,7 @@ mod tests {
 import greptime as gt
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
-def test(number)->vector[u32]:
+def test(number)-> vector[u32]:
     return query.sql("select * from numbers")[0][0]
 "#;
         let script = script_engine
@@ -405,7 +404,7 @@ def test(number)->vector[u32]:
 
         let script = r#"
 @copr(returns = ["number"])
-def test(**params)->vector[i64]:
+def test(**params)-> vector[i64]:
     return int(params['a']) + int(params['b'])
 "#;
         let script = script_engine
@@ -438,7 +437,7 @@ import greptime as gt
 from data_frame import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
-def test(number)->vector[u32]:
+def test(number)-> vector[u32]:
     return dataframe.filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
@@ -470,7 +469,7 @@ def add(a, b):
     return a + b;
 
 @copr(args=["a", "b", "c"], returns = ["r"], sql="select number as a,number as b,number as c from numbers limit 100")
-def test(a, b, c)->vector[f64]:
+def test(a, b, c)-> vector[f64]:
     return add(a, b) / g.sqrt(c + 1)
 "#;
         let script = script_engine
@@ -508,7 +507,7 @@ def test(a, b, c)->vector[f64]:
 import greptime as gt
 
 @copr(args=["number"], returns = ["r"], sql="select number from numbers limit 100")
-def test(a)->vector[i64]:
+def test(a)-> vector[i64]:
     return gt.vector([x for x in a if x % 2 == 0])
 "#;
         let script = script_engine

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -377,7 +377,7 @@ mod tests {
 import greptime as gt
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
-def test(number)-> vector[u32]:
+def test(number) -> vector[u32]:
     return query.sql("select * from numbers")[0][0]
 "#;
         let script = script_engine
@@ -404,7 +404,7 @@ def test(number)-> vector[u32]:
 
         let script = r#"
 @copr(returns = ["number"])
-def test(**params)-> vector[i64]:
+def test(**params) -> vector[i64]:
     return int(params['a']) + int(params['b'])
 "#;
         let script = script_engine
@@ -436,7 +436,7 @@ def test(**params)-> vector[i64]:
 from greptime import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
-def test(number)-> vector[u32]:
+def test(number) -> vector[u32]:
     return dataframe.filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
@@ -468,7 +468,7 @@ def add(a, b):
     return a + b;
 
 @copr(args=["a", "b", "c"], returns = ["r"], sql="select number as a,number as b,number as c from numbers limit 100")
-def test(a, b, c)-> vector[f64]:
+def test(a, b, c) -> vector[f64]:
     return add(a, b) / g.sqrt(c + 1)
 "#;
         let script = script_engine
@@ -506,7 +506,7 @@ def test(a, b, c)-> vector[f64]:
 import greptime as gt
 
 @copr(args=["number"], returns = ["r"], sql="select number from numbers limit 100")
-def test(a)-> vector[i64]:
+def test(a) -> vector[i64]:
     return gt.vector([x for x in a if x % 2 == 0])
 "#;
         let script = script_engine

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -30,7 +30,7 @@ use common_recordbatch::{
     RecordBatch, RecordBatchStream, RecordBatches, SendableRecordBatchStream,
 };
 use datafusion_expr::Volatility;
-use datatypes::schema::{ColumnSchema, SchemaRef};
+use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::VectorRef;
 use futures::Stream;
 use query::parser::{QueryLanguageParser, QueryStatement};
@@ -40,9 +40,8 @@ use snafu::{ensure, ResultExt};
 use sql::statements::statement::Statement;
 
 use crate::engine::{CompileContext, EvalContext, Script, ScriptEngine};
-use crate::python::error::{self, Result};
+use crate::python::error::{self, PyRuntimeSnafu, Result};
 use crate::python::ffi_types::copr::{exec_parsed, parse, AnnotationInfo, CoprocessorRef};
-
 const PY_ENGINE: &str = "python";
 
 #[derive(Debug)]
@@ -81,10 +80,21 @@ impl PyUDF {
 
     /// Fake a schema, should only be used with dynamically eval a Python Udf
     fn fake_schema(&self, columns: &[VectorRef]) -> SchemaRef {
+        // try to give schema right names in args so script can run as UDF without modify
+        // because when running as PyUDF, the incoming columns should have matching names to make sense
+        // for Coprocessor
+        let args = self.copr.deco_args.arg_names.clone();
+        let try_get_name = |i: usize| {
+            if let Some(args) = args.as_ref() {
+                args[i].clone()
+            } else {
+                format!("name_{i}")
+            }
+        };
         let col_sch: Vec<_> = columns
             .iter()
             .enumerate()
-            .map(|(i, col)| ColumnSchema::new(format!("name_{i}"), col.data_type(), true))
+            .map(|(i, col)| ColumnSchema::new(try_get_name(i), col.data_type(), true))
             .collect();
         let schema = datatypes::schema::Schema::new(col_sch);
         Arc::new(schema)
@@ -139,6 +149,7 @@ impl Function for PyUDF {
         _func_ctx: common_function::scalars::function::FunctionContext,
         columns: &[datatypes::vectors::VectorRef],
     ) -> common_query::error::Result<datatypes::vectors::VectorRef> {
+        // FIXME(discord9): the returned vector will be truncated if no args is provided
         // FIXME(discord9): exec_parsed require a RecordBatch(basically a Vector+Schema), where schema can't pop out from nowhere, right?
         let schema = self.fake_schema(columns);
         let columns = columns.to_vec();
@@ -165,7 +176,7 @@ impl Function for PyUDF {
 
 pub struct PyScript {
     query_engine: QueryEngineRef,
-    copr: CoprocessorRef,
+    pub(crate) copr: CoprocessorRef,
 }
 
 impl PyScript {
@@ -181,12 +192,48 @@ impl PyScript {
 pub struct CoprStream {
     stream: SendableRecordBatchStream,
     copr: CoprocessorRef,
+    ret_schema: SchemaRef,
     params: HashMap<String, String>,
+}
+
+impl CoprStream {
+    fn try_new(
+        stream: SendableRecordBatchStream,
+        copr: CoprocessorRef,
+        params: HashMap<String, String>,
+    ) -> Result<Self> {
+        let mut schema = vec![];
+        for (ty, name) in copr.return_types.iter().zip(&copr.deco_args.ret_names) {
+            let ty = ty.clone().ok_or(
+                PyRuntimeSnafu {
+                    msg: "return type not annotated, can't generate schema",
+                }
+                .build(),
+            )?;
+            let is_nullable = ty.is_nullable;
+            let ty = ty.datatype.ok_or(
+                PyRuntimeSnafu {
+                    msg: "return type not annotated, can't generate schema",
+                }
+                .build(),
+            )?;
+            let col_schema = ColumnSchema::new(name, ty, is_nullable);
+            schema.push(col_schema);
+        }
+        let ret_schema = Arc::new(Schema::new(schema));
+        Ok(Self {
+            stream,
+            copr,
+            ret_schema,
+            params,
+        })
+    }
 }
 
 impl RecordBatchStream for CoprStream {
     fn schema(&self) -> SchemaRef {
-        self.stream.schema()
+        // FIXME(discord9): use copr returns for schema
+        self.ret_schema.clone()
     }
 }
 
@@ -200,7 +247,6 @@ impl Stream for CoprStream {
                 let batch = exec_parsed(&self.copr, &Some(recordbatch), &self.params)
                     .map_err(BoxedError::new)
                     .context(ExternalSnafu)?;
-
                 Poll::Ready(Some(Ok(batch)))
             }
             Poll::Ready(other) => Poll::Ready(other),
@@ -239,11 +285,9 @@ impl Script for PyScript {
             let res = self.query_engine.execute(&plan).await?;
             let copr = self.copr.clone();
             match res {
-                Output::Stream(stream) => Ok(Output::Stream(Box::pin(CoprStream {
-                    params,
-                    copr,
-                    stream,
-                }))),
+                Output::Stream(stream) => Ok(Output::Stream(Box::pin(CoprStream::try_new(
+                    stream, copr, params,
+                )?))),
                 _ => unreachable!(),
             }
         } else {
@@ -289,7 +333,8 @@ impl ScriptEngine for PyEngine {
         })
     }
 }
-
+#[cfg(test)]
+pub(crate) use tests::sample_script_engine;
 #[cfg(test)]
 mod tests {
     use catalog::local::{MemoryCatalogProvider, MemorySchemaProvider};
@@ -304,7 +349,7 @@ mod tests {
 
     use super::*;
 
-    fn sample_script_engine() -> PyEngine {
+    pub(crate) fn sample_script_engine() -> PyEngine {
         let catalog_list = catalog::local::new_memory_catalog_list().unwrap();
 
         let default_schema = Arc::new(MemorySchemaProvider::new());

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -433,8 +433,7 @@ def test(**params)-> vector[i64]:
         let script_engine = sample_script_engine();
 
         let script = r#"
-import greptime as gt
-from data_frame import col
+from greptime import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number)-> vector[u32]:

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -470,7 +470,7 @@ def add(a, b):
     return a + b;
 
 @copr(args=["a", "b", "c"], returns = ["r"], sql="select number as a,number as b,number as c from numbers limit 100")
-def test(a, b, c):
+def test(a, b, c)->vector[f64]:
     return add(a, b) / g.sqrt(c + 1)
 "#;
         let script = script_engine
@@ -508,7 +508,7 @@ def test(a, b, c):
 import greptime as gt
 
 @copr(args=["number"], returns = ["r"], sql="select number from numbers limit 100")
-def test(a):
+def test(a)->vector[i64]:
     return gt.vector([x for x in a if x % 2 == 0])
 "#;
         let script = script_engine

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -81,17 +81,10 @@ impl PyUDF {
 
     /// Fake a schema, should only be used with dynamically eval a Python Udf
     fn fake_schema(&self, columns: &[VectorRef]) -> SchemaRef {
-        let empty_args = vec![];
-        let arg_names = self
-            .copr
-            .deco_args
-            .arg_names
-            .as_ref()
-            .unwrap_or(&empty_args);
         let col_sch: Vec<_> = columns
             .iter()
             .enumerate()
-            .map(|(i, col)| ColumnSchema::new(arg_names[i].clone(), col.data_type(), true))
+            .map(|(i, col)| ColumnSchema::new(format!("name_{i}"), col.data_type(), true))
             .collect();
         let schema = datatypes::schema::Schema::new(col_sch);
         Arc::new(schema)

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -20,8 +20,6 @@ use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
 use common_recordbatch::{RecordBatch, RecordBatches};
-#[cfg(not(feature = "pyo3_backend"))]
-use common_telemetry::warn;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -20,7 +20,6 @@ use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
 use common_recordbatch::{RecordBatch, RecordBatches};
-use common_telemetry::tracing::warn;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -20,7 +20,7 @@ use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
 use common_recordbatch::{RecordBatch, RecordBatches};
-use common_telemetry::tracing::error;
+use common_telemetry::tracing::warn;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};
@@ -438,7 +438,7 @@ pub fn exec_parsed(
             {
                 pyo3_exec_parsed(copr, rb, params)
             }
-            // FIXME(discord9): rethink if this is ok to
+            // FIXME(discord9): rethink if this is ok to fall back
             #[cfg(not(feature = "pyo3_backend"))]
             {
                 warn!("pyo3_backend` feature is disabled, therefore can't run scripts in cpython, fall back to rustpython backend");

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -20,6 +20,7 @@ use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
 use common_recordbatch::{RecordBatch, RecordBatches};
+use common_telemetry::tracing::error;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};
@@ -437,12 +438,12 @@ pub fn exec_parsed(
             {
                 pyo3_exec_parsed(copr, rb, params)
             }
+            // FIXME(discord9): rethink if this is ok to
             #[cfg(not(feature = "pyo3_backend"))]
-            OtherSnafu {
-                reason: "`pyo3` feature is disabled, therefore can't run scripts in cpython"
-                    .to_string(),
+            {
+                warn!("pyo3_backend` feature is disabled, therefore can't run scripts in cpython, fall back to rustpython backend");
+                rspy_exec_parsed(copr, rb, params)
             }
-            .fail()
         }
     }
 }

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -439,11 +439,13 @@ pub fn exec_parsed(
             {
                 pyo3_exec_parsed(copr, rb, params)
             }
-            // FIXME(discord9): rethink if this is ok to fall back
             #[cfg(not(feature = "pyo3_backend"))]
             {
-                warn!("pyo3_backend` feature is disabled, therefore can't run scripts in cpython, fall back to rustpython backend");
-                rspy_exec_parsed(copr, rb, params)
+                OtherSnafu {
+                    reason: "`pyo3` feature is disabled, therefore can't run scripts in cpython"
+                        .to_string(),
+                }
+                .fail()
             }
         }
     }

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -20,6 +20,8 @@ use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
 use common_recordbatch::{RecordBatch, RecordBatches};
+#[cfg(not(feature = "pyo3_backend"))]
+use common_telemetry::warn;
 use datatypes::arrow::array::Array;
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use common_query::Output;
 use common_recordbatch::RecordBatch;
-use common_telemetry::info;
 use datafusion::arrow::array::Float64Array;
 use datafusion::arrow::compute;
 use datatypes::arrow::datatypes::DataType as ArrowDataType;
@@ -76,6 +75,7 @@ async fn integrated_py_copr_test() {
     let testcases = generate_copr_intgrate_tests();
     let script_engine = sample_script_engine();
     for (idx, case) in testcases.into_iter().enumerate() {
+        dbg!(idx);
         let script = case.script;
         let script = script_engine
             .compile(&script, CompileContext::default())
@@ -104,7 +104,6 @@ async fn integrated_py_copr_test() {
                 }
             }
         }
-        info!("Testcase {idx} .. Ok");
         dbg!(rb);
     }
 }

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -55,7 +55,7 @@ struct CodeBlockTestCase {
 struct CoprTestCase {
     // will be build to a RecordBatch and feed to coprocessor
     script: String,
-    expect: Option<HashMap<String, VectorRef>>
+    expect: Option<HashMap<String, VectorRef>>,
 }
 
 #[allow(unused)]

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -39,7 +39,7 @@ use crate::python::ffi_types::PyVector;
 use crate::python::pyo3::{init_cpython_interpreter, vector_impl::into_pyo3_cell};
 use crate::python::rspython::init_interpreter;
 
-//TODO(discord9): paired test for slicing Vector
+// TODO(discord9): paired test for slicing Vector
 // & slice tests & lit() function for dataframe & test with full coprocessor&query engine ability
 /// generate testcases that should be tested in paired both in RustPython and CPython
 #[derive(Debug, Clone)]

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use common_query::Output;
 use common_recordbatch::RecordBatch;
+use common_telemetry::info;
 use datafusion::arrow::array::Float64Array;
 use datafusion::arrow::compute;
 use datatypes::arrow::datatypes::DataType as ArrowDataType;
@@ -30,7 +31,6 @@ use rustpython_compiler::Mode;
 
 use crate::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use crate::python::engine::sample_script_engine;
-use crate::python::ffi_types::copr::BackendType;
 use crate::python::ffi_types::pair_tests::sample_testcases::{
     generate_copr_intgrate_tests, sample_test_case,
 };
@@ -72,7 +72,7 @@ fn into_recordbatch(input: HashMap<String, VectorRef>) -> RecordBatch {
 }
 
 #[tokio::test]
-async fn integrated_copr_test() {
+async fn integrated_py_copr_test() {
     let testcases = generate_copr_intgrate_tests();
     let script_engine = sample_script_engine();
     for (idx, case) in testcases.into_iter().enumerate() {
@@ -104,7 +104,7 @@ async fn integrated_copr_test() {
                 }
             }
         }
-        println!("Testcase {idx} .. Ok");
+        info!("Testcase {idx} .. Ok");
         dbg!(rb);
     }
 }

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -30,6 +30,8 @@ use crate::python::ffi_types::PyVector;
 use crate::python::pyo3::{init_cpython_interpreter, vector_impl::into_pyo3_cell};
 use crate::python::rspython::init_interpreter;
 
+//TODO(discord9): paired test for slicing Vector 
+// & slice tests & lit() function for dataframe
 /// generate testcases that should be tested in paired both in RustPython and CPython
 #[derive(Debug, Clone)]
 struct TestCase {

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -71,11 +71,12 @@ fn into_recordbatch(input: HashMap<String, VectorRef>) -> RecordBatch {
 }
 
 #[tokio::test]
+#[allow(clippy::print_stdout)]
 async fn integrated_py_copr_test() {
     let testcases = generate_copr_intgrate_tests();
     let script_engine = sample_script_engine();
     for (idx, case) in testcases.into_iter().enumerate() {
-        dbg!(idx);
+        println!("Testcase {idx}:\n script: {}", case.script);
         let script = case.script;
         let script = script_engine
             .compile(&script, CompileContext::default())
@@ -104,7 +105,7 @@ async fn integrated_py_copr_test() {
                 }
             }
         }
-        dbg!(rb);
+        println!(".. Ok");
     }
 }
 

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -19,27 +19,27 @@ use std::sync::Arc;
 use datatypes::prelude::ScalarVector;
 use datatypes::vectors::{BooleanVector, Float64Vector, Int64Vector, VectorRef};
 
-use crate::python::ffi_types::pair_tests::TestCase;
+use crate::python::ffi_types::pair_tests::CodeBlockTestCase;
 
-macro_rules! vector {
-    ($ty: ident, $slice: expr) => {
-        Arc::new($ty::from_slice($slice)) as VectorRef
-    };
-}
-
-macro_rules! ronish {
-    ($($key: literal : $expr: expr),*$(,)?) => {
-        HashMap::from([
-            $(($key.to_string(), $expr)),*
-        ])
-    };
-}
-
+/// Generate tests for basic vector operations and basic builtin functions
 /// Using a function to generate testcase instead of `.ron` configure file because it's more flexible and we are in #[cfg(test)] so no binary bloat worrying
 #[allow(clippy::approx_constant)]
-pub(super) fn sample_test_case() -> Vec<TestCase> {
+pub(super) fn sample_test_case() -> Vec<CodeBlockTestCase> {
+    macro_rules! vector {
+        ($ty: ident, $slice: expr) => {
+            Arc::new($ty::from_slice($slice)) as VectorRef
+        };
+    }
+
+    macro_rules! ronish {
+        ($($key: literal : $expr: expr),*$(,)?) => {
+            HashMap::from([
+                $(($key.to_string(), $expr)),*
+            ])
+        };
+    }
     vec![
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0f64, 2.0, 3.0])
             },
@@ -53,7 +53,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1.0f64, 2.0, 3.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0f64, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [3.0f64, 2.0, 1.0])
@@ -65,7 +65,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [4.0f64, 4.0, 4.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0f64, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [3.0f64, 2.0, 1.0])
@@ -77,7 +77,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [-2.0f64, 0.0, 2.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0f64, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [3.0f64, 2.0, 1.0])
@@ -89,7 +89,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [3.0f64, 4.0, 3.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0f64, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [3.0f64, 2.0, 1.0])
@@ -101,7 +101,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1. / 3., 1.0, 3.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0f64, 2.0, 3.0])
             },
@@ -115,7 +115,7 @@ ret"#
                 [1.0f64, std::f64::consts::SQRT_2, 1.7320508075688772,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -129,7 +129,7 @@ ret"#
                 [0.8414709848078965, 0.9092974268256817, 0.1411200080598672,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -143,7 +143,7 @@ ret"#
                 [0.5403023058681398, -0.4161468365471424, -0.9899924966004454,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -157,7 +157,7 @@ ret"#
                 [1.5574077246549023, -2.185039863261519, -0.1425465430742778,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.0])
             },
@@ -171,7 +171,7 @@ ret"#
                 [0.3046926540153975, 0.5235987755982989, 1.5707963267948966,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.0])
             },
@@ -185,7 +185,7 @@ ret"#
                 [1.2661036727794992, 1.0471975511965979, 0.0,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.1])
             },
@@ -199,7 +199,7 @@ ret"#
                 [0.2914567944778671, 0.4636476090008061, 0.8329812666744317,]
             ),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.1])
             },
@@ -210,7 +210,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, 0.0, 1.0,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.1])
             },
@@ -221,7 +221,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1.0, 1.0, 2.0,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.1])
             },
@@ -232,7 +232,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, 1.0, 1.0,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0.3, 0.5, 1.1])
             },
@@ -243,7 +243,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, 0.0, 1.0,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [-0.3, 0.5, -1.1])
             },
@@ -254,7 +254,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.3, 0.5, 1.1,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [-0.3, 0.5, -1.1])
             },
@@ -265,7 +265,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [-1.0, 1.0, -1.0,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [0., 1.0, 2.0])
             },
@@ -276,7 +276,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1.0, consts::E, 7.38905609893065,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -287,7 +287,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, consts::LN_2, 1.0986122886681098,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -298,7 +298,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, 1.0, 1.584962500721156,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -309,7 +309,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [0.0, consts::LOG10_2, 0.47712125471966244,]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {},
             script: r#"
 from greptime import *
@@ -318,7 +318,7 @@ ret"#
                 .to_string(),
             expect: vector!(BooleanVector, &[true, true, true]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Int64Vector, [1, 2, 2, 3])
             },
@@ -329,7 +329,7 @@ ret"#
                 .to_string(),
             expect: vector!(Int64Vector, [3]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Int64Vector, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
             },
@@ -340,7 +340,7 @@ ret"#
                 .to_string(),
             expect: vector!(Int64Vector, [6]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -351,7 +351,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1.0, 2.0, 3.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1.0, 2.0, 3.0])
             },
@@ -362,7 +362,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [2.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [1.0, 0.0, -1.0])
@@ -374,7 +374,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [-1.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Int64Vector, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
             },
@@ -385,7 +385,7 @@ ret"#
                 .to_string(),
             expect: vector!(Int64Vector, [10]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [1.0, 0.0, -1.0])
@@ -397,7 +397,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [-1.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0, 2.0, 3.0]),
                 "b": vector!(Float64Vector, [1.0, 0.0, -1.0])
@@ -409,7 +409,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [-0.6666666666666666]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0, 2.0, 3.0]),
             },
@@ -420,7 +420,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [3.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "a": vector!(Float64Vector, [1.0, 2.0, 3.0]),
             },
@@ -431,7 +431,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [1.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]),
             },
@@ -442,7 +442,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [3.0276503540974917]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]),
             },
@@ -453,7 +453,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [2.8722813232690143]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]),
             },
@@ -464,7 +464,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [55.0]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]),
             },
@@ -475,7 +475,7 @@ ret"#
                 .to_string(),
             expect: vector!(Float64Vector, [9.166666666666666]),
         },
-        TestCase {
+        CodeBlockTestCase {
             input: ronish! {
                 "values": vector!(Float64Vector, [1., 2., 3., 4., 5., 6., 7., 8., 9., 10.]),
             },

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -28,8 +28,8 @@ pub(super) fn generate_copr_intgrate_tests() -> Vec<CoprTestCase> {
             script: r#"
 @copr(args=["number", "number"],
     returns=["value"],
-    sql = "select number from numbers limit 5", backend = "rspy")
-def add_vecs(n1, n2)->vector[i32]:
+    sql="select number from numbers limit 5", backend="rspy")
+def add_vecs(n1, n2) -> vector[i32]:
     return n1 + n2
 "#
             .to_string(),
@@ -40,8 +40,8 @@ def add_vecs(n1, n2)->vector[i32]:
             script: r#"
 @copr(args=["number", "number"],
     returns=["value"],
-    sql = "select number from numbers limit 5", backend = "pyo3")
-def add_vecs(n1, n2)->vector[i32]:
+    sql="select number from numbers limit 5", backend="pyo3")
+def add_vecs(n1, n2) -> vector[i32]:
     return n1 + n2
 "#
             .to_string(),
@@ -60,10 +60,21 @@ def answer() -> vector[i64]:
         #[cfg(feature = "pyo3_backend")]
         CoprTestCase {
             script: r#"
-@copr(returns=["value"], backend = "pyo3")
+@copr(returns=["value"], backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
     return vector([42, 43, 44])
+"#
+            .to_string(),
+            ..Default::default()
+        },
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def answer() -> vector[i64]:
+    from greptime import vector, col, lit
+    ret = dataframe.select([col("number")]).filter(col("number")<lit(3)).collect()[0][0]
+    return ret
 "#
             .to_string(),
             ..Default::default()

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -80,6 +80,29 @@ def answer() -> vector[i64]:
             .to_string(),
             expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44]))),
         },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def answer() -> vector[i64]:
+    from greptime import vector
+    return vector.from_py(vector([42, 43, 44]).to_py())
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44])))
+        },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def answer() -> vector[i64]:
+    from greptime import vector
+    import pyarrow as pa
+    return vector.from_py(pa.array([42, 43, 44]))
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44]))),
+        },
         CoprTestCase {
             script: r#"
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="rspy")

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -19,7 +19,46 @@ use std::sync::Arc;
 use datatypes::prelude::ScalarVector;
 use datatypes::vectors::{BooleanVector, Float64Vector, Int64Vector, VectorRef};
 
+use super::CoprTestCase;
+use crate::python::ffi_types::copr::BackendType;
 use crate::python::ffi_types::pair_tests::CodeBlockTestCase;
+
+pub(super) fn generate_copr_intgrate_tests() -> Vec<CoprTestCase> {
+    vec![
+        CoprTestCase {
+            script: r#"
+@copr(args=["number", "number"],
+    returns=["value"],
+    sql = "select number from numbers limit 5", backend = "rspy")
+def add_vecs(n1, n2)->vector[i32]:
+    return n1 + n2
+"#
+            .to_string(),
+            ..Default::default()
+        },
+        CoprTestCase {
+            script: r#"
+@copr(args=["number", "number"],
+    returns=["value"],
+    sql = "select number from numbers limit 5", backend = "pyo3")
+def add_vecs(n1, n2)->vector[i32]:
+    return n1 + n2
+"#
+            .to_string(),
+            ..Default::default()
+        },
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"])
+def answer() -> vector[i64]:
+    from greptime import vector
+    return vector([42, 43, 44])
+"#
+            .to_string(),
+            ..Default::default()
+        },
+    ]
+}
 
 /// Generate tests for basic vector operations and basic builtin functions
 /// Using a function to generate testcase instead of `.ron` configure file because it's more flexible and we are in #[cfg(test)] so no binary bloat worrying

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -123,7 +123,6 @@ def answer() -> vector[i64]:
     from greptime import vector, col, lit
     # Bitwise Operator  pred comparison operator
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
-    print(expr_0)
     ret = dataframe.select([col("number")]).filter(expr_0).collect()[0][0]
     return ret
 "#

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -98,7 +98,7 @@ def answer() -> vector[i64]:
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector, col, lit
-    # Bitwise Operator  pred comparsion operator
+    # Bitwise Operator  pred comparison operator
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
     print(expr_0)
     ret = dataframe.select([col("number")]).filter(expr_0).collect()[0][0]

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -20,7 +20,6 @@ use datatypes::prelude::ScalarVector;
 use datatypes::vectors::{BooleanVector, Float64Vector, Int64Vector, VectorRef};
 
 use super::CoprTestCase;
-use crate::python::ffi_types::copr::BackendType;
 use crate::python::ffi_types::pair_tests::CodeBlockTestCase;
 
 pub(super) fn generate_copr_intgrate_tests() -> Vec<CoprTestCase> {
@@ -36,6 +35,7 @@ def add_vecs(n1, n2)->vector[i32]:
             .to_string(),
             ..Default::default()
         },
+        #[cfg(feature = "pyo3_backend")]
         CoprTestCase {
             script: r#"
 @copr(args=["number", "number"],
@@ -50,6 +50,17 @@ def add_vecs(n1, n2)->vector[i32]:
         CoprTestCase {
             script: r#"
 @copr(returns=["value"])
+def answer() -> vector[i64]:
+    from greptime import vector
+    return vector([42, 43, 44])
+"#
+            .to_string(),
+            ..Default::default()
+        },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend = "pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
     return vector([42, 43, 44])

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -89,7 +89,7 @@ def answer() -> vector[i64]:
     return vector.from_py(vector([42, 43, 44]).to_py())
 "#
             .to_string(),
-            expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44])))
+            expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44]))),
         },
         #[cfg(feature = "pyo3_backend")]
         CoprTestCase {

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -86,7 +86,7 @@ def answer() -> vector[i64]:
 @copr(returns=["value"], backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
-    return vector.from_py(vector([42, 43, 44]).to_py())
+    return vector.from_pyarrow(vector([42, 43, 44]).to_pyarrow())
 "#
             .to_string(),
             expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44]))),
@@ -98,7 +98,7 @@ def answer() -> vector[i64]:
 def answer() -> vector[i64]:
     from greptime import vector
     import pyarrow as pa
-    return vector.from_py(pa.array([42, 43, 44]))
+    return vector.from_pyarrow(pa.array([42, 43, 44]))
 "#
             .to_string(),
             expect: Some(ronish!("value": vector!(Int64Vector, [42, 43, 44]))),

--- a/src/script/src/python/ffi_types/vector/tests.rs
+++ b/src/script/src/python/ffi_types/vector/tests.rs
@@ -57,9 +57,9 @@ fn test_eval_py_vector_in_pairs() {
 fn sample_py_vector() -> HashMap<String, VectorRef> {
     let b1 = Arc::new(BooleanVector::from_slice(&[false, false, true, true])) as VectorRef;
     let b2 = Arc::new(BooleanVector::from_slice(&[false, true, false, true])) as VectorRef;
-    let f1 = Arc::new(Float64Vector::from_slice(&[0.0f64, 2.0, 10.0, 42.0])) as VectorRef;
-    let f2 = Arc::new(Float64Vector::from_slice(&[-0.1f64, -42.0, 2., 7.0])) as VectorRef;
-    let f3 = Arc::new(Float64Vector::from_slice(&[1.0f64, -42.0, 2., 7.0])) as VectorRef;
+    let f1 = Arc::new(Float64Vector::from_slice([0.0f64, 2.0, 10.0, 42.0])) as VectorRef;
+    let f2 = Arc::new(Float64Vector::from_slice([-0.1f64, -42.0, 2., 7.0])) as VectorRef;
+    let f3 = Arc::new(Float64Vector::from_slice([1.0f64, -42.0, 2., 7.0])) as VectorRef;
     HashMap::from([
         ("b1".to_owned(), b1),
         ("b2".to_owned(), b2),
@@ -109,7 +109,7 @@ fn get_test_cases() -> Vec<TestCase> {
         },
         TestCase {
             eval: "f2.__rtruediv__(f1)".to_string(),
-            result: Arc::new(Float64Vector::from_slice(&[
+            result: Arc::new(Float64Vector::from_slice([
                 0.0 / -0.1f64,
                 2. / -42.,
                 10. / 2.,
@@ -118,15 +118,15 @@ fn get_test_cases() -> Vec<TestCase> {
         },
         TestCase {
             eval: "f2.__floordiv__(f3)".to_string(),
-            result: Arc::new(Int64Vector::from_slice(&[0, 1, 1, 1])) as VectorRef,
+            result: Arc::new(Int64Vector::from_slice([0, 1, 1, 1])) as VectorRef,
         },
         TestCase {
             eval: "f3.__rfloordiv__(f2)".to_string(),
-            result: Arc::new(Int64Vector::from_slice(&[0, 1, 1, 1])) as VectorRef,
+            result: Arc::new(Int64Vector::from_slice([0, 1, 1, 1])) as VectorRef,
         },
         TestCase {
             eval: "f3.filter(b1)".to_string(),
-            result: Arc::new(Float64Vector::from_slice(&[2.0, 7.0])) as VectorRef,
+            result: Arc::new(Float64Vector::from_slice([2.0, 7.0])) as VectorRef,
         },
     ];
     Vec::from(testcases)

--- a/src/script/src/python/ffi_types/vector/tests.rs
+++ b/src/script/src/python/ffi_types/vector/tests.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use datatypes::scalars::ScalarVector;
-use datatypes::vectors::{BooleanVector, Float64Vector, VectorRef};
+use datatypes::vectors::{BooleanVector, Float64Vector, Int64Vector, VectorRef};
 #[cfg(feature = "pyo3_backend")]
 use pyo3::{types::PyDict, Python};
 use rustpython_compiler::Mode;
@@ -57,13 +57,15 @@ fn test_eval_py_vector_in_pairs() {
 fn sample_py_vector() -> HashMap<String, VectorRef> {
     let b1 = Arc::new(BooleanVector::from_slice(&[false, false, true, true])) as VectorRef;
     let b2 = Arc::new(BooleanVector::from_slice(&[false, true, false, true])) as VectorRef;
-    let f1 = Arc::new(Float64Vector::from_slice([0.0f64, 2.0, 10.0, 42.0])) as VectorRef;
-    let f2 = Arc::new(Float64Vector::from_slice([-0.1f64, -42.0, 2., 7.0])) as VectorRef;
+    let f1 = Arc::new(Float64Vector::from_slice(&[0.0f64, 2.0, 10.0, 42.0])) as VectorRef;
+    let f2 = Arc::new(Float64Vector::from_slice(&[-0.1f64, -42.0, 2., 7.0])) as VectorRef;
+    let f3 = Arc::new(Float64Vector::from_slice(&[1.0f64, -42.0, 2., 7.0])) as VectorRef;
     HashMap::from([
         ("b1".to_owned(), b1),
         ("b2".to_owned(), b2),
         ("f1".to_owned(), f1),
         ("f2".to_owned(), f2),
+        ("f3".to_owned(), f3),
     ])
 }
 
@@ -104,6 +106,27 @@ fn get_test_cases() -> Vec<TestCase> {
                 10. / 2.,
                 42. / 7.,
             ])) as VectorRef,
+        },
+        TestCase {
+            eval: "f2.__rtruediv__(f1)".to_string(),
+            result: Arc::new(Float64Vector::from_slice(&[
+                0.0 / -0.1f64,
+                2. / -42.,
+                10. / 2.,
+                42. / 7.,
+            ])) as VectorRef,
+        },
+        TestCase {
+            eval: "f2.__floordiv__(f3)".to_string(),
+            result: Arc::new(Int64Vector::from_slice(&[0, 1, 1, 1])) as VectorRef,
+        },
+        TestCase {
+            eval: "f3.__rfloordiv__(f2)".to_string(),
+            result: Arc::new(Int64Vector::from_slice(&[0, 1, 1, 1])) as VectorRef,
+        },
+        TestCase {
+            eval: "f3.filter(b1)".to_string(),
+            result: Arc::new(Float64Vector::from_slice(&[2.0, 7.0])) as VectorRef,
         },
     ];
     Vec::from(testcases)

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -22,7 +22,6 @@ use datafusion_physical_expr::{math_expressions, AggregateExpr};
 use datatypes::vectors::VectorRef;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::PyList;
 
 use super::utils::scalar_value_to_py_any;
 use crate::python::ffi_types::utils::all_to_f64;
@@ -202,11 +201,6 @@ macro_rules! simple_vector_fn {
             eval_aggr_func(py, $name_str, &[$($arg),*])
         }
     };
-}
-
-#[pyfunction]
-fn vector(iterable: &PyList) -> PyResult<PyVector> {
-    PyVector::py_new(iterable)
 }
 
 // TODO(discord9): More Aggr functions& allow threads

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -27,7 +27,7 @@ use pyo3::types::PyList;
 use super::utils::scalar_value_to_py_any;
 use crate::python::ffi_types::utils::all_to_f64;
 use crate::python::ffi_types::PyVector;
-use crate::python::pyo3::dataframe_impl::col;
+use crate::python::pyo3::dataframe_impl::{col, lit};
 use crate::python::pyo3::utils::{
     columnar_value_to_py_any, try_into_columnar_value, val_to_py_any,
 };
@@ -44,6 +44,7 @@ pub(crate) fn greptime_builtins(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     batch_import!(
         m,
         [
+            lit,
             col,
             vector,
             pow,

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::sync::Arc;
+
 use common_function::scalars::{FunctionRef, FUNCTION_REGISTRY};
 use datafusion::arrow::array::{ArrayRef, NullArray};
 use datafusion::physical_plan::expressions;

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -32,13 +32,16 @@ use crate::python::pyo3::utils::{
 };
 
 /// Try to extract a `PyVector` or convert from a `pyarrow.array` object
+#[inline]
 fn try_into_py_vector(py: Python, obj: PyObject) -> PyResult<PyVector> {
     if let Ok(v) = obj.extract::<PyVector>(py) {
         Ok(v)
     } else {
-        PyVector::from_py(obj.as_ref(py).get_type(), py, obj.clone())
+        PyVector::from_pyarrow(obj.as_ref(py).get_type(), py, obj.clone())
     }
 }
+
+#[inline]
 fn to_array_of_py_vec(py: Python, obj: &[&PyObject]) -> PyResult<Vec<PyVector>> {
     obj.iter()
         .map(|v| try_into_py_vector(py, v.to_object(py)))

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -41,12 +41,12 @@ macro_rules! batch_import {
 #[pymodule]
 #[pyo3(name = "greptime")]
 pub(crate) fn greptime_builtins(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyVector>()?;
     batch_import!(
         m,
         [
             lit,
             col,
-            vector,
             pow,
             clip,
             diff,

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -73,7 +73,7 @@ pub(crate) fn pyo3_exec_parsed(
     };
     let args: Vec<PyVector> = if let Some(rb) = rb {
         let args = select_from_rb(rb, arg_names)?;
-        check_args_anno_real_type(&args, copr, rb)?;
+        check_args_anno_real_type(arg_names, &args, copr, rb)?;
         args
     } else {
         Vec::new()
@@ -221,10 +221,10 @@ mod copr_test {
 @copr(args=["cpu", "mem"], returns=["ref"], backend="pyo3")
 def a(cpu, mem, **kwargs):
     import greptime as gt
-    from greptime import vector, log2, sum, pow, col
+    from greptime import vector, log2, sum, pow, col, lit
     for k, v in kwargs.items():
         print("%s == %s" % (k, v))
-    print(dataframe.select([col("cpu")]).collect())
+    print(dataframe.select([col("cpu")<lit(0.3)]).collect())
     return (0.5 < cpu) & ~( cpu >= 0.75)
     "#;
         let cpu_array = Float32Vector::from_slice([0.9f32, 0.8, 0.7, 0.3]);

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -83,12 +83,16 @@ pub(crate) fn pyo3_exec_parsed(
     Python::with_gil(|py| -> Result<_> {
         let mut cols = (|| -> PyResult<_> {
             let dummy_decorator = "
+# Postponed evaluation of annotations(PEP 563) so annotation can be set freely
+# This is needed for Python < 3.9
+from __future__ import annotations
 # A dummy decorator, actual implementation is in Rust code
 def copr(*dummy, **kwdummy):
     def inner(func):
         return func
     return inner
 coprocessor = copr
+from greptime import vector
 ";
             let gen_call = format!("\n_return_from_coprocessor = {}(*_args_for_coprocessor, **_kwargs_for_coprocessor)", copr.name);
             let script = format!("{}{}{}", dummy_decorator, copr.script, gen_call);

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -63,14 +63,8 @@ pub(crate) fn pyo3_exec_parsed(
     rb: &Option<RecordBatch>,
     params: &HashMap<String, String>,
 ) -> Result<RecordBatch> {
-    let arg_names = if let Some(names) = &copr.deco_args.arg_names {
-        names
-    } else {
-        return OtherSnafu {
-            reason: "PyO3 Backend doesn't support params yet".to_string(),
-        }
-        .fail();
-    };
+    // i.e params or use `vector(..)` to construct a PyVector
+    let arg_names = &copr.deco_args.arg_names.clone().unwrap_or(vec![]);
     let args: Vec<PyVector> = if let Some(rb) = rb {
         let args = select_from_rb(rb, arg_names)?;
         check_args_anno_real_type(arg_names, &args, copr, rb)?;

--- a/src/script/src/python/pyo3/dataframe_impl.rs
+++ b/src/script/src/python/pyo3/dataframe_impl.rs
@@ -232,6 +232,7 @@ pub(crate) fn lit(py: Python<'_>, value: PyObject) -> PyResult<PyExpr> {
     Ok(expr)
 }
 
+#[derive(Clone)]
 #[pyclass]
 pub(crate) struct PyExpr {
     inner: DfExpr,
@@ -251,7 +252,8 @@ pub(crate) fn col(name: String) -> PyExpr {
 
 #[pymethods]
 impl PyExpr {
-    fn __richcmp__(&self, py: Python<'_>, other: &Self, op: CompareOp) -> PyResult<Self> {
+    fn __richcmp__(&self, py: Python<'_>, other: PyObject, op: CompareOp) -> PyResult<Self> {
+        let other = other.extract::<Self>(py).or_else(|_| lit(py, other))?;
         let op = match op {
             CompareOp::Lt => DfExpr::lt,
             CompareOp::Le => DfExpr::lt_eq,
@@ -278,5 +280,8 @@ impl PyExpr {
     }
     fn sort(&self, asc: bool, nulls_first: bool) -> PyExpr {
         self.inner.clone().sort(asc, nulls_first).into()
+    }
+    fn __repr__(&self) -> String {
+        format!("{:#?}", &self.inner)
     }
 }

--- a/src/script/src/python/pyo3/dataframe_impl.rs
+++ b/src/script/src/python/pyo3/dataframe_impl.rs
@@ -23,6 +23,7 @@ use snafu::ResultExt;
 
 use crate::python::error::DataFusionSnafu;
 use crate::python::ffi_types::PyVector;
+use crate::python::pyo3::utils::pyo3_obj_try_to_typed_scalar_value;
 use crate::python::utils::block_on_async;
 type PyExprRef = Py<PyExpr>;
 #[pyclass]
@@ -223,6 +224,13 @@ impl PyDataFrame {
     }
 }
 
+#[pyfunction]
+pub(crate) fn lit(py: Python<'_>, value: PyObject) -> PyResult<PyExpr> {
+    let value = pyo3_obj_try_to_typed_scalar_value(value.as_ref(py), None)?;
+    let expr: PyExpr = DfExpr::Literal(value).into();
+    Ok(expr)
+}
+
 #[pyclass]
 pub(crate) struct PyExpr {
     inner: DfExpr,
@@ -242,7 +250,7 @@ pub(crate) fn col(name: String) -> PyExpr {
 
 #[pymethods]
 impl PyExpr {
-    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<Self> {
+    fn __richcmp__(&self, py: Python<'_>, other: &Self, op: CompareOp) -> PyResult<Self> {
         let op = match op {
             CompareOp::Lt => DfExpr::lt,
             CompareOp::Le => DfExpr::lt_eq,
@@ -251,20 +259,18 @@ impl PyExpr {
             CompareOp::Gt => DfExpr::gt,
             CompareOp::Ge => DfExpr::gt_eq,
         };
-        Ok(op(self.inner.clone(), other.inner.clone()).into())
+        py.allow_threads(|| Ok(op(self.inner.clone(), other.inner.clone()).into()))
     }
     fn alias(&self, name: String) -> PyResult<PyExpr> {
         Ok(self.inner.clone().alias(name).into())
     }
     fn __and__(&self, py: Python<'_>, other: PyExprRef) -> PyResult<PyExpr> {
-        Ok(self
-            .inner
-            .clone()
-            .and(other.borrow(py).inner.clone())
-            .into())
+        let other = other.borrow(py).inner.clone();
+        py.allow_threads(|| Ok(self.inner.clone().and(other).into()))
     }
     fn __or__(&self, py: Python<'_>, other: PyExprRef) -> PyResult<PyExpr> {
-        Ok(self.inner.clone().or(other.borrow(py).inner.clone()).into())
+        let other = other.borrow(py).inner.clone();
+        py.allow_threads(|| Ok(self.inner.clone().or(other).into()))
     }
     fn __invert__(&self) -> PyResult<PyExpr> {
         Ok(self.inner.clone().not().into())

--- a/src/script/src/python/pyo3/dataframe_impl.rs
+++ b/src/script/src/python/pyo3/dataframe_impl.rs
@@ -224,6 +224,7 @@ impl PyDataFrame {
     }
 }
 
+/// Convert a Python Object into a `Expr` for use in constructing literal i.e. `col("number") < lit(42)`
 #[pyfunction]
 pub(crate) fn lit(py: Python<'_>, value: PyObject) -> PyResult<PyExpr> {
     let value = pyo3_obj_try_to_typed_scalar_value(value.as_ref(py), None)?;

--- a/src/script/src/python/pyo3/utils.rs
+++ b/src/script/src/python/pyo3/utils.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Mutex;
 
+use arrow::pyarrow::PyArrowException;
 use common_telemetry::info;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
@@ -32,7 +33,9 @@ use crate::python::pyo3::builtins::greptime_builtins;
 
 /// prevent race condition of init cpython
 static START_PYO3: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
-
+pub(crate) fn to_py_err(err: impl ToString)->PyErr{
+    PyArrowException::new_err(err.to_string())
+}
 pub(crate) fn init_cpython_interpreter() {
     let mut start = START_PYO3.lock().unwrap();
     if !*start {

--- a/src/script/src/python/pyo3/utils.rs
+++ b/src/script/src/python/pyo3/utils.rs
@@ -33,7 +33,7 @@ use crate::python::pyo3::builtins::greptime_builtins;
 
 /// prevent race condition of init cpython
 static START_PYO3: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
-pub(crate) fn to_py_err(err: impl ToString)->PyErr{
+pub(crate) fn to_py_err(err: impl ToString) -> PyErr {
     PyArrowException::new_err(err.to_string())
 }
 pub(crate) fn init_cpython_interpreter() {

--- a/src/script/src/python/pyo3/utils.rs
+++ b/src/script/src/python/pyo3/utils.rs
@@ -100,6 +100,15 @@ macro_rules! to_con_type {
     };
 }
 
+/// Convert PyAny to [`ScalarValue`]
+pub(crate) fn pyo3_obj_try_to_typed_scalar_value(
+    obj: &PyAny,
+    dtype: Option<ConcreteDataType>,
+) -> PyResult<ScalarValue> {
+    let val = pyo3_obj_try_to_typed_val(obj, dtype)?;
+    val.try_to_scalar_value(&val.data_type())
+        .map_err(|e| PyValueError::new_err(e.to_string()))
+}
 /// to int/float/boolean, if dtype is None, then convert to highest prec type
 pub(crate) fn pyo3_obj_try_to_typed_val(
     obj: &PyAny,

--- a/src/script/src/python/pyo3/vector_impl.rs
+++ b/src/script/src/python/pyo3/vector_impl.rs
@@ -268,12 +268,12 @@ impl PyVector {
         Ok(format!("{self:#?}"))
     }
     /// Convert to `pyarrow` 's array
-    pub(crate) fn to_py(&self, py: Python) -> PyResult<PyObject> {
+    pub(crate) fn to_pyarrow(&self, py: Python) -> PyResult<PyObject> {
         self.to_arrow_array().data().to_pyarrow(py)
     }
     /// Convert from `pyarrow`'s array
     #[classmethod]
-    pub(crate) fn from_py(_cls: &PyType, py: Python, obj: PyObject) -> PyResult<PyVector> {
+    pub(crate) fn from_pyarrow(_cls: &PyType, py: Python, obj: PyObject) -> PyResult<PyVector> {
         let array = make_array(ArrayData::from_pyarrow(obj.as_ref(py))?);
         let v = Helper::try_into_vector(array).map_err(to_py_err)?;
         Ok(v.into())

--- a/src/script/src/python/pyo3/vector_impl.rs
+++ b/src/script/src/python/pyo3/vector_impl.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow::array::{ArrayData, make_array};
+use arrow::array::{make_array, ArrayData};
 use arrow::pyarrow::PyArrowConvert;
 use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::compute;

--- a/src/script/src/python/pyo3/vector_impl.rs
+++ b/src/script/src/python/pyo3/vector_impl.rs
@@ -12,16 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use datafusion::arrow::array::BooleanArray;
+use datafusion::arrow::compute;
 use datafusion::arrow::compute::kernels::{arithmetic, comparison};
 use datatypes::arrow::array::{Array, ArrayRef};
 use datatypes::arrow::datatypes::DataType as ArrowDataType;
 use datatypes::prelude::{ConcreteDataType, DataType};
-use pyo3::exceptions::{PyNotImplementedError, PyValueError};
+use datatypes::vectors::Helper;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::pyclass::CompareOp;
 use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyString};
 
-use crate::python::ffi_types::vector::{wrap_bool_result, wrap_result, PyVector};
+use crate::python::ffi_types::vector::{arrow_rtruediv, wrap_bool_result, wrap_result, PyVector};
 use crate::python::pyo3::utils::pyo3_obj_try_to_typed_val;
 
 macro_rules! get_con_type {
@@ -179,15 +182,47 @@ impl PyVector {
     }
     #[allow(unused)]
     fn __rtruediv__(&self, py: Python<'_>, other: PyObject) -> PyResult<Self> {
-        Err(PyNotImplementedError::new_err(()))
+        if pyo3_is_obj_scalar(other.as_ref(py)) {
+            self.pyo3_scalar_arith_op(py, other, Some(ArrowDataType::Float64), arrow_rtruediv)
+        } else {
+            self.pyo3_vector_arith_op(
+                py,
+                other,
+                Some(ArrowDataType::Float64),
+                wrap_result(|a, b| arithmetic::divide_dyn(b, a)),
+            )
+        }
     }
     #[allow(unused)]
     fn __floordiv__(&self, py: Python<'_>, other: PyObject) -> PyResult<Self> {
-        Err(PyNotImplementedError::new_err(()))
+        if pyo3_is_obj_scalar(other.as_ref(py)) {
+            self.pyo3_scalar_arith_op(
+                py,
+                other,
+                Some(ArrowDataType::Int64),
+                wrap_result(arithmetic::divide_dyn),
+            )
+        } else {
+            self.pyo3_vector_arith_op(
+                py,
+                other,
+                Some(ArrowDataType::Int64),
+                wrap_result(arithmetic::divide_dyn),
+            )
+        }
     }
     #[allow(unused)]
     fn __rfloordiv__(&self, py: Python<'_>, other: PyObject) -> PyResult<Self> {
-        Err(PyNotImplementedError::new_err(()))
+        if pyo3_is_obj_scalar(other.as_ref(py)) {
+            self.pyo3_scalar_arith_op(py, other, Some(ArrowDataType::Int64), arrow_rtruediv)
+        } else {
+            self.pyo3_vector_arith_op(
+                py,
+                other,
+                Some(ArrowDataType::Int64),
+                wrap_result(|a, b| arithmetic::divide_dyn(b, a)),
+            )
+        }
     }
     fn __and__(&self, other: &Self) -> PyResult<Self> {
         Self::vector_and(self, other).map_err(PyValueError::new_err)
@@ -197,6 +232,29 @@ impl PyVector {
     }
     fn __invert__(&self) -> PyResult<Self> {
         Self::vector_invert(self).map_err(PyValueError::new_err)
+    }
+    /// take a boolean array and filters the Array, returning elements matching the filter (i.e. where the values are true).
+    #[pyo3(name = "filter")]
+    fn pyo3_filter(&self, py: Python<'_>, other: &Self) -> PyResult<Self> {
+        py.allow_threads(|| {
+            let left = self.to_arrow_array();
+            let right = other.to_arrow_array();
+            if let Some(filter) = right.as_any().downcast_ref::<BooleanArray>() {
+                let res = compute::filter(left.as_ref(), filter);
+                let res =
+                    res.map_err(|err| PyValueError::new_err(format!("Arrow Error: {err:#?}")))?;
+                let ret = Helper::try_into_vector(res.clone()).map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "Can't cast result into vector, result: {res:?}, err: {e:?}",
+                    ))
+                })?;
+                Ok(ret.into())
+            } else {
+                Err(PyValueError::new_err(format!(
+                    "Can't cast operand into a Boolean Array, which is {right:#?}"
+                )))
+            }
+        })
     }
     fn __len__(&self) -> usize {
         self.len()

--- a/src/script/src/python/pyo3/vector_impl.rs
+++ b/src/script/src/python/pyo3/vector_impl.rs
@@ -294,10 +294,10 @@ mod test {
         let b: PyVector = (Arc::new(b) as VectorRef).into();
         locals.insert("bv2".to_string(), b);
 
-        let f = Float64Vector::from_slice(&[0.0f64, 1.0, 42.0, 3.0]);
+        let f = Float64Vector::from_slice([0.0f64, 1.0, 42.0, 3.0]);
         let f: PyVector = (Arc::new(f) as VectorRef).into();
         locals.insert("fv1".to_string(), f);
-        let f = Float64Vector::from_slice(&[1919.810f64, 0.114, 51.4, 3.0]);
+        let f = Float64Vector::from_slice([1919.810f64, 0.114, 51.4, 3.0]);
         let f: PyVector = (Arc::new(f) as VectorRef).into();
         locals.insert("fv2".to_string(), f);
         locals

--- a/src/script/src/python/rspython/builtins.rs
+++ b/src/script/src/python/rspython/builtins.rs
@@ -308,7 +308,7 @@ pub(crate) mod greptime_builtin {
     };
     use crate::python::ffi_types::vector::val_to_pyobj;
     use crate::python::ffi_types::PyVector;
-    use crate::python::rspython::utils::{is_instance, py_vec_obj_to_array, PyVectorRef};
+    use crate::python::rspython::utils::{is_instance, py_obj_to_vec, PyVectorRef};
 
     #[pyfunction]
     fn vector(args: OptionalArg<PyObjectRef>, vm: &VirtualMachine) -> PyResult<PyVector> {
@@ -966,7 +966,7 @@ pub(crate) mod greptime_builtin {
                 let args = FuncArgs::new(vec![v.into_pyobject(vm)], KwArgs::default());
                 let ret = func.invoke(args, vm);
                 match ret{
-                        Ok(obj) => match py_vec_obj_to_array(&obj, vm, 1){
+                        Ok(obj) => match py_obj_to_vec(&obj, vm, 1){
                             Ok(v) => if v.len()==1{
                                 Ok(v)
                             }else{

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -251,7 +251,7 @@ pub(crate) mod data_frame {
         }
     }
 
-    #[rspyclass(module = "data_frame", name = "Expr")]
+    #[rspyclass(module = "data_frame", name = "PyExpr")]
     #[derive(PyPayload, Debug, Clone)]
     pub struct PyExpr {
         pub inner: DfExpr,

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -35,7 +35,7 @@ pub(crate) mod data_frame {
 
     use crate::python::error::DataFusionSnafu;
     use crate::python::ffi_types::PyVector;
-    use crate::python::rspython::utils::py_obj_to_value;
+    use crate::python::rspython::builtins::greptime_builtin::lit;
     use crate::python::utils::block_on_async;
     #[rspyclass(module = "data_frame", name = "DataFrame")]
     #[derive(PyPayload, Debug)]
@@ -258,25 +258,9 @@ pub(crate) mod data_frame {
         pub inner: DfExpr,
     }
 
-    #[pyfunction]
-    fn col(name: String, vm: &VirtualMachine) -> PyExprRef {
-        let expr: PyExpr = DfExpr::Column(datafusion_common::Column::from_name(name)).into();
-        expr.into_ref(vm)
-    }
-
-    #[pyfunction]
-    fn lit(obj: PyObjectRef, vm: &VirtualMachine) -> PyResult<PyExprRef> {
-        let val = py_obj_to_value(&obj, vm)?;
-        let scalar_val = val
-            .try_to_scalar_value(&val.data_type())
-            .map_err(|e| vm.new_runtime_error(format!("{e}")))?;
-        let expr: PyExpr = DfExpr::Literal(scalar_val).into();
-        Ok(expr.into_ref(vm))
-    }
-
     // TODO(discord9): lit function that take PyObject and turn it into ScalarValue
 
-    type PyExprRef = PyRef<PyExpr>;
+    pub(crate) type PyExprRef = PyRef<PyExpr>;
 
     impl From<datafusion_expr::Expr> for PyExpr {
         fn from(value: DfExpr) -> Self {
@@ -291,10 +275,8 @@ pub(crate) mod data_frame {
             op: PyComparisonOp,
             vm: &VirtualMachine,
         ) -> PyResult<rustpython_vm::function::Either<PyObjectRef, PyComparisonValue>> {
-            if let (Some(zelf), Some(other)) =
-                (zelf.downcast_ref::<Self>(), other.downcast_ref::<Self>())
-            {
-                let ret = zelf.richcompare((**other).clone(), op, vm)?;
+            if let Some(zelf) = zelf.downcast_ref::<Self>() {
+                let ret = zelf.richcompare(other.to_owned(), op, vm)?;
                 let ret = ret.into_pyobject(vm);
                 Ok(rustpython_vm::function::Either::A(ret))
             } else {
@@ -318,10 +300,15 @@ pub(crate) mod data_frame {
     impl PyExpr {
         fn richcompare(
             &self,
-            other: Self,
+            other: PyObjectRef,
             op: PyComparisonOp,
-            _vm: &VirtualMachine,
+            vm: &VirtualMachine,
         ) -> PyResult<Self> {
+            let other = if let Some(other) = other.downcast_ref::<Self>() {
+                other.to_owned()
+            } else {
+                lit(other, vm)?
+            };
             let f = match op {
                 PyComparisonOp::Eq => DfExpr::eq,
                 PyComparisonOp::Ne => DfExpr::not_eq,
@@ -330,7 +317,7 @@ pub(crate) mod data_frame {
                 PyComparisonOp::Ge => DfExpr::gt_eq,
                 PyComparisonOp::Le => DfExpr::lt_eq,
             };
-            Ok(f(self.inner.clone(), other.inner).into())
+            Ok(f(self.inner.clone(), other.inner.clone()).into())
         }
         #[pymethod]
         fn alias(&self, name: String) -> PyResult<PyExpr> {

--- a/src/script/src/python/rspython/testcases.ron
+++ b/src/script/src/python/rspython/testcases.ron
@@ -559,7 +559,7 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         // constant column(int)
         name: "test_data_frame",
         code: r#"
-from data_frame import col
+from greptime import col
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
@@ -593,7 +593,7 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         // constant column(int)
         name: "test_data_frame",
         code: r#"
-from data_frame import col
+from greptime import col
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):

--- a/src/script/src/python/rspython/utils.rs
+++ b/src/script/src/python/rspython/utils.rs
@@ -115,17 +115,3 @@ pub fn py_vec_obj_to_array(
         ret_other_error_with(format!("Expect a vector or a constant, found {obj:?}")).fail()
     }
 }
-
-/// a terrible hack to call async from sync by:
-/// TODO(discord9): find a better way
-/// 1. spawn a new thread
-/// 2. create a new runtime in new thread and call `block_on` on it
-#[allow(unused)]
-pub fn block_on_async<T, F>(f: F) -> std::thread::Result<T>
-where
-    F: Future<Output = T> + Send + 'static,
-    T: Send + 'static,
-{
-    let rt = tokio::runtime::Runtime::new().map_err(|e| Box::new(e) as _)?;
-    std::thread::spawn(move || rt.block_on(f)).join()
-}

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -30,7 +30,7 @@ async fn test_insert_py_udf_and_query() -> Result<()> {
     let instance = create_testing_instance(table);
     let src = r#"
 @coprocessor(args=["uint32s"], returns = ["ret"])
-def double_that(col)->vector[u32]:
+def double_that(col) -> vector[u32]:
     return col*2
     "#;
     instance

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -341,7 +341,7 @@ pub async fn test_scripts_api(store_type: StorageType) {
         .body(
             r#"
 @copr(sql='select number from numbers limit 10', args=['number'], returns=['n'])
-def test(n):
+def test(n)->vector[f64]:
     return n + 1;
 "#,
         )

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -341,7 +341,7 @@ pub async fn test_scripts_api(store_type: StorageType) {
         .body(
             r#"
 @copr(sql='select number from numbers limit 10', args=['number'], returns=['n'])
-def test(n)->vector[f64]:
+def test(n) -> vector[f64]:
     return n + 1;
 "#,
         )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Added Integrated Test for Coprocessor, fix some minor bugs.

- Integrated tests for both RsPy and CPython backend
- fix `CoprStream` 's schema not set to it's output types' problem
- fix UDF have useless truncate of it's output's bug
- cache `Runtime` used in `block_on_async`
- added `lit` function for DataFrame API for both backend
- impl `rfloordiv`&`floordiv`&`filter` for pyo3 backend&tested
- added `to_pyarrow` and `from_to_pyarrow` for vector to convert to `pyarrow.array`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
