### PR TITLE
refactor: replace Copy Format with datasource Format

### DIFF
--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[snafu(display("Unsupported backend protocol: {}", protocol))]
     UnsupportedBackendProtocol { protocol: String },
 
+    #[snafu(display("Unsupported format protocol: {}", format))]
+    UnsupportedFormat { format: String },
+
     #[snafu(display("empty host: {}", url))]
     EmptyHostPath { url: String },
 
@@ -102,6 +105,9 @@ pub enum Error {
         source: arrow_schema::ArrowError,
         location: Location,
     },
+
+    #[snafu(display("Missing required field: {}", name))]
+    MissingRequiredField { name: String, location: Location },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -116,6 +122,7 @@ impl ErrorExt for Error {
 
             UnsupportedBackendProtocol { .. }
             | UnsupportedCompressionType { .. }
+            | UnsupportedFormat { .. }
             | InvalidConnection { .. }
             | InvalidUrl { .. }
             | EmptyHostPath { .. }
@@ -124,7 +131,8 @@ impl ErrorExt for Error {
             | ReadParquetSnafu { .. }
             | ParquetToSchema { .. }
             | ParseFormat { .. }
-            | MergeSchema { .. } => StatusCode::InvalidArguments,
+            | MergeSchema { .. }
+            | MissingRequiredField { .. } => StatusCode::InvalidArguments,
 
             Decompression { .. } | JoinHandle { .. } => StatusCode::Unexpected,
         }
@@ -147,13 +155,15 @@ impl ErrorExt for Error {
             JoinHandle { location, .. } => Some(*location),
             ParseFormat { location, .. } => Some(*location),
             MergeSchema { location, .. } => Some(*location),
+            MissingRequiredField { location, .. } => Some(*location),
 
             UnsupportedBackendProtocol { .. }
             | EmptyHostPath { .. }
             | InvalidPath { .. }
             | InvalidUrl { .. }
             | InvalidConnection { .. }
-            | UnsupportedCompressionType { .. } => None,
+            | UnsupportedCompressionType { .. }
+            | UnsupportedFormat { .. } => None,
         }
     }
 }

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -22,22 +22,32 @@ use url::ParseError;
 #[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display("Unsupported compression type: {}", compression_type))]
-    UnsupportedCompressionType { compression_type: String },
+    UnsupportedCompressionType {
+        compression_type: String,
+        location: Location,
+    },
 
     #[snafu(display("Unsupported backend protocol: {}", protocol))]
-    UnsupportedBackendProtocol { protocol: String },
+    UnsupportedBackendProtocol {
+        protocol: String,
+        location: Location,
+    },
 
     #[snafu(display("Unsupported format protocol: {}", format))]
-    UnsupportedFormat { format: String },
+    UnsupportedFormat { format: String, location: Location },
 
     #[snafu(display("empty host: {}", url))]
-    EmptyHostPath { url: String },
+    EmptyHostPath { url: String, location: Location },
 
     #[snafu(display("Invalid path: {}", path))]
-    InvalidPath { path: String },
+    InvalidPath { path: String, location: Location },
 
     #[snafu(display("Invalid url: {}, error :{}", url, source))]
-    InvalidUrl { url: String, source: ParseError },
+    InvalidUrl {
+        url: String,
+        source: ParseError,
+        location: Location,
+    },
 
     #[snafu(display("Failed to decompression, source: {}", source))]
     Decompression {
@@ -85,7 +95,7 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid connection: {}", msg))]
-    InvalidConnection { msg: String },
+    InvalidConnection { msg: String, location: Location },
 
     #[snafu(display("Failed to join handle: {}", source))]
     JoinHandle {
@@ -157,13 +167,13 @@ impl ErrorExt for Error {
             MergeSchema { location, .. } => Some(*location),
             MissingRequiredField { location, .. } => Some(*location),
 
-            UnsupportedBackendProtocol { .. }
-            | EmptyHostPath { .. }
-            | InvalidPath { .. }
-            | InvalidUrl { .. }
-            | InvalidConnection { .. }
-            | UnsupportedCompressionType { .. }
-            | UnsupportedFormat { .. } => None,
+            UnsupportedBackendProtocol { location, .. } => Some(*location),
+            EmptyHostPath { location, .. } => Some(*location),
+            InvalidPath { location, .. } => Some(*location),
+            InvalidUrl { location, .. } => Some(*location),
+            InvalidConnection { location, .. } => Some(*location),
+            UnsupportedCompressionType { location, .. } => Some(*location),
+            UnsupportedFormat { location, .. } => Some(*location),
         }
     }
 }

--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -31,7 +31,7 @@ use snafu::ResultExt;
 use crate::error::{self, Result};
 use crate::file_format::FileFormat;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ParquetFormat {}
 
 #[async_trait]
@@ -142,7 +142,6 @@ impl AsyncFileReader for LazyParquetFileReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file_format::FileFormat;
     use crate::test_util::{self, format_schema, test_store};
 
     fn test_data_root() -> String {

--- a/src/common/datasource/src/file_format/tests.rs
+++ b/src/common/datasource/src/file_format/tests.rs
@@ -241,8 +241,5 @@ fn test_format() {
 
     let value = HashMap::new();
 
-    assert_matches!(
-        Format::try_from(&value).unwrap_err(),
-        error::Error::MissingRequiredField { .. }
-    );
+    assert_matches!(Format::try_from(&value).unwrap(), Format::Parquet(_));
 }

--- a/src/common/datasource/src/lib.rs
+++ b/src/common/datasource/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(assert_matches)]
+
 pub mod compression;
 pub mod error;
 pub mod file_format;

