### PR TITLE
feat: from/to numpy&collect concat

### DIFF
--- a/src/script/src/lib.rs
+++ b/src/script/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // TODO(discord9): spawn new process for executing python script(if hit gil limit) and use shared memory to communicate
+#![deny(clippy::implicit_clone)]
 pub mod engine;
 pub mod error;
 #[cfg(feature = "python")]

--- a/src/script/src/lib.rs
+++ b/src/script/src/lib.rs
@@ -14,6 +14,7 @@
 
 // TODO(discord9): spawn new process for executing python script(if hit gil limit) and use shared memory to communicate
 #![deny(clippy::implicit_clone)]
+
 pub mod engine;
 pub mod error;
 #[cfg(feature = "python")]

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -439,8 +439,8 @@ from greptime import col
 
 @copr(args=["number"], returns = ["number"], sql = "select * from numbers")
 def test(number) -> vector[u32]:
-    from greptime import dataframe
-    return dataframe().filter(col("number")==col("number")).collect()[0][0]
+    from greptime import PyDataFrame
+    return PyDataFrame.from_sql("select * from numbers").filter(col("number")==col("number")).collect()[0][0]
 "#;
         let script = script_engine
             .compile(script, CompileContext::default())

--- a/src/script/src/python/ffi_types.rs
+++ b/src/script/src/python/ffi_types.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) mod copr;
+pub(crate) mod py_recordbatch;
 pub(crate) mod utils;
 pub(crate) mod vector;
 pub(crate) use copr::{check_args_anno_real_type, select_from_rb, Coprocessor};

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -410,7 +410,9 @@ impl PyQueryEngine {
             .map_err(|e| format!("Dedicated thread for sql query panic: {e:?}"))?
     }
     // TODO(discord9): find a better way to call sql query api, now we don't if we are in async context or not
-    /// return sql query results in List[PyVector], or List[usize] for AffectedRows number if no recordbatches is returned
+    /// - return sql query results in `PyRecordBatch`,  or
+    /// - a empty `PyDict` if query results is empty
+    /// - or number of AffectedRows
     #[pymethod]
     fn sql(&self, s: String, vm: &VirtualMachine) -> PyResult<PyObjectRef> {
         self.query_with_new_thread(s)

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -447,6 +447,7 @@ def boolean_array() -> vector[f64]:
     df = PyDataFrame.from_sql("select number from numbers limit 5").filter(col("number") > 2)
     collected = df.collect()
     assert len(collected[0]) == 2
+    assert collected[0] == collected["number"]
     print("query()=", query())
 
     assert "query_engine object at" in repr(query())
@@ -478,6 +479,7 @@ def boolean_array() -> vector[f64]:
     df = PyDataFrame.from_sql("select number from numbers limit 5").filter(col("number") > 2)
     collected = df.collect()
     assert len(collected[0]) == 2
+    assert collected[0] == collected["number"]
     return ret[0]
 "#
             .to_string(),

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -414,7 +414,7 @@ def boolean_array() -> vector[f64]:
 @copr(returns=["value"], backend="pyo3")
 def boolean_array() -> vector[f64]:
     from greptime import vector
-    from greptime import query, dataframe
+    from greptime import query
     
     print("query()=", query())
     assert "query_engine object at" in str(query())
@@ -424,12 +424,6 @@ def boolean_array() -> vector[f64]:
     print(rb)
     assert len(rb) == 5
 
-    try: 
-        print("dataframe()=", dataframe())
-    except KeyError as e:
-        print("dataframe()=", e)
-        print(str(e), type(str(e)), 'No __dataframe__' in str(e))
-        assert 'No __dataframe__' in str(e)
 
     v = vector([1.0, 2.0, 3.0])
     # This returns a vector([2.0])
@@ -443,7 +437,7 @@ def boolean_array() -> vector[f64]:
 @copr(returns=["value"], backend="rspy")
 def boolean_array() -> vector[f64]:
     from greptime import vector, col
-    from greptime import query, dataframe, PyDataFrame
+    from greptime import query, PyDataFrame
     
     df = PyDataFrame.from_sql("select number from numbers limit 5")
     print("df from sql=", df)
@@ -462,11 +456,6 @@ def boolean_array() -> vector[f64]:
     )
     print(rb)
     assert len(rb) == 5
