### PR TITLE
fix: vector and matrix in Prometheus use different field

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -184,9 +184,6 @@ pub enum Error {
     #[snafu(display("Invalid prometheus remote read query result, msg: {}", msg))]
     InvalidPromRemoteReadQueryResult { msg: String, location: Location },
 
-    #[snafu(display("Expect query result but not found"))]
-    QueryResultNotFound { location: Location },
-
     #[snafu(display("Invalid Flight ticket, source: {}", source))]
     InvalidFlightTicket {
         source: api::DecodeError,
@@ -304,7 +301,6 @@ impl ErrorExt for Error {
             | CatalogError { .. }
             | GrpcReflectionService { .. }
             | BuildingContext { .. }
-            | QueryResultNotFound { .. }
             | BuildHttpResponse { .. } => StatusCode::Internal,
 
             InsertScript { source, .. }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -184,6 +184,9 @@ pub enum Error {
     #[snafu(display("Invalid prometheus remote read query result, msg: {}", msg))]
     InvalidPromRemoteReadQueryResult { msg: String, location: Location },
 
+    #[snafu(display("Expect query result but not found"))]
+    QueryResultNotFound { location: Location },
+
     #[snafu(display("Invalid Flight ticket, source: {}", source))]
     InvalidFlightTicket {
         source: api::DecodeError,
@@ -301,6 +304,7 @@ impl ErrorExt for Error {
             | CatalogError { .. }
             | GrpcReflectionService { .. }
             | BuildingContext { .. }
+            | QueryResultNotFound { .. }
             | BuildHttpResponse { .. } => StatusCode::Internal,
 
             InsertScript { source, .. }

--- a/src/servers/src/prom.rs
+++ b/src/servers/src/prom.rs
@@ -321,8 +321,10 @@ impl PromJsonResponse {
                 // TODO(ruihang): push table name `__metric__`
                 let mut tags = vec![metric_name.clone()];
                 for (tag_column, tag_name) in tag_columns.iter().zip(tag_names.iter()) {
-                    let tag_value = tag_column.get_data(row_index).unwrap().to_string();
-                    tags.push((tag_name.to_string(), tag_value));
+                    // TODO(ruihang): add test for NULL tag
+                    if let Some(tag_value) = tag_column.get_data(row_index) {
+                        tags.push((tag_name.to_string(), tag_value.to_string()));
+                    }
                 }
 
                 // retrieve timestamp

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -367,7 +367,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
     let expected = PromJsonResponse {
         status: "success".to_string(),
         data: PromData {
-            result_type: "matrix".to_string(),
+            result_type: "vector".to_string(),
             result: vec![
                 PromSeries {
                     metric: [
@@ -376,7 +376,8 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                     ]
                     .into_iter()
                     .collect(),
-                    values: vec![(5.0, "2".to_string())],
+                    value: Some((5.0, "2".to_string())),
+                    ..Default::default()
                 },
                 PromSeries {
                     metric: [
@@ -385,7 +386,8 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                     ]
                     .into_iter()
                     .collect(),
-                    values: vec![(5.0, "1".to_string())],
+                    value: Some((5.0, "1".to_string())),
+                    ..Default::default()
                 },
             ],
         },
@@ -426,6 +428,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                     .into_iter()
                     .collect(),
                     values: vec![(5.0, "2".to_string()), (10.0, "2".to_string())],
+                    ..Default::default()
                 },
                 PromSeries {
                     metric: [
@@ -435,6 +438,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
                     .into_iter()
                     .collect(),
                     values: vec![(5.0, "1".to_string()), (10.0, "1".to_string())],
+                    ..Default::default()
                 },
             ],
         },


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix the query result of prometheus compatible interfaces. Results from `query` and `query_range` should use different result type and different fields for data

![image](https://user-images.githubusercontent.com/15380403/236395876-1580f9f0-b973-4751-8bf9-87fa12c1b11d.png)


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
