### PR TITLE
fix: allow larger compaction window to reduce parallel task num

### DIFF
--- a/src/storage/src/compaction/strategy.rs
+++ b/src/storage/src/compaction/strategy.rs
@@ -143,12 +143,14 @@ fn infer_time_bucket(files: &[FileHandle]) -> i64 {
 }
 
 /// A set of predefined time buckets.
-const TIME_BUCKETS: [i64; 5] = [
-    60 * 60,          // one hour
-    2 * 60 * 60,      // two hours
-    12 * 60 * 60,     // twelve hours
-    24 * 60 * 60,     // one day
-    7 * 24 * 60 * 60, // one week
+const TIME_BUCKETS: [i64; 7] = [
+    60 * 60,                 // one hour
+    2 * 60 * 60,             // two hours
+    12 * 60 * 60,            // twelve hours
+    24 * 60 * 60,            // one day
+    7 * 24 * 60 * 60,        // one week
+    365 * 24 * 60 * 60,      // one year
+    10 * 365 * 24 * 60 * 60, // ten years
 ];
 
 /// Fits a given time span into time bucket by find the minimum bucket that can cover the span.
@@ -213,7 +215,7 @@ mod tests {
         assert_eq!(TIME_BUCKETS[2], fit_time_bucket(TIME_BUCKETS[2] - 1));
         assert_eq!(TIME_BUCKETS[2], fit_time_bucket(TIME_BUCKETS[2]));
         assert_eq!(TIME_BUCKETS[3], fit_time_bucket(TIME_BUCKETS[3] - 1));
-        assert_eq!(TIME_BUCKETS[4], fit_time_bucket(i64::MAX));
+        assert_eq!(TIME_BUCKETS[6], fit_time_bucket(i64::MAX));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR allows a larger compaction time bucket so that when compaction input involves a very wide time span, it won't be splitted into enumerous output files and exhaust file descriptors.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
