### PR TITLE
fix: update cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.23",
  "criterion-plot 0.5.0",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -1997,6 +1998,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -6891,6 +6893,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "console",
+ "criterion 0.4.0",
  "crossbeam-utils",
  "datafusion",
  "datafusion-common",
@@ -6905,6 +6908,7 @@ dependencies = [
  "paste",
  "pyo3",
  "query",
+ "rayon",
  "ron",
  "rustpython-ast",
  "rustpython-codegen",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Update dependency changes introduced in  #1356 so that nightly build won't fail 

https://github.com/GreptimeTeam/greptime-config/actions/runs/4684021761/jobs/8299707216#step:15:16

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
