### PR TITLE
refactor: make sql function in scripts return a list of column vectors

### DIFF
--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -380,7 +380,7 @@ import greptime as gt
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number) -> vector[u32]:
     from greptime import query
-    return query().sql("select * from numbers")[0][0]
+    return query().sql("select * from numbers")[0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/ffi_types.rs
+++ b/src/script/src/python/ffi_types.rs
@@ -16,6 +16,6 @@ pub(crate) mod copr;
 pub(crate) mod utils;
 pub(crate) mod vector;
 pub(crate) use copr::{check_args_anno_real_type, select_from_rb, Coprocessor};
-pub(crate) use vector::PyVector;
+pub(crate) use vector::{PyVector, PyVectorRef};
 #[cfg(test)]
 mod pair_tests;

--- a/src/script/src/python/ffi_types/vector.rs
+++ b/src/script/src/python/ffi_types/vector.rs
@@ -49,6 +49,8 @@ pub struct PyVector {
     pub(crate) vector: VectorRef,
 }
 
+pub(crate) type PyVectorRef = PyRef<PyVector>;
+
 impl From<VectorRef> for PyVector {
     fn from(vector: VectorRef) -> Self {
         Self { vector }

--- a/src/script/src/python/rspython/builtins.rs
+++ b/src/script/src/python/rspython/builtins.rs
@@ -307,15 +307,13 @@ pub(crate) mod greptime_builtin {
 
     use crate::python::ffi_types::copr::PyQueryEngine;
     use crate::python::ffi_types::vector::val_to_pyobj;
-    use crate::python::ffi_types::PyVector;
+    use crate::python::ffi_types::{PyVector, PyVectorRef};
     use crate::python::rspython::builtins::{
         all_to_f64, eval_aggr_fn, from_df_err, try_into_columnar_value, try_into_py_obj,
         type_cast_error,
     };
     use crate::python::rspython::dataframe_impl::data_frame::{PyExpr, PyExprRef};
-    use crate::python::rspython::utils::{
-        is_instance, py_obj_to_value, py_obj_to_vec, PyVectorRef,
-    };
+    use crate::python::rspython::utils::{is_instance, py_obj_to_value, py_obj_to_vec};
 
     #[pyattr]
     #[pyclass(module = "greptime_builtin", name = "PyDataFrame")]

--- a/src/script/src/python/rspython/utils.rs
+++ b/src/script/src/python/rspython/utils.rs
@@ -22,15 +22,13 @@ use datatypes::vectors::{
     BooleanVector, Float64Vector, Helper, Int64Vector, NullVector, StringVector, VectorRef,
 };
 use rustpython_vm::builtins::{PyBaseExceptionRef, PyBool, PyFloat, PyInt, PyList, PyStr};
-use rustpython_vm::{PyObjectRef, PyPayload, PyRef, PyResult, VirtualMachine};
+use rustpython_vm::{PyObjectRef, PyPayload, PyResult, VirtualMachine};
 use snafu::{Backtrace, GenerateImplicitData, OptionExt, ResultExt};
 
 use crate::python::error;
 use crate::python::error::ret_other_error_with;
 use crate::python::ffi_types::PyVector;
 use crate::python::rspython::builtins::try_into_columnar_value;
-
-pub(crate) type PyVectorRef = PyRef<PyVector>;
 
 /// use `rustpython`'s `is_instance` method to check if a PyObject is a instance of class.
 /// if `PyResult` is Err, then this function return `false`


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The current `sql` function in the coprocessor returns a list of lists such as `list[list[vector]]`. The query result is a list of `RecordBatch` and it converts each`RecordBatch` into a list of column vectors. It's not friendly to users and batch splitting is not necessary at all for the coprocessor.

So in this PR, I changed the return result type to `list[Vector]`: a list of column vectors. It concatenates all vectors from each batch into one vector for each column.

For example:

```python
import greptime

greptime.query().sql("select number as a, number as b from numbers limit 10")
```

It will return a list of two elements:
* The first one is `a` column and which is a vector.
* The second one is `b` column and which is a vector too.

It's much easier for users to process the query result.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
