### PR TITLE
ci: set 'continue-on-error' to false since the problem of compiling binary was resolved

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,17 +33,17 @@ jobs:
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-2004-16-cores
             file: greptime-linux-arm64
-            continue-on-error: true
+            continue-on-error: false
             opts: "-F pyo3_backend"
           - arch: aarch64-apple-darwin
             os: macos-latest
             file: greptime-darwin-arm64
-            continue-on-error: true
+            continue-on-error: false
             opts: "-F pyo3_backend"
           - arch: x86_64-apple-darwin
             os: macos-latest
             file: greptime-darwin-amd64
-            continue-on-error: true
+            continue-on-error: false
             opts: "-F pyo3_backend"
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

set 'continue-on-error' to false since the problem of compiling binary was resolved

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
