### PR TITLE
feat!: improve region manifest service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
 name = "common-runtime"
 version = "0.1.1"
 dependencies = [
+ "async-trait",
  "common-error",
  "common-telemetry",
  "metrics",
@@ -1672,6 +1673,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tokio-test",
+ "tokio-util",
 ]
 
 [[package]]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -44,9 +44,11 @@ max_purge_tasks = 32
 
 # Storage manifest options
 [storage.manifest]
-# Checkpoint actions margin.
-# Create a checkpoint every <manifest_checkpoint_margin> actions.
-manifest_checkpoint_margin = 10
+# Region checkpoint actions margin.
+# Create a checkpoint every <checkpoint_margin> actions.
+checkpoint_margin = 10
+# Region manifest logs and checkpoints gc execution duration
+gc_duration = '30s'
 
 # Procedure storage options, see `standalone.example.toml`.
 # [procedure.store]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -37,10 +37,16 @@ type = "File"
 data_dir = "/tmp/greptimedb/data/"
 
 # Compaction options, see `standalone.example.toml`.
-[compaction]
+[storage.compaction]
 max_inflight_tasks = 4
 max_files_in_level0 = 8
 max_purge_tasks = 32
+
+# Storage manifest options
+[storage.manifest]
+# Checkpoint actions margin.
+# Create a checkpoint every <manifest_checkpoint_margin> actions.
+manifest_checkpoint_margin = 10
 
 # Procedure storage options, see `standalone.example.toml`.
 # [procedure.store]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -109,9 +109,12 @@ max_purge_tasks = 32
 
 # Storage manifest options
 [storage.manifest]
-# Checkpoint actions margin.
-# Create a checkpoint every <manifest_checkpoint_margin> actions.
-manifest_checkpoint_margin = 3
+# Region checkpoint actions margin.
+# Create a checkpoint every <checkpoint_margin> actions.
+checkpoint_margin = 3
+# Region manifest logs and checkpoints gc execution duration
+gc_duration = '30s'
+
 
 # Procedure storage options.
 # Uncomment to enable.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -111,7 +111,7 @@ max_purge_tasks = 32
 [storage.manifest]
 # Region checkpoint actions margin.
 # Create a checkpoint every <checkpoint_margin> actions.
-checkpoint_margin = 3
+checkpoint_margin = 10
 # Region manifest logs and checkpoints gc execution duration
 gc_duration = '30s'
 

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -99,13 +99,19 @@ type = "File"
 data_dir = "/tmp/greptimedb/data/"
 
 # Compaction options.
-[compaction]
+[storage.compaction]
 # Max task number that can concurrently run.
 max_inflight_tasks = 4
 # Max files in level 0 to trigger compaction.
 max_files_in_level0 = 8
 # Max task number for SST purge task after compaction.
 max_purge_tasks = 32
