### PR TITLE
feat: add table id and engine to information_schema.TABLES

### DIFF
--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -76,7 +76,7 @@ struct InformationSchemaTablesBuilder {
     table_names: StringVectorBuilder,
     table_types: StringVectorBuilder,
     table_ids: UInt32VectorBuilder,
-    table_engines: StringVectorBuilder,
+    engines: StringVectorBuilder,
 }
 
 impl InformationSchemaTablesBuilder {
@@ -90,7 +90,7 @@ impl InformationSchemaTablesBuilder {
             table_names: StringVectorBuilder::with_capacity(42),
             table_types: StringVectorBuilder::with_capacity(42),
             table_ids: UInt32VectorBuilder::with_capacity(42),
-            table_engines: StringVectorBuilder::with_capacity(42),
+            engines: StringVectorBuilder::with_capacity(42),
         }
     }
 
@@ -138,7 +138,7 @@ impl InformationSchemaTablesBuilder {
         table_name: &str,
         table_type: TableType,
         table_id: Option<u32>,
-        table_engine: Option<&str>,
+        engine: Option<&str>,
     ) {
         self.catalog_names.push(Some(catalog_name));
         self.schema_names.push(Some(schema_name));
@@ -149,7 +149,7 @@ impl InformationSchemaTablesBuilder {
             TableType::Temporary => "LOCAL TEMPORARY",
         }));
         self.table_ids.push(table_id);
