### PR TITLE
feat: unify describe table execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,6 @@ dependencies = [
  "tower",
  "tower-http",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -2911,6 +2910,7 @@ dependencies = [
  "itertools",
  "meta-client",
  "meta-srv",
+ "mito",
  "moka",
  "openmetrics-parser",
  "partition",
@@ -2931,6 +2931,7 @@ dependencies = [
  "toml",
  "tonic",
  "tower",
+ "uuid",
 ]
 
 [[package]]

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -66,7 +66,6 @@ tonic.workspace = true
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
 url = "2.3.1"
-uuid.workspace = true
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -124,11 +124,6 @@ impl Instance {
                     .execute(SqlRequest::ShowTables(show_tables), query_ctx)
                     .await
             }
-            QueryStatement::Sql(Statement::DescribeTable(describe_table)) => {
-                self.sql_handler
-                    .execute(SqlRequest::DescribeTable(describe_table), query_ctx)
-                    .await
-            }
             QueryStatement::Sql(Statement::ShowCreateTable(_show_create_table)) => {
                 unimplemented!("SHOW CREATE TABLE is unimplemented yet");
             }
@@ -185,6 +180,7 @@ impl Instance {
             | QueryStatement::Sql(Statement::Use(_))
             | QueryStatement::Sql(Statement::Tql(_))
             | QueryStatement::Sql(Statement::Delete(_))
+            | QueryStatement::Sql(Statement::DescribeTable(_))
             | QueryStatement::Promql(_) => unreachable!(),
         }
     }

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -207,16 +207,6 @@ pub(crate) async fn setup_test_instance(test_name: &str) -> MockInstance {
     MockInstance::new(test_name).await
 }
 
-pub async fn check_output_stream(output: Output, expected: String) {
-    let recordbatches = match output {
-        Output::Stream(stream) => util::collect_batches(stream).await.unwrap(),
-        Output::RecordBatches(recordbatches) => recordbatches,
-        _ => unreachable!(),
-    };
-    let pretty_print = recordbatches.pretty_print().unwrap();
-    assert_eq!(pretty_print, expected, "{}", pretty_print);
-}
-
 pub async fn check_unordered_output_stream(output: Output, expected: String) {
     let sort_table = |table: String| -> String {
         let replaced = table.replace("\\n", "\n");

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3"
 futures-util.workspace = true
 itertools = "0.10"
 meta-client = { path = "../meta-client" }
+mito = { path = "../mito", features = ["test"] }
 moka = { version = "0.9", features = ["future"] }
 openmetrics-parser = "0.4"
 partition = { path = "../partition" }
@@ -56,3 +57,4 @@ meta-srv = { path = "../meta-srv", features = ["mock"] }
 strfmt = "0.2"
 toml = "0.5"
 tower = "0.4"
+uuid.workspace = true

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -46,7 +46,7 @@ use partition::partition::{PartitionBound, PartitionDef};
 use query::error::QueryExecutionSnafu;
 use query::parser::QueryStatement;
 use query::query_engine::StatementHandler;
-use query::sql::{describe_table, show_databases, show_tables};
+use query::sql::{show_databases, show_tables};
 use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::ast::Value as SqlValue;
@@ -346,20 +346,6 @@ impl DistInstance {
             Statement::ShowDatabases(stmt) => show_databases(stmt, self.catalog_manager.clone()),
             Statement::ShowTables(stmt) => {
                 show_tables(stmt, self.catalog_manager.clone(), query_ctx)
-            }
-            Statement::DescribeTable(stmt) => {
-                let (catalog, schema, table) = table_idents_to_full_name(stmt.name(), query_ctx)
-                    .map_err(BoxedError::new)
-                    .context(error::ExternalSnafu)?;
-                let table = self
-                    .catalog_manager
-                    .table(&catalog, &schema, &table)
-                    .await
-                    .context(CatalogSnafu)?
-                    .with_context(|| TableNotFoundSnafu {
-                        table_name: stmt.name().to_string(),
-                    })?;
-                describe_table(table)
             }
             Statement::Insert(insert) => {
                 let (catalog, schema, table) =

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod instance_test;
+mod test_util;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/frontend/src/tests/test_util.rs
+++ b/src/frontend/src/tests/test_util.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(LFC): These tests should be moved to frontend crate. They are actually standalone instance tests.
-mod promql_test;
-pub(crate) mod test_util;
+use common_query::Output;
+use common_recordbatch::util;
+
+pub(crate) async fn check_output_stream(output: Output, expected: String) {
+    let recordbatches = match output {
+        Output::Stream(stream) => util::collect_batches(stream).await.unwrap(),
+        Output::RecordBatches(recordbatches) => recordbatches,
+        _ => unreachable!(),
+    };
+    let pretty_print = recordbatches.pretty_print().unwrap();
+    assert_eq!(pretty_print, expected, "{}", pretty_print);
+}

--- a/tests/cases/standalone/alter/rename_table.result
+++ b/tests/cases/standalone/alter/rename_table.result
@@ -31,7 +31,7 @@ Affected Rows: 0
 
 DESC TABLE t;
 
-Error: 4001(TableNotFound), Table not found: t
+Error: 4001(TableNotFound), Table `t` not exist
 
 SELECT * FROM t;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Make "describe table" SQL executed at Frontend instance. 

Part of #1010.

After this PR, I think there are no more statements that should be rewritten to be executed in query engine. What's left stmts are all differently handled in distributed and standalone modes, can't be unified.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
