### PR TITLE
feat(mito): Combine the original and procedure's implementation

### DIFF
--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -236,7 +236,7 @@ impl EngineInner {
             } else {
                 // If the procedure retry this method. It is possible to return error
                 // when the table is already created.
-                // TODO(yingwen): Refactor this.
+                // TODO(yingwen): Refactor this like the mito engine.
                 TableExistsSnafu { table_name }.fail()
             };
         }

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -234,6 +234,9 @@ impl EngineInner {
             return if request.create_if_not_exists {
                 Ok(table)
             } else {
+                // If the procedure retry this method. It is possible to return error
+                // when the table is already created.
+                // TODO(yingwen): Refactor this.
                 TableExistsSnafu { table_name }.fail()
             };
         }

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 pub(crate) use alter::AlterMitoTable;
 use common_procedure::ProcedureManager;
-pub(crate) use create::CreateMitoTable;
+pub(crate) use create::{CreateMitoTable, TableCreator};
 pub(crate) use drop::DropMitoTable;
 use store_api::storage::StorageEngine;
 

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -175,7 +175,7 @@ impl<S: StorageEngine> AlterMitoTable<S> {
 
         if let AlterKind::RenameTable { new_table_name } = &self.data.request.alter_kind {
             let mut table_ref = self.data.table_ref();
-            table_ref.table = &new_table_name;
+            table_ref.table = new_table_name;
             ensure!(
                 self.engine_inner.get_mito_table(&table_ref).is_none(),
                 TableExistsSnafu {

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use common_procedure::error::{Error, FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{Context, LockKey, Procedure, ProcedureManager, Result, Status};
 use common_telemetry::logging;
+use common_telemetry::metric::Timer;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::manifest::Manifest;
@@ -32,6 +33,7 @@ use crate::error::{
     BuildTableMetaSnafu, TableNotFoundSnafu, UpdateTableManifestSnafu, VersionChangedSnafu,
 };
 use crate::manifest::action::{TableChange, TableMetaAction, TableMetaActionList};
+use crate::metrics;
 use crate::table::{create_alter_operation, MitoTable};
 
 /// Procedure to alter a [MitoTable].
@@ -41,6 +43,7 @@ pub(crate) struct AlterMitoTable<S: StorageEngine> {
     table: Arc<MitoTable<S::Region>>,
     /// The table info after alteration.
     new_info: Option<TableInfo>,
+    _timer: Timer,
 }
 
 #[async_trait]
@@ -114,6 +117,7 @@ impl<S: StorageEngine> AlterMitoTable<S> {
             engine_inner,
             table,
             new_info: None,
+            _timer: common_telemetry::timer!(metrics::MITO_ALTER_TABLE_ELAPSED),
         })
     }
 
@@ -151,6 +155,7 @@ impl<S: StorageEngine> AlterMitoTable<S> {
             engine_inner,
             table,
             new_info: None,
+            _timer: common_telemetry::timer!(metrics::MITO_ALTER_TABLE_ELAPSED),
         })
     }
 

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -270,7 +270,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
         let table_ref = self.data.table_ref();
         if let Some((manifest, table_info)) = self
             .engine_inner
-            .recover_table_manifest_and_info(&self.data.request.table_name, &table_dir)
+            .recover_table_manifest_and_info(&self.data.request.table_name, table_dir)
             .await?
         {
             let table = Arc::new(MitoTable::new(table_info, self.regions.clone(), manifest));

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_procedure::error::{FromJsonSnafu, ToJsonSnafu};
 use common_procedure::{Context, Error, LockKey, Procedure, ProcedureManager, Result, Status};
+use common_telemetry::metric::Timer;
 use datatypes::schema::{Schema, SchemaRef};
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};
@@ -34,6 +35,7 @@ use crate::error::{
     BuildRegionDescriptorSnafu, BuildTableInfoSnafu, BuildTableMetaSnafu, InvalidRawSchemaSnafu,
     TableExistsSnafu,
 };
+use crate::metrics;
 use crate::table::MitoTable;
 
 /// Procedure to create a [MitoTable].
@@ -44,6 +46,7 @@ pub(crate) struct CreateMitoTable<S: StorageEngine> {
     regions: HashMap<RegionNumber, S::Region>,
     /// Schema of the table.
     table_schema: SchemaRef,
+    _timer: Timer,
 }
 
 #[async_trait]
@@ -97,6 +100,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             engine_inner,
             regions: HashMap::new(),
             table_schema: Arc::new(table_schema),
+            _timer: common_telemetry::timer!(metrics::MITO_CREATE_TABLE_ELAPSED),
         })
     }
 
@@ -129,6 +133,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
             engine_inner,
             regions: HashMap::new(),
             table_schema: Arc::new(table_schema),
+            _timer: common_telemetry::timer!(metrics::MITO_CREATE_TABLE_ELAPSED),
         })
     }
 

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -206,12 +206,6 @@ impl<S: StorageEngine> TableCreator<S> {
         );
 
         let table_ref = self.data.table_ref();
-        let _lock = self
-            .engine_inner
-            .table_mutex
-            .lock(table_ref.to_string())
-            .await;
-
         // It is possible that the procedure retries `CREATE TABLE` many times, so we
         // return the table if it exists.
         if let Some(table) = self.engine_inner.get_table(&table_ref) {

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -36,6 +36,7 @@ use table::metadata::TableType;
 use table::requests::{
     AddColumnRequest, AlterKind, DeleteRequest, FlushTableRequest, TableOptions,
 };
+use table::Table;
 
 use super::*;
 use crate::table::test_util::{

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -31,6 +31,8 @@ use storage::region::RegionImpl;
 use storage::EngineImpl;
 use store_api::manifest::Manifest;
 use store_api::storage::ReadContext;
+use table::engine::region_id;
+use table::metadata::TableType;
 use table::requests::{
     AddColumnRequest, AlterKind, DeleteRequest, FlushTableRequest, TableOptions,
 };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Combines the original and procedure's implementation
- Adds a struct `TableCreator` to create a mito table. Both the procedure and the engine use this creator
- Adds `MitoTable::alter_regions()` and `MitoTable::info_and_op_for_alter()` to reuse code
- Simplifies drop table procedure by calling the engine inner to drop the table

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #286