### PR TITLE
fix: object store cache bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,6 +5378,7 @@ dependencies = [
  "common-test-util",
  "futures",
  "lru 0.9.0",
+ "md5",
  "metrics",
  "opendal",
  "pin-project",

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -21,8 +21,6 @@ use snafu::Location;
 use storage::error::Error as StorageError;
 use table::error::Error as TableError;
 
-use crate::datanode::ObjectStoreConfig;
-
 /// Business error of datanode.
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -210,9 +208,8 @@ pub enum Error {
     #[snafu(display("Failed to storage engine, source: {}", source))]
     OpenStorageEngine { source: StorageError },
 
-    #[snafu(display("Failed to init backend, config: {:#?}, source: {}", config, source))]
+    #[snafu(display("Failed to init backend, source: {}", source))]
     InitBackend {
-        config: Box<ObjectStoreConfig>,
         source: object_store::Error,
         location: Location,
     },

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -470,9 +470,9 @@ pub(crate) async fn new_s3_object_store(store_config: &ObjectStoreConfig) -> Res
 
 fn clean_temp_dir(dir: &str) -> Result<()> {
     if path::Path::new(&dir).exists() {
-        info!("Begin to clean temp storage directory: {}", &dir);
+        info!("Begin to clean temp storage directory: {}", dir);
         fs::remove_dir_all(dir).context(error::RemoveDirSnafu { dir })?;
-        info!("Cleaned temp storage directory: {}", &dir);
+        info!("Cleaned temp storage directory: {}", dir);
     }
 
     Ok(())

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -379,9 +379,7 @@ pub(crate) async fn new_oss_object_store(store_config: &ObjectStoreConfig) -> Re
         .access_key_secret(oss_config.access_key_secret.expose_secret());
 
     let object_store = ObjectStore::new(builder)
-        .with_context(|_| error::InitBackendSnafu {
-            config: store_config.clone(),
-        })?
+        .context(error::InitBackendSnafu)?
         .finish();
 
     create_object_store_with_cache(object_store, store_config).await
@@ -416,15 +414,11 @@ async fn create_object_store_with_cache(
             .root(path)
             .atomic_write_dir(&atomic_temp_dir)
             .build()
-            .with_context(|_| error::InitBackendSnafu {
-                config: store_config.clone(),
-            })?;
+            .context(error::InitBackendSnafu)?;
 
         let cache_layer = LruCacheLayer::new(Arc::new(cache_store), cache_capacity.0 as usize)
             .await
-            .with_context(|_| error::InitBackendSnafu {
-                config: store_config.clone(),
-            })?;
+            .context(error::InitBackendSnafu)?;
         Ok(object_store.layer(cache_layer))
     } else {
         Ok(object_store)
@@ -459,9 +453,7 @@ pub(crate) async fn new_s3_object_store(store_config: &ObjectStoreConfig) -> Res
 
     create_object_store_with_cache(
         ObjectStore::new(builder)
-            .with_context(|_| error::InitBackendSnafu {
-                config: store_config.clone(),
-            })?
+            .context(error::InitBackendSnafu)?
             .finish(),
         store_config,
     )
@@ -495,9 +487,7 @@ pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Res
     builder.root(&data_dir).atomic_write_dir(&atomic_write_dir);
 
     let object_store = ObjectStore::new(builder)
-        .context(error::InitBackendSnafu {
-            config: store_config.clone(),
-        })?
+        .context(error::InitBackendSnafu)?
         .finish();
 
     Ok(object_store)

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -9,6 +9,7 @@ lru = "0.9"
 async-trait = "0.1"
 bytes = "1.4"
 futures = { version = "0.3" }
+md5 = "0.7"
 metrics = "0.20"
 opendal = { version = "0.33", features = ["layers-tracing", "layers-metrics"] }
 pin-project = "1.0"

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -38,15 +38,15 @@ pub struct LruCacheLayer<C> {
 
 impl<C: Accessor + Clone> LruCacheLayer<C> {
     pub async fn new(cache: Arc<C>, capacity: usize) -> Result<Self> {
-        let zelf = Self {
+        let layer = Self {
             cache,
             lru_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(capacity).unwrap(),
             ))),
         };
-        zelf.recover_keys().await?;
+        layer.recover_keys().await?;
 
-        Ok(zelf)
+        Ok(layer)
     }
 
     /// Recover existing keys from `cache` to `lru_cache`.

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -30,12 +30,13 @@ use crate::metrics::{
     OBJECT_STORE_LRU_CACHE_MISS,
 };
 
+#[derive(Clone)]
 pub struct LruCacheLayer<C> {
     cache: Arc<C>,
     lru_cache: Arc<Mutex<LruCache<String, ()>>>,
 }
 
-impl<C: Accessor> LruCacheLayer<C> {
+impl<C: Accessor + Clone> LruCacheLayer<C> {
     pub async fn new(cache: Arc<C>, capacity: usize) -> Result<Self> {
         let zelf = Self {
             cache,
@@ -60,6 +61,10 @@ impl<C: Accessor> LruCacheLayer<C> {
         }
 
         Ok(())
+    }
+
+    pub async fn lru_contains_key(&self, key: &str) -> bool {
+        self.lru_cache.lock().await.contains(key)
     }
 }
 

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -118,7 +118,8 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
         let cache_path = self.cache_path(&path, &args);
         let lru_cache = &self.lru_cache;
 
-        match self.cache.read(&cache_path, args.clone()).await {
+        // the args is already in the cache path, so we must create a new OpRead.
+        match self.cache.read(&cache_path, OpRead::default()).await {
             Ok((rp, r)) => {
                 increment_counter!(OBJECT_STORE_LRU_CACHE_HIT);
 
@@ -139,7 +140,7 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
 
                 writer.close().await?;
 
-                match self.cache.read(&cache_path, args.clone()).await {
+                match self.cache.read(&cache_path, OpRead::default()).await {
                     Ok((rp, reader)) => {
                         let r = {
                             // push new cache file name to lru

--- a/src/object-store/src/cache_policy.rs
+++ b/src/object-store/src/cache_policy.rs
@@ -187,7 +187,7 @@ impl<I: Accessor, C: Accessor> LayeredAccessor for LruCacheAccessor<I, C> {
         for file in cache_files {
             let _ = self.cache.delete(&file, OpDelete::new()).await;
         }
-        return self.inner.delete(path, args).await;
+        self.inner.delete(path, args).await
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -208,7 +208,11 @@ async fn test_object_store_cache_policy() -> Result<()> {
     let cache_store = OperatorBuilder::new(cache_accessor.clone()).finish();
 
     // create operator for cache dir to verify cache file
-    let store = store.layer(LruCacheLayer::new(Arc::new(cache_accessor), 3));
+    let store = store.layer(
+        LruCacheLayer::new(Arc::new(cache_accessor), 3)
+            .await
+            .unwrap(),
+    );
 
     // create several object handler.
     // write data into object;

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -234,21 +234,25 @@ async fn test_object_store_cache_policy() -> Result<()> {
     store.range_read(p1, 0..).await?;
     store.read(p1).await?;
     store.range_read(p2, 0..).await?;
+    store.range_read(p2, 7..).await?;
     store.read(p2).await?;
 
     assert_cache_files(
         &cache_store,
         &[
-            "test_file1.cache-bytes=0-",
-            "test_file2.cache-bytes=7-",
-            "test_file2.cache-bytes=0-",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=7-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-",
         ],
         &["Hello, object1!", "object2!", "Hello, object2!"],
     )
     .await?;
     assert_lru_cache(
         &cache_layer,
-        &["test_file1.cache-bytes=0-", "test_file2.cache-bytes=0-"],
+        &[
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-",
+        ],
     )
     .await;
 
@@ -256,11 +260,15 @@ async fn test_object_store_cache_policy() -> Result<()> {
 
     assert_cache_files(
         &cache_store,
-        &["test_file1.cache-bytes=0-"],
+        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-"],
         &["Hello, object1!"],
     )
     .await?;
-    assert_lru_cache(&cache_layer, &["test_file1.cache-bytes=0-"]).await;
+    assert_lru_cache(
+        &cache_layer,
+        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-"],
+    )
+    .await;
 
     let p3 = "test_file3";
     store.write(p3, "Hello, object3!").await.unwrap();
@@ -271,9 +279,9 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_cache_files(
         &cache_store,
         &[
-            "test_file1.cache-bytes=0-",
-            "test_file3.cache-bytes=0-",
-            "test_file3.cache-bytes=0-4",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
         &["Hello, object1!", "Hello, object3!", "Hello"],
     )
@@ -281,9 +289,9 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_lru_cache(
         &cache_layer,
         &[
-            "test_file1.cache-bytes=0-",
-            "test_file3.cache-bytes=0-",
-            "test_file3.cache-bytes=0-4",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
     )
     .await;
@@ -302,9 +310,9 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_lru_cache(
         &cache_layer,
         &[
-            "test_file1.cache-bytes=0-",
-            "test_file3.cache-bytes=0-",
-            "test_file3.cache-bytes=0-4",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
     )
     .await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:
* Recover LRU cache keys from local file cache path.
* Set `atomic_write_dir` for local file cache.
* Fixed reading cache file.
* Fixed writing cache file.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Fix #1458 