### PR TITLE
feat: memory profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,8 @@ dependencies = [
  "substrait 0.1.0",
  "tempdir",
  "tempfile",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "toml",
 ]
@@ -1564,6 +1566,15 @@ dependencies = [
  "datatypes",
  "snafu",
  "table",
+]
+
+[[package]]
+name = "common-mem-prof"
+version = "0.1.0"
+dependencies = [
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -6901,6 +6912,7 @@ dependencies = [
  "common-error",
  "common-grpc",
  "common-grpc-expr",
+ "common-mem-prof",
  "common-query",
  "common-recordbatch",
  "common-runtime",
@@ -7829,6 +7841,37 @@ dependencies = [
  "byteorder",
  "integer-encoding",
  "ordered-float 2.10.0",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.3+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a678df20055b43e57ef8cddde41cdfda9a3c1a060b67f4c5836dfb1d78543ba8"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20612db8a13a6c06d57ec83953694185a367e16945f66565e8028d2c0bd76979"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,9 +1572,13 @@ dependencies = [
 name = "common-mem-prof"
 version = "0.1.0"
 dependencies = [
+ "common-error",
+ "snafu",
+ "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemalloc-sys",
  "tikv-jemallocator",
+ "tokio",
 ]
 
 [[package]]
@@ -7673,16 +7677,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "src/common/function-macro",
     "src/common/grpc",
     "src/common/grpc-expr",
+    "src/common/mem-prof",
     "src/common/procedure",
     "src/common/query",
     "src/common/recordbatch",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -9,6 +9,12 @@ default-run = "greptime"
 name = "greptime"
 path = "src/bin/greptime.rs"
 
+[features]
+mem-prof = [
+    "tikv-jemallocator",
+    "tikv-jemalloc-ctl",
+]
+
 [dependencies]
 anymap = "1.0.0-beta.2"
 catalog = { path = "../catalog" }
@@ -18,10 +24,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-substrait = { path = "../common/substrait" }
-common-telemetry = { path = "../common/telemetry", features = [
-    "deadlock_detection",
-] }
+common-telemetry = { path = "../common/telemetry", features = ["deadlock_detection", ] }
 datanode = { path = "../datanode" }
 either = "1.8"
 frontend = { path = "../frontend" }
@@ -36,11 +39,11 @@ serde.workspace = true
 servers = { path = "../servers" }
 session = { path = "../session" }
 snafu.workspace = true
+substrait = { path = "../common/substrait" }
+tikv-jemalloc-ctl = { version = "0.5", optional = true }
+tikv-jemallocator = { version = "0.5", optional = true }
 tokio.workspace = true
 toml = "0.5"
-
-tikv-jemallocator = "0.5"
-tikv-jemalloc-ctl = "0.5"
 
 
 [dev-dependencies]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -39,6 +39,10 @@ snafu.workspace = true
 tokio.workspace = true
 toml = "0.5"
 
+tikv-jemallocator = "0.5"
+tikv-jemalloc-ctl = "0.5"
+
+
 [dev-dependencies]
 rexpect = "0.5"
 serde.workspace = true

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -10,10 +10,7 @@ name = "greptime"
 path = "src/bin/greptime.rs"
 
 [features]
-mem-prof = [
-    "tikv-jemallocator",
-    "tikv-jemalloc-ctl",
-]
+mem-prof = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 
 [dependencies]
 anymap = "1.0.0-beta.2"
@@ -24,7 +21,9 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry", features = ["deadlock_detection", ] }
+common-telemetry = { path = "../common/telemetry", features = [
+    "deadlock_detection",
+] }
 datanode = { path = "../datanode" }
 either = "1.8"
 frontend = { path = "../frontend" }

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -87,8 +87,7 @@ fn print_version() -> &'static str {
     )
 }
 
-use tikv_jemallocator;
-
+#[cfg(feature = "mem-prof")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -87,6 +87,11 @@ fn print_version() -> &'static str {
     )
 }
 
