### PR TITLE
fix: add log on leader stepdown

### DIFF
--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -141,9 +141,9 @@ impl MetaSrv {
                                         error!("Failed to recover procedures, error: {e}");
                                     }
                                 }
-                                LeaderChangeMessage::StepDown(_) => {
+                                LeaderChangeMessage::StepDown(leader) => {
                                     // TODO(LFC): TBC
-                                    unimplemented!()
+                                    error!("Leader :{:?} step down", leader);
                                 }
                             }
                         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Just add a log to avoid panic when metasrv leader step down.
And when it has been a leader before and the lease renewal fails, a step-down message will be sent out.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
