### PR TITLE
feat: buffered parquet writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,7 +7484,6 @@ dependencies = [
  "common-test-util",
  "common-time",
  "criterion 0.3.6",
- "crossbeam",
  "datafusion-common",
  "datafusion-expr",
  "datatypes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7484,6 +7484,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "criterion 0.3.6",
+ "crossbeam",
  "datafusion-common",
  "datafusion-expr",
  "datatypes",

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -178,6 +178,7 @@ mod tests {
     use std::io::Write;
     use std::time::Duration;
 
+    use common_base::readable_size::ReadableSize;
     use common_test_util::temp_dir::create_named_temp_file;
     use datanode::datanode::{CompactionConfig, ObjectStoreConfig, RegionManifestConfig};
     use servers::Mode;
@@ -266,6 +267,7 @@ mod tests {
                 max_inflight_tasks: 3,
                 max_files_in_level0: 7,
                 max_purge_tasks: 32,
+                sst_write_buffer_size: ReadableSize::mb(8),
             },
             options.storage.compaction,
         );

--- a/src/common/base/src/readable_size.rs
+++ b/src/common/base/src/readable_size.rs
@@ -53,6 +53,10 @@ impl ReadableSize {
     pub const fn as_mb(self) -> u64 {
         self.0 / MIB
     }
+
+    pub const fn as_bytes(self) -> u64 {
+        self.0
+    }
 }
 
 impl Div<u64> for ReadableSize {

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -150,6 +150,8 @@ pub struct CompactionConfig {
     pub max_files_in_level0: usize,
     /// Max task number for SST purge task after compaction.
     pub max_purge_tasks: usize,
+    /// Buffer threshold while writing SST files
+    pub sst_write_buffer_size: ReadableSize,
 }
 
 impl Default for CompactionConfig {
@@ -158,6 +160,7 @@ impl Default for CompactionConfig {
             max_inflight_tasks: 4,
             max_files_in_level0: 8,
             max_purge_tasks: 32,
+            sst_write_buffer_size: ReadableSize::mb(8),
         }
     }
 }
@@ -177,6 +180,7 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
             manifest_gc_duration: value.storage.manifest.gc_duration,
             max_files_in_l0: value.storage.compaction.max_files_in_level0,
             max_purge_tasks: value.storage.compaction.max_purge_tasks,
+            sst_write_buffer_size: value.storage.compaction.sst_write_buffer_size,
         }
     }
 }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -508,6 +508,7 @@ pub enum Error {
         #[snafu(backtrace)]
         source: BoxedError,
     },
