### PR TITLE
feat: impl `__field__` special matcher to project value columns

### DIFF
--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -100,6 +100,9 @@ pub enum Error {
 
     #[snafu(display("Zero range in range selector"))]
     ZeroRangeSelector { backtrace: Backtrace },
+
+    #[snafu(display("Cannot find column {col}"))]
+    ColumnNotFound { col: String, backtrace: Backtrace },
 }
 
 impl ErrorExt for Error {
@@ -113,7 +116,8 @@ impl ErrorExt for Error {
             | MultipleVector { .. }
             | ExpectExpr { .. }
             | ExpectRangeSelector { .. }
-            | ZeroRangeSelector { .. } => StatusCode::InvalidArguments,
+            | ZeroRangeSelector { .. }
+            | ColumnNotFound { .. } => StatusCode::InvalidArguments,
 
             UnknownTable { .. }
             | DataFusionPlanning { .. }

--- a/src/promql/src/functions.rs
+++ b/src/promql/src/functions.rs
@@ -26,12 +26,14 @@ pub use aggr_over_time::{
     AbsentOverTime, AvgOverTime, CountOverTime, LastOverTime, MaxOverTime, MinOverTime,
     PresentOverTime, StddevOverTime, StdvarOverTime, SumOverTime,
 };
+pub use changes::Changes;
 use datafusion::arrow::array::ArrayRef;
 use datafusion::error::DataFusionError;
 use datafusion::physical_plan::ColumnarValue;
 pub use extrapolate_rate::{Delta, Increase, Rate};
 pub use idelta::IDelta;
 pub use quantile::QuantileOverTime;
+pub use resets::Resets;
 
 pub(crate) fn extract_array(columnar_value: &ColumnarValue) -> Result<ArrayRef, DataFusionError> {
     if let ColumnarValue::Array(array) = columnar_value {

--- a/src/promql/src/functions/aggr_over_time.rs
+++ b/src/promql/src/functions/aggr_over_time.rs
@@ -183,8 +183,6 @@ pub fn stddev_over_time(_: &TimestampMillisecondArray, values: &Float64Array) ->
     }
 }
 
-// TODO(ruihang): support quantile_over_time
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/promql/src/lib.rs
+++ b/src/promql/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(option_get_or_insert_default)]
+
 pub mod error;
 pub mod extension_plan;
 pub mod functions;

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -51,8 +51,9 @@ use crate::extension_plan::{
     EmptyMetric, InstantManipulate, Millisecond, RangeManipulate, SeriesDivide, SeriesNormalize,
 };
 use crate::functions::{
-    AbsentOverTime, AvgOverTime, CountOverTime, Delta, IDelta, Increase, LastOverTime, MaxOverTime,
-    MinOverTime, PresentOverTime, QuantileOverTime, Rate, SumOverTime,
+    AbsentOverTime, AvgOverTime, Changes, CountOverTime, Delta, IDelta, Increase, LastOverTime,
+    MaxOverTime, MinOverTime, PresentOverTime, QuantileOverTime, Rate, Resets, StddevOverTime,
+    StdvarOverTime, SumOverTime,
 };
 
 const LEFT_PLAN_JOIN_ALIAS: &str = "lhs";
@@ -684,6 +685,8 @@ impl PromPlanner {
             )),
             "idelta" => ScalarFunc::Udf(IDelta::<false>::scalar_udf()),
             "irate" => ScalarFunc::Udf(IDelta::<true>::scalar_udf()),
+            "resets" => ScalarFunc::Udf(Resets::scalar_udf()),
+            "changes" => ScalarFunc::Udf(Changes::scalar_udf()),
             "avg_over_time" => ScalarFunc::Udf(AvgOverTime::scalar_udf()),
             "min_over_time" => ScalarFunc::Udf(MinOverTime::scalar_udf()),
             "max_over_time" => ScalarFunc::Udf(MaxOverTime::scalar_udf()),