--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -166,7 +166,7 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
     let CopyTableArgument {
         location,
         connection,
-        pattern,
+        with,
         table_name,
         ..
     } = match stmt {
@@ -177,11 +177,14 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
         .map_err(BoxedError::new)
         .context(ExternalSnafu)?;
 
+    let pattern = with.get("PATTERN").cloned();
+
     Ok(CopyTableRequest {
         catalog_name,
         schema_name,
         table_name,
         location,
+        with,
         connection,
         pattern,
         direction,

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -137,9 +137,6 @@ pub enum Error {
         target_unit: TimeUnit,
     },
 
-    #[snafu(display("Unsupported format option: {}", name))]
-    UnsupportedCopyFormatOption { name: String },
-
     #[snafu(display("Unable to convert statement {} to DataFusion statement", statement))]
     ConvertToDfStatement {
         statement: String,
@@ -178,8 +175,7 @@ impl ErrorExt for Error {
             | ColumnTypeMismatch { .. }
             | InvalidTableName { .. }
             | InvalidSqlValue { .. }
-            | TimestampOverflow { .. }
-            | UnsupportedCopyFormatOption { .. } => StatusCode::InvalidArguments,
+            | TimestampOverflow { .. } => StatusCode::InvalidArguments,
 
             UnsupportedAlterTableStatement { .. } => StatusCode::InvalidSyntax,
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -68,10 +68,7 @@ impl<'a> ParserContext<'a> {
         let mut with = options
             .into_iter()
             .filter_map(|option| {
-                if let Some(v) = parse_option_string(option.value) {
-                    return Some((option.name.value.to_uppercase(), v));
-                }
-                None
+                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
 
@@ -85,10 +82,7 @@ impl<'a> ParserContext<'a> {
         let connection = connection_options
             .into_iter()
             .filter_map(|option| {
-                if let Some(v) = parse_option_string(option.value) {
-                    return Some((option.name.value.to_uppercase(), v));
-                }
-                None
+                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
         Ok(CopyTableArgument {
@@ -117,10 +111,7 @@ impl<'a> ParserContext<'a> {
         let mut with = options
             .into_iter()
             .filter_map(|option| {
-                if let Some(v) = parse_option_string(option.value) {
-                    return Some((option.name.value.to_uppercase(), v));
-                }
-                None
+                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
 
@@ -134,11 +125,7 @@ impl<'a> ParserContext<'a> {
         let connection = connection_options
             .into_iter()
             .filter_map(|option| {
-                if let Some(v) = parse_option_string(option.value) {
-                    Some((option.name.value.to_uppercase(), v))
-                } else {
-                    None
-                }
+                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
 

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -65,14 +65,12 @@ impl<'a> ParserContext<'a> {
             .parse_options(Keyword::WITH)
             .context(error::SyntaxSnafu { sql: self.sql })?;
 
-        let mut with = options
+        let with = options
             .into_iter()
             .filter_map(|option| {
                 parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
-
-        CopyTableArgument::with_default_format(&mut with);
 
         let connection_options = self
             .parser
@@ -108,14 +106,12 @@ impl<'a> ParserContext<'a> {
             .parse_options(Keyword::WITH)
             .context(error::SyntaxSnafu { sql: self.sql })?;
 
-        let mut with = options
+        let with = options
             .into_iter()
             .filter_map(|option| {
                 parse_option_string(option.value).map(|v| (option.name.to_string(), v))
             })
             .collect();
-
-        CopyTableArgument::with_default_format(&mut with);
 
         let connection_options = self
             .parser
@@ -261,7 +257,7 @@ mod tests {
             match statement {
                 Statement::Copy(CopyTable::From(copy_table)) => {
                     if let Some(expected_pattern) = test.expected_pattern {
-                        assert_eq!(copy_table.pattern().cloned().unwrap(), expected_pattern);
+                        assert_eq!(copy_table.pattern().unwrap(), expected_pattern);
                     }
                     assert_eq!(copy_table.connection.clone(), test.expected_connection);
                 }

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -37,7 +37,7 @@ impl CopyTableArgument {
     pub fn with_default_format(value: &mut HashMap<String, String>) {
         value
             .entry(FORMAT.to_string())
-            .or_insert("parquet".to_string());
+            .or_insert_with(|| "parquet".to_string());
     }
 }
 

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -31,23 +31,18 @@ pub struct CopyTableArgument {
     pub location: String,
 }
 
-const FORMAT: &str = "FORMAT";
-
-impl CopyTableArgument {
-    pub fn with_default_format(value: &mut HashMap<String, String>) {
-        value
-            .entry(FORMAT.to_string())
-            .or_insert_with(|| "parquet".to_string());
-    }
-}
-
 #[cfg(test)]
 impl CopyTableArgument {
-    pub fn format(&self) -> Option<&String> {
-        self.with.get(FORMAT)
+    const FORMAT: &str = "FORMAT";
+
+    pub fn format(&self) -> Option<String> {
+        self.with
+            .get(Self::FORMAT)
+            .cloned()
+            .or_else(|| Some("PARQUET".to_string()))
     }
 
-    pub fn pattern(&self) -> Option<&String> {
-        self.with.get("PATTERN")
+    pub fn pattern(&self) -> Option<String> {
+        self.with.get("PATTERN").cloned()
     }
 }

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -259,6 +259,7 @@ pub struct CopyTableRequest {
     pub schema_name: String,
     pub table_name: String,
     pub location: String,
+    pub with: HashMap<String, String>,
     pub connection: HashMap<String, String>,
     pub pattern: Option<String>,
     pub direction: CopyDirection,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Replace the `Copy` Format with `datasource` Format.

The prelude of #1305,  after merging this, some duplicated code in the #1424  also can be refactored

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1305 
- #1424
