### PR TITLE
feat: try to do manifest checkpoint on opening region

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -49,6 +49,8 @@ max_purge_tasks = 32
 checkpoint_margin = 10
 # Region manifest logs and checkpoints gc execution duration
 gc_duration = '30s'
+# Whether to try creating a manifest checkpoint on region opening
+checkpoint_on_startup = false
 
 # Procedure storage options, see `standalone.example.toml`.
 # [procedure.store]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -114,7 +114,8 @@ max_purge_tasks = 32
 checkpoint_margin = 10
 # Region manifest logs and checkpoints gc execution duration
 gc_duration = '30s'
-
+# Whether to try creating a manifest checkpoint on region opening
+checkpoint_on_startup = false
 
 # Procedure storage options.
 # Uncomment to enable.

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -224,6 +224,7 @@ mod tests {
             [storage.manifest]
             checkpoint_margin = 9
             gc_duration = '7s'
+            checkpoint_on_startup = true
         "#;
         write!(file, "{}", toml_str).unwrap();
 
@@ -275,6 +276,7 @@ mod tests {
             RegionManifestConfig {
                 checkpoint_margin: Some(9),
                 gc_duration: Some(Duration::from_secs(7)),
+                checkpoint_on_startup: true,
             },
             options.storage.manifest,
         );

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -129,6 +129,8 @@ pub struct RegionManifestConfig {
     /// Region manifest logs and checkpoints gc task execution duration.
     #[serde(with = "humantime_serde")]
     pub gc_duration: Option<Duration>,
+    /// Whether to try creating a manifest checkpoint on region opening
+    pub checkpoint_on_startup: bool,
 }
 
 impl Default for RegionManifestConfig {
@@ -136,6 +138,7 @@ impl Default for RegionManifestConfig {
         Self {
             checkpoint_margin: Some(10u16),
             gc_duration: Some(Duration::from_secs(30)),
+            checkpoint_on_startup: false,
         }
     }
 }
@@ -176,6 +179,7 @@ impl From<&DatanodeOptions> for SchedulerConfig {
 impl From<&DatanodeOptions> for StorageEngineConfig {
     fn from(value: &DatanodeOptions) -> Self {
         Self {
+            manifest_checkpoint_on_startup: value.storage.manifest.checkpoint_on_startup,
             manifest_checkpoint_margin: value.storage.manifest.checkpoint_margin,
             manifest_gc_duration: value.storage.manifest.gc_duration,
             max_files_in_l0: value.storage.compaction.max_files_in_level0,

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -20,6 +20,7 @@ use common_base::readable_size::ReadableSize;
 
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
+    pub manifest_checkpoint_on_startup: bool,
     pub manifest_checkpoint_margin: Option<u16>,
     pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
@@ -30,6 +31,7 @@ pub struct EngineConfig {
 impl Default for EngineConfig {
     fn default() -> Self {
         Self {
+            manifest_checkpoint_on_startup: false,
             manifest_checkpoint_margin: Some(10),
             manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -328,6 +328,12 @@ impl<S: LogStore> RegionImpl<S> {
             .replay(recovered_metadata_after_flushed, writer_ctx)
             .await?;
 
+        // Try to do a manifest checkpoint on opening
+        if store_config.engine_config.manifest_checkpoint_on_startup {
+            let manifest = &store_config.manifest;
+            manifest.may_do_checkpoint(manifest.last_version()).await?;
+        }
+
         let inner = Arc::new(RegionInner {
             shared,
             writer,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix #1317 :

* Adds a new option to `[storage.manifest]`:

```toml
# Whether to try creating a manifest checkpoint on region opening
checkpoint_on_startup = false
```
* Adds function `ManifestImpl#may_do_checkpoint(version)`.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