+
+# Storage manifest options
+[storage.manifest]
+# Checkpoint actions margin.
+# Create a checkpoint every <manifest_checkpoint_margin> actions.
+manifest_checkpoint_margin = 3
 
 # Procedure storage options.
 # Uncomment to enable.

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -212,7 +212,8 @@ mod tests {
             max_purge_tasks = 32
 
             [storage.manifest]
-            manifest_checkpoint_margin = 9
+            checkpoint_margin = 9
+            gc_duration = '7s'
         "#;
         write!(file, "{}", toml_str).unwrap();
 
@@ -261,7 +262,8 @@ mod tests {
         );
         assert_eq!(
             RegionManifestConfig {
-                manifest_checkpoint_margin: Some(9),
+                checkpoint_margin: Some(9),
+                gc_duration: Some(Duration::from_secs(7)),
             },
             *options.storage.manifest(),
         );

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -146,10 +146,7 @@ impl TryFrom<StartCommand> for DatanodeOptions {
         }
 
         if let Some(data_dir) = cmd.data_dir {
-            opts.storage = ObjectStoreConfig::File(FileConfig {
-                data_dir,
-                ..Default::default()
-            });
+            opts.storage.store = ObjectStoreConfig::File(FileConfig { data_dir });
         }
 
         if let Some(wal_dir) = cmd.wal_dir {
@@ -244,7 +241,7 @@ mod tests {
         assert_eq!(3000, timeout_millis);
         assert!(tcp_nodelay);
 
-        match &options.storage {
+        match &options.storage.store {
             ObjectStoreConfig::File(FileConfig { data_dir, .. }) => {
                 assert_eq!("/tmp/greptimedb/data/", data_dir)
             }
@@ -258,14 +255,14 @@ mod tests {
                 max_files_in_level0: 7,
                 max_purge_tasks: 32,
             },
-            *options.storage.compaction(),
+            options.storage.compaction,
         );
         assert_eq!(
             RegionManifestConfig {
                 checkpoint_margin: Some(9),
                 gc_duration: Some(Duration::from_secs(7)),
             },
-            *options.storage.manifest(),
+            options.storage.manifest,
         );
     }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -17,9 +17,7 @@ use std::sync::Arc;
 use clap::Parser;
 use common_base::Plugins;
 use common_telemetry::info;
-use datanode::datanode::{
-    CompactionConfig, Datanode, DatanodeOptions, ProcedureConfig, StorageConfig, WalConfig,
-};
+use datanode::datanode::{Datanode, DatanodeOptions, ProcedureConfig, StorageConfig, WalConfig};
 use datanode::instance::InstanceRef;
 use frontend::frontend::FrontendOptions;
 use frontend::grpc::GrpcOptions;
@@ -83,7 +81,6 @@ pub struct StandaloneOptions {
     pub prom_options: Option<PromOptions>,
     pub wal: WalConfig,
     pub storage: StorageConfig,
-    pub compaction: CompactionConfig,
     pub procedure: Option<ProcedureConfig>,
 }
 
@@ -102,7 +99,6 @@ impl Default for StandaloneOptions {
             prom_options: Some(PromOptions::default()),
             wal: WalConfig::default(),
             storage: StorageConfig::default(),
-            compaction: CompactionConfig::default(),
             procedure: None,
         }
     }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -18,7 +18,7 @@ use clap::Parser;
 use common_base::Plugins;
 use common_telemetry::info;
 use datanode::datanode::{
-    CompactionConfig, Datanode, DatanodeOptions, ObjectStoreConfig, ProcedureConfig, WalConfig,
+    CompactionConfig, Datanode, DatanodeOptions, ProcedureConfig, StorageConfig, WalConfig,
 };
 use datanode::instance::InstanceRef;
 use frontend::frontend::FrontendOptions;
@@ -82,7 +82,7 @@ pub struct StandaloneOptions {
     pub prometheus_options: Option<PrometheusOptions>,
     pub prom_options: Option<PromOptions>,
     pub wal: WalConfig,
-    pub storage: ObjectStoreConfig,
+    pub storage: StorageConfig,
     pub compaction: CompactionConfig,
     pub procedure: Option<ProcedureConfig>,
 }
@@ -101,7 +101,7 @@ impl Default for StandaloneOptions {
             prometheus_options: Some(PrometheusOptions::default()),
             prom_options: Some(PromOptions::default()),
             wal: WalConfig::default(),
-            storage: ObjectStoreConfig::default(),
+            storage: StorageConfig::default(),
             compaction: CompactionConfig::default(),
             procedure: None,
         }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -129,7 +129,6 @@ impl StandaloneOptions {
             enable_memory_catalog: self.enable_memory_catalog,
             wal: self.wal,
             storage: self.storage,
-            compaction: self.compaction,
             procedure: self.procedure,
             ..Default::default()
         }

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+async-trait.workspace = true
 common-error = { path = "../error" }
 common-telemetry = { path = "../telemetry" }
 metrics = "0.20"
@@ -12,6 +13,7 @@ once_cell = "1.12"
 paste.workspace = true
 snafu.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/common/runtime/src/error.rs
+++ b/src/common/runtime/src/error.rs
@@ -15,6 +15,7 @@
 use std::any::Any;
 
 use common_error::prelude::*;
+use tokio::task::JoinError;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -24,6 +25,15 @@ pub enum Error {
     #[snafu(display("Failed to build runtime, source: {}", source))]
     BuildRuntime {
         source: std::io::Error,
+        backtrace: Backtrace,
+    },
+    #[snafu(display("Repeated task {} not started yet", name))]
+    IllegalState { name: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to wait for repated task {} to stop, source: {}", name, source))]
+    WaitGcTaskStop {
+        name: String,
+        source: JoinError,
         backtrace: Backtrace,
     },
 }

--- a/src/common/runtime/src/error.rs
+++ b/src/common/runtime/src/error.rs
@@ -30,7 +30,7 @@ pub enum Error {
     #[snafu(display("Repeated task {} not started yet", name))]
     IllegalState { name: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to wait for repated task {} to stop, source: {}", name, source))]
+    #[snafu(display("Failed to wait for repeated task {} to stop, source: {}", name, source))]
     WaitGcTaskStop {
         name: String,
         source: JoinError,

--- a/src/common/runtime/src/error.rs
+++ b/src/common/runtime/src/error.rs
@@ -30,7 +30,11 @@ pub enum Error {
     #[snafu(display("Repeated task {} not started yet", name))]
     IllegalState { name: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to wait for repeated task {} to stop, source: {}", name, source))]
+    #[snafu(display(
+        "Failed to wait for repeated task {} to stop, source: {}",
+        name,
+        source
+    ))]
     WaitGcTaskStop {
         name: String,
         source: JoinError,

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod error;
 mod global;
 pub mod metric;
+mod repeated_task;
 pub mod runtime;
 
 pub use global::{
@@ -23,4 +24,5 @@ pub use global::{
     spawn_read, spawn_write, write_runtime,
 };
 
+pub use crate::repeated_task::{RepeatedTask, TaskFunction, TaskFunctionRef};
 pub use crate::runtime::{Builder, JoinError, JoinHandle, Runtime};

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -36,7 +36,7 @@ pub type TaskFunctionRef<E> = Arc<dyn TaskFunction<E> + Send + Sync>;
 
 pub struct RepeatedTask<E> {
     cancel_token: Mutex<Option<CancellationToken>>,
-    gc_task_handle: Mutex<Option<JoinHandle<()>>>,
+    task_handle: Mutex<Option<JoinHandle<()>>>,
     started: AtomicBool,
     interval: Duration,
     task_fn: TaskFunctionRef<E>,

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -109,14 +109,14 @@ impl<E: ErrorExt + 'static> RepeatedTask<E> {
                 .is_ok(),
             IllegalStateSnafu { name }
         );
-        let handle = self
-            .gc_task_handle
+        let token = self
+            .cancel_token
             .lock()
             .await
             .take()
             .context(IllegalStateSnafu { name })?;
-        let token = self
-            .cancel_token
+        let handle = self
+            .gc_task_handle
             .lock()
             .await
             .take()

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -1,0 +1,158 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_error::prelude::ErrorExt;
+use common_telemetry::logging;
+use snafu::{ensure, OptionExt, ResultExt};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{IllegalStateSnafu, Result, WaitGcTaskStopSnafu};
+use crate::Runtime;
+
+#[async_trait::async_trait]
+pub trait TaskFunction<E: ErrorExt> {
+    async fn call(&self) -> std::result::Result<(), E>;
+    fn name(&self) -> &str;
+}
+
+pub type TaskFunctionRef<E> = Arc<dyn TaskFunction<E> + Send + Sync>;
+
+pub struct RepeatedTask<E> {
+    cancel_token: Mutex<Option<CancellationToken>>,
+    gc_task_handle: Mutex<Option<JoinHandle<()>>>,
+    started: AtomicBool,
+    interval: Duration,
+    task_fn: TaskFunctionRef<E>,
+}
+
+impl<E: ErrorExt> std::fmt::Display for RepeatedTask<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RepeatedTask({})", self.task_fn.name())
+    }
+}
+
+impl<E: ErrorExt> std::fmt::Debug for RepeatedTask<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("").field(&self.task_fn.name()).finish()
+    }
+}
+
+impl<E: ErrorExt + 'static> RepeatedTask<E> {
+    pub fn new(interval: Duration, task_fn: TaskFunctionRef<E>) -> Self {
+        Self {
+            cancel_token: Mutex::new(None),
+            gc_task_handle: Mutex::new(None),
+            started: AtomicBool::new(false),
+            interval,
+            task_fn,
+        }
+    }
+
+    pub fn started(&self) -> bool {
+        self.started.load(Ordering::Relaxed)
+    }
+
+    pub async fn start(&self, runtime: Runtime) -> Result<()> {
+        let token = CancellationToken::new();
+        let interval = self.interval;
+        let child = token.child_token();
+        let task_fn = self.task_fn.clone();
+        // TODO(hl): Maybe spawn to a blocking runtime.
+        let handle = runtime.spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(interval) => {}
+                    _ = child.cancelled() => {
+                        return;
+                    }
+                }
+                if let Err(e) = task_fn.call().await {
+                    logging::error!(e; "Failed to run repeated task: {}", task_fn.name());
+                }
+            }
+        });
+        *self.cancel_token.lock().await = Some(token);
+        *self.gc_task_handle.lock().await = Some(handle);
+        self.started.store(true, Ordering::Relaxed);
+
+        logging::info!(
+            "Repeated task {} started with interval: {:?}",
+            self.task_fn.name(),
+            self.interval
+        );
+
+        Ok(())
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+        let name = self.task_fn.name();
+        ensure!(
+            self.started
+                .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok(),
+            IllegalStateSnafu { name }
+        );
+        let handle = self
+            .gc_task_handle
+            .lock()
+            .await
+            .take()
+            .context(IllegalStateSnafu { name })?;
+        let token = self
+            .cancel_token
+            .lock()
+            .await
+            .take()
+            .context(IllegalStateSnafu { name })?;
+
+        token.cancel();
+        handle.await.context(WaitGcTaskStopSnafu { name })?;
+
+        logging::info!("Repeated task {} stopped", name);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicI32;
+
+    use super::*;
+
+    struct TickTask {
+        n: AtomicI32,
+    }
+
+    #[async_trait::async_trait]
+    impl TaskFunction<crate::error::Error> for TickTask {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        async fn call(&self) -> Result<()> {
+            self.n.fetch_add(1, Ordering::Relaxed);
+
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_repeated_task() {
+        common_telemetry::init_default_ut_logging();
+
+        let task_fn = Arc::new(TickTask {
+            n: AtomicI32::new(0),
+        });
+
+        let task = RepeatedTask::new(Duration::from_millis(100), task_fn.clone());
+
+        task.start(crate::bg_runtime()).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(550)).await;
+        task.stop().await.unwrap();
+
+        assert_eq!(task_fn.n.load(Ordering::Relaxed), 5);
+    }
+}

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -50,7 +50,7 @@ impl<E: ErrorExt> std::fmt::Display for RepeatedTask<E> {
 
 impl<E: ErrorExt> std::fmt::Debug for RepeatedTask<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("").field(&self.task_fn.name()).finish()
+        f.debug_tuple("RepeatedTask").field(&self.task_fn.name()).finish()
     }
 }
 

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -60,7 +60,7 @@ impl<E: ErrorExt + 'static> RepeatedTask<E> {
     pub fn new(interval: Duration, task_fn: TaskFunctionRef<E>) -> Self {
         Self {
             cancel_token: Mutex::new(None),
-            gc_task_handle: Mutex::new(None),
+            task_handle: Mutex::new(None),
             started: AtomicBool::new(false),
             interval,
             task_fn,
@@ -91,7 +91,7 @@ impl<E: ErrorExt + 'static> RepeatedTask<E> {
             }
         });
         *self.cancel_token.lock().await = Some(token);
