### PR TITLE
fix: export 'PYO3_CROSS_LIB_DIR' when cargo build for aarch64-linux and refactor matrix opts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,12 @@ jobs:
             os: ubuntu-2004-16-cores
             file: greptime-linux-amd64
             continue-on-error: false
+            opts: "-F pyo3_backend"
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-2004-16-cores
             file: greptime-linux-arm64
             continue-on-error: true
+            opts: "-F pyo3_backend"
           - arch: aarch64-apple-darwin
             os: macos-latest
             file: greptime-darwin-arm64
@@ -103,8 +105,6 @@ jobs:
         run: |
           sudo chmod +x ./docker/aarch64/compile-python.sh
           sudo ./docker/aarch64/compile-python.sh
-          export PYO3_CROSS_LIB_DIR=$(pwd)/python_arm64_build/lib
-          echo $PYO3_CROSS_LIB_DIR
 
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -118,13 +118,18 @@ jobs:
       - name: Run tests
         run: make unit-test integration-test sqlness-test
 
-      - name: Run cargo build with pyo3-backend
-        if: contains(matrix.arch, 'linux') && endsWith(matrix.arch, '-gnu')
-        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} -F pyo3_backend
+      - name: Run cargo build for aarch64-linux
+        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu')
+        run: |
+          # TODO(zyy17): We should make PYO3_CROSS_LIB_DIR configurable.
+          export PYO3_CROSS_LIB_DIR=$(pwd)/python_arm64_build/lib
+          echo "PYO3_CROSS_LIB_DIR: $PYO3_CROSS_LIB_DIR"
+          alias python=python3
+          cargo build --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} ${{ matrix.opts }}
 
-      - name: Run cargo build with macos
-        if: contains(matrix.arch, 'darwin')
-        run: cargo build ${{ matrix.opts }} --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }}
+      - name: Run cargo build
+        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu') == false
+        run: cargo build --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} ${{ matrix.opts }}
 
       - name: Calculate checksum and rename binary
         shell: bash


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Export 'PYO3_CROSS_LIB_DIR' when cargo build for aarch64-linux;
2. Move `-F pyo3_backend` to `matrix.opts`;
3. Delete `export` when compiling python(the shell env can't propagate to the new step);

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
