### PR TITLE
fix: object store caching bug, #1466

### DIFF
--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -93,7 +93,7 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
         let cache_path = self.cache_path(&path, &args);
         let lru_cache = self.lru_cache.clone();
 
-        match self.cache.read(&cache_path, OpRead::default()).await {
+        match self.cache.read(&cache_path, args.clone()).await {
             Ok((rp, r)) => {
                 increment_counter!(OBJECT_STORE_LRU_CACHE_HIT);
 
@@ -116,7 +116,7 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
                 writer.write(Bytes::from(buf)).await?;
                 writer.close().await?;
 
-                match self.cache.read(&cache_path, OpRead::default()).await {
+                match self.cache.read(&cache_path, args.clone()).await {
                     Ok((rp, reader)) => {
                         let r = {
                             // push new cache file name to lru

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -17,5 +17,5 @@ mod grpc;
 #[macro_use]
 mod http;
 
-grpc_tests!(File, S3, Oss);
-http_tests!(File, S3, Oss);
+grpc_tests!(File, S3, S3WithCache, Oss);
+http_tests!(File, S3, S3WithCache, Oss);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix #1466  and add integration tests for s3 storage with cache enabled.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
