### PR TITLE
feat: update pgwire to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5824,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da58f2d096a2b20ee96420524c6156425575b64409a25acdf638bff450cf53a"
+checksum = "bd66851a4b1d6631371c931810e453b0319eb260bbd5853ebe98e37b15105b80"
 dependencies = [
  "async-trait",
  "base64 0.21.0",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = "1.16"
 openmetrics-parser = "0.4"
 opensrv-mysql = "0.4"
 parking_lot = "0.12"
-pgwire = "0.13"
+pgwire = "0.14"
 pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }
 promql-parser = "0.1.1"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Update pgwire to 0.14 with tcp_nodelay turned on by default.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
