### PR TITLE
feat: wait flush until the flush is done

### DIFF
--- a/src/datanode/src/server/grpc.rs
+++ b/src/datanode/src/server/grpc.rs
@@ -95,6 +95,7 @@ impl Instance {
             schema_name: expr.schema_name,
             table_name,
             region_number: expr.region_id,
+            wait: None,
         };
         self.sql_handler()
             .execute(SqlRequest::FlushTable(req), QueryContext::arc())

--- a/src/datanode/src/sql/flush_table.rs
+++ b/src/datanode/src/sql/flush_table.rs
@@ -28,6 +28,7 @@ impl SqlHandler {
                 &req.schema_name,
                 table,
                 req.region_number,
+                req.wait,
             )
             .await?;
         } else {
@@ -47,6 +48,7 @@ impl SqlHandler {
                     &req.schema_name,
                     table,
                     req.region_number,
+                    req.wait,
                 )
             }))
             .await
@@ -62,6 +64,7 @@ impl SqlHandler {
         schema: &str,
         table: &str,
         region: Option<u32>,
+        wait: Option<bool>,
     ) -> Result<()> {
         let table_ref = TableReference {
             catalog,
@@ -71,8 +74,11 @@ impl SqlHandler {
 
         let full_table_name = table_ref.to_string();
         let table = self.get_table(&table_ref)?;
-        table.flush(region).await.context(error::FlushTableSnafu {
-            table_name: full_table_name,
-        })
+        table
+            .flush(region, wait)
+            .await
+            .context(error::FlushTableSnafu {
+                table_name: full_table_name,
+            })
     }
 }

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -793,10 +793,10 @@ async fn test_flush_table_all_regions() {
     assert!(!has_parquet_file(&region_dir));
 
     // Trigger flush all region
-    table.flush(None).await.unwrap();
+    table.flush(None, None).await.unwrap();
 
     // Trigger again, wait for the previous task finished
-    table.flush(None).await.unwrap();
+    table.flush(None, None).await.unwrap();
 
     assert!(has_parquet_file(&region_dir));
 }
@@ -832,10 +832,10 @@ async fn test_flush_table_with_region_id() {
     };
 
     // Trigger flush all region
-    table.flush(req.region_number).await.unwrap();
+    table.flush(req.region_number, Some(false)).await.unwrap();
 
     // Trigger again, wait for the previous task finished
-    table.flush(req.region_number).await.unwrap();
+    table.flush(req.region_number, Some(true)).await.unwrap();
 
     assert!(has_parquet_file(&region_dir));
 }

--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -26,9 +26,9 @@ use datatypes::schema::{ColumnSchema, Schema};
 use storage::metadata::{RegionMetaImpl, RegionMetadata};
 use storage::write_batch::WriteBatch;
 use store_api::storage::{
-    AlterRequest, Chunk, ChunkReader, CreateOptions, EngineContext, GetRequest, GetResponse,
-    OpenOptions, ReadContext, Region, RegionDescriptor, RegionId, ScanRequest, ScanResponse,
-    SchemaRef, Snapshot, StorageEngine, WriteContext, WriteResponse,
+    AlterRequest, Chunk, ChunkReader, CreateOptions, EngineContext, FlushContext, GetRequest,
+    GetResponse, OpenOptions, ReadContext, Region, RegionDescriptor, RegionId, ScanRequest,
+    ScanResponse, SchemaRef, Snapshot, StorageEngine, WriteContext, WriteResponse,
 };
 
 pub type Result<T> = std::result::Result<T, MockError>;
@@ -201,7 +201,7 @@ impl Region for MockRegion {
         0
     }
 
-    async fn flush(&self) -> Result<()> {
+    async fn flush(&self, _ctx: &FlushContext) -> Result<()> {
         unimplemented!()
     }
 }

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -34,7 +34,7 @@ pub use self::chunk::{Chunk, ChunkReader};
 pub use self::descriptors::*;
 pub use self::engine::{CreateOptions, EngineContext, OpenOptions, StorageEngine};
 pub use self::metadata::RegionMeta;
-pub use self::region::{Region, WriteContext};
+pub use self::region::{FlushContext, Region, WriteContext};
 pub use self::requests::{
     AddColumn, AlterOperation, AlterRequest, GetRequest, ScanRequest, WriteRequest,
 };

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -77,7 +77,8 @@ pub trait Region: Send + Sync + Clone + std::fmt::Debug + 'static {
 
     fn disk_usage_bytes(&self) -> u64;
 
-    async fn flush(&self) -> Result<(), Self::Error>;
+    /// Flush memtable of the region to disk.
+    async fn flush(&self, ctx: &FlushContext) -> Result<(), Self::Error>;
 }
 
 /// Context for write operations.
@@ -87,5 +88,19 @@ pub struct WriteContext {}
 impl From<&OpenOptions> for WriteContext {
     fn from(_opts: &OpenOptions) -> WriteContext {
         WriteContext::default()
+    }
+}
+
+/// Context for flush operations.
+#[derive(Debug, Clone)]
+pub struct FlushContext {
+    /// If true, the flush will wait until the flush is done.
+    /// Default: true
+    pub wait: bool,
+}
+
+impl Default for FlushContext {
+    fn default() -> FlushContext {
+        FlushContext { wait: true }
     }
 }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -216,6 +216,8 @@ pub struct FlushTableRequest {
     pub schema_name: String,
     pub table_name: Option<String>,
     pub region_number: Option<RegionNumber>,
+    /// Wait until the flush is done.
+    pub wait: Option<bool>,
 }
 
 #[cfg(test)]

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -96,8 +96,12 @@ pub trait Table: Send + Sync {
     }
 
     /// Flush table.
-    async fn flush(&self, region_number: Option<RegionNumber>) -> Result<()> {
-        let _ = region_number;
+    ///
+    /// Options:
+    /// - region_number: specify region to flush.
+    /// - wait: Whether to wait until flush is done.
+    async fn flush(&self, region_number: Option<RegionNumber>, wait: Option<bool>) -> Result<()> {
+        let _ = (region_number, wait);
         UnsupportedSnafu { operation: "FLUSH" }.fail()?
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Add an argument to control whether `flush()` will wait until the flush is done

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
