### PR TITLE
feat(tql): add initial implementation for explain & analyze

### DIFF
--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -171,9 +171,7 @@ impl Instance {
     ) -> Result<Output> {
         let query = PromQuery {
             query: promql.to_string(),
-            start: "0".to_string(),
-            end: "0".to_string(),
-            step: "5m".to_string(),
+            ..PromQuery::default()
         };
         let mut stmt = QueryLanguageParser::parse_promql(&query).context(ExecuteSqlSnafu)?;
         match &mut stmt {

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -26,6 +26,12 @@ pub enum Error {
     #[snafu(display("Unsupported expr type: {}", name))]
     UnsupportedExpr { name: String, location: Location },
 
+    #[snafu(display("Operation {} not implemented yet", operation))]
+    Unimplemented {
+        operation: String,
+        location: Location,
+    },
+
     #[snafu(display("General catalog error: {}", source))]
     Catalog {
         #[snafu(backtrace)]
@@ -183,6 +189,7 @@ impl ErrorExt for Error {
         match self {
             QueryParse { .. } | MultipleStatements { .. } => StatusCode::InvalidSyntax,
             UnsupportedExpr { .. }
+            | Unimplemented { .. }
             | CatalogNotFound { .. }
             | SchemaNotFound { .. }
             | TableNotFound { .. }

--- a/src/sql/src/parsers/tql_parser.rs
+++ b/src/sql/src/parsers/tql_parser.rs
@@ -20,7 +20,7 @@ use sqlparser::tokenizer::Token;
 use crate::error::{self, Result};
 use crate::parser::ParserContext;
 use crate::statements::statement::Statement;
-use crate::statements::tql::{Tql, TqlEval, TqlExplain};
+use crate::statements::tql::{Tql, TqlAnalyze, TqlEval, TqlExplain};
 
 pub const TQL: &str = "TQL";
 const EVAL: &str = "EVAL";
@@ -31,6 +31,7 @@ use sqlparser::parser::Parser;
 /// TQL extension parser, including:
 /// - TQL EVAL <query>
 /// - TQL EXPLAIN <query>
+/// - TQL ANALYZE <query>
 impl<'a> ParserContext<'a> {
     pub(crate) fn parse_tql(&mut self) -> Result<Statement> {
         self.parser.next_token();
@@ -53,6 +54,11 @@ impl<'a> ParserContext<'a> {
                         self.parse_tql_explain()
                     }
 
+                    Keyword::ANALYZE => {
+                        self.parser.next_token();
+                        self.parse_tql_analyze()
+                            .context(error::SyntaxSnafu { sql: self.sql })
+                    }
                     _ => self.unsupported(self.peek_token_as_string()),
                 }
             }
@@ -122,10 +128,39 @@ impl<'a> ParserContext<'a> {
     }
 
     fn parse_tql_explain(&mut self) -> Result<Statement> {
-        let query = Self::parse_tql_query(&mut self.parser, self.sql, EXPLAIN)
+        let parser = &mut self.parser;
+        let delimiter = match parser.expect_token(&Token::LParen) {
+            Ok(_) => ")",
+            Err(_) => EXPLAIN,
+        };
+        let start = Self::parse_string_or_number(parser, Token::Comma).unwrap_or("0".to_string());
+        let end = Self::parse_string_or_number(parser, Token::Comma).unwrap_or("0".to_string());
+        let step = Self::parse_string_or_number(parser, Token::RParen).unwrap_or("5m".to_string());
+        let query = Self::parse_tql_query(parser, self.sql, delimiter)
             .context(error::SyntaxSnafu { sql: self.sql })?;
 
-        Ok(Statement::Tql(Tql::Explain(TqlExplain { query })))
+        Ok(Statement::Tql(Tql::Explain(TqlExplain {
+            query,
+            start,
+            end,
+            step,
+        })))
+    }
+
+    // TODO code reuse from `parse_tql_eval`
+    fn parse_tql_analyze(&mut self) -> std::result::Result<Statement, ParserError> {
+        let parser = &mut self.parser;
+        parser.expect_token(&Token::LParen)?;
+        let start = Self::parse_string_or_number(parser, Token::Comma)?;
+        let end = Self::parse_string_or_number(parser, Token::Comma)?;
+        let step = Self::parse_string_or_number(parser, Token::RParen)?;
+        let query = Self::parse_tql_query(parser, self.sql, ")")?;
+        Ok(Statement::Tql(Tql::Analyze(TqlAnalyze {
+            start,
+            end,
+            step,
+            query,
+        })))
     }
 }
 
@@ -135,7 +170,7 @@ mod tests {
 
     use super::*;
     #[test]
-    fn test_parse_tql() {
+    fn test_parse_tql_eval() {
         let sql = "TQL EVAL (1676887657, 1676887659, '1m') http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
         let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
@@ -191,7 +226,10 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
 
+    #[test]
+    fn test_parse_tql_explain() {
         let sql = "TQL EXPLAIN http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
         let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
@@ -201,6 +239,42 @@ mod tests {
         match statement {
             Statement::Tql(Tql::Explain(explain)) => {
                 assert_eq!(explain.query, "http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m");
+                assert_eq!(explain.start, "0");
+                assert_eq!(explain.end, "0");
+                assert_eq!(explain.step, "5m");
+            }
+            _ => unreachable!(),
+        }
+
+        let sql = "TQL EXPLAIN (20,100,10) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
+
+        let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
+        assert_eq!(1, result.len());
+
+        let statement = result.remove(0);
+        match statement {
+            Statement::Tql(Tql::Explain(explain)) => {
+                assert_eq!(explain.query, "http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m");
+                assert_eq!(explain.start, "20");
+                assert_eq!(explain.end, "100");
+                assert_eq!(explain.step, "10");
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn test_parse_tql_analyze() {
+        let sql = "TQL ANALYZE (1676887657.1, 1676887659.5, 30.3) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
+        let mut result = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
+        assert_eq!(1, result.len());
+        let statement = result.remove(0);
+        match statement {
+            Statement::Tql(Tql::Analyze(analyze)) => {
+                assert_eq!(analyze.start, "1676887657.1");
+                assert_eq!(analyze.end, "1676887659.5");
+                assert_eq!(analyze.step, "30.3");
+                assert_eq!(analyze.query, "http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m");
             }
             _ => unreachable!(),
         }

--- a/src/sql/src/statements/tql.rs
+++ b/src/sql/src/statements/tql.rs
@@ -15,6 +15,7 @@
 pub enum Tql {
     Eval(TqlEval),
     Explain(TqlExplain),
+    Analyze(TqlAnalyze),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,7 +26,20 @@ pub struct TqlEval {
     pub query: String,
 }
 
+/// TQL EXPLAIN (like SQL EXPLAIN): doesn't execute the query but tells how the query would be executed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TqlExplain {
+    pub start: String,
+    pub end: String,
+    pub step: String,
+    pub query: String,
+}
+
+/// TQL ANALYZE (like SQL ANALYZE): executes the plan and tells the detailed per-step execution time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TqlAnalyze {
+    pub start: String,
+    pub end: String,
+    pub step: String,
     pub query: String,
 }

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -42,9 +42,7 @@ async fn create_insert_query_assert(
 
     let query = PromQuery {
         query: promql.to_string(),
-        start: "0".to_string(),
-        end: "0".to_string(),
-        step: "5m".to_string(),
+        ..PromQuery::default()
     };
     let QueryStatement::Promql(mut eval_stmt) = QueryLanguageParser::parse_promql(&query).unwrap() else { unreachable!() };
     eval_stmt.start = start;

--- a/tests/cases/standalone/common/tql/analyze.result
+++ b/tests/cases/standalone/common/tql/analyze.result
@@ -8,20 +8,22 @@ Affected Rows: 3
 
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
 TQL ANALYZE (0, 10, '5s') test;
 
-+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| plan_type         | plan                                                                                                                                                                                             |
-+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-+-+
+| plan_type_| plan_|
++-+-+
 | Plan with Metrics | CoalescePartitionsExec, REDACTED
-|                   |   PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j], REDACTED
-|                   |     PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [false], REDACTED
-|                   |       PromSeriesDivideExec: tags=["k"], REDACTED
-|                   |         RepartitionExec: partitioning=REDACTED
-|                   |           RepartitionExec: partitioning=REDACTED
-|                   |             ExecutionPlan(PlaceHolder), REDACTED
-|                   |                                                                                                                                                                                                  |
-+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|_|_PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j], REDACTED
+|_|_PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [false], REDACTED
+|_|_PromSeriesDivideExec: tags=["k"], REDACTED
+|_|_RepartitionExec: partitioning=REDACTED
+|_|_RepartitionExec: partitioning=REDACTED
+|_|_ExecutionPlan(PlaceHolder), REDACTED
+|_|_|
++-+-+
 
 DROP TABLE test;
 

--- a/tests/cases/standalone/common/tql/analyze.result
+++ b/tests/cases/standalone/common/tql/analyze.result
@@ -1,0 +1,29 @@
+CREATE TABLE test(i DOUBLE, j TIMESTAMP TIME INDEX, k STRING PRIMARY KEY);
+
+Affected Rows: 0
+
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+Affected Rows: 3
+
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+TQL ANALYZE (0, 10, '5s') test;
+
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type         | plan                                                                                                                                                                                             |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Plan with Metrics | CoalescePartitionsExec, REDACTED
+|                   |   PromInstantManipulateExec: range=[0..10000], lookback=[300000], interval=[5000], time index=[j], REDACTED
+|                   |     PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [false], REDACTED
+|                   |       PromSeriesDivideExec: tags=["k"], REDACTED
+|                   |         RepartitionExec: partitioning=REDACTED
+|                   |           RepartitionExec: partitioning=REDACTED
+|                   |             ExecutionPlan(PlaceHolder), REDACTED
+|                   |                                                                                                                                                                                                  |
++-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+DROP TABLE test;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/tql/analyze.sql
+++ b/tests/cases/standalone/common/tql/analyze.sql
@@ -6,6 +6,8 @@ INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
 -- analyze at 0s, 5s and 10s. No point at 0s.
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
 TQL ANALYZE (0, 10, '5s') test;
 
 DROP TABLE test;

--- a/tests/cases/standalone/common/tql/analyze.sql
+++ b/tests/cases/standalone/common/tql/analyze.sql
@@ -1,0 +1,11 @@
+CREATE TABLE test(i DOUBLE, j TIMESTAMP TIME INDEX, k STRING PRIMARY KEY);
+
+-- insert two points at 1ms and one point at 2ms
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+-- analyze at 0s, 5s and 10s. No point at 0s.
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+TQL ANALYZE (0, 10, '5s') test;
+
+DROP TABLE test;

--- a/tests/cases/standalone/common/tql/explain.result
+++ b/tests/cases/standalone/common/tql/explain.result
@@ -1,0 +1,31 @@
+CREATE TABLE test(i DOUBLE, j TIMESTAMP TIME INDEX, k STRING PRIMARY KEY);
+
+Affected Rows: 0
+
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+Affected Rows: 3
+
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+TQL EXPLAIN (0, 10, '5s') test;
+
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                              |
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | PromInstantManipulate: range=[0..0], lookback=[300000], interval=[300000], time index=[j]                                                         |
+|               |   PromSeriesNormalize: offset=[0], time index=[j], filter NaN: [false]                                                                            |
+|               |     PromSeriesDivide: tags=["k"]                                                                                                                  |
+|               |       Sort: test.k DESC NULLS LAST, test.j DESC NULLS LAST                                                                                        |
+|               |         TableScan: test projection=[i, j, k], partial_filters=[j >= TimestampMillisecond(-300000, None), j <= TimestampMillisecond(300000, None)] |
+| physical_plan | PromInstantManipulateExec: range=[0..0], lookback=[300000], interval=[300000], time index=[j]                                                     |
+|               |   PromSeriesNormalizeExec: offset=[0], time index=[j], filter NaN: [false]                                                                        |
+|               |     PromSeriesDivideExec: tags=["k"]                                                                                                              |
+|               |       RepartitionExec: partitioning=REDACTED
+|               |         ExecutionPlan(PlaceHolder)                                                                                                                |
+|               |                                                                                                                                                   |
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
+
+DROP TABLE test;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/tql/explain.sql
+++ b/tests/cases/standalone/common/tql/explain.sql
@@ -1,0 +1,10 @@
+CREATE TABLE test(i DOUBLE, j TIMESTAMP TIME INDEX, k STRING PRIMARY KEY);
+
+-- insert two points at 1ms and one point at 2ms
+INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
+
+-- explain at 0s, 5s and 10s. No point at 0s.
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+TQL EXPLAIN (0, 10, '5s') test;
+
+DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add support for `TQL EXPLAIN`/ `TQL ANALYZE` clauses

- `TQL EXPLAIN` (similar to `EXPLAIN` from `SQL`) doesn't execute the query but tells how the query would be executed.
- `TQL ANALYZE`(similar to `ANALYZE` from `SQL`) executes the plan and tells the detailed per-step execution time.
- The implementation introduces a wrapper for Explain or Analyze node over the existing logical plan. 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link
https://github.com/GreptimeTeam/greptimedb/issues/986