### PR TITLE
fix: no active datanode when frontend start

### DIFF
--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -193,6 +193,15 @@ pub struct StatKey {
     pub node_id: u64,
 }
 
+impl From<&LeaseKey> for StatKey {
+    fn from(lease_key: &LeaseKey) -> Self {
+        StatKey {
+            cluster_id: lease_key.cluster_id,
+            node_id: lease_key.node_id,
+        }
+    }
+}
+
 impl From<StatKey> for Vec<u8> {
     fn from(value: StatKey) -> Self {
         format!("{}-{}-{}", DN_STAT_PREFIX, value.cluster_id, value.node_id).into_bytes()
@@ -394,5 +403,18 @@ mod tests {
         };
         let region_num = stat_val.region_num().unwrap();
         assert_eq!(1, region_num);
+    }
+
+    #[test]
+    fn test_lease_key_to_stat_key() {
+        let lease_key = LeaseKey {
+            cluster_id: 1,
+            node_id: 101,
+        };
+
+        let stat_key: StatKey = (&lease_key).into();
+
+        assert_eq!(1, stat_key.cluster_id);
+        assert_eq!(101, stat_key.node_id);
     }
 }

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -243,7 +243,7 @@ pub struct StatValue {
 
 impl StatValue {
     /// Get the region number from stat value.
-    pub fn region_num(&self) -> Option<u64> {
+    pub fn region_count(&self) -> Option<u64> {
         for stat in self.stats.iter() {
             match stat.region_num {
                 Some(region_num) => return Some(region_num),
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn test_get_region_num_from_stat_val() {
         let empty = StatValue { stats: vec![] };
-        let region_num = empty.region_num();
+        let region_num = empty.region_count();
         assert!(region_num.is_none());
 
         let wrong = StatValue {
@@ -373,7 +373,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let right = wrong.region_num();
+        let right = wrong.region_count();
         assert!(right.is_none());
 
         let stat_val = StatValue {
@@ -392,7 +392,7 @@ mod tests {
                 },
             ],
         };
-        let region_num = stat_val.region_num().unwrap();
+        let region_num = stat_val.region_count().unwrap();
         assert_eq!(1, region_num);
     }
 }

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -243,7 +243,7 @@ pub struct StatValue {
 
 impl StatValue {
     /// Get the region number from stat value.
-    pub fn region_count(&self) -> Option<u64> {
+    pub fn region_num(&self) -> Option<u64> {
         for stat in self.stats.iter() {
             match stat.region_num {
                 Some(region_num) => return Some(region_num),
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn test_get_region_num_from_stat_val() {
         let empty = StatValue { stats: vec![] };
-        let region_num = empty.region_count();
+        let region_num = empty.region_num();
         assert!(region_num.is_none());
 
         let wrong = StatValue {
@@ -373,7 +373,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let right = wrong.region_count();
+        let right = wrong.region_num();
         assert!(right.is_none());
 
         let stat_val = StatValue {
@@ -392,7 +392,7 @@ mod tests {
                 },
             ],
         };
-        let region_num = stat_val.region_count().unwrap();
+        let region_num = stat_val.region_num().unwrap();
         assert_eq!(1, region_num);
     }
 }

--- a/src/meta-srv/src/selector/load_based.rs
+++ b/src/meta-srv/src/selector/load_based.rs
@@ -25,7 +25,7 @@ use crate::lease;
 use crate::metasrv::Context;
 use crate::selector::{Namespace, Selector};
 
-const LARGEST_REGION_COUNT: u64 = u64::MAX;
+const LARGEST_REGION_NUMBER: u64 = u64::MAX;
 
 pub struct LoadBasedSelector {
     pub meta_peer_client: MetaPeerClient,
@@ -66,18 +66,18 @@ impl Selector for LoadBasedSelector {
             .map(|(lease_k, lease_v)| {
                 let stat_key: StatKey = to_stat_key(&lease_k);
 
-                let region_count = match stat_kvs
+                let region_num = match stat_kvs
                     .get(&stat_key)
-                    .and_then(|stat_val| stat_val.region_count())
+                    .and_then(|stat_val| stat_val.region_num())
                 {
-                    Some(region_count) => region_count,
+                    Some(region_num) => region_num,
                     None => {
                         warn!("Failed to get stat_val by stat_key {:?}", stat_key);
-                        LARGEST_REGION_COUNT
+                        LARGEST_REGION_NUMBER
                     }
                 };
 
-                (lease_k, lease_v, region_count)
+                (lease_k, lease_v, region_num)
             })
             .collect();
 

--- a/src/meta-srv/src/selector/load_based.rs
+++ b/src/meta-srv/src/selector/load_based.rs
@@ -25,7 +25,7 @@ use crate::lease;
 use crate::metasrv::Context;
 use crate::selector::{Namespace, Selector};
 
-const LARGEST_REGION_COUNT: u64 = 100000;
+const LARGEST_REGION_COUNT: u64 = u64::MAX;
 
 pub struct LoadBasedSelector {
     pub meta_peer_client: MetaPeerClient,

--- a/src/meta-srv/src/selector/load_based.rs
+++ b/src/meta-srv/src/selector/load_based.rs
@@ -72,7 +72,7 @@ impl Selector for LoadBasedSelector {
                 {
                     Some(region_count) => region_count,
                     None => {
-                        warn!("failed to get stat_val by stat_key {:?}", stat_key);
+                        warn!("Failed to get stat_val by stat_key {:?}", stat_key);
                         LARGEST_REGION_COUNT
                     }
                 };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Problems encountered:
When starting greptimedb cluster,  frontend will report an error, “no active datanode”. In addition metasrv uses loadbase selector. 

In the current loadbase selector implementation, when the region count of a datanode cannot be obtained, we will exclude the datanode.

When frontend starts, some system tables need to be created. At this time, metasrv does not receive the heartbeat of datanode. So, frontend report an error "no active datanode".

This PR mainly fix this problem.

When the region number of the datanode cannot be obtained and the datanode alive, we give the node largest region count and lower its priority.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
