### PR TITLE
ci: tolerate error while building arm64 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,6 @@ jobs:
     name: Build docker image
     needs: [build]
     runs-on: ubuntu-latest
-    continue-on-error: true
     if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,16 +30,21 @@ jobs:
           - arch: x86_64-unknown-linux-gnu
             os: ubuntu-2004-16-cores
             file: greptime-linux-amd64
-          # - arch: aarch64-unknown-linux-gnu
-          #   os: ubuntu-2004-16-cores
-          #   file: greptime-linux-arm64
-          # - arch: aarch64-apple-darwin
-          #   os: macos-latest
-          #   file: greptime-darwin-arm64
-          # - arch: x86_64-apple-darwin
-          #   os: macos-latest
-          #   file: greptime-darwin-amd64
+            continue-on-error: false
+          - arch: aarch64-unknown-linux-gnu
+            os: ubuntu-2004-16-cores
+            file: greptime-linux-arm64
+            continue-on-error: true
+          - arch: aarch64-apple-darwin
+            os: macos-latest
+            file: greptime-darwin-arm64
+            continue-on-error: true
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+            file: greptime-darwin-amd64
+            continue-on-error: true
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.continue-on-error }}
     if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources
@@ -176,34 +181,11 @@ jobs:
     name: Build docker image
     needs: [build]
     runs-on: ubuntu-latest
+    continue-on-error: true
     if: github.repository == 'GreptimeTeam/greptimedb'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
-      - name: Download amd64 binary
-        uses: actions/download-artifact@v3
-        with:
-          name: greptime-linux-amd64
-          path: amd64
-
-      - name: Unzip the amd64 artifacts
-        run: |
-          cd amd64
-          tar xvf greptime-linux-amd64.tgz
-          rm greptime-linux-amd64.tgz
-
-      # - name: Download arm64 binary
-      #   uses: actions/download-artifact@v3
-      #   with:
-      #     name: greptime-linux-arm64
-      #     path: arm64
-
-      # - name: Unzip the arm64 artifacts
-      #   run: |
-      #     cd arm64
-      #     tar xvf greptime-linux-arm64.tgz
-      #     rm greptime-linux-arm64.tgz
 
       - name: Login to UCloud Container Registry
         uses: docker/login-action@v2
@@ -239,13 +221,55 @@ jobs:
       - name: Set up buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and push
+      - name: Download amd64 binary
+        uses: actions/download-artifact@v3
+        with:
+          name: greptime-linux-amd64
+          path: amd64
+
+      - name: Unzip the amd64 artifacts
+        id: unzip-amd64
+        run: |
+          cd amd64
+          tar xvf greptime-linux-amd64.tgz
+          rm greptime-linux-amd64.tgz
+
+      - name: Download arm64 binary
+        id: download-arm64
+        uses: actions/download-artifact@v3
+        with:
+          name: greptime-linux-arm64
+          path: arm64
+
+      - name: Unzip the arm64 artifacts
+        id: unzip-arm64
+        if: success() || steps.download-arm64.conclusion == 'success'
+        run: |
+          cd arm64
+          tar xvf greptime-linux-arm64.tgz
+          rm greptime-linux-arm64.tgz
+
+      - name: Build and push all
         uses: docker/build-push-action@v3
+        if: success() || steps.unzip-arm64.conclusion == 'success' # Build and push all platform if unzip-arm64 succeeds
         with:
           context: .
           file: ./docker/ci/Dockerfile
           push: true
-          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            greptime/greptimedb:latest
+            greptime/greptimedb:${{ env.IMAGE_TAG }}
+            uhub.service.ucloud.cn/greptime/greptimedb:latest
+            uhub.service.ucloud.cn/greptime/greptimedb:${{ env.IMAGE_TAG }}
+
+      - name: Build and push amd64 only
+        uses: docker/build-push-action@v3
+        if: success() || steps.unzip-arm64.conclusion == 'failure' # Only build and push amd64 platform if unzip-arm64 fails
+        with:
+          context: .
+          file: ./docker/ci/Dockerfile
+          push: true
           platforms: linux/amd64
           tags: |
             greptime/greptimedb:latest


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
tolerate error while building arm64 releases

Reference
- https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
- [How to run a github-actions step, even if the previous step fails, while still failing the job](https://stackoverflow.com/a/75123818)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
