### PR TITLE
refactor: move PromQL execution to Frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,8 @@ dependencies = [
  "partition",
  "prost",
  "query",
+ "rstest",
+ "rstest_reuse",
  "rustls",
  "script",
  "serde",
@@ -3102,6 +3104,12 @@ name = "futures-task"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -6183,6 +6191,44 @@ dependencies = [
  "signature",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
+dependencies = [
+ "quote",
+ "rand",
+ "rustc_version 0.4.0",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -22,9 +22,7 @@ use common_telemetry::timer;
 use query::error::QueryExecutionSnafu;
 use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use query::query_engine::StatementHandler;
-use servers::error as server_error;
-use servers::prom::PromHandler;
-use session::context::{QueryContext, QueryContextRef};
+use session::context::QueryContextRef;
 use snafu::prelude::*;
 use sql::ast::ObjectName;
 use sql::statements::copy::{CopyTable, CopyTableArgument};
@@ -288,23 +286,6 @@ impl StatementHandler for Instance {
             .await
             .map_err(BoxedError::new)
             .context(QueryExecutionSnafu)
-    }
-}
-
-#[async_trait]
-impl PromHandler for Instance {
-    async fn do_query(&self, query: &PromQuery) -> server_error::Result<Output> {
-        let _timer = timer!(metrics::METRIC_HANDLE_PROMQL_ELAPSED);
-
-        self.execute_promql(query, QueryContext::arc())
-            .await
-            .map_err(BoxedError::new)
-            .with_context(|_| {
-                let query_literal = format!("{query:?}");
-                server_error::ExecuteQuerySnafu {
-                    query: query_literal,
-                }
-            })
     }
 }
 

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO(LFC): These tests should be moved to frontend crate. They are actually standalone instance tests.
-mod promql_test;
 pub(crate) mod test_util;

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -16,19 +16,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MIN_USER_TABLE_ID};
-use common_query::Output;
-use common_recordbatch::util;
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use mito::config::EngineConfig;
 use mito::table::test_util::{new_test_object_store, MockEngine, MockMitoEngine};
-use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use servers::Mode;
-use session::context::QueryContext;
 use snafu::ResultExt;
-use sql::statements::statement::Statement;
-use sql::statements::tql::Tql;
 use table::engine::{EngineContext, TableEngineRef};
 use table::requests::{CreateTableRequest, TableOptions};
 
@@ -77,40 +71,6 @@ impl MockInstance {
             instance,
             _guard,
             _procedure_dir: Some(procedure_dir),
-        }
-    }
-
-    pub(crate) async fn execute_sql(&self, sql: &str) -> Output {
-        let engine = self.inner().query_engine();
-        let planner = engine.planner();
-
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
-        match stmt {
-            QueryStatement::Sql(Statement::Query(_)) => {
-                let plan = planner.plan(stmt, QueryContext::arc()).await.unwrap();
-                engine.execute(plan, QueryContext::arc()).await.unwrap()
-            }
-            QueryStatement::Sql(Statement::Tql(tql)) => {
-                let plan = match tql {
-                    Tql::Eval(eval) => {
-                        let promql = PromQuery {
-                            start: eval.start,
-                            end: eval.end,
-                            step: eval.step,
-                            query: eval.query,
-                        };
-                        let stmt = QueryLanguageParser::parse_promql(&promql).unwrap();
-                        planner.plan(stmt, QueryContext::arc()).await.unwrap()
-                    }
-                    Tql::Explain(_) => unimplemented!(),
-                };
-                engine.execute(plan, QueryContext::arc()).await.unwrap()
-            }
-            _ => self
-                .inner()
-                .execute_stmt(stmt, QueryContext::arc())
-                .await
-                .unwrap(),
         }
     }
 
@@ -206,30 +166,4 @@ pub async fn create_mock_sql_handler() -> SqlHandler {
             .unwrap(),
     );
     SqlHandler::new(mock_engine.clone(), catalog_manager, mock_engine, None)
-}
-
-pub(crate) async fn setup_test_instance(test_name: &str) -> MockInstance {
-    MockInstance::new(test_name).await
-}
-
-pub async fn check_unordered_output_stream(output: Output, expected: String) {
-    let sort_table = |table: String| -> String {
-        let replaced = table.replace("\\n", "\n");
-        let mut lines = replaced.split('\n').collect::<Vec<_>>();
-        lines.sort();
-        lines
-            .into_iter()
-            .map(|s| s.to_string())
-            .reduce(|acc, e| format!("{acc}\\n{e}"))
-            .unwrap()
-    };
-
-    let recordbatches = match output {
-        Output::Stream(stream) => util::collect_batches(stream).await.unwrap(),
-        Output::RecordBatches(recordbatches) => recordbatches,
-        _ => unreachable!(),
-    };
-    let pretty_print = sort_table(recordbatches.pretty_print().unwrap());
-    let expected = sort_table(expected);
-    assert_eq!(pretty_print, expected);
 }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -59,6 +59,8 @@ common-test-util = { path = "../common/test-util" }
 datanode = { path = "../datanode" }
 futures = "0.3"
 meta-srv = { path = "../meta-srv", features = ["mock"] }