-    try: 
-        print("dataframe()=", dataframe())
-    except KeyError as e:
-        print("dataframe()=", e)
-        assert "__dataframe__" in str(e)
 
     v = vector([1.0, 2.0, 3.0])
     # This returns a vector([2.0])
@@ -481,7 +470,7 @@ def boolean_array() -> vector[f64]:
 @copr(returns=["value"], backend="pyo3")
 def boolean_array() -> vector[f64]:
     from greptime import vector
-    from greptime import query, dataframe, PyDataFrame, col
+    from greptime import query, PyDataFrame, col
     df = PyDataFrame.from_sql("select number from numbers limit 5")
     print("df from sql=", df)
     ret = df.collect()
@@ -563,6 +552,7 @@ def answer() -> vector[i64]:
         import pyarrow as pa
     except ImportError:
         # Python didn't have pyarrow
+        print("Warning: no pyarrow in current python")
         return vector([42, 43, 44])
     return vector.from_pyarrow(vector([42, 43, 44]).to_pyarrow())
 "#
@@ -579,6 +569,7 @@ def answer() -> vector[i64]:
         import pyarrow as pa
     except ImportError:
         # Python didn't have pyarrow
+        print("Warning: no pyarrow in current python")
         return vector([42, 43, 44])
     return vector.from_pyarrow(pa.array([42, 43, 44]))
 "#
@@ -589,9 +580,9 @@ def answer() -> vector[i64]:
             script: r#"
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="rspy")
 def answer() -> vector[i64]:
-    from greptime import vector, col, lit, dataframe
+    from greptime import vector, col, lit, PyDataFrame
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
-    ret = dataframe().select([col("number")]).filter(expr_0).collect()[0]
+    ret = PyDataFrame.from_sql("select * from numbers").select([col("number")]).filter(expr_0).collect()[0]
     return ret
 "#
             .to_string(),
@@ -602,10 +593,10 @@ def answer() -> vector[i64]:
             script: r#"
 @copr(args=[], returns = ["number"], sql = "select * from numbers", backend="pyo3")
 def answer() -> vector[i64]:
-    from greptime import vector, col, lit, dataframe
+    from greptime import vector, col, lit, PyDataFrame
     # Bitwise Operator  pred comparison operator
     expr_0 = (col("number")<lit(3)) & (col("number")>0)
-    ret = dataframe().select([col("number")]).filter(expr_0).collect()[0]
+    ret = PyDataFrame.from_sql("select * from numbers").select([col("number")]).filter(expr_0).collect()[0]
     return ret
 "#
             .to_string(),
@@ -621,6 +612,7 @@ def answer() -> vector[i64]:
         import pyarrow as pa
     except ImportError:
         # Python didn't have pyarrow
+        print("Warning: no pyarrow in current python")
         return vector([42, 43, 44])
     a = vector.from_pyarrow(pa.array([42]))
     return a[0:1]
@@ -733,8 +725,9 @@ def test_numpy() -> vector[i64]:
     try:
         import numpy as np
         import pyarrow as pa
-    except ImportError:
+    except ImportError as e:
         # Python didn't have numpy or pyarrow
+        print("Warning: no pyarrow or numpy found in current python", e)
         return vector([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,])
     from greptime import vector
     v = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,])

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -418,6 +418,12 @@ def boolean_array() -> vector[f64]:
     
     print("query()=", query())
     assert "query_engine object at" in str(query())
+    rb = query().sql(
+        "select number from numbers limit 5"
+    )
+    print(rb)
+    assert len(rb) == 5
+
     try: 
         print("dataframe()=", dataframe())
     except KeyError as e:
@@ -451,6 +457,11 @@ def boolean_array() -> vector[f64]:
     print("query()=", query())
 
     assert "query_engine object at" in repr(query())
+    rb = query().sql(
+        "select number from numbers limit 5"
+    )
+    print(rb)
+    assert len(rb) == 5
     try: 
         print("dataframe()=", dataframe())
     except KeyError as e:

