### PR TITLE
test: add manifest compatibility tests

### DIFF
--- a/src/mito/src/manifest/action.rs
+++ b/src/mito/src/manifest/action.rs
@@ -176,4 +176,25 @@ mod tests {
         assert_eq!(decode_list, action_list);
         assert_eq!(p.unwrap(), protocol);
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // These tests are used to ensure backward compatibility of manifest files.
+        // DO NOT modify the serialized string when they fail, check if your
+        // modification to manifest-related structs is compatible with older manifests.
+        #[test]
+        fn test_table_manifest_compatibility() {
+            let table_change = r#"{"table_info":{"ident":{"table_id":0,"version":0},"name":"demo","desc":null,"catalog_name":"greptime","schema_name":"public","meta":{"schema":{"column_schemas":[{"name":"host","data_type":{"String":null},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"cpu","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"memory","data_type":{"Float64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"ts","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":true,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}}],"timestamp_index":3,"version":0},"primary_key_indices":[0],"value_indices":[1,2,3],"engine":"mito","next_column_id":1,"region_numbers":[],"engine_options":{},"options":{"write_buffer_size":null,"ttl":null,"extra_options":{}},"created_on":"2023-03-06T08:50:34.662020Z"},"table_type":"Base"}}"#;
+            serde_json::from_str::<TableChange>(table_change).unwrap();
+
+            let table_remove =
+                r#"{"table_ident":{"table_id":42,"version":0},"table_name":"test_table"}"#;
+            serde_json::from_str::<TableRemove>(table_remove).unwrap();
+
+            let protocol_action = r#"{"min_reader_version":0,"min_writer_version":1}"#;
+            serde_json::from_str::<ProtocolAction>(protocol_action).unwrap();
+        }
+    }
 }

--- a/src/mito/src/manifest/action.rs
+++ b/src/mito/src/manifest/action.rs
@@ -177,24 +177,19 @@ mod tests {
         assert_eq!(p.unwrap(), protocol);
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
+    // These tests are used to ensure backward compatibility of manifest files.
+    // DO NOT modify the serialized string when they fail, check if your
+    // modification to manifest-related structs is compatible with older manifests.
+    #[test]
+    fn test_table_manifest_compatibility() {
+        let table_change = r#"{"table_info":{"ident":{"table_id":0,"version":0},"name":"demo","desc":null,"catalog_name":"greptime","schema_name":"public","meta":{"schema":{"column_schemas":[{"name":"host","data_type":{"String":null},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"cpu","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"memory","data_type":{"Float64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"ts","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":true,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}}],"timestamp_index":3,"version":0},"primary_key_indices":[0],"value_indices":[1,2,3],"engine":"mito","next_column_id":1,"region_numbers":[],"engine_options":{},"options":{"write_buffer_size":null,"ttl":null,"extra_options":{}},"created_on":"2023-03-06T08:50:34.662020Z"},"table_type":"Base"}}"#;
+        serde_json::from_str::<TableChange>(table_change).unwrap();
 
-        // These tests are used to ensure backward compatibility of manifest files.
-        // DO NOT modify the serialized string when they fail, check if your
-        // modification to manifest-related structs is compatible with older manifests.
-        #[test]
-        fn test_table_manifest_compatibility() {
-            let table_change = r#"{"table_info":{"ident":{"table_id":0,"version":0},"name":"demo","desc":null,"catalog_name":"greptime","schema_name":"public","meta":{"schema":{"column_schemas":[{"name":"host","data_type":{"String":null},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"cpu","data_type":{"Float64":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"memory","data_type":{"Float64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},{"name":"ts","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":true,"is_time_index":true,"default_constraint":null,"metadata":{"greptime:time_index":"true"}}],"timestamp_index":3,"version":0},"primary_key_indices":[0],"value_indices":[1,2,3],"engine":"mito","next_column_id":1,"region_numbers":[],"engine_options":{},"options":{"write_buffer_size":null,"ttl":null,"extra_options":{}},"created_on":"2023-03-06T08:50:34.662020Z"},"table_type":"Base"}}"#;
-            serde_json::from_str::<TableChange>(table_change).unwrap();
+        let table_remove =
+            r#"{"table_ident":{"table_id":42,"version":0},"table_name":"test_table"}"#;
+        serde_json::from_str::<TableRemove>(table_remove).unwrap();
 
-            let table_remove =
-                r#"{"table_ident":{"table_id":42,"version":0},"table_name":"test_table"}"#;
-            serde_json::from_str::<TableRemove>(table_remove).unwrap();
-
-            let protocol_action = r#"{"min_reader_version":0,"min_writer_version":1}"#;
-            serde_json::from_str::<ProtocolAction>(protocol_action).unwrap();
-        }
+        let protocol_action = r#"{"min_reader_version":0,"min_writer_version":1}"#;
+        serde_json::from_str::<ProtocolAction>(protocol_action).unwrap();
     }
 }

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -221,4 +221,22 @@ mod tests {
         assert_eq!(decode_list, action_list);
         assert_eq!(p.unwrap(), protocol);
     }
+
+    // These tests are used to ensure backward compatibility of manifest files.
+    // DO NOT modify the serialized string when they fail, check if your
+    // modification to manifest-related structs is compatible with older manifests.
+    #[test]
+    fn test_region_manifest_compatibility() {
+        let region_edit = r#"{"region_version":0,"flushed_sequence":null,"files_to_add":[{"region_id":4402341478400,"file_name":"4b220a70-2b03-4641-9687-b65d94641208.parquet","time_range":[{"value":1451609210000,"unit":"Millisecond"},{"value":1451609520000,"unit":"Millisecond"}],"level":1}],"files_to_remove":[{"region_id":4402341478400,"file_name":"34b6ebb9-b8a5-4a4b-b744-56f67defad02.parquet","time_range":[{"value":1451609210000,"unit":"Millisecond"},{"value":1451609520000,"unit":"Millisecond"}],"level":0}]}"#;
+        serde_json::from_str::<RegionEdit>(region_edit).unwrap();
+
+        let region_change = r#" {"committed_sequence":42,"metadata":{"id":0,"name":"region-0","columns":{"columns":[{"cf_id":0,"desc":{"id":2,"name":"k1","data_type":{"Int32":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"comment":""}},{"cf_id":0,"desc":{"id":1,"name":"timestamp","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":false,"is_time_index":true,"default_constraint":null,"comment":""}},{"cf_id":1,"desc":{"id":3,"name":"v1","data_type":{"Float32":{}},"is_nullable":true,"is_time_index":false,"default_constraint":null,"comment":""}},{"cf_id":1,"desc":{"id":2147483649,"name":"__sequence","data_type":{"UInt64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"comment":""}},{"cf_id":1,"desc":{"id":2147483650,"name":"__op_type","data_type":{"UInt8":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"comment":""}}],"row_key_end":2,"timestamp_key_index":1,"enable_version_column":false,"user_column_end":3},"column_families":{"column_families":[{"name":"default","cf_id":1,"column_index_start":2,"column_index_end":3}]},"version":0}}"#;
+        serde_json::from_str::<RegionChange>(region_change).unwrap();
+
+        let region_remove = r#"{"region_id":42}"#;
+        serde_json::from_str::<RegionRemove>(region_remove).unwrap();
+
+        let protocol_action = r#"{"min_reader_version":1,"min_writer_version":2}"#;
+        serde_json::from_str::<ProtocolAction>(protocol_action).unwrap();
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Add table/region manifest compatibility tests to ensure future modifications to some deeply nested structs that are persisted to manifest won't cause compatibility issue.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