+rstest = "0.17"
+rstest_reuse = "0.5"
 strfmt = "0.2"
 toml = "0.5"
 tower = "0.4"

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -34,3 +34,8 @@ mod server;
 mod table;
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+// allowed because https://docs.rs/rstest_reuse/0.5.0/rstest_reuse/#use-rstest_reuse-at-the-top-of-your-crate
+#[allow(clippy::single_component_path_imports)]
+use rstest_reuse;

--- a/src/frontend/src/tests.rs
+++ b/src/frontend/src/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod instance_test;
+mod promql_test;
 mod test_util;
 
 use std::collections::HashMap;

--- a/src/frontend/src/tests/promql_test.rs
+++ b/src/frontend/src/tests/promql_test.rs
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
+use rstest::rstest;
+use rstest_reuse::apply;
+use servers::query_handler::sql::SqlQueryHandler;
 use session::context::QueryContext;
 
-use super::test_util::check_unordered_output_stream;
-use crate::tests::test_util::setup_test_instance;
+use super::test_util::{check_unordered_output_stream, standalone, standalone_instance_case};
+use crate::instance::Instance;
+use crate::tests::test_util::MockInstance;
 
 #[allow(clippy::too_many_arguments)]
 async fn create_insert_query_assert(
+    instance: Arc<Instance>,
     create: &str,
     insert: &str,
     promql: &str,
@@ -30,15 +37,23 @@ async fn create_insert_query_assert(
     lookback: Duration,
     expected: &str,
 ) {
-    let instance = setup_test_instance("test_execute_insert").await;
+    instance.do_query(create, QueryContext::arc()).await;
+    instance.do_query(insert, QueryContext::arc()).await;
 
-    instance.execute_sql(create).await;
-
-    instance.execute_sql(insert).await;
+    let query = PromQuery {
+        query: promql.to_string(),
+        start: "0".to_string(),
+        end: "0".to_string(),
+        step: "5m".to_string(),
+    };
+    let QueryStatement::Promql(mut eval_stmt) = QueryLanguageParser::parse_promql(&query).unwrap() else { unreachable!() };
+    eval_stmt.start = start;
+    eval_stmt.end = end;
+    eval_stmt.interval = interval;
+    eval_stmt.lookback_delta = lookback;
 
     let query_output = instance
-        .inner()
-        .execute_promql_statement(promql, start, end, interval, lookback, QueryContext::arc())
+        .plan_exec(QueryStatement::Promql(eval_stmt), QueryContext::arc())
         .await
         .unwrap();
     let expected = String::from(expected);
@@ -46,21 +61,32 @@ async fn create_insert_query_assert(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn create_insert_tql_assert(create: &str, insert: &str, tql: &str, expected: &str) {
-    let instance = setup_test_instance("test_execute_insert").await;
+async fn create_insert_tql_assert(
+    instance: Arc<Instance>,
+    create: &str,
+    insert: &str,
+    tql: &str,
+    expected: &str,
+) {
+    instance.do_query(create, QueryContext::arc()).await;
+    instance.do_query(insert, QueryContext::arc()).await;
 
-    instance.execute_sql(create).await;
-
-    instance.execute_sql(insert).await;
-
-    let query_output = instance.execute_sql(tql).await;
+    let query_output = instance
+        .do_query(tql, QueryContext::arc())
+        .await
+        .remove(0)
+        .unwrap();
     let expected = String::from(expected);
     check_unordered_output_stream(query_output, expected).await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn sql_insert_tql_query_ceil() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn sql_insert_tql_query_ceil(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_tql_assert(
+        instance,
         r#"create table http_requests_total (
             host string,
             cpu double,
@@ -102,9 +128,13 @@ async fn sql_insert_tql_query_ceil() {
     .await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn sql_insert_promql_query_ceil() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn sql_insert_promql_query_ceil(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         r#"create table http_requests_total (
             host string,
             cpu double,
@@ -181,9 +211,13 @@ fn unix_epoch_plus_100s() -> SystemTime {
 // eval instant at 50m SUM BY (group) (http_requests{job="api-server"})
 //   {group="canary"} 700
 //   {group="production"} 300
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_simple_sum() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_simple_sum(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "SUM BY (group) (http_requests{job=\"api-server\"})",
@@ -205,9 +239,13 @@ async fn aggregators_simple_sum() {
 // eval instant at 50m avg by (group) (http_requests{job="api-server"})
 //   {group="canary"} 350
 //   {group="production"} 150
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_simple_avg() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_simple_avg(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "AVG BY (group) (http_requests{job=\"api-server\"})",
@@ -229,9 +267,13 @@ async fn aggregators_simple_avg() {
 // eval instant at 50m count by (group) (http_requests{job="api-server"})
 //   {group="canary"} 2
 //   {group="production"} 2
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_simple_count() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_simple_count(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "COUNT BY (group) (http_requests{job=\"api-server\"})",
@@ -253,9 +295,13 @@ async fn aggregators_simple_count() {
 // eval instant at 50m sum without (instance) (http_requests{job="api-server"})
 //   {group="canary",job="api-server"} 700
 //   {group="production",job="api-server"} 300
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_simple_without() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_simple_without(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "sum without (instance) (http_requests{job=\"api-server\"})",
@@ -276,9 +322,13 @@ async fn aggregators_simple_without() {
 // # Empty by.
 // eval instant at 50m sum by () (http_requests{job="api-server"})
 //   {} 1000
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_empty_by() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_empty_by(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "sum by () (http_requests{job=\"api-server\"})",
@@ -298,9 +348,13 @@ async fn aggregators_empty_by() {
 // # No by/without.
 // eval instant at 50m sum(http_requests{job="api-server"})
 //   {} 1000
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_no_by_without() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_no_by_without(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         r#"sum (http_requests{job="api-server"})"#,
@@ -321,9 +375,13 @@ async fn aggregators_no_by_without() {
 // eval instant at 50m sum without () (http_requests{job="api-server",group="production"})
 //   {group="production",job="api-server",instance="0"} 100
 //   {group="production",job="api-server",instance="1"} 200
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_empty_without() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_empty_without(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         r#"sum without () (http_requests{job="api-server",group="production"})"#,
@@ -345,9 +403,13 @@ async fn aggregators_empty_without() {
 // eval instant at 50m sum(http_requests) by (job) + min(http_requests) by (job) + max(http_requests) by (job) + avg(http_requests) by (job)
 //   {job="app-server"} 4550
 //   {job="api-server"} 1750
-#[tokio::test(flavor = "multi_thread")]
-async fn aggregators_complex_combined_aggrs() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn aggregators_complex_combined_aggrs(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "sum(http_requests) by (job) + min(http_requests) by (job) + max(http_requests) by (job) + avg(http_requests) by (job)",
@@ -366,9 +428,13 @@ async fn aggregators_complex_combined_aggrs() {
 }
 
 // This is not from prometheus test set. It's derived from `aggregators_complex_combined_aggrs()`
-#[tokio::test(flavor = "multi_thread")]
-async fn two_aggregators_combined_aggrs() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn two_aggregators_combined_aggrs(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         "sum(http_requests) by (job) + min(http_requests) by (job) ",
@@ -389,10 +455,14 @@ async fn two_aggregators_combined_aggrs() {
 // eval instant at 50m stddev by (instance)(http_requests)
 //   {instance="0"} 223.60679774998
 //   {instance="1"} 223.60679774998
-#[tokio::test(flavor = "multi_thread")]
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
 #[ignore = "TODO(ruihang): fix this case"]
-async fn stddev_by_label() {
+async fn stddev_by_label(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         r#"stddev by (instance)(http_requests)"#,
@@ -411,9 +481,13 @@ async fn stddev_by_label() {
 }
 
 // This is not derived from prometheus
-#[tokio::test(flavor = "multi_thread")]
-async fn binary_op_plain_columns() {
+// should apply to both instances. tracked in #1296
+#[apply(standalone_instance_case)]
+async fn binary_op_plain_columns(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+
     create_insert_query_assert(
+        instance,
         AGGREGATORS_CREATE_TABLE,
         AGGREGATORS_INSERT_DATA,
         r#"http_requests - http_requests"#,

--- a/src/frontend/src/tests/promql_test.rs
+++ b/src/frontend/src/tests/promql_test.rs
@@ -56,7 +56,6 @@ async fn create_insert_query_assert(
         .plan_exec(QueryStatement::Promql(eval_stmt), QueryContext::arc())
         .await
         .unwrap();
-    let expected = String::from(expected);
     check_unordered_output_stream(query_output, expected).await;
 }
 
@@ -76,7 +75,6 @@ async fn create_insert_tql_assert(
         .await
         .remove(0)
         .unwrap();
-    let expected = String::from(expected);
     check_unordered_output_stream(query_output, expected).await;
 }
 

--- a/src/frontend/src/tests/test_util.rs
+++ b/src/frontend/src/tests/test_util.rs
@@ -97,8 +97,8 @@ pub(crate) async fn check_output_stream(output: Output, expected: String) {
     assert_eq!(pretty_print, expected, "{}", pretty_print);
 }
 
-pub(crate) async fn check_unordered_output_stream(output: Output, expected: String) {
-    let sort_table = |table: String| -> String {
+pub(crate) async fn check_unordered_output_stream(output: Output, expected: &str) {
+    let sort_table = |table: &str| -> String {
         let replaced = table.replace("\\n", "\n");
         let mut lines = replaced.split('\n').collect::<Vec<_>>();
         lines.sort();
@@ -114,7 +114,7 @@ pub(crate) async fn check_unordered_output_stream(output: Output, expected: Stri
         Output::RecordBatches(recordbatches) => recordbatches,
         _ => unreachable!(),
     };
-    let pretty_print = sort_table(recordbatches.pretty_print().unwrap());
+    let pretty_print = sort_table(&recordbatches.pretty_print().unwrap());
     let expected = sort_table(expected);
     assert_eq!(pretty_print, expected);
 }

--- a/src/frontend/src/tests/test_util.rs
+++ b/src/frontend/src/tests/test_util.rs
@@ -12,8 +12,80 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_query::Output;
 use common_recordbatch::util;
+use rstest_reuse::{self, template};
+
+use crate::instance::Instance;
+use crate::tests::{
+    create_distributed_instance, create_standalone_instance, MockDistributedInstance,
+    MockStandaloneInstance,
+};
+
+pub(crate) trait MockInstance {
+    fn frontend(&self) -> Arc<Instance>;
+
+    fn is_distributed_mode(&self) -> bool;
+}
+
+impl MockInstance for MockStandaloneInstance {
+    fn frontend(&self) -> Arc<Instance> {
+        self.instance.clone()
+    }
+
+    fn is_distributed_mode(&self) -> bool {
+        false
+    }
+}
+
+impl MockInstance for MockDistributedInstance {
+    fn frontend(&self) -> Arc<Instance> {
+        self.frontend.clone()
+    }
+
+    fn is_distributed_mode(&self) -> bool {
+        true
+    }
+}
+
+pub(crate) async fn standalone() -> Arc<dyn MockInstance> {
+    let test_name = uuid::Uuid::new_v4().to_string();
+    let instance = create_standalone_instance(&test_name).await;
+    Arc::new(instance)
+}
+
+pub(crate) async fn distributed() -> Arc<dyn MockInstance> {
+    let test_name = uuid::Uuid::new_v4().to_string();
+    let instance = create_distributed_instance(&test_name).await;
+    Arc::new(instance)
+}
+
+#[template]
+#[rstest]
+#[case::test_with_standalone(standalone())]
+#[case::test_with_distributed(distributed())]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+pub(crate) fn both_instances_cases(
+    #[future]
+    #[case]
+    instance: Arc<dyn MockInstance>,
+) {
+}
+
+#[template]
+#[rstest]
+#[case::test_with_standalone(standalone())]
+#[awt]
+#[tokio::test(flavor = "multi_thread")]
+pub(crate) fn standalone_instance_case(
+    #[future]
+    #[case]
+    instance: Arc<dyn MockInstance>,
+) {
+}
 
 pub(crate) async fn check_output_stream(output: Output, expected: String) {
     let recordbatches = match output {
@@ -23,4 +95,26 @@ pub(crate) async fn check_output_stream(output: Output, expected: String) {
     };
     let pretty_print = recordbatches.pretty_print().unwrap();
     assert_eq!(pretty_print, expected, "{}", pretty_print);
+}
+
+pub(crate) async fn check_unordered_output_stream(output: Output, expected: String) {
+    let sort_table = |table: String| -> String {
+        let replaced = table.replace("\\n", "\n");
+        let mut lines = replaced.split('\n').collect::<Vec<_>>();
+        lines.sort();
+        lines
+            .into_iter()
+            .map(|s| s.to_string())
+            .reduce(|acc, e| format!("{acc}\\n{e}"))
+            .unwrap()
+    };
+
+    let recordbatches = match output {
+        Output::Stream(stream) => util::collect_batches(stream).await.unwrap(),
+        Output::RecordBatches(recordbatches) => recordbatches,
+        _ => unreachable!(),
+    };
+    let pretty_print = sort_table(recordbatches.pretty_print().unwrap());
+    let expected = sort_table(expected);
+    assert_eq!(pretty_print, expected);
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

part of #1010 

- make "instance_test.rs" also ran with distributed instance
- move promql exec to frontend
  - also move "promql_test.rs" to frontend

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
