### PR TITLE
refactor: put `dataframe` & `query` into `greptime` module

### DIFF
--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -379,7 +379,8 @@ import greptime as gt
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number) -> vector[u32]:
-    return query.sql("select * from numbers")[0][0]
+    from greptime import query
+    return query().sql("select * from numbers")[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())
@@ -438,7 +439,8 @@ from greptime import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number) -> vector[u32]:
-    return dataframe.filter(col("number")==col("number")).collect()[0][0]
+    from greptime import dataframe
+    return dataframe().filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -335,7 +335,7 @@ pub fn exec_coprocessor(script: &str, rb: &Option<RecordBatch>) -> Result<Record
 
 #[cfg_attr(feature = "pyo3_backend", pyo3class(name = "query_engine"))]
 #[rspyclass(module = false, name = "query_engine")]
-#[derive(Debug, PyPayload)]
+#[derive(Debug, PyPayload, Clone)]
 pub struct PyQueryEngine {
     inner: QueryEngineWeakRef,
 }

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -140,7 +140,7 @@ impl Coprocessor {
             cols.len() == names.len() && names.len() == anno.len(),
             OtherSnafu {
                 reason: format!(
-                    "Unmatched length for cols({}), names({}) and anno({})",
+                    "Unmatched length for cols({}), names({}) and annotation({})",
                     cols.len(),
                     names.len(),
                     anno.len()

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -92,7 +92,6 @@ async fn integrated_py_copr_test() {
             _ => unreachable!(),
         };
         let rb = res.iter().next().expect("One and only one recordbatch");
-        println!("Result: {:?}", rb);
         if let Some(expect_result) = case.expect {
             let mut actual_result = HashMap::new();
             for col_sch in rb.schema.column_schemas() {

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -92,6 +92,7 @@ async fn integrated_py_copr_test() {
             _ => unreachable!(),
         };
         let rb = res.iter().next().expect("One and only one recordbatch");
+        println!("Result: {:?}",rb);
         if let Some(expect_result) = case.expect {
             let mut actual_result = HashMap::new();
             for col_sch in rb.schema.column_schemas() {

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -92,7 +92,7 @@ async fn integrated_py_copr_test() {
             _ => unreachable!(),
         };
         let rb = res.iter().next().expect("One and only one recordbatch");
-        println!("Result: {:?}",rb);
+        println!("Result: {:?}", rb);
         if let Some(expect_result) = case.expect {
             let mut actual_result = HashMap::new();
             for col_sch in rb.schema.column_schemas() {
@@ -185,7 +185,7 @@ fn eval_rspy(case: CodeBlockTestCase) {
 
 #[cfg(feature = "pyo3_backend")]
 fn eval_pyo3(case: CodeBlockTestCase) {
-    init_cpython_interpreter();
+    init_cpython_interpreter().unwrap();
     Python::with_gil(|py| {
         let locals = {
             let locals_dict = PyDict::new(py);

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -54,6 +54,22 @@ def boolean_array() -> vector[f64]:
 @copr(returns=["value"], backend="pyo3")
 def boolean_array() -> vector[f64]:
     from greptime import vector
+    from greptime import query, dataframe
+    assert "query_engine" in str(type(query))
+    assert "ValueError" in str(type(dataframe))
+    v = vector([1.0, 2.0, 3.0])
+    # This returns a vector([2.0])
+    return v[(v > 1) & (v < 3)]
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Float64Vector, [2.0f64]))),
+        },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def boolean_array() -> vector[f64]:
+    from greptime import vector
     v = vector([1.0, 2.0, 3.0])
     # This returns a vector([2.0])
     return v[(v > 1) & (v < 3)]

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -55,8 +55,16 @@ def boolean_array() -> vector[f64]:
 def boolean_array() -> vector[f64]:
     from greptime import vector
     from greptime import query, dataframe
-    assert "query_engine" in str(type(query))
-    assert "ValueError" in str(type(dataframe))
+    
+    try: 
+        print("query()=", query())
+    except KeyError as e:
+        print("query()=", e)
+    try: 
+        print("dataframe()=", dataframe())
+    except KeyError as e:
+        print("dataframe()=", e)
+
     v = vector([1.0, 2.0, 3.0])
     # This returns a vector([2.0])
     return v[(v > 1) & (v < 3)]

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -38,6 +38,31 @@ pub(super) fn generate_copr_intgrate_tests() -> Vec<CoprTestCase> {
     vec![
         CoprTestCase {
             script: r#"
+from greptime import vector
+@copr(returns=["value"])
+def boolean_array() -> vector[f64]:
+    v = vector([1.0, 2.0, 3.0])
+    # This returns a vector([2.0])
+    return v[(v > 1) & (v < 3)]
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Float64Vector, [2.0f64]))),
+        },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def boolean_array() -> vector[f64]:
+    from greptime import vector
+    v = vector([1.0, 2.0, 3.0])
+    # This returns a vector([2.0])
+    return v[(v > 1) & (v < 3)]
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Float64Vector, [2.0f64]))),
+        },
+        CoprTestCase {
+            script: r#"
 @copr(args=["number", "number"],
     returns=["value"],
     sql="select number from numbers limit 5", backend="rspy")

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -148,9 +148,9 @@ def answer() -> vector[i64]:
             script: r#"
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="rspy")
 def answer() -> vector[i64]:
-    from greptime import vector, col, lit
+    from greptime import vector, col, lit, dataframe
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
-    ret = dataframe.select([col("number")]).filter(expr_0).collect()[0][0]
+    ret = dataframe().select([col("number")]).filter(expr_0).collect()[0][0]
     return ret
 "#
             .to_string(),
@@ -161,10 +161,10 @@ def answer() -> vector[i64]:
             script: r#"
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="pyo3")
 def answer() -> vector[i64]:
-    from greptime import vector, col, lit
+    from greptime import vector, col, lit, dataframe
     # Bitwise Operator  pred comparison operator
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
-    ret = dataframe.select([col("number")]).filter(expr_0).collect()[0][0]
+    ret = dataframe().select([col("number")]).filter(expr_0).collect()[0][0]
     return ret
 "#
             .to_string(),

--- a/src/script/src/python/ffi_types/vector/tests.rs
+++ b/src/script/src/python/ffi_types/vector/tests.rs
@@ -133,7 +133,7 @@ fn get_test_cases() -> Vec<TestCase> {
 }
 #[cfg(feature = "pyo3_backend")]
 fn eval_pyo3(testcase: TestCase, locals: HashMap<String, PyVector>) {
-    init_cpython_interpreter();
+    init_cpython_interpreter().unwrap();
     Python::with_gil(|py| {
         let locals = {
             let locals_dict = PyDict::new(py);

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -59,7 +59,11 @@ impl PyQueryEngine {
 }
 
 /// dynamically insert a module into sys.modules so you can use `import MODULE_NAME` in python
-fn insert_module_to_sys_table(py: Python, name: &str, module: &PyModule) -> PyResult<()> {
+pub(crate) fn insert_module_to_sys_table(
+    py: Python,
+    name: &str,
+    module: &PyModule,
+) -> PyResult<()> {
     // Import and get sys.modules
     let sys = PyModule::import(py, "sys")?;
     let py_modules: &PyDict = sys.getattr("modules")?.downcast()?;
@@ -85,7 +89,7 @@ pub(crate) fn pyo3_exec_parsed(
         Vec::new()
     };
     // Just in case cpython is not inited
-    init_cpython_interpreter();
+    init_cpython_interpreter().unwrap();
     Python::with_gil(|py| -> Result<_> {
         let mut cols = (|| -> PyResult<_> {
             let dummy_decorator = "
@@ -235,7 +239,7 @@ mod copr_test {
 @copr(args=["cpu", "mem"], returns=["ref"], backend="pyo3")
 def a(cpu, mem, **kwargs):
     import greptime as gt
-    from greptime import vector, log2, sum, pow, col, lit
+    from greptime import vector, log2, sum, pow, col, lit, dataframe
     for k, v in kwargs.items():
         print("%s == %s" % (k, v))
     print(dataframe.select([col("cpu")<lit(0.3)]).collect())

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -86,7 +86,6 @@ def copr(*dummy, **kwdummy):
         return func
     return inner
 coprocessor = copr
-from greptime import vector
 ";
             let gen_call = format!("\n_return_from_coprocessor = {}(*_args_for_coprocessor, **_kwargs_for_coprocessor)", copr.name);
             let script = format!("{}{}{}", dummy_decorator, copr.script, gen_call);

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -130,10 +130,7 @@ coprocessor = copr
             if let Some(engine) = &copr.query_engine {
                 let query_engine = PyQueryEngine::from_weakref(engine.clone());
                 let query_engine = PyCell::new(py, query_engine)?;
-                greptime.add("query", query_engine)?;
-            }else{
-                greptime.add("query", PyValueError::new_err(
-                    "No query engine found for coprocessor".to_string()))?;
+                globals.set_item("__query__", query_engine)?;
             }
 
             // TODO(discord9): find out why `dataframe` is not in scope
@@ -146,10 +143,7 @@ coprocessor = copr
                     )
                 )?;
                 let dataframe = PyCell::new(py, dataframe)?;
-                greptime.add("dataframe", dataframe)?;
-            }else{
-                greptime.add("dataframe", PyValueError::new_err(
-                    "No dataframe found for coprocessor".to_string()))?;
+                globals.set_item("__dataframe__", dataframe)?;
             }
 
             insert_module_to_sys_table(py, "greptime", greptime)?;
@@ -242,7 +236,7 @@ def a(cpu, mem, **kwargs):
     from greptime import vector, log2, sum, pow, col, lit, dataframe
     for k, v in kwargs.items():
         print("%s == %s" % (k, v))
-    print(dataframe.select([col("cpu")<lit(0.3)]).collect())
+    print(dataframe().select([col("cpu")<lit(0.3)]).collect())
     return (0.5 < cpu) & ~( cpu >= 0.75)
     "#;
         let cpu_array = Float32Vector::from_slice([0.9f32, 0.8, 0.7, 0.3]);

--- a/src/script/src/python/pyo3/dataframe_impl.rs
+++ b/src/script/src/python/pyo3/dataframe_impl.rs
@@ -26,6 +26,8 @@ use crate::python::ffi_types::PyVector;
 use crate::python::pyo3::utils::pyo3_obj_try_to_typed_scalar_value;
 use crate::python::utils::block_on_async;
 type PyExprRef = Py<PyExpr>;
+
+#[derive(Debug, Clone)]
 #[pyclass]
 pub(crate) struct PyDataFrame {
     inner: DfDataFrame,
@@ -47,6 +49,9 @@ impl PyDataFrame {
 
 #[pymethods]
 impl PyDataFrame {
+    fn __call__(&self) -> PyResult<Self> {
+        Ok(self.clone())
+    }
     fn select_columns(&self, columns: Vec<String>) -> PyResult<Self> {
         Ok(self
             .inner
@@ -252,6 +257,9 @@ pub(crate) fn col(name: String) -> PyExpr {
 
 #[pymethods]
 impl PyExpr {
+    fn __call__(&self) -> PyResult<Self> {
+        Ok(self.clone())
+    }
     fn __richcmp__(&self, py: Python<'_>, other: PyObject, op: CompareOp) -> PyResult<Self> {
         let other = other.extract::<Self>(py).or_else(|_| lit(py, other))?;
         let op = match op {

--- a/src/script/src/python/pyo3/utils.rs
+++ b/src/script/src/python/pyo3/utils.rs
@@ -39,7 +39,6 @@ pub(crate) fn to_py_err(err: impl ToString) -> PyErr {
 pub(crate) fn init_cpython_interpreter() {
     let mut start = START_PYO3.lock().unwrap();
     if !*start {
-        pyo3::append_to_inittab!(greptime_builtins);
         pyo3::prepare_freethreaded_python();
         *start = true;
         info!("Started CPython Interpreter");

--- a/src/script/src/python/pyo3/utils.rs
+++ b/src/script/src/python/pyo3/utils.rs
@@ -30,7 +30,6 @@ use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyTuple};
 use crate::python::ffi_types::utils::{collect_diff_types_string, new_item_field};
 use crate::python::ffi_types::PyVector;
 use crate::python::pyo3::builtins::greptime_builtins;
-use crate::python::pyo3::copr_impl::insert_module_to_sys_table;
 
 /// prevent race condition of init cpython
 static START_PYO3: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
@@ -38,16 +37,12 @@ pub(crate) fn to_py_err(err: impl ToString) -> PyErr {
     PyArrowException::new_err(err.to_string())
 }
 
-/// init cpython interpreter with `greptime` builtins, if already inited, ignored
+/// init cpython interpreter with `greptime` builtins, if already inited, do nothing
 pub(crate) fn init_cpython_interpreter() -> PyResult<()> {
     let mut start = START_PYO3.lock().unwrap();
     if !*start {
+        pyo3::append_to_inittab!(greptime_builtins);
         pyo3::prepare_freethreaded_python();
-        Python::with_gil(|py| -> PyResult<()> {
-            let greptime = PyModule::new(py, "greptime")?;
-            greptime_builtins(py, greptime)?;
-            insert_module_to_sys_table(py, "greptime", greptime)
-        })?;
         *start = true;
         info!("Started CPython Interpreter");
     }

--- a/src/script/src/python/rspython/copr_impl.rs
+++ b/src/script/src/python/rspython/copr_impl.rs
@@ -81,12 +81,13 @@ fn set_items_in_scope(
 fn set_query_engine_in_scope(
     scope: &Scope,
     vm: &VirtualMachine,
+    name: &str,
     query_engine: PyQueryEngine,
 ) -> Result<()> {
     scope
         .locals
         .as_object()
-        .set_item("query", query_engine.to_pyobject(vm), vm)
+        .set_item(name, query_engine.to_pyobject(vm), vm)
         .map_err(|e| format_py_error(e, vm))
 }
 
@@ -101,7 +102,7 @@ pub(crate) fn exec_with_cached_vm(
         // set arguments with given name and values
         let scope = vm.new_scope_with_builtins();
         if let Some(rb) = rb {
-            set_dataframe_in_scope(&scope, vm, "dataframe", rb)?;
+            set_dataframe_in_scope(&scope, vm, "__dataframe__", rb)?;
         }
 
         if let Some(arg_names) = &copr.deco_args.arg_names {
@@ -113,7 +114,7 @@ pub(crate) fn exec_with_cached_vm(
             let query_engine = PyQueryEngine::from_weakref(engine.clone());
 
             // put a object named with query of class PyQueryEngine in scope
-            set_query_engine_in_scope(&scope, vm, query_engine)?;
+            set_query_engine_in_scope(&scope, vm, "__query__", query_engine)?;
         }
 
         if let Some(kwarg) = &copr.kwarg {

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -38,7 +38,7 @@ pub(crate) mod data_frame {
     use crate::python::rspython::builtins::greptime_builtin::lit;
     use crate::python::utils::block_on_async;
     #[rspyclass(module = "data_frame", name = "DataFrame")]
-    #[derive(PyPayload, Debug)]
+    #[derive(PyPayload, Debug, Clone)]
     pub struct PyDataFrame {
         pub inner: DfDataFrame,
     }

--- a/src/script/src/python/rspython/test.rs
+++ b/src/script/src/python/rspython/test.rs
@@ -287,7 +287,7 @@ def a(cpu, mem):
     abc = vector([v[0] > v[1] for v in zip(cpu, mem)])
     fed = cpu.filter(abc)
     ref = log2(fed/prev(fed))
-    return (0.5 < cpu) & ~( cpu >= 0.75)
+    return cpu[(cpu > 0.5) & ~( cpu >= 0.75)]
 "#;
     let cpu_array = Float32Vector::from_slice([0.9f32, 0.8, 0.7, 0.3]);
     let mem_array = Float64Vector::from_slice([0.1f64, 0.2, 0.3, 0.4]);

--- a/src/script/src/python/rspython/testcases.ron
+++ b/src/script/src/python/rspython/testcases.ron
@@ -559,11 +559,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         // constant column(int)
         name: "test_data_frame",
         code: r#"
-from greptime import col
+from greptime import col, dataframe
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    ret = dataframe.select([col("cpu"), col("mem")]).collect()[0]
+    ret = dataframe().select([col("cpu"), col("mem")]).collect()[0]
     return ret[0], ret[1]
 "#,
         predicate: ExecIsOk(
@@ -593,11 +593,11 @@ def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
         // constant column(int)
         name: "test_data_frame",
         code: r#"
-from greptime import col
+from greptime import col, dataframe
 @copr(args=["cpu", "mem"], returns=["perf", "what"])
 def a(cpu: vector[f32], mem: vector[f64])->(vector[f64|None],
     vector[f32]):
-    ret = dataframe.filter(col("cpu")>col("mem")).collect()[0]
+    ret = dataframe().filter(col("cpu")>col("mem")).collect()[0]
     return ret[0], ret[1]
 "#,
         predicate: ExecIsOk(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Put `dataframe` and `query` into `greptime` module
notice this currently only works for PyO3 backend, because RustPython doesn't support modifying modules after creation of interpreter(unless init interpreter per call of script, which is way too costy)

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
do this in python script(Only in pyo3) to get access to dataframe api and query in sql
`from greptime import dataframe, query`
- How does this PR work? Need a brief introduction for the changed logic (optional)
added `dataframe` & `query`  into `greptime` module in pyo3 every time coprocessor is called with a RecordBatch and within a `QueryEngine`, and use it like:
`query().sql(...)` and `dataframe().collect()...`
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
This works in pyo3 module by dynamically insert both var into module everytime, and in rustpython backend is using hidden variable `__dataframe__` and `__query__`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
