### PR TITLE
feat: add catalog/schema/table count as catalog metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,7 @@ dependencies = [
  "lazy_static",
  "log-store",
  "meta-client",
+ "metrics",
  "mito",
  "object-store",
  "parking_lot",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -27,6 +27,7 @@ futures-util.workspace = true
 key-lock = "0.1"
 lazy_static = "1.4"
 meta-client = { path = "../meta-client" }
+metrics.workspace = true
 parking_lot = "0.12"
 regex = "1.6"
 serde = "1.0"

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -33,6 +33,7 @@ pub mod error;
 pub mod helper;
 pub(crate) mod information_schema;
 pub mod local;
+mod metrics;
 pub mod remote;
 pub mod schema;
 pub mod system;

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -26,6 +26,7 @@ use common_telemetry::{error, info};
 use datatypes::prelude::ScalarVector;
 use datatypes::vectors::{BinaryVector, UInt8Vector};
 use futures_util::lock::Mutex;
+use metrics::increment_gauge;
 use snafu::{ensure, OptionExt, ResultExt};
 use table::engine::manager::TableEngineManagerRef;
 use table::engine::EngineContext;
@@ -370,6 +371,7 @@ impl CatalogManager for LocalCatalogManager {
                 schema
                     .register_table(request.table_name, request.table)
                     .await?;
+                increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
                 Ok(true)
             }
         }
@@ -499,6 +501,7 @@ impl CatalogManager for LocalCatalogManager {
             catalog
                 .register_schema(request.schema, Arc::new(MemorySchemaProvider::new()))
                 .await?;
+
             Ok(true)
         }
     }
@@ -513,7 +516,7 @@ impl CatalogManager for LocalCatalogManager {
 
         let mut sys_table_requests = self.system_table_requests.lock().await;
         sys_table_requests.push(request);
-
+        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
         Ok(())
     }
 

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -20,7 +20,7 @@ use common_catalog::consts::{
     DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME, MIN_USER_TABLE_ID,
     MITO_ENGINE, SYSTEM_CATALOG_NAME, SYSTEM_CATALOG_TABLE_NAME,
 };
-use common_catalog::{build_db_string, format_full_table_name};
+use common_catalog::format_full_table_name;
 use common_recordbatch::{RecordBatch, SendableRecordBatchStream};
 use common_telemetry::{error, info};
 use datatypes::prelude::ScalarVector;
@@ -374,10 +374,7 @@ impl CatalogManager for LocalCatalogManager {
                 increment_gauge!(
                     crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
                     1.0,
-                    &[(
-                        crate::metrics::METRIC_DB_LABEL,
-                        build_db_string(catalog_name, schema_name)
-                    )],
+                    &[crate::metrics::db_label(catalog_name, schema_name)],
                 );
                 Ok(true)
             }
@@ -529,10 +526,7 @@ impl CatalogManager for LocalCatalogManager {
         increment_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(&catalog_name, &schema_name)
-            )],
+            &[crate::metrics::db_label(&catalog_name, &schema_name)],
         );
         Ok(())
     }

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, RwLock};
 use async_trait::async_trait;
 use common_catalog::consts::MIN_USER_TABLE_ID;
 use common_telemetry::error;
+use metrics::{decrement_gauge, increment_gauge};
 use snafu::{ensure, OptionExt};
 use table::metadata::TableId;
 use table::table::TableIdProvider;
@@ -86,6 +87,7 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog: &request.catalog,
                 schema: &request.schema,
             })?;
+        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
         schema
             .register_table(request.table_name, request.table)
             .await
@@ -124,6 +126,7 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog: &request.catalog,
                 schema: &request.schema,
             })?;
+        decrement_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
         schema
             .deregister_table(&request.table_name)
             .await
@@ -139,6 +142,7 @@ impl CatalogManager for MemoryCatalogManager {
         catalog
             .register_schema(request.schema, Arc::new(MemorySchemaProvider::new()))
             .await?;
+        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_SCHEMA_COUNT, 1.0);
         Ok(true)
     }
 
