### PR TITLE
ci: Fix step "build and push amd64" not triggered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,6 @@ jobs:
           path: amd64
 
       - name: Unzip the amd64 artifacts
-        id: unzip-amd64
         run: |
           cd amd64
           tar xvf greptime-linux-amd64.tgz
@@ -264,7 +263,7 @@ jobs:
 
       - name: Build and push amd64 only
         uses: docker/build-push-action@v3
-        if: success() || steps.unzip-arm64.conclusion == 'failure' # Only build and push amd64 platform if unzip-arm64 fails
+        if: success() || steps.download-arm64.conclusion == 'failure' # Only build and push amd64 platform if download-arm64 fails
         with:
           context: .
           file: ./docker/ci/Dockerfile


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix step "build and push amd64" not triggered.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