-        self.table_engines.push(table_engine);
+        self.engines.push(engine);
     }
 
     fn finish(&mut self) -> Result<RecordBatch> {
@@ -159,7 +159,7 @@ impl InformationSchemaTablesBuilder {
             Arc::new(self.table_names.finish()),
             Arc::new(self.table_types.finish()),
             Arc::new(self.table_ids.finish()),
-            Arc::new(self.table_engines.finish()),
+            Arc::new(self.engines.finish()),
         ];
         RecordBatch::new(self.schema.clone(), columns).context(CreateRecordBatchSnafu)
     }

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -45,7 +45,7 @@ impl InformationSchemaTables {
             ColumnSchema::new("table_name", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_type", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_id", ConcreteDataType::uint32_datatype(), true),
-            ColumnSchema::new("table_engine", ConcreteDataType::string_datatype(), true),
+            ColumnSchema::new("engine", ConcreteDataType::string_datatype(), true),
         ]));
         Self {
             schema,

--- a/src/frontend/src/tests/instance_test.rs
+++ b/src/frontend/src/tests/instance_test.rs
@@ -913,27 +913,27 @@ async fn test_information_schema(instance: Arc<dyn MockInstance>) {
 
     // User can only see information schema under current catalog.
     // A necessary requirement to GreptimeCloud.
-    let sql = "select table_catalog, table_schema, table_name, table_type from information_schema.tables where table_type != 'SYSTEM VIEW' order by table_name";
+    let sql = "select table_catalog, table_schema, table_name, table_type, table_id, engine from information_schema.tables where table_type != 'SYSTEM VIEW' order by table_name";
 
     let output = execute_sql(&instance, sql).await;
     let expected = "\
-+---------------+--------------------+------------+------------+
-| table_catalog | table_schema       | table_name | table_type |
-+---------------+--------------------+------------+------------+
-| greptime      | public             | numbers    | BASE TABLE |
-| greptime      | public             | scripts    | BASE TABLE |
-| greptime      | information_schema | tables     | VIEW       |
-+---------------+--------------------+------------+------------+";
++---------------+--------------------+------------+------------+----------+-------------+
+| table_catalog | table_schema       | table_name | table_type | table_id | engine      |
++---------------+--------------------+------------+------------+----------+-------------+
+| greptime      | public             | numbers    | BASE TABLE | 1        | test_engine |
+| greptime      | public             | scripts    | BASE TABLE | 1        | mito        |
+| greptime      | information_schema | tables     | VIEW       |          |             |
++---------------+--------------------+------------+------------+----------+-------------+";
     check_output_stream(output, expected).await;
 
     let output = execute_sql_with(&instance, sql, query_ctx).await;
     let expected = "\
-+-----------------+--------------------+---------------+------------+
-| table_catalog   | table_schema       | table_name    | table_type |
-+-----------------+--------------------+---------------+------------+
-| another_catalog | another_schema     | another_table | BASE TABLE |
-| another_catalog | information_schema | tables        | VIEW       |
-+-----------------+--------------------+---------------+------------+";
++-----------------+--------------------+---------------+------------+----------+--------+
+| table_catalog   | table_schema       | table_name    | table_type | table_id | engine |
++-----------------+--------------------+---------------+------------+----------+--------+
+| another_catalog | another_schema     | another_table | BASE TABLE | 1024     | mito   |
+| another_catalog | information_schema | tables        | VIEW       |          |        |
++-----------------+--------------------+---------------+------------+----------+--------+";
     check_output_stream(output, expected).await;
 }
 

--- a/src/frontend/src/tests/instance_test.rs
+++ b/src/frontend/src/tests/instance_test.rs
@@ -913,27 +913,27 @@ async fn test_information_schema(instance: Arc<dyn MockInstance>) {
 
     // User can only see information schema under current catalog.
     // A necessary requirement to GreptimeCloud.
-    let sql = "select table_catalog, table_schema, table_name, table_type, table_id, engine from information_schema.tables where table_type != 'SYSTEM VIEW' order by table_name";
+    let sql = "select table_catalog, table_schema, table_name, table_type, engine from information_schema.tables where table_type != 'SYSTEM VIEW' order by table_name";
 
     let output = execute_sql(&instance, sql).await;
     let expected = "\
-+---------------+--------------------+------------+------------+----------+-------------+
-| table_catalog | table_schema       | table_name | table_type | table_id | engine      |
-+---------------+--------------------+------------+------------+----------+-------------+
-| greptime      | public             | numbers    | BASE TABLE | 1        | test_engine |
-| greptime      | public             | scripts    | BASE TABLE | 1        | mito        |
-| greptime      | information_schema | tables     | VIEW       |          |             |
-+---------------+--------------------+------------+------------+----------+-------------+";
++---------------+--------------------+------------+------------+-------------+
+| table_catalog | table_schema       | table_name | table_type | engine      |
++---------------+--------------------+------------+------------+-------------+
+| greptime      | public             | numbers    | BASE TABLE | test_engine |
+| greptime      | public             | scripts    | BASE TABLE | mito        |
+| greptime      | information_schema | tables     | VIEW       |             |
++---------------+--------------------+------------+------------+-------------+";
     check_output_stream(output, expected).await;
 
     let output = execute_sql_with(&instance, sql, query_ctx).await;
     let expected = "\
-+-----------------+--------------------+---------------+------------+----------+--------+
-| table_catalog   | table_schema       | table_name    | table_type | table_id | engine |
-+-----------------+--------------------+---------------+------------+----------+--------+
-| another_catalog | another_schema     | another_table | BASE TABLE | 1024     | mito   |
-| another_catalog | information_schema | tables        | VIEW       |          |        |
-+-----------------+--------------------+---------------+------------+----------+--------+";
++-----------------+--------------------+---------------+------------+--------+
+| table_catalog   | table_schema       | table_name    | table_type | engine |
++-----------------+--------------------+---------------+------------+--------+
+| another_catalog | another_schema     | another_table | BASE TABLE | mito   |
+| another_catalog | information_schema | tables        | VIEW       |        |
++-----------------+--------------------+---------------+------------+--------+";
     check_output_stream(output, expected).await;
 }
 

--- a/src/frontend/src/tests/test_util.rs
+++ b/src/frontend/src/tests/test_util.rs
@@ -26,17 +26,27 @@ use crate::tests::{
 
 pub(crate) trait MockInstance {
     fn frontend(&self) -> Arc<Instance>;
+
+    fn is_distributed_mode(&self) -> bool;
 }
 
 impl MockInstance for MockStandaloneInstance {
     fn frontend(&self) -> Arc<Instance> {
         self.instance.clone()
     }
+
+    fn is_distributed_mode(&self) -> bool {
+        false
+    }
 }
 
 impl MockInstance for MockDistributedInstance {
     fn frontend(&self) -> Arc<Instance> {
         self.frontend.clone()
+    }
+
+    fn is_distributed_mode(&self) -> bool {
+        true
     }
 }
 

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -37,7 +37,7 @@ order by table_schema, table_name;
 | table_catalog | table_schema       | table_name | table_type | table_id | engine |
 +---------------+--------------------+------------+------------+----------+--------+
 | greptime      | information_schema | tables     | VIEW       |          |        |
-| greptime      | my_db              | foo        | BASE TABLE | 1024     | mito   |
+| greptime      | my_db              | foo        | BASE TABLE | 1067     | mito   |
 +---------------+--------------------+------------+------------+----------+--------+
 
 use

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -27,18 +27,18 @@ order by table_name;
 | foo        |
 +------------+
 
-select table_catalog, table_schema, table_name, table_type, table_id, engine
+select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-+---------------+--------------------+------------+------------+----------+--------+
-| table_catalog | table_schema       | table_name | table_type | table_id | engine |
-+---------------+--------------------+------------+------------+----------+--------+
-| greptime      | information_schema | tables     | VIEW       |          |        |
-| greptime      | my_db              | foo        | BASE TABLE | 1067     | mito   |
-+---------------+--------------------+------------+------------+----------+--------+
++---------------+--------------------+------------+------------+--------+
+| table_catalog | table_schema       | table_name | table_type | engine |
++---------------+--------------------+------------+------------+--------+
+| greptime      | information_schema | tables     | VIEW       |        |
+| greptime      | my_db              | foo        | BASE TABLE | mito   |
++---------------+--------------------+------------+------------+--------+
 
 use
 public;

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -27,18 +27,18 @@ order by table_name;
 | foo        |
 +------------+
 
-select table_catalog, table_schema, table_name, table_type
+select table_catalog, table_schema, table_name, table_type, table_id, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-+---------------+--------------------+------------+------------+
-| table_catalog | table_schema       | table_name | table_type |
-+---------------+--------------------+------------+------------+
-| greptime      | information_schema | tables     | VIEW       |
-| greptime      | my_db              | foo        | BASE TABLE |
-+---------------+--------------------+------------+------------+
++---------------+--------------------+------------+------------+----------+--------+
+| table_catalog | table_schema       | table_name | table_type | table_id | engine |
++---------------+--------------------+------------+------------+----------+--------+
+| greptime      | information_schema | tables     | VIEW       |          |        |
+| greptime      | my_db              | foo        | BASE TABLE | 1024     | mito   |
++---------------+--------------------+------------+------------+----------+--------+
 
 use
 public;

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -14,7 +14,7 @@ from information_schema.tables
 where table_schema = 'my_db'
 order by table_name;
 
-select table_catalog, table_schema, table_name, table_type, table_id, engine
+select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -14,7 +14,7 @@ from information_schema.tables
 where table_schema = 'my_db'
 order by table_name;
 
-select table_catalog, table_schema, table_name, table_type
+select table_catalog, table_schema, table_name, table_type, table_id, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add `table_id` and `table_engine` to information_schema.TABLES

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1355 