### PR TITLE
feat: Use actual key/value size as memtable size

### DIFF
--- a/src/storage/src/memtable/tests.rs
+++ b/src/storage/src/memtable/tests.rs
@@ -241,8 +241,7 @@ fn write_iter_memtable_case(ctx: &TestContext) {
         &[(None, None), (Some(5), None), (None, None)], // values
     );
 
-    // 9 key value pairs (6 + 3).
-    assert_eq!(704, ctx.memtable.bytes_allocated());
+    assert_eq!(1872, ctx.memtable.bytes_allocated());
 
     let batch_sizes = [1, 4, 8, consts::READ_BATCH_SIZE];
     for batch_size in batch_sizes {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Use actual key/value size as memtable's memory usage.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
