### PR TITLE
chore: don't render reproduce as shell in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -81,6 +81,5 @@ body:
         Please walk us through and provide steps and details on how
         to reproduce the issue. If possible, provide scripts that we
         can run to trigger the bug.
-      render: bash
     validations:
       required: true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

the last "how to reproduce" section in bug-report issue template will be rendered as `bash`. But it usually contains some extra descriptions along with commands. Thus it would be better to keep it as plain text and let others to write markdown.

E.g.: #1396 
![image](https://user-images.githubusercontent.com/15380403/232423913-6b382c64-57d9-4b97-88b5-a417bddb180f.png)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
