### PR TITLE
fix: incorrect show create table output

### DIFF
--- a/src/query/src/sql/show.rs
+++ b/src/query/src/sql/show.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 use std::fmt::Display;
 
+use common_catalog::consts::IMMUTABLE_FILE_ENGINE;
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, SchemaRef, COMMENT_KEY};
 use humantime::format_duration;
 use snafu::ResultExt;
@@ -321,7 +322,7 @@ WITH(
         let sql = format!("\n{}", stmt);
         assert_eq!(
             r#"
-CREATE TABLE IF NOT EXISTS system_metrics (
+CREATE EXTERNAL TABLE IF NOT EXISTS system_metrics (
   host STRING NULL,
   cpu DOUBLE NULL,
 

--- a/src/query/src/sql/show.rs
+++ b/src/query/src/sql/show.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 use std::fmt::Display;
 
-use common_catalog::consts::IMMUTABLE_FILE_ENGINE;
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, SchemaRef, COMMENT_KEY};
 use humantime::format_duration;
 use snafu::ResultExt;

--- a/tests/cases/standalone/show/show_create.result
+++ b/tests/cases/standalone/show/show_create.result
@@ -32,8 +32,8 @@ SHOW CREATE TABLE system_metrics;
 |                | ENGINE=mito                                             |
 |                | WITH(                                                   |
 |                |   regions = 1,                                          |
-|                |   write_buffer_size = '1.0KiB',                         |
-|                |   ttl = '7days'                                         |
+|                |   ttl = '7days',                                        |
+|                |   write_buffer_size = '1.0KiB'                          |
 |                | )                                                       |
 +----------------+---------------------------------------------------------+
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When running `show create table` on an external table, this PR fixes `greptimedb` showing `IMMUTABLE_TABLE_META`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

close #1459