### PR TITLE
ci: enable test on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ env:
 
   CARGO_PROFILE: nightly
 
-  ## FIXME(zyy17): Enable it after the tests are stabled.
-  DISABLE_RUN_TESTS: true
+  # Controls whether to run tests, include unit-test, integration-test and sqlness.
+  DISABLE_RUN_TESTS: false
 
 jobs:
   build:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

It might be stable after weeks (I hope 🫥 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
