### PR TITLE
feat: bump opendal to 0.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5071,7 +5071,7 @@ dependencies = [
  "twox-hash",
  "url",
  "webpki",
- "webpki-roots 0.23.0",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5430,9 +5430,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.30.5"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89d32f1761175aff31cb233330e206c2a8d9c3e96b0af3e74d0e7eff978b46a"
+checksum = "8c582b11500656b4f6210f868a0a26395cdf30183c5597c45d0a34525dd94512"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5440,6 +5440,7 @@ dependencies = [
  "backon 0.4.0",
  "base64 0.21.0",
  "bytes",
+ "chrono",
  "flagset",
  "futures",
  "http",
@@ -5456,10 +5457,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.20",
  "tokio",
  "tracing",
- "ureq",
  "uuid",
 ]
 
@@ -6760,18 +6759,19 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.8.5"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db6d8d2cd7fa61403d14de670f98d7cedac38143681c124943d7bb69258b3a"
+checksum = "6f753b768a9d691395e7db3dc74452cc39a5da55293c3fa2241e2aeaf9d94028"
 dependencies = [
  "anyhow",
- "backon 0.4.0",
+ "async-trait",
  "base64 0.21.0",
  "bytes",
- "dirs",
+ "chrono",
  "form_urlencoded",
  "hex",
  "hmac",
+ "home",
  "http",
  "jsonwebtoken",
  "log",
@@ -6779,14 +6779,14 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.28.2",
  "rand",
+ "reqwest",
  "rsa",
  "rust-ini",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
- "time 0.3.20",
- "ureq",
+ "tokio",
 ]
 
 [[package]]
@@ -9724,22 +9724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
-dependencies = [
- "base64 0.13.1",
- "log",
- "once_cell",
- "rustls 0.20.8",
- "rustls-native-certs",
- "url",
- "webpki",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9971,15 +9955,6 @@ checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -10,7 +10,7 @@ async-trait = "0.1"
 bytes = "1.4"
 futures = { version = "0.3" }
 metrics = "0.20"
-opendal = { version = "0.30", features = ["layers-tracing", "layers-metrics"] }
+opendal = { version = "0.33", features = ["layers-tracing", "layers-metrics"] }
 pin-project = "1.0"
 tokio.workspace = true
 

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -176,7 +176,7 @@ impl BufferedWriter {
             };
             let size = chunk.len();
             object_writer
-                .append(chunk)
+                .write(chunk)
                 .await
                 .context(WriteObjectSnafu { path: file_name })?;
             *flushed = true;
@@ -187,7 +187,7 @@ impl BufferedWriter {
             let remain = shared_buffer.buffer.lock().unwrap().split();
             let size = remain.len();
             object_writer
-                .append(remain)
+                .write(remain)
                 .await
                 .context(WriteObjectSnafu { path: file_name })?;
             *flushed = true;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump opendal to 0.33 https://github.com/apache/incubator-opendal/releases



## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
