### PR TITLE
feat: impl instant query interface

### DIFF
--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -290,11 +290,16 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     let client = TestClient::new(app);
 
     // instant query
-    let res = client.get("/api/v1/query?query=up").send().await;
+    let res = client.get("/api/v1/query?query=up&time=1").send().await;
     assert_eq!(res.status(), StatusCode::OK);
-    let res = client.post("/api/v1/query?query=up").send().await;
+    let res = client
+        .post("/api/v1/query?query=up&time=1")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .send()
+        .await;
     assert_eq!(res.status(), StatusCode::OK);
 
+    // range query
     let res = client
         .get("/api/v1/query_range?query=up&start=1&end=100&step=5")
         .send()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Implement the [`query`](https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries) API of Prometheus server. It's used to perform instant query

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
