### PR TITLE
feat: upgrade opendal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ dependencies = [
 name = "common-procedure"
 version = "0.1.1"
 dependencies = [
+ "async-stream",
  "async-trait",
  "backon 0.4.0",
  "common-error",
@@ -4558,11 +4559,13 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "common-telemetry",
  "common-test-util",
  "futures",
  "lru 0.9.0",
  "opendal",
+ "pin-project",
  "tokio",
  "uuid",
 ]
@@ -4601,9 +4604,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.27.2"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6f7b936f2f8483e19643357cb50d9ec9a49c506971ef69ca676913cf5afd91"
+checksum = "bc08c1c75e26f33f13f22c46b0c222132df5e12519fd67046ecf061b58e8c26f"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -482,11 +482,9 @@ mod tests {
     pub async fn prepare_table_engine() -> (TempDir, TableEngineRef) {
         let dir = create_temp_dir("system-table-test");
         let store_dir = dir.path().to_string_lossy();
-        let accessor = object_store::services::Fs::default()
-            .root(&store_dir)
-            .build()
-            .unwrap();
-        let object_store = ObjectStore::new(accessor).finish();
+        let mut builder = object_store::services::Fs::default();
+        builder.root(&store_dir);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
         let noop_compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
         let table_engine = Arc::new(MitoEngine::new(
             EngineConfig::default(),

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -400,7 +400,7 @@ mod tests {
     use log_store::NoopLogStore;
     use mito::config::EngineConfig;
     use mito::engine::MitoEngine;
-    use object_store::{ObjectStore, ObjectStoreBuilder};
+    use object_store::ObjectStore;
     use storage::compaction::noop::NoopCompactionScheduler;
     use storage::config::EngineConfig as StorageEngineConfig;
     use storage::EngineImpl;

--- a/src/common/datasource/src/lister.rs
+++ b/src/common/datasource/src/lister.rs
@@ -73,10 +73,10 @@ impl Lister {
                 let file_full_path = format!("{}{}", self.path, filename);
                 let _ = self.object_store.stat(&file_full_path).await.context(
                     error::ListObjectsSnafu {
-                        path: file_full_path,
+                        path: &file_full_path,
                     },
-                );
-                Ok(vec![Entry::new(&self.path)])
+                )?;
+                Ok(vec![Entry::new(&file_full_path)])
             }
         }
     }

--- a/src/common/datasource/src/lister.rs
+++ b/src/common/datasource/src/lister.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use futures::{future, TryStreamExt};
-use object_store::{Object, ObjectStore};
+use object_store::{Entry, ObjectStore};
 use regex::Regex;
 use snafu::ResultExt;
 
@@ -46,13 +46,12 @@ impl Lister {
         }
     }
 
-    pub async fn list(&self) -> Result<Vec<Object>> {
+    pub async fn list(&self) -> Result<Vec<Entry>> {
         match &self.source {
             Source::Dir => {
                 let streamer = self
                     .object_store
-                    .object(&self.path)
-                    .list()
+                    .list(&self.path)
                     .await
                     .context(error::ListObjectsSnafu { path: &self.path })?;
 
@@ -70,11 +69,14 @@ impl Lister {
                     .context(error::ListObjectsSnafu { path: &self.path })
             }
             Source::Filename(filename) => {
-                let obj = self
-                    .object_store
-                    .object(&format!("{}{}", self.path, filename));
-
-                Ok(vec![obj])
+                // make sure this file exists
+                let file_full_path = format!("{}{}", self.path, filename);
+                let _ = self.object_store.stat(&file_full_path).await.context(
+                    error::ListObjectsSnafu {
+                        path: file_full_path,
+                    },
+                );
+                Ok(vec![Entry::new(&self.path)])
             }
         }
     }

--- a/src/common/datasource/src/object_store/fs.rs
+++ b/src/common/datasource/src/object_store/fs.rs
@@ -13,16 +13,16 @@
 // limitations under the License.
 
 use object_store::services::Fs;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::ObjectStore;
 use snafu::ResultExt;
 
-use crate::error::{self, Result};
+use crate::error::{BuildBackendSnafu, Result};
 
 pub fn build_fs_backend(root: &str) -> Result<ObjectStore> {
-    let accessor = Fs::default()
-        .root(root)
-        .build()
-        .context(error::BuildBackendSnafu)?;
-
-    Ok(ObjectStore::new(accessor).finish())
+    let mut builder = Fs::default();
+    builder.root(root);
+    let object_store = ObjectStore::new(builder)
+        .context(BuildBackendSnafu)?
+        .finish();
+    Ok(object_store)
 }

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use object_store::services::S3;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::ObjectStore;
 use snafu::ResultExt;
 
 use crate::error::{self, Result};
@@ -73,7 +73,7 @@ pub fn build_s3_backend(
         }
     }
 
-    let accessor = builder.build().context(error::BuildBackendSnafu)?;
-
-    Ok(ObjectStore::new(accessor).finish())
+    Ok(ObjectStore::new(builder)
+        .context(error::BuildBackendSnafu)?
+        .finish())
 }

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+async-stream.workspace = true
 common-error = { path = "../error" }
 common-runtime = { path = "../runtime" }
 common-telemetry = { path = "../telemetry" }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -434,7 +434,7 @@ mod test_util {
     pub(crate) fn new_object_store(dir: &TempDir) -> ObjectStore {
         let store_dir = dir.path().to_str().unwrap();
         let mut builder = Builder::default();
-        builder.root(store_dir).build().unwrap();
+        builder.root(store_dir);
         ObjectStore::new(builder).unwrap().finish()
     }
 }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -423,7 +423,6 @@ impl ProcedureManager for LocalManager {
 mod test_util {
     use common_test_util::temp_dir::TempDir;
     use object_store::services::Fs as Builder;
-    use object_store::ObjectStoreBuilder;
 
     use super::*;
 

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -433,8 +433,9 @@ mod test_util {
 
     pub(crate) fn new_object_store(dir: &TempDir) -> ObjectStore {
         let store_dir = dir.path().to_str().unwrap();
-        let accessor = Builder::default().root(store_dir).build().unwrap();
-        ObjectStore::new(accessor).finish()
+        let mut builder = Builder::default();
+        builder.root(store_dir).build().unwrap();
+        ObjectStore::new(builder).unwrap().finish()
     }
 }
 

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -473,8 +473,7 @@ mod tests {
 
     async fn check_files(object_store: &ObjectStore, procedure_id: ProcedureId, files: &[&str]) {
         let dir = format!("{procedure_id}/");
-        let object = object_store.object(&dir);
-        let lister = object.list().await.unwrap();
+        let lister = object_store.list(&dir).await.unwrap();
         let mut files_in_dir: Vec<_> = lister
             .map_ok(|de| de.name().to_string())
             .try_collect()

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -248,7 +248,6 @@ mod tests {
     use async_trait::async_trait;
     use common_test_util::temp_dir::{create_temp_dir, TempDir};
     use object_store::services::Fs as Builder;
-    use object_store::ObjectStoreBuilder;
 
     use super::*;
     use crate::{Context, LockKey, Procedure, Status};

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -255,8 +255,9 @@ mod tests {
 
     fn procedure_store_for_test(dir: &TempDir) -> ProcedureStore {
         let store_dir = dir.path().to_str().unwrap();
-        let accessor = Builder::default().root(store_dir).build().unwrap();
-        let object_store = ObjectStore::new(accessor).finish();
+        let mut builder = Builder::default();
+        builder.root(store_dir).build().unwrap();
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         ProcedureStore::from(object_store)
     }

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -256,7 +256,7 @@ mod tests {
     fn procedure_store_for_test(dir: &TempDir) -> ProcedureStore {
         let store_dir = dir.path().to_str().unwrap();
         let mut builder = Builder::default();
-        builder.root(store_dir).build().unwrap();
+        builder.root(store_dir);
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
         ProcedureStore::from(object_store)

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
-use futures::{Stream, StreamExt, TryStreamExt};
+use futures::{Stream, StreamExt};
 use object_store::{EntryMode, Metakey, ObjectStore};
 use snafu::ResultExt;
 
@@ -117,6 +117,7 @@ impl StateStore for ObjectStateStore {
 #[cfg(test)]
 mod tests {
     use common_test_util::temp_dir::create_temp_dir;
+    use futures_util::TryStreamExt;
     use object_store::services::Fs as Builder;
 
     use super::*;

--- a/src/datanode/src/sql/copy_table_from.rs
+++ b/src/datanode/src/sql/copy_table_from.rs
@@ -48,7 +48,6 @@ impl SqlHandler {
             build_backend(&req.location, req.connection).context(error::BuildBackendSnafu)?;
 
         let (dir, filename) = find_dir_and_filename(&path);
-
         let regex = req
             .pattern
             .as_ref()

--- a/src/datanode/src/sql/copy_table_from.rs
+++ b/src/datanode/src/sql/copy_table_from.rs
@@ -62,16 +62,18 @@ impl SqlHandler {
             Source::Dir
         };
 
-        let lister = Lister::new(object_store, source, dir, regex);
+        let lister = Lister::new(object_store.clone(), source, dir, regex);
 
-        let objects = lister.list().await.context(error::ListObjectsSnafu)?;
+        let entries = lister.list().await.context(error::ListObjectsSnafu)?;
 
         let mut buf: Vec<RecordBatch> = Vec::new();
 
-        for obj in objects.iter() {
-            let reader = obj.reader().await.context(error::ReadObjectSnafu {
-                path: &obj.path().to_string(),
-            })?;
+        for entry in entries.iter() {
+            let path = entry.path();
+            let reader = object_store
+                .reader(path)
+                .await
+                .context(error::ReadObjectSnafu { path })?;
 
             let buf_reader = BufReader::new(reader.compat());
 

--- a/src/datanode/src/sql/copy_table_to.rs
+++ b/src/datanode/src/sql/copy_table_to.rs
@@ -136,10 +136,10 @@ impl ParquetWriter {
             // "file_name_1_1000000"        (row num: 1 ~ 1000000),
             // "file_name_1000001_xxx"      (row num: 1000001 ~ xxx)
             let file_name = format!("{}_{}_{}", self.file_name, start_row_num, total_rows);
-            let object = self.object_store.object(&file_name);
-            object.write(buf).await.context(error::WriteObjectSnafu {
-                path: object.path(),
-            })?;
+            self.object_store
+                .write(&file_name, buf)
+                .await
+                .context(error::WriteObjectSnafu { path: file_name })?;
 
             if end_loop {
                 return Ok(total_rows);

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -98,8 +98,9 @@ pub fn build_test_table_info() -> TableInfo {
 pub async fn new_test_object_store(prefix: &str) -> (TempDir, ObjectStore) {
     let dir = create_temp_dir(prefix);
     let store_dir = dir.path().to_string_lossy();
-    let accessor = Builder::default().root(&store_dir).build().unwrap();
-    (dir, ObjectStore::new(accessor).finish())
+    let mut builder = Builder::default();
+    builder.root(&store_dir);
+    (dir, ObjectStore::new(builder).unwrap().finish())
 }
 
 pub fn new_create_request(schema: SchemaRef) -> CreateTableRequest {

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -23,7 +23,7 @@ use datatypes::schema::{ColumnSchema, RawSchema, Schema, SchemaBuilder, SchemaRe
 use datatypes::vectors::{Float64Vector, StringVector, TimestampMillisecondVector, VectorRef};
 use log_store::NoopLogStore;
 use object_store::services::Fs as Builder;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::ObjectStore;
 use storage::compaction::noop::NoopCompactionScheduler;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -7,8 +7,10 @@ license.workspace = true
 [dependencies]
 lru = "0.9"
 async-trait = "0.1"
+bytes = "1.4"
 futures = { version = "0.3" }
-opendal = { version = "0.27", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.30", features = ["layers-tracing", "layers-metrics"] }
+pin-project = "1.0"
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -99,8 +99,8 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
                 let size = rp.clone().into_metadata().content_length();
                 let (_, mut writer) = self.cache.write(&cache_path, OpWrite::new()).await?;
 
-                // Looks like we don't have any other choice than loading content from reader to memory
-                // given that writer *may* not support append.
+                // TODO(hl): We can use [Writer::append](https://docs.rs/opendal/0.30.4/opendal/struct.Writer.html#method.append)
+                // here to avoid loading whole file into memory once all our backend supports `Writer`.
                 let mut buf = vec![0; size as usize];
                 reader.read(&mut buf).await?;
                 writer.write(Bytes::from(buf)).await?;

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io;
 use std::num::NonZeroUsize;
 use std::ops::DerefMut;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
 use async_trait::async_trait;
-use futures::AsyncRead;
+use bytes::Bytes;
 use lru::LruCache;
 use opendal::ops::*;
+use opendal::raw::oio::{Read, Reader, Write};
 use opendal::raw::*;
 use opendal::{ErrorKind, Result};
 use tokio::sync::Mutex;
@@ -68,11 +66,15 @@ impl<I, C> LruCacheAccessor<I, C> {
     }
 }
 
+use opendal::raw::oio::ReadExt;
+
 #[async_trait]
 impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
     type Inner = I;
-    type Reader = output::Reader;
+    type Reader = Box<dyn Read>;
     type BlockingReader = I::BlockingReader;
+    type Writer = I::Writer;
+    type BlockingWriter = I::BlockingWriter;
     type Pager = I::Pager;
     type BlockingPager = I::BlockingPager;
 
@@ -92,17 +94,15 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
                 lru_cache.get_or_insert(cache_path.clone(), || ());
                 Ok(to_output_reader((rp, r)))
             }
-            Err(err) if err.kind() == ErrorKind::ObjectNotFound => {
-                let (rp, reader) = self.inner.read(&path, args.clone()).await?;
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                let (rp, mut reader) = self.inner.read(&path, args.clone()).await?;
                 let size = rp.clone().into_metadata().content_length();
-                let _ = self
-                    .cache
-                    .write(
-                        &cache_path,
-                        OpWrite::new(size),
-                        Box::new(ReadWrapper(reader)),
-                    )
-                    .await?;
+                let (_, mut writer) = self.cache.write(&cache_path, OpWrite::new()).await?;
+
+                let mut buf = Vec::with_capacity(size as usize);
+                reader.read(&mut buf).await?;
+                writer.write(Bytes::from(buf)).await?;
+
                 match self.cache.read(&cache_path, OpRead::default()).await {
                     Ok((rp, reader)) => {
                         let r = {
@@ -123,8 +123,8 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
         }
     }
 
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        self.inner.blocking_read(path, args)
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        self.inner.write(path, args).await
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
@@ -158,6 +158,14 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
         self.inner.scan(path, args).await
     }
 
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        self.inner.blocking_read(path, args)
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        self.inner.blocking_write(path, args)
+    }
+
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
         self.inner.blocking_list(path, args)
     }
@@ -167,22 +175,24 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
     }
 }
 
-/// TODO: Workaround for output::Read doesn't implement input::Read
-///
-/// Should be remove after opendal fixed it.
-struct ReadWrapper<R>(R);
-
-impl<R: output::Read> AsyncRead for ReadWrapper<R> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<io::Result<usize>> {
-        self.0.poll_read(cx, buf)
-    }
-}
+// /// TODO: Workaround for output::Read doesn't implement input::Read
+// ///
+// /// Should be remove after opendal fixed it.
+// #[pin_project]
+// struct ReadWrapper<R>(R);
+//
+// impl<R: Read> AsyncRead for ReadWrapper<R> {
+//     fn poll_read(
+//         mut self: Pin<&mut Self>,
+//         cx: &mut Context<'_>,
+//         buf: &mut [u8],
+//     ) -> Poll<io::Result<usize>> {
+//         let this = self.project();
+//         (&this as &dyn Read).poll_read(cx, buf)
+//     }
+// }
 
 #[inline]
-fn to_output_reader<R: output::Read + 'static>(input: (RpRead, R)) -> (RpRead, output::Reader) {
+fn to_output_reader<R: Read + 'static>(input: (RpRead, R)) -> (RpRead, Reader) {
     (input.0, Box::new(input.1))
 }

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -99,7 +99,7 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
                 let size = rp.clone().into_metadata().content_length();
                 let (_, mut writer) = self.cache.write(&cache_path, OpWrite::new()).await?;
 
-                let mut buf = Vec::with_capacity(size as usize);
+                let mut buf = vec![0; size as usize];
                 reader.read(&mut buf).await?;
                 writer.write(Bytes::from(buf)).await?;
 

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use lru::LruCache;
-use opendal::ops::*;
+use opendal::ops::{OpDelete, OpList, OpRead, OpScan, OpWrite};
 use opendal::raw::oio::{Read, Reader, Write};
-use opendal::raw::*;
+use opendal::raw::{Accessor, Layer, LayeredAccessor, RpDelete, RpList, RpRead, RpScan, RpWrite};
 use opendal::{ErrorKind, Result};
 use tokio::sync::Mutex;
 

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use opendal::raw::oio::Pager;
 pub use opendal::{
-    layers, services, Builder as ObjectStoreBuilder, Error, ErrorKind, Object, ObjectLister,
-    ObjectMetadata, ObjectMode, Operator as ObjectStore, Result,
+    layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
+    Operator as ObjectStore, Result,
 };
+
 pub mod cache_policy;
 pub mod test_util;
 pub mod util;

--- a/src/object-store/src/test_util.rs
+++ b/src/object-store/src/test_util.rs
@@ -29,7 +29,6 @@ impl TempFolder {
     }
 
     pub async fn remove_all(&mut self) -> Result<()> {
-        let batch = self.store.batch();
-        batch.remove_all(&self.path).await
+        self.store.remove_all(&self.path).await
     }
 }

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -13,10 +13,9 @@
 // limitations under the License.
 
 use futures::TryStreamExt;
+use opendal::{Entry, Lister};
 
-use crate::{Object, ObjectLister};
-
-pub async fn collect(stream: ObjectLister) -> Result<Vec<Object>, opendal::Error> {
+pub async fn collect(stream: Lister) -> Result<Vec<Entry>, opendal::Error> {
     stream.try_collect::<Vec<_>>().await
 }
 

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -53,28 +53,31 @@ async fn test_object_crud(store: &ObjectStore) -> Result<()> {
 async fn test_object_list(store: &ObjectStore) -> Result<()> {
     // Create  some object handlers.
     // Write something
-    store.write("test_file1", "Hello, object1!").await?;
-    store.write("test_file2", "Hello, object2!").await?;
-    store.write("test_file3", "Hello, object3!").await?;
+    let p1 = "test_file1";
+    let p2 = "test_file2";
+    let p3 = "test_file3";
+    store.write(p1, "Hello, object1!").await?;
+    store.write(p2, "Hello, object2!").await?;
+    store.write(p3, "Hello, object3!").await?;
 
     // List objects
     let lister = store.list("/").await?;
     let entries = util::collect(lister).await?;
     assert_eq!(3, entries.len());
 
-    store.delete(entries.get(0).unwrap().path()).await?;
-    store.delete(entries.get(2).unwrap().path()).await?;
+    store.delete(p1).await?;
+    store.delete(p3).await?;
 
-    // List obejcts again
+    // List objects again
+    // Only o2 is exists
     let entries = util::collect(store.list("/").await?).await?;
     assert_eq!(1, entries.len());
+    assert_eq!(p2, entries.get(0).unwrap().path());
 
-    // Only o2 is exists
-    let o2 = entries.get(0).unwrap();
-    let content = store.read(o2.path()).await?;
+    let content = store.read(p2).await?;
     assert_eq!("Hello, object2!", String::from_utf8(content)?);
 
-    store.delete(o2.path()).await?;
+    store.delete(p2).await?;
     let entries = util::collect(store.list("/").await?).await?;
     assert!(entries.is_empty());
     Ok(())

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -277,8 +277,10 @@ mod tests {
     async fn test_sst_reader() {
         let dir = create_temp_dir("write_parquet");
         let path = dir.path().to_str().unwrap();
-        let backend = Fs::default().root(path).build().unwrap();
-        let object_store = ObjectStore::new(backend).finish();
+        let mut builder = Fs::default();
+        builder.root(path);
+
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let seq = AtomicU64::new(0);
         let schema = schema_for_test();
@@ -354,8 +356,9 @@ mod tests {
     async fn test_sst_split() {
         let dir = create_temp_dir("write_parquet");
         let path = dir.path().to_str().unwrap();
-        let backend = Fs::default().root(path).build().unwrap();
-        let object_store = ObjectStore::new(backend).finish();
+        let mut builder = Fs::default();
+        builder.root(path);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let schema = schema_for_test();
         let seq = AtomicU64::new(0);

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -93,7 +93,7 @@ mod tests {
         TimestampMillisecondVector, TimestampMillisecondVectorBuilder, UInt64VectorBuilder,
     };
     use object_store::services::Fs;
-    use object_store::{ObjectStore, ObjectStoreBuilder};
+    use object_store::ObjectStore;
     use store_api::storage::{ChunkReader, OpType, SequenceNumber};
 
     use super::*;

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -396,8 +396,9 @@ mod tests {
         let dir = create_temp_dir("test_create_new_region");
         let store_dir = dir.path().to_string_lossy();
 
-        let accessor = Fs::default().root(&store_dir).build().unwrap();
-        let object_store = ObjectStore::new(accessor).finish();
+        let mut builder = Fs::default();
+        builder.root(&store_dir);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let config = EngineConfig::default();
 

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -381,7 +381,6 @@ mod tests {
     use datatypes::type_id::LogicalTypeId;
     use log_store::test_util::log_store_util;
     use object_store::services::Fs;
-    use object_store::ObjectStoreBuilder;
     use store_api::storage::Region;
 
     use super::*;

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -77,6 +77,13 @@ pub enum Error {
         source: object_store::Error,
     },
 
+    #[snafu(display("Fail to delete object in batch, msg: {}, source: {}", msg, source))]
+    BatchDeleteObject {
+        msg: String,
+        backtrace: Backtrace,
+        source: object_store::Error,
+    },
+
     #[snafu(display("Fail to list objects in path: {}, source: {}", path, source))]
     ListObjects {
         path: String,
@@ -495,6 +502,7 @@ impl ErrorExt for Error {
             | WriteObject { .. }
             | ListObjects { .. }
             | DeleteObject { .. }
+            | BatchDeleteObject { .. }
             | WriteWal { .. }
             | DecodeWalHeader { .. }
             | EncodeWalHeader { .. }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -77,13 +77,6 @@ pub enum Error {
         source: object_store::Error,
     },
 
-    #[snafu(display("Fail to delete object in batch, msg: {}, source: {}", msg, source))]
-    BatchDeleteObject {
-        msg: String,
-        backtrace: Backtrace,
-        source: object_store::Error,
-    },
-
     #[snafu(display("Fail to list objects in path: {}, source: {}", path, source))]
     ListObjects {
         path: String,
@@ -502,7 +495,6 @@ impl ErrorExt for Error {
             | WriteObject { .. }
             | ListObjects { .. }
             | DeleteObject { .. }
-            | BatchDeleteObject { .. }
             | WriteWal { .. }
             | DecodeWalHeader { .. }
             | EncodeWalHeader { .. }

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -107,7 +107,7 @@ pub mod noop {
 mod tests {
     use common_test_util::temp_dir::create_temp_dir;
     use object_store::services::Fs;
-    use object_store::{ObjectStore, ObjectStoreBuilder};
+    use object_store::ObjectStore;
     use store_api::storage::OpType;
 
     use super::*;

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -168,13 +168,9 @@ mod tests {
     #[tokio::test]
     async fn test_file_purger_handler() {
         let dir = create_temp_dir("file-purge");
-        let object_store = ObjectStore::new(
-            Fs::default()
-                .root(dir.path().to_str().unwrap())
-                .build()
-                .unwrap(),
-        )
-        .finish();
+        let mut builder = Fs::default();
+        builder.root(dir.path().to_str().unwrap());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let sst_file_id = FileId::random();
 
@@ -198,22 +194,20 @@ mod tests {
             .unwrap();
 
         notify.notified().await;
-
-        let object = object_store.object(&format!("{}/{}", path, sst_file_id.as_parquet()));
-        assert!(!object.is_exist().await.unwrap());
+        let exists = object_store
+            .is_exist(&format!("{}/{}", path, sst_file_id.as_parquet()))
+            .await
+            .unwrap();
+        assert!(!exists);
     }
 
     #[tokio::test]
     async fn test_file_purge_loop() {
         common_telemetry::init_default_ut_logging();
         let dir = create_temp_dir("file-purge");
-        let object_store = ObjectStore::new(
-            Fs::default()
-                .root(dir.path().to_str().unwrap())
-                .build()
-                .unwrap(),
-        )
-        .finish();
+        let mut builder = Fs::default();
+        builder.root(dir.path().to_str().unwrap());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
         let sst_file_id = FileId::random();
         let scheduler = Arc::new(LocalScheduler::new(
             SchedulerConfig::default(),
@@ -228,9 +222,9 @@ mod tests {
             drop(handle);
         }
         scheduler.stop(true).await.unwrap();
+
         assert!(!object_store
-            .object(&format!("{}/{}", path, sst_file_id.as_parquet()))
-            .is_exist()
+            .is_exist(&format!("{}/{}", path, sst_file_id.as_parquet()))
             .await
             .unwrap());
     }

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -167,7 +167,7 @@ mod tests {
 
     use common_test_util::temp_dir::create_temp_dir;
     use object_store::services::Fs;
-    use object_store::{ObjectStore, ObjectStoreBuilder};
+    use object_store::ObjectStore;
     use store_api::manifest::action::ProtocolAction;
     use store_api::manifest::{Manifest, MetaActionIterator, MAX_VERSION};
 

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -290,13 +290,9 @@ mod tests {
     async fn test_region_manifest_checkpoint() {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_region_manifest_checkpoint");
-        let object_store = ObjectStore::new(
-            Fs::default()
-                .root(&tmp_dir.path().to_string_lossy())
-                .build()
-                .unwrap(),
-        )
-        .finish();
+        let mut builder = Fs::default();
+        builder.root(&tmp_dir.path().to_string_lossy());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let manifest = RegionManifest::with_checkpointer("/manifest/", object_store);
 

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -180,13 +180,9 @@ mod tests {
     async fn test_region_manifest() {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_region_manifest");
-        let object_store = ObjectStore::new(
-            Fs::default()
-                .root(&tmp_dir.path().to_string_lossy())
-                .build()
-                .unwrap(),
-        )
-        .finish();
+        let mut builder = Fs::default();
+        builder.root(&tmp_dir.path().to_string_lossy());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let manifest = RegionManifest::with_checkpointer("/manifest/", object_store);
 

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use common_telemetry::logging;
 use futures::TryStreamExt;
 use lazy_static::lazy_static;
-use object_store::{util, Object, ObjectStore};
+use object_store::{util, ObjectStore};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -268,10 +268,7 @@ impl ManifestLogStorage for ManifestObjectStore {
     async fn load_last_checkpoint(&self) -> Result<Option<(ManifestVersion, Vec<u8>)>> {
         let last_checkpoint = self.object_store.object(&self.last_checkpoint_path());
 
-        // TODO(hl): any better solution?
-        let result = self.object_store.read(&last_checkpoint_path).await;
-
-        let last_checkpoint_data = match result {
+        let last_checkpoint_data = match self.object_store.read(&last_checkpoint_path).await {
             Ok(last_checkpoint_data) => last_checkpoint_data,
             Err(e) if e.kind() == ErrorKind::NotFound => {
                 return Ok(None);
@@ -311,7 +308,6 @@ mod tests {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_manifest_log_store");
         let mut builder = Fs::default();
-        println!("tmp_dir: {:?}", tmp_dir);
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -20,7 +20,6 @@ use common_telemetry::logging;
 use futures::TryStreamExt;
 use lazy_static::lazy_static;
 use object_store::{util, Entry, ErrorKind, ObjectStore};
-use regex::internal::Input;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};
@@ -196,7 +195,7 @@ impl ManifestLogStorage for ManifestObjectStore {
     async fn delete(&self, start: ManifestVersion, end: ManifestVersion) -> Result<()> {
         self.object_store
             .remove_via(futures::stream::iter(
-                (start..end).into_iter().map(|v| self.delta_file_path(v)),
+                (start..end).map(|v| self.delta_file_path(v)),
             ))
             .await
             .with_context(|_| BatchDeleteObjectSnafu {
@@ -301,7 +300,7 @@ impl ManifestLogStorage for ManifestObjectStore {
 mod tests {
     use common_test_util::temp_dir::create_temp_dir;
     use object_store::services::Fs;
-    use object_store::{ObjectStore, ObjectStoreBuilder};
+    use object_store::ObjectStore;
 
     use super::*;
 

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -286,13 +286,9 @@ async fn test_recover_region_manifets() {
     let tmp_dir = create_temp_dir("test_recover_region_manifets");
     let memtable_builder = Arc::new(DefaultMemtableBuilder::default()) as _;
 
-    let object_store = ObjectStore::new(
-        Fs::default()
-            .root(&tmp_dir.path().to_string_lossy())
-            .build()
-            .unwrap(),
-    )
-    .finish();
+    let mut builder = Fs::default();
+    builder.root(&tmp_dir.path().to_string_lossy());
+    let object_store = ObjectStore::new(builder).unwrap().finish();
 
     let manifest = RegionManifest::with_checkpointer("/manifest/", object_store.clone());
     let region_meta = Arc::new(build_region_meta());

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -31,7 +31,7 @@ use datatypes::vectors::{Int64Vector, TimestampMillisecondVector, VectorRef};
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::NoopLogStore;
 use object_store::services::Fs;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::ObjectStore;
 use store_api::manifest::MAX_VERSION;
 use store_api::storage::{
     consts, Chunk, ChunkReader, RegionMeta, ScanRequest, SequenceNumber, Snapshot, WriteRequest,

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -508,8 +508,10 @@ impl AccessLayer for FsAccessLayer {
     /// Deletes a SST file with given file id.
     async fn delete_sst(&self, file_id: FileId) -> Result<()> {
         let path = self.sst_file_path(&file_id.as_parquet());
-        let object = self.object_store.object(&path);
-        object.delete().await.context(DeleteSstSnafu)
+        self.object_store
+            .delete(&path)
+            .await
+            .context(DeleteSstSnafu)
     }
 }
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -546,7 +546,6 @@ mod tests {
     use datatypes::types::{TimestampMillisecondType, TimestampType};
     use datatypes::vectors::TimestampMillisecondVector;
     use object_store::services::Fs;
-    use object_store::ObjectStoreBuilder;
     use store_api::storage::OpType;
 
     use super::*;

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -981,8 +981,9 @@ mod tests {
 
         let dir = create_temp_dir("read-parquet-by-range");
         let path = dir.path().to_str().unwrap();
-        let backend = Fs::default().root(path).build().unwrap();
-        let object_store = ObjectStore::new(backend).finish();
+        let mut builder = Fs::default();
+        builder.root(path);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
         let sst_file_name = "test-read.parquet";
         let iter = memtable.iter(&IterContext::default()).unwrap();
         let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -43,8 +43,10 @@ pub async fn new_store_config(
     let sst_dir = engine::region_sst_dir(parent_dir, region_name);
     let manifest_dir = engine::region_manifest_dir(parent_dir, region_name);
 
-    let accessor = Builder::default().root(store_dir).build().unwrap();
-    let object_store = ObjectStore::new(accessor).finish();
+    let mut builder = Builder::default();
+    builder.root(store_dir);
+
+    let object_store = ObjectStore::new(builder).unwrap().finish();
     let sst_layer = Arc::new(FsAccessLayer::new(&sst_dir, object_store.clone()));
     let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store);
     let job_pool = Arc::new(JobPoolImpl {});

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::LogConfig;
 use object_store::services::Fs as Builder;
-use object_store::{ObjectStore};
+use object_store::ObjectStore;
 
 use crate::background::JobPoolImpl;
 use crate::compaction::noop::NoopCompactionScheduler;

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::LogConfig;
 use object_store::services::Fs as Builder;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::{ObjectStore};
 
 use crate::background::JobPoolImpl;
 use crate::compaction::noop::NoopCompactionScheduler;

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -24,7 +24,7 @@ use log_store::NoopLogStore;
 use mito::config::EngineConfig;
 use mito::engine::MitoEngine;
 use object_store::services::Fs;
-use object_store::{ObjectStore};
+use object_store::ObjectStore;
 use storage::compaction::noop::NoopCompactionScheduler;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -40,8 +40,9 @@ impl TestEnv {
     pub fn new(prefix: &str) -> TestEnv {
         let dir = create_temp_dir(prefix);
         let store_dir = format!("{}/db", dir.path().to_string_lossy());
-        let accessor = Fs::default().root(&store_dir).build().unwrap();
-        let object_store = ObjectStore::new(accessor).finish();
+        let mut builder = Fs::default();
+        builder.root(&store_dir);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
         let storage_engine = EngineImpl::new(
@@ -57,8 +58,9 @@ impl TestEnv {
         ));
 
         let procedure_dir = format!("{}/procedure", dir.path().to_string_lossy());
-        let accessor = Fs::default().root(&procedure_dir).build().unwrap();
-        let object_store = ObjectStore::new(accessor).finish();
+        let mut builder = Fs::default();
+        builder.root(&procedure_dir);
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let procedure_manager = Arc::new(LocalManager::new(ManagerConfig {
             object_store,

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -24,7 +24,7 @@ use log_store::NoopLogStore;
 use mito::config::EngineConfig;
 use mito::engine::MitoEngine;
 use object_store::services::Fs;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::{ObjectStore};
 use storage::compaction::noop::NoopCompactionScheduler;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -104,18 +104,17 @@ fn get_test_store_config(
                 cache_capacity: None,
             };
 
-            let accessor = Oss::default()
+            let mut builder = Oss::default();
+            builder
                 .root(&oss_config.root)
                 .endpoint(&oss_config.endpoint)
                 .access_key_id(&oss_config.access_key_id)
                 .access_key_secret(&oss_config.access_key_secret)
-                .bucket(&oss_config.bucket)
-                .build()
-                .unwrap();
+                .bucket(&oss_config.bucket);
 
             let config = ObjectStoreConfig::Oss(oss_config);
 
-            let store = ObjectStore::new(accessor).finish();
+            let store = ObjectStore::new(builder).unwrap().finish();
 
             (
                 config,
@@ -134,17 +133,16 @@ fn get_test_store_config(
                 cache_capacity: None,
             };
 
-            let accessor = S3::default()
+            let mut builder = S3::default();
+            builder
                 .root(&s3_config.root)
                 .access_key_id(&s3_config.access_key_id)
                 .secret_access_key(&s3_config.secret_access_key)
-                .bucket(&s3_config.bucket)
-                .build()
-                .unwrap();
+                .bucket(&s3_config.bucket);
 
             let config = ObjectStoreConfig::S3(s3_config);
 
-            let store = ObjectStore::new(accessor).finish();
+            let store = ObjectStore::new(builder).unwrap().finish();
 
             (config, Some(TempDirGuard::S3(TempFolder::new(&store, "/"))))
         }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -34,7 +34,7 @@ use datatypes::schema::{ColumnSchema, RawSchema};
 use frontend::instance::Instance as FeInstance;
 use object_store::services::{Oss, S3};
 use object_store::test_util::TempFolder;
-use object_store::{ObjectStore, ObjectStoreBuilder};
+use object_store::ObjectStore;
 use once_cell::sync::OnceCell;
 use rand::Rng;
 use servers::grpc::GrpcServer;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Upgrades opendal from 0.27 to 0.30. This is the prerequisite of #1248 .

The major changes are:
- [Constructor of `ObjectStore`](https://docs.rs/opendal/0.30.4/opendal/struct.Operator.html#method.new) now takes a `Builder` instead of an `Accessor`.
- `Object` is completely removed from opendal in [#1477](https://github.com/apache/incubator-opendal/pull/1477). Thus lots of file read/write stuff needs rewrite.
- `list/scan` now returns a stream of `Entry` instead of `Object`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
