### PR TITLE
chore: minor fix about metrics component 

### DIFF
--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -23,6 +23,7 @@ use servers::auth::UserProviderRef;
 use servers::error::Error::InternalIo;
 use servers::grpc::GrpcServer;
 use servers::http::HttpServerBuilder;
+use servers::metrics_handler::MetricsHandler;
 use servers::mysql::server::{MysqlServer, MysqlSpawnConfig, MysqlSpawnRef};
 use servers::opentsdb::OpentsdbServer;
 use servers::postgres::PostgresServer;
@@ -175,6 +176,7 @@ impl Services {
             ) {
                 http_server_builder.with_prom_handler(instance.clone());
             }
+            http_server_builder.with_metrics_handler(MetricsHandler);
             http_server_builder.with_script_handler(instance.clone());
             let http_server = http_server_builder.build();
             result.push((Box::new(http_server), http_addr));

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -94,7 +94,7 @@ impl MetaSrvInstance {
         let http_srv = self.http_srv.start(addr);
         select! {
             v = meta_srv => v?,
-            v = http_srv => v.map(|_| ()).context(error::StartMetricsExportSnafu)?,
+            v = http_srv => v.map(|_| ()).context(error::StartHttpSnafu)?,
         }
 
         Ok(())

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -62,8 +62,8 @@ pub enum Error {
         source: tonic::transport::Error,
         backtrace: Backtrace,
     },
-    #[snafu(display("Failed to start gRPC server, source: {}", source))]
-    StartMetricsExport {
+    #[snafu(display("Failed to start http server, source: {}", source))]
+    StartHttp {
         #[snafu(backtrace)]
         source: servers::error::Error,
     },
@@ -365,7 +365,7 @@ impl ErrorExt for Error {
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
             Error::MetaInternal { source } => source.status_code(),
             Error::RecoverProcedure { source } => source.status_code(),
-            Error::ShutdownServer { source, .. } | Error::StartMetricsExport { source } => {
+            Error::ShutdownServer { source, .. } | Error::StartHttp { source } => {
                 source.status_code()
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* The original `StartMetricsExport` error message was wrong.
* http server can not only expose metrics, so change `StartMetricsExport` to `StartHttp`
* After the HTTP metrics handler was changed to optional. Forget to add it in frontend.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
