### PR TITLE
feat: add metrics for protocol interfaces

### DIFF
--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use api::v1::auth_header::AuthScheme;
 use api::v1::{Basic, GreptimeRequest, RequestHeader};
+use common_error::prelude::ErrorExt;
 use common_query::Output;
 use common_runtime::Runtime;
 use common_telemetry::timer;
@@ -119,7 +120,13 @@ impl GreptimeRequestHandler {
             }),
         }
         .map_err(|e| {
-            increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
+            increment_counter!(
+                crate::metrics::METRIC_AUTH_FAILURE,
+                &[(
+                    crate::metrics::METRIC_CODE_LABEL,
+                    format!("{}", e.status_code())
+                )]
+            );
             Status::unauthenticated(e.to_string())
         })?;
         Ok(())

--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -18,6 +18,8 @@ use api::v1::auth_header::AuthScheme;
 use api::v1::{Basic, GreptimeRequest, RequestHeader};
 use common_query::Output;
 use common_runtime::Runtime;
+use common_telemetry::timer;
+use metrics::increment_counter;
 use session::context::{QueryContext, QueryContextRef};
 use snafu::OptionExt;
 use tonic::Status;
@@ -57,6 +59,10 @@ impl GreptimeRequestHandler {
 
         self.auth(header, &query_ctx).await?;
 
+        let _timer = timer!(
+            crate::metrics::METRIC_SERVER_GRPC_DB_REQUEST_TIMER,
+            &[(crate::metrics::METRIC_DB_LABEL, &query_ctx.get_db_string())]
+        );
         let handler = self.handler.clone();
 
         // Executes requests in another runtime to
@@ -112,7 +118,10 @@ impl GreptimeRequestHandler {
                 name: "Token AuthScheme".to_string(),
             }),
         }
-        .map_err(|e| Status::unauthenticated(e.to_string()))?;
+        .map_err(|e| {
+            increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
+            Status::unauthenticated(e.to_string())
+        })?;
         Ok(())
     }
 }

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -63,7 +63,13 @@ impl PrometheusGateway for PrometheusGatewayService {
         };
 
         let query_context = create_query_context(inner.header.as_ref());
-        let _timer = timer!(crate::metrics::METRIC_SERVER_GRPC_PROM_REQUEST_TIMER);
+        let _timer = timer!(
+            crate::metrics::METRIC_SERVER_GRPC_PROM_REQUEST_TIMER,
+            &[(
+                crate::metrics::METRIC_DB_LABEL,
+                &query_context.get_db_string()
+            )]
+        );
         let result = self.handler.do_query(&prom_query, query_context).await;
         let (metric_name, result_type) =
             retrieve_metric_name_and_result_type(&prom_query.query).unwrap_or_default();

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -19,6 +19,7 @@ use api::v1::prometheus_gateway_server::PrometheusGateway;
 use api::v1::promql_request::Promql;
 use api::v1::{PromqlRequest, PromqlResponse, ResponseHeader};
 use async_trait::async_trait;
+use common_telemetry::timer;
 use common_time::util::current_time_rfc3339;
 use query::parser::PromQuery;
 use snafu::OptionExt;
@@ -62,6 +63,7 @@ impl PrometheusGateway for PrometheusGatewayService {
         };
 
         let query_context = create_query_context(inner.header.as_ref());
+        let _timer = timer!(crate::metrics::METRIC_SERVER_GRPC_PROM_REQUEST_TIMER);
         let result = self.handler.do_query(&prom_query, query_context).await;
         let (metric_name, result_type) =
             retrieve_metric_name_and_result_type(&prom_query.query).unwrap_or_default();

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -16,6 +16,7 @@ use std::marker::PhantomData;
 
 use axum::http::{self, Request, StatusCode};
 use axum::response::Response;
+use common_error::prelude::ErrorExt;
 use common_telemetry::warn;
 use futures::future::BoxFuture;
 use http_body::Body;
@@ -82,7 +83,13 @@ where
                 Ok((username, password)) => (username, password),
                 Err(e) => {
                     warn!("extract username and password failed: {}", e);
-                    increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
+                    increment_counter!(
+                        crate::metrics::METRIC_AUTH_FAILURE,
+                        &[(
+                            crate::metrics::METRIC_CODE_LABEL,
+                            format!("{}", e.status_code())
+                        )]
+                    );
                     return Err(unauthorized_resp());
                 }
             };
@@ -91,7 +98,13 @@ where
                 Ok((catalog, schema)) => (catalog, schema),
                 Err(e) => {
                     warn!("extract catalog and schema failed: {}", e);
-                    increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
+                    increment_counter!(
+                        crate::metrics::METRIC_AUTH_FAILURE,
+                        &[(
+                            crate::metrics::METRIC_CODE_LABEL,
+                            format!("{}", e.status_code())
+                        )]
+                    );
                     return Err(unauthorized_resp());
                 }
             };
