### PR TITLE
refactor: port div_ceil from stdlib to avoid unstable features

### DIFF
--- a/src/common/time/src/lib.rs
+++ b/src/common/time/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(int_roundings)]
 // Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -26,6 +26,7 @@ use snafu::{OptionExt, ResultExt};
 
 use crate::error;
 use crate::error::{ArithmeticOverflowSnafu, Error, ParseTimestampSnafu, TimestampOverflowSnafu};
+use crate::util::div_ceil;
 
 #[derive(Debug, Clone, Default, Copy, Serialize, Deserialize)]
 pub struct Timestamp {
@@ -143,8 +144,7 @@ impl Timestamp {
             Some(Timestamp::new(value, unit))
         } else {
             let mul = unit.factor() / self.unit().factor();
-            let new_ts = self.value as f64 / mul as f64;
-            Some(Timestamp::new(new_ts.ceil() as i64, unit))
+            Some(Timestamp::new(div_ceil(self.value, mul as i64), unit))
         }
     }
 

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -143,7 +143,8 @@ impl Timestamp {
             Some(Timestamp::new(value, unit))
         } else {
             let mul = unit.factor() / self.unit().factor();
-            Some(Timestamp::new(self.value.div_ceil(mul as i64), unit))
+            let new_ts = self.value as f64 / mul as f64;
+            Some(Timestamp::new(new_ts.ceil() as i64, unit))
         }
     }
 

--- a/src/common/time/src/util.rs
+++ b/src/common/time/src/util.rs
@@ -17,6 +17,17 @@ pub fn current_time_millis() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
+/// Port of rust unstable features `int_roundings`.
+pub(crate) fn div_ceil(this: i64, rhs: i64) -> i64 {
+    let d = this / rhs;
+    let r = this % rhs;
+    if r > 0 && rhs > 0 {
+        d + 1
+    } else {
+        d
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{self, SystemTime};
@@ -41,5 +52,11 @@ mod tests {
         assert_eq!(datetime_std.day(), datetime_now.day());
         assert_eq!(datetime_std.hour(), datetime_now.hour());
         assert_eq!(datetime_std.minute(), datetime_now.minute());
+    }
+
+    #[test]
+    fn test_div_ceil() {
+        let v0 = 9223372036854676001;
+        assert_eq!(9223372036854677, div_ceil(v0, 1000));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When using our code base with those repos requires stable toolchains, like vector, unstable features block its compilation. This patch removes replaceable unstable feature in time module.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
