### PR TITLE
fix: Holds FileHandle in ParquetReader to avoid the purger purges it

### DIFF
--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -187,7 +187,7 @@ impl ChunkReaderBuilder {
                 );
                 continue;
             }
-            let reader = self.sst_layer.read_sst(file.file_id(), &read_opts).await?;
+            let reader = self.sst_layer.read_sst(file.clone(), &read_opts).await?;
 
             reader_builder = reader_builder.push_batch_reader(reader);
         }

--- a/src/storage/src/test_util/access_layer_util.rs
+++ b/src/storage/src/test_util/access_layer_util.rs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 use crate::read::BoxedBatchReader;
-use crate::sst::{AccessLayer, FileId, ReadOptions, Source, SstInfo, WriteOptions};
+use crate::sst::{AccessLayer, FileHandle, FileId, ReadOptions, Source, SstInfo, WriteOptions};
 
 #[derive(Debug)]
 pub struct MockAccessLayer;
 
 #[async_trait::async_trait]
 impl AccessLayer for MockAccessLayer {
+    fn sst_file_path(&self, file_name: &str) -> String {
+        file_name.to_string()
+    }
+
     async fn write_sst(
         &self,
         _file_id: FileId,
@@ -31,7 +35,7 @@ impl AccessLayer for MockAccessLayer {
 
     async fn read_sst(
         &self,
-        _file_id: FileId,
+        _file_handle: FileHandle,
         _opts: &ReadOptions,
     ) -> crate::error::Result<BoxedBatchReader> {
         unimplemented!()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Holds FileHandle in ParquetReader to avoid the purger purges it

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1215 