@@ -111,7 +124,13 @@ where
                 }
                 Err(e) => {
                     warn!("authenticate failed: {}", e);
-                    increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
+                    increment_counter!(
+                        crate::metrics::METRIC_AUTH_FAILURE,
+                        &[(
+                            crate::metrics::METRIC_CODE_LABEL,
+                            format!("{}", e.status_code())
+                        )]
+                    );
                     Err(unauthorized_resp())
                 }
             }

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -20,6 +20,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_grpc::writer::Precision;
+use common_telemetry::timer;
 use session::context::QueryContext;
 
 use crate::error::{Result, TimePrecisionSnafu};
@@ -45,6 +46,7 @@ pub async fn influxdb_write(
     Query(mut params): Query<HashMap<String, String>>,
     lines: String,
 ) -> Result<impl IntoResponse> {
+    let _timer = timer!(crate::metrics::METRIC_HTTP_INFLUXDB_WRITE_ELAPSED);
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -46,10 +46,13 @@ pub async fn influxdb_write(
     Query(mut params): Query<HashMap<String, String>>,
     lines: String,
 ) -> Result<impl IntoResponse> {
-    let _timer = timer!(crate::metrics::METRIC_HTTP_INFLUXDB_WRITE_ELAPSED);
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
+    let _timer = timer!(
+        crate::metrics::METRIC_HTTP_INFLUXDB_WRITE_ELAPSED,
+        &[(crate::metrics::METRIC_DB_LABEL, &db)]
+    );
     let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
     let ctx = Arc::new(QueryContext::with(catalog, schema));
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -19,6 +19,7 @@ use axum::extract::{Query, RawBody, State};
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use common_telemetry::timer;
 use hyper::Body;
 use prost::Message;
 use schemars::JsonSchema;
@@ -50,6 +51,7 @@ pub async fn remote_write(
     Query(params): Query<DatabaseQuery>,
     RawBody(body): RawBody,
 ) -> Result<(StatusCode, ())> {
+    let _timer = timer!(crate::metrics::METRIC_HTTP_PROMETHEUS_WRITE_ELAPSED);
     let request = decode_remote_write_request(body).await?;
 
     let ctx = if let Some(db) = params.db {
@@ -83,6 +85,7 @@ pub async fn remote_read(
     Query(params): Query<DatabaseQuery>,
     RawBody(body): RawBody,
 ) -> Result<PrometheusResponse> {
+    let _timer = timer!(crate::metrics::METRIC_HTTP_PROMETHEUS_READ_ELAPSED);
     let request = decode_remote_read_request(body).await?;
 
     let ctx = if let Some(db) = params.db {

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -51,9 +51,15 @@ pub async fn remote_write(
     Query(params): Query<DatabaseQuery>,
     RawBody(body): RawBody,
 ) -> Result<(StatusCode, ())> {
-    let _timer = timer!(crate::metrics::METRIC_HTTP_PROMETHEUS_WRITE_ELAPSED);
     let request = decode_remote_write_request(body).await?;
 
+    let _timer = timer!(
+        crate::metrics::METRIC_HTTP_PROMETHEUS_WRITE_ELAPSED,
+        &[(
+            crate::metrics::METRIC_DB_LABEL,
+            params.db.as_deref().unwrap_or("")
+        )]
+    );
     let ctx = if let Some(db) = params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
         Arc::new(QueryContext::with(catalog, schema))
@@ -85,9 +91,15 @@ pub async fn remote_read(
     Query(params): Query<DatabaseQuery>,
     RawBody(body): RawBody,
 ) -> Result<PrometheusResponse> {
-    let _timer = timer!(crate::metrics::METRIC_HTTP_PROMETHEUS_READ_ELAPSED);
     let request = decode_remote_read_request(body).await?;
 
+    let _timer = timer!(
+        crate::metrics::METRIC_HTTP_PROMETHEUS_READ_ELAPSED,
+        &[(
+            crate::metrics::METRIC_DB_LABEL,
+            params.db.as_deref().unwrap_or("")
+        )]
+    );
     let ctx = if let Some(db) = params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
         Arc::new(QueryContext::with(catalog, schema))

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -14,3 +14,23 @@
 
 pub(crate) const METRIC_HTTP_SQL_ELAPSED: &str = "servers.http_sql_elapsed";
 pub(crate) const METRIC_HTTP_PROMQL_ELAPSED: &str = "servers.http_promql_elapsed";
+pub(crate) const METRIC_AUTH_FAILURE: &str = "servers.auth_failure_count";
+pub(crate) const METRIC_HTTP_INFLUXDB_WRITE_ELAPSED: &str = "servers.http_influxdb_write_elapsed";
+pub(crate) const METRIC_HTTP_PROMETHEUS_WRITE_ELAPSED: &str =
+    "servers.http_prometheus_write_elapsed";
+pub(crate) const METRIC_HTTP_PROMETHEUS_READ_ELAPSED: &str = "servers.http_prometheus_read_elapsed";
+pub(crate) const METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED: &str =
+    "servers.opentsdb_line_write_elapsed";
+
+pub(crate) const METRIC_MYSQL_CONNECTIONS: &str = "servers.mysql_connection_count";
+pub(crate) const METRIC_MYSQL_QUERY_TIMER: &str = "servers.mysql_query";
+pub(crate) const METRIC_MYSQL_SUBPROTOCOL_LABEL: &str = "subprotocol";
+pub(crate) const METRIC_MYSQL_BINQUERY: &str = "binquery";
+pub(crate) const METRIC_MYSQL_TEXTQUERY: &str = "textquery";
+pub(crate) const METRIC_MYSQL_PREPARED_COUNT: &str = "servers.mysql_prepared_count";
+
+// pub(crate) const METRIC_POSTGRES_CONNECTIONS: &str = "servers.postgres_connection_count";
+// pub(crate) const METRIC_POSTGRES_QUERY_TIMER: &str = "servers.postgres_query";
+// pub(crate) const METRIC_POSTGRES_SUBPROTOCOL_LABEL: &str = "subprotocol";
+// pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
+// pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -31,8 +31,9 @@ pub(crate) const METRIC_MYSQL_BINQUERY: &str = "binquery";
 pub(crate) const METRIC_MYSQL_TEXTQUERY: &str = "textquery";
 pub(crate) const METRIC_MYSQL_PREPARED_COUNT: &str = "servers.mysql_prepared_count";
 
-// pub(crate) const METRIC_POSTGRES_CONNECTIONS: &str = "servers.postgres_connection_count";
-// pub(crate) const METRIC_POSTGRES_QUERY_TIMER: &str = "servers.postgres_query";
-// pub(crate) const METRIC_POSTGRES_SUBPROTOCOL_LABEL: &str = "subprotocol";
-// pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
-// pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";
+pub(crate) const METRIC_POSTGRES_CONNECTIONS: &str = "servers.postgres_connection_count";
+pub(crate) const METRIC_POSTGRES_QUERY_TIMER: &str = "servers.postgres_query";
+pub(crate) const METRIC_POSTGRES_SUBPROTOCOL_LABEL: &str = "subprotocol";
+pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
+pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";
+pub(crate) const METRIC_POSTGRES_PREPARED_COUNT: &str = "servers.postgres_prepared_count";

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -25,18 +25,18 @@ pub(crate) const METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED: &str =
     "servers.opentsdb_line_write_elapsed";
 
 pub(crate) const METRIC_MYSQL_CONNECTIONS: &str = "servers.mysql_connection_count";
-pub(crate) const METRIC_MYSQL_QUERY_TIMER: &str = "servers.mysql_query";
+pub(crate) const METRIC_MYSQL_QUERY_TIMER: &str = "servers.mysql_query_elapsed";
 pub(crate) const METRIC_MYSQL_SUBPROTOCOL_LABEL: &str = "subprotocol";
 pub(crate) const METRIC_MYSQL_BINQUERY: &str = "binquery";
 pub(crate) const METRIC_MYSQL_TEXTQUERY: &str = "textquery";
 pub(crate) const METRIC_MYSQL_PREPARED_COUNT: &str = "servers.mysql_prepared_count";
 
 pub(crate) const METRIC_POSTGRES_CONNECTIONS: &str = "servers.postgres_connection_count";
-pub(crate) const METRIC_POSTGRES_QUERY_TIMER: &str = "servers.postgres_query";
+pub(crate) const METRIC_POSTGRES_QUERY_TIMER: &str = "servers.postgres_query_elapsed";
 pub(crate) const METRIC_POSTGRES_SUBPROTOCOL_LABEL: &str = "subprotocol";
 pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
 pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";
 pub(crate) const METRIC_POSTGRES_PREPARED_COUNT: &str = "servers.postgres_prepared_count";
 
-pub(crate) const METRIC_SERVER_GRPC_DB_REQUEST_TIMER: &str = "servers.grpc.db_request_timer";
-pub(crate) const METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: &str = "servers.grpc.prom_request_timer";
+pub(crate) const METRIC_SERVER_GRPC_DB_REQUEST_TIMER: &str = "servers.grpc.db_request_elapsed";
+pub(crate) const METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: &str = "servers.grpc.prom_request_elapsed";

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub(crate) const METRIC_DB_LABEL: &str = "db";
+pub(crate) const METRIC_CODE_LABEL: &str = "code";
 
 pub(crate) const METRIC_HTTP_SQL_ELAPSED: &str = "servers.http_sql_elapsed";
 pub(crate) const METRIC_HTTP_PROMQL_ELAPSED: &str = "servers.http_promql_elapsed";

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -37,3 +37,6 @@ pub(crate) const METRIC_POSTGRES_SUBPROTOCOL_LABEL: &str = "subprotocol";
 pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
 pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";
 pub(crate) const METRIC_POSTGRES_PREPARED_COUNT: &str = "servers.postgres_prepared_count";
+
+pub(crate) const METRIC_SERVER_GRPC_DB_REQUEST_TIMER: &str = "servers.grpc.db_request_timer";
+pub(crate) const METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: &str = "servers.grpc.prom_request_timer";

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) const METRIC_DB_LABEL: &str = "db";
+
 pub(crate) const METRIC_HTTP_SQL_ELAPSED: &str = "servers.http_sql_elapsed";
 pub(crate) const METRIC_HTTP_PROMQL_ELAPSED: &str = "servers.http_promql_elapsed";
 pub(crate) const METRIC_AUTH_FAILURE: &str = "servers.auth_failure_count";

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -277,6 +277,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
 
         if let Some(schema_validator) = &self.user_provider {
             if let Err(e) = schema_validator.authorize(catalog, schema, user_info).await {
+                increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
                 return w
                     .error(
                         ErrorKind::ER_DBACCESS_DENIED_ERROR,

--- a/src/servers/src/opentsdb/handler.rs
+++ b/src/servers/src/opentsdb/handler.rs
@@ -14,6 +14,7 @@
 
 //! Modified from Tokio's mini-redis example.
 
+use common_telemetry::timer;
 use session::context::QueryContext;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -91,6 +92,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin> Handler<S> {
 
             match DataPoint::try_create(&line) {
                 Ok(data_point) => {
+                    let _timer = timer!(crate::metrics::METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED);
                     let result = self.query_handler.exec(&data_point, ctx.clone()).await;
                     if let Err(e) = result {
                         self.connection.write_line(e.to_string()).await?;

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -16,6 +16,7 @@ use std::fmt::Debug;
 
 use async_trait::async_trait;
 use futures::{Sink, SinkExt};
+use metrics::increment_counter;
 use pgwire::api::auth::StartupHandler;
 use pgwire::api::{auth, ClientInfo, PgWireConnectionState};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
@@ -173,6 +174,7 @@ impl StartupHandler for PostgresServerHandler {
                 // do authenticate
                 let auth_result = self.login_verifier.auth(&login_info, pwd.password()).await;
                 if !matches!(auth_result, Ok(true)) {
+                    increment_counter!(crate::metrics::METRIC_AUTH_FAILURE);
                     return send_error(
                         client,
                         "FATAL",

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -92,6 +92,12 @@ impl QueryContext {
             )
         }
     }
+
+    pub fn get_db_string(&self) -> String {
+        let catalog = self.current_catalog();
+        let schema = self.current_schema();
+        format!("{catalog}-{schema}")
+    }
 }
 
 pub const DEFAULT_USERNAME: &str = "greptime";
@@ -148,6 +154,7 @@ pub enum Channel {
 
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::context::{Channel, UserInfo};
     use crate::Session;
 
@@ -166,5 +173,15 @@ mod test {
             "127.0.0.1"
         );
         assert_eq!(session.conn_info().client_host.port(), 9000);
+    }
+
+    #[test]
+    fn test_context_db_string() {
+        let context = QueryContext::new();
+
+        context.set_current_catalog("a0b1c2d3");
+        context.set_current_schema("test");
+
+        assert_eq!("a0b1c2d3-test", context.get_db_string());
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -96,7 +96,11 @@ impl QueryContext {
     pub fn get_db_string(&self) -> String {
         let catalog = self.current_catalog();
         let schema = self.current_schema();
-        format!("{catalog}-{schema}")
+        if catalog == DEFAULT_CATALOG_NAME {
+            schema
+        } else {
+            format!("{catalog}-{schema}")
+        }
     }
 }
 
@@ -183,5 +187,10 @@ mod test {
         context.set_current_schema("test");
 
         assert_eq!("a0b1c2d3-test", context.get_db_string());
+
+        context.set_current_catalog(DEFAULT_CATALOG_NAME);
+        context.set_current_schema("test");
+
+        assert_eq!("test", context.get_db_string());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds metrics for various protocol interfaces including;

- prometheus remote read/writes
- influxdb writes
- opentsdb writes
- mysql/postgres
  - connections
  - queries
  - prepared statements
- grpc
  - database/flight requests
  - prom requests
- authentication failures

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
