### PR TITLE
fix: a minor misuse of tokio::select

### DIFF
--- a/src/meta-srv/src/handler/failure_handler/runner.rs
+++ b/src/meta-srv/src/handler/failure_handler/runner.rs
@@ -16,7 +16,7 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use common_telemetry::error;
+use common_telemetry::{error, warn};
 use common_time::util::current_time_millis;
 use dashmap::mapref::multiple::RefMulti;
 use dashmap::DashMap;
@@ -110,6 +110,10 @@ impl FailureDetectRunner {
                             let mut detector = container.get_failure_detector(ident);
                             detector.heartbeat(heartbeat.heartbeat_time);
                         }
+                    }
+                    else => {
+                        warn!("Both control and heartbeat senders are closed, quit receiving.");
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add an "else" arm to tokio::select, otherwise it panics with error "all branches are disabled and there is no else branch"

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
