### PR TITLE
feat: add semantic_type to information_schema.columns

### DIFF
--- a/src/common/catalog/src/consts.rs
+++ b/src/common/catalog/src/consts.rs
@@ -30,3 +30,7 @@ pub const SCRIPTS_TABLE_ID: u32 = 1;
 
 pub const MITO_ENGINE: &str = "mito";
 pub const IMMUTABLE_FILE_ENGINE: &str = "file";
+
+pub const SEMANTIC_TYPE_PRIMARY_KEY: &str = "PRIMARY KEY";
+pub const SEMANTIC_TYPE_FIELD: &str = "FIELD";
+pub const SEMANTIC_TYPE_TIME_INDEX: &str = "TIME INDEX";

--- a/src/frontend/src/tests/instance_test.rs
+++ b/src/frontend/src/tests/instance_test.rs
@@ -1304,32 +1304,32 @@ async fn test_information_schema_dot_columns(instance: Arc<dyn MockInstance>) {
 
     // User can only see information schema under current catalog.
     // A necessary requirement to GreptimeCloud.
-    let sql = "select table_catalog, table_schema, table_name, column_name, data_type from information_schema.columns  order by table_name";
+    let sql = "select table_catalog, table_schema, table_name, column_name, data_type, semantic_type from information_schema.columns  order by table_name";
 
     let output = execute_sql(&instance, sql).await;
     let expected = "\
-+---------------+--------------+------------+--------------+----------------------+
-| table_catalog | table_schema | table_name | column_name  | data_type            |
-+---------------+--------------+------------+--------------+----------------------+
-| greptime      | public       | numbers    | number       | UInt32               |
-| greptime      | public       | scripts    | schema       | String               |
-| greptime      | public       | scripts    | name         | String               |
-| greptime      | public       | scripts    | script       | String               |
-| greptime      | public       | scripts    | engine       | String               |
-| greptime      | public       | scripts    | timestamp    | TimestampMillisecond |
-| greptime      | public       | scripts    | gmt_created  | TimestampMillisecond |
-| greptime      | public       | scripts    | gmt_modified | TimestampMillisecond |
-+---------------+--------------+------------+--------------+----------------------+";
++---------------+--------------+------------+--------------+----------------------+---------------+
+| table_catalog | table_schema | table_name | column_name  | data_type            | semantic_type |
++---------------+--------------+------------+--------------+----------------------+---------------+
+| greptime      | public       | numbers    | number       | UInt32               | PRIMARY KEY   |
+| greptime      | public       | scripts    | schema       | String               | PRIMARY KEY   |
+| greptime      | public       | scripts    | name         | String               | PRIMARY KEY   |
+| greptime      | public       | scripts    | script       | String               | FIELD         |
+| greptime      | public       | scripts    | engine       | String               | FIELD         |
+| greptime      | public       | scripts    | timestamp    | TimestampMillisecond | TIME INDEX    |
+| greptime      | public       | scripts    | gmt_created  | TimestampMillisecond | FIELD         |
+| greptime      | public       | scripts    | gmt_modified | TimestampMillisecond | FIELD         |
++---------------+--------------+------------+--------------+----------------------+---------------+";
 
     check_output_stream(output, expected).await;
 
     let output = execute_sql_with(&instance, sql, query_ctx).await;
     let expected = "\
-+-----------------+----------------+---------------+-------------+-----------+
-| table_catalog   | table_schema   | table_name    | column_name | data_type |
-+-----------------+----------------+---------------+-------------+-----------+
-| another_catalog | another_schema | another_table | i           | Int64     |
-+-----------------+----------------+---------------+-------------+-----------+";
++-----------------+----------------+---------------+-------------+-----------+---------------+
+| table_catalog   | table_schema   | table_name    | column_name | data_type | semantic_type |
++-----------------+----------------+---------------+-------------+-----------+---------------+
+| another_catalog | another_schema | another_table | i           | Int64     | TIME INDEX    |
++-----------------+----------------+---------------+-------------+-----------+---------------+";
 
     check_output_stream(output, expected).await;
 }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -18,7 +18,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use catalog::CatalogManagerRef;
-use common_catalog::consts::DEFAULT_CATALOG_NAME;
+use common_catalog::consts::{
+    DEFAULT_CATALOG_NAME, SEMANTIC_TYPE_FIELD, SEMANTIC_TYPE_PRIMARY_KEY, SEMANTIC_TYPE_TIME_INDEX,
+};
 use common_datasource::file_format::{infer_schemas, FileFormat, Format};
 use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::build_backend;
@@ -49,10 +51,6 @@ const COLUMN_TYPE_COLUMN: &str = "Type";
 const COLUMN_NULLABLE_COLUMN: &str = "Null";
 const COLUMN_DEFAULT_COLUMN: &str = "Default";
 const COLUMN_SEMANTIC_TYPE_COLUMN: &str = "Semantic Type";
-
-const SEMANTIC_TYPE_PRIMARY_KEY: &str = "PRIMARY KEY";
-const SEMANTIC_TYPE_FIELD: &str = "FIELD";
-const SEMANTIC_TYPE_TIME_INDEX: &str = "TIME INDEX";
 
 const NULLABLE_YES: &str = "YES";
 const NULLABLE_NO: &str = "NO";

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -39,17 +39,17 @@ order by table_schema, table_name;
 | greptime      | my_db        | foo        | BASE TABLE | mito   |
 +---------------+--------------+------------+------------+--------+
 
-select table_catalog, table_schema, table_name, column_name, data_type
+select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
 from information_schema.columns
 where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-+---------------+--------------+------------+-------------+-----------+
-| table_catalog | table_schema | table_name | column_name | data_type |
-+---------------+--------------+------------+-------------+-----------+
-| greptime      | my_db        | foo        | ts          | Int64     |
-+---------------+--------------+------------+-------------+-----------+
++---------------+--------------+------------+-------------+-----------+---------------+
+| table_catalog | table_schema | table_name | column_name | data_type | semantic_type |
++---------------+--------------+------------+-------------+-----------+---------------+
+| greptime      | my_db        | foo        | ts          | Int64     | TIME INDEX    |
++---------------+--------------+------------+-------------+-----------+---------------+
 
 use
 public;

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -20,7 +20,7 @@ where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-select table_catalog, table_schema, table_name, column_name, data_type
+select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
 from information_schema.columns
 where table_catalog = 'greptime'
   and table_schema != 'public'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds semantic type column to information_schema.columns

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