--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -548,6 +548,11 @@ def answer() -> vector[i64]:
 @copr(returns=["value"], backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
+    try:
+        import pyarrow as pa
+    except ImportError:
+        # Python didn't have pyarrow
+        return vector([42, 43, 44])
     return vector.from_pyarrow(vector([42, 43, 44]).to_pyarrow())
 "#
             .to_string(),
@@ -559,7 +564,11 @@ def answer() -> vector[i64]:
 @copr(returns=["value"], backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
-    import pyarrow as pa
+    try:
+        import pyarrow as pa
+    except ImportError:
+        # Python didn't have pyarrow
+        return vector([42, 43, 44])
     return vector.from_pyarrow(pa.array([42, 43, 44]))
 "#
             .to_string(),
@@ -597,8 +606,12 @@ def answer() -> vector[i64]:
 @copr(returns=["value"], backend="pyo3")
 def answer() -> vector[i64]:
     from greptime import vector
-    import pyarrow as pa
-    a = vector.from_pyarrow(pa.array([42, 43, 44]))
+    try:
+        import pyarrow as pa
+    except ImportError:
+        # Python didn't have pyarrow
+        return vector([42, 43, 44])
+    a = vector.from_pyarrow(pa.array([42]))
     return a[0:1]
 "#
             .to_string(),
@@ -706,8 +719,12 @@ import math
 
 @coprocessor(args=[], returns=["value"], backend="pyo3")
 def test_numpy() -> vector[i64]:
-    import numpy as np
-    import pyarrow as pa
+    try:
+        import numpy as np
+        import pyarrow as pa
+    except ImportError:
+        # Python didn't have numpy or pyarrow
+        return vector([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,])
     from greptime import vector
     v = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9,])
     v = pa.array(v)

--- a/src/script/src/python/ffi_types/py_recordbatch.rs
+++ b/src/script/src/python/ffi_types/py_recordbatch.rs
@@ -4,10 +4,11 @@
 
 use common_recordbatch::RecordBatch;
 use crossbeam_utils::atomic::AtomicCell;
-use pyo3::exceptions::{PyKeyError, PyRuntimeError};
 #[cfg(feature = "pyo3_backend")]
-use pyo3::pyclass as pyo3class;
-use pyo3::{pymethods, PyObject, PyResult, Python};
+use pyo3::{
+    exceptions::{PyKeyError, PyRuntimeError},
+    pyclass as pyo3class, pymethods, PyObject, PyResult, Python,
+};
 use rustpython_vm::builtins::PyStr;
 use rustpython_vm::protocol::PyMappingMethods;
 use rustpython_vm::types::AsMapping;