-        *self.gc_task_handle.lock().await = Some(handle);
+        *self.task_handle.lock().await = Some(handle);
         self.started.store(true, Ordering::Relaxed);
 
         logging::info!(
@@ -118,7 +118,7 @@ impl<E: ErrorExt + 'static> RepeatedTask<E> {
             .take()
             .context(IllegalStateSnafu { name })?;
         let handle = self
-            .gc_task_handle
+            .task_handle
             .lock()
             .await
             .take()

--- a/src/common/runtime/src/repeated_task.rs
+++ b/src/common/runtime/src/repeated_task.rs
@@ -50,7 +50,9 @@ impl<E: ErrorExt> std::fmt::Display for RepeatedTask<E> {
 
 impl<E: ErrorExt> std::fmt::Debug for RepeatedTask<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RepeatedTask").field(&self.task_fn.name()).finish()
+        f.debug_tuple("RepeatedTask")
+            .field(&self.task_fn.name())
+            .finish()
     }
 }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -139,7 +139,7 @@ pub struct RegionManifestConfig {
     /// Region manifest checkpoint actions margin.
     /// Manifest service create a checkpoint every [checkpoint_margin] actions.
     pub checkpoint_margin: Option<u16>,
-    /// Region manifest logs and checkpoints gc task exeuction duration.
+    /// Region manifest logs and checkpoints gc task execution duration.
     #[serde(with = "humantime_serde")]
     pub gc_duration: Option<Duration>,
 }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -137,7 +137,7 @@ impl Default for WalConfig {
 #[serde(default)]
 pub struct RegionManifestConfig {
     /// Region manifest checkpoint actions margin.
-    /// Manifest service create a checkpint every [manifest_checkpoint_margin] actions.
+    /// Manifest service create a checkpoint every [manifest_checkpoint_margin] actions.
     pub manifest_checkpoint_margin: Option<u16>,
 }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -40,6 +40,7 @@ pub enum ObjectStoreConfig {
 
 /// Storage engine config
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
 pub struct StorageConfig {
     #[serde(flatten)]
     pub store: ObjectStoreConfig,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -137,14 +137,18 @@ impl Default for WalConfig {
 #[serde(default)]
 pub struct RegionManifestConfig {
     /// Region manifest checkpoint actions margin.
-    /// Manifest service create a checkpoint every [manifest_checkpoint_margin] actions.
-    pub manifest_checkpoint_margin: Option<u16>,
+    /// Manifest service create a checkpoint every [checkpoint_margin] actions.
+    pub checkpoint_margin: Option<u16>,
+    /// Region manifest logs and checkpoints gc task exeuction duration.
+    #[serde(with = "humantime_serde")]
+    pub gc_duration: Option<Duration>,
 }
 
 impl Default for RegionManifestConfig {
     fn default() -> Self {
         Self {
-            manifest_checkpoint_margin: Some(10u16),
+            checkpoint_margin: Some(10u16),
+            gc_duration: Some(Duration::from_secs(30)),
         }
     }
 }
@@ -182,7 +186,8 @@ impl From<&DatanodeOptions> for SchedulerConfig {
 impl From<&DatanodeOptions> for StorageEngineConfig {
     fn from(value: &DatanodeOptions) -> Self {
         Self {
-            manifest_checkpoint_margin: value.storage.manifest().manifest_checkpoint_margin,
+            manifest_checkpoint_margin: value.storage.manifest().checkpoint_margin,
+            manifest_gc_duration: value.storage.manifest().gc_duration,
             max_files_in_l0: value.storage.compaction().max_files_in_level0,
             max_purge_tasks: value.storage.compaction().max_purge_tasks,
         }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -181,6 +181,9 @@ pub enum Error {
     #[snafu(display("Failed to create directory {}, source: {}", dir, source))]
     CreateDir { dir: String, source: std::io::Error },
 
+    #[snafu(display("Failed to remove directory {}, source: {}", dir, source))]
+    RemoveDir { dir: String, source: std::io::Error },
+
     #[snafu(display("Failed to open log store, source: {}", source))]
     OpenLogStore {
         #[snafu(backtrace)]
@@ -576,6 +579,7 @@ impl ErrorExt for Error {
             | TcpBind { .. }
             | StartGrpc { .. }
             | CreateDir { .. }
+            | RemoveDir { .. }
             | InsertSystemCatalog { .. }
             | RenameTable { .. }
             | Catalog { .. }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -104,7 +104,7 @@ impl Instance {
         meta_client: Option<Arc<MetaClient>>,
         compaction_scheduler: CompactionSchedulerRef<RaftEngineLogStore>,
     ) -> Result<Self> {
-        let object_store = new_object_store(&opts.storage).await?;
+        let object_store = new_object_store(&opts.storage.store).await?;
         let log_store = Arc::new(create_log_store(&opts.wal).await?);
 
         let table_engine = Arc::new(DefaultEngine::new(

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -431,6 +431,10 @@ pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Res
 
     let atomic_write_dir = format!("{data_dir}/.tmp/");
     if path::Path::new(&atomic_write_dir).exists() {
+        info!(
+            "Begin to clean temp storage directory: {}",
+            &atomic_write_dir
+        );
         fs::remove_dir_all(&atomic_write_dir).context(error::RemoveDirSnafu {
             dir: &atomic_write_dir,
         })?;

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -32,7 +32,9 @@ use sql::statements::tql::Tql;
 use table::engine::{EngineContext, TableEngineRef};
 use table::requests::{CreateTableRequest, TableOptions};
 
-use crate::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, ProcedureConfig, WalConfig};
+use crate::datanode::{
+    DatanodeOptions, FileConfig, ObjectStoreConfig, ProcedureConfig, StorageConfig, WalConfig,
+};
 use crate::error::{CreateTableSnafu, Result};
 use crate::instance::Instance;
 use crate::sql::SqlHandler;
@@ -63,7 +65,6 @@ impl MockInstance {
         opts.procedure = Some(ProcedureConfig {
             store: ObjectStoreConfig::File(FileConfig {
                 data_dir: procedure_dir.path().to_str().unwrap().to_string(),
-                ..Default::default()
             }),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
@@ -131,10 +132,12 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File(FileConfig {
-            data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+        storage: StorageConfig {
+            store: ObjectStoreConfig::File(FileConfig {
+                data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            }),
             ..Default::default()
-        }),
+        },
         mode: Mode::Standalone,
         ..Default::default()
     };

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -63,6 +63,7 @@ impl MockInstance {
         opts.procedure = Some(ProcedureConfig {
             store: ObjectStoreConfig::File(FileConfig {
                 data_dir: procedure_dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
             }),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
@@ -132,6 +133,7 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
         },
         storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
         }),
         mode: Mode::Standalone,
         ..Default::default()

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -21,7 +21,9 @@ use client::Client;
 use common_grpc::channel_manager::ChannelManager;
 use common_runtime::Builder as RuntimeBuilder;
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
-use datanode::datanode::{DatanodeOptions, FileConfig, ObjectStoreConfig, WalConfig};
+use datanode::datanode::{
+    DatanodeOptions, FileConfig, ObjectStoreConfig, StorageConfig, WalConfig,
+};
 use datanode::instance::Instance as DatanodeInstance;
 use meta_client::client::MetaClientBuilder;
 use meta_client::rpc::Peer;
@@ -95,10 +97,12 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File(FileConfig {
-            data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+        storage: StorageConfig {
+            store: ObjectStoreConfig::File(FileConfig {
+                data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            }),
             ..Default::default()
-        }),
+        },
         mode: Mode::Standalone,
         ..Default::default()
     };
@@ -183,10 +187,12 @@ async fn create_distributed_datanode(
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage: ObjectStoreConfig::File(FileConfig {
-            data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+        storage: StorageConfig {
+            store: ObjectStoreConfig::File(FileConfig {
+                data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            }),
             ..Default::default()
-        }),
+        },
         mode: Mode::Distributed,
         ..Default::default()
     };

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -97,6 +97,7 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
         },
         storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
         }),
         mode: Mode::Standalone,
         ..Default::default()
@@ -184,6 +185,7 @@ async fn create_distributed_datanode(
         },
         storage: ObjectStoreConfig::File(FileConfig {
             data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
         }),
         mode: Mode::Distributed,
         ..Default::default()

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
         source: RuntimeError,
     },
 
-    #[snafu(display("Failed to start log store gc task, source: {}", source))]
+    #[snafu(display("Failed to stop log store gc task, source: {}", source))]
     StopGcTask {
         #[snafu(backtrace)]
         source: RuntimeError,

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -15,16 +15,22 @@
 use std::any::Any;
 
 use common_error::prelude::{ErrorExt, Snafu};
+use common_runtime::error::Error as RuntimeError;
 use snafu::{Backtrace, ErrorCompat};
-use tokio::task::JoinError;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Failed to wait for gc task to stop, source: {}", source))]
-    WaitGcTaskStop {
-        source: JoinError,
-        backtrace: Backtrace,
+    #[snafu(display("Failed to start log store gc task, source: {}", source))]
+    StartGcTask {
+        #[snafu(backtrace)]
+        source: RuntimeError,
+    },
+
+    #[snafu(display("Failed to start log store gc task, source: {}", source))]
+    StopGcTask {
+        #[snafu(backtrace)]
+        source: RuntimeError,
     },
 
     #[snafu(display("Failed to add entry to LogBatch, source: {}", source))]

--- a/src/mito/src/manifest.rs
+++ b/src/mito/src/manifest.rs
@@ -80,7 +80,7 @@ mod tests {
     async fn test_table_manifest() {
         let (_dir, object_store) = test_util::new_test_object_store("test_table_manifest").await;
 
-        let manifest = TableManifest::new("manifest/", object_store, None, None);
+        let manifest = TableManifest::create("manifest/", object_store);
 
         let mut iter = manifest.scan(0, 100).await.unwrap();
         assert!(iter.next_action().await.unwrap().is_none());

--- a/src/mito/src/manifest.rs
+++ b/src/mito/src/manifest.rs
@@ -80,7 +80,7 @@ mod tests {
     async fn test_table_manifest() {
         let (_dir, object_store) = test_util::new_test_object_store("test_table_manifest").await;
 
-        let manifest = TableManifest::new("manifest/", object_store, None);
+        let manifest = TableManifest::new("manifest/", object_store, None, None);
 
         let mut iter = manifest.scan(0, 100).await.unwrap();
         assert!(iter.next_action().await.unwrap().is_none());

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -471,7 +471,7 @@ impl<R: Region> MitoTable<R> {
         regions: HashMap<RegionNumber, R>,
         object_store: ObjectStore,
     ) -> Result<MitoTable<R>> {
-        let manifest = TableManifest::new(&table_manifest_dir(table_dir), object_store, None);
+        let manifest = TableManifest::new(&table_manifest_dir(table_dir), object_store, None, None);
 
         // TODO(dennis): save manifest version into catalog?
         let _manifest_version = manifest
@@ -487,7 +487,7 @@ impl<R: Region> MitoTable<R> {
     }
 
     pub(crate) fn build_manifest(table_dir: &str, object_store: ObjectStore) -> TableManifest {
-        TableManifest::new(&table_manifest_dir(table_dir), object_store, None)
+        TableManifest::new(&table_manifest_dir(table_dir), object_store, None, None)
     }
 
     pub(crate) async fn recover_table_info(

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -471,7 +471,7 @@ impl<R: Region> MitoTable<R> {
         regions: HashMap<RegionNumber, R>,
         object_store: ObjectStore,
     ) -> Result<MitoTable<R>> {
-        let manifest = TableManifest::new(&table_manifest_dir(table_dir), object_store, None, None);
+        let manifest = TableManifest::create(&table_manifest_dir(table_dir), object_store);
 
         // TODO(dennis): save manifest version into catalog?
         let _manifest_version = manifest
@@ -487,7 +487,7 @@ impl<R: Region> MitoTable<R> {
     }
 
     pub(crate) fn build_manifest(table_dir: &str, object_store: ObjectStore) -> TableManifest {
-        TableManifest::new(&table_manifest_dir(table_dir), object_store, None, None)
+        TableManifest::create(&table_manifest_dir(table_dir), object_store)
     }
 
     pub(crate) async fn recover_table_info(

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use opendal::raw::normalize_path as raw_normalize_path;
 pub use opendal::raw::oio::Pager;
 pub use opendal::{
     layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -14,9 +14,12 @@
 
 //! storage engine config
 
+use std::time::Duration;
+
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
     pub manifest_checkpoint_margin: Option<u16>,
+    pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
     pub max_purge_tasks: usize,
 }
@@ -25,6 +28,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             manifest_checkpoint_margin: Some(10),
+            manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,
             max_purge_tasks: 32,
         }

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -16,6 +16,7 @@
 
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
+    pub manifest_checkpoint_margin: Option<u16>,
     pub max_files_in_l0: usize,
     pub max_purge_tasks: usize,
 }
@@ -23,6 +24,7 @@ pub struct EngineConfig {
 impl Default for EngineConfig {
     fn default() -> Self {
         Self {
+            manifest_checkpoint_margin: Some(10),
             max_files_in_l0: 8,
             max_purge_tasks: 32,
         }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -290,8 +290,13 @@ impl<S: LogStore> EngineInner<S> {
 
         let mut guard = SlotGuard::new(name, &self.regions);
 
-        let store_config =
-            self.region_store_config(&opts.parent_dir, opts.write_buffer_size, name, opts.ttl);
+        let store_config = self.region_store_config(
+            &opts.parent_dir,
+            opts.write_buffer_size,
+            name,
+            self.config.manifest_checkpoint_margin,
+            opts.ttl,
+        );
 
         let region = match RegionImpl::open(name.to_string(), store_config, opts).await? {
             None => return Ok(None),
@@ -325,6 +330,7 @@ impl<S: LogStore> EngineInner<S> {
             &opts.parent_dir,
             opts.write_buffer_size,
             &region_name,
+            self.config.manifest_checkpoint_margin,
             opts.ttl,
         );
 
@@ -347,6 +353,7 @@ impl<S: LogStore> EngineInner<S> {
         parent_dir: &str,
         write_buffer_size: Option<usize>,
         region_name: &str,
+        manifest_checkpoint_margin: Option<u16>,
         ttl: Option<Duration>,
     ) -> StoreConfig<S> {
         let parent_dir = util::normalize_dir(parent_dir);
@@ -354,7 +361,11 @@ impl<S: LogStore> EngineInner<S> {
         let sst_dir = &region_sst_dir(&parent_dir, region_name);
         let sst_layer = Arc::new(FsAccessLayer::new(sst_dir, self.object_store.clone()));
         let manifest_dir = region_manifest_dir(&parent_dir, region_name);
-        let manifest = RegionManifest::with_checkpointer(&manifest_dir, self.object_store.clone());
+        let manifest = RegionManifest::with_checkpointer(
+            &manifest_dir,
+            self.object_store.clone(),
+            manifest_checkpoint_margin,
+        );
 
         let flush_strategy = write_buffer_size
             .map(|size| Arc::new(SizeBasedStrategy::new(size)) as Arc<_>)

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -21,6 +21,7 @@ use common_telemetry::logging::info;
 use object_store::{util, ObjectStore};
 use snafu::ResultExt;
 use store_api::logstore::LogStore;
+use store_api::manifest::Manifest;
 use store_api::storage::{
     CreateOptions, EngineContext, OpenOptions, Region, RegionDescriptor, StorageEngine,
 };
@@ -290,13 +291,15 @@ impl<S: LogStore> EngineInner<S> {
 
         let mut guard = SlotGuard::new(name, &self.regions);
 
-        let store_config = self.region_store_config(
-            &opts.parent_dir,
-            opts.write_buffer_size,
-            name,
-            self.config.manifest_checkpoint_margin,
-            opts.ttl,
-        );
+        let store_config = self
+            .region_store_config(
+                &opts.parent_dir,
+                opts.write_buffer_size,
+                name,
+                self.config.manifest_checkpoint_margin,
+                opts.ttl,
+            )
+            .await?;
 
         let region = match RegionImpl::open(name.to_string(), store_config, opts).await? {
             None => return Ok(None),
@@ -326,13 +329,15 @@ impl<S: LogStore> EngineInner<S> {
                 .context(error::InvalidRegionDescSnafu {
                     region: &region_name,
                 })?;
-        let store_config = self.region_store_config(
-            &opts.parent_dir,
-            opts.write_buffer_size,
-            &region_name,
-            self.config.manifest_checkpoint_margin,
-            opts.ttl,
-        );
+        let store_config = self
+            .region_store_config(
+                &opts.parent_dir,
+                opts.write_buffer_size,
+                &region_name,
+                self.config.manifest_checkpoint_margin,
+                opts.ttl,
+            )
+            .await?;
 
         let region = RegionImpl::create(metadata, store_config).await?;
 
@@ -348,14 +353,14 @@ impl<S: LogStore> EngineInner<S> {
         slot.get_ready_region()
     }
 
-    fn region_store_config(
+    async fn region_store_config(
         &self,
         parent_dir: &str,
         write_buffer_size: Option<usize>,
         region_name: &str,
         manifest_checkpoint_margin: Option<u16>,
         ttl: Option<Duration>,
-    ) -> StoreConfig<S> {
+    ) -> Result<StoreConfig<S>> {
         let parent_dir = util::normalize_dir(parent_dir);
 
         let sst_dir = &region_sst_dir(&parent_dir, region_name);
@@ -366,12 +371,13 @@ impl<S: LogStore> EngineInner<S> {
             self.object_store.clone(),
             manifest_checkpoint_margin,
         );
+        manifest.start().await?;
 
         let flush_strategy = write_buffer_size
             .map(|size| Arc::new(SizeBasedStrategy::new(size)) as Arc<_>)
             .unwrap_or_else(|| self.flush_strategy.clone());
 
-        StoreConfig {
+        Ok(StoreConfig {
             log_store: self.log_store.clone(),
             sst_layer,
             manifest,
@@ -382,7 +388,7 @@ impl<S: LogStore> EngineInner<S> {
             engine_config: self.config.clone(),
             file_purger: self.file_purger.clone(),
             ttl,
-        }
+        })
     }
 }
 

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -296,7 +296,7 @@ impl<S: LogStore> EngineInner<S> {
                 &opts.parent_dir,
                 opts.write_buffer_size,
                 name,
-                self.config.manifest_checkpoint_margin,
+                &self.config,
                 opts.ttl,
             )
             .await?;
@@ -334,7 +334,7 @@ impl<S: LogStore> EngineInner<S> {
                 &opts.parent_dir,
                 opts.write_buffer_size,
                 &region_name,
-                self.config.manifest_checkpoint_margin,
+                &self.config,
                 opts.ttl,
             )
             .await?;
@@ -358,7 +358,7 @@ impl<S: LogStore> EngineInner<S> {
         parent_dir: &str,
         write_buffer_size: Option<usize>,
         region_name: &str,
-        manifest_checkpoint_margin: Option<u16>,
+        config: &EngineConfig,
         ttl: Option<Duration>,
     ) -> Result<StoreConfig<S>> {
         let parent_dir = util::normalize_dir(parent_dir);
@@ -369,7 +369,8 @@ impl<S: LogStore> EngineInner<S> {
         let manifest = RegionManifest::with_checkpointer(
             &manifest_dir,
             self.object_store.clone(),
-            manifest_checkpoint_margin,
+            config.manifest_checkpoint_margin,
+            config.manifest_gc_duration,
         );
         manifest.start().await?;
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -424,13 +424,13 @@ pub enum Error {
     #[snafu(display("Cannot schedule request, scheduler's already stopped"))]
     IllegalSchedulerState { backtrace: Backtrace },
 
-    #[snafu(display("Failed to start manifest gc task"))]
+    #[snafu(display("Failed to start manifest gc task: {}", source))]
     StartManifestGcTask {
         #[snafu(backtrace)]
         source: RuntimeError,
     },
 
-    #[snafu(display("Failed to stop manifest gc task"))]
+    #[snafu(display("Failed to stop manifest gc task: {}", source))]
     StopManifestGcTask {
         #[snafu(backtrace)]
         source: RuntimeError,

--- a/src/storage/src/manifest/impl_.rs
+++ b/src/storage/src/manifest/impl_.rs
@@ -66,6 +66,7 @@ impl<S: 'static + Checkpoint<Error = Error>, M: 'static + MetaAction<Error = Err
         } else {
             None
         };
+
         ManifestImpl {
             inner,
             checkpointer,

--- a/src/storage/src/manifest/impl_.rs
+++ b/src/storage/src/manifest/impl_.rs
@@ -232,7 +232,12 @@ impl<S: Checkpoint<Error = Error>, M: MetaAction<Error = Error>> ManifestImplInn
     async fn gc_manifest_checkpoint(store: Arc<ManifestObjectStore>) -> Result<()> {
         if let Some((last_version, _)) = store.load_last_checkpoint().await? {
             // Purge all manifest and checkpoint files before last_version.
-            store.delete_until(last_version).await?;
+            let deleted = store.delete_until(last_version).await?;
+            debug!(
+                "Deleted {} logs from region manifest storage(path={}).",
+                deleted,
+                store.path()
+            );
         }
 
         Ok(())

--- a/src/storage/src/manifest/impl_.rs
+++ b/src/storage/src/manifest/impl_.rs
@@ -35,6 +35,7 @@ use crate::manifest::checkpoint::Checkpointer;
 use crate::manifest::storage::{ManifestObjectStore, ObjectStoreLogIterator};
 
 const CHECKPOINT_ACTIONS_MARGIN: u16 = 10;
+const CHECKPOINT_GC_DURATION_SECS: u64 = 60;
 
 #[derive(Clone, Debug)]
 pub struct ManifestImpl<S: Checkpoint<Error = Error>, M: MetaAction<Error = Error>> {
@@ -58,7 +59,7 @@ impl<S: 'static + Checkpoint<Error = Error>, M: 'static + MetaAction<Error = Err
         let gc_task = if checkpointer.is_some() {
             // only start gc task when checkpoint is enabled.
             Some(Arc::new(RepeatedTask::new(
-                Duration::from_secs(60),
+                Duration::from_secs(CHECKPOINT_GC_DURATION_SECS),
                 inner.clone() as _,
             )))
         } else {

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -138,10 +138,15 @@ impl Checkpointer for RegionManifestCheckpointer {
 }
 
 impl RegionManifest {
-    pub fn with_checkpointer(manifest_dir: &str, object_store: ObjectStore) -> Self {
+    pub fn with_checkpointer(
+        manifest_dir: &str,
+        object_store: ObjectStore,
+        checkpoint_actions_margin: Option<u16>,
+    ) -> Self {
         Self::new(
             manifest_dir,
             object_store,
+            checkpoint_actions_margin,
             Some(Arc::new(RegionManifestCheckpointer {
                 flushed_manifest_version: AtomicU64::new(0),
             })),
@@ -184,7 +189,7 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store);
+        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None);
 
         let region_meta = Arc::new(build_region_meta());
 
@@ -294,7 +299,7 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store);
+        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None);
 
         let region_meta = Arc::new(build_region_meta());
         let new_region_meta = Arc::new(build_altered_region_meta());

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -16,6 +16,7 @@
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use common_telemetry::info;
@@ -135,11 +136,13 @@ impl RegionManifest {
         manifest_dir: &str,
         object_store: ObjectStore,
         checkpoint_actions_margin: Option<u16>,
+        gc_duration: Option<Duration>,
     ) -> Self {
         Self::new(
             manifest_dir,
             object_store,
             checkpoint_actions_margin,
+            gc_duration,
             Some(Arc::new(RegionManifestCheckpointer {
                 flushed_manifest_version: AtomicU64::new(0),
             })),
@@ -182,7 +185,7 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None);
+        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None, None);
 
         let region_meta = Arc::new(build_region_meta());
 
@@ -292,7 +295,7 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None);
+        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None, None);
 
         let region_meta = Arc::new(build_region_meta());
         let new_region_meta = Arc::new(build_altered_region_meta());

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -115,7 +115,6 @@ impl Checkpointer for RegionManifestCheckpointer {
         };
 
         manifest.save_checkpoint(&checkpoint).await?;
-        // TODO(dennis): background task to clean old manifest actions and checkpoints.
         manifest
             .manifest_store()
             .delete(start_version, last_version + 1)

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -119,12 +119,6 @@ impl Checkpointer for RegionManifestCheckpointer {
             .manifest_store()
             .delete(start_version, last_version + 1)
             .await?;
-        if start_version > MIN_VERSION {
-            manifest
-                .manifest_store()
-                .delete_checkpoint(start_version - 1)
-                .await?
-        }
 
         info!("Region manifest checkpoint, start_version: {}, last_version: {}, compacted actions: {}", start_version, last_version, compacted_actions);
 

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -300,12 +300,8 @@ impl ManifestLogStorage for ManifestObjectStore {
         let path = self.checkpoint_file_path(version);
         match self.object_store.read(&path).await {
             Ok(checkpoint) => Ok(Some((version, checkpoint))),
-            Err(e) if e.kind() == ErrorKind::NotFound => {
-                return Ok(None);
-            }
-            Err(e) => {
-                return Err(e).context(ReadObjectSnafu { path });
-            }
+            Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e).context(ReadObjectSnafu { path }),
         }
     }
 

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -416,7 +416,7 @@ mod tests {
         let mut it = log_store.scan(0, 11).await.unwrap();
         let (version, bytes) = it.next_log().await.unwrap().unwrap();
         assert_eq!(4, version);
-        assert_eq!(format!("hello, 4").as_bytes(), bytes);
+        assert_eq!("hello, 4".as_bytes(), bytes);
         assert!(it.next_log().await.unwrap().is_none());
 
         // delete all logs and checkpoints

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -607,7 +607,8 @@ impl<S: LogStore> RegionInner<S> {
     }
 
     async fn close(&self) -> Result<()> {
-        self.writer.close().await
+        self.writer.close().await?;
+        self.manifest.stop().await
     }
 
     async fn flush(&self, ctx: &FlushContext) -> Result<()> {

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -290,7 +290,7 @@ async fn test_recover_region_manifets() {
     builder.root(&tmp_dir.path().to_string_lossy());
     let object_store = ObjectStore::new(builder).unwrap().finish();
 
-    let manifest = RegionManifest::with_checkpointer("/manifest/", object_store.clone());
+    let manifest = RegionManifest::with_checkpointer("/manifest/", object_store.clone(), None);
     let region_meta = Arc::new(build_region_meta());
 
     let sst_layer = Arc::new(FsAccessLayer::new("sst", object_store)) as _;

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -290,7 +290,8 @@ async fn test_recover_region_manifets() {
     builder.root(&tmp_dir.path().to_string_lossy());
     let object_store = ObjectStore::new(builder).unwrap().finish();
 
-    let manifest = RegionManifest::with_checkpointer("/manifest/", object_store.clone(), None);
+    let manifest =
+        RegionManifest::with_checkpointer("/manifest/", object_store.clone(), None, None);
     let region_meta = Arc::new(build_region_meta());
 
     let sst_layer = Arc::new(FsAccessLayer::new("sst", object_store)) as _;

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -18,6 +18,7 @@ use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::LogConfig;
 use object_store::services::Fs as Builder;
 use object_store::ObjectStore;
+use store_api::manifest::Manifest;
 
 use crate::background::JobPoolImpl;
 use crate::compaction::noop::NoopCompactionScheduler;
@@ -49,6 +50,7 @@ pub async fn new_store_config(
     let object_store = ObjectStore::new(builder).unwrap().finish();
     let sst_layer = Arc::new(FsAccessLayer::new(&sst_dir, object_store.clone()));
     let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store, None);
+    manifest.start().await.unwrap();
     let job_pool = Arc::new(JobPoolImpl {});
     let flush_scheduler = Arc::new(FlushSchedulerImpl::new(job_pool));
     let log_config = LogConfig {

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -49,7 +49,7 @@ pub async fn new_store_config(
 
     let object_store = ObjectStore::new(builder).unwrap().finish();
     let sst_layer = Arc::new(FsAccessLayer::new(&sst_dir, object_store.clone()));
-    let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store, None);
+    let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store, None, None);
     manifest.start().await.unwrap();
     let job_pool = Arc::new(JobPoolImpl {});
     let flush_scheduler = Arc::new(FlushSchedulerImpl::new(job_pool));

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -48,7 +48,7 @@ pub async fn new_store_config(
 
     let object_store = ObjectStore::new(builder).unwrap().finish();
     let sst_layer = Arc::new(FsAccessLayer::new(&sst_dir, object_store.clone()));
-    let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store);
+    let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store, None);
     let job_pool = Arc::new(JobPoolImpl {});
     let flush_scheduler = Arc::new(FlushSchedulerImpl::new(job_pool));
     let log_config = LogConfig {

--- a/src/store-api/src/manifest.rs
+++ b/src/store-api/src/manifest.rs
@@ -102,4 +102,13 @@ pub trait Manifest: Send + Sync + Clone + 'static {
 
     /// Returns the last(or latest) manifest version.
     fn last_version(&self) -> ManifestVersion;
+
+    /// Start the service
+    async fn start(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+    /// Stop the service
+    async fn stop(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }

--- a/src/store-api/src/manifest/storage.rs
+++ b/src/store-api/src/manifest/storage.rs
@@ -36,6 +36,9 @@ pub trait ManifestLogStorage {
         end: ManifestVersion,
     ) -> Result<Self::Iter, Self::Error>;
 
+    /// Delete logs which version is less than specified version.
+    async fn delete_until(&self, version: ManifestVersion) -> Result<(), Self::Error>;
+
     /// Save  a log
     async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<(), Self::Error>;
 

--- a/src/store-api/src/manifest/storage.rs
+++ b/src/store-api/src/manifest/storage.rs
@@ -37,7 +37,8 @@ pub trait ManifestLogStorage {
     ) -> Result<Self::Iter, Self::Error>;
 
     /// Delete logs which version is less than specified version.
-    async fn delete_until(&self, version: ManifestVersion) -> Result<(), Self::Error>;
+    /// Returns the delete logs number.
+    async fn delete_until(&self, version: ManifestVersion) -> Result<usize, Self::Error>;
 
     /// Save  a log
     async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<(), Self::Error>;

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -100,8 +100,7 @@ fn get_test_store_config(
                 access_key_secret: env::var("GT_OSS_ACCESS_KEY").unwrap(),
                 bucket: env::var("GT_OSS_BUCKET").unwrap(),
                 endpoint: env::var("GT_OSS_ENDPOINT").unwrap(),
-                cache_path: None,
-                cache_capacity: None,
+                ..Default::default()
             };
 
             let mut builder = Oss::default();
@@ -127,10 +126,7 @@ fn get_test_store_config(
                 access_key_id: env::var("GT_S3_ACCESS_KEY_ID").unwrap(),
                 secret_access_key: env::var("GT_S3_ACCESS_KEY").unwrap(),
                 bucket: env::var("GT_S3_BUCKET").unwrap(),
-                endpoint: None,
-                region: None,
-                cache_path: None,
-                cache_capacity: None,
+                ..Default::default()
             };
 
             let mut builder = S3::default();
@@ -152,6 +148,7 @@ fn get_test_store_config(
             (
                 ObjectStoreConfig::File(FileConfig {
                     data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+                    ..Default::default()
                 }),
                 Some(TempDirGuard::File(data_tmp_dir)),
             )

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -24,7 +24,7 @@ use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MIN_USER
 use common_runtime::Builder as RuntimeBuilder;
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use datanode::datanode::{
-    DatanodeOptions, FileConfig, ObjectStoreConfig, OssConfig, S3Config, WalConfig,
+    DatanodeOptions, FileConfig, ObjectStoreConfig, OssConfig, S3Config, StorageConfig, WalConfig,
 };
 use datanode::error::{CreateTableSnafu, Result};
 use datanode::instance::{Instance, InstanceRef};
@@ -148,7 +148,6 @@ fn get_test_store_config(
             (
                 ObjectStoreConfig::File(FileConfig {
                     data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
-                    ..Default::default()
                 }),
                 Some(TempDirGuard::File(data_tmp_dir)),
             )
@@ -186,14 +185,17 @@ pub fn create_tmp_dir_and_datanode_opts(
 ) -> (DatanodeOptions, TestGuard) {
     let wal_tmp_dir = create_temp_dir(&format!("gt_wal_{name}"));
 
-    let (storage, data_tmp_dir) = get_test_store_config(&store_type, name);
+    let (store, data_tmp_dir) = get_test_store_config(&store_type, name);
 
     let opts = DatanodeOptions {
         wal: WalConfig {
             dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
             ..Default::default()
         },
-        storage,
+        storage: StorageConfig {
+            store,
+            ..Default::default()
+        },
         mode: Mode::Standalone,
         ..Default::default()
     };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:
* Adds GC task to clean manifest old checkpoints and logs.
* Adds `RepeatedTask` to run the repeated task with an interval.Refactor some code.
* Clean `atomic_write_dir` dir when using the local file system as storage at startup.
* Delete manifest logs in batch by OpenDAL new API.
* Breaking change in config:
  * Move `[compaction]` section to `[storage.compaction]`.
  * Adds `[storage.manifest]` to configure region manifest service.
  
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
