### PR TITLE
feat: procedures for file table engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-procedure-test"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "common-procedure",
+]
+
+[[package]]
 name = "common-query"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ dependencies = [
  "common-catalog",
  "common-error",
  "common-procedure",
+ "common-procedure-test",
  "common-query",
  "common-recordbatch",
  "common-telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2908,6 +2908,7 @@ dependencies = [
  "common-catalog",
  "common-error",
  "common-procedure",
+ "common-procedure-test",
  "common-query",
  "common-telemetry",
  "common-test-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "src/common/grpc-expr",
     "src/common/mem-prof",
     "src/common/procedure",
+    "src/common/procedure-test",
     "src/common/query",
     "src/common/recordbatch",
     "src/common/runtime",

--- a/src/common/procedure-test/Cargo.toml
+++ b/src/common/procedure-test/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "common-procedure-test"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+async-trait.workspace = true
+common-procedure = { path = "../procedure" }

--- a/src/common/procedure-test/src/lib.rs
+++ b/src/common/procedure-test/src/lib.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test utilities for procedures.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_procedure::{
+    BoxedProcedure, Context, ContextProvider, ProcedureId, ProcedureState, Result, Status,
+};
+
+/// A Mock [ContextProvider] that always return [ProcedureState::Done].
+struct MockContextProvider {}
+
+#[async_trait]
+impl ContextProvider for MockContextProvider {
+    async fn procedure_state(&self, _procedure_id: ProcedureId) -> Result<Option<ProcedureState>> {
+        Ok(Some(ProcedureState::Done))
+    }
+}
+
+/// Executes a procedure until it returns [Status::Done].
+///
+/// # Panics
+/// Panics if the `procedure` has subprocedure to execute.
+pub async fn execute_procedure_until_done(procedure: &mut BoxedProcedure) {
+    let ctx = Context {
+        procedure_id: ProcedureId::random(),
+        provider: Arc::new(MockContextProvider {}),
+    };
+
+    loop {
+        match procedure.execute(&ctx).await.unwrap() {
+            Status::Executing { .. } => (),
+            Status::Suspended { subprocedures, .. } => assert!(
+                subprocedures.is_empty(),
+                "Executing subprocedure is unsupported"
+            ),
+            Status::Done => break,
+        }
+    }
+}

--- a/src/file-table-engine/Cargo.toml
+++ b/src/file-table-engine/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1"
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-procedure = { path = "../common/procedure" }
+common-procedure-test = { path = "../common/procedure-test" }
 common-query = { path = "../common/query" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }

--- a/src/file-table-engine/src/engine.rs
+++ b/src/file-table-engine/src/engine.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod immutable;
+mod procedure;
 #[cfg(test)]
 mod tests;
 

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -39,7 +39,7 @@ use crate::manifest::immutable::{delete_table_manifest, ImmutableMetadata};
 use crate::manifest::table_manifest_dir;
 use crate::table::immutable::{ImmutableFileTable, ImmutableFileTableRef};
 
-///  [TableEngine] implementation.
+/// [TableEngine] implementation.
 #[derive(Clone)]
 pub struct ImmutableFileTableEngine {
     inner: Arc<EngineInner>,

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -18,11 +18,12 @@ use std::sync::{Arc, RwLock};
 use async_trait::async_trait;
 use common_catalog::consts::IMMUTABLE_FILE_ENGINE;
 use common_error::prelude::BoxedError;
+use common_procedure::{BoxedProcedure, ProcedureManager};
 use common_telemetry::{debug, logging};
 use datatypes::schema::Schema;
 use object_store::ObjectStore;
 use snafu::ResultExt;
-use table::engine::{table_dir, EngineContext, TableEngine, TableReference};
+use table::engine::{table_dir, EngineContext, TableEngine, TableEngineProcedure, TableReference};
 use table::error::TableOperationSnafu;
 use table::metadata::{TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
@@ -30,6 +31,7 @@ use table::{error as table_error, Result as TableResult, Table, TableRef};
 use tokio::sync::Mutex;
 
 use crate::config::EngineConfig;
+use crate::engine::procedure::{self, CreateImmutableFileTable, DropImmutableFileTable};
 use crate::engine::INIT_TABLE_VERSION;
 use crate::error::{
     BuildTableInfoSnafu, BuildTableMetaSnafu, DropTableSnafu, InvalidRawSchemaSnafu, Result,
@@ -115,6 +117,38 @@ impl TableEngine for ImmutableFileTableEngine {
     }
 }
 
+#[async_trait]
+impl TableEngineProcedure for ImmutableFileTableEngine {
+    fn create_table_procedure(
+        &self,
+        _ctx: &EngineContext,
+        request: CreateTableRequest,
+    ) -> TableResult<BoxedProcedure> {
+        let procedure = Box::new(CreateImmutableFileTable::new(request, self.clone()));
+        Ok(procedure)
+    }
+
+    fn alter_table_procedure(
+        &self,
+        _ctx: &EngineContext,
+        _request: AlterTableRequest,
+    ) -> TableResult<BoxedProcedure> {
+        table_error::UnsupportedSnafu {
+            operation: "ALTER TABLE",
+        }
+        .fail()
+    }
+
+    fn drop_table_procedure(
+        &self,
+        _ctx: &EngineContext,
+        request: DropTableRequest,
+    ) -> TableResult<BoxedProcedure> {
+        let procedure = Box::new(DropImmutableFileTable::new(request, self.clone()));
+        Ok(procedure)
+    }
+}
+
 #[cfg(test)]
 impl ImmutableFileTableEngine {
     pub async fn close_table(&self, table_ref: &TableReference<'_>) -> TableResult<()> {
@@ -127,6 +161,14 @@ impl ImmutableFileTableEngine {
         ImmutableFileTableEngine {
             inner: Arc::new(EngineInner::new(config, object_store)),
         }
+    }
+
+    /// Register all procedure loaders to the procedure manager.
+    ///
+    /// # Panics
+    /// Panics on error.
+    pub fn register_procedure_loaders(&self, procedure_manager: &dyn ProcedureManager) {
+        procedure::register_procedure_loaders(self.clone(), procedure_manager);
     }
 }
 

--- a/src/file-table-engine/src/engine/procedure.rs
+++ b/src/file-table-engine/src/engine/procedure.rs
@@ -1,0 +1,34 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Procedures for immutable file table engine.
+
+mod create;
+
+use common_procedure::ProcedureManager;
+
+use crate::engine::immutable::ImmutableFileTableEngine;
+use crate::engine::procedure::create::CreateImmutableFileTable;
+
+/// Register all procedure loaders to the procedure manager.
+///
+/// # Panics
+/// Panics on error.
+pub(crate) fn register_procedure_loaders(
+    engine: ImmutableFileTableEngine,
+    procedure_manager: &dyn ProcedureManager,
+) {
+    // The procedure names are expected to be unique, so we just panic on error.
+    CreateImmutableFileTable::register_loader(engine.clone(), procedure_manager);
+}

--- a/src/file-table-engine/src/engine/procedure.rs
+++ b/src/file-table-engine/src/engine/procedure.rs
@@ -15,11 +15,13 @@
 //! Procedures for immutable file table engine.
 
 mod create;
+mod drop;
 
 use common_procedure::ProcedureManager;
 
 use crate::engine::immutable::ImmutableFileTableEngine;
-use crate::engine::procedure::create::CreateImmutableFileTable;
+pub(crate) use crate::engine::procedure::create::CreateImmutableFileTable;
+pub(crate) use crate::engine::procedure::drop::DropImmutableFileTable;
 
 /// Register all procedure loaders to the procedure manager.
 ///
@@ -31,4 +33,5 @@ pub(crate) fn register_procedure_loaders(
 ) {
     // The procedure names are expected to be unique, so we just panic on error.
     CreateImmutableFileTable::register_loader(engine.clone(), procedure_manager);
+    DropImmutableFileTable::register_loader(engine, procedure_manager);
 }

--- a/src/file-table-engine/src/engine/procedure/create.rs
+++ b/src/file-table-engine/src/engine/procedure/create.rs
@@ -1,0 +1,167 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Procedure to create an immutable file table.
+
+use async_trait::async_trait;
+use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
+use common_procedure::{Context, Error, LockKey, Procedure, ProcedureManager, Result, Status};
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt};
+use table::engine::{EngineContext, TableEngine, TableReference};
+use table::requests::CreateTableRequest;
+
+use crate::engine::immutable::ImmutableFileTableEngine;
+use crate::error::TableExistsSnafu;
+
+/// Procedure to create an immutable file table.
+pub(crate) struct CreateImmutableFileTable {
+    data: CreateTableData,
+    engine: ImmutableFileTableEngine,
+}
+
+#[async_trait]
+impl Procedure for CreateImmutableFileTable {
+    fn type_name(&self) -> &str {
+        Self::TYPE_NAME
+    }
+
+    async fn execute(&mut self, _ctx: &Context) -> Result<Status> {
+        match self.data.state {
+            CreateTableState::Prepare => self.on_prepare(),
+            CreateTableState::CreateTable => self.on_create_table().await,
+        }
+    }
+
+    fn dump(&self) -> Result<String> {
+        let json = serde_json::to_string(&self.data).context(ToJsonSnafu)?;
+        Ok(json)
+    }
+
+    fn lock_key(&self) -> LockKey {
+        let table_ref = self.data.table_ref();
+        let keys = self
+            .data
+            .request
+            .region_numbers
+            .iter()
+            .map(|number| format!("{table_ref}/region-{number}"));
+        LockKey::new(keys)
+    }
+}
+
+impl CreateImmutableFileTable {
+    const TYPE_NAME: &str = "file-table-engine:CreateImmutableFileTable";
+
+    pub(crate) fn new(request: CreateTableRequest, engine: ImmutableFileTableEngine) -> Self {
+        CreateImmutableFileTable {
+            data: CreateTableData {
+                state: CreateTableState::Prepare,
+                request,
+            },
+            engine,
+        }
+    }
+
+    pub(crate) fn register_loader(
+        engine: ImmutableFileTableEngine,
+        procedure_manager: &dyn ProcedureManager,
+    ) {
+        procedure_manager
+            .register_loader(
+                Self::TYPE_NAME,
+                Box::new(move |data| {
+                    Self::from_json(data, engine.clone()).map(|p| Box::new(p) as _)
+                }),
+            )
+            .unwrap()
+    }
+
+    fn from_json(json: &str, engine: ImmutableFileTableEngine) -> Result<Self> {
+        let data: CreateTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
+
+        Ok(CreateImmutableFileTable { data, engine })
+    }
+
+    fn on_prepare(&mut self) -> Result<Status> {
+        let engine_ctx = EngineContext::default();
+        let table_ref = self.data.table_ref();
+        // Safety: Current get_table implementation always returns Ok.
+        if self
+            .engine
+            .get_table(&engine_ctx, &table_ref)
+            .unwrap()
+            .is_some()
+        {
+            // The table already exists.
+            ensure!(
+                self.data.request.create_if_not_exists,
+                TableExistsSnafu {
+                    table_name: table_ref.to_string(),
+                }
+            );
+
+            return Ok(Status::Done);
+        }
+
+        self.data.state = CreateTableState::CreateTable;
+
+        Ok(Status::executing(true))
+    }
+
+    async fn on_create_table(&mut self) -> Result<Status> {
+        let engine_ctx = EngineContext::default();
+        let table_ref = self.data.table_ref();
+        // Safety: Current get_table implementation always returns Ok.
+        if self
+            .engine
+            .get_table(&engine_ctx, &table_ref)
+            .unwrap()
+            .is_some()
+        {
+            // Table already created. We don't need to check create_if_not_exists as
+            // we have checked it in prepare state.
+            return Ok(Status::Done);
+        }
+
+        self.engine
+            .create_table(&engine_ctx, self.data.request.clone())
+            .await
+            .map_err(Error::from_error_ext)?;
+
+        Ok(Status::Done)
+    }
+}
+
+/// Represents each step while creating table in the immutable file engine.
+#[derive(Debug, Serialize, Deserialize)]
+enum CreateTableState {
+    /// Prepare to create table.
+    Prepare,
+    /// Create table.
+    CreateTable,
+}
+
+/// Serializable data of [CreateImmutableFileTable].
+#[derive(Debug, Serialize, Deserialize)]
+struct CreateTableData {
+    state: CreateTableState,
+    request: CreateTableRequest,
+}
+
+impl CreateTableData {
+    fn table_ref(&self) -> TableReference {
+        self.request.table_ref()
+    }
+}

--- a/src/file-table-engine/src/engine/procedure/create.rs
+++ b/src/file-table-engine/src/engine/procedure/create.rs
@@ -50,14 +50,10 @@ impl Procedure for CreateImmutableFileTable {
     }
 
     fn lock_key(&self) -> LockKey {
+        // We don't need to support multiple region so we only lock region-0.
         let table_ref = self.data.table_ref();
-        let keys = self
-            .data
-            .request
-            .region_numbers
-            .iter()
-            .map(|number| format!("{table_ref}/region-{number}"));
-        LockKey::new(keys)
+        let key = format!("{table_ref}/region-0");
+        LockKey::single(key)
     }
 }
 

--- a/src/file-table-engine/src/engine/procedure/create.rs
+++ b/src/file-table-engine/src/engine/procedure/create.rs
@@ -94,12 +94,7 @@ impl CreateImmutableFileTable {
         let engine_ctx = EngineContext::default();
         let table_ref = self.data.table_ref();
         // Safety: Current get_table implementation always returns Ok.
-        if self
-            .engine
-            .get_table(&engine_ctx, &table_ref)
-            .unwrap()
-            .is_some()
-        {
+        if self.engine.table_exists(&engine_ctx, &table_ref) {
             // The table already exists.
             ensure!(
                 self.data.request.create_if_not_exists,
@@ -119,13 +114,7 @@ impl CreateImmutableFileTable {
     async fn on_create_table(&mut self) -> Result<Status> {
         let engine_ctx = EngineContext::default();
         let table_ref = self.data.table_ref();
-        // Safety: Current get_table implementation always returns Ok.
-        if self
-            .engine
-            .get_table(&engine_ctx, &table_ref)
-            .unwrap()
-            .is_some()
-        {
+        if self.engine.table_exists(&engine_ctx, &table_ref) {
             // Table already created. We don't need to check create_if_not_exists as
             // we have checked it in prepare state.
             return Ok(Status::Done);

--- a/src/file-table-engine/src/engine/procedure/drop.rs
+++ b/src/file-table-engine/src/engine/procedure/drop.rs
@@ -40,6 +40,8 @@ impl Procedure for DropImmutableFileTable {
         // To simplify the implementation, we skip prepare phase and drop
         // the table directly.
         let engine_ctx = EngineContext::default();
+        // Currently, `drop_table()` of ImmutableFileTableEngine is idempotent so we just
+        // invoke it.
         self.engine
             .drop_table(&engine_ctx, self.data.request.clone())
             .await

--- a/src/file-table-engine/src/engine/procedure/drop.rs
+++ b/src/file-table-engine/src/engine/procedure/drop.rs
@@ -1,0 +1,105 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Procedure to drop an immutable file table.
+
+use async_trait::async_trait;
+use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
+use common_procedure::{Context, Error, LockKey, Procedure, ProcedureManager, Result, Status};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use table::engine::{EngineContext, TableEngine, TableReference};
+use table::requests::DropTableRequest;
+
+use crate::engine::immutable::ImmutableFileTableEngine;
+
+/// Procedure to drop an immutable file table.
+pub(crate) struct DropImmutableFileTable {
+    data: DropTableData,
+    engine: ImmutableFileTableEngine,
+}
+
+#[async_trait]
+impl Procedure for DropImmutableFileTable {
+    fn type_name(&self) -> &str {
+        Self::TYPE_NAME
+    }
+
+    async fn execute(&mut self, _ctx: &Context) -> Result<Status> {
+        // To simplify the implementation, we skip prepare phase and drop
+        // the table directly.
+        let engine_ctx = EngineContext::default();
+        self.engine
+            .drop_table(&engine_ctx, self.data.request.clone())
+            .await
+            .map_err(Error::from_error_ext)?;
+
+        Ok(Status::Done)
+    }
+
+    fn dump(&self) -> Result<String> {
+        let json = serde_json::to_string(&self.data).context(ToJsonSnafu)?;
+        Ok(json)
+    }
+
+    fn lock_key(&self) -> LockKey {
+        // We don't need to support multiple region so we only lock region-0.
+        let table_ref = self.data.table_ref();
+        let key = format!("{table_ref}/region-0");
+        LockKey::single(key)
+    }
+}
+
+impl DropImmutableFileTable {
+    const TYPE_NAME: &str = "file-table-engine:DropImmutableFileTable";
+
+    pub(crate) fn new(request: DropTableRequest, engine: ImmutableFileTableEngine) -> Self {
+        DropImmutableFileTable {
+            data: DropTableData { request },
+            engine,
+        }
+    }
+
+    pub(crate) fn register_loader(
+        engine: ImmutableFileTableEngine,
+        procedure_manager: &dyn ProcedureManager,
+    ) {
+        procedure_manager
+            .register_loader(
+                Self::TYPE_NAME,
+                Box::new(move |data| {
+                    Self::from_json(data, engine.clone()).map(|p| Box::new(p) as _)
+                }),
+            )
+            .unwrap()
+    }
+
+    fn from_json(json: &str, engine: ImmutableFileTableEngine) -> Result<Self> {
+        let data: DropTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
+
+        Ok(DropImmutableFileTable { data, engine })
+    }
+}
+
+/// Serializable data of [DropImmutableFileTable].
+#[derive(Debug, Serialize, Deserialize)]
+struct DropTableData {
+    request: DropTableRequest,
+}
+
+impl DropTableData {
+    fn table_ref(&self) -> TableReference {
+        self.request.table_ref()
+    }
+}

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -40,3 +40,4 @@ tokio.workspace = true
 
 [dev-dependencies]
 common-test-util = { path = "../common/test-util" }
+common-procedure-test = { path = "../common/procedure-test" }

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -334,11 +334,7 @@ struct AlterTableData {
 
 impl AlterTableData {
     fn table_ref(&self) -> TableReference {
-        TableReference {
-            catalog: &self.request.catalog_name,
-            schema: &self.request.schema_name,
-            table: &self.request.table_name,
-        }
+        self.request.table_ref()
     }
 }
 

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -345,11 +345,7 @@ struct CreateTableData {
 
 impl CreateTableData {
     fn table_ref(&self) -> TableReference {
-        TableReference {
-            catalog: &self.request.catalog_name,
-            schema: &self.request.schema_name,
-            table: &self.request.table_name,
-        }
+        self.request.table_ref()
     }
 }
 

--- a/src/mito/src/engine/procedure/drop.rs
+++ b/src/mito/src/engine/procedure/drop.rs
@@ -175,11 +175,7 @@ struct DropTableData {
 
 impl DropTableData {
     fn table_ref(&self) -> TableReference {
-        TableReference {
-            catalog: &self.request.catalog_name,
-            schema: &self.request.schema_name,
-            table: &self.request.table_name,
-        }
+        self.request.table_ref()
     }
 }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -24,6 +24,7 @@ use datatypes::schema::{ColumnSchema, RawSchema};
 use serde::{Deserialize, Serialize};
 use store_api::storage::RegionNumber;
 
+use crate::engine::TableReference;
 use crate::error;
 use crate::error::ParseTableOptionSnafu;
 use crate::metadata::TableId;
@@ -48,6 +49,16 @@ pub struct CreateTableRequest {
     pub create_if_not_exists: bool,
     pub table_options: TableOptions,
     pub engine: String,
+}
+
+impl CreateTableRequest {
+    pub fn table_ref(&self) -> TableReference {
+        TableReference {
+            catalog: &self.catalog_name,
+            schema: &self.schema_name,
+            table: &self.table_name,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -167,6 +178,14 @@ pub struct AlterTableRequest {
 }
 
 impl AlterTableRequest {
+    pub fn table_ref(&self) -> TableReference {
+        TableReference {
+            catalog: &self.catalog_name,
+            schema: &self.schema_name,
+            table: &self.table_name,
+        }
+    }
+
     pub fn is_rename_table(&self) -> bool {
         matches!(self.alter_kind, AlterKind::RenameTable { .. })
     }
@@ -192,6 +211,16 @@ pub struct DropTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
+}
+
+impl DropTableRequest {
+    pub fn table_ref(&self) -> TableReference {
+        TableReference {
+            catalog: &self.catalog_name,
+            schema: &self.schema_name,
+            table: &self.table_name,
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements procedures for the immutable file table engine:
- Adds `CreateImmutableFileTable` for creating a table
- Adds `DropImmutableFileTable` for dropping a table
- ImmutableFileTableEngine now implements the `TableEngineProcedure` trait
- Adds a `common-procedure-test` crate for common test utilities for procedures

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286 