### PR TITLE
fix: stream inserts when copying from external file

### DIFF
--- a/src/datanode/src/sql/copy_table_from.rs
+++ b/src/datanode/src/sql/copy_table_from.rs
@@ -153,9 +153,7 @@ async fn batch_insert(
     let batch = pending.drain(..);
     let res: usize = futures::future::try_join_all(batch)
         .await
-        .context(error::InsertSnafu {
-            table_name: table_name.to_string(),
-        })?
+        .context(error::InsertSnafu { table_name })?
         .iter()
         .sum();
     *pending_bytes = 0;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

This PR changes the behavior when copying data from external file into tables. 

Instead of reading all rows from all files into memory and writing them into tables at a time, now rows are written into tables as soon as memory consumption reaches a predefined threshold.

This may helps to reduce memory consumption when importing a large file like in [this thread](https://github.com/GreptimeTeam/greptimedb/discussions/1303).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
