### PR TITLE
fix: concurrent rename two table to same name may cause override

### DIFF
--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -427,19 +427,23 @@ impl CatalogManager for LocalCatalogManager {
             })?;
 
         let engine = old_table.table_info().meta.engine.to_string();
-        // rename table in system catalog
-        self.system
-            .register_table(
-                catalog_name.clone(),
-                schema_name.clone(),
-                request.new_table_name.clone(),
-                request.table_id,
-                engine,
-            )
-            .await?;
-        Ok(schema
-            .rename_table(&request.table_name, request.new_table_name)
-            .is_ok())
+
+        let renamed = schema
+            .rename_table(&request.table_name, request.new_table_name.clone())
+            .is_ok();
+        if renamed {
+            // rename table in system catalog
+            self.system
+                .register_table(
+                    catalog_name.clone(),
+                    schema_name.clone(),
+                    request.new_table_name.clone(),
+                    request.table_id,
+                    engine,
+                )
+                .await?;
+        }
+        Ok(renamed)
     }
 
     async fn deregister_table(&self, request: DeregisterTableRequest) -> Result<bool> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
fix concurrent rename two table to same name may cause override

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

fixes #1369 
