### PR TITLE
feat: implement restart argument for sqlness-runner

### DIFF
--- a/tests/cases/standalone/alter/rename_table.result
+++ b/tests/cases/standalone/alter/rename_table.result
@@ -50,6 +50,7 @@ DESC TABLE new_table;
 | j     | Int64 | NO   |         | TIME INDEX    |
 +-------+-------+------+---------+---------------+
 
+-- SQLNESS ARG restart=true
 SELECT * FROM new_table;
 
 +---+---+

--- a/tests/cases/standalone/alter/rename_table.sql
+++ b/tests/cases/standalone/alter/rename_table.sql
@@ -16,6 +16,7 @@ CREATE TABLE t(i INTEGER, j BIGINT TIME INDEX);
 
 DESC TABLE new_table;
 
+-- SQLNESS ARG restart=true
 SELECT * FROM new_table;
 
 ALTER TABLE new_table RENAME new_table;

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -206,7 +206,6 @@ impl Env {
             data_dir: String,
         }
 
-        // let current_time = common_time::util::current_time_millis();
         let greptimedb_dir = format!("/tmp/greptimedb-{subcommand}-{}", db_ctx.time);
         let ctx = Context {
             wal_dir: format!("{greptimedb_dir}/wal/"),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


- Able to restart during test execution. This uses the `ARG` interceptor from sqlness and listens on `restart` key. Example:
  ```sql
  create table t1 values ();
  
  -- SQLNESS ARG restart=true
  select * from t1;
  ```
- Refactor sqlness-runner. Reuse some common util functions

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
