### PR TITLE
feat(stddev_over_time): add initial implementation

### DIFF
--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -42,7 +42,7 @@ pub(crate) fn extract_array(columnar_value: &ColumnarValue) -> Result<ArrayRef, 
 }
 
 #[allow(dead_code)]
-pub(crate) fn kahan_sum_inc(inc: f64, sum: f64, mut c: f64) -> (f64, f64) {
+pub(crate) fn compensated_sum_inc(inc: f64, sum: f64, mut c: f64) -> (f64, f64) {
     let t = sum + inc;
     if sum.abs() >= inc.abs() {
         c += (sum - t) + inc;

--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -40,3 +40,14 @@ pub(crate) fn extract_array(columnar_value: &ColumnarValue) -> Result<ArrayRef, 
         ))
     }
 }
+
+#[allow(dead_code)]
+pub(crate) fn kahan_sum_inc(inc: f64, sum: f64, mut c: f64) -> (f64, f64) {
+    let t = sum + inc;
+    if sum.abs() >= inc.abs() {
+        c += (sum - t) + inc;
+    } else {
+        c += (inc - t) + sum;
+    }
+    (t, c)
+}

--- a/src/promql/src/functions/aggr_over_time.rs
+++ b/src/promql/src/functions/aggr_over_time.rs
@@ -120,6 +120,7 @@ pub fn present_over_time(_: &TimestampMillisecondArray, values: &Float64Array) -
 // TODO(ruihang): support quantile_over_time, and stdvar_over_time
 
 /// the population standard deviation of the values in the specified interval.
+/// Prometheus's implementation: https://github.com/prometheus/prometheus/blob/f55ab2217984770aa1eecd0f2d5f54580029b1c0/promql/functions.go#L556-L569
 #[range_fn(
     name = "StddevOverTime",
     ret = "Float64Array",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Implemented the `stddev_over_time` function from PromQL, and added a corresponding test. Verified the calculation using [this](https://www.calculator.net/standard-deviation-calculator.html) page. 


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link 
  https://github.com/GreptimeTeam/greptimedb/issues/1228