+use tikv_jemallocator;
+
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cmd = Command::parse();

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "common-mem-prof"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+tikv-jemallocator = "0.5"
+tikv-jemalloc-ctl = "0.5"
+
+[dependencies.tikv-jemalloc-sys]
+version = "0.5.3+5.3.0-patched"
+features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+
+[profile.release]
+debug = true

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -8,12 +8,17 @@ license.workspace = true
 mem-prof = [
     "tikv-jemalloc-sys/stats",
     "tikv-jemalloc-sys/profiling",
-    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms"
+    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
+    "tikv-jemalloc-ctl/use_std"
 ]
 
 [dependencies]
-tikv-jemallocator = "0.5"
+common-error = {path = "../error"}
+snafu.workspace = true
+tempfile = "3.4"
 tikv-jemalloc-ctl = "0.5"
+tikv-jemallocator = "0.5"
+tokio.workspace = true
 
 [dependencies.tikv-jemalloc-sys]
 version = "0.5"

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -4,24 +4,21 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[features]
-mem-prof = [
-    "tikv-jemalloc-sys/stats",
-    "tikv-jemalloc-sys/profiling",
-    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms",
-    "tikv-jemalloc-ctl/use_std"
-]
-
 [dependencies]
-common-error = {path = "../error"}
+common-error = { path = "../error" }
 snafu.workspace = true
 tempfile = "3.4"
-tikv-jemalloc-ctl = "0.5"
+tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tikv-jemallocator = "0.5"
 tokio.workspace = true
 
 [dependencies.tikv-jemalloc-sys]
 version = "0.5"
+features = [
+    "stats",
+    "profiling",
+    "unprefixed_malloc_on_supported_platforms",
+]
 
 [profile.release]
 debug = true

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -14,11 +14,7 @@ tokio.workspace = true
 
 [dependencies.tikv-jemalloc-sys]
 version = "0.5"
-features = [
-    "stats",
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-]
+features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
 
 [profile.release]
 debug = true

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -4,13 +4,19 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+mem-prof = [
+    "tikv-jemalloc-sys/stats",
+    "tikv-jemalloc-sys/profiling",
+    "tikv-jemalloc-sys/unprefixed_malloc_on_supported_platforms"
+]
+
 [dependencies]
 tikv-jemallocator = "0.5"
 tikv-jemalloc-ctl = "0.5"
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5.3+5.3.0-patched"
-features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+version = "0.5"
 
 [profile.release]
 debug = true

--- a/src/common/mem-prof/README.md
+++ b/src/common/mem-prof/README.md
@@ -2,9 +2,6 @@
 
 This crate provides an easy approach to dump memory profiling info.
 
-To enable memory profiling, build GreptimeDB binary with `mem-prof` feature enabled: 
-
-
 ## Prerequisites
 ### jemalloc
 ```bash
@@ -21,10 +18,10 @@ sudo apt install libjemalloc-dev
 curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl > ./flamegraph.pl 
 ```
 
-### Build GreptimeDB with `mem-profa` feature.
+### Build GreptimeDB with `mem-prof` feature.
 
 ```bash
-cargo build --features=mem-profa
+cargo build --features=mem-prof
 ```
 
 ## Profiling
@@ -43,7 +40,7 @@ curl localhost:4000/v1/prof/mem > greptime.hprof
 
 You can periodically dump profiling data and compare them to find the delta memory usage.
 
-## Ananlyze profiling data with flamegraph
+## Analyze profiling data with flamegraph
 
 To create flamegraph according to dumped profiling data:
 

