### PR TITLE
feat: slicing PyVector&Create DataFrame from sql

### DIFF
--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -353,18 +353,10 @@ impl PyQueryEngine {
                     rbs.schema().arrow_schema(),
                     rbs.iter().map(|r| r.df_record_batch()),
                 )
-                .map_err(|e| {
-                    format!(
-                        "Concat batches failed for query {sql}: {e}",
-                        sql = sql,
-                        e = e
-                    )
-                })?;
+                .map_err(|e| format!("Concat batches failed for query {sql}: {e}"))?;
                 RecordBatch::try_from_df_record_batch(rbs.schema(), rb).map_err(|e|
                     format!(
-                        "Convert datafusion record batch to record batch failed for query {sql}: {e}",
-                        sql = sql,
-                        e = e
+                        "Convert datafusion record batch to record batch failed for query {sql}: {e}"
                     )
                 )
             }

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -260,11 +260,12 @@ pub(crate) fn check_args_anno_real_type(
                 .unwrap_or(true),
             OtherSnafu {
                 reason: format!(
-                    "column {}'s Type annotation is {:?}, but actual type is {:?}",
+                    "column {}'s Type annotation is {:?}, but actual type is {:?} with nullable=={}",
                     // It's safe to unwrap here, we already ensure the args and types number is the same when parsing
                     copr.deco_args.arg_names.as_ref().unwrap()[idx],
                     anno_ty,
-                    real_ty
+                    real_ty,
+                    is_nullable
                 )
             }
         )

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -113,6 +113,7 @@ async fn integrated_py_copr_test() {
 fn pyo3_rspy_test_in_pairs() {
     let testcases = sample_test_case();
     for case in testcases {
+        println!("Testcase: {}", case.script);
         eval_rspy(case.clone());
         #[cfg(feature = "pyo3_backend")]
         eval_pyo3(case);
@@ -122,6 +123,9 @@ fn pyo3_rspy_test_in_pairs() {
 fn check_equal(v0: VectorRef, v1: VectorRef) -> bool {
     let v0 = v0.to_arrow_array();
     let v1 = v1.to_arrow_array();
+    if v0.len() != v1.len() {
+        return false;
+    }
     fn is_float(ty: &ArrowDataType) -> bool {
         use ArrowDataType::*;
         matches!(ty, Float16 | Float32 | Float64)

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -109,6 +109,7 @@ async fn integrated_py_copr_test() {
     }
 }
 
+#[allow(clippy::print_stdout)]
 #[test]
 fn pyo3_rspy_test_in_pairs() {
     let testcases = sample_test_case();

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -17,12 +17,11 @@ use std::f64::consts;
 use std::sync::Arc;
 
 use datatypes::prelude::ScalarVector;
-use datatypes::vectors::{
-    BooleanVector, Float64Vector, Int32Vector, Int64Vector, UInt32Vector, VectorRef,
-};
+#[cfg(feature = "pyo3_backend")]
+use datatypes::vectors::UInt32Vector;
+use datatypes::vectors::{BooleanVector, Float64Vector, Int32Vector, Int64Vector, VectorRef};
 
-use super::CoprTestCase;
-use crate::python::ffi_types::pair_tests::CodeBlockTestCase;
+use crate::python::ffi_types::pair_tests::{CodeBlockTestCase, CoprTestCase};
 macro_rules! vector {
     ($ty: ident, $slice: expr) => {
         Arc::new($ty::from_slice($slice)) as VectorRef
@@ -79,8 +78,10 @@ def boolean_array() -> vector[f64]:
 @copr(returns=["value"], backend="rspy")
 def boolean_array() -> vector[f64]:
     from greptime import vector
-    from greptime import query, dataframe
+    from greptime import query, dataframe, PyDataFrame
     
+    df = PyDataFrame.from_sql("select number from numbers limit 5")
+    print("df from sql=", df)
     try: 
         print("query()=", query())
     except KeyError as e:

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -238,12 +238,29 @@ def answer() -> vector[i64]:
     from greptime import vector
     import pyarrow as pa
     a = vector.from_pyarrow(pa.array([42, 43, 44]))
+    return a[0:1]
+"#
+            .to_string(),
+            expect: Some(ronish!("value": vector!(Int64Vector, [42]))),
+        },
+        #[cfg(feature = "pyo3_backend")]
+        CoprTestCase {
+            script: r#"
+@copr(returns=["value"], backend="pyo3")
+def answer() -> vector[i64]:
+    from greptime import vector
+    a = vector([42, 43, 44])
     # slicing test
     assert a[0:2] == a[:-1]
-    assert len(a[:-1]) == 2
+    assert len(a[:-1]) == vector([42,44])
     assert a[0:1] == a[:-2] 
-    assert len(a[:-2]) == 1
-    print("a[:-2]=", a[:-2])
+    assert a[0:1] == vector([42])
+    assert a[:-2] == vector([42])
+    assert a[:-1:2] == vector([42])
+    assert a[::2] == vector([42,44])
+    # negative step
+    assert a[-1::-2] == vector([44, 42])
+    assert a[-2::-2] == vector([44])
     return a[0:1]
 "#
             .to_string(),
@@ -255,11 +272,17 @@ def answer() -> vector[i64]:
 def answer() -> vector[i64]:
     from greptime import vector
     a = vector([42, 43, 44])
-    assert a[0:2] == a[:-1]
-    assert len(a[:-1]) == 2
-    assert a[0:1] == a[:-2] 
-    assert len(a[:-2]) == 1
     # slicing test
+    assert a[0:2] == a[:-1]
+    assert len(a[:-1]) == vector([42,44])
+    assert a[0:1] == a[:-2] 
+    assert a[0:1] == vector([42])
+    assert a[:-2] == vector([42])
+    assert a[:-1:2] == vector([42])
+    assert a[::2] == vector([42,44])
+    # negative step
+    assert a[-1::-2] == vector([44, 42])
+    assert a[-2::-2] == vector([44])
     return a[-2:-1]
 "#
             .to_string(),

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -82,6 +82,9 @@ def boolean_array() -> vector[f64]:
     
     df = PyDataFrame.from_sql("select number from numbers limit 5")
     print("df from sql=", df)
+    collected = df.collect()
+    print("df.collect()=", collected)
+    assert len(collected[0][0]) == 5
     try: 
         print("query()=", query())
     except KeyError as e:
@@ -107,9 +110,10 @@ def boolean_array() -> vector[f64]:
     from greptime import query, dataframe, PyDataFrame
     df = PyDataFrame.from_sql("select number from numbers limit 5")
     print("df from sql=", df)
-    ret = df.collect()[0][0]
+    ret = df.collect()
     print("df.collect()=", ret)
-    return ret
+    assert len(ret[0][0]) == 5
+    return ret[0][0]
 "#
             .to_string(),
             expect: Some(ronish!("value": vector!(UInt32Vector, [0, 1, 2, 3, 4]))),
@@ -228,6 +232,7 @@ def answer() -> vector[i64]:
     from greptime import vector
     import pyarrow as pa
     a = vector.from_pyarrow(pa.array([42, 43, 44]))
+    # slicing test
     return a[0:1]
 "#
             .to_string(),
@@ -239,6 +244,7 @@ def answer() -> vector[i64]:
 def answer() -> vector[i64]:
     from greptime import vector
     a = vector([42, 43, 44])
+    # slicing test
     return a[-2:-1]
 "#
             .to_string(),

--- a/src/script/src/python/ffi_types/vector.rs
+++ b/src/script/src/python/ffi_types/vector.rs
@@ -391,7 +391,8 @@ impl PyVector {
             Ok(v.into_pyobject(vm))
         } else if step.is_negative() {
             // Negative step require special treatment
-            for i in range.rev().step_by(step.unsigned_abs()) {
+            // range.start > range.stop if slice can found no-empty
+            for i in (range.end+1..range.start).rev().step_by(step.unsigned_abs()) {
                 // Safety: This mutable vector is created from the vector's data type.
                 buf.push_value_ref(vector.get_ref(i));
             }

--- a/src/script/src/python/ffi_types/vector.rs
+++ b/src/script/src/python/ffi_types/vector.rs
@@ -381,7 +381,6 @@ impl PyVector {
         // adjust_indices so negative number is transform to usize
         let (mut range, step, slice_len) = slice.adjust_indices(self.len());
         let vector = self.as_vector_ref();
-
         let mut buf = vector.data_type().create_mutable_vector(slice_len);
         if slice_len == 0 {
             let v: PyVector = buf.to_vector().into();
@@ -392,7 +391,7 @@ impl PyVector {
         } else if step.is_negative() {
             // Negative step require special treatment
             // range.start > range.stop if slice can found no-empty
-            for i in (range.end+1..range.start).rev().step_by(step.unsigned_abs()) {
+            for i in range.rev().step_by(step.unsigned_abs()) {
                 // Safety: This mutable vector is created from the vector's data type.
                 buf.push_value_ref(vector.get_ref(i));
             }

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -61,6 +61,7 @@ macro_rules! batch_import {
 #[pyo3(name = "greptime")]
 pub(crate) fn greptime_builtins(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyVector>()?;
+    m.add_class::<PyDataFrame>()?;
     use self::query_engine;
     batch_import!(
         m,

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -137,7 +137,7 @@ fn dataframe(py: Python) -> PyResult<PyDataFrame> {
 
 #[pyfunction]
 #[pyo3(name = "query")]
-fn query_engine(py: Python) -> PyResult<PyQueryEngine> {
+pub(crate) fn query_engine(py: Python) -> PyResult<PyQueryEngine> {
     let globals = get_globals(py)?;
     let query = globals
         .get_item("__query__")

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -142,7 +142,7 @@ coprocessor = copr
             py_any_to_vec(result, col_len)
         })()
         .map_err(|err| error::Error::PyRuntime {
-            msg: err.to_string(),
+            msg: err.into_value(py).to_string(),
             backtrace: Backtrace::generate(),
         })?;
         ensure!(
@@ -172,7 +172,7 @@ fn py_any_to_vec(obj: &PyAny, col_len: usize) -> PyResult<Vec<VectorRef>> {
 
         (0..tuple.len())
             .map(|idx| tuple.get_item(idx).map(|i| i.is_instance_of::<PyVector>()))
-            .all(|i| i.and_then(|i| i).unwrap_or(false))
+            .all(|i| matches!(i, Ok(Ok(true))))
     } else {
         obj.is_instance_of::<PyVector>()?
     };

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -31,9 +31,8 @@ use crate::python::pyo3::utils::{init_cpython_interpreter, pyo3_obj_try_to_typed
 impl PyQueryEngine {
     #[pyo3(name = "sql")]
     pub(crate) fn sql_pyo3(&self, py: Python<'_>, s: String) -> PyResult<PyObject> {
-        let query = self.get_ref();
         let res = self
-            .query_with_new_thread(query, s)
+            .query_with_new_thread(s)
             .map_err(PyValueError::new_err)?;
         match res {
             crate::python::ffi_types::copr::Either::Rb(rbs) => {

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -164,9 +164,9 @@ coprocessor = copr
 /// Cast return of py script result to `Vec<VectorRef>`,
 /// constants will be broadcast to length of `col_len`
 fn py_any_to_vec(obj: &PyAny, col_len: usize) -> PyResult<Vec<VectorRef>> {
-    // 1. check if obj is of two types:
-    // tuples of PyVector
-    // a single PyVector
+    // check if obj is of two types:
+    // 1. tuples of PyVector
+    // 2. a single PyVector
     let check = if obj.is_instance_of::<PyTuple>()? {
         let tuple = obj.downcast::<PyTuple>()?;
 

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -219,7 +219,7 @@ def a(cpu, mem, **kwargs):
     for k, v in kwargs.items():
         print("%s == %s" % (k, v))
     print(dataframe().select([col("cpu")<lit(0.3)]).collect())
-    return (0.5 < cpu) & ~( cpu >= 0.75)
+    return (0.5 < cpu) & ~(cpu >= 0.75)
     "#;
         let cpu_array = Float32Vector::from_slice([0.9f32, 0.8, 0.7, 0.3]);
         let mem_array = Float64Vector::from_slice([0.1f64, 0.2, 0.3, 0.4]);

--- a/src/script/src/python/pyo3/dataframe_impl.rs
+++ b/src/script/src/python/pyo3/dataframe_impl.rs
@@ -23,6 +23,7 @@ use snafu::ResultExt;
 
 use crate::python::error::DataFusionSnafu;
 use crate::python::ffi_types::PyVector;
+use crate::python::pyo3::builtins::query_engine;
 use crate::python::pyo3::utils::pyo3_obj_try_to_typed_scalar_value;
 use crate::python::utils::block_on_async;
 type PyExprRef = Py<PyExpr>;
@@ -50,14 +51,13 @@ impl PyDataFrame {
 #[pymethods]
 impl PyDataFrame {
     #[classmethod]
-    fn from_sql(_cls: &PyType, sql: String) -> PyResult<Self> {
-        block_on_async(async move {
-            let ctx = datafusion::execution::context::SessionContext::new();
-            ctx.sql(&sql).await
-        })
-        .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))?
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))
-        .map(|df| df.into())
+    fn from_sql(_cls: &PyType, py: Python, sql: String) -> PyResult<Self> {
+        let query = query_engine(py)?;
+        let rb = query.sql_to_rb(sql).map_err(PyRuntimeError::new_err)?;
+        let ctx = datafusion::execution::context::SessionContext::new();
+        ctx.read_batch(rb.df_record_batch().clone())
+            .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))
+            .map(Self::from)
     }
     fn __call__(&self) -> PyResult<Self> {
         Ok(self.clone())

--- a/src/script/src/python/pyo3/vector_impl.rs
+++ b/src/script/src/python/pyo3/vector_impl.rs
@@ -301,7 +301,7 @@ impl PyVector {
             Ok(ret)
         } else if let Ok(slice) = needle.downcast::<PySlice>(py) {
             let indices = slice.indices(self.len() as i64)?;
-            let (start, stop, step, slicelength) = (
+            let (start, stop, step, _slicelength) = (
                 indices.start,
                 indices.stop,
                 indices.step,
@@ -319,8 +319,6 @@ impl PyVector {
                 .create_mutable_vector(indices.slicelength as usize);
             let v = if indices.slicelength == 0 {
                 buf.to_vector()
-            } else if step == 1 {
-                vector.slice(start as usize, slicelength as usize)
             } else {
                 if indices.step > 0 {
                     let range = if stop == -1 {

--- a/src/script/src/python/rspython/builtins.rs
+++ b/src/script/src/python/rspython/builtins.rs
@@ -290,6 +290,7 @@ pub(crate) mod greptime_builtin {
     use common_function::scalars::math::PowFunction;
     use common_function::scalars::{Function, FunctionRef, FUNCTION_REGISTRY};
     use datafusion::arrow::datatypes::DataType as ArrowDataType;
+    use datafusion::dataframe::DataFrame as DfDataFrame;
     use datafusion::physical_plan::expressions;
     use datafusion_expr::{ColumnarValue as DFColValue, Expr as DfExpr};
     use datafusion_physical_expr::math_expressions;
@@ -300,19 +301,28 @@ pub(crate) mod greptime_builtin {
     use paste::paste;
     use rustpython_vm::builtins::{PyFloat, PyFunction, PyInt, PyStr};
     use rustpython_vm::function::{FuncArgs, KwArgs, OptionalArg};
-    use rustpython_vm::{AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine};
-
-    use super::{
-        all_to_f64, eval_aggr_fn, from_df_err, try_into_columnar_value, try_into_py_obj,
-        type_cast_error,
+    use rustpython_vm::{
+        pyclass, AsObject, PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine,
     };
+
     use crate::python::ffi_types::copr::PyQueryEngine;
     use crate::python::ffi_types::vector::val_to_pyobj;
     use crate::python::ffi_types::PyVector;
-    use crate::python::rspython::dataframe_impl::data_frame::{PyDataFrame, PyExpr, PyExprRef};
+    use crate::python::rspython::builtins::{
+        all_to_f64, eval_aggr_fn, from_df_err, try_into_columnar_value, try_into_py_obj,
+        type_cast_error,
+    };
+    use crate::python::rspython::dataframe_impl::data_frame::{PyExpr, PyExprRef};
     use crate::python::rspython::utils::{
         is_instance, py_obj_to_value, py_obj_to_vec, PyVectorRef,
     };
+
+    #[pyattr]
+    #[pyclass(module = "greptime_builtin", name = "PyDataFrame")]
+    #[derive(PyPayload, Debug, Clone)]
+    pub struct PyDataFrame {
+        pub inner: DfDataFrame,
+    }
 
     /// get `__dataframe__` from globals and return it
     /// TODO(discord9): this is a terrible hack, we should find a better way to get `__dataframe__`

--- a/src/script/src/python/rspython/builtins.rs
+++ b/src/script/src/python/rspython/builtins.rs
@@ -329,7 +329,7 @@ pub(crate) mod greptime_builtin {
     /// get `__query__` from globals and return it
     /// TODO(discord9): this is a terrible hack, we should find a better way to get `__query__`
     #[pyfunction]
-    fn query(vm: &VirtualMachine) -> PyResult<PyQueryEngine> {
+    pub(crate) fn query(vm: &VirtualMachine) -> PyResult<PyQueryEngine> {
         let query_engine = vm.current_globals().get_item("__query__", vm)?;
         let query_engine = query_engine.payload::<PyQueryEngine>().ok_or_else(|| {
             vm.new_type_error(format!("object {:?} is not a QueryEngine", query_engine))

--- a/src/script/src/python/rspython/builtins.rs
+++ b/src/script/src/python/rspython/builtins.rs
@@ -327,7 +327,7 @@ pub(crate) mod greptime_builtin {
     }
 
     /// get `__query__` from globals and return it
-    /// TODO(discord9): this is a terrible hack, we should find a better way to get `__dataframe__`
+    /// TODO(discord9): this is a terrible hack, we should find a better way to get `__query__`
     #[pyfunction]
     fn query(vm: &VirtualMachine) -> PyResult<PyQueryEngine> {
         let query_engine = vm.current_globals().get_item("__query__", vm)?;

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -14,8 +14,10 @@
 
 use rustpython_vm::class::PyClassImpl;
 use rustpython_vm::{pymodule as rspymodule, VirtualMachine};
+
+use crate::python::rspython::builtins::greptime_builtin::PyDataFrame;
 pub(crate) fn init_data_frame(module_name: &str, vm: &mut VirtualMachine) {
-    data_frame::PyDataFrame::make_class(&vm.ctx);
+    PyDataFrame::make_class(&vm.ctx);
     data_frame::PyExpr::make_class(&vm.ctx);
     vm.add_native_module(module_name.to_owned(), Box::new(data_frame::make_module));
 }
@@ -36,13 +38,10 @@ pub(crate) mod data_frame {
 
     use crate::python::error::DataFusionSnafu;
     use crate::python::ffi_types::PyVector;
-    use crate::python::rspython::builtins::greptime_builtin::{lit, query as get_query_engine};
+    use crate::python::rspython::builtins::greptime_builtin::{
+        lit, query as get_query_engine, PyDataFrame,
+    };
     use crate::python::utils::block_on_async;
-    #[rspyclass(module = "data_frame", name = "DataFrame")]
-    #[derive(PyPayload, Debug, Clone)]
-    pub struct PyDataFrame {
-        pub inner: DfDataFrame,
-    }
 
     impl From<DfDataFrame> for PyDataFrame {
         fn from(inner: DfDataFrame) -> Self {

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -63,6 +63,16 @@ pub(crate) mod data_frame {
     }
     #[rspyclass]
     impl PyDataFrame {
+        #[pymethod]
+        fn from_sql(sql: String, vm: &VirtualMachine) -> PyResult<Self> {
+            block_on_async(async move {
+                let ctx = datafusion::execution::context::SessionContext::new();
+                ctx.sql(&sql).await
+            })
+            .map_err(|e| vm.new_runtime_error(format!("{e:?}")))?
+            .map_err(|e| vm.new_runtime_error(e.to_string()))
+            .map(|df| df.into())
+        }
         /// TODO(discord9): error handling
         fn from_record_batch(rb: &DfRecordBatch) -> crate::python::error::Result<Self> {
             let ctx = datafusion::execution::context::SessionContext::new();

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -24,6 +24,7 @@ pub(crate) fn init_data_frame(module_name: &str, vm: &mut VirtualMachine) {
 pub(crate) mod data_frame {
     use common_recordbatch::{DfRecordBatch, RecordBatch};
     use datafusion::dataframe::DataFrame as DfDataFrame;
+    use datafusion::execution::context::SessionContext;
     use datafusion_expr::Expr as DfExpr;
     use rustpython_vm::builtins::{PyList, PyListRef};
     use rustpython_vm::function::PyComparisonValue;
@@ -69,14 +70,14 @@ pub(crate) mod data_frame {
             let rb = query_engine.sql_to_rb(sql.clone()).map_err(|e| {
                 vm.new_runtime_error(format!("failed to execute sql: {:?}, error: {:?}", sql, e))
             })?;
-            let ctx = datafusion::execution::context::SessionContext::new();
+            let ctx = SessionContext::new();
             ctx.read_batch(rb.df_record_batch().clone())
                 .map_err(|e| vm.new_runtime_error(format!("{e:?}")))
                 .map(|df| df.into())
         }
         /// TODO(discord9): error handling
         fn from_record_batch(rb: &DfRecordBatch) -> crate::python::error::Result<Self> {
-            let ctx = datafusion::execution::context::SessionContext::new();
+            let ctx = SessionContext::new();
             let inner = ctx.read_batch(rb.clone()).context(DataFusionSnafu)?;
             Ok(Self { inner })
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

You can now slice PyVector in Pythonic ways, i.e:
`a[1:2]` `a[-2:-1]` `a[-1:-2:-1]`

And be able to create DataFrame from sql! This use `query().sql()` to get a `RecordBatch` and convert it to `Dataframe` :
```python
dataframe.from_sql(...)
```

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
