### PR TITLE
feat: ignoring time zone info when import from external files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,6 +2441,7 @@ name = "datatypes"
 version = "0.1.1"
 dependencies = [
  "arrow",
+ "arrow-array",
  "arrow-schema",
  "common-base",
  "common-error",

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -423,11 +423,13 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "File Schema mismatch, expected table schema: {} but found :{}",
+        "File schema mismatch at index {}, expected table schema: {} but found :{}",
+        index,
         table_schema,
         file_schema
     ))]
     InvalidSchema {
+        index: usize,
         table_schema: String,
         file_schema: String,
     },

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -423,7 +423,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "File schema mismatch at index {}, expected table schema: {} but found :{}",
+        "File schema mismatch at index {}, expected table schema: {} but found: {}",
         index,
         table_schema,
         file_schema

--- a/src/datanode/src/sql/copy_table_from.rs
+++ b/src/datanode/src/sql/copy_table_from.rs
@@ -24,7 +24,6 @@ use common_query::Output;
 use common_recordbatch::error::DataTypesSnafu;
 use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datatypes::arrow::datatypes::{DataType, SchemaRef};
-use datatypes::arrow::record_batch::RecordBatch;
 use datatypes::vectors::Helper;
 use futures_util::StreamExt;
 use regex::Regex;

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -10,6 +10,7 @@ test = []
 
 [dependencies]
 arrow.workspace = true
+arrow-array = "36"
 arrow-schema.workspace = true
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }

--- a/src/datatypes/src/vectors/helper.rs
+++ b/src/datatypes/src/vectors/helper.rs
@@ -238,16 +238,18 @@ impl Helper {
             ArrowDataType::Date64 => Arc::new(DateTimeVector::try_from_arrow_array(array)?),
             ArrowDataType::List(_) => Arc::new(ListVector::try_from_arrow_array(array)?),
             ArrowDataType::Timestamp(unit, _) => match unit {
-                TimeUnit::Second => Arc::new(TimestampSecondVector::try_from_arrow_array(array)?),
-                TimeUnit::Millisecond => {
-                    Arc::new(TimestampMillisecondVector::try_from_arrow_array(array)?)
-                }
-                TimeUnit::Microsecond => {
-                    Arc::new(TimestampMicrosecondVector::try_from_arrow_array(array)?)
-                }
-                TimeUnit::Nanosecond => {
-                    Arc::new(TimestampNanosecondVector::try_from_arrow_array(array)?)
-                }
+                TimeUnit::Second => Arc::new(
+                    TimestampSecondVector::try_from_arrow_timestamp_array(array)?,
+                ),
+                TimeUnit::Millisecond => Arc::new(
+                    TimestampMillisecondVector::try_from_arrow_timestamp_array(array)?,
+                ),
+                TimeUnit::Microsecond => Arc::new(
+                    TimestampMicrosecondVector::try_from_arrow_timestamp_array(array)?,
+                ),
+                TimeUnit::Nanosecond => Arc::new(
+                    TimestampNanosecondVector::try_from_arrow_timestamp_array(array)?,
+                ),
             },
             ArrowDataType::Float16
             | ArrowDataType::Time32(_)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR allows users to import parquet files with explicit time zone info in schema by ignoring the time zone info and treating the `i64` value as time elapsed since UNIX epoch.


### Why ignoring time zone in arrow array is correct?

According to [Timezone Aware Timestamp Parsing - arrow-rs](https://github.com/apache/arrow-rs/issues/3794), the time zone info in schema is an indicator of the desired time zone, but the underlying value (the `i64` value) is always adjusted to UTC time. 

That is being to say, if we can a timestamp in secinds with value 28800 (8*60*60) and time zone "+08:00", what is the UTC time point of this timestamp? Is it "1970-01:01 00:00:00"? Actually no, it "1970-01:01 08:00:00" in UTC and "1970-01:01 16:00:00" in CST.

```rust
use arrow_array::timezone::Tz;
#[test]
fn test_parsing_timestamp_to_arrow_array() {
    let arr = TimestampSecondArray::from(vec![28800]).with_timezone("+08:00".to_string());
    let tz: Tz = arr.timezone().unwrap().parse().unwrap();

    println!(
        "Timestamp with time zone: {:?}",
        arr.value_as_datetime_with_tz(0, tz).unwrap().to_string()
    );
}

// it prints: "1970-01-01 16:00:00 +08:00"
```

### Why ignoring time zone in parquet schema is ok?
Parquet has an ["isAdjustedToUTC" flag](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#timestamp) which indicates if the INT96 value in Parquet is already adjusted to UTC time, but arrow/parquet does not provide a method to read that flag. So we can only ignore the flag and treat all INT96 values in parquet's timestamp columns as timestamp relative to UTC time, just like 



## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1319