### PR TITLE
chore: add some metrics for grpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4226,9 +4226,8 @@ dependencies = [
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
+version = "0.11.1"
+source = "git+https://github.com/GreptimeTeam/metrics.git?rev=174de287e9f7f9f57c0272be56c95df156489476#174de287e9f7f9f57c0272be56c95df156489476"
 dependencies = [
  "indexmap",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ tokio = { version = "1.24.2", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io-util"] }
 tonic = { version = "0.9", features = ["tls"] }
 uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
+metrics = "0.20"
 
 [profile.release]
 debug = true

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -107,7 +107,7 @@ impl Database {
     }
 
     pub async fn insert(&self, request: InsertRequest) -> Result<u32> {
-        let _timer = timer!(metrics::METRIC_INSERT);
+        let _timer = timer!(metrics::METRIC_GRPC_INSERT);
         let mut client = self.client.make_database_client()?.inner;
         let request = GreptimeRequest {
             header: Some(RequestHeader {
@@ -131,7 +131,7 @@ impl Database {
     }
 
     pub async fn sql(&self, sql: &str) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_SQL);
+        let _timer = timer!(metrics::METRIC_GRPC_SQL);
         self.do_get(Request::Query(QueryRequest {
             query: Some(Query::Sql(sql.to_string())),
         }))
@@ -139,7 +139,7 @@ impl Database {
     }
 
     pub async fn logical_plan(&self, logical_plan: Vec<u8>) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_LOGICAL_PLAN);
+        let _timer = timer!(metrics::METRIC_GRPC_LOGICAL_PLAN);
         self.do_get(Request::Query(QueryRequest {
             query: Some(Query::LogicalPlan(logical_plan)),
         }))
@@ -153,7 +153,7 @@ impl Database {
         end: &str,
         step: &str,
     ) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_PROMQL_RANGE_QUERY);
+        let _timer = timer!(metrics::METRIC_GRPC_PROMQL_RANGE_QUERY);
         self.do_get(Request::Query(QueryRequest {
             query: Some(Query::PromRangeQuery(PromRangeQuery {
                 query: promql.to_string(),
@@ -166,7 +166,7 @@ impl Database {
     }
 
     pub async fn create(&self, expr: CreateTableExpr) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_CREATE_TABLE);
+        let _timer = timer!(metrics::METRIC_GRPC_CREATE_TABLE);
         self.do_get(Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::CreateTable(expr)),
         }))
@@ -174,7 +174,7 @@ impl Database {
     }
 
     pub async fn alter(&self, expr: AlterExpr) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_ALTER);
+        let _timer = timer!(metrics::METRIC_GRPC_ALTER);
         self.do_get(Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::Alter(expr)),
         }))
@@ -182,7 +182,7 @@ impl Database {
     }
 
     pub async fn drop_table(&self, expr: DropTableExpr) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_DROP_TABLE);
+        let _timer = timer!(metrics::METRIC_GRPC_DROP_TABLE);
         self.do_get(Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::DropTable(expr)),
         }))
