### PR TITLE
feat: support timestamp precision on creating table

### DIFF
--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -112,6 +112,12 @@ pub enum Error {
         reason: String,
         backtrace: Backtrace,
     },
+
+    #[snafu(display("Invalid timestamp precision: {}", precision))]
+    InvalidTimestampPrecision {
+        precision: u64,
+        backtrace: Backtrace,
+    },
 }
 
 impl ErrorExt for Error {

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -42,6 +42,11 @@ use crate::vectors::{
     TimestampNanosecondVectorBuilder, TimestampSecondVector, TimestampSecondVectorBuilder,
 };
 
+const SECOND_VARIATION: u64 = 0;
+const MILLISECOND_VARIATION: u64 = 3;
+const MICROSECOND_VARIATION: u64 = 6;
+const NANOSECOND_VARIATION: u64 = 9;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[enum_dispatch(DataType)]
 pub enum TimestampType {
@@ -61,14 +66,16 @@ impl TryFrom<u64> for TimestampType {
     /// - 9: nanosecond
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(TimestampType::Second(TimestampSecondType::default())),
-            3 => Ok(TimestampType::Millisecond(
+            SECOND_VARIATION => Ok(TimestampType::Second(TimestampSecondType::default())),
+            MILLISECOND_VARIATION => Ok(TimestampType::Millisecond(
                 TimestampMillisecondType::default(),
             )),
-            6 => Ok(TimestampType::Microsecond(
+            MICROSECOND_VARIATION => Ok(TimestampType::Microsecond(
                 TimestampMicrosecondType::default(),
             )),
-            9 => Ok(TimestampType::Nanosecond(TimestampNanosecondType::default())),
+            NANOSECOND_VARIATION => {
+                Ok(TimestampType::Nanosecond(TimestampNanosecondType::default()))
+            }
             _ => InvalidTimestampPrecisionSnafu { precision: value }.fail(),
         }
     }
@@ -82,6 +89,15 @@ impl TimestampType {
             TimestampType::Millisecond(_) => TimeUnit::Millisecond,
             TimestampType::Microsecond(_) => TimeUnit::Microsecond,
             TimestampType::Nanosecond(_) => TimeUnit::Nanosecond,
+        }
+    }
+
+    pub fn precision(&self) -> u64 {
+        match self {
+            TimestampType::Second(_) => SECOND_VARIATION,
+            TimestampType::Millisecond(_) => MILLISECOND_VARIATION,
+            TimestampType::Microsecond(_) => MICROSECOND_VARIATION,
+            TimestampType::Nanosecond(_) => NANOSECOND_VARIATION,
         }
     }
 }

--- a/tests/cases/standalone/common/timestamp/timestamp.result
+++ b/tests/cases/standalone/common/timestamp/timestamp.result
@@ -1,0 +1,21 @@
+CREATE TABLE timestamp_with_precision (ts TIMESTAMP(6) TIME INDEX, cnt INT);
+
+Affected Rows: 0
+
+INSERT INTO timestamp_with_precision(ts,cnt) VALUES ('2023-04-04 08:00:00.0052+0000', 1);
+
+Affected Rows: 1
+
+insert into timestamp_with_precision(ts,cnt) values ('2023-04-04 08:00:00.0052+0800', 2);
+
+Affected Rows: 1
+
+select * from timestamp_with_precision order by ts asc;
+
++----------------------------+-----+
+| ts                         | cnt |
++----------------------------+-----+
+| 2023-04-04T00:00:00.005200 | 2   |
+| 2023-04-04T08:00:00.005200 | 1   |
++----------------------------+-----+
+

--- a/tests/cases/standalone/common/timestamp/timestamp.result
+++ b/tests/cases/standalone/common/timestamp/timestamp.result
@@ -6,11 +6,11 @@ INSERT INTO timestamp_with_precision(ts,cnt) VALUES ('2023-04-04 08:00:00.0052+0
 
 Affected Rows: 1
 
-insert into timestamp_with_precision(ts,cnt) values ('2023-04-04 08:00:00.0052+0800', 2);
+INSERT INTO timestamp_with_precision(ts,cnt) VALUES ('2023-04-04 08:00:00.0052+0800', 2);
 
 Affected Rows: 1
 
-select * from timestamp_with_precision order by ts asc;
+SELECT * FROM timestamp_with_precision ORDER BY ts ASC;
 
 +----------------------------+-----+
 | ts                         | cnt |

--- a/tests/cases/standalone/common/timestamp/timestamp.sql
+++ b/tests/cases/standalone/common/timestamp/timestamp.sql
@@ -1,0 +1,7 @@
+CREATE TABLE timestamp_with_precision (ts TIMESTAMP(6) TIME INDEX, cnt INT);
+
+INSERT INTO timestamp_with_precision(ts,cnt) VALUES ('2023-04-04 08:00:00.0052+0000', 1);
+
+INSERT INTO timestamp_with_precision(ts,cnt) VALUES ('2023-04-04 08:00:00.0052+0800', 2);
+
+SELECT * FROM timestamp_with_precision ORDER BY ts ASC;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

This PR enhances `Timestamp` to support specifying precision when creating tables, following the [fractional seconds syntax in MySQL](https://dev.mysql.com/doc/refman/8.0/en/fractional-seconds.html). 
Fractional seconds option now accepts:
- 0: no factional seconds, time unit is `TimeUnit::Second`
- 3: `TimeUnit::Millisecond`
- 6: `TimeUnit::Microsecond`
- 9: `TimeUnit::Nanosecond`

Also, this precision value is used in [substrait type variation](https://substrait.io/types/type_parsing/) to distinguish between different timestamp units:
> When expressing a type, a user can define the type based on a type variation. Some systems use type variations to describe different underlying representations of the same data type. 

This is a behavior change since originally all timestamp types in substrait are interpreted as `TimestampMillisecond`

Now we can specify the time precision to microseconds like:
```bash
mysql> create table demo (ts timestamp(6) time index, cnt int);
Query OK, 0 rows affected (0.05 sec)
```
And insert timestamps with different time zones:
```bash
mysql> insert into demo(ts,cnt) values ('2023-04-04 08:00:00.52+0000', 1);
Query OK, 1 row affected (0.00 sec)

mysql> insert into demo(ts,cnt) values ('2023-04-04 08:00:00.52+0800', 2);
Query OK, 1 row affected (0.01 sec)
```

And all timestamps will be displayed in UTC time:
```bash
mysql> select * from demo order by ts asc;
+------------------------------+------+
| ts                           | cnt  |
+------------------------------+------+
| 2023-04-04 00:00:00.520+0000 |    2 |
| 2023-04-04 08:00:00.520+0000 |    1 |
+------------------------------+------+
2 rows in set (0.01 sec)
```


Also, this PR format timestamps to ISO8601 format when write query result to MySQL protocol writer so that time zone and fractional parts can be displayed.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
