### PR TITLE
fix: respect MySQL timestamp format

### DIFF
--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -164,14 +164,14 @@ impl Timestamp {
     /// Format timestamp to ISO8601 string. If the timestamp exceeds what chrono timestamp can
     /// represent, this function simply print the timestamp unit and value in plain string.
     pub fn to_iso8601_string(&self) -> String {
-        self.to_formatted_string("%Y-%m-%d %H:%M:%S%.f%z")
+        self.as_formatted_string("%Y-%m-%d %H:%M:%S%.f%z")
     }
 
     pub fn to_local_string(&self) -> String {
-        self.to_formatted_string("%Y-%m-%d %H:%M:%S%.f")
+        self.as_formatted_string("%Y-%m-%d %H:%M:%S%.f")
     }
 
-    fn to_formatted_string(&self, pattern: &str) -> String {
+    fn as_formatted_string(self, pattern: &str) -> String {
         if let Some(v) = self.to_chrono_datetime() {
             let local = Local {};
             format!("{}", local.from_utc_datetime(&v).format(pattern))

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -164,12 +164,17 @@ impl Timestamp {
     /// Format timestamp to ISO8601 string. If the timestamp exceeds what chrono timestamp can
     /// represent, this function simply print the timestamp unit and value in plain string.
     pub fn to_iso8601_string(&self) -> String {
+        self.to_formatted_string("%Y-%m-%d %H:%M:%S%.f%z")
+    }
+
+    pub fn to_local_string(&self) -> String {
+        self.to_formatted_string("%Y-%m-%d %H:%M:%S%.f")
+    }
+
+    fn to_formatted_string(&self, pattern: &str) -> String {
         if let Some(v) = self.to_chrono_datetime() {
             let local = Local {};
-            format!(
-                "{}",
-                local.from_utc_datetime(&v).format("%Y-%m-%d %H:%M:%S%.f%z")
-            )
+            format!("{}", local.from_utc_datetime(&v).format(pattern))
         } else {
             format!("[Timestamp{}: {}]", self.unit, self.value)
         }
@@ -887,6 +892,26 @@ mod tests {
         assert_eq!(
             Timestamp::new(0, TimeUnit::Second),
             Timestamp::from_str("1970-01-01 08:00:00").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_to_local_string() {
+        std::env::set_var("TZ", "Asia/Shanghai");
+
+        assert_eq!(
+            "1970-01-01 08:00:00.000000001",
+            Timestamp::new(1, TimeUnit::Nanosecond).to_local_string()
+        );
+
+        assert_eq!(
+            "1970-01-01 08:00:00.001",
+            Timestamp::new(1, TimeUnit::Millisecond).to_local_string()
+        );
+
+        assert_eq!(
+            "1970-01-01 08:00:01",
+            Timestamp::new(1, TimeUnit::Second).to_local_string()
         );
     }
 }

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -161,7 +161,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                     Value::Binary(v) => row_writer.write_col(v.deref())?,
                     Value::Date(v) => row_writer.write_col(v.val())?,
                     Value::DateTime(v) => row_writer.write_col(v.val())?,
-                    Value::Timestamp(v) => row_writer.write_col(v.to_iso8601_string())?,
+                    Value::Timestamp(v) => row_writer.write_col(v.to_local_string())?,
                     Value::List(_) => {
                         return Err(Error::Internal {
                             err_msg: format!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

closes #1508 
