### PR TITLE
chore(datasource): make CompressionType follow the style of the guide

### DIFF
--- a/src/common/datasource/src/compression.rs
+++ b/src/common/datasource/src/compression.rs
@@ -26,15 +26,15 @@ use crate::error::{self, Error, Result};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompressionType {
     /// Gzip-ed file
-    GZIP,
+    Gzip,
     /// Bzip2-ed file
-    BZIP2,
+    Bzip2,
     /// Xz-ed file (liblzma)
-    XZ,
+    Xz,
     /// Zstd-ed file,
-    ZSTD,
+    Zstd,
     /// Uncompressed file
-    UNCOMPRESSED,
+    Uncompressed,
 }
 
 impl FromStr for CompressionType {
@@ -43,11 +43,11 @@ impl FromStr for CompressionType {
     fn from_str(s: &str) -> Result<Self> {
         let s = s.to_uppercase();
         match s.as_str() {
-            "GZIP" | "GZ" => Ok(Self::GZIP),
-            "BZIP2" | "BZ2" => Ok(Self::BZIP2),
-            "XZ" => Ok(Self::XZ),
-            "ZST" | "ZSTD" => Ok(Self::ZSTD),
-            "" => Ok(Self::UNCOMPRESSED),
+            "GZIP" | "GZ" => Ok(Self::Gzip),
+            "BZIP2" | "BZ2" => Ok(Self::Bzip2),
+            "XZ" => Ok(Self::Xz),
+            "ZST" | "ZSTD" => Ok(Self::Zstd),
+            "" => Ok(Self::Uncompressed),
             _ => error::UnsupportedCompressionTypeSnafu {
                 compression_type: s,
             }
@@ -59,18 +59,18 @@ impl FromStr for CompressionType {
 impl Display for CompressionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
-            Self::GZIP => "GZIP",
-            Self::BZIP2 => "BZIP2",
-            Self::XZ => "XZ",
-            Self::ZSTD => "ZSTD",
-            Self::UNCOMPRESSED => "",
+            Self::Gzip => "GZIP",
+            Self::Bzip2 => "BZIP2",
+            Self::Xz => "XZ",
+            Self::Zstd => "ZSTD",
+            Self::Uncompressed => "",
         })
     }
 }
 
 impl CompressionType {
     pub const fn is_compressed(&self) -> bool {
-        !matches!(self, &Self::UNCOMPRESSED)
+        !matches!(self, &Self::Uncompressed)
     }
 
     pub fn convert_async_read<T: AsyncRead + Unpin + Send + 'static>(
@@ -78,11 +78,11 @@ impl CompressionType {
         s: T,
     ) -> Box<dyn AsyncRead + Unpin + Send> {
         match self {
-            CompressionType::GZIP => Box::new(GzipDecoder::new(BufReader::new(s))),
-            CompressionType::BZIP2 => Box::new(BzDecoder::new(BufReader::new(s))),
-            CompressionType::XZ => Box::new(XzDecoder::new(BufReader::new(s))),
-            CompressionType::ZSTD => Box::new(ZstdDecoder::new(BufReader::new(s))),
-            CompressionType::UNCOMPRESSED => Box::new(s),
+            CompressionType::Gzip => Box::new(GzipDecoder::new(BufReader::new(s))),
+            CompressionType::Bzip2 => Box::new(BzDecoder::new(BufReader::new(s))),
+            CompressionType::Xz => Box::new(XzDecoder::new(BufReader::new(s))),
+            CompressionType::Zstd => Box::new(ZstdDecoder::new(BufReader::new(s))),
+            CompressionType::Uncompressed => Box::new(s),
         }
     }
 
@@ -91,19 +91,19 @@ impl CompressionType {
         s: T,
     ) -> Box<dyn Stream<Item = io::Result<Bytes>> + Send + Unpin> {
         match self {
-            CompressionType::GZIP => {
+            CompressionType::Gzip => {
                 Box::new(ReaderStream::new(GzipDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::BZIP2 => {
+            CompressionType::Bzip2 => {
                 Box::new(ReaderStream::new(BzDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::XZ => {
+            CompressionType::Xz => {
                 Box::new(ReaderStream::new(XzDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::ZSTD => {
+            CompressionType::Zstd => {
                 Box::new(ReaderStream::new(ZstdDecoder::new(StreamReader::new(s))))
             }
-            CompressionType::UNCOMPRESSED => Box::new(s),
+            CompressionType::Uncompressed => Box::new(s),
         }
     }
 }

--- a/src/common/datasource/src/file_format/csv.rs
+++ b/src/common/datasource/src/file_format/csv.rs
@@ -94,7 +94,7 @@ impl Default for CsvFormat {
             has_header: true,
             delimiter: b',',
             schema_infer_max_record: Some(file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD),
-            compression_type: CompressionType::UNCOMPRESSED,
+            compression_type: CompressionType::Uncompressed,
         }
     }
 }
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(
             format,
             CsvFormat {
-                compression_type: CompressionType::ZSTD,
+                compression_type: CompressionType::Zstd,
                 schema_infer_max_record: Some(2000),
                 delimiter: b'\t',
                 has_header: false,

--- a/src/common/datasource/src/file_format/json.rs
+++ b/src/common/datasource/src/file_format/json.rs
@@ -73,7 +73,7 @@ impl Default for JsonFormat {
     fn default() -> Self {
         Self {
             schema_infer_max_record: Some(file_format::DEFAULT_SCHEMA_INFER_MAX_RECORD),
-            compression_type: CompressionType::UNCOMPRESSED,
+            compression_type: CompressionType::Uncompressed,
         }
     }
 }
@@ -230,7 +230,7 @@ mod tests {
         assert_eq!(
             format,
             JsonFormat {
-                compression_type: CompressionType::ZSTD,
+                compression_type: CompressionType::Zstd,
                 schema_infer_max_record: Some(2000),
             }
         );

--- a/src/common/datasource/src/file_format/tests.rs
+++ b/src/common/datasource/src/file_format/tests.rs
@@ -67,7 +67,7 @@ async fn test_json_opener() {
         100,
         schema.clone(),
         store.clone(),
-        CompressionType::UNCOMPRESSED,
+        CompressionType::Uncompressed,
     );
 
     let path = &test_util::get_data_dir("tests/json/basic.json")
@@ -119,7 +119,7 @@ async fn test_csv_opener() {
         .build()
         .unwrap();
 
-    let csv_opener = CsvOpener::new(csv_conf, store, CompressionType::UNCOMPRESSED);
+    let csv_opener = CsvOpener::new(csv_conf, store, CompressionType::Uncompressed);
 
     let tests = [
         Test {

--- a/src/common/datasource/src/test_util.rs
+++ b/src/common/datasource/src/test_util.rs
@@ -100,7 +100,7 @@ pub async fn setup_stream_to_json_test(origin_path: &str, threshold: impl Fn(usi
         test_util::TEST_BATCH_SIZE,
         schema.clone(),
         store.clone(),
-        CompressionType::UNCOMPRESSED,
+        CompressionType::Uncompressed,
     );
 
     let size = store.read(origin_path).await.unwrap().len();
@@ -143,7 +143,7 @@ pub async fn setup_stream_to_csv_test(origin_path: &str, threshold: impl Fn(usiz
         .build()
         .unwrap();
 
-    let csv_opener = CsvOpener::new(csv_conf, store.clone(), CompressionType::UNCOMPRESSED);
+    let csv_opener = CsvOpener::new(csv_conf, store.clone(), CompressionType::Uncompressed);
 
     let size = store.read(origin_path).await.unwrap().len();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Make `CompressionType` follow the style of the guide

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