@@ -180,6 +184,7 @@ impl CatalogManager for MemoryCatalogManager {
         name: String,
         catalog: CatalogProviderRef,
     ) -> Result<Option<CatalogProviderRef>> {
+        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_CATALOG_COUNT, 1.0);
         self.register_catalog_sync(name, catalog)
     }
 
@@ -255,6 +260,7 @@ impl MemoryCatalogProvider {
             !schemas.contains_key(&name),
             error::SchemaExistsSnafu { schema: &name }
         );
+        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_SCHEMA_COUNT, 1.0);
         Ok(schemas.insert(name, schema))
     }
 

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
-use common_catalog::build_db_string;
 use common_catalog::consts::MIN_USER_TABLE_ID;
 use common_telemetry::error;
 use metrics::{decrement_gauge, increment_gauge};
@@ -91,10 +90,7 @@ impl CatalogManager for MemoryCatalogManager {
         increment_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(&request.catalog, &request.schema)
-            )],
+            &[crate::metrics::db_label(&request.catalog, &request.schema)],
         );
         schema
             .register_table(request.table_name, request.table)
@@ -137,10 +133,7 @@ impl CatalogManager for MemoryCatalogManager {
         decrement_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(&request.catalog, &request.schema)
-            )],
+            &[crate::metrics::db_label(&request.catalog, &request.schema)],
         );
         schema
             .deregister_table(&request.table_name)

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use common_catalog::build_db_string;
 use common_catalog::consts::MIN_USER_TABLE_ID;
 use common_telemetry::error;
 use metrics::{decrement_gauge, increment_gauge};
@@ -87,7 +88,14 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog: &request.catalog,
                 schema: &request.schema,
             })?;
-        increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
+        increment_gauge!(
+            crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
+            1.0,
+            &[(
+                crate::metrics::METRIC_DB_LABEL,
+                build_db_string(&request.catalog, &request.schema)
+            )],
+        );
         schema
             .register_table(request.table_name, request.table)
             .await
@@ -126,7 +134,14 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog: &request.catalog,
                 schema: &request.schema,
             })?;
-        decrement_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT, 1.0);
+        decrement_gauge!(
+            crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
+            1.0,
+            &[(
+                crate::metrics::METRIC_DB_LABEL,
+                build_db_string(&request.catalog, &request.schema)
+            )],
+        );
         schema
             .deregister_table(&request.table_name)
             .await

--- a/src/catalog/src/metrics.rs
+++ b/src/catalog/src/metrics.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) const METRIC_CATALOG_MANAGER_CATALOG_COUNT: &str = "catalog.catalog_count";
+pub(crate) const METRIC_CATALOG_MANAGER_SCHEMA_COUNT: &str = "catalog.schema_count";
+pub(crate) const METRIC_CATALOG_MANAGER_TABLE_COUNT: &str = "catalog.table_count";

--- a/src/catalog/src/metrics.rs
+++ b/src/catalog/src/metrics.rs
@@ -12,8 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_catalog::build_db_string;
+
 pub(crate) const METRIC_DB_LABEL: &str = "db";
 
 pub(crate) const METRIC_CATALOG_MANAGER_CATALOG_COUNT: &str = "catalog.catalog_count";
 pub(crate) const METRIC_CATALOG_MANAGER_SCHEMA_COUNT: &str = "catalog.schema_count";
 pub(crate) const METRIC_CATALOG_MANAGER_TABLE_COUNT: &str = "catalog.table_count";
+
+#[inline]
+pub(crate) fn db_label(catalog: &str, schema: &str) -> (&'static str, String) {
+    (METRIC_DB_LABEL, build_db_string(catalog, schema))
+}

