### PR TITLE
feat: Support sending multiple affected rows

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -273,6 +273,7 @@ fn check_others(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
     recordbatches.map(Output::RecordBatches)
 }
 
+// TODO(yingwen): Skip check for insert statements
 // Check whether the query is a federated or driver setup command,
 // and return some faked results if there are any.
 pub(crate) fn check(query: &str, query_ctx: QueryContextRef) -> Option<Output> {

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -273,10 +273,15 @@ fn check_others(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
     recordbatches.map(Output::RecordBatches)
 }
 
-// TODO(yingwen): Skip check for insert statements
 // Check whether the query is a federated or driver setup command,
 // and return some faked results if there are any.
 pub(crate) fn check(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
+    // INSERT don't need MySQL federated check. We assume the query doesn't contain
+    // federated or driver setup command if it starts with a 'INSERT' statement.
+    if query.len() > 6 && query[..6].eq_ignore_ascii_case("INSERT") {
+        return None;
+    }
+
     // First to check the query is like "select @@variables".
     let output = check_select_variable(query);
     if output.is_some() {

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -227,7 +227,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         writer: QueryResultWriter<'a, W>,
     ) -> Result<()> {
         let outputs = self.do_query(query).await;
-        writer::write_output(writer, &query, outputs).await?;
+        writer::write_output(writer, query, outputs).await?;
         Ok(())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

MySQL server supports sending multiple affected rows to the client. This is possible when the client is using JDBC to execute multiple insert statements.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