@@ -692,6 +695,8 @@ impl PromPlanner {
             "last_over_time" => ScalarFunc::Udf(LastOverTime::scalar_udf()),
             "absent_over_time" => ScalarFunc::Udf(AbsentOverTime::scalar_udf()),
             "present_over_time" => ScalarFunc::Udf(PresentOverTime::scalar_udf()),
+            "stddev_over_time" => ScalarFunc::Udf(StddevOverTime::scalar_udf()),
+            "stdvar_over_time" => ScalarFunc::Udf(StdvarOverTime::scalar_udf()),
             "quantile_over_time" => {
                 let quantile_expr = match other_input_exprs.get(0) {
                     Some(DfExpr::Literal(ScalarValue::Float64(Some(quantile)))) => *quantile,

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -505,7 +505,7 @@ impl PromPlanner {
                 .chain(self.create_tag_column_exprs()?.into_iter())
                 .chain(Some(self.create_time_index_column_expr()?))
                 .collect::<Vec<_>>();
-            // reuse this variable for simplicy
+            // reuse this variable for simplicity
             table_scan = LogicalPlanBuilder::from(table_scan)
                 .project(exprs)
                 .context(DataFusionPlanningSnafu)?

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -1892,5 +1892,18 @@ mod test {
             expected.sort();
             assert_eq!(fields, expected, "case: {:?}", case.0);
         }
+
+        let bad_cases = [
+            r#"some_metric{__field__="nonexistent"}"#,
+            r#"some_metric{__field__!="nonexistent"}"#,
+        ];
+
+        for case in bad_cases {
+            let prom_expr = parser::parse(case).unwrap();
+            eval_stmt.expr = prom_expr;
+            let table_provider = build_test_table_provider("some_metric".to_string(), 3, 3).await;
+            let plan = PromPlanner::stmt_to_plan(table_provider, eval_stmt.clone()).await;
+            assert!(plan.is_err(), "case: {:?}", case);
+        }
     }
 }

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -80,7 +80,7 @@ struct PromPlannerContext {
     time_index_column: Option<String>,
     value_columns: Vec<String>,
     tag_columns: Vec<String>,
-    value_column_matcher: Option<Vec<Matcher>>,
+    field_column_matcher: Option<Vec<Matcher>>,
     /// The range in millisecond of range selector. None if there is no range selector.
     range: Option<Millisecond>,
 }
@@ -406,7 +406,7 @@ impl PromPlanner {
                 self.ctx.table_name = Some(matcher.value.clone());
             } else if matcher.name == FIELD_COLUMN_MATCHER {
                 self.ctx
-                    .value_column_matcher
+                    .field_column_matcher
                     .get_or_insert_default()
                     .push(matcher.clone());
             } else {
@@ -445,14 +445,14 @@ impl PromPlanner {
             .create_table_scan_plan(&table_name, filters.clone())
             .await?;
 
-        // make a projection plan if there is any `__value__` matcher
-        if let Some(value_matchers) = &self.ctx.value_column_matcher {
+        // make a projection plan if there is any `__field__` matcher
+        if let Some(field_matchers) = &self.ctx.field_column_matcher {
             let col_set = self.ctx.value_columns.iter().collect::<HashSet<_>>();
             // opt-in set
             let mut result_set = HashSet::new();
             // opt-out set
             let mut reverse_set = HashSet::new();
-            for matcher in value_matchers {
+            for matcher in field_matchers {
                 match &matcher.op {
                     MatchOp::Equal => {
                         if col_set.contains(&matcher.value) {

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -64,8 +64,8 @@ const SPECIAL_TIME_FUNCTION: &str = "time";
 /// default value column name for empty metric
 const DEFAULT_VALUE_COLUMN: &str = "value";
 
-/// Special modifier to project value columns under multi-value mode
-const VALUE_COLUMN_MATCHER: &str = "__value__";
+/// Special modifier to project field columns under multi-field mode
+const FIELD_COLUMN_MATCHER: &str = "__field__";
 
 #[derive(Default, Debug, Clone)]
 struct PromPlannerContext {
@@ -404,7 +404,7 @@ impl PromPlanner {
             // TODO(ruihang): support other metric match ops
             if matcher.name == METRIC_NAME && matches!(matcher.op, MatchOp::Equal) {
                 self.ctx.table_name = Some(matcher.value.clone());
-            } else if matcher.name == VALUE_COLUMN_MATCHER {
+            } else if matcher.name == FIELD_COLUMN_MATCHER {
                 self.ctx
                     .value_column_matcher
                     .get_or_insert_default()
@@ -1789,7 +1789,7 @@ mod test {
         let cases = [
             // single equal matcher
             (
-                r#"some_metric{__value__="field_1"}"#,
+                r#"some_metric{__field__="field_1"}"#,
                 vec![
                     "some_metric.field_1",
                     "some_metric.tag_0",
@@ -1800,7 +1800,7 @@ mod test {
             ),
             // two equal matchers
             (
-                r#"some_metric{__value__="field_1", __value__="field_0"}"#,
+                r#"some_metric{__field__="field_1", __field__="field_0"}"#,
                 vec![
                     "some_metric.field_0",
                     "some_metric.field_1",
@@ -1812,7 +1812,7 @@ mod test {
             ),
             // single not_eq mathcer
             (
-                r#"some_metric{__value__!="field_1"}"#,
+                r#"some_metric{__field__!="field_1"}"#,
                 vec![
                     "some_metric.field_0",
                     "some_metric.field_2",
@@ -1824,7 +1824,7 @@ mod test {
             ),
             // two not_eq mathcers
             (
-                r#"some_metric{__value__!="field_1", __value__!="field_2"}"#,
+                r#"some_metric{__field__!="field_1", __field__!="field_2"}"#,
                 vec![
                     "some_metric.field_0",
                     "some_metric.tag_0",
@@ -1835,7 +1835,7 @@ mod test {
             ),
             // equal and not_eq matchers (no conflict)
             (
-                r#"some_metric{__value__="field_1", __value__!="field_0"}"#,
+                r#"some_metric{__field__="field_1", __field__!="field_0"}"#,
                 vec![
                     "some_metric.field_1",
                     "some_metric.tag_0",
@@ -1846,7 +1846,7 @@ mod test {
             ),
             // equal and not_eq matchers (conflict)
             (
-                r#"some_metric{__value__="field_2", __value__!="field_2"}"#,
+                r#"some_metric{__field__="field_2", __field__!="field_2"}"#,
                 vec![
                     "some_metric.tag_0",
                     "some_metric.tag_1",
@@ -1856,7 +1856,7 @@ mod test {
             ),
             // single regex eq matcher
             (
-                r#"some_metric{__value__=~"field_1|field_2"}"#,
+                r#"some_metric{__field__=~"field_1|field_2"}"#,
                 vec![
                     "some_metric.field_1",
                     "some_metric.field_2",
@@ -1868,7 +1868,7 @@ mod test {
             ),
             // single regex not_eq matcher
             (
-                r#"some_metric{__value__!~"field_1|field_2"}"#,
+                r#"some_metric{__field__!~"field_1|field_2"}"#,
                 vec![
                     "some_metric.field_0",
                     "some_metric.tag_0",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Implement `__field__` special matcher. It can do projection on value columns under multi-value model. E.g.:

```sql
MySQL [(none)]> TQL eval (1667446797, 1667446807, '10s') system_metrics{ __field__="cpu_util"};
+----------+-------+-------+---------------------+
| cpu_util | host  | idc   | ts                  |
+----------+-------+-------+---------------------+
|     11.8 | host1 | idc_a | 2022-11-03 03:40:07 |
|       50 | host1 | idc_b | 2022-11-03 03:40:07 |
|     80.1 | host2 | idc_a | 2022-11-03 03:40:07 |
+----------+-------+-------+---------------------+
3 rows in set (0.005 sec)

MySQL [(none)]> TQL eval (1667446797, 1667446807, '10s') system_metrics{ __field__="cpu_util", __value__="disk_util"};
+-----------+----------+-------+-------+---------------------+
| disk_util | cpu_util | host  | idc   | ts                  |
+-----------+----------+-------+-------+---------------------+
|      10.3 |     11.8 | host1 | idc_a | 2022-11-03 03:40:07 |
|      40.6 |       50 | host1 | idc_b | 2022-11-03 03:40:07 |
|        90 |     80.1 | host2 | idc_a | 2022-11-03 03:40:07 |
+-----------+----------+-------+-------+---------------------+
3 rows in set (0.004 sec)

MySQL [(none)]> TQL eval (1667446797, 1667446807, '10s') system_metrics{ __field__!="cpu_util"};
+-----------+-------------+-------+-------+---------------------+
| disk_util | memory_util | host  | idc   | ts                  |
+-----------+-------------+-------+-------+---------------------+
|      10.3 |        10.3 | host1 | idc_a | 2022-11-03 03:40:07 |
|      40.6 |        66.7 | host1 | idc_b | 2022-11-03 03:40:07 |
|        90 |        70.3 | host2 | idc_a | 2022-11-03 03:40:07 |
+-----------+-------------+-------+-------+---------------------+
3 rows in set (0.005 sec)
```

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
