### PR TITLE
chore: remove Release prefix from release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,7 +351,7 @@ jobs:
         uses: ncipollo/release-action@v1
         if: github.event_name != 'schedule'
         with:
-          name: "Release ${{ github.ref_name }}"
+          name: "${{ github.ref_name }}"
           prerelease: ${{ env.prerelease }}
           makeLatest: ${{ env.makeLatest }}
           generateReleaseNotes: true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Remove "release" prefix from release name.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
