### PR TITLE
fix: add s3 region info

### DIFF
--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -114,6 +114,7 @@ async fn test_s3_backend() -> Result<()> {
                 .root(&root)
                 .access_key_id(&env::var("GT_S3_ACCESS_KEY_ID")?)
                 .secret_access_key(&env::var("GT_S3_ACCESS_KEY")?)
+                .region(&env::var("GT_S3_REGION")?)
                 .bucket(&bucket);
 
             let store = ObjectStore::new(builder).unwrap().finish();

--- a/tests-integration/README.md
+++ b/tests-integration/README.md
@@ -7,6 +7,7 @@ Take `s3` for example. You need to set your S3 bucket, access key id and secret 
 ```sh
 # Settings for s3 test
 GT_S3_BUCKET=S3 bucket
+GT_S3_REGION=S3 region
 GT_S3_ACCESS_KEY_ID=S3 access key id
 GT_S3_ACCESS_KEY=S3 secret access key
 ```

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -98,6 +98,7 @@ fn s3_test_config() -> S3Config {
         access_key_id: env::var("GT_S3_ACCESS_KEY_ID").unwrap(),
         secret_access_key: env::var("GT_S3_ACCESS_KEY").unwrap(),
         bucket: env::var("GT_S3_BUCKET").unwrap(),
+        region: Some(env::var("GT_S3_REGION").unwrap()),
         ..Default::default()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add region info

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
