### PR TITLE
fix: remove profile in mem-prof crate to suppress compiler warnings

### DIFF
--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -15,6 +15,3 @@ tokio.workspace = true
 [dependencies.tikv-jemalloc-sys]
 version = "0.5"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
-
-[profile.release]
-debug = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Remove useless profile section in Cargo.toml of mem-prof crate.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fix #1144 