### PR TITLE
chore(datanode): derive serde default for Wal/CompactionConfig

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -77,6 +77,7 @@ impl Default for ObjectStoreConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct WalConfig {
     // wal directory
     pub dir: String,
@@ -108,6 +109,7 @@ impl Default for WalConfig {
 
 /// Options for table compaction
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(default)]
 pub struct CompactionConfig {
     /// Max task number that can concurrently run.
     pub max_inflight_tasks: usize,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
derive serde default for Wal/CompactionConfig

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