--- a/src/script/src/python/ffi_types/py_recordbatch.rs
+++ b/src/script/src/python/ffi_types/py_recordbatch.rs
@@ -1,0 +1,105 @@
+//! PyRecordBatch is a Python class that wraps a RecordBatch,
+//! and provide a PyMapping Protocol to
+//! access the columns of the RecordBatch.
+
+use common_recordbatch::RecordBatch;
+use crossbeam_utils::atomic::AtomicCell;
+use pyo3::exceptions::{PyKeyError, PyRuntimeError};
+#[cfg(feature = "pyo3_backend")]
+use pyo3::pyclass as pyo3class;
+use pyo3::{pymethods, PyObject, PyResult, Python};
+use rustpython_vm::builtins::PyStr;
+use rustpython_vm::protocol::PyMappingMethods;
+use rustpython_vm::types::AsMapping;
+use rustpython_vm::{
+    atomic_func, pyclass as rspyclass, PyObject as RsPyObject, PyPayload, PyResult as RsPyResult,
+    VirtualMachine,
+};
+
+use crate::python::ffi_types::PyVector;
+
+#[cfg_attr(feature = "pyo3_backend", pyo3class(name = "PyRecordBatch"))]
+#[rspyclass(module = false, name = "PyRecordBatch")]
+#[derive(Debug, PyPayload)]
+pub(crate) struct PyRecordBatch {
+    record_batch: RecordBatch,
+}
+
+impl PyRecordBatch {
+    pub fn new(record_batch: RecordBatch) -> Self {
+        Self { record_batch }
+    }
+}
+
+#[cfg(feature = "pyo3_backend")]
+#[pymethods]
+impl PyRecordBatch {
+    fn __getitem__(&self, py: Python, key: PyObject) -> PyResult<PyVector> {
+        let column = if let Ok(key) = key.extract::<String>(py) {
+            self.record_batch.column_by_name(&key)
+        } else if let Ok(key) = key.extract::<usize>(py) {
+            Some(self.record_batch.column(key))
+        } else {
+            return Err(PyRuntimeError::new_err(format!(
+                "Expect either str or int, found {key:?}"
+            )));
+        }
+        .ok_or_else(|| PyKeyError::new_err(format!("Column {} not found", key)))?;
+        let v = PyVector::from(column.clone());
+        Ok(v)
+    }
+    fn __iter__(&self) -> PyResult<Vec<PyVector>> {
+        let iter: Vec<_> = self
+            .record_batch
+            .columns()
+            .iter()
+            .map(|i| PyVector::from(i.clone()))
+            .collect();
+        Ok(iter)
+    }
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.len())
+    }
+}
+
+impl PyRecordBatch {
+    fn len(&self) -> usize {
+        self.record_batch.num_rows()
+    }
+    fn get_item(&self, needle: &RsPyObject, vm: &VirtualMachine) -> RsPyResult {
+        if let Ok(index) = needle.to_owned().try_into_value::<usize>(vm) {
+            let column = self.record_batch.column(index);
+            let v = PyVector::from(column.clone());
+            Ok(v.into_pyobject(vm))
+        } else if let Some(index) = needle.to_owned().payload::<PyStr>() {
+            let key = index.as_str();
+
+            let v = self.record_batch.column_by_name(key).ok_or_else(|| {
+                vm.new_key_error(PyStr::from(format!("Column {} not found", key)).into_pyobject(vm))
+            })?;
+            let v: PyVector = v.clone().into();
+            Ok(v.into_pyobject(vm))
+        } else {
+            Err(vm.new_key_error(
+                PyStr::from(format!("Expect either str or int, found {needle:?}"))
+                    .into_pyobject(vm),
+            ))
+        }
+    }
+}
+
+#[rspyclass(with(AsMapping))]
+impl PyRecordBatch {}
+
+impl AsMapping for PyRecordBatch {
+    fn as_mapping() -> &'static PyMappingMethods {
+        static AS_MAPPING: PyMappingMethods = PyMappingMethods {
+            length: atomic_func!(|mapping, _vm| Ok(PyRecordBatch::mapping_downcast(mapping).len())),
+            subscript: atomic_func!(
+                |mapping, needle, vm| PyRecordBatch::mapping_downcast(mapping).get_item(needle, vm)
+            ),
+            ass_subscript: AtomicCell::new(None),
+        };
+        &AS_MAPPING
+    }
+}

