### PR TITLE
ci: release the standalone binaries with pyo3 and install python utils in images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,20 +32,36 @@ jobs:
             os: ubuntu-2004-16-cores
             file: greptime-linux-amd64
             continue-on-error: false
-            opts: "-F pyo3_backend"
           - arch: aarch64-unknown-linux-gnu
             os: ubuntu-2004-16-cores
             file: greptime-linux-arm64
             continue-on-error: false
-            opts: "-F pyo3_backend"
           - arch: aarch64-apple-darwin
             os: macos-latest
             file: greptime-darwin-arm64
             continue-on-error: false
-            opts: "-F pyo3_backend"
           - arch: x86_64-apple-darwin
             os: macos-latest
             file: greptime-darwin-amd64
+            continue-on-error: false
+          - arch: x86_64-unknown-linux-gnu
+            os: ubuntu-2004-16-cores
+            file: greptime-linux-amd64-pyo3
+            continue-on-error: false
+            opts: "-F pyo3_backend"
+          - arch: aarch64-unknown-linux-gnu
+            os: ubuntu-2004-16-cores
+            file: greptime-linux-arm64-pyo3
+            continue-on-error: false
+            opts: "-F pyo3_backend"
+          - arch: aarch64-apple-darwin
+            os: macos-latest
+            file: greptime-darwin-arm64-pyo3
+            continue-on-error: false
+            opts: "-F pyo3_backend"
+          - arch: x86_64-apple-darwin
+            os: macos-latest
+            file: greptime-darwin-amd64-pyo3
             continue-on-error: false
             opts: "-F pyo3_backend"
     runs-on: ${{ matrix.os }}
@@ -105,8 +121,8 @@ jobs:
           sudo apt-get -y update
           sudo apt-get -y install libssl-dev pkg-config g++-aarch64-linux-gnu gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu wget
 
-      - name: Compile Python 3.10.10 from source for Aarch64
-        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu')
+      - name: Compile Python 3.10.10 from source for aarch64-linux
+        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu') && contains(matrix.opts, 'pyo3_backend')
         run: |
           sudo chmod +x ./docker/aarch64/compile-python.sh
           sudo ./docker/aarch64/compile-python.sh
@@ -124,8 +140,8 @@ jobs:
         if: env.DISABLE_RUN_TESTS == 'false'
         run: make unit-test integration-test sqlness-test
 
-      - name: Run cargo build for aarch64-linux
-        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu')
+      - name: Run cargo build with pyo3 for aarch64-linux
+        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu') && contains(matrix.opts, 'pyo3_backend')
         run: |
           # TODO(zyy17): We should make PYO3_CROSS_LIB_DIR configurable.
           export PYO3_CROSS_LIB_DIR=$(pwd)/python_arm64_build/lib
@@ -134,7 +150,7 @@ jobs:
           cargo build --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} ${{ matrix.opts }}
 
       - name: Run cargo build
-        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu') == false
+        if: contains(matrix.arch, 'aarch64-unknown-linux-gnu') == false || contains(matrix.opts, 'pyo3_backend') == false
         run: cargo build --profile ${{ env.CARGO_PROFILE }} --locked --target ${{ matrix.arch }} ${{ matrix.opts }}
 
       - name: Calculate checksum and rename binary
@@ -196,20 +212,20 @@ jobs:
       - name: Download amd64 binary
         uses: actions/download-artifact@v3
         with:
-          name: greptime-linux-amd64
+          name: greptime-linux-amd64-pyo3
           path: amd64
 
       - name: Unzip the amd64 artifacts
         run: |
           cd amd64
-          tar xvf greptime-linux-amd64.tgz
-          rm greptime-linux-amd64.tgz
+          tar xvf greptime-linux-amd64-pyo3.tgz
+          rm greptime-linux-amd64-pyo3.tgz
 
       - name: Download arm64 binary
         id: download-arm64
         uses: actions/download-artifact@v3
         with:
-          name: greptime-linux-arm64
+          name: greptime-linux-arm64-pyo3
           path: arm64
 
       - name: Unzip the arm64 artifacts
@@ -217,8 +233,8 @@ jobs:
         if: success() || steps.download-arm64.conclusion == 'success'
         run: |
           cd arm64
-          tar xvf greptime-linux-arm64.tgz
-          rm greptime-linux-arm64.tgz
+          tar xvf greptime-linux-arm64-pyo3.tgz
+          rm greptime-linux-arm64-pyo3.tgz
 
       - name: Build and push all
         uses: docker/build-push-action@v3

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -3,7 +3,10 @@ FROM ubuntu:22.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
     python3 \
-    python3-dev
+    python3-dev \
+    python3-pip
+
+RUN pip install pyarrow
 
 ARG TARGETARCH
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,6 +1,9 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates \
+    python3 \
+    python3-dev
 
 ARG TARGETARCH
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,11 +2,11 @@ FROM ubuntu:22.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
-    python3 \
-    python3-dev \
+    python3.10 \
+    python3.10-dev \
     python3-pip
 
-RUN pip install pyarrow
+RUN python3 -m pip install pyarrow
 
 ARG TARGETARCH
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Release the standalone binaries with pyo3 support for multiple platforms;
2. Install `python3`/`python3-dev`/`python3-pip`/`pyarrow`(**We release the images with pyo3 function**);


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
