### PR TITLE
refactor: remove redundant plugins argument

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -121,7 +121,7 @@ impl StartCommand {
             .context(error::StartFrontendSnafu)?;
 
         instance
-            .build_servers(&opts, plugins)
+            .build_servers(&opts)
             .await
             .context(error::StartFrontendSnafu)?;
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -223,7 +223,7 @@ impl StartCommand {
         let mut frontend = build_frontend(plugins.clone(), datanode.get_instance()).await?;
 
         frontend
-            .build_servers(&fe_opts, plugins)
+            .build_servers(&fe_opts)
             .await
             .context(StartFrontendSnafu)?;
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -221,12 +221,8 @@ impl Instance {
         })
     }
 
-    pub async fn build_servers(
-        &mut self,
-        opts: &FrontendOptions,
-        plugins: Arc<Plugins>,
-    ) -> Result<()> {
-        let servers = Services::build(opts, Arc::new(self.clone()), plugins).await?;
+    pub async fn build_servers(&mut self, opts: &FrontendOptions) -> Result<()> {
+        let servers = Services::build(opts, Arc::new(self.clone()), self.plugins.clone()).await?;
         self.servers = Arc::new(servers);
 
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove plugins from `build_servers` as instance already holds plugins

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
