### PR TITLE
fix: recompile&register scripts as UDF on reboot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7595,6 +7595,7 @@ dependencies = [
  "common-function",
  "common-query",
  "common-recordbatch",
+ "common-runtime",
  "common-telemetry",
  "common-test-util",
  "common-time",

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -27,8 +27,11 @@ use crate::DeregisterTableRequest;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
-    #[snafu(display("Failed to re-compile script scripts table, source: {}", source))]
-    CompileScript {
+    #[snafu(display(
+        "Failed to re-compile script due to internal error, source: {}",
+        source
+    ))]
+    CompileScriptInternal {
         #[snafu(backtrace)]
         source: BoxedError,
     },
@@ -306,7 +309,7 @@ impl ErrorExt for Error {
             Error::SystemCatalogTableScanExec { source } => source.status_code(),
             Error::InvalidTableInfoInCatalog { source } => source.status_code(),
 
-            Error::CompileScript { source }
+            Error::CompileScriptInternal { source }
             | Error::SchemaProviderOperation { source }
             | Error::Internal { source } => source.status_code(),
 

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -27,6 +27,11 @@ use crate::DeregisterTableRequest;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
+    #[snafu(display("Failed to re-compile script scripts table, source: {}", source))]
+    CompileScript {
+        #[snafu(backtrace)]
+        source: BoxedError,
+    },
     #[snafu(display("Failed to open system catalog table, source: {}", source))]
     OpenSystemCatalog {
         #[snafu(backtrace)]
@@ -300,9 +305,10 @@ impl ErrorExt for Error {
             Error::SystemCatalogTableScan { source } => source.status_code(),
             Error::SystemCatalogTableScanExec { source } => source.status_code(),
             Error::InvalidTableInfoInCatalog { source } => source.status_code(),
-            Error::SchemaProviderOperation { source } | Error::Internal { source } => {
-                source.status_code()
-            }
+
+            Error::CompileScript { source }
+            | Error::SchemaProviderOperation { source }
+            | Error::Internal { source } => source.status_code(),
 
             Error::Unimplemented { .. } | Error::NotSupported { .. } => StatusCode::Unsupported,
             Error::QueryAccessDenied { .. } => StatusCode::AccessDenied,

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -34,6 +34,7 @@ common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+common-runtime = { path = "../common/runtime" }
 console = "0.15"
 crossbeam-utils = "0.8.14"
 datafusion = { workspace = true, optional = true }

--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
         source: catalog::error::Error,
     },
 
+    #[snafu(display("Failed to find column in scripts table, name: {}", name))]
+    FindColumnInScriptsTable { name: String, location: Location },
+
     #[snafu(display("Failed to register scripts table, source: {}", source))]
     RegisterScriptsTable {
         #[snafu(backtrace)]
@@ -93,7 +96,7 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         use Error::*;
         match self {
-            CastType { .. } => StatusCode::Unexpected,
+            FindColumnInScriptsTable { .. } | CastType { .. } => StatusCode::Unexpected,
             ScriptsTableNotFound { .. } => StatusCode::TableNotFound,
             RegisterScriptsTable { source } | FindScriptsTable { source } => source.status_code(),
             InsertScript { source, .. } => source.status_code(),

--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -71,6 +71,12 @@ pub enum Error {
         source: query::error::Error,
     },
 
+    #[snafu(display("Failed to find all script in scripts table"))]
+    FindAllScript {
+        #[snafu(backtrace)]
+        source: query::error::Error,
+    },
+
     #[snafu(display("Failed to collect record batch, source: {}", source))]
     CollectRecords {
         #[snafu(backtrace)]
@@ -92,7 +98,7 @@ impl ErrorExt for Error {
             RegisterScriptsTable { source } | FindScriptsTable { source } => source.status_code(),
             InsertScript { source, .. } => source.status_code(),
             CompilePython { source, .. } | ExecutePython { source, .. } => source.status_code(),
-            FindScript { source, .. } => source.status_code(),
+            FindScript { source, .. } | FindAllScript { source } => source.status_code(),
             CollectRecords { source } => source.status_code(),
             ScriptNotFound { .. } => StatusCode::InvalidArguments,
         }

--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -74,12 +74,6 @@ pub enum Error {
         source: query::error::Error,
     },
 
-    #[snafu(display("Failed to find all script in scripts table"))]
-    FindAllScript {
-        #[snafu(backtrace)]
-        source: query::error::Error,
-    },
-
     #[snafu(display("Failed to collect record batch, source: {}", source))]
     CollectRecords {
         #[snafu(backtrace)]
@@ -101,7 +95,7 @@ impl ErrorExt for Error {
             RegisterScriptsTable { source } | FindScriptsTable { source } => source.status_code(),
             InsertScript { source, .. } => source.status_code(),
             CompilePython { source, .. } | ExecutePython { source, .. } => source.status_code(),
-            FindScript { source, .. } | FindAllScript { source } => source.status_code(),
+            FindScript { source, .. } => source.status_code(),
             CollectRecords { source } => source.status_code(),
             ScriptNotFound { .. } => StatusCode::InvalidArguments,
         }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -179,6 +179,14 @@ pub struct PyScript {
 }
 
 impl PyScript {
+    pub fn from_script(script: &str, query_engine: QueryEngineRef) -> Result<Self> {
+        let copr = Arc::new(parse::parse_and_compile_copr(
+            script,
+            Some(query_engine.clone()),
+        )?);
+
+        Ok(PyScript { copr, query_engine })
+    }
     /// Register Current Script as UDF, register name is same as script name
     /// FIXME(discord9): possible inject attack?
     pub fn register_udf(&self) {

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -189,7 +189,7 @@ impl PyScript {
     }
     /// Register Current Script as UDF, register name is same as script name
     /// FIXME(discord9): possible inject attack?
-    pub fn register_udf(&self) {
+    pub async fn register_udf(&self) {
         let udf = PyUDF::from_copr(self.copr.clone());
         PyUDF::register_as_udf(udf.clone());
         PyUDF::register_to_query_engine(udf, self.query_engine.clone());

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -117,6 +117,8 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_recordbatch::error::Error,
     },
+    #[snafu(display("Failed to create tokio task, source: {}", source))]
+    TokioJoin { source: tokio::task::JoinError },
 }
 
 impl From<QueryError> for Error {
@@ -131,6 +133,7 @@ impl ErrorExt for Error {
             Error::DataFusion { .. }
             | Error::Arrow { .. }
             | Error::PyRuntime { .. }
+            | Error::TokioJoin { .. }
             | Error::Other { .. } => StatusCode::Internal,
 
             Error::RecordBatch { source } | Error::NewRecordBatch { source } => {

--- a/src/script/src/python/utils.rs
+++ b/src/script/src/python/utils.rs
@@ -41,7 +41,7 @@ where
 
 /// Please only use this method because you are calling from (optionally first as async) to sync then to a async
 /// a terrible hack to call async from sync by:
-/// 
+///
 /// TODO(discord9): find a better way
 /// 1. using a cached runtime
 /// 2. block on that runtime

--- a/src/script/src/python/utils.rs
+++ b/src/script/src/python/utils.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_runtime::JoinHandle;
 use futures::Future;
-use once_cell::sync::OnceCell;
 use rustpython_vm::builtins::PyBaseExceptionRef;
 use rustpython_vm::VirtualMachine;
-use tokio::runtime::Runtime;
 
 use crate::python::error;
 
@@ -30,22 +29,29 @@ pub fn format_py_error(excep: PyBaseExceptionRef, vm: &VirtualMachine) -> error:
     }
     error::PyRuntimeSnafu { msg }.build()
 }
-static LOCAL_RUNTIME: OnceCell<tokio::runtime::Runtime> = OnceCell::new();
-fn get_local_runtime() -> std::thread::Result<&'static Runtime> {
-    let rt = LOCAL_RUNTIME
-        .get_or_try_init(|| tokio::runtime::Runtime::new().map_err(|e| Box::new(e) as _))?;
-    Ok(rt)
+
+/// just like [`tokio::task::spawn_blocking`] but using a dedicated runtime(runtime `bg`) using by `scripts` crate
+pub fn spawn_blocking_script<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    common_runtime::spawn_blocking_bg(f)
 }
+
+/// Please only use this method because you are calling from (optionally first as async) to sync then to a async
 /// a terrible hack to call async from sync by:
+/// 
 /// TODO(discord9): find a better way
-/// 1. spawn a new thread
-/// 2. create a new runtime in new thread and call `block_on` on it
+/// 1. using a cached runtime
+/// 2. block on that runtime
 pub fn block_on_async<T, F>(f: F) -> std::thread::Result<T>
 where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    let rt = get_local_runtime()?;
-
+    let rt = common_runtime::bg_runtime();
+    // spawn a thread to block on the runtime, also should prevent `start a runtime inside of runtime` error
+    // it's ok to block here, assume calling from async to sync is using a `spawn_blocking_*` call
     std::thread::spawn(move || rt.block_on(f)).join()
 }

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -74,6 +74,10 @@ impl ScriptsTable {
             .await
             .map_err(BoxedError::new)
             .context(CompileScriptSnafu)?;
+        if records.is_empty() {
+            // scripts table is empty, no need to recompile
+            return Ok(());
+        }
         assert_eq!(records.len(), 1);
         let record = &records[0];
         let get_col_by_name = |name: &str| -> Result<_> {

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -139,9 +139,13 @@ impl ScriptsTable {
                 }
             })
             .collect();
-        match futures::future::try_join_all(handles).await {
-            Ok(_) => (),
-            Err(err) => logging::error!("Unexpected error when re-registering Python UDF: {}", err),
+        for i in handles {
+            match i.await {
+                Ok(_) => (),
+                Err(err) => {
+                    logging::error!("Unexpected error when re-registering Python UDF: {}", err)
+                }
+            }
         }
         Ok(())
     }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -119,7 +119,7 @@ impl ScriptHandler for DummyInstance {
             .compile(script, CompileContext::default())
             .await
             .unwrap();
-        script.register_udf();
+        script.register_udf().await;
         self.scripts
             .write()
             .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Recompile and re-register scripts on reboot

register scripts in create `scripts` table's callback
currently insert new row into `scripts` table wouldn't trigger compile and register of new python script, so sqlness tests can't be done yet, might impl it later

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
