### PR TITLE
feat: expose output_ordering on scan plan

### DIFF
--- a/src/common/query/src/physical_plan.rs
+++ b/src/common/query/src/physical_plan.rs
@@ -49,13 +49,18 @@ pub trait PhysicalPlan: Debug + Send + Sync {
     /// Specifies the output partitioning scheme of this plan
     fn output_partitioning(&self) -> Partitioning;
 
+    /// returns `Some(keys)` that describes how the output was sorted.
+    fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
+        None
+    }
+
     /// Get a list of child physical plans that provide the input for this plan. The returned list
     /// will be empty for leaf nodes, will contain a single value for unary nodes, or two
     /// values for binary nodes (such as joins).
     fn children(&self) -> Vec<PhysicalPlanRef>;
 
     /// Returns a new plan where all children were replaced by new plans.
-    /// The size of `children` must be equal to the size of `PhysicalPlan::children()`.
+    /// The size of `children` must be equal to the size of [`PhysicalPlan::children()`].
     fn with_new_children(&self, children: Vec<PhysicalPlanRef>) -> Result<PhysicalPlanRef>;
 
     /// Creates an RecordBatch stream.
@@ -149,7 +154,7 @@ impl DfPhysicalPlan for DfPhysicalPlanAdapter {
     }
 
     fn output_ordering(&self) -> Option<&[PhysicalSortExpr]> {
-        None
+        self.0.output_ordering()
     }
 
     fn children(&self) -> Vec<Arc<dyn DfPhysicalPlan>> {

--- a/tests/cases/standalone/common/optimizer/order_by.result
+++ b/tests/cases/standalone/common/optimizer/order_by.result
@@ -1,0 +1,60 @@
+explain select * from numbers;
+
++---------------+----------------------------------------+
+| plan_type     | plan                                   |
++---------------+----------------------------------------+
+| logical_plan  | TableScan: numbers projection=[number] |
+| physical_plan | ExecutionPlan(PlaceHolder)             |
+|               |                                        |
++---------------+----------------------------------------+
+
+explain select * from numbers order by number desc;
+
++---------------+------------------------------------------+
+| plan_type     | plan                                     |
++---------------+------------------------------------------+
+| logical_plan  | Sort: numbers.number DESC NULLS FIRST    |
+|               |   TableScan: numbers projection=[number] |
+| physical_plan | SortExec: expr=[number@0 DESC]           |
+|               |   ExecutionPlan(PlaceHolder)             |
+|               |                                          |
++---------------+------------------------------------------+
+
+explain select * from numbers order by number asc;
+
++---------------+------------------------------------------+
+| plan_type     | plan                                     |
++---------------+------------------------------------------+
+| logical_plan  | Sort: numbers.number ASC NULLS LAST      |
+|               |   TableScan: numbers projection=[number] |
+| physical_plan | ExecutionPlan(PlaceHolder)               |
+|               |                                          |
++---------------+------------------------------------------+
+
+explain select * from numbers order by number desc limit 10;
+
++---------------+---------------------------------------------------+
+| plan_type     | plan                                              |
++---------------+---------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=10                           |
+|               |   Sort: numbers.number DESC NULLS FIRST, fetch=10 |
+|               |     TableScan: numbers projection=[number]        |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                 |
+|               |   SortExec: fetch=10, expr=[number@0 DESC]        |
+|               |     ExecutionPlan(PlaceHolder)                    |
+|               |                                                   |
++---------------+---------------------------------------------------+
+
+explain select * from numbers order by number asc limit 10;
+
++---------------+-------------------------------------------------+
+| plan_type     | plan                                            |
++---------------+-------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=10                         |
+|               |   Sort: numbers.number ASC NULLS LAST, fetch=10 |
+|               |     TableScan: numbers projection=[number]      |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10               |
+|               |   ExecutionPlan(PlaceHolder)                    |
+|               |                                                 |
++---------------+-------------------------------------------------+
+

--- a/tests/cases/standalone/common/optimizer/order_by.sql
+++ b/tests/cases/standalone/common/optimizer/order_by.sql
@@ -1,0 +1,9 @@
+explain select * from numbers;
+
+explain select * from numbers order by number desc;
+
+explain select * from numbers order by number asc;
+
+explain select * from numbers order by number desc limit 10;
+
+explain select * from numbers order by number asc limit 10;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Provide information regarding the output ordering in our `TableScan` plan to enable optimization of the `Sort` plan when feasible.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
