### PR TITLE
refactor: add disable_dashboard option and disable dashboard in metasrv and datanode

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -168,6 +168,9 @@ impl TryFrom<StartCommand> for DatanodeOptions {
             opts.http_opts.timeout = Duration::from_secs(http_timeout)
         }
 
+        // Disable dashboard in datanode.
+        opts.http_opts.disable_dashboard = true;
+
         Ok(opts)
     }
 }

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -107,6 +107,8 @@ pub struct StartCommand {
     tls_key_path: Option<String>,
     #[clap(long)]
     user_provider: Option<String>,
+    #[clap(long)]
+    disable_dashboard: bool,
 }
 
 impl StartCommand {
@@ -149,18 +151,24 @@ impl TryFrom<StartCommand> for FrontendOptions {
 
         let tls_option = TlsOption::new(cmd.tls_mode, cmd.tls_cert_path, cmd.tls_key_path);
 
+        opts.http_options = Some(HttpOptions::default());
         if let Some(addr) = cmd.http_addr {
-            opts.http_options = Some(HttpOptions {
-                addr,
-                ..Default::default()
-            });
+            if let Some(ref mut http_options) = opts.http_options {
+                http_options.addr = addr;
+            }
         }
+
+        if let Some(ref mut http_options) = opts.http_options {
+            http_options.disable_dashboard = cmd.disable_dashboard
+        }
+
         if let Some(addr) = cmd.grpc_addr {
             opts.grpc_options = Some(GrpcOptions {
                 addr,
                 ..Default::default()
             });
         }
+
         if let Some(addr) = cmd.mysql_addr {
             opts.mysql_options = Some(MysqlOptions {
                 addr,
@@ -227,6 +235,7 @@ mod tests {
             tls_cert_path: None,
             tls_key_path: None,
             user_provider: None,
+            disable_dashboard: false,
         };
 
         let opts: FrontendOptions = command.try_into().unwrap();
@@ -289,6 +298,7 @@ mod tests {
             tls_cert_path: None,
             tls_key_path: None,
             user_provider: None,
+            disable_dashboard: false,
         };
 
         let fe_opts = FrontendOptions::try_from(command).unwrap();
@@ -319,6 +329,7 @@ mod tests {
             tls_cert_path: None,
             tls_key_path: None,
             user_provider: Some("static_user_provider:cmd:test=test".to_string()),
+            disable_dashboard: false,
         };
 
         let plugins = load_frontend_plugins(&command.user_provider);

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -151,16 +151,16 @@ impl TryFrom<StartCommand> for FrontendOptions {
 
         let tls_option = TlsOption::new(cmd.tls_mode, cmd.tls_cert_path, cmd.tls_key_path);
 
-        opts.http_options = Some(HttpOptions::default());
+        let mut http_options = HttpOptions {
+            disable_dashboard: cmd.disable_dashboard,
+            ..Default::default()
+        };
+
         if let Some(addr) = cmd.http_addr {
-            if let Some(ref mut http_options) = opts.http_options {
-                http_options.addr = addr;
-            }
+            http_options.addr = addr;
         }
 
-        if let Some(ref mut http_options) = opts.http_options {
-            http_options.disable_dashboard = cmd.disable_dashboard
-        }
+        opts.http_options = Some(http_options);
 
         if let Some(addr) = cmd.grpc_addr {
             opts.grpc_options = Some(GrpcOptions {

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -141,6 +141,9 @@ impl TryFrom<StartCommand> for MetaSrvOptions {
             opts.http_opts.timeout = Duration::from_secs(http_timeout);
         }
 
+        // Disable dashboard in metasrv.
+        opts.http_opts.disable_dashboard = true;
+
         Ok(opts)
     }
 }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -120,6 +120,8 @@ pub struct HttpOptions {
     pub addr: String,
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
+
+    pub disable_dashboard: bool,
 }
 
 impl Default for HttpOptions {
@@ -127,6 +129,7 @@ impl Default for HttpOptions {
         Self {
             addr: "127.0.0.1:4000".to_string(),
             timeout: Duration::from_secs(30),
+            disable_dashboard: false,
         }
     }
 }
@@ -502,7 +505,10 @@ impl HttpServer {
 
         #[cfg(feature = "dashboard")]
         {
-            router = router.nest("/dashboard", dashboard::dashboard());
+            if !self.options.disable_dashboard {
+                info!("Enable dashboard service at '/dashboard'");
+                router = router.nest("/dashboard", dashboard::dashboard());
+            }
         }
 
         router

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -118,9 +118,11 @@ pub struct HttpServer {
 #[serde(default)]
 pub struct HttpOptions {
     pub addr: String,
+
     #[serde(with = "humantime_serde")]
     pub timeout: Duration,
 
+    #[serde(skip)]
     pub disable_dashboard: bool,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add disable_dashboard option and disable dashboard in metasrv and datanode.

Resolve #1337 

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
