### PR TITLE
fix: avoid panic when no region found in table

### DIFF
--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -39,7 +39,9 @@ use store_api::storage::{
     RegionMeta, RegionNumber, ScanRequest, SchemaRef, Snapshot, WriteContext, WriteRequest,
 };
 use table::error as table_error;
-use table::error::{RegionSchemaMismatchSnafu, Result as TableResult, TableOperationSnafu};
+use table::error::{
+    InvalidTableSnafu, RegionSchemaMismatchSnafu, Result as TableResult, TableOperationSnafu,
+};
 use table::metadata::{
     FilterPushDownType, RawTableInfo, TableInfo, TableInfoRef, TableMeta, TableType,
 };
@@ -193,7 +195,10 @@ impl<R: Region> Table for MitoTable<R> {
 
         // TODO(hl): we assume table contains at least one region, but with region migration this
         // assumption may become invalid.
-        let stream_schema = first_schema.unwrap();
+        let stream_schema = first_schema.context(InvalidTableSnafu {
+            table_id: table_info.ident.table_id,
+        })?;
+
         let schema = stream_schema.clone();
         let stream = Box::pin(async_stream::try_stream! {
             for mut reader in readers {

--- a/src/table/src/error.rs
+++ b/src/table/src/error.rs
@@ -20,6 +20,8 @@ use datafusion::error::DataFusionError;
 use datatypes::arrow::error::ArrowError;
 use snafu::Location;
 
+use crate::metadata::TableId;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Default error implementation of table.
@@ -106,6 +108,7 @@ pub enum Error {
         column_name: String,
         location: Location,
     },
+
     #[snafu(display("Regions schemas mismatch in table: {}", table))]
     RegionSchemaMismatch { table: String, location: Location },
 
@@ -119,6 +122,12 @@ pub enum Error {
     ParseTableOption {
         key: String,
         value: String,
+        location: Location,
+    },
+
+    #[snafu(display("Invalid table state: {}", table_id))]
+    InvalidTable {
+        table_id: TableId,
         location: Location,
     },
 }
@@ -143,6 +152,7 @@ impl ErrorExt for Error {
             Error::ParseTableOption { .. }
             | Error::EngineNotFound { .. }
             | Error::EngineExist { .. } => StatusCode::InvalidArguments,
+            Error::InvalidTable { .. } => StatusCode::Internal,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR prevents panicking when no regions are found in table during table scan.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #1024