### PR TITLE
fix: remove backtrace from ratelimit error

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -418,7 +418,7 @@ pub enum Error {
     DecodeParquetTimeRange { msg: String, backtrace: Backtrace },
 
     #[snafu(display("Scheduler rate limited, msg: {}", msg))]
-    RateLimited { msg: String, backtrace: Backtrace },
+    RateLimited { msg: String },
 
     #[snafu(display("Cannot schedule request, scheduler's already stopped"))]
     IllegalSchedulerState { backtrace: Backtrace },


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Remove backtrace to reduce CPU and mem consumption in high workload.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
