### PR TITLE
feat: improve metrics and log level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4812,6 +4812,7 @@ dependencies = [
  "h2",
  "http-body",
  "lazy_static",
+ "metrics",
  "parking_lot",
  "prost",
  "rand",

--- a/src/common/telemetry/src/panic_hook.rs
+++ b/src/common/telemetry/src/panic_hook.rs
@@ -17,6 +17,7 @@ use std::panic;
 use std::time::Duration;
 
 use backtrace::Backtrace;
+use metrics::increment_counter;
 
 pub fn set_panic_hook() {
     // Set a panic hook that records the panic as a `tracing` event at the
@@ -40,6 +41,7 @@ pub fn set_panic_hook() {
         } else {
             tracing::error!(message = %panic, backtrace = %backtrace);
         }
+        increment_counter!("panic_counter");
         default_hook(panic);
     }));
 

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -34,7 +34,7 @@ use catalog::{
 };
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::prelude::BoxedError;
-use common_telemetry::error;
+use common_telemetry::warn;
 use futures::StreamExt;
 use meta_client::rpc::TableName;
 use partition::manager::PartitionRuleManagerRef;
@@ -269,7 +269,7 @@ impl CatalogList for FrontendCatalogManager {
                     if let Ok(key) = CatalogKey::parse(catalog_key.as_ref()) {
                         res.insert(key.catalog_name);
                     } else {
-                        error!("invalid catalog key: {:?}", catalog_key);
+                        warn!("invalid catalog key: {:?}", catalog_key);
                     }
                 }
                 Ok(res.into_iter().collect())

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -28,6 +28,7 @@ futures.workspace = true
 h2 = "0.3"
 http-body = "0.4"
 lazy_static = "1.4"
+metrics.workspace = true
 parking_lot = "0.12"
 prost.workspace = true
 rand.workspace = true

--- a/src/meta-srv/src/metrics.rs
+++ b/src/meta-srv/src/metrics.rs
@@ -12,27 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(async_closure)]
-#![feature(btree_drain_filter)]
-
-pub mod bootstrap;
-pub mod cluster;
-pub mod election;
-pub mod error;
-mod failure_detector;
-pub mod handler;
-pub mod keys;
-pub mod lease;
-pub mod lock;
-pub mod metadata_service;
-pub mod metasrv;
-mod metrics;
-#[cfg(feature = "mock")]
-pub mod mocks;
-mod procedure;
-pub mod selector;
-mod sequence;
-pub mod service;
-pub mod util;
-
-pub use crate::error::Result;
+pub(crate) const METRIC_META_CREATE_CATALOG: &str = "meta.create_catalog";
+pub(crate) const METRIC_META_CREATE_SCHEMA: &str = "meta.create_schema";

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -19,6 +19,7 @@ use aide::transform::TransformOperation;
 use axum::extract::{Json, Query, State};
 use axum::{Extension, Form};
 use common_error::status_code::StatusCode;
+use common_telemetry::timer;
 use query::parser::PromQuery;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -42,6 +43,8 @@ pub async fn sql(
     _user_info: Extension<UserInfo>,
     Form(form_params): Form<SqlQuery>,
 ) -> Json<JsonResponse> {
+    let _timer = timer!(crate::metrics::METRIC_HTTP_SQL_ELAPSED);
+
     let sql_handler = &state.sql_handler;
 
     let start = Instant::now();
@@ -93,6 +96,8 @@ pub async fn promql(
     // TODO(fys): pass _user_info into query context
     _user_info: Extension<UserInfo>,
 ) -> Json<JsonResponse> {
+    let _timer = timer!(crate::metrics::METRIC_HTTP_PROMQL_ELAPSED);
+
     let sql_handler = &state.sql_handler;
     let exec_start = Instant::now();
     let db = params.db.clone();

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -25,6 +25,7 @@ pub mod http;
 pub mod influxdb;
 pub mod interceptor;
 pub mod line_writer;
+mod metrics;
 pub mod metrics_handler;
 pub mod mysql;
 pub mod opentsdb;

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -12,27 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(async_closure)]
-#![feature(btree_drain_filter)]
-
-pub mod bootstrap;
-pub mod cluster;
-pub mod election;
-pub mod error;
-mod failure_detector;
-pub mod handler;
-pub mod keys;
-pub mod lease;
-pub mod lock;
-pub mod metadata_service;
-pub mod metasrv;
-mod metrics;
-#[cfg(feature = "mock")]
-pub mod mocks;
-mod procedure;
-pub mod selector;
-mod sequence;
-pub mod service;
-pub mod util;
-
-pub use crate::error::Result;
+pub(crate) const METRIC_HTTP_SQL_ELAPSED: &str = "servers.http_sql_elapsed";
+pub(crate) const METRIC_HTTP_PROMQL_ELAPSED: &str = "servers.http_promql_elapsed";


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds:

- timer for http sql/promql apis
- metrics for catalog/schema creation on meta
- counter for panic hook
- log level improvement for mysql handler, change non-fatal error to `warn`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
