### PR TITLE
feat: implement ParquetFileReaderFactory

### DIFF
--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -120,11 +120,9 @@ impl AsyncFileReader for LazyParquetFileReader {
         range: std::ops::Range<usize>,
     ) -> BoxFuture<'_, ParquetResult<bytes::Bytes>> {
         Box::pin(async move {
-            if self.reader.is_none() {
-                self.maybe_initialize()
-                    .await
-                    .map_err(|e| ParquetError::External(Box::new(e)))?;
-            }
+            self.maybe_initialize()
+                .await
+                .map_err(|e| ParquetError::External(Box::new(e)))?;
             // Safety: Must initialized
             self.reader.as_mut().unwrap().get_bytes(range).await
         })
@@ -132,11 +130,9 @@ impl AsyncFileReader for LazyParquetFileReader {
 
     fn get_metadata(&mut self) -> BoxFuture<'_, ParquetResult<Arc<ParquetMetaData>>> {
         Box::pin(async move {
-            if self.reader.is_none() {
-                self.maybe_initialize()
-                    .await
-                    .map_err(|e| ParquetError::External(Box::new(e)))?;
-            }
+            self.maybe_initialize()
+                .await
+                .map_err(|e| ParquetError::External(Box::new(e)))?;
             // Safety: Must initialized
             self.reader.as_mut().unwrap().get_metadata().await
         })

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -16,7 +16,7 @@ pub use opendal::raw::normalize_path as raw_normalize_path;
 pub use opendal::raw::oio::Pager;
 pub use opendal::{
     layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
-    Operator as ObjectStore, Result, Writer,
+    Operator as ObjectStore, Reader, Result, Writer,
 };
 
 pub mod cache_policy;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Implement `DefaultParquetFileReaderFactory`. 
The upstream `ParquetExec` supports decoupling with `object_store::ObjectStore` using the `ParquetFileReaderFactory`. (However, `CsvExec` and `NdJsonExec` doesn't support the feature, and I checked the source code to implement similar features will be a little tricky)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1372 
- #1041 