### PR TITLE
build: Download assets to cargo output dir

### DIFF
--- a/scripts/fetch-dashboard-assets.sh
+++ b/scripts/fetch-dashboard-assets.sh
@@ -2,7 +2,7 @@
 
 # This script is used to download built dashboard assets from the "GreptimeTeam/dashboard" repository.
 
-set -x
+set -e
 
 declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
@@ -12,7 +12,7 @@ OUT_DIR="${1:-$SCRIPT_DIR}"
 RELEASE_VERSION="$(cat $STATIC_DIR/VERSION)"
 
 echo "Downloading assets to dir: $OUT_DIR"
-pushd $OUT_DIR
+cd $OUT_DIR
 # Download the SHA256 checksum attached to the release. To verify the integrity
 # of the download, this checksum will be used to check the download tar file
 # containing the built dashboard assets.
@@ -38,7 +38,5 @@ esac
 tar -xzf build.tar.gz -C "$STATIC_DIR"
 rm sha256.txt
 rm build.tar.gz
-
-popd
 
 echo "Successfully download dashboard assets to $STATIC_DIR"

--- a/scripts/fetch-dashboard-assets.sh
+++ b/scripts/fetch-dashboard-assets.sh
@@ -2,14 +2,17 @@
 
 # This script is used to download built dashboard assets from the "GreptimeTeam/dashboard" repository.
 
-set -e
+set -x
 
 declare -r SCRIPT_DIR=$(cd $(dirname ${0}) >/dev/null 2>&1 && pwd)
 declare -r ROOT_DIR=$(dirname ${SCRIPT_DIR})
 declare -r STATIC_DIR="$ROOT_DIR/src/servers/dashboard"
+OUT_DIR="${1:-$SCRIPT_DIR}"
 
 RELEASE_VERSION="$(cat $STATIC_DIR/VERSION)"
 
+echo "Downloading assets to dir: $OUT_DIR"
+pushd $OUT_DIR
 # Download the SHA256 checksum attached to the release. To verify the integrity
 # of the download, this checksum will be used to check the download tar file
 # containing the built dashboard assets.
@@ -35,5 +38,7 @@ esac
 tar -xzf build.tar.gz -C "$STATIC_DIR"
 rm sha256.txt
 rm build.tar.gz
+
+popd
 
 echo "Successfully download dashboard assets to $STATIC_DIR"

--- a/src/servers/build.rs
+++ b/src/servers/build.rs
@@ -42,7 +42,7 @@ or it's a network error, just try again or enable/disable some proxy."#;
             );
         }
         Err(e) => {
-            let e = format!(r#"{message}: {e}.\n{help}"#);
+            let e = format!("{message}: {e}.\n{help}");
             panic!("{}", e);
         }
     }


### PR DESCRIPTION
Also remove the output from the build script and only print the output on failure

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Download assets to cargo output dir and only print message on failure.

Now the error message looks like this
```bash
error: failed to run custom build command for `servers v0.2.0 (/xxx/greptime/greptimedb/src/servers)`

Caused by:
  process didn't exit successfully: `/xxx/greptime/greptimedb/target/debug/build/servers-8dc45d9bbbf1d1ce/build-script-build` (exit status: 101)
  --- stderr
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2066k  100 2066k    0     0  1119k      0  0:00:01  0:00:01 --:--:-- 3928k
  shasum: build.tar.gz: No such file or directory
  shasum: WARNING: 1 listed file could not be read
  thread 'main' panicked at 'Failed to fetch dashboard assets.
  Downloading assets to dir: /xxx/greptime/greptimedb/target/debug/build/servers-bbeb8e2fe22a0b91/out
  build.tar.gz: FAILED open or read
  Checksums did not match for downloaded dashboard assets!

```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
