### PR TITLE
fix: insert distributed table if partition column has default value

### DIFF
--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -85,7 +85,7 @@ impl Table for DistTable {
 
         let splits = self
             .partition_manager
-            .split_insert_request(&self.table_name, request)
+            .split_insert_request(&self.table_name, request, &self.schema())
             .await
             .map_err(BoxedError::new)
             .context(TableOperationSnafu)?;

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -68,6 +68,20 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Failed to read column {}, could not create default value, source: {}",
+        column,
+        source
+    ))]
+    CreateDefaultToRead {
+        column: String,
+        #[snafu(backtrace)]
+        source: datatypes::error::Error,
+    },
+
+    #[snafu(display("The column '{}' does not have a default value.", column))]
+    MissingDefaultValue { column: String },
+
     #[snafu(display("Expect {} region keys, actual {}", expect, actual))]
     RegionKeysSize {
         expect: usize,
@@ -136,6 +150,8 @@ impl ErrorExt for Error {
             Error::InvalidTableRouteData { .. } => StatusCode::Internal,
             Error::ConvertScalarValue { .. } => StatusCode::Internal,
             Error::FindDatanode { .. } => StatusCode::InvalidArguments,
+            Error::CreateDefaultToRead { .. } => StatusCode::Internal,
+            Error::MissingDefaultValue { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use common_query::prelude::Expr;
 use datafusion_expr::{BinaryExpr, Expr as DfExpr, Operator};
 use datatypes::prelude::Value;
+use datatypes::schema::Schema;
 use meta_client::rpc::{Peer, TableName, TableRoute};
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::storage::{RegionId, RegionNumber};
@@ -226,10 +227,11 @@ impl PartitionRuleManager {
         &self,
         table: &TableName,
         req: InsertRequest,
+        schema: &Schema,
     ) -> Result<InsertRequestSplit> {
         let partition_rule = self.find_table_partition_rule(table).await.unwrap();
         let splitter = WriteSplitter::with_partition_rule(partition_rule);
-        splitter.split_insert(req)
+        splitter.split_insert(req, schema)
     }
 }
 

--- a/tests/cases/standalone/common/basic.result
+++ b/tests/cases/standalone/common/basic.result
@@ -58,3 +58,25 @@ DROP TABLE system_metrics;
 
 Affected Rows: 1
 
+create table foo (
+    host string,
+    ts timestamp DEFAULT CURRENT_TIMESTAMP,
+    cpu double default 0,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+) engine=mito with(regions=1);
+
+Affected Rows: 0
+
+insert into foo (host, cpu, ts) values ('host1', 1.1, 1000);
+
+Affected Rows: 1
+
+insert into foo (host, cpu) values ('host2', 2.2);
+
+Affected Rows: 1
+
+DROP TABLE foo;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/basic.sql
+++ b/tests/cases/standalone/common/basic.sql
@@ -24,3 +24,17 @@ SELECT avg(cpu_util) FROM system_metrics;
 SELECT idc, avg(memory_util) FROM system_metrics GROUP BY idc ORDER BY idc;
 
 DROP TABLE system_metrics;
+
+create table foo (
+    host string,
+    ts timestamp DEFAULT CURRENT_TIMESTAMP,
+    cpu double default 0,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+) engine=mito with(regions=1);
+
+insert into foo (host, cpu, ts) values ('host1', 1.1, 1000);
+
+insert into foo (host, cpu) values ('host2', 2.2);
+
+DROP TABLE foo;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

This PR allows `greptime` to insert data into a distributed table without explicitly setting the partition column value if it has a default value.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#1293
