### PR TITLE
refactor: rename "value" semantic type to "field"

### DIFF
--- a/src/promql/src/extension_plan/empty_metric.rs
+++ b/src/promql/src/extension_plan/empty_metric.rs
@@ -51,7 +51,7 @@ impl EmptyMetric {
         end: Millisecond,
         interval: Millisecond,
         time_index_column_name: String,
-        value_column_name: String,
+        field_column_name: String,
     ) -> DataFusionResult<Self> {
         let schema = Arc::new(DFSchema::new_with_metadata(
             vec![
@@ -61,7 +61,7 @@ impl EmptyMetric {
                     DataType::Timestamp(TimeUnit::Millisecond, None),
                     false,
                 ),
-                DFField::new(Some(""), &value_column_name, DataType::Float64, true),
+                DFField::new(Some(""), &field_column_name, DataType::Float64, true),
             ],
             HashMap::new(),
         )?);
@@ -253,11 +253,11 @@ mod test {
         end: Millisecond,
         interval: Millisecond,
         time_column_name: String,
-        value_column_name: String,
+        field_column_name: String,
         expected: String,
     ) {
         let empty_metric =
-            EmptyMetric::new(start, end, interval, time_column_name, value_column_name).unwrap();
+            EmptyMetric::new(start, end, interval, time_column_name, field_column_name).unwrap();
         let empty_metric_exec = empty_metric.to_execution_plan();
 
         let session_context = SessionContext::default();

--- a/src/promql/src/extension_plan/instant_manipulate.rs
+++ b/src/promql/src/extension_plan/instant_manipulate.rs
@@ -388,11 +388,11 @@ mod test {
             180_000, 240_000, // every 60s
             241_000, 271_000, 291_000, // others
         ])) as _;
-        let value_column = Arc::new(Float64Array::from_slice([1.0; 10])) as _;
+        let field_column = Arc::new(Float64Array::from_slice([1.0; 10])) as _;
         let path_column = Arc::new(StringArray::from_slice(["foo"; 10])) as _;
         let data = RecordBatch::try_new(
             schema.clone(),
-            vec![timestamp_column, value_column, path_column],
+            vec![timestamp_column, field_column, path_column],
         )
         .unwrap();
 

--- a/src/promql/src/extension_plan/normalize.rs
+++ b/src/promql/src/extension_plan/normalize.rs
@@ -299,12 +299,12 @@ mod test {
         let timestamp_column = Arc::new(TimestampMillisecondArray::from_slice([
             60_000, 120_000, 0, 30_000, 90_000,
         ])) as _;
-        let value_column = Arc::new(Float64Array::from_slice([0.0, 1.0, 10.0, 100.0, 1000.0])) as _;
+        let field_column = Arc::new(Float64Array::from_slice([0.0, 1.0, 10.0, 100.0, 1000.0])) as _;
         let path_column =
             Arc::new(StringArray::from_slice(["foo", "foo", "foo", "foo", "foo"])) as _;
         let data = RecordBatch::try_new(
             schema.clone(),
-            vec![timestamp_column, value_column, path_column],
+            vec![timestamp_column, field_column, path_column],
         )
         .unwrap();
 

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -38,7 +38,7 @@ const COLUMN_DEFAULT_COLUMN: &str = "Default";
 const COLUMN_SEMANTIC_TYPE_COLUMN: &str = "Semantic Type";
 
 const SEMANTIC_TYPE_PRIMARY_KEY: &str = "PRIMARY KEY";
-const SEMANTIC_TYPE_VALUE: &str = "VALUE";
+const SEMANTIC_TYPE_FIELD: &str = "FIELD";
 const SEMANTIC_TYPE_TIME_INDEX: &str = "TIME INDEX";
 
 const NULLABLE_YES: &str = "YES";
@@ -217,7 +217,7 @@ fn describe_column_semantic_types(
                 } else if cs.is_time_index() {
                     String::from(SEMANTIC_TYPE_TIME_INDEX)
                 } else {
-                    String::from(SEMANTIC_TYPE_VALUE)
+                    String::from(SEMANTIC_TYPE_FIELD)
                 }
             })
             .collect::<Vec<String>>(),
