### PR TITLE
feat: Implement procedure to alter a table for mito engine

### DIFF
--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -215,6 +215,7 @@ impl Instance {
     }
 
     pub async fn start(&self) -> Result<()> {
+        // FIXME(yingwen): Recover procedure manager after catalog manager is started.
         self.catalog_manager
             .start()
             .await

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -74,6 +74,7 @@ pub struct Instance {
     pub(crate) script_executor: ScriptExecutor,
     pub(crate) table_id_provider: Option<TableIdProviderRef>,
     pub(crate) heartbeat_task: Option<HeartbeatTask>,
+    procedure_manager: Option<ProcedureManagerRef>,
 }
 
 pub type InstanceRef = Arc<Instance>;
@@ -183,6 +184,7 @@ impl Instance {
         };
 
         let procedure_manager = create_procedure_manager(&opts.procedure).await?;
+        // Register all procedures.
         if let Some(procedure_manager) = &procedure_manager {
             table_engine.register_procedure_loaders(&**procedure_manager);
             table_procedure::register_procedure_loaders(
@@ -191,12 +193,6 @@ impl Instance {
                 table_engine.clone(),
                 &**procedure_manager,
             );
-
-            // Recover procedures.
-            procedure_manager
-                .recover()
-                .await
-                .context(RecoverProcedureSnafu)?;
         }
 
         Ok(Self {
@@ -205,23 +201,32 @@ impl Instance {
                 table_engine.clone(),
                 catalog_manager.clone(),
                 table_engine,
-                procedure_manager,
+                procedure_manager.clone(),
             ),
             catalog_manager,
             script_executor,
             heartbeat_task,
             table_id_provider,
+            procedure_manager,
         })
     }
 
     pub async fn start(&self) -> Result<()> {
-        // FIXME(yingwen): Recover procedure manager after catalog manager is started.
         self.catalog_manager
             .start()
             .await
             .context(NewCatalogSnafu)?;
         if let Some(task) = &self.heartbeat_task {
             task.start().await?;
+        }
+
+        // Recover procedures after the catalog manager is started, so we can
+        // ensure we can access all tables from the catalog manager.
+        if let Some(procedure_manager) = &self.procedure_manager {
+            procedure_manager
+                .recover()
+                .await
+                .context(RecoverProcedureSnafu)?;
         }
         Ok(())
     }

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -166,7 +166,11 @@ impl<S: StorageEngine> TableEngineProcedure for MitoEngine<S> {
             .map_err(BoxedError::new)
             .context(table_error::TableOperationSnafu)?;
 
-        let procedure = Box::new(CreateMitoTable::new(request, self.inner.clone()));
+        let procedure = Box::new(
+            CreateMitoTable::new(request, self.inner.clone())
+                .map_err(BoxedError::new)
+                .context(table_error::TableOperationSnafu)?,
+        );
         Ok(procedure)
     }
 

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -47,7 +47,7 @@ use table::{error as table_error, Result as TableResult, Table};
 use tokio::sync::Mutex;
 
 use crate::config::EngineConfig;
-use crate::engine::procedure::CreateMitoTable;
+use crate::engine::procedure::{AlterMitoTable, CreateMitoTable};
 use crate::error::{
     self, BuildColumnDescriptorSnafu, BuildColumnFamilyDescriptorSnafu, BuildRegionDescriptorSnafu,
     BuildRowKeyDescriptorSnafu, InvalidPrimaryKeySnafu, InvalidRawSchemaSnafu,
@@ -167,6 +167,19 @@ impl<S: StorageEngine> TableEngineProcedure for MitoEngine<S> {
             .context(table_error::TableOperationSnafu)?;
 
         let procedure = Box::new(CreateMitoTable::new(request, self.inner.clone()));
+        Ok(procedure)
+    }
+
+    fn alter_table_procedure(
+        &self,
+        _ctx: &EngineContext,
+        request: AlterTableRequest,
+    ) -> TableResult<BoxedProcedure> {
+        let procedure = Box::new(
+            AlterMitoTable::new(request, self.inner.clone())
+                .map_err(BoxedError::new)
+                .context(table_error::TableOperationSnafu)?,
+        );
         Ok(procedure)
     }
 }

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -17,6 +17,7 @@ mod create;
 
 use std::sync::Arc;
 
+pub(crate) use alter::AlterMitoTable;
 use common_procedure::ProcedureManager;
 pub(crate) use create::CreateMitoTable;
 use store_api::storage::StorageEngine;

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -33,7 +33,7 @@ pub(crate) fn register_procedure_loaders<S: StorageEngine>(
     procedure_manager: &dyn ProcedureManager,
 ) {
     // The procedure names are expected to be unique, so we just panic on error.
-    CreateMitoTable::register_loader(engine_inner.clone(), procedure_manager.clone());
+    CreateMitoTable::register_loader(engine_inner.clone(), procedure_manager);
     AlterMitoTable::register_loader(engine_inner, procedure_manager);
 }
 

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -33,7 +33,8 @@ pub(crate) fn register_procedure_loaders<S: StorageEngine>(
     procedure_manager: &dyn ProcedureManager,
 ) {
     // The procedure names are expected to be unique, so we just panic on error.
-    CreateMitoTable::register_loader(engine_inner, procedure_manager);
+    CreateMitoTable::register_loader(engine_inner.clone(), procedure_manager.clone());
+    AlterMitoTable::register_loader(engine_inner, procedure_manager);
 }
 
 #[cfg(test)]

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod alter;
 mod create;
 
 use std::sync::Arc;

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use snafu::ResultExt;
+use common_procedure::{Status, Result, LockKey, Procedure, Context};
+use common_procedure::error::ToJsonSnafu;
+use store_api::storage::StorageEngine;
+use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use crate::engine::{MitoEngineInner};
+use table::requests::AlterTableRequest;
+
+/// Procedure to alter a [MitoTable].
+pub(crate) struct AlterMitoTable<S: StorageEngine> {
+    data: AlterTableData,
+    engine_inner: Arc<MitoEngineInner<S>>,
+    // TODO(yingwen): Table.
+    // problem: What if table isn't opened.
+}
+
+#[async_trait]
+impl<S: StorageEngine> Procedure for AlterMitoTable<S> {
+    fn type_name(&self) -> &str {
+        Self::TYPE_NAME
+    }
+
+    async fn execute(&mut self, _ctx: &Context) -> Result<Status> {
+        match self.data.state {
+            AlterTableState::Prepare => self.on_prepare(),
+            AlterTableState::AlterRegions => self.on_alter_regions().await,
+            AlterTableState::UpdateTableManifest => self.on_update_table_manifest().await,
+        }
+    }
+
+    fn dump(&self) -> Result<String> {
+        let json = serde_json::to_string(&self.data).context(ToJsonSnafu)?;
+        Ok(json)
+    }
+
+    fn lock_key(&self) -> LockKey {
+        unimplemented!()
+    }
+}
+
+impl<S: StorageEngine> AlterMitoTable<S> {
+    const TYPE_NAME: &str = "mito::AlterMitoTable";
+
+    fn on_prepare(&mut self) -> Result<Status> {
+        unimplemented!()
+    }
+
+    async fn on_alter_regions(&mut self) -> Result<Status> {
+        unimplemented!()
+    }
+
+    async fn on_update_table_manifest(&mut self) -> Result<Status> {
+        unimplemented!()
+    }
+}
+
+/// Represents each step while altering table in the mito engine.
+#[derive(Debug, Serialize, Deserialize)]
+enum AlterTableState {
+    /// Prepare to alter table.
+    Prepare,
+    /// Alter regions.
+    AlterRegions,
+    /// Update table manifest.
+    UpdateTableManifest,
+}
+
+/// Serializable data of [AlterMitoTable].
+#[derive(Debug, Serialize, Deserialize)]
+struct AlterTableData {
+    state: AlterTableState,
+    request: AlterTableRequest,
+}

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -115,12 +115,14 @@ impl<S: StorageEngine> CreateMitoTable<S> {
     /// Recover the procedure from json.
     fn from_json(json: &str, engine_inner: Arc<MitoEngineInner<S>>) -> Result<Self> {
         let data: CreateTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
+        let table_schema =
+            Schema::try_from(data.request.schema.clone()).context(InvalidRawSchemaSnafu)?;
 
         Ok(CreateMitoTable {
             data,
             engine_inner,
             regions: HashMap::new(),
-            table_schema: None,
+            table_schema: Some(Arc::new(table_schema)),
         })
     }
 

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -43,7 +43,7 @@ pub(crate) struct CreateMitoTable<S: StorageEngine> {
     /// Created regions of the table.
     regions: HashMap<RegionNumber, S::Region>,
     /// Schema of the table.
-    table_schema: Option<SchemaRef>,
+    table_schema: SchemaRef,
 }
 
 #[async_trait]
@@ -81,8 +81,14 @@ impl<S: StorageEngine> CreateMitoTable<S> {
     const TYPE_NAME: &str = "mito::CreateMitoTable";
 
     /// Returns a new [CreateMitoTable].
-    pub(crate) fn new(request: CreateTableRequest, engine_inner: Arc<MitoEngineInner<S>>) -> Self {
-        CreateMitoTable {
+    pub(crate) fn new(
+        request: CreateTableRequest,
+        engine_inner: Arc<MitoEngineInner<S>>,
+    ) -> Result<Self> {
+        let table_schema =
+            Schema::try_from(request.schema.clone()).context(InvalidRawSchemaSnafu)?;
+
+        Ok(CreateMitoTable {
             data: CreateTableData {
                 state: CreateTableState::Prepare,
                 request,
@@ -90,8 +96,8 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             },
             engine_inner,
             regions: HashMap::new(),
-            table_schema: None,
-        }
+            table_schema: Arc::new(table_schema),
+        })
     }
 
     /// Register the loader of this procedure to the `procedure_manager`.
@@ -122,7 +128,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             data,
             engine_inner,
             regions: HashMap::new(),
-            table_schema: Some(Arc::new(table_schema)),
+            table_schema: Arc::new(table_schema),
         })
     }
 
@@ -168,19 +174,17 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             ttl,
         };
 
