### PR TITLE
fix: remove unnecessary braces around block return value

### DIFF
--- a/src/store-api/src/logstore/entry_stream.rs
+++ b/src/store-api/src/logstore/entry_stream.rs
@@ -122,7 +122,7 @@ mod tests {
     #[tokio::test]
     pub async fn test_entry_stream() {
         let stream =
-            async_stream::stream!({ yield Ok(vec![SimpleEntry::new("test_entry".as_bytes())]) });
+            async_stream::stream!(yield Ok(vec![SimpleEntry::new("test_entry".as_bytes())]));
 
         let mut stream_impl = EntryStreamImpl {
             inner: Box::pin(stream),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly remove unnecessary braces around block return value.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
