### PR TITLE
feat: Report disk usage stats to metasrv thru heartbeat

### DIFF
--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -204,6 +204,21 @@ pub enum Error {
 
     #[snafu(display("Illegal access to catalog: {} and schema: {}", catalog, schema))]
     QueryAccessDenied { catalog: String, schema: String },
+
+    #[snafu(display(
+        "Failed to get region stats, catalog: {}, schema: {}, table: {}source: {}",
+        catalog,
+        schema,
+        table,
+        source
+    ))]
+    RegionStats {
+        catalog: String,
+        schema: String,
+        table: String,
+        #[snafu(backtrace)]
+        source: table::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -238,7 +253,8 @@ impl ErrorExt for Error {
             | Error::InsertCatalogRecord { source, .. }
             | Error::OpenTable { source, .. }
             | Error::CreateTable { source, .. }
-            | Error::DeregisterTable { source, .. } => source.status_code(),
+            | Error::DeregisterTable { source, .. }
+            | Error::RegionStats { source, .. } => source.status_code(),
 
             Error::MetaSrv { source, .. } => source.status_code(),
             Error::SystemCatalogTableScan { source } => source.status_code(),

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -206,7 +206,7 @@ pub enum Error {
     QueryAccessDenied { catalog: String, schema: String },
 
     #[snafu(display(
-        "Failed to get region stats, catalog: {}, schema: {}, table: {}source: {}",
+        "Failed to get region stats, catalog: {}, schema: {}, table: {}, source: {}",
         catalog,
         schema,
         table,

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -227,7 +227,7 @@ pub(crate) async fn handle_system_table_request<'a, M: CatalogManager>(
 }
 
 /// The stat of regions in the datanode node.
-/// number of regions can be got from len of vec.
+/// The number of regions can be got from len of vec.
 pub async fn region_stats(catalog_manager: &CatalogManagerRef) -> Result<Vec<RegionStat>> {
     let mut region_stats = Vec::new();
     for catalog_name in catalog_manager.catalog_names()? {

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -332,7 +332,7 @@ impl<R: Region> Table for MitoTable<R> {
         Ok(())
     }
 
-    fn region_stats(&self) -> table::error::Result<Vec<RegionStat>> {
+    fn region_stats(&self) -> TableResult<Vec<RegionStat>> {
         Ok(self
             .regions
             .values()

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -47,7 +47,7 @@ use table::requests::{
     AddColumnRequest, AlterKind, AlterTableRequest, DeleteRequest, InsertRequest,
 };
 use table::table::scan::SimpleTableScan;
-use table::table::{AlterContext, Table};
+use table::table::{AlterContext, RegionStat, Table};
 use tokio::sync::Mutex;
 
 use crate::error;
@@ -330,6 +330,17 @@ impl<R: Region> Table for MitoTable<R> {
             .context(table_error::TableOperationSnafu)?;
 
         Ok(())
+    }
+
+    fn region_stats(&self) -> table::error::Result<Vec<RegionStat>> {
+        Ok(self
+            .regions
+            .values()
+            .map(|region| RegionStat {
+                region_id: region.id(),
+                disk_usage_bytes: region.disk_usage_bytes(),
+            })
+            .collect())
     }
 }
 

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -98,6 +98,14 @@ pub trait Table: Send + Sync {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    /// Get region stats in this table.
+    fn region_stats(&self) -> Result<Vec<RegionStat>> {
+        UnsupportedSnafu {
+            operation: "REGION_STATS",
+        }
+        .fail()?
+    }
 }
 
 pub type TableRef = Arc<dyn Table>;
@@ -108,3 +116,9 @@ pub trait TableIdProvider {
 }
 
 pub type TableIdProviderRef = Arc<dyn TableIdProvider + Send + Sync>;
+
+#[derive(Default, Debug)]
+pub struct RegionStat {
+    pub region_id: u64,
+    pub disk_usage_bytes: u64,
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Report region disk usage stats to metasrv through heartbeat.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Add `region_stats` on `table` trait.
- Collect region disk usage in heartbeat.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1003 