### PR TITLE
chore: set keep lease heartbeat log level to trace

### DIFF
--- a/src/meta-srv/src/handler/keep_lease_handler.rs
+++ b/src/meta-srv/src/handler/keep_lease_handler.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use api::v1::meta::{BatchPutRequest, HeartbeatRequest, KeyValue};
-use common_telemetry::{info, warn};
+use common_telemetry::{trace, warn};
 use common_time::util as time_util;
 use tokio::sync::mpsc::{self, Sender};
 
@@ -76,7 +76,7 @@ impl HeartbeatHandler for KeepLeaseHandler {
                 node_addr: peer.addr.clone(),
             };
 
-            info!("Receive a heartbeat: {key:?}, {value:?}");
+            trace!("Receive a heartbeat: {key:?}, {value:?}");
 
             let key = key.try_into()?;
             let value = value.try_into()?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* set keep lease heartbeat log level to trace to avoid too many heartbeat log.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