--- a/src/script/src/python/ffi_types/py_recordbatch.rs
+++ b/src/script/src/python/ffi_types/py_recordbatch.rs
@@ -94,11 +94,11 @@ impl PyRecordBatch {
         self.record_batch.num_rows()
     }
     fn get_item(&self, needle: &RsPyObject, vm: &VirtualMachine) -> RsPyResult {
-        if let Ok(index) = needle.to_owned().try_into_value::<usize>(vm) {
+        if let Ok(index) = needle.try_to_value::<usize>(vm) {
             let column = self.record_batch.column(index);
             let v = PyVector::from(column.clone());
             Ok(v.into_pyobject(vm))
-        } else if let Some(index) = needle.to_owned().payload::<PyStr>() {
+        } else if let Ok(index) = needle.try_to_value::<String>(vm) {
             let key = index.as_str();
 
             let v = self.record_batch.column_by_name(key).ok_or_else(|| {

--- a/src/script/src/python/ffi_types/py_recordbatch.rs
+++ b/src/script/src/python/ffi_types/py_recordbatch.rs
@@ -1,3 +1,18 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//! PyRecordBatch is a Python class that wraps a RecordBatch,
+
 //! PyRecordBatch is a Python class that wraps a RecordBatch,
 //! and provide a PyMapping Protocol to
 //! access the columns of the RecordBatch.

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -126,6 +126,7 @@ fn get_globals(py: Python) -> PyResult<&PyDict> {
     Ok(globals)
 }
 
+// TODO(discord9): deprecate this
 #[pyfunction]
 fn dataframe(py: Python) -> PyResult<PyDataFrame> {
     let globals = get_globals(py)?;

--- a/src/script/src/python/pyo3/builtins.rs
+++ b/src/script/src/python/pyo3/builtins.rs
@@ -126,7 +126,8 @@ fn get_globals(py: Python) -> PyResult<&PyDict> {
     Ok(globals)
 }
 
-// TODO(discord9): deprecate this
+/// In case of not wanting to repeat the same sql statement in sql,
+/// this function is still useful even we already have PyDataFrame.from_sql()
 #[pyfunction]
 fn dataframe(py: Python) -> PyResult<PyDataFrame> {
     let globals = get_globals(py)?;

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -23,7 +23,7 @@ use datatypes::vectors::{Helper, VectorRef};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyModule, PyString, PyTuple};
 use pyo3::{pymethods, IntoPy, PyAny, PyCell, PyObject, PyResult, Python, ToPyObject};
-use snafu::{ensure, ResultExt, Location};
+use snafu::{ensure, Location, ResultExt};
 
 use crate::python::error::{self, NewRecordBatchSnafu, OtherSnafu, Result};
 use crate::python::ffi_types::copr::PyQueryEngine;

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use arrow::compute;
 use common_recordbatch::RecordBatch;
 use common_telemetry::timer;
 use datafusion_common::ScalarValue;
@@ -21,11 +22,12 @@ use datatypes::prelude::ConcreteDataType;
 use datatypes::vectors::{Helper, VectorRef};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyModule, PyString, PyTuple};
-use pyo3::{pymethods, PyAny, PyCell, PyObject, PyResult, Python, ToPyObject};
-use snafu::{ensure, Location, ResultExt};
+use pyo3::{pymethods, IntoPy, PyAny, PyCell, PyObject, PyResult, Python, ToPyObject};
+use snafu::{ensure, Backtrace, GenerateImplicitData, ResultExt};
 
 use crate::python::error::{self, NewRecordBatchSnafu, OtherSnafu, Result};
 use crate::python::ffi_types::copr::PyQueryEngine;
+use crate::python::ffi_types::py_recordbatch::PyRecordBatch;
 use crate::python::ffi_types::{check_args_anno_real_type, select_from_rb, Coprocessor, PyVector};
 use crate::python::metric;
 use crate::python::pyo3::dataframe_impl::PyDataFrame;
@@ -36,23 +38,22 @@ impl PyQueryEngine {
     #[pyo3(name = "sql")]
     pub(crate) fn sql_pyo3(&self, py: Python<'_>, s: String) -> PyResult<PyObject> {
         let res = self
-            .query_with_new_thread(s)
+            .query_with_new_thread(s.clone())
             .map_err(PyValueError::new_err)?;
         match res {
             crate::python::ffi_types::copr::Either::Rb(rbs) => {
-                let mut top_vec = Vec::with_capacity(rbs.iter().count());
-                for rb in rbs.iter() {
-                    let mut vec_of_vec = Vec::with_capacity(rb.columns().len());
-                    for v in rb.columns() {
-                        let v = PyVector::from(v.clone());
-                        let v = PyCell::new(py, v)?;
-                        vec_of_vec.push(v.to_object(py));
-                    }
-                    let vec_of_vec = PyList::new(py, vec_of_vec);
-                    top_vec.push(vec_of_vec);
-                }
-                let top_vec = PyList::new(py, top_vec);
-                Ok(top_vec.to_object(py))
+                let rb = compute::concat_batches(
+                    rbs.schema().arrow_schema(),
+                    rbs.iter().map(|rb| rb.df_record_batch()),
+                )
+                .map_err(|e| PyRuntimeError::new_err(format!("{e:?}")))?;
+                let rb = RecordBatch::try_from_df_record_batch(rbs.schema(), rb).map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "Convert datafusion record batch to record batch failed for query {s}: {e}"
+                    ))
+                })?;
+                let rb = PyRecordBatch::new(rb);
+                Ok(rb.into_py(py))
             }
             crate::python::ffi_types::copr::Either::AffectedRows(count) => Ok(count.to_object(py)),
         }

--- a/src/script/src/python/pyo3/copr_impl.rs
+++ b/src/script/src/python/pyo3/copr_impl.rs
@@ -23,7 +23,7 @@ use datatypes::vectors::{Helper, VectorRef};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyModule, PyString, PyTuple};
 use pyo3::{pymethods, IntoPy, PyAny, PyCell, PyObject, PyResult, Python, ToPyObject};
-use snafu::{ensure, Backtrace, GenerateImplicitData, ResultExt};
+use snafu::{ensure, ResultExt, Location};
 
 use crate::python::error::{self, NewRecordBatchSnafu, OtherSnafu, Result};
 use crate::python::ffi_types::copr::PyQueryEngine;

--- a/src/script/src/python/rspython/copr_impl.rs
+++ b/src/script/src/python/rspython/copr_impl.rs
@@ -29,6 +29,7 @@ use snafu::{OptionExt, ResultExt};
 
 use crate::python::error::{ensure, ret_other_error_with, NewRecordBatchSnafu, OtherSnafu, Result};
 use crate::python::ffi_types::copr::PyQueryEngine;
+use crate::python::ffi_types::py_recordbatch::PyRecordBatch;
 use crate::python::ffi_types::{check_args_anno_real_type, select_from_rb, Coprocessor, PyVector};
 use crate::python::metric;
 use crate::python::rspython::builtins::init_greptime_builtins;
@@ -216,6 +217,7 @@ pub(crate) fn init_interpreter() -> Arc<Interpreter> {
                     // add our own custom datatype and module
                     PyVector::make_class(&vm.ctx);
                     PyQueryEngine::make_class(&vm.ctx);
+                    PyRecordBatch::make_class(&vm.ctx);
                     init_greptime_builtins("greptime", vm);
                     init_data_frame("data_frame", vm);
                 }));

