### PR TITLE
chore(toolchain): update rust-toolchain to 2023-05-03

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,4 +12,5 @@ rustflags = [
     "-Wclippy::print_stdout",
     "-Wclippy::print_stderr",
     "-Wclippy::implicit_clone",
+    "-Aclippy::items_after_test_module",
 ]

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -13,7 +13,7 @@ on:
 name: Build API docs
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-02-26
+  RUST_TOOLCHAIN: nightly-2023-05-03
 
 jobs:
   apidoc:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,7 +24,7 @@ on:
 name: CI
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-02-26
+  RUST_TOOLCHAIN: nightly-2023-05-03
 
 jobs:
   typos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 name: Release
 
 env:
-  RUST_TOOLCHAIN: nightly-2023-02-26
+  RUST_TOOLCHAIN: nightly-2023-05-03
 
   SCHEDULED_BUILD_VERSION_PREFIX: v0.3.0
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-02-26"
+channel = "nightly-2023-05-03"

--- a/src/common/recordbatch/src/util.rs
+++ b/src/common/recordbatch/src/util.rs
@@ -31,7 +31,6 @@ pub async fn collect_batches(stream: SendableRecordBatchStream) -> Result<Record
 
 #[cfg(test)]
 mod tests {
-    use std::mem;
     use std::pin::Pin;
     use std::sync::Arc;
 
@@ -59,7 +58,7 @@ mod tests {
         type Item = Result<RecordBatch>;
 
         fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-            let batch = mem::replace(&mut self.batch, None);
+            let batch = self.batch.take();
 
             if let Some(batch) = batch {
                 Poll::Ready(Some(Ok(batch)))

--- a/src/servers/src/auth/user_provider.rs
+++ b/src/servers/src/auth/user_provider.rs
@@ -54,7 +54,7 @@ impl TryFrom<&str> for StaticUserProvider {
                 let file = File::open(path).context(IoSnafu)?;
                 let credential = io::BufReader::new(file)
                     .lines()
-                    .filter_map(|line| line.ok())
+                    .map_while(std::result::Result::ok)
                     .filter_map(|line| {
                         if let Some((k, v)) = line.split_once('=') {
                             Some((k.to_string(), v.as_bytes().to_vec()))

--- a/src/store-api/src/manifest/action.rs
+++ b/src/store-api/src/manifest/action.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-///! Common actions for manifest
+//! Common actions for manifest
 use serde::{Deserialize, Serialize};
 
 use crate::manifest::ManifestVersion;

--- a/src/table-procedure/src/lib.rs
+++ b/src/table-procedure/src/lib.rs
@@ -32,6 +32,7 @@ use table::engine::{TableEngineProcedureRef, TableEngineRef};
 ///
 /// # Panics
 /// Panics on error.
+#[allow(clippy::items_after_test_module)]
 pub fn register_procedure_loaders(
     catalog_manager: CatalogManagerRef,
     engine_procedure: TableEngineProcedureRef,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump rust toolchain to 2023-05-23, inspired by https://www.reddit.com/r/rust/comments/136z613/sudden_99_build_time_improvement_going_from_1661/ This version is rust 1.71, which uses LLVM 16

Cold build in my env has slightly improved, but most of the time is occupied by non-rust deps (like before). 
After: 
![image](https://user-images.githubusercontent.com/15380403/236404233-1a2bedf8-c2d8-4c4f-9945-c8318c674439.png)

Before:
![image](https://user-images.githubusercontent.com/15380403/236406278-2274ccd3-6444-4343-a7ea-e3e5feb5d698.png)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
