### PR TITLE
refactor: refactor stmt_options_to_table_options

### DIFF
--- a/src/datanode/src/sql/create.rs
+++ b/src/datanode/src/sql/create.rs
@@ -21,9 +21,10 @@ use common_telemetry::tracing::{error, info};
 use datatypes::schema::RawSchema;
 use session::context::QueryContextRef;
 use snafu::{ensure, OptionExt, ResultExt};
-use sql::ast::{ColumnOption, SqlOption, TableConstraint, Value};
+use sql::ast::{ColumnOption, TableConstraint};
 use sql::statements::column_def_to_schema;
 use sql::statements::create::CreateTable;
+use sql::util::to_lowercase_options_map;
 use store_api::storage::consts::TIME_INDEX_NAME;
 use table::engine::{EngineContext, TableReference};
 use table::metadata::TableId;
@@ -285,7 +286,8 @@ impl SqlHandler {
             })
             .collect::<Result<Vec<_>>>()?;
 
-        let table_options = stmt_options_to_table_options(&stmt.options)?;
+        let table_options = TableOptions::try_from(&to_lowercase_options_map(&stmt.options))
+            .context(UnrecognizedTableOptionSnafu)?;
         let schema = RawSchema::new(columns_schemas);
         let request = CreateTableRequest {
             id: table_id,
@@ -302,20 +304,6 @@ impl SqlHandler {
         };
         Ok(request)
     }
-}
-
-fn stmt_options_to_table_options(opts: &[SqlOption]) -> error::Result<TableOptions> {
-    let mut map = HashMap::with_capacity(opts.len());
-    for SqlOption { name, value } in opts {
-        let value_str = match value {
-            Value::SingleQuotedString(s) => s.clone(),
-            Value::DoubleQuotedString(s) => s.clone(),
-            _ => value.to_string(),
-        };
-        map.insert(name.value.clone(), value_str);
-    }
-    let options = TableOptions::try_from(&map).context(UnrecognizedTableOptionSnafu)?;
-    Ok(options)
 }
 
 #[cfg(test)]

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -20,4 +20,4 @@ pub mod error;
 pub mod parser;
 pub mod parsers;
 pub mod statements;
-mod util;
+pub mod util;

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -60,5 +60,7 @@ pub struct CreateExternalTable {
     pub columns: Vec<ColumnDef>,
     pub constraints: Vec<TableConstraint>,
     /// Table options in `WITH`.
+    /// All keys are uppercase.
+    /// TODO(weny): unify the key's case styling.
     pub options: HashMap<String, String>,
 }

--- a/src/sql/src/util.rs
+++ b/src/sql/src/util.rs
@@ -12,11 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use sqlparser::ast::Value;
+use std::collections::HashMap;
+
+use sqlparser::ast::{SqlOption, Value};
 
 pub fn parse_option_string(value: Value) -> Option<String> {
     match value {
         Value::SingleQuotedString(v) | Value::DoubleQuotedString(v) => Some(v),
         _ => None,
     }
+}
+
+/// Converts options to HashMap<String, String>.
+/// All keys are lowercase.
+pub fn to_lowercase_options_map(opts: &[SqlOption]) -> HashMap<String, String> {
+    let mut map = HashMap::with_capacity(opts.len());
+    for SqlOption { name, value } in opts {
+        let value_str = match value {
+            Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => s.clone(),
+            _ => value.to_string(),
+        };
+        map.insert(name.value.to_lowercase().clone(), value_str);
+    }
+    map
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

move stmt_options_to_table_options to query crate

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1010