### PR TITLE
fix!: not allowed to create column name same with keyword without quoted

### DIFF
--- a/src/datanode/src/sql/create.rs
+++ b/src/datanode/src/sql/create.rs
@@ -349,7 +349,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_table_with_options() {
-        let sql = r#"CREATE TABLE demo_table (timestamp BIGINT TIME INDEX, value DOUBLE, host STRING PRIMARY KEY) engine=mito with(regions=1, ttl='7days',write_buffer_size='32MB',some='other');"#;
+        let sql = r#"
+            CREATE TABLE demo_table (
+                "timestamp" BIGINT TIME INDEX, 
+                "value" DOUBLE,
+                host STRING PRIMARY KEY
+            ) engine=mito with(regions=1, ttl='7days',write_buffer_size='32MB',some='other');"#;
         let parsed_stmt = sql_to_statement(sql);
         let handler = create_mock_sql_handler().await;
         let c = handler
@@ -368,7 +373,12 @@ mod tests {
     pub async fn test_create_with_inline_primary_key() {
         let handler = create_mock_sql_handler().await;
         let parsed_stmt = sql_to_statement(
-            r#"CREATE TABLE demo_table (timestamp BIGINT TIME INDEX, value DOUBLE, host STRING PRIMARY KEY) engine=mito with(regions=1);"#,
+            r#"
+            CREATE TABLE demo_table(
+                "timestamp" BIGINT TIME INDEX, 
+                "value" DOUBLE,
+                host STRING PRIMARY KEY
+            ) engine=mito with(regions=1);"#,
         );
         let c = handler
             .create_to_request(42, parsed_stmt, &TableReference::bare("demo_table"))
@@ -407,8 +417,8 @@ mod tests {
         let handler = create_mock_sql_handler().await;
         let parsed_stmt = sql_to_statement(
             r#"create table demo_table (
-                      timestamp BIGINT TIME INDEX,
-                      value DOUBLE,
+                      "timestamp" BIGINT TIME INDEX,
+                      "value" DOUBLE,
                       host STRING PRIMARY KEY,
                       PRIMARY KEY(host)) engine=mito with(regions=1);"#,
         );
@@ -423,8 +433,8 @@ mod tests {
         let handler = create_mock_sql_handler().await;
         let parsed_stmt = sql_to_statement(
             r#"create table demo_table (
-                      timestamp BIGINT TIME INDEX,
-                      value DOUBLE PRIMARY KEY,
+                      "timestamp" BIGINT TIME INDEX,
+                      "value" DOUBLE PRIMARY KEY,
                       host STRING PRIMARY KEY) engine=mito with(regions=1);"#,
         );
         let error = handler

--- a/src/frontend/src/tests/promql_test.rs
+++ b/src/frontend/src/tests/promql_test.rs
@@ -176,8 +176,8 @@ async fn sql_insert_promql_query_ceil(instance: Arc<dyn MockInstance>) {
 const AGGREGATORS_CREATE_TABLE: &str = r#"create table http_requests (
     job string,
     instance string,
-    group string,
-    value double,
+    "group" string,
+    "value" double,
     ts timestamp TIME INDEX,
     PRIMARY KEY (job, instance, group),
 );"#;

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -1460,7 +1460,7 @@ ENGINE=mito";
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Cannot use keyword 'user' as column name!"));
+            .contains("Cannot use keyword 'user' as column name"));
 
         // If column name is quoted, it's valid even same with keyword.
         let sql = r#"

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -392,7 +392,7 @@ impl<'a> ParserContext<'a> {
             ALL_KEYWORDS.binary_search(&name.value.to_uppercase().as_str()).is_ok()
         {
             return Err(ParserError::ParserError(format!(
-                "Cannot use keyword '{}' as column name!",
+                "Cannot use keyword '{}' as column name. Hint: add quotes to the name.",
                 &name.value
             )));
         }

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -88,7 +88,7 @@ DROP TABLE test2;
 
 Affected Rows: 1
 
-CREATE TABLE test_pk (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE);
+CREATE TABLE test_pk ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE);
 
 Affected Rows: 0
 
@@ -106,15 +106,15 @@ DROP TABLE test_pk;
 
 Affected Rows: 1
 
-CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));
+CREATE TABLE test_multiple_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE, PRIMARY KEY(host));
 
 Error: 1004(InvalidArguments), Illegal primary keys definition: found definitions of primary keys in multiple places
 
-CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
+CREATE TABLE test_multiple_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
 
 Error: 1004(InvalidArguments), Illegal primary keys definition: found definitions of primary keys in multiple places
 
-CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);
+CREATE TABLE test_multiple_inline_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE PRIMARY KEY);
 
 Error: 1004(InvalidArguments), Illegal primary keys definition: not allowed to inline multiple primary keys in columns options
 

--- a/tests/cases/standalone/common/create/create.sql
+++ b/tests/cases/standalone/common/create/create.sql
@@ -36,15 +36,15 @@ DROP TABLE test1;
 
 DROP TABLE test2;
 
-CREATE TABLE test_pk (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE);
+CREATE TABLE test_pk ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE);
 
 DESC TABLE test_pk;
 
 DROP TABLE test_pk;
 
-CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host));
+CREATE TABLE test_multiple_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE, PRIMARY KEY(host));
 
-CREATE TABLE test_multiple_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
+CREATE TABLE test_multiple_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE, PRIMARY KEY(host), PRIMARY KEY(host));
 
-CREATE TABLE test_multiple_inline_pk_definitions (timestamp BIGINT TIME INDEX, host STRING PRIMARY KEY, value DOUBLE PRIMARY KEY);
+CREATE TABLE test_multiple_inline_pk_definitions ("timestamp" BIGINT TIME INDEX, host STRING PRIMARY KEY, "value" DOUBLE PRIMARY KEY);
 

--- a/tests/cases/standalone/order/order_variable_size_payload.result
+++ b/tests/cases/standalone/order/order_variable_size_payload.result
@@ -352,8 +352,8 @@ CREATE TABLE DirectReports
     Name varchar NOT NULL,
     Title varchar NOT NULL,
     EmployeeLevel int NOT NULL,
-    Sort varchar NOT NULL,
-    Timestamp BIGINT TIME INDEX,
+    "Sort" varchar NOT NULL,
+    "Timestamp" BIGINT TIME INDEX,
 );
 
 Affected Rows: 0

--- a/tests/cases/standalone/order/order_variable_size_payload.sql
+++ b/tests/cases/standalone/order/order_variable_size_payload.sql
@@ -87,8 +87,8 @@ CREATE TABLE DirectReports
     Name varchar NOT NULL,
     Title varchar NOT NULL,
     EmployeeLevel int NOT NULL,
-    Sort varchar NOT NULL,
-    Timestamp BIGINT TIME INDEX,
+    "Sort" varchar NOT NULL,
+    "Timestamp" BIGINT TIME INDEX,
 );
 
 INSERT INTO DirectReports VALUES


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix #1299 

After some investigation, I found that #1299 is hard to find a walkaround, without breaking any compatibilities to pg or mysql. However, I did find that both pg and mysql not allowed to create column name same with keyword without quoted. So I think we should do the same.

After this PR, create table like this is invalid: `create table my_table(user string, i bigint time index);`, the error msg is:

ERROR 1815 (HY000): Failed to execute query: create table my_table(user string, i bigint time index), source: Failed to parse SQL, source: Syntax error, sql: create table my_table(user string, i bigint time index), source: sql parser error: Cannot use keyword 'user' as column name!

However, quote column name "user" with "", it's ok to execute: `create table my_table("user" string, i bigint time index);`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
