### PR TITLE
feat: add gRPC reflection service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/MichaelScofield/greptime-proto.git?rev=94d603a098b10ee9b0c331b46356f31ea609d139#94d603a098b10ee9b0c331b46356f31ea609d139"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=eb760d219206c77dd3a105ecb6a3ba97d9d650ec#eb760d219206c77dd3a105ecb6a3ba97d9d650ec"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=dcf253314a05c9821bd90e7e09a168256c84f250#dcf253314a05c9821bd90e7e09a168256c84f250"
+source = "git+https://github.com/MichaelScofield/greptime-proto.git?rev=94d603a098b10ee9b0c331b46356f31ea609d139#94d603a098b10ee9b0c331b46356f31ea609d139"
 dependencies = [
  "prost",
  "tonic",
@@ -6927,6 +6927,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tonic",
+ "tonic-reflection",
  "tower",
  "tower-http",
 ]
@@ -8114,6 +8115,20 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67494bad4dda4c9bffae901dfe14e2b2c0f760adb4706dc10beeb81799f7f7b2"
+dependencies = [
+ "bytes",
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
 ]
 
 [[package]]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,7 +10,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-greptime-proto = { git = "https://github.com/MichaelScofield/greptime-proto.git", rev = "94d603a098b10ee9b0c331b46356f31ea609d139" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "eb760d219206c77dd3a105ecb6a3ba97d9d650ec" }
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tonic.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,7 +10,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "dcf253314a05c9821bd90e7e09a168256c84f250" }
+greptime-proto = { git = "https://github.com/MichaelScofield/greptime-proto.git", rev = "94d603a098b10ee9b0c331b46356f31ea609d139" }
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tonic.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -68,6 +68,7 @@ tokio-rustls = "0.23"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 tonic.workspace = true
+tonic-reflection = "0.6"
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
 

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -269,6 +269,12 @@ pub enum Error {
 
     #[snafu(display("Invalid flush argument: {}", err_msg))]
     InvalidFlushArgument { err_msg: String },
+
+    #[snafu(display("Failed to build gRPC reflection service, source: {}", source))]
+    GrpcReflectionService {
+        source: tonic_reflection::server::Error,
+        backtrace: Backtrace,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -287,6 +293,7 @@ impl ErrorExt for Error {
             | InvalidPromRemoteReadQueryResult { .. }
             | TcpBind { .. }
             | CatalogError { .. }
+            | GrpcReflectionService { .. }
             | BuildingContext { .. } => StatusCode::Internal,
 
             InsertScript { source, .. }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add gRPC server reflection, suitable for debugging and illustrating purpose.

Use [grpcurl](https://github.com/fullstorydev/grpcurl):

```text
➜  ~ grpcurl -plaintext 127.0.0.1:4001 list
greptime.v1.GreptimeDatabase
➜  ~ grpcurl -plaintext 127.0.0.1:4001 list greptime.v1.GreptimeDatabase
greptime.v1.GreptimeDatabase.Handle
greptime.v1.GreptimeDatabase.HandleRequests
➜  ~ grpcurl -plaintext 127.0.0.1:4001 describe greptime.v1.GreptimeDatabase.Handle
greptime.v1.GreptimeDatabase.Handle is a method:
rpc Handle ( .greptime.v1.GreptimeRequest ) returns ( .greptime.v1.GreptimeResponse );
➜  ~ grpcurl -plaintext 127.0.0.1:4001 describe greptime.v1.GreptimeRequest
greptime.v1.GreptimeRequest is a message:
message GreptimeRequest {
  .greptime.v1.RequestHeader header = 1;
  oneof request {
    .greptime.v1.InsertRequest insert = 2;
    .greptime.v1.QueryRequest query = 3;
    .greptime.v1.DdlRequest ddl = 4;
  }
}
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
