### PR TITLE
feat: Add metrics for cache hit/miss for object store cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5334,6 +5334,7 @@ dependencies = [
  "common-test-util",
  "futures",
  "lru 0.9.0",
+ "metrics",
  "opendal",
  "pin-project",
  "tokio",

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -9,6 +9,7 @@ lru = "0.9"
 async-trait = "0.1"
 bytes = "1.4"
 futures = { version = "0.3" }
+metrics = "0.20"
 opendal = { version = "0.30", features = ["layers-tracing", "layers-metrics"] }
 pin-project = "1.0"
 tokio.workspace = true

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -26,7 +26,10 @@ use opendal::raw::{Accessor, Layer, LayeredAccessor, RpDelete, RpList, RpRead, R
 use opendal::{ErrorKind, Result};
 use tokio::sync::Mutex;
 
-use crate::metrics::{OBJECT_STORE_LRU_CACHE_HIT, OBJECT_STORE_LRU_CACHE_MISS, OBJECT_STORE_LRU_CACHE_ERROR, OBJECT_STORE_LRU_CACHE_ERROR_KIND};
+use crate::metrics::{
+    OBJECT_STORE_LRU_CACHE_ERROR, OBJECT_STORE_LRU_CACHE_ERROR_KIND, OBJECT_STORE_LRU_CACHE_HIT,
+    OBJECT_STORE_LRU_CACHE_MISS,
+};
 
 pub struct LruCacheLayer<C> {
     cache: Arc<C>,

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -26,7 +26,7 @@ use opendal::raw::{Accessor, Layer, LayeredAccessor, RpDelete, RpList, RpRead, R
 use opendal::{ErrorKind, Result};
 use tokio::sync::Mutex;
 
-use crate::metrics::*;
+use crate::metrics::{OBJECT_STORE_LRU_CACHE_HIT, OBJECT_STORE_LRU_CACHE_MISS, OBJECT_STORE_LRU_CACHE_ERROR, OBJECT_STORE_LRU_CACHE_ERROR_KIND};
 
 pub struct LruCacheLayer<C> {
     cache: Arc<C>,

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -17,4 +17,4 @@
 pub const OBJECT_STORE_LRU_CACHE_HIT: &str = "object_store_lru_cache.hit";
 pub const OBJECT_STORE_LRU_CACHE_MISS: &str = "object_store_lru_cache.miss";
 pub const OBJECT_STORE_LRU_CACHE_ERROR: &str = "object_store_lru_cache.error";
-pub const OBJECT_STORE_LRU_CACHE_ERROR_KIND: &str = "error_kind";
+pub const OBJECT_STORE_LRU_CACHE_ERROR_KIND: &str = "error";

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -12,14 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use opendal::raw::normalize_path as raw_normalize_path;
-pub use opendal::raw::oio::Pager;
-pub use opendal::{
-    layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
-    Operator as ObjectStore, Result, Writer,
-};
+// ! object-store metrics
 
-pub mod cache_policy;
-mod metrics;
-pub mod test_util;
-pub mod util;
+pub const OBJECT_STORE_LRU_CACHE_HIT: &str = "object_store_lru_cache.hit";
+pub const OBJECT_STORE_LRU_CACHE_MISS: &str = "object_store_lru_cache.miss";
+pub const OBJECT_STORE_LRU_CACHE_ERROR: &str = "object_store_lru_cache.error";
+pub const OBJECT_STORE_LRU_CACHE_ERROR_KIND: &str = "error_kind";

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -14,7 +14,7 @@
 
 // ! object-store metrics
 
-pub const OBJECT_STORE_LRU_CACHE_HIT: &str = "object_store_lru_cache.hit";
-pub const OBJECT_STORE_LRU_CACHE_MISS: &str = "object_store_lru_cache.miss";
-pub const OBJECT_STORE_LRU_CACHE_ERROR: &str = "object_store_lru_cache.error";
+pub const OBJECT_STORE_LRU_CACHE_HIT: &str = "object_store.lru_cache.hit";
+pub const OBJECT_STORE_LRU_CACHE_MISS: &str = "object_store.lru_cache.miss";
+pub const OBJECT_STORE_LRU_CACHE_ERROR: &str = "object_store.lru_cache.error";
 pub const OBJECT_STORE_LRU_CACHE_ERROR_KIND: &str = "error";

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// ! object-store metrics
+//! object-store metrics
 
 pub const OBJECT_STORE_LRU_CACHE_HIT: &str = "object_store.lru_cache.hit";
 pub const OBJECT_STORE_LRU_CACHE_MISS: &str = "object_store.lru_cache.miss";

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -262,11 +262,8 @@ async fn test_object_store_cache_policy() -> Result<()> {
     let handle = metric::try_handle().unwrap();
     let metric_text = handle.render();
 
-    assert!(metric_text.contains("lru_cache_hit{lru_cache_name=\"test_file1\""));
-    assert!(metric_text.contains("lru_cache_hit{lru_cache_name=\"test_file2\""));
-    assert!(metric_text.contains("lru_cache_miss{lru_cache_name=\"test_file1\""));
-    assert!(metric_text.contains("lru_cache_miss{lru_cache_name=\"test_file2\""));
-    assert!(metric_text.contains("lru_cache_miss{lru_cache_name=\"test_file3\""));
+    assert!(metric_text.contains("object_store_lru_cache_hit"));
+    assert!(metric_text.contains("object_store_lru_cache_miss"));
 
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add two cache metrics to record cache hit/miss. #1276 
- Metric names:
  - lru_cache.hit
  - lru_cache.miss
- Metric labels:
  - lru_cache.name: its value is set as "path"
  - lru_cache.range: its value is set as the range in the read arguments.

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
  - Add metrics to record cache hit/miss

Note: I'm not sure about these:
- Which labels should we use. I assume the cardinality of "range" is limited, and it's helpful to include it as a label. Let me know if my understanding is wrong.
- Naming convention about the metrics.
 
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1276 
