### PR TITLE
refactor: default catalog and schema are created at Metasrv

### DIFF
--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -187,13 +187,6 @@ impl RemoteCatalogManager {
         let mut res = HashMap::new();
         let max_table_id = MIN_USER_TABLE_ID - 1;
 
-        // initiate default catalog and schema
-        let default_catalog = self
-            .create_catalog_and_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME)
-            .await?;
-        res.insert(DEFAULT_CATALOG_NAME.to_string(), default_catalog);
-        info!("Default catalog and schema registered");
-
         let mut catalogs = self.iter_remote_catalogs().await;
         while let Some(r) = catalogs.next().await {
             let CatalogKey { catalog_name, .. } = r?;

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -20,9 +20,7 @@ use std::sync::Arc;
 use arc_swap::ArcSwap;
 use async_stream::stream;
 use async_trait::async_trait;
-use common_catalog::consts::{
-    DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MIN_USER_TABLE_ID, MITO_ENGINE,
-};
+use common_catalog::consts::{MIN_USER_TABLE_ID, MITO_ENGINE};
 use common_telemetry::{debug, error, info};
 use dashmap::DashMap;
 use futures::Stream;

--- a/src/catalog/tests/mock.rs
+++ b/src/catalog/tests/mock.rs
@@ -57,6 +57,7 @@ impl Default for MockKvBackend {
         }
         .to_string();
 
+        // create default catalog and schema
         map.insert(default_catalog_key.into(), catalog_value);
         map.insert(default_schema_key.into(), schema_value);
 

--- a/src/catalog/tests/mock.rs
+++ b/src/catalog/tests/mock.rs
@@ -20,7 +20,9 @@ use std::sync::Arc;
 
 use async_stream::stream;
 use catalog::error::Error;
+use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
 use catalog::remote::{Kv, KvBackend, ValueIter};
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_recordbatch::RecordBatch;
 use common_telemetry::logging::info;
 use datatypes::data_type::ConcreteDataType;
@@ -34,9 +36,33 @@ use table::test_util::MemTable;
 use table::TableRef;
 use tokio::sync::RwLock;
 
-#[derive(Default)]
 pub struct MockKvBackend {
     map: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,
+}
+
+impl Default for MockKvBackend {
+    fn default() -> Self {
+        let mut map = BTreeMap::default();
+        let catalog_value = CatalogValue {}.as_bytes().unwrap();
+        let schema_value = SchemaValue {}.as_bytes().unwrap();
+
+        let default_catalog_key = CatalogKey {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        }
+        .to_string();
+
+        let default_schema_key = SchemaKey {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+        }
+        .to_string();
+
+        map.insert(default_catalog_key.into(), catalog_value);
+        map.insert(default_schema_key.into(), schema_value);
+
+        let map = RwLock::new(map);
+        Self { map }
+    }
 }
 
 impl Display for MockKvBackend {

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -285,6 +285,12 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_procedure::Error,
     },
+
+    #[snafu(display("Schema already exists, name: {schema_name}"))]
+    SchemaAlreadyExists {
+        schema_name: String,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -325,6 +331,7 @@ impl ErrorExt for Error {
             | Error::ExceededRetryLimit { .. }
             | Error::SendShutdownSignal { .. }
             | Error::ParseAddr { .. }
+            | Error::SchemaAlreadyExists { .. }
             | Error::StartGrpc { .. } => StatusCode::Internal,
             Error::EmptyKey { .. }
             | Error::MissingRequiredParameter { .. }

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -24,6 +24,7 @@ pub mod handler;
 pub mod keys;
 pub mod lease;
 pub mod lock;
+pub mod metadata_service;
 pub mod metasrv;
 #[cfg(feature = "mock")]
 pub mod mocks;

--- a/src/meta-srv/src/metadata_service.rs
+++ b/src/meta-srv/src/metadata_service.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use api::v1::meta::CompareAndPutRequest;
+use async_trait::async_trait;
+use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
+use common_telemetry::info;
+use snafu::ResultExt;
+
+use crate::error;
+use crate::error::Result;
+use crate::service::store::kv::KvStoreRef;
+
+/// This trait defines some methods of metadata
+#[async_trait]
+pub trait MetadataService: Send + Sync {
+    async fn create_schema(&self, catalog_name: &str, schema_name: &str) -> Result<()>;
+
+    async fn delete_schema(&self, catalog_name: &str, schema_name: &str) -> Result<()>;
+}
+
+pub type MetadataServiceRef = Arc<dyn MetadataService>;
+
+#[derive(Clone)]
+pub struct DefaultMetadataService {
+    kv_store: KvStoreRef,
+}
+
+impl DefaultMetadataService {
+    pub fn new(kv_store: KvStoreRef) -> Self {
+        Self { kv_store }
+    }
+}
+
+#[async_trait]
+impl MetadataService for DefaultMetadataService {
+    async fn create_schema(&self, catalog_name: &str, schema_name: &str) -> Result<()> {
+        let kv_store = self.kv_store.clone();
+
+        let default_catalog_key = CatalogKey {
+            catalog_name: catalog_name.to_string(),
+        }
+        .to_string();
+
+        let default_schema_key = SchemaKey {
+            catalog_name: catalog_name.to_string(),
+            schema_name: schema_name.to_string(),
+        }
+        .to_string();
+
+        let req = CompareAndPutRequest {
+            key: default_catalog_key.into(),
+            expect: vec![],
+            value: CatalogValue {}
+                .as_bytes()
+                .context(error::InvalidCatalogValueSnafu)?,
+            ..Default::default()
+        };
+
+        let resp = kv_store.compare_and_put(req).await?;
+
+        if resp.success {
+            info!("Successfully created the default catalog: {}", catalog_name);
+        }
+
+        let req = CompareAndPutRequest {
+            key: default_schema_key.into(),
+            expect: vec![],
+            value: SchemaValue {}
+                .as_bytes()
+                .context(error::InvalidCatalogValueSnafu)?,
+            ..Default::default()
+        };
+        let resp = kv_store.compare_and_put(req).await?;
+
+        if resp.success {
+            info!("Successfully created the default schema: {}", schema_name);
+        }
+
+        Ok(())
+    }
+
+    async fn delete_schema(&self, _catalog_name: &str, _schema_name: &str) -> Result<()> {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::meta::PutRequest;
+    use catalog::helper::{CatalogKey, SchemaKey};
+
+    use super::{DefaultMetadataService, MetadataService};
+    use crate::service::store::ext::KvStoreExt;
+    use crate::service::store::kv::{KvStore, KvStoreRef};
+    use crate::service::store::memory::MemStore;
+
+    #[tokio::test]
+    async fn test_create_schema() {
+        let empty_kv_store = Arc::new(MemStore::default());
+        do_test_create_schema(empty_kv_store).await;
+
+        let kv_store = MemStore::default();
+        let key: Vec<u8> = CatalogKey {
+            catalog_name: "catalog".to_string(),
+        }
+        .to_string()
+        .into();
+        kv_store
+            .put(PutRequest {
+                key,
+                value: vec![],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        do_test_create_schema(Arc::new(kv_store)).await;
+    }
+
+    async fn do_test_create_schema(kv_store: KvStoreRef) {
+        let service = DefaultMetadataService::new(kv_store.clone());
+        let result = service.create_schema("catalog", "public").await;
+        assert!(result.is_ok());
+
+        let key: Vec<u8> = CatalogKey {
+            catalog_name: "catalog".to_string(),
+        }
+        .to_string()
+        .into();
+
+        let result = kv_store.get(key.clone()).await.unwrap();
+
+        assert!(result.is_some());
+        let kv = result.unwrap();
+
+        assert_eq!(key, kv.key);
+
+        let key: Vec<u8> = SchemaKey {
+            catalog_name: "catalog".to_string(),
+            schema_name: "public".to_string(),
+        }
+        .to_string()
+        .into();
+
+        let result = kv_store.get(key.clone()).await.unwrap();
+
+        assert!(result.is_some());
+        let kv = result.unwrap();
+
+        assert_eq!(key, kv.key);
+    }
+}

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -126,7 +126,7 @@ impl MetaSrv {
             return Ok(());
         }
 
-        self.create_default_catalog_and_schema().await?;
+        self.create_default_catalog_and_schema_if_absent().await?;
 
         if let Some(election) = self.election() {
             let procedure_manager = self.procedure_manager.clone();
@@ -182,9 +182,9 @@ impl MetaSrv {
         Ok(())
     }
 
-    async fn create_default_catalog_and_schema(&self) -> Result<()> {
+    async fn create_default_catalog_and_schema_if_absent(&self) -> Result<()> {
         self.metadata_service
-            .create_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME)
+            .create_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, true)
             .await
     }
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -29,7 +29,7 @@ use tokio::sync::broadcast::error::RecvError;
 
 use crate::cluster::MetaPeerClient;
 use crate::election::{Election, LeaderChangeMessage};
-use crate::error::{RecoverProcedureSnafu, Result};
+use crate::error::{InvalidCatalogValueSnafu, RecoverProcedureSnafu, Result};
 use crate::handler::HeartbeatHandlerGroup;
 use crate::lock::DistLockRef;
 use crate::selector::{Selector, SelectorType};
@@ -198,7 +198,9 @@ impl MetaSrv {
         let req = CompareAndPutRequest {
             key: default_catalog_key.into(),
             expect: vec![],
-            value: catalog::helper::CatalogValue {}.as_bytes().unwrap(),
+            value: catalog::helper::CatalogValue {}
+                .as_bytes()
+                .context(InvalidCatalogValueSnafu)?,
             ..Default::default()
         };
 
@@ -214,7 +216,9 @@ impl MetaSrv {
         let req = CompareAndPutRequest {
             key: default_schema_key.into(),
             expect: vec![],
-            value: catalog::helper::SchemaValue {}.as_bytes().unwrap(),
+            value: catalog::helper::SchemaValue {}
+                .as_bytes()
+                .context(InvalidCatalogValueSnafu)?,
             ..Default::default()
         };
         let resp = kv_store.compare_and_put(req).await?;

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use api::v1::meta::{CompareAndPutRequest, Peer};
-use catalog::helper::{CatalogKey, SchemaKey};
+use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_procedure::ProcedureManagerRef;
 use common_telemetry::{error, info, warn};
@@ -198,7 +198,7 @@ impl MetaSrv {
         let req = CompareAndPutRequest {
             key: default_catalog_key.into(),
             expect: vec![],
-            value: catalog::helper::CatalogValue {}
+            value: CatalogValue {}
                 .as_bytes()
                 .context(InvalidCatalogValueSnafu)?,
             ..Default::default()
@@ -216,7 +216,7 @@ impl MetaSrv {
         let req = CompareAndPutRequest {
             key: default_schema_key.into(),
             expect: vec![],
-            value: catalog::helper::SchemaValue {}
+            value: SchemaValue {}
                 .as_bytes()
                 .context(InvalidCatalogValueSnafu)?,
             ..Default::default()

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -126,7 +126,7 @@ impl MetaSrv {
             return Ok(());
         }
 
-        self.create_default_catalog_and_schema_if_absent().await?;
+        self.create_default_schema_if_not_exist().await?;
 
         if let Some(election) = self.election() {
             let procedure_manager = self.procedure_manager.clone();
@@ -182,7 +182,7 @@ impl MetaSrv {
         Ok(())
     }
 
-    async fn create_default_catalog_and_schema_if_absent(&self) -> Result<()> {
+    async fn create_default_schema_if_not_exist(&self) -> Result<()> {
         self.metadata_service
             .create_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, true)
             .await

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -60,7 +60,7 @@ pub async fn mock(
     let metadata_service = DefaultMetadataService::new(kv_store.clone());
 
     metadata_service
-        .create_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME)
+        .create_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, true)
         .await
         .unwrap();
 

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -72,6 +72,7 @@ pub async fn mock(
     }
     .to_string();
 
+    // create default catalog
     kv_store
         .put(PutRequest {
             key: default_catalog_key.into(),
@@ -81,6 +82,7 @@ pub async fn mock(
         .await
         .unwrap();
 
+    // create default schema
     kv_store
         .put(PutRequest {
             key: default_schema_key.into(),

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -18,6 +18,9 @@ use std::time::Duration;
 use api::v1::meta::heartbeat_server::HeartbeatServer;
 use api::v1::meta::router_server::RouterServer;
 use api::v1::meta::store_server::StoreServer;
+use api::v1::meta::PutRequest;
+use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
 use tower::service_fn;
 
@@ -54,6 +57,38 @@ pub async fn mock(
     selector: Option<SelectorRef>,
 ) -> MockInfo {
     let server_addr = opts.server_addr.clone();
+
+    let catalog_value = CatalogValue {}.as_bytes().unwrap();
+    let schema_value = SchemaValue {}.as_bytes().unwrap();
+
+    let default_catalog_key = CatalogKey {
+        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+    }
+    .to_string();
+
+    let default_schema_key = SchemaKey {
+        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+    }
+    .to_string();
+
+    kv_store
+        .put(PutRequest {
+            key: default_catalog_key.into(),
+            value: catalog_value,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    kv_store
+        .put(PutRequest {
+            key: default_schema_key.into(),
+            value: schema_value,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
 
     let builder = MetaSrvBuilder::new().options(opts).kv_store(kv_store);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly change: 
Default catalog and schema are created at Metasrv, instead of datanode.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1265 