### PR TITLE
chore: unify code styling

### DIFF
--- a/src/common/datasource/src/compression.rs
+++ b/src/common/datasource/src/compression.rs
@@ -26,15 +26,15 @@ use crate::error::{self, Error, Result};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompressionType {
     /// Gzip-ed file
-    GZIP,
+    Gzip,
     /// Bzip2-ed file
-    BZIP2,
+    Bzip2,
     /// Xz-ed file (liblzma)
-    XZ,
+    Xz,
     /// Zstd-ed file,
-    ZSTD,
+    Zstd,
     /// Uncompressed file
-    UNCOMPRESSED,
+    Uncompressed,
 }
 
 impl FromStr for CompressionType {
@@ -43,11 +43,11 @@ impl FromStr for CompressionType {
     fn from_str(s: &str) -> Result<Self> {
         let s = s.to_uppercase();
         match s.as_str() {
-            "GZIP" | "GZ" => Ok(Self::GZIP),
-            "BZIP2" | "BZ2" => Ok(Self::BZIP2),
-            "XZ" => Ok(Self::XZ),
-            "ZST" | "ZSTD" => Ok(Self::ZSTD),
-            "" => Ok(Self::UNCOMPRESSED),
+            "GZIP" | "GZ" => Ok(Self::Gzip),
+            "BZIP2" | "BZ2" => Ok(Self::Bzip2),
+            "XZ" => Ok(Self::Xz),
+            "ZST" | "ZSTD" => Ok(Self::Zstd),
+            "" => Ok(Self::Uncompressed),
             _ => error::UnsupportedCompressionTypeSnafu {
                 compression_type: s,
             }
@@ -59,18 +59,18 @@ impl FromStr for CompressionType {
 impl Display for CompressionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::GZIP => "GZIP",
-            Self::BZIP2 => "BZIP2",
-            Self::XZ => "XZ",
-            Self::ZSTD => "ZSTD",
-            Self::UNCOMPRESSED => "",
+            Self::Gzip => "GZIP",
+            Self::Bzip2 => "BZIP2",
+            Self::Xz => "XZ",
+            Self::Zstd => "ZSTD",
+            Self::Uncompressed => "",
         })
     }
 }
 
 impl CompressionType {
     pub const fn is_compressed(&self) -> bool {
-        !matches!(self, &Self::UNCOMPRESSED)
+        !matches!(self, &Self::Uncompressed)
     }
 
     pub fn convert_async_read<T: AsyncRead + Unpin + Send + 'static>(
@@ -78,11 +78,11 @@ impl CompressionType {
         s: T,
     ) -> Box<dyn AsyncRead + Unpin + Send> {
         match self {
-            CompressionType::GZIP => Box::new(GzipDecoder::new(BufReader::new(s))),
-            CompressionType::BZIP2 => Box::new(BzDecoder::new(BufReader::new(s))),
-            CompressionType::XZ => Box::new(XzDecoder::new(BufReader::new(s))),
-            CompressionType::ZSTD => Box::new(ZstdDecoder::new(BufReader::new(s))),
-            CompressionType::UNCOMPRESSED => Box::new(s),
+            CompressionType::Gzip => Box::new(GzipDecoder::new(BufReader::new(s))),
+            CompressionType::Bzip2 => Box::new(BzDecoder::new(BufReader::new(s))),
+            CompressionType::Xz => Box::new(XzDecoder::new(BufReader::new(s))),
+            CompressionType::Zstd => Box::new(ZstdDecoder::new(BufReader::new(s))),
+            CompressionType::Uncompressed => Box::new(s),
         }
     }
 
@@ -91,19 +91,19 @@ impl CompressionType {
         s: T,
     ) -> Box<dyn Stream<Item = io::Result<Bytes>> + Send + Unpin> {
         match self {
-            CompressionType::GZIP => {
+            CompressionType::Gzip => {
                 Box::new(ReaderStream::new(GzipDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::BZIP2 => {
+            CompressionType::Bzip2 => {
                 Box::new(ReaderStream::new(BzDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::XZ => {
+            CompressionType::Xz => {
                 Box::new(ReaderStream::new(XzDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::ZSTD => {
+            CompressionType::Zstd => {
                 Box::new(ReaderStream::new(ZstdDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::UNCOMPRESSED => Box::new(s),
+            CompressionType::Uncompressed => Box::new(s),
         }
     }
 }

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -45,11 +45,11 @@ use crate::compression::CompressionType;
 use crate::error::{self, Result};
 use crate::share_buffer::SharedBuffer;
 
-pub const FORMAT_COMPRESSION_TYPE: &str = "COMPRESSION_TYPE";
-pub const FORMAT_DELIMTERL: &str = "DELIMTERL";
-pub const FORMAT_SCHEMA_INFER_MAX_RECORD: &str = "SCHEMA_INFER_MAX_RECORD";
-pub const FORMAT_HAS_HEADER: &str = "FORMAT_HAS_HEADER";
-pub const FORMAT_TYPE: &str = "FORMAT";
+pub const FORMAT_COMPRESSION_TYPE: &str = "compression_type";
+pub const FORMAT_DELIMITER: &str = "delimiter";
+pub const FORMAT_SCHEMA_INFER_MAX_RECORD: &str = "schema_infer_max_record";
+pub const FORMAT_HAS_HEADER: &str = "has_header";
+pub const FORMAT_TYPE: &str = "format";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Format {

--- a/src/common/datasource/src/file_format/csv.rs
+++ b/src/common/datasource/src/file_format/csv.rs
@@ -50,11 +50,11 @@ impl TryFrom<&HashMap<String, String>> for CsvFormat {
 
     fn try_from(value: &HashMap<String, String>) -> Result<Self> {
         let mut format = CsvFormat::default();
-        if let Some(delimiter) = value.get(file_format::FORMAT_DELIMTERL) {
+        if let Some(delimiter) = value.get(file_format::FORMAT_DELIMITER) {
             // TODO(weny): considers to support parse like "\t" (not only b'\t')
             format.delimiter = u8::from_str(delimiter).map_err(|_| {
                 error::ParseFormatSnafu {
-                    key: file_format::FORMAT_DELIMTERL,
+                    key: file_format::FORMAT_DELIMITER,
                     value: delimiter,
                 }
                 .build()
@@ -94,7 +94,7 @@ impl Default for CsvFormat {
             has_header: true,
             delimiter: b',',
             schema_infer_max_record: Some(file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD),
-            compression_type: CompressionType::UNCOMPRESSED,
+            compression_type: CompressionType::Uncompressed,
         }
     }
 }
@@ -210,7 +210,7 @@ mod tests {
 
     use super::*;
     use crate::file_format::{
-        FileFormat, FORMAT_COMPRESSION_TYPE, FORMAT_DELIMTERL, FORMAT_HAS_HEADER,
+        FileFormat, FORMAT_COMPRESSION_TYPE, FORMAT_DELIMITER, FORMAT_HAS_HEADER,
         FORMAT_SCHEMA_INFER_MAX_RECORD,
     };
     use crate::test_util::{self, format_schema, test_store};
@@ -301,7 +301,7 @@ mod tests {
         );
 
         map.insert(FORMAT_COMPRESSION_TYPE.to_string(), "zstd".to_string());
-        map.insert(FORMAT_DELIMTERL.to_string(), b'\t'.to_string());
+        map.insert(FORMAT_DELIMITER.to_string(), b'\t'.to_string());
         map.insert(FORMAT_HAS_HEADER.to_string(), "false".to_string());
 
         let format = CsvFormat::try_from(&map).unwrap();
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(
             format,
             CsvFormat {
-                compression_type: CompressionType::ZSTD,
+                compression_type: CompressionType::Zstd,
                 schema_infer_max_record: Some(2000),
                 delimiter: b'\t',
                 has_header: false,

--- a/src/common/datasource/src/file_format/json.rs
+++ b/src/common/datasource/src/file_format/json.rs
@@ -73,7 +73,7 @@ impl Default for JsonFormat {
     fn default() -> Self {
         Self {
             schema_infer_max_record: Some(file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD),
-            compression_type: CompressionType::UNCOMPRESSED,
+            compression_type: CompressionType::Uncompressed,
         }
     }
 }
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(
             format,
             JsonFormat {
-                compression_type: CompressionType::ZSTD,
+                compression_type: CompressionType::Zstd,
                 schema_infer_max_record: Some(2000),
             }
         );

--- a/src/common/datasource/src/file_format/tests.rs
+++ b/src/common/datasource/src/file_format/tests.rs
@@ -67,7 +67,7 @@ async fn test_json_opener() {
         100,
         schema.clone(),
         store.clone(),
-        CompressionType::UNCOMPRESSED,
+        CompressionType::Uncompressed,
     );
 
     let path = &test_util::get_data_dir("tests/json/basic.json")
@@ -119,7 +119,7 @@ async fn test_csv_opener() {
         .build()
         .unwrap();
 
-    let csv_opener = CsvOpener::new(csv_conf, store, CompressionType::UNCOMPRESSED);
+    let csv_opener = CsvOpener::new(csv_conf, store, CompressionType::Uncompressed);
 
     let tests = [
         Test {

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -20,12 +20,12 @@ use snafu::ResultExt;
 
 use crate::error::{self, Result};
 
-const ENDPOINT_URL: &str = "ENDPOINT_URL";
-const ACCESS_KEY_ID: &str = "ACCESS_KEY_ID";
-const SECRET_ACCESS_KEY: &str = "SECRET_ACCESS_KEY";
-const SESSION_TOKEN: &str = "SESSION_TOKEN";
-const REGION: &str = "REGION";
-const ENABLE_VIRTUAL_HOST_STYLE: &str = "ENABLE_VIRTUAL_HOST_STYLE";
+const ENDPOINT_URL: &str = "endpoint_url";
+const ACCESS_KEY_ID: &str = "access_key_id";
+const SECRET_ACCESS_KEY: &str = "secret_access_key";
+const SESSION_TOKEN: &str = "session_token";
+const REGION: &str = "region";
+const ENABLE_VIRTUAL_HOST_STYLE: &str = "enable_virtual_host_style";
 
 pub fn build_s3_backend(
     host: &str,

--- a/src/common/datasource/src/test_util.rs
+++ b/src/common/datasource/src/test_util.rs
@@ -100,7 +100,7 @@ pub async fn setup_stream_to_json_test(origin_path: &str, threshold: impl Fn(usi
         test_util::TEST_BATCH_SIZE,
         schema.clone(),
         store.clone(),
-        CompressionType::UNCOMPRESSED,
+        CompressionType::Uncompressed,
     );
 
     let size = store.read(origin_path).await.unwrap().len();
@@ -143,7 +143,7 @@ pub async fn setup_stream_to_csv_test(origin_path: &str, threshold: impl Fn(usiz
         .build()
         .unwrap();
 
-    let csv_opener = CsvOpener::new(csv_conf, store.clone(), CompressionType::UNCOMPRESSED);
+    let csv_opener = CsvOpener::new(csv_conf, store.clone(), CompressionType::Uncompressed);
 
     let size = store.read(origin_path).await.unwrap().len();
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 
 use common_error::prelude::*;
 use datafusion::parquet;
+use datatypes::arrow::error::ArrowError;
 use datatypes::value::Value;
 use snafu::Location;
 use store_api::storage::RegionId;
@@ -523,6 +524,12 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to project schema: {}", source))]
+    ProjectSchema {
+        source: ArrowError,
+        location: Location,
+    },
+
     #[snafu(display("Failed to encode object into json, source: {}", source))]
     EncodeJson {
         source: serde_json::error::Error,
@@ -556,7 +563,8 @@ impl ErrorExt for Error {
             | Error::BuildRegex { .. }
             | Error::InvalidSchema { .. }
             | Error::PrepareImmutableTable { .. }
-            | Error::BuildCsvConfig { .. } => StatusCode::InvalidArguments,
+            | Error::BuildCsvConfig { .. }
+            | Error::ProjectSchema { .. } => StatusCode::InvalidArguments,
 
             Error::NotSupported { .. } => StatusCode::Unsupported,
 

--- a/src/frontend/src/tests/instance_test.rs
+++ b/src/frontend/src/tests/instance_test.rs
@@ -1137,6 +1137,90 @@ async fn test_execute_copy_to_s3(instance: Arc<dyn MockInstance>) {
 }
 
 #[apply(both_instances_cases)]
+async fn test_copy_table_to_fs_csv_issue_1519(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+    execute_sql(
+        &instance,
+        "create table demo(host string, cpu double, memory double, ts timestamp time index);",
+    )
+    .await;
+
+    let output = execute_sql(
+        &instance,
+        r#"insert into demo(host, cpu, memory, ts) values
+                    ('host1', 66.6, 1024, 1655276557000),
+                    ('host2', 88.8,  333.3, 1655276558000)
+                    "#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+
+    let output = execute_sql(
+        &instance,
+        r#"Copy demo TO '/tmp/demo/export/csv/demo.csv' with (format='csv');
+        "#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+
+    let output = execute_sql(
+        &instance,
+        r#"CREATE TABLE with_filename(host string, cpu double, memory double, ts timestamp time index);"#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(0)));
+
+    let output = execute_sql(
+        &instance,
+        r#"Copy with_filename FROM '/tmp/demo/export/csv/demo.csv' with (format='csv');"#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+}
+
+#[apply(both_instances_cases)]
+async fn test_copy_table_to_fs_json_issue_1519(instance: Arc<dyn MockInstance>) {
+    let instance = instance.frontend();
+    execute_sql(
+        &instance,
+        "create table demo(host string, cpu double, memory double, ts timestamp time index);",
+    )
+    .await;
+
+    let output = execute_sql(
+        &instance,
+        r#"insert into demo(host, cpu, memory, ts) values
+                    ('host1', 66.6, 1024, 1655276557000),
+                    ('host2', 88.8,  333.3, 1655276558000)
+                    "#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+
+    let output = execute_sql(
+        &instance,
+        r#"Copy demo TO '/tmp/demo/export/json/demo.json' with (format='json');
+        "#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+
+    let output = execute_sql(
+        &instance,
+        r#"CREATE TABLE with_filename(host string, cpu double, memory double, ts timestamp time index);"#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(0)));
+
+    let output = execute_sql(
+        &instance,
+        r#"Copy with_filename FROM '/tmp/demo/export/json/demo.json' with (format='json');"#,
+    )
+    .await;
+    assert!(matches!(output, Output::AffectedRows(2)));
+}
+
+#[apply(both_instances_cases)]
 async fn test_execute_copy_from_s3(instance: Arc<dyn MockInstance>) {
     logging::init_default_ut_logging();
     if let Ok(bucket) = env::var("GT_S3_BUCKET") {

--- a/src/query/src/sql/show.rs
+++ b/src/query/src/sql/show.rs
@@ -328,8 +328,8 @@ CREATE EXTERNAL TABLE IF NOT EXISTS system_metrics (
 )
 ENGINE=file
 WITH(
-  FORMAT = 'csv',
-  LOCATION = 'foo.csv'
+  format = 'csv',
+  location = 'foo.csv'
 )"#,
             sql
         );

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -109,7 +109,7 @@ impl<'a> ParserContext<'a> {
         let with = options
             .into_iter()
             .filter_map(|option| {
-                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
+                parse_option_string(option.value).map(|v| (option.name.value.to_lowercase(), v))
             })
             .collect();
 
@@ -121,7 +121,7 @@ impl<'a> ParserContext<'a> {
         let connection = connection_options
             .into_iter()
             .filter_map(|option| {
-                parse_option_string(option.value).map(|v| (option.name.to_string(), v))
+                parse_option_string(option.value).map(|v| (option.name.value.to_lowercase(), v))
             })
             .collect();
 
@@ -280,11 +280,11 @@ mod tests {
             },
             Test {
                 sql: "COPY catalog0.schema0.tbl TO 'tbl_file.parquet' CONNECTION (FOO='Bar', ONE='two')",
-                expected_connection: [("FOO","Bar"),("ONE","two")].into_iter().map(|(k,v)|{(k.to_string(),v.to_string())}).collect()
+                expected_connection: [("foo","Bar"),("one","two")].into_iter().map(|(k,v)|{(k.to_string(),v.to_string())}).collect()
             },
             Test {
                 sql:"COPY catalog0.schema0.tbl TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')",
-                expected_connection: [("FOO","Bar"),("ONE","two")].into_iter().map(|(k,v)|{(k.to_string(),v.to_string())}).collect()
+                expected_connection: [("foo","Bar"),("one","two")].into_iter().map(|(k,v)|{(k.to_string(),v.to_string())}).collect()
             },
         ];
 

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -85,7 +85,7 @@ impl<'a> ParserContext<'a> {
             .into_iter()
             .filter_map(|option| {
                 if let Some(v) = parse_option_string(option.value) {
-                    Some((option.name.value.to_uppercase(), v))
+                    Some((option.name.value.to_lowercase(), v))
                 } else {
                     None
                 }
@@ -803,8 +803,8 @@ mod tests {
                 sql: "CREATE EXTERNAL TABLE city with(location='/var/data/city.csv',format='csv');",
                 expected_table_name: "city",
                 expected_options: HashMap::from([
-                    ("LOCATION".to_string(), "/var/data/city.csv".to_string()),
-                    ("FORMAT".to_string(), "csv".to_string()),
+                    ("location".to_string(), "/var/data/city.csv".to_string()),
+                    ("format".to_string(), "csv".to_string()),
                 ]),
                 expected_engine: IMMUTABLE_FILE_ENGINE,
                 expected_if_not_exist: false,
@@ -813,8 +813,8 @@ mod tests {
                 sql: "CREATE EXTERNAL TABLE IF NOT EXISTS city ENGINE=foo with(location='/var/data/city.csv',format='csv');",
                 expected_table_name: "city",
                 expected_options: HashMap::from([
-                    ("LOCATION".to_string(), "/var/data/city.csv".to_string()),
-                    ("FORMAT".to_string(), "csv".to_string()),
+                    ("location".to_string(), "/var/data/city.csv".to_string()),
+                    ("format".to_string(), "csv".to_string()),
                 ]),
                 expected_engine: "foo",
                 expected_if_not_exist: true,
@@ -848,8 +848,8 @@ mod tests {
         ) with(location='/var/data/city.csv',format='csv');";
 
         let options = HashMap::from([
-            ("LOCATION".to_string(), "/var/data/city.csv".to_string()),
-            ("FORMAT".to_string(), "csv".to_string()),
+            ("location".to_string(), "/var/data/city.csv".to_string()),
+            ("format".to_string(), "csv".to_string()),
         ]);
 
         let stmts = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -33,7 +33,7 @@ pub struct CopyTableArgument {
 
 #[cfg(test)]
 impl CopyTableArgument {
-    const FORMAT: &str = "FORMAT";
+    const FORMAT: &str = "format";
 
     pub fn format(&self) -> Option<String> {
         self.with

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -198,8 +198,7 @@ pub struct CreateExternalTable {
     pub columns: Vec<ColumnDef>,
     pub constraints: Vec<TableConstraint>,
     /// Table options in `WITH`.
-    /// All keys are uppercase.
-    /// TODO(weny): unify the key's case styling.
+    /// All keys are lowercase.
     pub options: HashMap<String, String>,
     pub if_not_exists: bool,
     pub engine: String,

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -29,10 +29,10 @@ use crate::error;
 use crate::error::ParseTableOptionSnafu;
 use crate::metadata::TableId;
 
-pub const IMMUTABLE_TABLE_META_KEY: &str = "IMMUTABLE_TABLE_META";
-pub const IMMUTABLE_TABLE_LOCATION_KEY: &str = "LOCATION";
-pub const IMMUTABLE_TABLE_PATTERN_KEY: &str = "PATTERN";
-pub const IMMUTABLE_TABLE_FORMAT_KEY: &str = "FORMAT";
+pub const IMMUTABLE_TABLE_META_KEY: &str = "__private.immutable_table_meta";
+pub const IMMUTABLE_TABLE_LOCATION_KEY: &str = "location";
+pub const IMMUTABLE_TABLE_PATTERN_KEY: &str = "pattern";
+pub const IMMUTABLE_TABLE_FORMAT_KEY: &str = "format";
 
 #[derive(Debug, Clone)]
 pub struct CreateDatabaseRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

### Chore
1. Unify the case value of constants 
2. Make `CompressionType` follow the style of the guide
### Fix
1. Fix the `Copy from` must the order of fields in files issues
### Feat
1. Support to import data with compatible schema

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1519
close #1330