-        let table_schema =
-            Schema::try_from(self.data.request.schema.clone()).context(InvalidRawSchemaSnafu)?;
         let primary_key_indices = &self.data.request.primary_key_indices;
         let (next_column_id, default_cf) = engine::build_column_family(
             engine::INIT_COLUMN_ID,
             &self.data.request.table_name,
-            &table_schema,
+            &self.table_schema,
             primary_key_indices,
         )?;
         let (next_column_id, row_key) = engine::build_row_key_desc(
             next_column_id,
             &self.data.request.table_name,
-            &table_schema,
+            &self.table_schema,
             primary_key_indices,
         )?;
         self.data.next_column_id = Some(next_column_id);
@@ -230,7 +234,6 @@ impl<S: StorageEngine> CreateMitoTable<S> {
 
         // All regions are created, moves to the next step.
         self.data.state = CreateTableState::WriteTableManifest;
-        self.table_schema = Some(Arc::new(table_schema));
 
         Ok(Status::executing(true))
     }
@@ -278,10 +281,9 @@ impl<S: StorageEngine> CreateMitoTable<S> {
     ) -> Result<MitoTable<S::Region>> {
         // Safety: We are in `WriteTableManifest` state.
         let next_column_id = self.data.next_column_id.unwrap();
-        let table_schema = self.table_schema.clone().unwrap();
 
         let table_meta = TableMetaBuilder::default()
-            .schema(table_schema)
+            .schema(self.table_schema.clone())
             .engine(engine::MITO_ENGINE)
             .next_column_id(next_column_id)
             .primary_key_indices(self.data.request.primary_key_indices.clone())

--- a/src/mito/src/error.rs
+++ b/src/mito/src/error.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use common_error::ext::BoxedError;
 use common_error::prelude::*;
 use store_api::storage::RegionNumber;
-use table::metadata::{TableInfoBuilderError, TableMetaBuilderError};
+use table::metadata::{TableInfoBuilderError, TableMetaBuilderError, TableVersion};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -187,6 +187,12 @@ pub enum Error {
 
     #[snafu(display("Invalid schema, source: {}", source))]
     InvalidRawSchema { source: datatypes::error::Error },
+
+    #[snafu(display("Table version changed, expect: {}, actual: {}", expect, actual))]
+    VersionChanged {
+        expect: TableVersion,
+        actual: TableVersion,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -211,7 +217,8 @@ impl ErrorExt for Error {
             | InvalidPrimaryKey { .. }
             | MissingTimestampIndex { .. }
             | TableNotFound { .. }
-            | InvalidRawSchema { .. } => StatusCode::InvalidArguments,
+            | InvalidRawSchema { .. }
+            | VersionChanged { .. } => StatusCode::InvalidArguments,
 
             TableInfoNotFound { .. } | ConvertRaw { .. } => StatusCode::Unexpected,
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -558,7 +558,7 @@ impl<R: Region> MitoTable<R> {
 }
 
 /// Create [`AlterOperation`] according to given `alter_kind`.
-fn create_alter_operation(
+pub(crate) fn create_alter_operation(
     table_name: &str,
     alter_kind: &AlterKind,
     table_meta: &mut TableMeta,

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -29,7 +29,9 @@ use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;
 use table::engine::{EngineContext, TableEngine};
 use table::metadata::{TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
-use table::requests::{CreateTableRequest, InsertRequest, TableOptions};
+use table::requests::{
+    AlterKind, AlterTableRequest, CreateTableRequest, InsertRequest, TableOptions,
+};
 use table::{Table, TableRef};
 
 use crate::config::EngineConfig;
@@ -115,6 +117,15 @@ pub fn new_create_request(schema: SchemaRef) -> CreateTableRequest {
         create_if_not_exists: true,
         primary_key_indices: vec![0],
         table_options: TableOptions::default(),
+    }
+}
+
+pub fn new_alter_request(alter_kind: AlterKind) -> AlterTableRequest {
+    AlterTableRequest {
+        catalog_name: "greptime".to_string(),
+        schema_name: "public".to_string(),
+        table_name: TABLE_NAME.to_string(),
+        alter_kind,
     }
 }
 

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -121,6 +121,13 @@ pub trait TableEngineProcedure: Send + Sync {
         ctx: &EngineContext,
         request: CreateTableRequest,
     ) -> Result<BoxedProcedure>;
+
+    /// Returns a procedure that alter table by specific `request`.
+    fn alter_table_procedure(
+        &self,
+        ctx: &EngineContext,
+        request: AlterTableRequest,
+    ) -> Result<BoxedProcedure>;
 }
 
 pub type TableEngineProcedureRef = Arc<dyn TableEngineProcedure>;

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -122,7 +122,7 @@ pub trait TableEngineProcedure: Send + Sync {
         request: CreateTableRequest,
     ) -> Result<BoxedProcedure>;
 
-    /// Returns a procedure that alter table by specific `request`.
+    /// Returns a procedure that alters table by specific `request`.
     fn alter_table_procedure(
         &self,
         ctx: &EngineContext,

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -136,7 +136,7 @@ pub struct OpenTableRequest {
 }
 
 /// Alter table request
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AlterTableRequest {
     pub catalog_name: String,
     pub schema_name: String,

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -136,7 +136,7 @@ pub struct OpenTableRequest {
 }
 
 /// Alter table request
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct AlterTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
@@ -151,13 +151,13 @@ impl AlterTableRequest {
 }
 
 /// Add column request
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddColumnRequest {
     pub column_schema: ColumnSchema,
     pub is_key: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AlterKind {
     AddColumns { columns: Vec<AddColumnRequest> },
     DropColumns { names: Vec<String> },


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements procedure to alter a table in mito engine.

It adds an `alter_table_procedure` method to the `TableEngineProcedure` trait.
```rust
pub trait TableEngineProcedure: Send + Sync {
    /// Returns a procedure that alters table by specific `request`.
    fn alter_table_procedure(
        &self,
        ctx: &EngineContext,
        request: AlterTableRequest,
    ) -> Result<BoxedProcedure>;
}
```

Now the procedure uses the version of the schema to check whether the alteration is applied.

It also fixes several issues:
- The procedure manager should not recover until the catalog manager is started since procedures might need to access the tables in the catalog manager
- The create table procedure recovers table schema from the raw schema in `from_json()`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 
