### PR TITLE
feat: add dbname and health check for grpc api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5c3f6f1387e62a5e6939bb0c881712cc2594fa6c#5c3f6f1387e62a5e6939bb0c881712cc2594fa6c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ff8c55bed0fa6e20577aa95af5b87f9c9e39b1e7#ff8c55bed0fa6e20577aa95af5b87f9c9e39b1e7"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e01556310c0c5fa2b71fcbeb3332d795965ac41a#e01556310c0c5fa2b71fcbeb3332d795965ac41a"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5c3f6f1387e62a5e6939bb0c881712cc2594fa6c#5c3f6f1387e62a5e6939bb0c881712cc2594fa6c"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,7 +3097,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=eb760d219206c77dd3a105ecb6a3ba97d9d650ec#eb760d219206c77dd3a105ecb6a3ba97d9d650ec"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e01556310c0c5fa2b71fcbeb3332d795965ac41a#e01556310c0c5fa2b71fcbeb3332d795965ac41a"
 dependencies = [
  "prost",
  "tonic",

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,7 +10,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5c3f6f1387e62a5e6939bb0c881712cc2594fa6c" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ff8c55bed0fa6e20577aa95af5b87f9c9e39b1e7" }
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tonic.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,7 +10,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e01556310c0c5fa2b71fcbeb3332d795965ac41a" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5c3f6f1387e62a5e6939bb0c881712cc2594fa6c" }
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tonic.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,7 +10,7 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "eb760d219206c77dd3a105ecb6a3ba97d9d650ec" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e01556310c0c5fa2b71fcbeb3332d795965ac41a" }
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tonic.workspace = true

--- a/src/client/src/client.rs
+++ b/src/client/src/client.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use api::v1::greptime_database_client::GreptimeDatabaseClient;
+use api::v1::health_check_client::HealthCheckClient;
+use api::v1::HealthCheckRequest;
 use arrow_flight::flight_service_client::FlightServiceClient;
 use common_grpc::channel_manager::ChannelManager;
 use parking_lot::RwLock;
@@ -152,6 +154,13 @@ impl Client {
         Ok(DatabaseClient {
             inner: GreptimeDatabaseClient::new(channel),
         })
+    }
+
+    pub async fn health_check(&self) -> Result<()> {
+        let (_, channel) = self.find_channel()?;
+        let mut client = HealthCheckClient::new(channel);
+        client.health_check(HealthCheckRequest {}).await?;
+        Ok(())
     }
 }
 

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -18,8 +18,8 @@ use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use api::v1::{
     greptime_response, AffectedRows, AlterExpr, AuthHeader, CreateTableExpr, DdlRequest,
-    DropTableExpr, FlushTableExpr, GreptimeRequest, HealthCheckRequest, InsertRequest,
-    PromRangeQuery, QueryRequest, RequestHeader,
+    DropTableExpr, FlushTableExpr, GreptimeRequest, InsertRequest, PromRangeQuery, QueryRequest,
+    RequestHeader,
 };
 use arrow_flight::{FlightData, Ticket};
 use common_error::prelude::*;
@@ -188,13 +188,6 @@ impl Database {
             expr: Some(DdlExpr::FlushTable(expr)),
         }))
         .await
-    }
-
-    pub async fn healthcheck(&self) -> Result<()> {
-        let mut client = self.client.make_database_client()?.inner;
-        let request = HealthCheckRequest {};
-        client.health_check(request).await?;
-        Ok(())
     }
 
     async fn do_get(&self, request: Request) -> Result<Output> {

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -114,7 +114,6 @@ impl Database {
                 schema: self.schema.clone(),
                 authorization: self.ctx.auth_header.clone(),
                 dbname: self.dbname.clone(),
-                ..Default::default()
             }),
             request: Some(Request::Insert(request)),
         };
@@ -197,7 +196,6 @@ impl Database {
                 schema: self.schema.clone(),
                 authorization: self.ctx.auth_header.clone(),
                 dbname: self.dbname.clone(),
-                ..Default::default()
             }),
             request: Some(request),
         };

--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -16,9 +16,7 @@ use std::sync::Arc;
 
 use api::v1::greptime_database_server::GreptimeDatabase;
 use api::v1::greptime_response::Response as RawResponse;
-use api::v1::{
-    AffectedRows, GreptimeRequest, GreptimeResponse, HealthCheckRequest, HealthCheckResponse,
-};
+use api::v1::{AffectedRows, GreptimeRequest, GreptimeResponse};
 use async_trait::async_trait;
 use common_query::Output;
 use futures::StreamExt;
@@ -84,12 +82,5 @@ impl GreptimeDatabase for DatabaseService {
             })),
         };
         Ok(Response::new(response))
-    }
-
-    async fn health_check(
-        &self,
-        _req: Request<HealthCheckRequest>,
-    ) -> TonicResult<Response<HealthCheckResponse>> {
-        Ok(Response::new(HealthCheckResponse {}))
     }
 }

--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -16,7 +16,9 @@ use std::sync::Arc;
 
 use api::v1::greptime_database_server::GreptimeDatabase;
 use api::v1::greptime_response::Response as RawResponse;
-use api::v1::{AffectedRows, GreptimeRequest, GreptimeResponse};
+use api::v1::{
+    AffectedRows, GreptimeRequest, GreptimeResponse, HealthCheckRequest, HealthCheckResponse,
+};
 use async_trait::async_trait;
 use common_query::Output;
 use futures::StreamExt;
@@ -82,5 +84,12 @@ impl GreptimeDatabase for DatabaseService {
             })),
         };
         Ok(Response::new(response))
+    }
+
+    async fn health_check(
+        &self,
+        _req: Request<HealthCheckRequest>,
+    ) -> TonicResult<Response<HealthCheckResponse>> {
+        Ok(Response::new(HealthCheckResponse {}))
     }
 }

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -50,6 +50,8 @@ pub enum Mode {
 /// and switch database using `USE` command
 /// - Postgres `database` parameter in Postgres wire protocol, required
 /// - HTTP RESTful API: the database parameter, optional
+/// - gRPC: the dbname field in header, optional but has a higher priority than
+/// original catalog/schema
 ///
 /// When database name is provided, we attempt to parse catalog and schema from
 /// it. We assume the format `[<catalog>-]<schema>`:

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -306,3 +306,16 @@ fn testing_create_expr() -> CreateTableExpr {
         region_ids: vec![0],
     }
 }
+
+#[tokio::test]
+pub async fn test_health_check() {
+    let (addr, mut guard, fe_grpc_server) =
+        setup_grpc_server(StorageType::File, "auto_create_table").await;
+
+    let grpc_client = Client::with_urls(vec![addr]);
+    let r = grpc_client.health_check().await;
+    assert!(r.is_ok());
+
+    let _ = fe_grpc_server.shutdown().await;
+    guard.remove_all().await;
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Please merge https://github.com/GreptimeTeam/greptime-proto/pull/18 first.

This patch provides two new additions for our grpc protocol:

- new `dbname` field that compatible with naming rule with http/mysql/postgresql protocol servers, so that in multi-tenant environment we won't expose catalog/schema concepts to user. 
- a new health check service as it requires health probe in some environment

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
