### PR TITLE
refactor: merge `authenticate` and `authorize` api

### DIFF
--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -35,6 +35,20 @@ pub trait UserProvider: Send + Sync {
     /// from a certain user to a certain catalog/schema is legal.
     /// This method should be called after [`authenticate`].
     async fn authorize(&self, catalog: &str, schema: &str, user_info: &UserInfo) -> Result<()>;
+
+    /// [`auth`] is a combination of [`authenticate`] and [`authorize`].
+    /// In most cases it's preferred for both convenience and performance.
+    async fn auth(
+        &self,
+        id: Identity<'_>,
+        password: Password<'_>,
+        catalog: &str,
+        schema: &str,
+    ) -> Result<UserInfo> {
+        let user_info = self.authenticate(id, password).await?;
+        self.authorize(catalog, schema, &user_info).await?;
+        Ok(user_info)
+    }
 }
 
 pub type UserProviderRef = Arc<dyn UserProvider>;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly introduces `auth` api, which is a simple combination of `authenticate` and `authorize`, but allow to be implemented for optimization. In most cases(other than MySQL auth process) it would be much easier to just use `auth` api. 

PostgreSQL, gRPC and HTTP auth process have been refactored to use the new `auth` api.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
