### PR TITLE
chore: add `build_table_route_prefix`

### DIFF
--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -178,6 +178,15 @@ pub(crate) fn to_removed_key(key: &str) -> String {
     format!("{REMOVED_PREFIX}-{key}")
 }
 
+pub fn build_table_route_prefix(catalog: impl AsRef<str>, schema: impl AsRef<str>) -> String {
+    format!(
+        "{}-{}-{}-",
+        TABLE_ROUTE_PREFIX,
+        catalog.as_ref(),
+        schema.as_ref()
+    )
+}
+
 #[derive(Eq, PartialEq, Debug, Clone, Hash, Copy)]
 pub struct StatKey {
     pub cluster_id: u64,
@@ -278,6 +287,14 @@ impl TryFrom<Vec<u8>> for StatValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_build_prefix() {
+        assert_eq!(
+            "__meta_table_route-CATALOG-SCHEMA-",
+            build_table_route_prefix("CATALOG", "SCHEMA")
+        )
+    }
 
     #[test]
     fn test_stat_key_round_trip() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly adds `build_table_route_prefix` for table route key, which returning prefix with given catalog and schema. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