@@ -190,7 +190,7 @@ impl Database {
     }
 
     pub async fn flush_table(&self, expr: FlushTableExpr) -> Result<Output> {
-        let _timer = timer!(metrics::METRIC_FLUSH_TABLE);
+        let _timer = timer!(metrics::METRIC_GRPC_FLUSH_TABLE);
         self.do_get(Request::Ddl(DdlRequest {
             expr: Some(DdlExpr::FlushTable(expr)),
         }))
@@ -198,7 +198,7 @@ impl Database {
     }
 
     async fn do_get(&self, request: Request) -> Result<Output> {
-        // FIXME: should be added some labels for metrics
+        // FIXME(paomian): should be added some labels for metrics
         let _timer = timer!(metrics::METRIC_GRPC_DO_GET);
         let request = GreptimeRequest {
             header: Some(RequestHeader {

--- a/src/client/src/metrics.rs
+++ b/src/client/src/metrics.rs
@@ -12,15 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod client;
-mod database;
-mod error;
-pub mod load_balance;
-mod metrics;
-
-pub use api;
-pub use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-
-pub use self::client::Client;
-pub use self::database::Database;
-pub use self::error::{Error, Result};
+//! client metrics
+pub const METRIC_CREATE_TABLE: &str = "create.table";
+pub const METRIC_PROMQL_RANGE_QUERY: &str = "promql.range.query";
+pub const METRIC_INSERT: &str = "insert";
+pub const METRIC_SQL: &str = "sql";
+pub const METRIC_LOGICAL_PLAN: &str = "logical.plan";
+pub const METRIC_ALTER: &str = "alter";
+pub const METRIC_DROP_TABLE: &str = "drop.table";
+pub const METRIC_FLUSH_TABLE: &str = "flush.table";
+pub const METRIC_GRPC_DO_GET: &str = "grpc.do.get";

--- a/src/client/src/metrics.rs
+++ b/src/client/src/metrics.rs
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 //! client metrics
-pub const METRIC_CREATE_TABLE: &str = "create.table";
-pub const METRIC_PROMQL_RANGE_QUERY: &str = "promql.range.query";
-pub const METRIC_INSERT: &str = "insert";
-pub const METRIC_SQL: &str = "sql";
-pub const METRIC_LOGICAL_PLAN: &str = "logical.plan";
-pub const METRIC_ALTER: &str = "alter";
-pub const METRIC_DROP_TABLE: &str = "drop.table";
-pub const METRIC_FLUSH_TABLE: &str = "flush.table";
-pub const METRIC_GRPC_DO_GET: &str = "grpc.do.get";
+pub const METRIC_GRPC_CREATE_TABLE: &str = "grpc.create_table";
+pub const METRIC_GRPC_PROMQL_RANGE_QUERY: &str = "grpc.promql.range_query";
+pub const METRIC_GRPC_INSERT: &str = "grpc.insert";
+pub const METRIC_GRPC_SQL: &str = "grpc.sql";
+pub const METRIC_GRPC_LOGICAL_PLAN: &str = "grpc.logical_plan";
+pub const METRIC_GRPC_ALTER: &str = "grpc.alter";
+pub const METRIC_GRPC_DROP_TABLE: &str = "grpc.drop_table";
+pub const METRIC_GRPC_FLUSH_TABLE: &str = "grpc.flush_table";
+pub const METRIC_GRPC_DO_GET: &str = "grpc.do_get";

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 async-trait.workspace = true
 common-error = { path = "../error" }
 common-telemetry = { path = "../telemetry" }
-metrics = "0.20"
+metrics.workspace = true
 once_cell = "1.12"
 paste.workspace = true
 snafu.workspace = true

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -12,8 +12,8 @@ deadlock_detection = ["parking_lot"]
 backtrace = "0.3"
 common-error = { path = "../error" }
 console-subscriber = { version = "0.1", optional = true }
-metrics = "0.20.1"
-metrics-exporter-prometheus = { version = "0.11", default-features = false }
+metrics-exporter-prometheus = { git = "https://github.com/GreptimeTeam/metrics.git", rev = "174de287e9f7f9f57c0272be56c95df156489476", default-features = false }
+metrics.workspace = true
 once_cell = "1.10"
 opentelemetry = { version = "0.17", default-features = false, features = [
     "trace",

--- a/src/common/telemetry/src/metric.rs
+++ b/src/common/telemetry/src/metric.rs
@@ -60,6 +60,7 @@ pub fn try_handle() -> Option<PrometheusHandle> {
 pub struct Timer {
     start: Instant,
     name: &'static str,
+    labels: Vec<(String, String)>,
 }
 
 impl Timer {
@@ -67,7 +68,23 @@ impl Timer {
         Self {
             start: Instant::now(),
             name,
+            labels: Vec::new(),
         }
+    }
+
+    pub fn new_with_labels<S: Into<String> + Clone>(name: &'static str, labels: &[(S, S)]) -> Self {
+        Self {
+            start: Instant::now(),
+            name,
+            labels: labels
+                .iter()
+                .map(|(k, v)| (k.to_owned().into(), v.to_owned().into()))
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    pub fn labels_mut(&mut self) -> &mut Vec<(String, String)> {
+        self.labels.as_mut()
     }
 
     pub fn elapsed(&self) -> Duration {
@@ -77,7 +94,11 @@ impl Timer {
 
 impl Drop for Timer {
     fn drop(&mut self) {
-        histogram!(self.name, self.start.elapsed());
+        if !self.labels.is_empty() {
+            histogram!(self.name, self.start.elapsed(), &self.labels);
+        } else {
+            histogram!(self.name, self.start.elapsed());
+        }
     }
 }
 
@@ -85,6 +106,9 @@ impl Drop for Timer {
 macro_rules! timer {
     ($name: expr) => {
         $crate::metric::Timer::new($name)
+    };
+    ($name:expr,$labels:expr) => {
+        $crate::metric::Timer::new_with_labels($name, $labels)
     };
 }
 
@@ -108,5 +132,49 @@ mod tests {
         let text = handle.render();
         assert!(text.contains("test_elapsed_timer_a"));
         assert!(text.contains("test_elapsed_timer_b"));
+    }
+
+    #[test]
+    fn test_elapsed_timer_with_label() {
+        init_default_metrics_recorder();
+        {
+            let t = Timer::new("test_elapsed_timer_a");
+            drop(t);
+        }
+        let handle = try_handle().unwrap();
+        let text = handle.render();
+        assert!(text.contains("test_elapsed_timer_a"));
+        assert!(!text.contains("test_elapsed_timer_b"));
+        let label_a = "label_a";
+        let label_b = "label_b";
+        let label_c = "label_c";
+        let label_d = "label_d";
+        let label_e = "label_e";
+        assert!(!text.contains(label_a));
+        assert!(!text.contains(label_b));
+
+        {
+            let mut timer_b = timer!("test_elapsed_timer_b", &[(label_a, "a"), (label_b, "b")]);
+            let labels = timer_b.labels_mut();
+            labels.push((label_c.to_owned(), "d".to_owned()));
+        }
+        let text = handle.render();
+        assert!(text.contains("test_elapsed_timer_a"));
+        assert!(text.contains("test_elapsed_timer_b"));
+        assert!(text.contains(label_a));
+        assert!(text.contains(label_b));
+        assert!(text.contains(label_c));
+
+        {
+            let mut timer_c = timer!("test_elapsed_timer_c");
+            let labels = timer_c.labels_mut();
+            labels.push((label_d.to_owned(), "d".to_owned()));
+            labels.push((label_e.to_owned(), "e".to_owned()));
+        }
+
+        let text = handle.render();
+        assert!(text.contains("test_elapsed_timer_c"));
+        assert!(text.contains(label_d));
+        assert!(text.contains(label_e));
     }
 }

--- a/src/common/telemetry/src/metric.rs
+++ b/src/common/telemetry/src/metric.rs
@@ -32,7 +32,9 @@ pub fn init_default_metrics_recorder() {
 
 /// Init prometheus recorder.
 fn init_prometheus_recorder() {
-    let recorder = PrometheusBuilder::new().build_recorder();
+    let recorder = PrometheusBuilder::new()
+        .add_global_prefix("greptime".to_string())
+        .build_recorder();
     let mut h = PROMETHEUS_HANDLE.as_ref().write().unwrap();
     *h = Some(recorder.handle());
     // TODO(LFC): separate metrics for testing and metrics for production
@@ -78,7 +80,7 @@ impl Timer {
             name,
             labels: labels
                 .iter()
-                .map(|(k, v)| (k.to_owned().into(), v.to_owned().into()))
+                .map(|(k, v)| (k.clone().into(), v.clone().into()))
                 .collect::<Vec<_>>(),
         }
     }

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -38,7 +38,7 @@ log = "0.4"
 log-store = { path = "../log-store" }
 meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv", features = ["mock"] }
-metrics = "0.20"
+metrics.workspace = true
 mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }
 pin-project = "1.0"

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -27,7 +27,7 @@ datafusion-sql.workspace = true
 datatypes = { path = "../datatypes" }
 futures = "0.3"
 futures-util.workspace = true
-metrics = "0.20"
+metrics.workspace = true
 once_cell = "1.10"
 promql = { path = "../promql" }
 promql-parser = "0.1.0"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -39,7 +39,7 @@ http-body = "0.4"
 humantime-serde = "1.1"
 hyper = { version = "0.14", features = ["full"] }
 influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", branch = "feat/line-protocol" }
-metrics = "0.20"
+metrics.workspace = true
 mime_guess = "2.0"
 num_cpus = "1.13"
 once_cell = "1.16"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* add metrics for grpc client
* add the ability to set lables to an existing timer macro
* add `greptime` prefix for all metrics

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
