### PR TITLE
chore: use centos7 as builder base image to relax requirements for glibc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,26 @@
-FROM ubuntu:22.04 as builder
+FROM centos:7 as builder
 
 ENV LANG en_US.utf8
 WORKDIR /greptimedb
 
+RUN sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+             -e 's|^#baseurl=http://mirror.centos.org/centos|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos|g' \
+             -i.bak \
+             /etc/yum.repos.d/CentOS-*.repo
+
 # Install dependencies.
-RUN apt-get update && apt-get install -y \
-    libssl-dev \
-    protobuf-compiler \
-    curl \
-    build-essential \
-    pkg-config \
-    python3 \
-    python3-dev \
-    && pip install pyarrow
+RUN RUN ulimit -n 1024000 && yum install -y epel-release openssl openssl-devel centos-release-scl
+RUN yum groupinstall -y 'Development Tools'
+RUN yum install -y rh-python38 rh-python38-python-devel
+
+# Install protoc
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
+RUN unzip protoc-3.15.8-linux-x86_64.zip -d /usr/local/
 
 # Install Rust.
 SHELL ["/bin/bash", "-c"]
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --default-toolchain none -y
-ENV PATH /root/.cargo/bin/:$PATH
+ENV PATH /opt/rh/rh-python38/root/usr/bin:/usr/local/bin:/root/.cargo/bin/:$PATH
 
 # Build the project in release mode.
 COPY . .


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use centos7 as base image to relax glibc version requirement

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
