### PR TITLE
fix: noop flush impl for numbers table

### DIFF
--- a/src/table/src/table/numbers.rs
+++ b/src/table/src/table/numbers.rs
@@ -112,7 +112,7 @@ impl Table for NumbersTable {
         Ok(Arc::new(SimpleTableScan::new(stream)))
     }
 
-    async fn flush(&self, region_number: Option<RegionNumber>, wait: Option<bool>) -> Result<()> {
+    async fn flush(&self, _region_number: Option<RegionNumber>, _wait: Option<bool>) -> Result<()> {
         Ok(())
     }
 }

--- a/src/table/src/table/numbers.rs
+++ b/src/table/src/table/numbers.rs
@@ -26,6 +26,7 @@ use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, SchemaBuilder, SchemaRef};
 use futures::task::{Context, Poll};
 use futures::Stream;
+use store_api::storage::RegionNumber;
 
 use crate::error::Result;
 use crate::metadata::{TableId, TableInfoBuilder, TableInfoRef, TableMetaBuilder, TableType};
@@ -109,6 +110,10 @@ impl Table for NumbersTable {
             already_run: false,
         });
         Ok(Arc::new(SimpleTableScan::new(stream)))
+    }
+
+    async fn flush(&self, region_number: Option<RegionNumber>, wait: Option<bool>) -> Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add a no-op flush implementation to `NumbersTable` so that it won't complain "Unspported flush operation" when a full-flush is triggered during database shutdown.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #1246 