+
     #[snafu(display("Failed to copy table to parquet file, source: {}", source))]
     WriteParquet {
         #[snafu(backtrace)]

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -439,12 +439,6 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to write parquet file, source: {}", source))]
-    WriteParquet {
-        source: parquet::errors::ParquetError,
-        backtrace: Backtrace,
-    },
-
     #[snafu(display("Failed to poll stream, source: {}", source))]
     PollStream {
         source: datafusion_common::DataFusionError,
@@ -513,6 +507,11 @@ pub enum Error {
     ShutdownInstance {
         #[snafu(backtrace)]
         source: BoxedError,
+    },
+    #[snafu(display("Failed to copy table to parquet file, source: {}", source))]
+    WriteParquet {
+        #[snafu(backtrace)]
+        source: storage::error::Error,
     },
 }
 

--- a/src/datanode/src/sql/copy_table_to.rs
+++ b/src/datanode/src/sql/copy_table_to.rs
@@ -12,24 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::pin::Pin;
-
 use common_datasource;
 use common_datasource::object_store::{build_backend, parse_url};
 use common_query::physical_plan::SessionContext;
 use common_query::Output;
-use common_recordbatch::adapter::DfRecordBatchStreamAdapter;
-use datafusion::parquet::arrow::ArrowWriter;
-use datafusion::parquet::basic::{Compression, Encoding, ZstdLevel};
-use datafusion::parquet::file::properties::WriterProperties;
-use datafusion::physical_plan::RecordBatchStream;
-use futures::TryStreamExt;
-use object_store::ObjectStore;
 use snafu::ResultExt;
+use storage::sst::SstInfo;
+use storage::{ParquetWriter, Source};
 use table::engine::TableReference;
 use table::requests::CopyTableRequest;
 
-use crate::error::{self, Result};
+use crate::error::{self, Result, WriteParquetSnafu};
 use crate::sql::SqlHandler;
 
 impl SqlHandler {
@@ -51,99 +44,20 @@ impl SqlHandler {
         let stream = stream
             .execute(0, SessionContext::default().task_ctx())
             .context(error::TableScanExecSnafu)?;
-        let stream = Box::pin(DfRecordBatchStreamAdapter::new(stream));
 
         let (_schema, _host, path) = parse_url(&req.location).context(error::ParseUrlSnafu)?;
         let object_store =
             build_backend(&req.location, req.connection).context(error::BuildBackendSnafu)?;
 
-        let mut parquet_writer = ParquetWriter::new(path.to_string(), stream, object_store);
-        // TODO(jiachun):
-        // For now, COPY is implemented synchronously.
-        // When copying large table, it will be blocked for a long time.
-        // Maybe we should make "copy" runs in background?
-        // Like PG: https://www.postgresql.org/docs/current/sql-copy.html
-        let rows = parquet_writer.flush().await?;
+        let writer = ParquetWriter::new(&path, Source::Stream(stream), object_store);
 
-        Ok(Output::AffectedRows(rows))
-    }
-}
+        let rows_copied = writer
+            .write_sst(&storage::sst::WriteOptions {})
+            .await
+            .context(WriteParquetSnafu)?
+            .map(|SstInfo { num_rows, .. }| num_rows)
+            .unwrap_or(0);
 
-type DfRecordBatchStream = Pin<Box<DfRecordBatchStreamAdapter>>;
-
-struct ParquetWriter {
-    file_name: String,
-    stream: DfRecordBatchStream,
-    object_store: ObjectStore,
-    max_row_group_size: usize,
-    max_rows_in_segment: usize,
-}
-
-impl ParquetWriter {
-    pub fn new(file_name: String, stream: DfRecordBatchStream, object_store: ObjectStore) -> Self {
-        Self {
-            file_name,
-            stream,
-            object_store,
-            // TODO(jiachun): make these configurable: WITH (max_row_group_size=xxx, max_rows_in_segment=xxx)
-            max_row_group_size: 4096,
-            max_rows_in_segment: 5000000, // default 5M rows per segment
-        }
-    }
-
-    pub async fn flush(&mut self) -> Result<usize> {
-        let schema = self.stream.as_ref().schema();
-        let writer_props = WriterProperties::builder()
-            .set_compression(Compression::ZSTD(ZstdLevel::default()))
-            .set_encoding(Encoding::PLAIN)
-            .set_max_row_group_size(self.max_row_group_size)
-            .build();
-        let mut total_rows = 0;
-        loop {
-            let mut buf = vec![];
-            let mut arrow_writer =
-                ArrowWriter::try_new(&mut buf, schema.clone(), Some(writer_props.clone()))
-                    .context(error::WriteParquetSnafu)?;
-
-            let mut rows = 0;
-            let mut end_loop = true;
-            // TODO(hl & jiachun): Since OpenDAL's writer is async and ArrowWriter requires a `std::io::Write`,
-            // here we use a Vec<u8> to buffer all parquet bytes in memory and write to object store
-            // at a time. Maybe we should find a better way to bridge ArrowWriter and OpenDAL's object.
-            while let Some(batch) = self
-                .stream
-                .try_next()
-                .await
-                .context(error::PollStreamSnafu)?
-            {
-                arrow_writer
-                    .write(&batch)
-                    .context(error::WriteParquetSnafu)?;
-                rows += batch.num_rows();
-                if rows >= self.max_rows_in_segment {
-                    end_loop = false;
-                    break;
-                }
-            }
-
-            let start_row_num = total_rows + 1;
-            total_rows += rows;
-            arrow_writer.close().context(error::WriteParquetSnafu)?;
-
-            // if rows == 0, we just end up with an empty file.
-            //
-            // file_name like:
-            // "file_name_1_1000000"        (row num: 1 ~ 1000000),
-            // "file_name_1000001_xxx"      (row num: 1000001 ~ xxx)
-            let file_name = format!("{}_{}_{}", self.file_name, start_row_num, total_rows);
-            self.object_store
-                .write(&file_name, buf)
-                .await
-                .context(error::WriteObjectSnafu { path: file_name })?;
-
-            if end_loop {
-                return Ok(total_rows);
-            }
-        }
+        Ok(Output::AffectedRows(rows_copied))
     }
 }

--- a/src/datanode/src/sql/copy_table_to.rs
+++ b/src/datanode/src/sql/copy_table_to.rs
@@ -52,7 +52,7 @@ impl SqlHandler {
         let writer = ParquetWriter::new(&path, Source::Stream(stream), object_store);
 
         let rows_copied = writer
-            .write_sst(&storage::sst::WriteOptions {})
+            .write_sst(&storage::sst::WriteOptions::default())
             .await
             .context(WriteParquetSnafu)?
             .map(|SstInfo { num_rows, .. }| num_rows)

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -16,7 +16,7 @@ pub use opendal::raw::normalize_path as raw_normalize_path;
 pub use opendal::raw::oio::Pager;
 pub use opendal::{
     layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
-    Operator as ObjectStore, Result,
+    Operator as ObjectStore, Result, Writer,
 };
 
 pub mod cache_policy;

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -19,7 +19,6 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-crossbeam = "0.8"
 datatypes = { path = "../datatypes" }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -19,6 +19,7 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+crossbeam = "0.8"
 datatypes = { path = "../datatypes" }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -132,6 +132,7 @@ impl<S: LogStore> Picker for SimplePicker<S> {
                 wal: req.wal.clone(),
                 manifest: req.manifest.clone(),
                 expired_ssts,
+                sst_write_buffer_size: req.sst_write_buffer_size,
             }));
         }
 