--- a/src/catalog/src/metrics.rs
+++ b/src/catalog/src/metrics.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) const METRIC_DB_LABEL: &str = "db";
+
 pub(crate) const METRIC_CATALOG_MANAGER_CATALOG_COUNT: &str = "catalog.catalog_count";
 pub(crate) const METRIC_CATALOG_MANAGER_SCHEMA_COUNT: &str = "catalog.schema_count";
 pub(crate) const METRIC_CATALOG_MANAGER_TABLE_COUNT: &str = "catalog.table_count";

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use async_stream::stream;
 use async_trait::async_trait;
-use common_catalog::build_db_string;
 use common_catalog::consts::{MAX_SYS_TABLE_ID, MITO_ENGINE};
 use common_telemetry::{debug, error, info, warn};
 use dashmap::DashMap;
@@ -234,10 +233,7 @@ impl RemoteCatalogManager {
             increment_gauge!(
                 crate::metrics::METRIC_CATALOG_MANAGER_SCHEMA_COUNT,
                 1.0,
-                &[(
-                    crate::metrics::METRIC_DB_LABEL,
-                    build_db_string(&catalog_name, &schema_name)
-                )],
+                &[crate::metrics::db_label(&catalog_name, &schema_name)],
             );
             self.initiate_tables(&catalog_name, &schema_name, schema, max_table_id)
                 .await?;
@@ -283,10 +279,7 @@ impl RemoteCatalogManager {
         increment_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(catalog_name, schema_name)
-            )],
+            &[crate::metrics::db_label(catalog_name, schema_name)],
         );
         info!(
             "initialized tables in {}.{}, total: {}",
@@ -476,10 +469,7 @@ impl CatalogManager for RemoteCatalogManager {
         increment_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(&catalog_name, &schema_name)
-            )],
+            &[crate::metrics::db_label(&catalog_name, &schema_name)],
         );
         schema_provider
             .register_table(request.table_name, request.table)
@@ -503,10 +493,7 @@ impl CatalogManager for RemoteCatalogManager {
         decrement_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(catalog_name, schema_name)
-            )],
+            &[crate::metrics::db_label(catalog_name, schema_name)],
         );
         Ok(result.is_none())
     }
@@ -563,10 +550,7 @@ impl CatalogManager for RemoteCatalogManager {
         increment_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
             1.0,
-            &[(
-                crate::metrics::METRIC_DB_LABEL,
-                build_db_string(&catalog_name, &schema_name)
-            )],
+            &[crate::metrics::db_label(&catalog_name, &schema_name)],
         );
         Ok(())
     }

--- a/src/common/catalog/src/lib.rs
+++ b/src/common/catalog/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use consts::DEFAULT_CATALOG_NAME;
+
 pub mod consts;
 pub mod error;
 
