### PR TITLE
chore: switch mysql_async to git dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4393,9 +4393,8 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7089295150273e5d211a11222dcae3974c9aa4f7691c288e10e2e8aa43b3b1e9"
+version = "0.32.1"
+source = "git+https://github.com/blackbeam/mysql_async.git?rev=32c6f2a986789f97108502c2d0c755a089411b66#32c6f2a986789f97108502c2d0c755a089411b66"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -8330,8 +8329,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres-rustls"
-version = "0.9.0"
-source = "git+https://github.com/sunng87/tokio-postgres-rustls.git?branch=patch-1#9f6e8a1c11e33c43a80618acd6b5135a7fb9a4be"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5831152cb0d3f79ef5523b357319ba154795d64c7078b2daa95a803b54057f"
 dependencies = [
  "futures",
  "ring",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -81,7 +81,7 @@ axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", br
 client = { path = "../client" }
 common-base = { path = "../common/base" }
 common-test-util = { path = "../common/test-util" }
-mysql_async = { version = "0.32", default-features = false, features = [
+mysql_async = { git = "https://github.com/blackbeam/mysql_async.git", rev = "32c6f2a986789f97108502c2d0c755a089411b66", default-features = false, features = [
     "default-rustls",
 ] }
 rand.workspace = true
@@ -90,5 +90,5 @@ script = { path = "../script", features = ["python"] }
 serde_json = "1.0"
 table = { path = "../table" }
 tokio-postgres = "0.7"
-tokio-postgres-rustls = { git = "https://github.com/sunng87/tokio-postgres-rustls.git", branch = "patch-1" }
+tokio-postgres-rustls = "0.10"
 tokio-test = "0.4"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- mysql-async 0.32 was yanked, switch to a git deps until newer version released
- postgresql-tokio-rustls has a newer release, switch to crate.io version

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
