### PR TITLE
chore: Bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow-flight",
  "common-base",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "clap 4.1.8",
@@ -1086,7 +1086,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1359,7 +1359,7 @@ dependencies = [
  "prost",
  "rand",
  "snafu",
- "substrait 0.1.0",
+ "substrait 0.1.1",
  "substrait 0.4.1",
  "tokio",
  "tonic",
@@ -1389,7 +1389,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anymap",
  "build-data",
@@ -1417,7 +1417,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.1.0",
+ "substrait 0.1.1",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -1453,7 +1453,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "snafu",
  "strum",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "chrono-tz",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "common-function-macro"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "common-error",
  "snafu",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "common-base",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "common-error",
  "datafusion",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "common-error",
  "common-telemetry",
@@ -1654,7 +1654,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1676,14 +1676,14 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tempfile",
 ]
 
 [[package]]
 name = "common-time"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "async-compat",
@@ -2296,7 +2296,7 @@ dependencies = [
  "sql",
  "storage",
  "store-api",
- "substrait 0.1.0",
+ "substrait 0.1.1",
  "table",
  "table-procedure",
  "tokio",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "async-stream",
@@ -2800,7 +2800,7 @@ dependencies = [
  "sql",
  "store-api",
  "strfmt",
- "substrait 0.1.0",
+ "substrait 0.1.1",
  "table",
  "tokio",
  "toml",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "log-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -3951,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "async-trait",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anymap",
  "api",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anymap",
  "arc-swap",
@@ -4516,7 +4516,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "common-catalog",
  "common-error",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "approx_eq",
  "arc-swap",
@@ -6604,7 +6604,7 @@ checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "script"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6834,7 +6834,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aide",
  "api",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "common-catalog",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "catalog",
@@ -7182,7 +7182,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "client",
@@ -7260,7 +7260,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -7569,7 +7569,7 @@ dependencies = [
 
 [[package]]
 name = "table-procedure"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "catalog",
@@ -7651,7 +7651,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "api",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Bump version to 0.1.1 since 0.1.0 is released

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
