### PR TITLE
fix: unit test fails when try to copy table to s3 and copy back 

### DIFF
--- a/src/frontend/src/tests/instance_test.rs
+++ b/src/frontend/src/tests/instance_test.rs
@@ -849,7 +849,7 @@ async fn test_execute_copy_from_s3() {
             let tests = [
                 Test {
                     sql: &format!(
-                        "Copy with_filename FROM 's3://{}/{}/export/demo.parquet_1_2'",
+                        "Copy with_filename FROM 's3://{}/{}/export/demo.parquet'",
                         bucket, root
                     ),
                     table_name: "with_filename",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes the unit test that export table content to s3 and import the exported file back again, because #1263 changed the output file of table export into one single file instead of a set of parquet files.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #1301