### PR TITLE
fix: disable dashboard

### DIFF
--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -35,7 +35,7 @@ partition = { path = "../partition" }
 query = { path = "../query" }
 rustyline = "10.1"
 serde.workspace = true
-servers = { path = "../servers", features = ["dashboard"] }
+servers = { path = "../servers" }
 
 session = { path = "../session" }
 snafu.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Disable default dashboard feature

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