--- a/src/common/mem-prof/README.md
+++ b/src/common/mem-prof/README.md
@@ -1,0 +1,53 @@
+# Profile memory usage of GreptimeDB
+
+This crate provides an easy approach to dump memory profiling info.
+
+To enable memory profiling, build GreptimeDB binary with `mem-prof` feature enabled: 
+
+
+## Prerequisites
+### jemalloc
+```bash
+# for macOS
+brew install jemalloc
+
+# for Ubuntu
+sudo apt install libjemalloc-dev
+```
+
+### [flamegraph](https://github.com/brendangregg/FlameGraph) 
+
+```bash
+curl https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl > ./flamegraph.pl 
+```
+
+### Build GreptimeDB with `mem-profa` feature.
+
+```bash
+cargo build --features=mem-profa
+```
+
+## Profiling
+
+Start GreptimeDB instance with environment variables:
+
+```bash
+MALLOC_CONF=prof:true,lg_prof_interval:28 ./target/debug/greptime standalone start
+```
+
+Dump memory profiling data through HTTP API:
+
+```bash
+curl localhost:4000/v1/prof/mem > greptime.hprof
+```
+
+You can periodically dump profiling data and compare them to find the delta memory usage.
+
+## Ananlyze profiling data with flamegraph
+
+To create flamegraph according to dumped profiling data:
+
+```bash
+jeprof --svg <path_to_greptimedb_binary> --base=<baseline_prof> <profile_data> > output.svg
+```
+

