### PR TITLE
fix: checkpoint GC task also deletes the file with the last version

### DIFF
--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -20,6 +20,7 @@ use common_error::prelude::*;
 use common_runtime::error::Error as RuntimeError;
 use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
+use object_store::ErrorKind;
 use serde_json::error::Error as JsonError;
 use snafu::Location;
 use store_api::manifest::action::ProtocolVersion;
@@ -457,6 +458,18 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// Returns true if the error is the object path to delete
+    /// doesn't exist.
+    pub(crate) fn is_object_to_delete_not_found(&self) -> bool {
+        if let Error::DeleteObject { source, .. } = self {
+            source.kind() == ErrorKind::NotFound
+        } else {
+            false
+        }
+    }
+}
 
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {

--- a/src/storage/src/manifest/impl_.rs
+++ b/src/storage/src/manifest/impl_.rs
@@ -251,12 +251,13 @@ impl<S: Checkpoint<Error = Error>, M: MetaAction<Error = Error>> TaskFunction<Er
 
     async fn call(&self) -> Result<()> {
         if let Some((last_version, _)) = self.store.load_last_checkpoint().await? {
-            // Purge all manifest and checkpoint files before last_version.
-            let deleted = self.store.delete_until(last_version).await?;
+            // Purge all manifest and checkpoint files <= last_version.
+            let deleted = self.store.delete_until(last_version + 1).await?;
             debug!(
-                "Deleted {} logs from region manifest storage(path={}).",
+                "Deleted {} logs from region manifest storage(path={}), last_version: {}.",
                 deleted,
-                self.store.path()
+                self.store.path(),
+                last_version,
             );
         }
 

--- a/src/storage/src/manifest/impl_.rs
+++ b/src/storage/src/manifest/impl_.rs
@@ -251,8 +251,8 @@ impl<S: Checkpoint<Error = Error>, M: MetaAction<Error = Error>> TaskFunction<Er
 
     async fn call(&self) -> Result<()> {
         if let Some((last_version, _)) = self.store.load_last_checkpoint().await? {
-            // Purge all manifest and checkpoint files <= last_version.
-            let deleted = self.store.delete_until(last_version + 1).await?;
+            // Purge all manifest <= last_version and checkpoint files < last_version.
+            let deleted = self.store.delete_until(last_version + 1, true).await?;
             debug!(
                 "Deleted {} logs from region manifest storage(path={}), last_version: {}.",
                 deleted,

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use common_telemetry::{error, info};
+use common_telemetry::{info, warn};
 use object_store::ObjectStore;
 use store_api::manifest::action::ProtocolAction;
 use store_api::manifest::{
@@ -122,10 +122,13 @@ impl Checkpointer for RegionManifestCheckpointer {
             .await
         {
             // It doesn't matter when deletion fails, they will be purged by gc task.
-            error!(e; "Failed to delete manifest logs [{},{}] in path: {}.",
-                   start_version,
-                   last_version,
-                   manifest.manifest_store().path());
+            warn!(
+                "Failed to delete manifest logs [{},{}] in path: {}. err: {}",
+                start_version,
+                last_version,
+                manifest.manifest_store().path(),
+                e
+            );
         }
 
         info!("Region manifest checkpoint, start_version: {}, last_version: {}, compacted actions: {}", start_version, last_version, compacted_actions);

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -197,14 +197,16 @@ mod tests {
 
         let region_meta = Arc::new(build_region_meta());
 
-        assert!(manifest
-            .scan(0, MAX_VERSION)
-            .await
-            .unwrap()
-            .next_action()
-            .await
-            .unwrap()
-            .is_none());
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
 
         manifest
             .update(RegionMetaActionList::with_action(RegionMetaAction::Change(
@@ -365,14 +367,16 @@ mod tests {
                          files.contains_key(&file_ids[1]) &&
                          *metadata == alterd_raw_meta));
         // all actions were compacted
-        assert!(manifest
-            .scan(0, MAX_VERSION)
-            .await
-            .unwrap()
-            .next_action()
-            .await
-            .unwrap()
-            .is_none());
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
 
         assert!(manifest.do_checkpoint().await.unwrap().is_none());
         let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
@@ -441,14 +445,16 @@ mod tests {
                          *metadata == RawRegionMetadata::from(region_meta.as_ref())));
 
         // all actions were compacted
-        assert!(manifest
-            .scan(0, MAX_VERSION)
-            .await
-            .unwrap()
-            .next_action()
-            .await
-            .unwrap()
-            .is_none());
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
 
         // wait for gc
         tokio::time::sleep(Duration::from_millis(60)).await;

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -121,14 +121,17 @@ impl Checkpointer for RegionManifestCheckpointer {
             .delete(start_version, last_version + 1)
             .await
         {
-            // It doesn't matter when deletion fails, they will be purged by gc task.
-            warn!(
-                "Failed to delete manifest logs [{},{}] in path: {}. err: {}",
-                start_version,
-                last_version,
-                manifest.manifest_store().path(),
-                e
-            );
+            // We only log when the error kind isn't `NotFound`
+            if !e.is_object_to_delete_not_found() {
+                // It doesn't matter when deletion fails, they will be purged by gc task.
+                warn!(
+                    "Failed to delete manifest logs [{},{}] in path: {}. err: {}",
+                    start_version,
+                    last_version,
+                    manifest.manifest_store().path(),
+                    e
+                );
+            }
         }
 
         info!("Region manifest checkpoint, start_version: {}, last_version: {}, compacted actions: {}", start_version, last_version, compacted_actions);

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -216,9 +216,10 @@ impl ManifestLogStorage for ManifestObjectStore {
         let ret = paths.len();
 
         logging::debug!(
-            "Deleting {} logs from manifest storage path {}.",
+            "Deleting {} logs from manifest storage path {} until end {}.",
             ret,
-            self.path
+            self.path,
+            end,
         );
 
         self.object_store
@@ -233,6 +234,9 @@ impl ManifestLogStorage for ManifestObjectStore {
 
     async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<()> {
         let path = self.delta_file_path(version);
+
+        logging::debug!("Save log to manifest storage, version: {}", version);
+
         self.object_store
             .write(&path, bytes.to_vec())
             .await
@@ -243,6 +247,12 @@ impl ManifestLogStorage for ManifestObjectStore {
         let raw_paths = (start..end)
             .map(|v| self.delta_file_path(v))
             .collect::<Vec<_>>();
+
+        logging::debug!(
+            "Deleting logs from manifest storage, start: {}, end: {}",
+            start,
+            end
+        );
 
         let paths = raw_paths
             .iter()

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -190,20 +190,26 @@ impl ManifestLogStorage for ManifestObjectStore {
         })
     }
 
-    async fn delete_until(&self, end: ManifestVersion) -> Result<usize> {
+    async fn delete_until(
+        &self,
+        end: ManifestVersion,
+        keep_last_checkpoint: bool,
+    ) -> Result<usize> {
         let streamer = self
             .object_store
             .list(&self.path)
             .await
             .context(ListObjectsSnafu { path: &self.path })?;
 
-        let paths: Vec<_> = streamer
+        // Stores (entry, is_checkpoint, version) in a Vec.
+        let entries: Vec<_> = streamer
             .try_filter_map(|e| async move {
                 let file_name = e.name();
+                let is_checkpoint = is_checkpoint_file(file_name);
                 if is_delta_file(file_name) || is_checkpoint_file(file_name) {
                     let version = file_version(file_name);
                     if version < end {
-                        Ok(Some(e.path().to_string()))
+                        Ok(Some((e, is_checkpoint, version)))
                     } else {
                         Ok(None)
                     }
@@ -214,13 +220,51 @@ impl ManifestLogStorage for ManifestObjectStore {
             .try_collect::<Vec<_>>()
             .await
             .context(ListObjectsSnafu { path: &self.path })?;
+        let checkpoint_version = if keep_last_checkpoint {
+            // Note that the order of entries is unspecific.
+            entries
+                .iter()
+                .filter_map(
+                    |(_e, is_checkpoint, version)| {
+                        if *is_checkpoint {
+                            Some(version)
+                        } else {
+                            None
+                        }
+                    },
+                )
+                .max()
+        } else {
+            None
+        };
+
+        let paths: Vec<_> = entries
+            .iter()
+            .filter(|(_e, is_checkpoint, version)| {
+                if let Some(max_version) = checkpoint_version {
+                    if *is_checkpoint {
+                        // We need to keep the checkpoint file.
+                        version < max_version
+                    } else {
+                        // We can delete the log file with max_version as the checkpoint
+                        // file contains the log file's content.
+                        version <= max_version
+                    }
+                } else {
+                    true
+                }
+            })
+            .map(|e| e.0.path().to_string())
+            .collect();
         let ret = paths.len();
 
         logging::debug!(
-            "Deleting {} logs from manifest storage path {} until end {}.",
+            "Deleting {} logs from manifest storage path {} until {}, checkpoint: {:?}, paths: {:?}",
             ret,
             self.path,
             end,
+            checkpoint_version,
+            paths,
         );
 
         self.object_store
@@ -416,10 +460,10 @@ mod tests {
         assert_eq!(checkpoint, "checkpoint".as_bytes());
         assert_eq!(3, v);
 
-        //delete (,4) logs and checkpoints
-        log_store.delete_until(4).await.unwrap();
-        assert!(log_store.load_checkpoint(3).await.unwrap().is_none());
-        assert!(log_store.load_last_checkpoint().await.unwrap().is_none());
+        //delete (,4) logs and keep checkpoint 3.
+        log_store.delete_until(4, true).await.unwrap();
+        assert!(log_store.load_checkpoint(3).await.unwrap().is_some());
+        assert!(log_store.load_last_checkpoint().await.unwrap().is_some());
         let mut it = log_store.scan(0, 11).await.unwrap();
         let (version, bytes) = it.next_log().await.unwrap().unwrap();
         assert_eq!(4, version);
@@ -427,7 +471,7 @@ mod tests {
         assert!(it.next_log().await.unwrap().is_none());
 
         // delete all logs and checkpoints
-        log_store.delete_until(11).await.unwrap();
+        log_store.delete_until(11, false).await.unwrap();
         assert!(log_store.load_checkpoint(3).await.unwrap().is_none());
         assert!(log_store.load_last_checkpoint().await.unwrap().is_none());
         let mut it = log_store.scan(0, 11).await.unwrap();

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -128,6 +128,7 @@ impl ManifestObjectStore {
 #[derive(Serialize, Deserialize, Debug)]
 struct CheckpointMetadata {
     pub size: usize,
+    /// The latest version this checkpoint contains.
     pub version: ManifestVersion,
     pub checksum: Option<String>,
     pub extend_metadata: Option<HashMap<String, String>>,

--- a/src/store-api/src/manifest/storage.rs
+++ b/src/store-api/src/manifest/storage.rs
@@ -40,14 +40,14 @@ pub trait ManifestLogStorage {
     /// Returns the delete logs number.
     async fn delete_until(&self, version: ManifestVersion) -> Result<usize, Self::Error>;
 
-    /// Save  a log
+    /// Save a log
     async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<(), Self::Error>;
 
     /// Delete logs in [start, end)
     async fn delete(&self, start: ManifestVersion, end: ManifestVersion)
         -> Result<(), Self::Error>;
 
-    /// Save a checkpoint
+    /// Save a checkpoint.
     async fn save_checkpoint(
         &self,
         version: ManifestVersion,

--- a/src/store-api/src/manifest/storage.rs
+++ b/src/store-api/src/manifest/storage.rs
@@ -36,14 +36,20 @@ pub trait ManifestLogStorage {
         end: ManifestVersion,
     ) -> Result<Self::Iter, Self::Error>;
 
-    /// Delete logs which version is less than specified version.
+    /// Delete logs and checkpoints which version is less than specified `end`.
+    /// Keep the last checkpoint and remaining logs if `keep_last_checkpoint` is true.
+    ///
     /// Returns the delete logs number.
-    async fn delete_until(&self, version: ManifestVersion) -> Result<usize, Self::Error>;
+    async fn delete_until(
+        &self,
+        end: ManifestVersion,
+        keep_last_checkpoint: bool,
+    ) -> Result<usize, Self::Error>;
 
     /// Save a log
     async fn save(&self, version: ManifestVersion, bytes: &[u8]) -> Result<(), Self::Error>;
 
-    /// Delete logs in [start, end)
+    /// Delete logs in [start, end) and ignore checkpoints.
     async fn delete(&self, start: ManifestVersion, end: ManifestVersion)
         -> Result<(), Self::Error>;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
The checkpoint GC task also deletes the file with the last version. To avoid the last checkpoint file being deleted, we add a `keep_last_checkpoint` option to `delete_until`

This PR also adjusts the level of the log when do_checkpoint() is unable to delete manifest files as it is an expected behavior.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- fixes #1490 