--- a/src/script/src/python/rspython/dataframe_impl.rs
+++ b/src/script/src/python/rspython/dataframe_impl.rs
@@ -28,7 +28,6 @@ pub(crate) mod data_frame {
     use datafusion::dataframe::DataFrame as DfDataFrame;
     use datafusion::execution::context::SessionContext;
     use datafusion_expr::Expr as DfExpr;
-    use rustpython_vm::builtins::{PyList, PyListRef};
     use rustpython_vm::function::PyComparisonValue;
     use rustpython_vm::types::{Comparable, PyComparisonOp};
     use rustpython_vm::{
@@ -37,7 +36,7 @@ pub(crate) mod data_frame {
     use snafu::ResultExt;
 
     use crate::python::error::DataFusionSnafu;
-    use crate::python::ffi_types::PyVector;
+    use crate::python::ffi_types::py_recordbatch::PyRecordBatch;
     use crate::python::rspython::builtins::greptime_builtin::{
         lit, query as get_query_engine, PyDataFrame,
     };
@@ -236,7 +235,7 @@ pub(crate) mod data_frame {
 
         #[pymethod]
         /// collect `DataFrame` results into `List[Vector]`
-        fn collect(&self, vm: &VirtualMachine) -> PyResult<PyListRef> {
+        fn collect(&self, vm: &VirtualMachine) -> PyResult<PyRecordBatch> {
             let inner = self.inner.clone();
             let res = block_on_async(async { inner.collect().await });
             let res = res
@@ -248,18 +247,22 @@ pub(crate) mod data_frame {
                         "Concat batches failed for dataframe {self:?}: {e}"
                     ))
                 })?;
-            // TODO(discord9): wrap RecordBatch in a dict-like type
-            let vector_list: Vec<_> = concat_rb
-                .columns()
-                .iter()
-                .map(|arr| {
-                    datatypes::vectors::Helper::try_into_vector(arr)
-                        .map(PyVector::from)
-                        .map(|v| vm.new_pyobj(v))
-                        .map_err(|e| vm.new_runtime_error(e.to_string()))
-                })
-                .collect::<Result<_, _>>()?;
-            Ok(PyList::new_ref(vector_list, vm.as_ref()))
+
+            // we are inside a macro, so using full path
+            let schema = datatypes::schema::Schema::try_from(concat_rb.schema()).map_err(|e| {
+                vm.new_runtime_error(format!(
+                    "Convert to Schema failed for dataframe {self:?}: {e}"
+                ))
+            })?;
+            let rb =
+                RecordBatch::try_from_df_record_batch(schema.into(), concat_rb).map_err(|e| {
+                    vm.new_runtime_error(format!(
+                        "Convert to RecordBatch failed for dataframe {self:?}: {e}"
+                    ))
+                })?;
+
+            let rb = PyRecordBatch::new(rb);
+            Ok(rb)
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- from/to_numpy for `PyVector`
- PyDataFrame now `collect` to concated batch(So no `collect()[0][0]` just `collect()[0]`
- Added `PyRecordBatch` type as return values of `PyDataFrame.collect()` allowing indexing like `collected[0]` or `collected["number"]`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
