### PR TITLE
feat: add shutdown for datanode

### DIFF
--- a/src/catalog/tests/mock.rs
+++ b/src/catalog/tests/mock.rs
@@ -221,4 +221,8 @@ impl TableEngine for MockTableEngine {
     ) -> table::Result<bool> {
         unimplemented!()
     }
+
+    async fn close(&self) -> table::Result<()> {
+        Ok(())
+    }
 }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -240,6 +240,20 @@ impl Datanode {
     pub fn get_instance(&self) -> InstanceRef {
         self.instance.clone()
     }
+
+    async fn shutdown_instance(&self) -> Result<()> {
+        self.instance.shutdown().await
+    }
+
+    async fn shutdown_services(&self) -> Result<()> {
+        self.services.shutdown().await
+    }
+
+    pub async fn shutdown(&self) -> Result<()> {
+        // We must shutdown services first
+        self.shutdown_services().await?;
+        self.shutdown_instance().await
+    }
 }
 
 #[cfg(test)]

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -482,6 +482,24 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_procedure::error::Error,
     },
+
+    #[snafu(display("Failed to close table engine, source: {}", source))]
+    CloseTableEngine {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
+
+    #[snafu(display("Failed to shutdown server, source: {}", source))]
+    ShutdownServer {
+        #[snafu(backtrace)]
+        source: servers::error::Error,
+    },
+
+    #[snafu(display("Failed to shutdown instance, source: {}", source))]
+    ShutdownInstance {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -550,7 +568,10 @@ impl ErrorExt for Error {
             | BuildParquetRecordBatchStream { .. }
             | InvalidSchema { .. }
             | ParseDataTypes { .. }
-            | IncorrectInternalState { .. } => StatusCode::Internal,
+            | IncorrectInternalState { .. }
+            | ShutdownServer { .. }
+            | ShutdownInstance { .. }
+            | CloseTableEngine { .. } => StatusCode::Internal,
 
             BuildBackend { .. }
             | InitBackend { .. }

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -144,6 +144,18 @@ impl HeartbeatTask {
 
         Ok(())
     }
+
+    pub async fn close(&self) -> Result<()> {
+        let running = self.running.clone();
+        if running
+            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            warn!("Call close heartbeat task multiple times");
+        }
+
+        Ok(())
+    }
 }
 
 /// Resolves hostname:port address for meta registration

--- a/src/datanode/src/sql.rs
+++ b/src/datanode/src/sql.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use catalog::CatalogManagerRef;
+use common_error::prelude::BoxedError;
 use common_procedure::ProcedureManagerRef;
 use common_query::Output;
 use common_telemetry::error;
@@ -28,7 +29,9 @@ use table::engine::{EngineContext, TableEngineProcedureRef, TableEngineRef, Tabl
 use table::requests::*;
 use table::TableRef;
 
-use crate::error::{self, ExecuteSqlSnafu, GetTableSnafu, Result, TableNotFoundSnafu};
+use crate::error::{
+    self, CloseTableEngineSnafu, ExecuteSqlSnafu, GetTableSnafu, Result, TableNotFoundSnafu,
+};
 use crate::instance::sql::table_idents_to_full_name;
 
 mod alter;
@@ -138,6 +141,14 @@ impl SqlHandler {
 
     pub fn table_engine(&self) -> TableEngineRef {
         self.table_engine.clone()
+    }
+
+    pub async fn close(&self) -> Result<()> {
+        self.table_engine
+            .close()
+            .await
+            .map_err(BoxedError::new)
+            .context(CloseTableEngineSnafu)
     }
 }
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -322,6 +322,15 @@ impl<R: Region> Table for MitoTable<R> {
         }
         Ok(rows_deleted)
     }
+
+    async fn close(&self) -> TableResult<()> {
+        futures::future::try_join_all(self.regions.values().map(|region| region.close()))
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
+
+        Ok(())
+    }
 }
 
 struct ChunkStream {

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -100,6 +100,9 @@ pub trait TableEngine: Send + Sync {
 
     /// Drops the given table. Return true if the table is dropped, or false if the table doesn't exist.
     async fn drop_table(&self, ctx: &EngineContext, request: DropTableRequest) -> Result<bool>;
+
+    /// Close the table.
+    async fn close(&self) -> Result<()>;
 }
 
 pub type TableEngineRef = Arc<dyn TableEngine>;

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -93,6 +93,11 @@ pub trait Table: Send + Sync {
         }
         .fail()?
     }
+
+    /// Close the table.
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub type TableRef = Arc<dyn Table>;

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -96,4 +96,8 @@ impl TableEngine for MockTableEngine {
     async fn drop_table(&self, _ctx: &EngineContext, _request: DropTableRequest) -> Result<bool> {
         unimplemented!()
     }
+
+    async fn close(&self) -> Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `shutdown` method for datanode

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1158 