@@ -19,4 +21,24 @@ pub mod error;
 #[inline]
 pub fn format_full_table_name(catalog: &str, schema: &str, table: &str) -> String {
     format!("{catalog}.{schema}.{table}")
+}
+
+/// Build db name from catalog and schema string
+pub fn build_db_string(catalog: &str, schema: &str) -> String {
+    if catalog == DEFAULT_CATALOG_NAME {
+        schema.to_string()
+    } else {
+        format!("{catalog}-{schema}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_db_string() {
+        assert_eq!("test", build_db_string(DEFAULT_CATALOG_NAME, "test"));
+        assert_eq!("a0b1c2d3-test", build_db_string("a0b1c2d3", "test"));
+    }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -17,6 +17,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use arc_swap::ArcSwap;
+use common_catalog::build_db_string;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_telemetry::debug;
 
@@ -96,11 +97,7 @@ impl QueryContext {
     pub fn get_db_string(&self) -> String {
         let catalog = self.current_catalog();
         let schema = self.current_schema();
-        if catalog == DEFAULT_CATALOG_NAME {
-            schema
-        } else {
-            format!("{catalog}-{schema}")
-        }
+        build_db_string(&catalog, &schema)
     }
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -56,6 +56,7 @@ macro_rules! http_tests {
                 test_prometheus_promql_api,
                 test_prom_http_api,
                 test_metrics_api,
+                test_catalog_metrics,
                 test_scripts_api,
                 test_health_api,
                 test_dashboard_path,
@@ -334,6 +335,50 @@ pub async fn test_metrics_api(store_type: StorageType) {
     assert_eq!(res.status(), StatusCode::OK);
     let body = res.text().await;
     assert!(body.contains("frontend_handle_sql_elapsed"));
+    guard.remove_all().await;
+}
+
+pub async fn test_catalog_metrics(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    common_telemetry::init_default_metrics_recorder();
+    let (app, mut guard) = setup_test_http_app(store_type, "metrics_api").await;
+    let client = TestClient::new(app);
+
+    // Call metrics api
+    let body = client.get("/metrics").send().await.text().await;
+    assert!(body.contains("catalog_schema_count 3"));
+    assert!(body.contains("catalog_table_count 2"));
+
+    // create new schema
+    let res = client.get("/v1/sql?sql=create database tommy").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Call metrics api
+    let body = client.get("/metrics").send().await.text().await;
+    assert!(body.contains("catalog_schema_count 4"));
+    assert!(body.contains("catalog_table_count 2"));
+
+    // create new schema
+    let res = client
+        .get("/v1/sql?sql=create table ints (i BIGINT, ii TIMESTAMP TIME INDEX)")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Call metrics api
+    let body = client.get("/metrics").send().await.text().await;
+    assert!(body.contains("catalog_schema_count 4"));
+    assert!(body.contains("catalog_table_count 3"));
+
+    // create new schema
+    let res = client.get("/v1/sql?sql=drop table ints").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // Call metrics api
+    let body = client.get("/metrics").send().await.text().await;
+    assert!(body.contains("catalog_schema_count 4"));
+    assert!(body.contains("catalog_table_count 2"));
+
     guard.remove_all().await;
 }
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -341,13 +341,14 @@ pub async fn test_metrics_api(store_type: StorageType) {
 pub async fn test_catalog_metrics(store_type: StorageType) {
     common_telemetry::init_default_ut_logging();
     common_telemetry::init_default_metrics_recorder();
+
     let (app, mut guard) = setup_test_http_app(store_type, "metrics_api").await;
     let client = TestClient::new(app);
 
     // Call metrics api
     let body = client.get("/metrics").send().await.text().await;
     assert!(body.contains("catalog_schema_count 3"));
-    assert!(body.contains("catalog_table_count 2"));
+    assert!(body.contains("catalog_table_count{db=\"public\"}"));
 
     // create new schema
     let res = client.get("/v1/sql?sql=create database tommy").send().await;
@@ -356,7 +357,7 @@ pub async fn test_catalog_metrics(store_type: StorageType) {
     // Call metrics api
     let body = client.get("/metrics").send().await.text().await;
     assert!(body.contains("catalog_schema_count 4"));
-    assert!(body.contains("catalog_table_count 2"));
+    assert!(body.contains("catalog_table_count{db=\"public\"}"));
 
     // create new schema
     let res = client
@@ -368,7 +369,7 @@ pub async fn test_catalog_metrics(store_type: StorageType) {
     // Call metrics api
     let body = client.get("/metrics").send().await.text().await;
     assert!(body.contains("catalog_schema_count 4"));
-    assert!(body.contains("catalog_table_count 3"));
+    assert!(body.contains("catalog_table_count{db=\"public\"}"));
 
     // create new schema
     let res = client.get("/v1/sql?sql=drop table ints").send().await;
@@ -377,7 +378,7 @@ pub async fn test_catalog_metrics(store_type: StorageType) {
     // Call metrics api
     let body = client.get("/metrics").send().await.text().await;
     assert!(body.contains("catalog_schema_count 4"));
-    assert!(body.contains("catalog_table_count 2"));
+    assert!(body.contains("catalog_table_count{db=\"public\"}"));
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds catalog/schema/table count as metrics.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