@@ -242,7 +242,7 @@ mod test {
     use crate::error::Result;
     use crate::sql::{
         describe_table, DESCRIBE_TABLE_OUTPUT_SCHEMA, NULLABLE_NO, NULLABLE_YES,
-        SEMANTIC_TYPE_TIME_INDEX, SEMANTIC_TYPE_VALUE,
+        SEMANTIC_TYPE_FIELD, SEMANTIC_TYPE_TIME_INDEX,
     };
 
     #[test]
@@ -271,7 +271,7 @@ mod test {
             Arc::new(StringVector::from(vec![NULLABLE_YES, NULLABLE_NO])) as _,
             Arc::new(StringVector::from(vec!["", "current_timestamp()"])) as _,
             Arc::new(StringVector::from(vec![
-                SEMANTIC_TYPE_VALUE,
+                SEMANTIC_TYPE_FIELD,
                 SEMANTIC_TYPE_TIME_INDEX,
             ])) as _,
         ];

--- a/src/servers/src/opentsdb/codec.rs
+++ b/src/servers/src/opentsdb/codec.rs
@@ -18,7 +18,7 @@ use api::v1::{column, Column, ColumnDataType, InsertRequest as GrpcInsertRequest
 use crate::error::{self, Result};
 
 pub const OPENTSDB_TIMESTAMP_COLUMN_NAME: &str = "greptime_timestamp";
-pub const OPENTSDB_VALUE_COLUMN_NAME: &str = "greptime_value";
+pub const OPENTSDB_FIELD_COLUMN_NAME: &str = "greptime_value";
 
 #[derive(Debug)]
 pub struct DataPoint {
@@ -139,8 +139,8 @@ impl DataPoint {
         };
         columns.push(ts_column);
 
-        let value_column = Column {
-            column_name: OPENTSDB_VALUE_COLUMN_NAME.to_string(),
+        let field_column = Column {
+            column_name: OPENTSDB_FIELD_COLUMN_NAME.to_string(),
             values: Some(column::Values {
                 f64_values: vec![self.value],
                 ..Default::default()
@@ -149,7 +149,7 @@ impl DataPoint {
             datatype: ColumnDataType::Float64 as i32,
             ..Default::default()
         };
-        columns.push(value_column);
+        columns.push(field_column);
 
         for (tagk, tagv) in self.tags.iter() {
             columns.push(Column {
@@ -273,7 +273,7 @@ mod test {
             vec![1000]
         );
 
-        assert_eq!(columns[1].column_name, OPENTSDB_VALUE_COLUMN_NAME);
+        assert_eq!(columns[1].column_name, OPENTSDB_FIELD_COLUMN_NAME);
         assert_eq!(columns[1].values.as_ref().unwrap().f64_values, vec![1.0]);
 
         assert_eq!(columns[2].column_name, "tagk1");

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -32,7 +32,7 @@ use snap::raw::{Decoder, Encoder};
 use crate::error::{self, Result};
 
 const TIMESTAMP_COLUMN_NAME: &str = "greptime_timestamp";
-const VALUE_COLUMN_NAME: &str = "greptime_value";
+const FIELD_COLUMN_NAME: &str = "greptime_value";
 pub const METRIC_NAME_LABEL: &str = "__name__";
 
 /// Metrics for push gateway protocol
@@ -185,7 +185,7 @@ fn collect_timeseries_ids(table_name: &str, recordbatch: &RecordBatch) -> Vec<Ti
         ));
 
         for (i, column_schema) in recordbatch.schema.column_schemas().iter().enumerate() {
-            if column_schema.name == VALUE_COLUMN_NAME
+            if column_schema.name == FIELD_COLUMN_NAME
                 || column_schema.name == TIMESTAMP_COLUMN_NAME
             {
                 continue;
@@ -235,17 +235,17 @@ fn recordbatch_to_timeseries(table: &str, recordbatch: RecordBatch) -> Result<Ve
         }
     );
 
-    let value_column = recordbatch.column_by_name(VALUE_COLUMN_NAME).context(
+    let field_column = recordbatch.column_by_name(FIELD_COLUMN_NAME).context(
         error::InvalidPromRemoteReadQueryResultSnafu {
             msg: "missing greptime_value column in query result",
         },
     )?;
     ensure!(
-        value_column.data_type() == ConcreteDataType::float64_datatype(),
+        field_column.data_type() == ConcreteDataType::float64_datatype(),
         error::InvalidPromRemoteReadQueryResultSnafu {
             msg: format!(
                 "Expect value column of datatype Float64, actual {:?}",
-                value_column.data_type()
+                field_column.data_type()
             )
         }
     );
@@ -263,11 +263,11 @@ fn recordbatch_to_timeseries(table: &str, recordbatch: RecordBatch) -> Result<Ve
                 ..Default::default()
             });
 
-        if ts_column.is_null(row) || value_column.is_null(row) {
+        if ts_column.is_null(row) || field_column.is_null(row) {
             continue;
         }
 
-        let value: f64 = match value_column.get(row) {
+        let value: f64 = match field_column.get(row) {
             Value::Float64(value) => value.into(),
             _ => unreachable!("checked by the \"ensure\" above"),
         };
@@ -308,8 +308,8 @@ fn to_grpc_insert_request(mut timeseries: TimeSeries) -> Result<GrpcInsertReques
     };
     columns.push(ts_column);
 
-    let value_column = Column {
-        column_name: VALUE_COLUMN_NAME.to_string(),
+    let field_column = Column {
+        column_name: FIELD_COLUMN_NAME.to_string(),
         values: Some(column::Values {
             f64_values: samples.iter().map(|x| x.value).collect(),
             ..Default::default()
@@ -318,7 +318,7 @@ fn to_grpc_insert_request(mut timeseries: TimeSeries) -> Result<GrpcInsertReques
         datatype: ColumnDataType::Float64 as i32,
         ..Default::default()
     };
-    columns.push(value_column);
+    columns.push(field_column);
 
     let mut table_name = None;
 
@@ -527,7 +527,7 @@ mod tests {
             vec![1000, 2000]
         );
 
-        assert_eq!(columns[1].column_name, VALUE_COLUMN_NAME);
+        assert_eq!(columns[1].column_name, FIELD_COLUMN_NAME);
         assert_eq!(
             columns[1].values.as_ref().unwrap().f64_values,
             vec![1.0, 2.0]
@@ -553,7 +553,7 @@ mod tests {
             vec![1000, 2000]
         );
 
-        assert_eq!(columns[1].column_name, VALUE_COLUMN_NAME);
+        assert_eq!(columns[1].column_name, FIELD_COLUMN_NAME);
         assert_eq!(
             columns[1].values.as_ref().unwrap().f64_values,
             vec![3.0, 4.0]
@@ -584,7 +584,7 @@ mod tests {
             vec![1000, 2000, 3000]
         );
 
-        assert_eq!(columns[1].column_name, VALUE_COLUMN_NAME);
+        assert_eq!(columns[1].column_name, FIELD_COLUMN_NAME);
         assert_eq!(
             columns[1].values.as_ref().unwrap().f64_values,
             vec![5.0, 6.0, 7.0]
@@ -611,7 +611,7 @@ mod tests {
                 true,
             ),
             ColumnSchema::new(
-                VALUE_COLUMN_NAME,
+                FIELD_COLUMN_NAME,
                 ConcreteDataType::float64_datatype(),
                 true,
             ),

--- a/src/storage/benches/memtable/util/mod.rs
+++ b/src/storage/benches/memtable/util/mod.rs
@@ -28,8 +28,8 @@ pub const TIMESTAMP_NAME: &str = "timestamp";
 pub fn schema_for_test() -> RegionSchemaRef {
     let desc = RegionDescBuilder::new("bench")
         .enable_version_column(true)
-        .push_value_column(("v1", LogicalTypeId::UInt64, true))
-        .push_value_column(("v2", LogicalTypeId::String, true))
+        .push_field_column(("v1", LogicalTypeId::UInt64, true))
+        .push_field_column(("v2", LogicalTypeId::String, true))
         .build();
     let metadata: RegionMetadata = desc.try_into().unwrap();
 

--- a/src/storage/benches/memtable/util/regiondesc_util.rs
+++ b/src/storage/benches/memtable/util/regiondesc_util.rs
@@ -54,7 +54,7 @@ impl RegionDescBuilder {
         self
     }
 
-    pub fn push_value_column(mut self, column_def: ColumnDef) -> Self {
+    pub fn push_field_column(mut self, column_def: ColumnDef) -> Self {
         let column = self.new_column(column_def);
         self.default_cf_builder = self.default_cf_builder.push_column(column);
         self

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -111,7 +111,7 @@ mod tests {
         // Just build a region desc and use its columns metadata.
         let desc = RegionDescBuilder::new("test")
             .enable_version_column(false)
-            .push_value_column(("v", LogicalTypeId::UInt64, true))
+            .push_field_column(("v", LogicalTypeId::UInt64, true))
             .build();
         let metadata: RegionMetadata = desc.try_into().unwrap();
         metadata.schema().clone()

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -439,7 +439,7 @@ mod tests {
         let region_name = "region-0";
         let desc = RegionDescBuilder::new(region_name)
             .push_key_column(("k1", LogicalTypeId::Int32, false))
-            .push_value_column(("v1", LogicalTypeId::Float32, true))
+            .push_field_column(("v1", LogicalTypeId::Float32, true))
             .build();
         let ctx = EngineContext::default();
         let region = engine

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -364,7 +364,7 @@ mod tests {
     fn test_region_manifest_builder() {
         let desc = RegionDescBuilder::new("test_region_manifest_builder")
             .enable_version_column(true)
-            .push_value_column(("v0", LogicalTypeId::Int64, true))
+            .push_field_column(("v0", LogicalTypeId::Int64, true))
             .build();
         let region_metadata: RegionMetadata = desc.try_into().unwrap();
 

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -27,7 +27,7 @@ pub fn build_region_meta() -> RegionMetadata {
     let desc = RegionDescBuilder::new(region_name)
         .id(0)
         .push_key_column(("k1", LogicalTypeId::Int32, false))
-        .push_value_column(("v1", LogicalTypeId::Float32, true))
+        .push_field_column(("v1", LogicalTypeId::Float32, true))
         .build();
     desc.try_into().unwrap()
 }
@@ -37,8 +37,8 @@ pub fn build_altered_region_meta() -> RegionMetadata {
     let desc = RegionDescBuilder::new(region_name)
         .id(0)
         .push_key_column(("k1", LogicalTypeId::Int32, false))
-        .push_value_column(("v1", LogicalTypeId::Float32, true))
-        .push_value_column(("v2", LogicalTypeId::Float32, true))
+        .push_field_column(("v1", LogicalTypeId::Float32, true))
+        .push_field_column(("v2", LogicalTypeId::Float32, true))
         .build();
     desc.try_into().unwrap()
 }

--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -190,7 +190,7 @@ impl BTreeIterator {
             .map(|column_meta| column_meta.desc.data_type.clone());
         let value_data_types = self
             .schema
-            .value_columns()
+            .field_columns()
             .map(|column_meta| column_meta.desc.data_type.clone());
 
         let key_columns = rows_to_vectors(
@@ -198,7 +198,7 @@ impl BTreeIterator {
             self.adapter.source_key_needed(),
             keys.as_slice(),
         );
-        let value_columns = rows_to_vectors(
+        let field_columns = rows_to_vectors(
             value_data_types,
             self.adapter.source_value_needed(),
             values.as_slice(),
@@ -206,7 +206,7 @@ impl BTreeIterator {
 
         let batch = self.adapter.batch_from_parts(
             key_columns,
-            value_columns,
+            field_columns,
             Arc::new(sequences),
             Arc::new(op_types),
         )?;

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -150,7 +150,7 @@ mod tests {
     fn new_region_schema() -> RegionSchemaRef {
         let desc = RegionDescBuilder::new("test")
             .timestamp(("ts", LogicalTypeId::TimestampMillisecond, false))
-            .push_value_column(("value", LogicalTypeId::Int64, true))
+            .push_field_column(("value", LogicalTypeId::Int64, true))
             .enable_version_column(false)
             .build();
         let metadata: RegionMetadata = desc.try_into().unwrap();

--- a/src/storage/src/memtable/tests.rs
+++ b/src/storage/src/memtable/tests.rs
@@ -32,8 +32,8 @@ pub fn schema_for_test() -> RegionSchemaRef {
     // Just build a region desc and use its columns metadata.
     let desc = RegionDescBuilder::new("test")
         .enable_version_column(true)
-        .push_value_column(("v0", LogicalTypeId::UInt64, true))
-        .push_value_column(("v1", LogicalTypeId::UInt64, true))
+        .push_field_column(("v0", LogicalTypeId::UInt64, true))
+        .push_field_column(("v1", LogicalTypeId::UInt64, true))
         .build();
     let metadata: RegionMetadata = desc.try_into().unwrap();
 

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -53,7 +53,7 @@ use crate::test_util::{self, config_util, schema_util, write_batch_util};
 pub fn new_metadata(region_name: &str, enable_version_column: bool) -> RegionMetadata {
     let desc = RegionDescBuilder::new(region_name)
         .enable_version_column(enable_version_column)
-        .push_value_column(("v0", LogicalTypeId::Int64, true))
+        .push_field_column(("v0", LogicalTypeId::Int64, true))
         .build();
     desc.try_into().unwrap()
 }
@@ -269,7 +269,7 @@ async fn test_new_region() {
     let desc = RegionDescBuilder::new(region_name)
         .enable_version_column(true)
         .push_key_column(("k1", LogicalTypeId::Int32, false))
-        .push_value_column(("v0", LogicalTypeId::Float32, true))
+        .push_field_column(("v0", LogicalTypeId::Float32, true))
         .build();
     let metadata: RegionMetadata = desc.try_into().unwrap();
 

--- a/src/storage/src/region/tests/alter.rs
+++ b/src/storage/src/region/tests/alter.rs
@@ -457,7 +457,7 @@ async fn test_replay_metadata_after_open() {
 
     let desc = RegionDescBuilder::new(REGION_NAME)
         .push_key_column(("k1", LogicalTypeId::Int32, false))
-        .push_value_column(("v0", LogicalTypeId::Float32, true))
+        .push_field_column(("v0", LogicalTypeId::Float32, true))
         .build();
     let metadata: &RegionMetadata = &desc.try_into().unwrap();
     let mut raw_metadata: RawRegionMetadata = metadata.into();

--- a/src/storage/src/region/tests/projection.rs
+++ b/src/storage/src/region/tests/projection.rs
@@ -32,7 +32,7 @@ use crate::write_batch::WriteBatch;
 
 /// Create metadata with schema (k0, timestamp, v0, v1)
 fn new_metadata(region_name: &str) -> RegionMetadata {
-    let desc = descriptor_util::desc_with_value_columns(region_name, 2);
+    let desc = descriptor_util::desc_with_field_columns(region_name, 2);
     desc.try_into().unwrap()
 }
 

--- a/src/storage/src/schema.rs
+++ b/src/storage/src/schema.rs
@@ -37,13 +37,13 @@ mod tests {
         new_batch_with_num_values(1)
     }
 
-    pub(crate) fn new_batch_with_num_values(num_value_columns: usize) -> Batch {
+    pub(crate) fn new_batch_with_num_values(num_field_columns: usize) -> Batch {
         let k0 = Int64Vector::from_slice([1, 2, 3]);
         let timestamp = TimestampMillisecondVector::from_vec(vec![4, 5, 6]);
 
         let mut columns: Vec<VectorRef> = vec![Arc::new(k0), Arc::new(timestamp)];
 
-        for i in 0..num_value_columns {
+        for i in 0..num_field_columns {
             let vi = Int64Vector::from_slice([i as i64, i as i64, i as i64]);
             columns.push(Arc::new(vi));
         }

--- a/src/storage/src/schema/region.rs
+++ b/src/storage/src/schema/region.rs
@@ -91,8 +91,8 @@ impl RegionSchema {
     }
 
     #[inline]
-    pub fn value_columns(&self) -> impl Iterator<Item = &ColumnMetadata> {
-        self.columns.iter_value_columns()
+    pub fn field_columns(&self) -> impl Iterator<Item = &ColumnMetadata> {
+        self.columns.iter_field_columns()
     }
 
     #[inline]
@@ -101,8 +101,8 @@ impl RegionSchema {
     }
 
     #[inline]
-    pub fn num_value_columns(&self) -> usize {
-        self.columns.num_value_columns()
+    pub fn num_field_columns(&self) -> usize {
+        self.columns.num_field_columns()
     }
 
     #[inline]
@@ -193,10 +193,10 @@ mod tests {
         assert_eq!(2, region_schema.num_row_key_columns());
 
         // Checks value column.
-        let mut values = region_schema.value_columns();
+        let mut values = region_schema.field_columns();
         assert_eq!("v0", values.next().unwrap().desc.name);
         assert_eq!(None, values.next());
-        assert_eq!(1, region_schema.num_value_columns());
+        assert_eq!(1, region_schema.num_field_columns());
 
         // Checks version.
         assert_eq!(123, region_schema.version());

--- a/src/storage/src/schema/store.rs
+++ b/src/storage/src/schema/store.rs
@@ -181,13 +181,13 @@ impl StoreSchema {
     }
 
     #[inline]
-    pub(crate) fn value_columns(&self) -> &[ColumnMetadata] {
+    pub(crate) fn field_columns(&self) -> &[ColumnMetadata] {
         &self.columns[self.row_key_end..self.user_column_end]
     }
 
     /// Returns the index of the value column according its `offset`.
     #[inline]
-    pub(crate) fn value_column_index_by_offset(&self, offset: usize) -> usize {
+    pub(crate) fn field_column_index_by_offset(&self, offset: usize) -> usize {
         self.row_key_end + offset
     }
 

--- a/src/storage/src/test_util/descriptor_util.rs
+++ b/src/storage/src/test_util/descriptor_util.rs
@@ -76,7 +76,7 @@ impl RegionDescBuilder {
         self
     }
 
-    pub fn push_value_column(mut self, column_def: ColumnDef) -> Self {
+    pub fn push_field_column(mut self, column_def: ColumnDef) -> Self {
         let column = self.new_column(column_def);
         self.default_cf_builder = self.default_cf_builder.push_column(column);
         self
@@ -125,12 +125,12 @@ impl RegionDescBuilder {
 }
 
 /// Create desc with schema (k0, timestamp, v0, ... vn-1)
-pub fn desc_with_value_columns(region_name: &str, num_value_columns: usize) -> RegionDescriptor {
+pub fn desc_with_field_columns(region_name: &str, num_field_columns: usize) -> RegionDescriptor {
     let mut builder =
         RegionDescBuilder::new(region_name).push_key_column(("k0", LogicalTypeId::Int64, false));
-    for i in 0..num_value_columns {
+    for i in 0..num_field_columns {
         let name = format!("v{i}");
-        builder = builder.push_value_column((&name, LogicalTypeId::Int64, true));
+        builder = builder.push_field_column((&name, LogicalTypeId::Int64, true));
     }
     builder.build()
 }

--- a/src/storage/src/test_util/read_util.rs
+++ b/src/storage/src/test_util/read_util.rs
@@ -31,7 +31,7 @@ use crate::test_util::descriptor_util::RegionDescBuilder;
 fn new_region_schema() -> RegionSchemaRef {
     let desc = RegionDescBuilder::new("read-util")
         .enable_version_column(false)
-        .push_value_column(("v0", LogicalTypeId::Int64, true))
+        .push_field_column(("v0", LogicalTypeId::Int64, true))
         .build();
     let metadata: RegionMetadata = desc.try_into().unwrap();
     metadata.schema().clone()

--- a/src/storage/src/test_util/schema_util.rs
+++ b/src/storage/src/test_util/schema_util.rs
@@ -58,9 +58,9 @@ pub fn new_schema_ref(column_defs: &[ColumnDef], timestamp_index: Option<usize>)
     Arc::new(new_schema(column_defs, timestamp_index))
 }
 
-pub fn new_region_schema(version: u32, num_value_columns: usize) -> RegionSchema {
+pub fn new_region_schema(version: u32, num_field_columns: usize) -> RegionSchema {
     let metadata: RegionMetadata =
-        descriptor_util::desc_with_value_columns("REGION_NAME", num_value_columns)
+        descriptor_util::desc_with_field_columns("REGION_NAME", num_field_columns)
             .try_into()
             .unwrap();
 

--- a/src/table/src/metadata.rs
+++ b/src/table/src/metadata.rs
@@ -138,7 +138,7 @@ impl TableMeta {
             .map(|idx| &columns_schemas[*idx].name)
     }
 
-    pub fn value_column_names(&self) -> impl Iterator<Item = &String> {
+    pub fn field_column_names(&self) -> impl Iterator<Item = &String> {
         let columns_schemas = &self.schema.column_schemas();
         self.value_indices.iter().filter_map(|idx| {
             let column = &columns_schemas[*idx];

--- a/tests/cases/standalone/alter/rename_table.result
+++ b/tests/cases/standalone/alter/rename_table.result
@@ -7,7 +7,7 @@ DESC TABLE t;
 +-------+-------+------+---------+---------------+
 | Field | Type  | Null | Default | Semantic Type |
 +-------+-------+------+---------+---------------+
-| i     | Int32 | YES  |         | VALUE         |
+| i     | Int32 | YES  |         | FIELD         |
 | j     | Int64 | NO   |         | TIME INDEX    |
 +-------+-------+------+---------+---------------+
 
@@ -46,7 +46,7 @@ DESC TABLE new_table;
 +-------+-------+------+---------+---------------+
 | Field | Type  | Null | Default | Semantic Type |
 +-------+-------+------+---------+---------------+
-| i     | Int32 | YES  |         | VALUE         |
+| i     | Int32 | YES  |         | FIELD         |
 | j     | Int64 | NO   |         | TIME INDEX    |
 +-------+-------+------+---------+---------------+
 

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -59,7 +59,7 @@ DESC TABLE test1;
 +-------+-------+------+---------+---------------+
 | Field | Type  | Null | Default | Semantic Type |
 +-------+-------+------+---------+---------------+
-| i     | Int32 | YES  |         | VALUE         |
+| i     | Int32 | YES  |         | FIELD         |
 | j     | Int64 | NO   |         | TIME INDEX    |
 +-------+-------+------+---------+---------------+
 
@@ -68,7 +68,7 @@ DESC TABLE test2;
 +-------+-------+------+---------+---------------+
 | Field | Type  | Null | Default | Semantic Type |
 +-------+-------+------+---------+---------------+
-| i     | Int32 | YES  |         | VALUE         |
+| i     | Int32 | YES  |         | FIELD         |
 | j     | Int64 | NO   |         | TIME INDEX    |
 +-------+-------+------+---------+---------------+
 
@@ -99,7 +99,7 @@ DESC TABLE test_pk;
 +-----------+---------+------+---------+---------------+
 | timestamp | Int64   | NO   |         | TIME INDEX    |
 | host      | String  | YES  |         | PRIMARY KEY   |
-| value     | Float64 | YES  |         | VALUE         |
+| value     | Float64 | YES  |         | FIELD         |
 +-----------+---------+------+---------+---------------+
 
 DROP TABLE test_pk;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr replaces "value_column" with "field_column" globally, and updated the corresponding `describe_table` utility accordingly.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
