### PR TITLE
test: ignore two test cases due to arrow-datafusion#5513

### DIFF
--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -366,17 +366,13 @@ impl PromPlanner {
                         expr: prom_expr.clone(),
                     })?)
                     .await?;
-                println!("input schema ident:\n{}", input.display_indent_schema());
-                println!("input schema: {:?}", input.schema());
                 let mut func_exprs = self.create_function_expr(func, args.literals)?;
                 func_exprs.insert(0, self.create_time_index_column_expr()?);
                 func_exprs.extend_from_slice(&self.create_tag_column_exprs()?);
 
-                let plan_result = LogicalPlanBuilder::from(input)
+                LogicalPlanBuilder::from(input)
                     .project(func_exprs)
-                    .context(DataFusionPlanningSnafu);
-                println!("project plan result: {:?}", plan_result);
-                plan_result?
+                    .context(DataFusionPlanningSnafu)?
                     .filter(self.create_empty_values_filter_expr()?)
                     .context(DataFusionPlanningSnafu)?
                     .build()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Ignore two cases `increase_aggr` and `count_over_time`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
closes #1136