--- a/src/storage/src/compaction/scheduler.rs
+++ b/src/storage/src/compaction/scheduler.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common_base::readable_size::ReadableSize;
 use common_telemetry::{debug, error, info};
 use store_api::logstore::LogStore;
 use store_api::storage::RegionId;
@@ -60,6 +61,8 @@ pub struct CompactionRequestImpl<S: LogStore> {
     pub ttl: Option<Duration>,
     /// Compaction result sender.
     pub sender: Option<Sender<Result<()>>>,
+
+    pub sst_write_buffer_size: ReadableSize,
 }
 
 impl<S: LogStore> CompactionRequestImpl<S> {

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -74,12 +74,7 @@ impl<S: LogStore> CompactionTaskImpl<S> {
             compacted_inputs.extend(output.inputs.iter().map(FileHandle::meta));
 
             // TODO(hl): Maybe spawn to runtime to exploit in-job parallelism.
-            futs.push(async move {
-                match output.build(region_id, schema, sst_layer).await {
-                    Ok(meta) => Ok(meta),
-                    Err(e) => Err(e),
-                }
-            });
+            futs.push(async move { output.build(region_id, schema, sst_layer).await });
         }
 
         let mut outputs = HashSet::with_capacity(futs.len());
@@ -192,6 +187,7 @@ impl CompactionOutput {
                 |SstInfo {
                      time_range,
                      file_size,
+                     ..
                  }| FileMeta {
                     region_id,
                     file_id: output_file_id,

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -224,6 +224,7 @@ mod tests {
         let SstInfo {
             time_range,
             file_size,
+            ..
         } = writer
             .write_sst(&sst::WriteOptions::default())
             .await

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -85,6 +85,7 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
 
+    use common_base::readable_size::ReadableSize;
     use common_test_util::temp_dir::create_temp_dir;
     use common_time::Timestamp;
     use datatypes::prelude::{LogicalTypeId, ScalarVector, ScalarVectorBuilder};
@@ -412,7 +413,9 @@ mod tests {
             .await
             .unwrap();
 
-        let opts = WriteOptions {};
+        let opts = WriteOptions {
+            sst_write_buffer_size: ReadableSize::mb(8),
+        };
         let s1 = ParquetWriter::new(
             &output_file_ids[0].as_parquet(),
             Source::Reader(reader1),

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -15,6 +15,7 @@
 //! storage engine config
 
 use std::time::Duration;
+
 use common_base::readable_size::ReadableSize;
 
 #[derive(Debug, Clone)]

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -15,6 +15,7 @@
 //! storage engine config
 
 use std::time::Duration;
+use common_base::readable_size::ReadableSize;
 
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
@@ -22,6 +23,7 @@ pub struct EngineConfig {
     pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
     pub max_purge_tasks: usize,
+    pub sst_write_buffer_size: ReadableSize,
 }
 
 impl Default for EngineConfig {
@@ -31,6 +33,7 @@ impl Default for EngineConfig {
             manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,
             max_purge_tasks: 32,
+            sst_write_buffer_size: ReadableSize::mb(8),
         }
     }
 }

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -147,7 +147,7 @@ mod tests {
         let sst_path = "table1";
         let layer = Arc::new(FsAccessLayer::new(sst_path, os.clone()));
         let sst_info = layer
-            .write_sst(sst_file_id, Source::Iter(iter), &WriteOptions {})
+            .write_sst(sst_file_id, Source::Iter(iter), &WriteOptions::default())
             .await
             .unwrap()
             .unwrap();

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -209,6 +209,7 @@ impl<S: LogStore> FlushJob<S> {
                         |SstInfo {
                              time_range,
                              file_size,
+                             ..
                          }| FileMeta {
                             region_id,
                             file_id,

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -31,7 +31,7 @@ pub mod region;
 pub mod scheduler;
 pub mod schema;
 mod snapshot;
-mod sst;
+pub mod sst;
 mod sync;
 #[cfg(test)]
 mod test_util;
@@ -41,3 +41,6 @@ pub mod write_batch;
 
 pub use engine::EngineImpl;
 mod file_purger;
+
+pub use sst::parquet::ParquetWriter;
+pub use sst::Source;

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod parquet;
+mod stream_writer;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use common_base::readable_size::ReadableSize;
 use common_recordbatch::SendableRecordBatchStream;
 use common_telemetry::{error, info};
 use common_time::range::TimestampRange;
@@ -390,9 +391,18 @@ where
     FileId::from_str(stripped).map_err(<D::Error as serde::de::Error>::custom)
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct WriteOptions {
     // TODO(yingwen): [flush] row group size.
+    pub sst_write_buffer_size: ReadableSize,
+}
+
+impl Default for WriteOptions {
+    fn default() -> Self {
+        Self {
+            sst_write_buffer_size: ReadableSize::mb(8),
+        }
+    }
 }
 
 pub struct ReadOptions {

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -102,7 +102,7 @@ impl<'a> ParquetWriter<'a> {
             self.object_store.clone(),
             &schema,
             Some(writer_props),
-            4 * 1024 * 1024,
+            4 * 1024 * 1024, // this value is optimal for multipart upload.
         )
         .await?;
         let mut rows_written = 0;

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -38,7 +38,7 @@ use datatypes::prelude::ConcreteDataType;
 use futures_util::{Stream, StreamExt, TryStreamExt};
 use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::{ArrowPredicate, RowFilter};
-use parquet::arrow::{ArrowWriter, ParquetRecordBatchStreamBuilder, ProjectionMask};
+use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
 use parquet::basic::{Compression, Encoding, ZstdLevel};
 use parquet::file::metadata::KeyValue;
 use parquet::file::properties::WriterProperties;

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -1,0 +1,111 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use bytes::{BufMut, BytesMut};
+use common_base::buffer::BufferMut;
+use crossbeam::channel::Sender;
+use object_store::Writer;
+
+use crate::error;
+
+struct StreamWriter {
+    buf: BytesMut,
+    tx: Option<Sender<BytesMut>>,
+    finish: Option<tokio::sync::oneshot::Receiver<()>>,
+    threshold: usize,
+}
+
+impl std::io::Write for StreamWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.write_from_slice(buf).unwrap();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        while self.buf.len() >= self.threshold {
+            let full = self.buf.split_to(self.threshold);
+            self.tx.as_ref().unwrap().send(full).unwrap();
+        }
+        Ok(())
+    }
+}
+
+impl StreamWriter {
+    pub fn new(mut writer: Writer, threshold: usize) -> Self {
+        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let (tx, rx) = crossbeam::channel::unbounded();
+        common_runtime::spawn_write(async move {
+            while let Ok(buf) = rx.recv().unwrap() {
+                writer.append(buf).await.unwrap();
+            }
+            finished_tx.send(()).unwrap();
+        });
+
+        Self {
+            buf: BytesMut::with_capacity(threshold),
+            tx: Some(tx),
+            finish: Some(finished_rx),
+            threshold,
+        }
+    }
+
+    pub async fn close(mut self) -> error::Result<()> {
+        // make sure existing data are written in chunks with size of threshold.
+        self.flush().unwrap();
+        if let Some(v) = self.finish.take() {
+            let all = self.buf.split();
+            let tx = self.tx.take().unwrap();
+            let len = all.len();
+            tx.send(all).unwrap();
+            println!("Close, remaining: {}", len);
+            drop(tx);
+            v.await.unwrap();
+        } else {
+            panic!("Cannot close twice")
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use common_test_util::temp_dir::create_temp_dir;
+    use object_store::services::Fs;
+    use object_store::ObjectStore;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_append() {
+        let mut builder = Fs::default();
+        builder.root("/Users/lei/test_data");
+        let store = ObjectStore::new(builder).unwrap().finish();
+        let mut writer = store.writer("abcd").await.unwrap();
+
+        let mut stream_writer = StreamWriter::new(writer, 4);
+        stream_writer.write("ab".as_bytes()).unwrap();
+        stream_writer.flush().unwrap();
+        println!("write ab");
+        stream_writer.write("cd".as_bytes()).unwrap();
+        stream_writer.flush().unwrap();
+        println!("write cd");
+        stream_writer.write("efg".as_bytes()).unwrap();
+        stream_writer.close().await.unwrap();
+    }
+}

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -93,7 +93,7 @@ impl BufferedWriter {
     /// Write a record batch to stream writer.
     pub async fn write(&mut self, batch: &RecordBatch) -> error::Result<()> {
         self.arrow_writer.write(batch).context(WriteParquetSnafu)?;
-        let writen = Self::try_flush(
+        let written = Self::try_flush(
             &self.path,
             &self.buffer,
             &mut self.object_writer,
@@ -102,7 +102,7 @@ impl BufferedWriter {
             self.threshold,
         )
         .await?;
-        self.bytes_written.fetch_add(writen, Ordering::Relaxed);
+        self.bytes_written.fetch_add(written, Ordering::Relaxed);
         Ok(())
     }
 

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -13,99 +13,164 @@
 // limitations under the License.
 
 use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
+use arrow::datatypes::SchemaRef;
+use arrow_array::RecordBatch;
 use bytes::{BufMut, BytesMut};
-use common_base::buffer::BufferMut;
-use crossbeam::channel::Sender;
 use object_store::Writer;
+use parquet::arrow::ArrowWriter;
+use parquet::file::properties::WriterProperties;
+use parquet::format::FileMetaData;
+use snafu::ResultExt;
 
 use crate::error;
+use crate::error::{WriteObjectSnafu, WriteParquetSnafu};
 
-struct StreamWriter {
-    buf: BytesMut,
-    tx: Option<Sender<BytesMut>>,
-    finish: Option<tokio::sync::oneshot::Receiver<()>>,
-    threshold: usize,
+#[derive(Clone, Default)]
+struct Buffer {
+    // It's lightweight since writer/flusher never tries to contend this mutex.
+    buffer: Arc<Mutex<BytesMut>>,
 }
 
-impl std::io::Write for StreamWriter {
+impl Buffer {
+    pub fn with_capacity(size: usize) -> Self {
+        Self {
+            buffer: Arc::new(Mutex::new(BytesMut::with_capacity(size))),
+        }
+    }
+}
+
+impl Write for Buffer {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buf.write_from_slice(buf).unwrap();
-        Ok(buf.len())
+        let len = buf.len();
+        let mut buffer = self.buffer.lock().unwrap();
+        buffer.put_slice(buf);
+        Ok(len)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
-        while self.buf.len() >= self.threshold {
-            let full = self.buf.split_to(self.threshold);
-            self.tx.as_ref().unwrap().send(full).unwrap();
-        }
         Ok(())
     }
 }
 
-impl StreamWriter {
-    pub fn new(mut writer: Writer, threshold: usize) -> Self {
-        let (finished_tx, finished_rx) = tokio::sync::oneshot::channel::<()>();
-
-        let (tx, rx) = crossbeam::channel::unbounded();
-        common_runtime::spawn_write(async move {
-            while let Ok(buf) = rx.recv().unwrap() {
-                writer.append(buf).await.unwrap();
-            }
-            finished_tx.send(()).unwrap();
-        });
-
-        Self {
-            buf: BytesMut::with_capacity(threshold),
-            tx: Some(tx),
-            finish: Some(finished_rx),
-            threshold,
-        }
-    }
-
-    pub async fn close(mut self) -> error::Result<()> {
-        // make sure existing data are written in chunks with size of threshold.
-        self.flush().unwrap();
-        if let Some(v) = self.finish.take() {
-            let all = self.buf.split();
-            let tx = self.tx.take().unwrap();
-            let len = all.len();
-            tx.send(all).unwrap();
-            println!("Close, remaining: {}", len);
-            drop(tx);
-            v.await.unwrap();
-        } else {
-            panic!("Cannot close twice")
-        }
-        Ok(())
-    }
+/// Parquet writer that buffers row groups in memory and writes buffered data to an underlying
+/// storage by chunks to reduce memory consumption.
+pub struct BufferedWriter {
+    path: String,
+    arrow_writer: ArrowWriter<Buffer>,
+    object_writer: Writer,
+    buffer: Buffer,
+    bytes_written: AtomicU64,
+    flushed: bool,
+    threshold: usize,
 }
 
-#[cfg(test)]
-mod tests {
-    use std::io::Write;
+impl BufferedWriter {
+    pub fn try_new(
+        path: String,
+        writer: Writer,
+        arrow_schema: SchemaRef,
+        props: Option<WriterProperties>,
+        buffer_threshold: usize,
+    ) -> error::Result<Self> {
+        let buffer = Buffer::with_capacity(buffer_threshold);
+        let arrow_writer =
+            ArrowWriter::try_new(buffer.clone(), arrow_schema, props).context(WriteParquetSnafu)?;
 
-    use common_test_util::temp_dir::create_temp_dir;
-    use object_store::services::Fs;
-    use object_store::ObjectStore;
+        Ok(Self {
+            path,
+            arrow_writer,
+            object_writer: writer,
+            buffer,
+            bytes_written: Default::default(),
+            flushed: false,
+            threshold: buffer_threshold,
+        })
+    }
 
-    use super::*;
+    /// Write a record batch to stream writer.
+    pub async fn write(&mut self, batch: &RecordBatch) -> error::Result<()> {
+        self.arrow_writer.write(batch).context(WriteParquetSnafu)?;
+        let writen = Self::try_flush(
+            &self.path,
+            &self.buffer,
+            &mut self.object_writer,
+            false,
+            &mut self.flushed,
+            self.threshold,
+        )
+        .await?;
+        self.bytes_written.fetch_add(writen, Ordering::Relaxed);
+        Ok(())
+    }
 
-    #[tokio::test]
-    async fn test_append() {
-        let mut builder = Fs::default();
-        builder.root("/Users/lei/test_data");
-        let store = ObjectStore::new(builder).unwrap().finish();
-        let mut writer = store.writer("abcd").await.unwrap();
+    /// Abort writer.
+    pub async fn abort(self) -> bool {
+        // TODO(hl): Currently we can do nothing if file's parts have been uploaded to remote storage
+        // on abortion, we need to find a way to abort the upload. see https://help.aliyun.com/document_detail/31996.htm?spm=a2c4g.11186623.0.0.3eb42cb7b2mwUz#reference-txp-bvx-wdb
+        !self.flushed
+    }
 
-        let mut stream_writer = StreamWriter::new(writer, 4);
-        stream_writer.write("ab".as_bytes()).unwrap();
-        stream_writer.flush().unwrap();
-        println!("write ab");
-        stream_writer.write("cd".as_bytes()).unwrap();
-        stream_writer.flush().unwrap();
-        println!("write cd");
-        stream_writer.write("efg".as_bytes()).unwrap();
-        stream_writer.close().await.unwrap();
+    /// Close parquet writer and ensure all buffered data are written into underlying storage.
+    pub async fn close(mut self) -> error::Result<(FileMetaData, u64)> {
+        let metadata = self.arrow_writer.close().context(WriteParquetSnafu)?;
+        let written = Self::try_flush(
+            &self.path,
+            &self.buffer,
+            &mut self.object_writer,
+            true,
+            &mut self.flushed,
+            self.threshold,
+        )
+        .await?;
+        self.bytes_written.fetch_add(written, Ordering::Relaxed);
+        self.object_writer
+            .close()
+            .await
+            .context(WriteObjectSnafu { path: &self.path })?;
+        Ok((metadata, self.bytes_written.load(Ordering::Relaxed)))
+    }
+
+    /// Try to flush buffered data to underlying storage if it's size exceeds threshold.
+    /// Set `all` to true if all buffered data should be flushed regardless of it's size.
+    async fn try_flush(
+        file_name: &str,
+        shared_buffer: &Buffer,
+        object_writer: &mut Writer,
+        all: bool,
+        flushed: &mut bool,
+        threshold: usize,
+    ) -> error::Result<u64> {
+        let mut bytes_written = 0;
+
+        // Once buffered data size reaches threshold, split the data in chunks (typically 4MB)
+        // and write to underlying storage.
+        while shared_buffer.buffer.lock().unwrap().len() >= threshold {
+            let chunk = {
+                let mut buffer = shared_buffer.buffer.lock().unwrap();
+                buffer.split_to(threshold)
+            };
+            let size = chunk.len();
+            object_writer
+                .append(chunk)
+                .await
+                .context(WriteObjectSnafu { path: file_name })?;
+            *flushed = true;
+            bytes_written += size;
+        }
+
+        if all {
+            let remain = shared_buffer.buffer.lock().unwrap().split();
+            let size = remain.len();
+            object_writer
+                .append(remain)
+                .await
+                .context(WriteObjectSnafu { path: file_name })?;
+            *flushed = true;
+            bytes_written += size;
+        }
+        Ok(bytes_written as u64)
     }
 }

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -52,6 +52,8 @@ impl Write for Buffer {
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
+        // This flush implementation is intentionally left to blank.
+        // The actual flush is in `BufferedWriter::try_flush`
         Ok(())
     }
 }

--- a/tests/cases/standalone/copy/copy_from_fs.result
+++ b/tests/cases/standalone/copy/copy_from_fs.result
@@ -14,7 +14,7 @@ CREATE TABLE with_filename(host string, cpu double, memory double, ts timestamp 
 
 Affected Rows: 0
 
-Copy with_filename FROM '/tmp/demo/export/demo.parquet_1_2';
+Copy with_filename FROM '/tmp/demo/export/demo.parquet';
 
 Affected Rows: 2
 

--- a/tests/cases/standalone/copy/copy_from_fs.sql
+++ b/tests/cases/standalone/copy/copy_from_fs.sql
@@ -6,7 +6,7 @@ Copy demo TO '/tmp/demo/export/demo.parquet';
 
 CREATE TABLE with_filename(host string, cpu double, memory double, ts timestamp time index);
 
-Copy with_filename FROM '/tmp/demo/export/demo.parquet_1_2';
+Copy with_filename FROM '/tmp/demo/export/demo.parquet';
 
 select * from with_filename order by ts;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR proposed a buffered parquet writer to avoid writing whole parquet file into memory and flush to underlying storage at a time, which is caused by the gap between [ArrowWriter](https://docs.rs/parquet/34.0.0/parquet/arrow/arrow_writer/struct.ArrowWriter.html) which requires a `std::io::Write` and opendal's [`Writer`](https://docs.rs/opendal/0.30.4/opendal/struct.Writer.html), which implements `futures::AsyncWrite` only.

This PR can help to reduce the memory consumption during flush/compaction. 

Given an experiment that writes 1,000,000,000 rows into parquet file (target file size 1.2GB), original code uses up to 1.5GB ram while `BufferedWriter` uses at most 270MB.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/6406592/227988898-8049a5ec-af9c-4e1e-8556-dd3346938c73.png">


Original `ParquetWriter` which used to export table data is also replaced by `BufferedWriter`. This change can write table content to single file instead of previous approach that exports into several fragments while significantly improves export performance to reduce cost time to nearly 60%. Additionally, it can smooth the memory footprint as demonstrated below

<img width="1979" alt="image" src="https://user-images.githubusercontent.com/6406592/229018400-54174464-c8e1-491c-bb6d-ed3664f51f7a.png">

### Known issue
This solution requires opendal's backend support `Writer` API to continously append data to the end of object. This API is supported by fs and s3 backend, but not yet by aliyun oss (which I'm working on).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
