### PR TITLE
fix: losing region numbers after altering table

### DIFF
--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -523,6 +523,7 @@ async fn test_alter_table_add_column() {
     assert_eq!(new_schema.timestamp_column(), old_schema.timestamp_column());
     assert_eq!(new_schema.version(), old_schema.version() + 1);
     assert_eq!(new_meta.next_column_id, old_meta.next_column_id + 2);
+    assert_eq!(new_meta.region_numbers, old_meta.region_numbers);
 }
 
 #[tokio::test]
@@ -572,6 +573,7 @@ async fn test_alter_table_remove_column() {
     assert_eq!(&[1, 2], &new_meta.value_indices[..]);
     assert_eq!(new_schema.timestamp_column(), old_schema.timestamp_column());
     assert_eq!(new_schema.version(), old_schema.version() + 1);
+    assert_eq!(new_meta.region_numbers, old_meta.region_numbers);
 }
 
 #[tokio::test]

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -89,6 +89,9 @@ pub struct TableIdent {
     pub version: TableVersion,
 }
 
+/// The table medatadata
+/// Note: if you add new fields to this struct, please ensure 'new_meta_builder' function works.
+/// TODO(dennis): find a better way to ensure 'new_meta_builder' works when adding new fields.
 #[derive(Clone, Debug, Builder, PartialEq, Eq)]
 #[builder(pattern = "mutable")]
 pub struct TableMeta {
@@ -197,6 +200,7 @@ impl TableMeta {
             .engine_options(self.engine_options.clone())
             .options(self.options.clone())
             .created_on(self.created_on)
+            .region_numbers(self.region_numbers.clone())
             .next_column_id(self.next_column_id);
 
         builder
@@ -572,6 +576,7 @@ mod tests {
             .unwrap();
 
         let new_meta = add_columns_to_meta(&meta);
+        assert_eq!(meta.region_numbers, new_meta.region_numbers);
 
         let names: Vec<String> = new_meta
             .schema
@@ -605,6 +610,8 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
+
+        assert_eq!(meta.region_numbers, new_meta.region_numbers);
 
         let names: Vec<String> = new_meta
             .schema


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

After altering tables such as adding/removing columns, the `region_numbers` in table metadata is lost. Then after restarting the db instance, the altered table can't be scanned data at all, because it doesn't contain any regions.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