--- a/src/common/mem-prof/src/error.rs
+++ b/src/common/mem-prof/src/error.rs
@@ -1,0 +1,13 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/src/common/mem-prof/src/error.rs
+++ b/src/common/mem-prof/src/error.rs
@@ -11,3 +11,56 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::any::Any;
+use std::path::PathBuf;
+
+use common_error::prelude::{ErrorExt, StatusCode};
+use snafu::{Backtrace, Snafu};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Failed to read OPT_PROF"))]
+    ReadOptProf { source: tikv_jemalloc_ctl::Error },
+
+    #[snafu(display("Memory profiling is not enabled"))]
+    ProfilingNotEnabled,
+
+    #[snafu(display("Failed to build temp file from given path: {:?}", path))]
+    BuildTempPath { path: PathBuf, backtrace: Backtrace },
+
+    #[snafu(display("Failed to open temp file: {}", path))]
+    OpenTempFile {
+        path: String,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Failed to dump profiling data to temp file: {:?}", path))]
+    DumpProfileData {
+        path: PathBuf,
+        source: tikv_jemalloc_ctl::Error,
+    },
+}
+
+impl ErrorExt for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::ReadOptProf { .. } => StatusCode::Internal,
+            Error::ProfilingNotEnabled => StatusCode::InvalidArguments,
+            Error::BuildTempPath { .. } => StatusCode::Internal,
+            Error::OpenTempFile { .. } => StatusCode::StorageUnavailable,
+            Error::DumpProfileData { .. } => StatusCode::StorageUnavailable,
+        }
+    }
+
+    fn backtrace_opt(&self) -> Option<&Backtrace> {
+        snafu::ErrorCompat::backtrace(self)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -28,7 +28,6 @@ use crate::error::{
 const PROF_DUMP: &[u8] = b"prof.dump\0";
 const OPT_PROF: &[u8] = b"opt.prof\0";
 
-#[cfg(feature = "mem-prof")]
 pub async fn dump_profile() -> error::Result<Vec<u8>> {
     ensure!(is_prof_enabled()?, ProfilingNotEnabledSnafu);
     let tmp_path = tempfile::tempdir().map_err(|_| {
@@ -69,7 +68,6 @@ pub async fn dump_profile() -> error::Result<Vec<u8>> {
     Ok(buf)
 }
 
-#[cfg(feature = "mem-prof")]
 fn is_prof_enabled() -> error::Result<bool> {
     // safety: OPT_PROF variable, if present, is always a boolean value.
     Ok(unsafe { tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF).context(ReadOptProfSnafu)? })

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -24,6 +24,7 @@ const OPT_PROF: &[u8] = b"opt.prof\0";
 
 // caller site is supposed to clean up the tmp_file
 // e.g. use `tempfile` to generate a temporary file
+#[cfg(feature = "mem-prof")]
 pub fn dump_profile(tmp_file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> {
     if !is_prof_enabled()? {
         return Err("opt.prof is not ON,
@@ -48,6 +49,7 @@ pub fn dump_profile(tmp_file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> {
     Ok(buf)
 }
 
+#[cfg(feature = "mem-prof")]
 fn is_prof_enabled() -> Result<bool, Box<dyn Error>> {
     Ok(unsafe {
         tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF)

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -12,47 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod error;
+pub mod error;
 
-use std::error::Error;
 use std::ffi::{c_char, CString};
-use std::fs::File;
-use std::io::Read;
+use std::path::PathBuf;
+
+use snafu::{ensure, ResultExt};
+use tokio::io::AsyncReadExt;
+
+use crate::error::{
+    BuildTempPathSnafu, DumpProfileDataSnafu, OpenTempFileSnafu, ProfilingNotEnabledSnafu,
+    ReadOptProfSnafu,
+};
 
 const PROF_DUMP: &[u8] = b"prof.dump\0";
 const OPT_PROF: &[u8] = b"opt.prof\0";
 
-// caller site is supposed to clean up the tmp_file
-// e.g. use `tempfile` to generate a temporary file
 #[cfg(feature = "mem-prof")]
-pub fn dump_profile(tmp_file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> {
-    if !is_prof_enabled()? {
-        return Err("opt.prof is not ON,
-                   please start the application with proper MALLOC env.
-                   e.g.  MALLOC_CONF=prof:true "
-            .into());
+pub async fn dump_profile() -> error::Result<Vec<u8>> {
+    ensure!(is_prof_enabled()?, ProfilingNotEnabledSnafu);
+    let tmp_path = tempfile::tempdir().map_err(|_| {
+        BuildTempPathSnafu {
+            path: std::env::temp_dir(),
+        }
+        .build()
+    })?;
+
+    let mut path_buf = PathBuf::from(tmp_path.path());
+    path_buf.push("greptimedb.hprof");
+
+    let path = path_buf
+        .to_str()
+        .ok_or_else(|| BuildTempPathSnafu { path: &path_buf }.build())?
+        .to_string();
+
+    let mut bytes = CString::new(path.as_str())
+        .map_err(|_| BuildTempPathSnafu { path: &path_buf }.build())?
+        .into_bytes_with_nul();
+
+    {
+        // #safety: we always expect a valid temp file path to write profiling data to.
+        let ptr = bytes.as_mut_ptr() as *mut c_char;
+        unsafe {
+            tikv_jemalloc_ctl::raw::write(PROF_DUMP, ptr)
+                .context(DumpProfileDataSnafu { path: path_buf })?
+        }
     }
 
-    let mut bytes = CString::new(tmp_file_path)?.into_bytes_with_nul();
-    let ptr = bytes.as_mut_ptr() as *mut c_char;
-    unsafe {
-        tikv_jemalloc_ctl::raw::write(PROF_DUMP, ptr).map_err(|e| {
-            format!(
-                "dump Jemalloc prof to path {}: failure: {}",
-                tmp_file_path, e
-            )
-        })?
-    }
-    let mut f = File::open(tmp_file_path)?;
-    let mut buf = Vec::new();
-    f.read_to_end(&mut buf)?;
+    let mut f = tokio::fs::File::open(path.as_str())
+        .await
+        .context(OpenTempFileSnafu { path: &path })?;
+    let mut buf = vec![];
+    f.read_to_end(&mut buf)
+        .await
+        .context(OpenTempFileSnafu { path })?;
     Ok(buf)
 }
 
 #[cfg(feature = "mem-prof")]
-fn is_prof_enabled() -> Result<bool, Box<dyn Error>> {
-    Ok(unsafe {
-        tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF)
-            .map_err(|e| format!("read opt.prof failure: {}", e))?
-    })
+fn is_prof_enabled() -> error::Result<bool> {
+    // safety: OPT_PROF variable, if present, is always a boolean value.
+    Ok(unsafe { tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF).context(ReadOptProfSnafu)? })
 }

--- a/src/common/mem-prof/src/lib.rs
+++ b/src/common/mem-prof/src/lib.rs
@@ -1,0 +1,56 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod error;
+
+use std::error::Error;
+use std::ffi::{c_char, CString};
+use std::fs::File;
+use std::io::Read;
+
+const PROF_DUMP: &[u8] = b"prof.dump\0";
+const OPT_PROF: &[u8] = b"opt.prof\0";
+
+// caller site is supposed to clean up the tmp_file
+// e.g. use `tempfile` to generate a temporary file
+pub fn dump_profile(tmp_file_path: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    if !is_prof_enabled()? {
+        return Err("opt.prof is not ON,
+                   please start the application with proper MALLOC env.
+                   e.g.  MALLOC_CONF=prof:true "
+            .into());
+    }
+
+    let mut bytes = CString::new(tmp_file_path)?.into_bytes_with_nul();
+    let ptr = bytes.as_mut_ptr() as *mut c_char;
+    unsafe {
+        tikv_jemalloc_ctl::raw::write(PROF_DUMP, ptr).map_err(|e| {
+            format!(
+                "dump Jemalloc prof to path {}: failure: {}",
+                tmp_file_path, e
+            )
+        })?
+    }
+    let mut f = File::open(tmp_file_path)?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn is_prof_enabled() -> Result<bool, Box<dyn Error>> {
+    Ok(unsafe {
+        tikv_jemalloc_ctl::raw::read::<bool>(OPT_PROF)
+            .map_err(|e| format!("read opt.prof failure: {}", e))?
+    })
+}

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -5,9 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-mem-prof = [
-    "dep:common-mem-prof"
-]
+mem-prof = ["dep:common-mem-prof"]
 
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -25,6 +25,8 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+common-mem-prof = { path = "../common/mem-prof" }
+
 datatypes = { path = "../datatypes" }
 derive_builder = "0.12"
 digest = "0.10"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+mem-prof=[
+    "common-mem-prof/mem-prof"
+]
+
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
 arrow-flight.workspace = true
@@ -25,7 +30,7 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-mem-prof = { path = "../common/mem-prof" }
+common-mem-prof = { path = "../common/mem-prof"}
 
 datatypes = { path = "../datatypes" }
 derive_builder = "0.12"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-mem-prof=[
-    "common-mem-prof/mem-prof"
+mem-prof = [
+    "dep:common-mem-prof"
 ]
 
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
-arrow-flight.workspace = true
 api = { path = "../api" }
+arrow-flight.workspace = true
 async-trait = "0.1"
 axum = "0.6"
 axum-macros = "0.3"
@@ -25,13 +25,12 @@ common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
 common-grpc-expr = { path = "../common/grpc-expr" }
+common-mem-prof = { path = "../common/mem-prof", optional = true }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-mem-prof = { path = "../common/mem-prof"}
-
 datatypes = { path = "../datatypes" }
 derive_builder = "0.12"
 digest = "0.10"
@@ -67,12 +66,13 @@ snap = "1"
 sql = { path = "../sql" }
 strum = { version = "0.24", features = ["derive"] }
 table = { path = "../table" }
-tokio.workspace = true
 tokio-rustls = "0.23"
 tokio-stream = { version = "0.1", features = ["net"] }
+tokio.workspace = true
 tonic.workspace = true
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
+
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -256,6 +256,12 @@ pub enum Error {
 
     #[snafu(display("Cannot find requested database: {}-{}", catalog, schema))]
     DatabaseNotFound { catalog: String, schema: String },
+
+    #[snafu(display("Failed to dump profile data, source: {}", source))]
+    DumpProfileData {
+        #[snafu(backtrace)]
+        source: common_mem_prof::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -315,6 +321,7 @@ impl ErrorExt for Error {
             | InvalidUtf8Value { .. } => StatusCode::InvalidAuthHeader,
 
             DatabaseNotFound { .. } => StatusCode::DatabaseNotFound,
+            DumpProfileData { source, .. } => source.status_code(),
         }
     }
 

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -257,6 +257,7 @@ pub enum Error {
     #[snafu(display("Cannot find requested database: {}-{}", catalog, schema))]
     DatabaseNotFound { catalog: String, schema: String },
 
+    #[cfg(feature = "mem-prof")]
     #[snafu(display("Failed to dump profile data, source: {}", source))]
     DumpProfileData {
         #[snafu(backtrace)]
@@ -321,6 +322,7 @@ impl ErrorExt for Error {
             | InvalidUtf8Value { .. } => StatusCode::InvalidAuthHeader,
 
             DatabaseNotFound { .. } => StatusCode::DatabaseNotFound,
+            #[cfg(feature = "mem-prof")]
             DumpProfileData { source, .. } => source.status_code(),
         }
     }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -15,10 +15,12 @@
 pub mod authorize;
 pub mod handler;
 pub mod influxdb;
-pub mod mem_prof;
 pub mod opentsdb;
 pub mod prometheus;
 pub mod script;
+
+#[cfg(feature = "mem-prof")]
+pub mod mem_prof;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -447,10 +449,13 @@ impl HttpServer {
         }
 
         // mem profiler
-        router = router.nest(
-            &format!("/{HTTP_API_VERSION}/prof"),
-            Router::new().route("/mem", routing::get(crate::http::mem_prof::mem_prof)),
-        );
+        #[cfg(feature = "mem-prof")]
+        {
+            router = router.nest(
+                &format!("/{HTTP_API_VERSION}/prof"),
+                Router::new().route("/mem", routing::get(crate::http::mem_prof::mem_prof)),
+            );
+        }
 
         router = router.route("/metrics", routing::get(handler::metrics));
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -15,6 +15,7 @@
 pub mod authorize;
 pub mod handler;
 pub mod influxdb;
+pub mod mem_prof;
 pub mod opentsdb;
 pub mod prometheus;
 pub mod script;
@@ -444,6 +445,12 @@ impl HttpServer {
                 self.route_prom(prom_handler),
             );
         }
+
+        // mem profiler
+        router = router.nest(
+            &format!("/{HTTP_API_VERSION}/prof"),
+            Router::new().route("/mem", routing::get(crate::http::mem_prof::mem_prof)),
+        );
 
         router = router.route("/metrics", routing::get(handler::metrics));
 

--- a/src/servers/src/http/mem_prof.rs
+++ b/src/servers/src/http/mem_prof.rs
@@ -14,12 +14,17 @@
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use snafu::ResultExt;
+
+use crate::error::DumpProfileDataSnafu;
 
 #[cfg(feature = "mem-prof")]
 #[axum_macros::debug_handler]
 pub async fn mem_prof() -> crate::error::Result<impl IntoResponse> {
     Ok((
         StatusCode::OK,
-        common_mem_prof::dump_profile("/tmp/greptimedb-prof").unwrap(),
+        common_mem_prof::dump_profile()
+            .await
+            .context(DumpProfileDataSnafu)?,
     ))
 }

--- a/src/servers/src/http/mem_prof.rs
+++ b/src/servers/src/http/mem_prof.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+#[axum_macros::debug_handler]
+pub async fn mem_prof() -> crate::error::Result<impl IntoResponse> {
+    Ok((
+        StatusCode::OK,
+        common_mem_prof::dump_profile("/tmp").unwrap(),
+    ))
+}

--- a/src/servers/src/http/mem_prof.rs
+++ b/src/servers/src/http/mem_prof.rs
@@ -15,10 +15,11 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
+#[cfg(feature = "mem-prof")]
 #[axum_macros::debug_handler]
 pub async fn mem_prof() -> crate::error::Result<impl IntoResponse> {
     Ok((
         StatusCode::OK,
-        common_mem_prof::dump_profile("/tmp").unwrap(),
+        common_mem_prof::dump_profile("/tmp/greptimedb-prof").unwrap(),
     ))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add memory profiling feature and HTTP handler to dump profiling data.

To enable memory profiling, try build binaries with feature `mem-prof`:
```bash
cargo build --features=mem-prof
```

and start GreptimeDB instance with env variables:

```bash
MALLOC_CONF=prof:true,lg_prof_interval:28 ./target/debug/greptime standalone start
```

To dump memory profiling data, use the HTTP API:
```bash
curl localhost:4000/v1/prof/mem > greptime.hprof
```

To create flamegraph according to dumped profiling data:

```bash
jeprof --svg <path_to_greptimedb_binary> --base=<baseline_prof> <profile_data> > output.svg
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
