### PR TITLE
chore: add cur `stat` to heartbeat handler's accumulator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ parquet = "34.0"
 paste = "1.0"
 prost = "0.11"
 rand = "0.8"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser = "0.32"

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -30,7 +30,7 @@ parking_lot = "0.12"
 prost.workspace = true
 rand.workspace = true
 regex = "1.6"
-serde = "1.0"
+serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true
 table = { path = "../table" }

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -237,6 +237,8 @@ fn need_retry(error: &error::Error) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use api::v1::meta::{Error, ErrorCode, KeyValue, ResponseHeader};
 
     use super::{check_resp_header, to_stat_kv_map, Context};
@@ -258,7 +260,11 @@ mod tests {
             is_leader: true,
             ..Default::default()
         };
-        let stat_val = StatValue { stats: vec![stat] }.try_into().unwrap();
+        let stat_val = StatValue {
+            stats: vec![Arc::new(stat)],
+        }
+        .try_into()
+        .unwrap();
 
         let kv = KeyValue {
             key: stat_key.clone().into(),

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -54,6 +54,10 @@ pub trait HeartbeatHandler: Send + Sync {
 #[derive(Debug, Default)]
 pub struct HeartbeatAccumulator {
     pub header: Option<ResponseHeader>,
+    /// current stat produced by [`collect_stats_handler`]
+    pub stat: Stat,
+    /// accumulated stats produced by [`collect_stats_handler`]
+    /// every [`max_cached_stats_per_key`] heartbeats
     pub stats: Vec<Stat>,
     pub instructions: Vec<Instruction>,
 }

--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -37,8 +37,8 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::RwLock;
 
 use self::instruction::Instruction;
-use self::node_stat::Stat;
 use crate::error::Result;
+use crate::handler::node_stat::StatRef;
 use crate::metasrv::Context;
 
 #[async_trait::async_trait]
@@ -55,10 +55,10 @@ pub trait HeartbeatHandler: Send + Sync {
 pub struct HeartbeatAccumulator {
     pub header: Option<ResponseHeader>,
     /// current stat produced by [`collect_stats_handler`]
-    pub stat: Stat,
+    pub stat: StatRef,
     /// accumulated stats produced by [`collect_stats_handler`]
     /// every [`max_cached_stats_per_key`] heartbeats
-    pub stats: Vec<Stat>,
+    pub stats: Vec<StatRef>,
     pub instructions: Vec<Instruction>,
 }
 

--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use api::v1::meta::HeartbeatRequest;
 use common_telemetry::debug;
@@ -21,6 +22,7 @@ use dashmap::DashMap;
 
 use super::node_stat::Stat;
 use crate::error::Result;
+use crate::handler::node_stat::StatRef;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
 
@@ -28,7 +30,7 @@ type StatKey = (u64, u64);
 
 pub struct CollectStatsHandler {
     max_cached_stats_per_key: usize,
-    cache: DashMap<StatKey, VecDeque<Stat>>,
+    cache: DashMap<StatKey, VecDeque<StatRef>>,
 }
 
 impl Default for CollectStatsHandler {
@@ -60,6 +62,7 @@ impl HeartbeatHandler for CollectStatsHandler {
 
         match Stat::try_from(req.clone()) {
             Ok(stat) => {
+                let stat = Arc::new(stat);
                 acc.stat = stat.clone();
 
                 let key = (stat.cluster_id, stat.id);

--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -60,6 +60,8 @@ impl HeartbeatHandler for CollectStatsHandler {
 
         match Stat::try_from(req.clone()) {
             Ok(stat) => {
+                acc.stat = stat.clone();
+
                 let key = (stat.cluster_id, stat.id);
                 match self.cache.entry(key) {
                     Entry::Occupied(mut e) => {

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use api::v1::meta::HeartbeatRequest;
 use common_time::util as time_util;
 use serde::{Deserialize, Serialize};
@@ -68,6 +70,8 @@ impl Stat {
         }
     }
 }
+
+pub type StatRef = Arc<Stat>;
 
 impl TryFrom<HeartbeatRequest> for Stat {
     type Error = ();

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::keys::StatKey;
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Stat {
     pub timestamp_millis: i64,
     pub cluster_id: u64,
@@ -46,7 +46,7 @@ pub struct Stat {
     pub region_stats: Vec<RegionStat>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RegionStat {
     pub id: u64,
     pub catalog: String,

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::keys::StatKey;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Stat {
     pub timestamp_millis: i64,
     pub cluster_id: u64,
@@ -44,7 +44,7 @@ pub struct Stat {
     pub region_stats: Vec<RegionStat>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegionStat {
     pub id: u64,
     pub catalog: String,

--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -87,12 +87,12 @@ mod tests {
 
         let req = HeartbeatRequest::default();
         let mut acc = HeartbeatAccumulator {
-            stats: vec![Stat {
+            stats: vec![Arc::new(Stat {
                 cluster_id: 3,
                 id: 101,
                 region_num: Some(100),
                 ..Default::default()
-            }],
+            })],
             ..Default::default()
         };
 

--- a/src/meta-srv/src/service/admin/heartbeat.rs
+++ b/src/meta-srv/src/service/admin/heartbeat.rs
@@ -79,6 +79,8 @@ fn filter_by_addr(stat_vals: Vec<StatValue>, addr: &str) -> Vec<StatValue> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::handler::node_stat::Stat;
     use crate::keys::StatValue;
     use crate::service::admin::heartbeat::filter_by_addr;
@@ -87,36 +89,36 @@ mod tests {
     async fn test_filter_by_addr() {
         let stat_value1 = StatValue {
             stats: vec![
-                Stat {
+                Arc::new(Stat {
                     addr: "127.0.0.1:3001".to_string(),
                     timestamp_millis: 1,
                     ..Default::default()
-                },
-                Stat {
+                }),
+                Arc::new(Stat {
                     addr: "127.0.0.1:3001".to_string(),
                     timestamp_millis: 2,
                     ..Default::default()
-                },
+                }),
             ],
         };
 
         let stat_value2 = StatValue {
             stats: vec![
-                Stat {
+                Arc::new(Stat {
                     addr: "127.0.0.1:3002".to_string(),
                     timestamp_millis: 3,
                     ..Default::default()
-                },
-                Stat {
+                }),
+                Arc::new(Stat {
                     addr: "127.0.0.1:3002".to_string(),
                     timestamp_millis: 4,
                     ..Default::default()
-                },
-                Stat {
+                }),
+                Arc::new(Stat {
                     addr: "127.0.0.1:3002".to_string(),
                     timestamp_millis: 5,
                     ..Default::default()
-                },
+                }),
             ],
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly
1. add a `stat` field to `HeartbeatAccumulator` so that later handler can make use of current heartbeat stat instead of re-make one from req
2. change to `Arc<Stat>` in `StatValue` to prevent cloning the whole struct

Please be aware, **this pr introduce serde's `rc` feature in root workspace**. If it's not preferred we can make `rc` feature restrict to `meta-srv` crate.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
