### PR TITLE
fix: use correct env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           sudo chmod +x ./docker/aarch64/compile-python.sh
           sudo ./docker/aarch64/compile-python.sh
-          export PYO3_CROSS_LIB_DIR=$PY_INSTALL_PATH/lib
+          export PYO3_CROSS_LIB_DIR=$(pwd)/python_arm64_build/lib
           echo $PYO3_CROSS_LIB_DIR
 
       - name: Install rust toolchain
@@ -118,8 +118,12 @@ jobs:
       - name: Run tests
         run: make unit-test integration-test sqlness-test
 
-      - name: Run cargo build
-        # TODO(discord9): remove `-F pyo3_backend` once make it default
+      - name: Run cargo build with pyo3-backend
+        if: contains(matrix.arch, 'linux') && endsWith(matrix.arch, '-gnu')
+        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} -F pyo3_backend
+
+      - name: Run cargo build with macos
+        if: contains(matrix.arch, 'darwin')
         run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }}
 
       - name: Calculate checksum and rename binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           sudo chmod +x ./docker/aarch64/compile-python.sh
           sudo ./docker/aarch64/compile-python.sh
-          export PYO3_CROSS_LIB_DIR=${PWD}/python310-aarch64/lib
+          export PYO3_CROSS_LIB_DIR=$PY_INSTALL_PATH/lib
           echo $PYO3_CROSS_LIB_DIR
 
       - name: Install rust toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run cargo build
         # TODO(discord9): remove `-F pyo3_backend` once make it default
-        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} -F pyo3_backend
+        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }}
 
       - name: Calculate checksum and rename binary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,8 @@ jobs:
         run: make unit-test integration-test sqlness-test
 
       - name: Run cargo build
-        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }}
+        # TODO: remove `-F pyo3_backend` once make it default
+        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} -F pyo3_backend
 
       - name: Calculate checksum and rename binary
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,7 +119,7 @@ jobs:
         run: make unit-test integration-test sqlness-test
 
       - name: Run cargo build
-        # TODO: remove `-F pyo3_backend` once make it default
+        # TODO(discord9): remove `-F pyo3_backend` once make it default
         run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} -F pyo3_backend
 
       - name: Calculate checksum and rename binary

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -37,7 +37,7 @@ RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo fetch
 # Set the environment variable for cross compiling and compile it
 # cross compiled python is `python3` in path, but pyo3 need `python` in path so alias it
-# Build the project in release mode. Set Net fetch with git cli to true to avoid git error with bad networking.
+# Build the project in release mode.
 RUN export PYO3_CROSS_LIB_DIR=$PY_INSTALL_PATH/lib && \ 
     alias python=python3 && \
     cargo build --target aarch64-unknown-linux-gnu --release -F pyo3_backend

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -22,20 +22,23 @@ RUN apt-get -y update && \
     apt-get -y install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu && \
     apt-get install binutils-aarch64-linux-gnu
 
-COPY . .
+COPY ./docker/aarch64/compile-python.sh ./docker/aarch64/
 # This three env var is set in script, so I set it manually in dockerfile.
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib/
-ENV PY_INSTALL_PATH=${PWD}/python_arm64_build
+ENV PY_INSTALL_PATH=/python_arm64_build
 RUN chmod +x ./docker/aarch64/compile-python.sh && \
     ./docker/aarch64/compile-python.sh
 # Install rustup target for cross compiling.
 RUN rustup target add aarch64-unknown-linux-gnu
+# Update dependency, using separate `RUN` to separate cache
+COPY . .
+RUN cargo fetch
 # Set the environment variable for cross compiling and compile it
-# Build the project in release mode. Set Net fetch with git cli to true to avoid git error.
+# cross compiled python is `python3` in path, but pyo3 need `python` in path so alias it
+# Build the project in release mode. Set Net fetch with git cli to true to avoid git error with bad networking.
 RUN export PYO3_CROSS_LIB_DIR=$PY_INSTALL_PATH/lib && \ 
     alias python=python3 && \
-    CARGO_NET_GIT_FETCH_WITH_CLI=1 && \
     cargo build --target aarch64-unknown-linux-gnu --release -F pyo3_backend
 
 # Exporting the binary to the clean image

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -29,10 +29,11 @@ ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib/
 ENV PY_INSTALL_PATH=/python_arm64_build
 RUN chmod +x ./docker/aarch64/compile-python.sh && \
     ./docker/aarch64/compile-python.sh
+
+COPY . .
 # Install rustup target for cross compiling.
 RUN rustup target add aarch64-unknown-linux-gnu
 # Update dependency, using separate `RUN` to separate cache
-COPY . .
 RUN cargo fetch
 # Set the environment variable for cross compiling and compile it
 # cross compiled python is `python3` in path, but pyo3 need `python` in path so alias it

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -23,18 +23,21 @@ RUN apt-get -y update && \
     apt-get install binutils-aarch64-linux-gnu
 
 COPY ./docker/aarch64/compile-python.sh ./docker/aarch64/
-# This three env var is set in script, so I set it manually in dockerfile.
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
-ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib/
-ENV PY_INSTALL_PATH=/python_arm64_build
 RUN chmod +x ./docker/aarch64/compile-python.sh && \
     ./docker/aarch64/compile-python.sh
 
-COPY . .
+COPY ./rust-toolchain.toml .
 # Install rustup target for cross compiling.
 RUN rustup target add aarch64-unknown-linux-gnu
+COPY . .
 # Update dependency, using separate `RUN` to separate cache
 RUN cargo fetch
+
+# This three env var is set in script, so I set it manually in dockerfile.
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
+ENV LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib/
+ENV PY_INSTALL_PATH=/greptimedb/python_arm64_build
+
 # Set the environment variable for cross compiling and compile it
 # cross compiled python is `python3` in path, but pyo3 need `python` in path so alias it
 # Build the project in release mode.

--- a/docker/aarch64/compile-python.sh
+++ b/docker/aarch64/compile-python.sh
@@ -26,7 +26,7 @@ make install
 cd ..
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib/
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/lib/
-export PY_INSTALL_PATH=${PWD}/python_arm64_build
+export PY_INSTALL_PATH=$(pwd)/python_arm64_build
 cd Python-3.10.10 && \
 make clean && \
 make distclean && \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

fix cross compile script by replacing `${pwd}` with correct `$(pwd)`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
