### PR TITLE
feat: clean procedure's state after it is done

### DIFF
--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -451,7 +451,7 @@ mod tests {
 
     use super::*;
     use crate::local::test_util;
-    use crate::store::PROC_PATH;
+    use crate::store::proc_path;
     use crate::{ContextProvider, Error, LockKey, Procedure};
 
     const ROOT_ID: &str = "9f805a1f-05f7-490c-9f91-bd56e3cc54c1";
@@ -473,7 +473,7 @@ mod tests {
     }
 
     async fn check_files(object_store: &ObjectStore, procedure_id: ProcedureId, files: &[&str]) {
-        let dir = format!("{PROC_PATH}/{procedure_id}/");
+        let dir = proc_path!("{procedure_id}/");
         let lister = object_store.list(&dir).await.unwrap();
         let mut files_in_dir: Vec<_> = lister
             .map_ok(|de| de.name().to_string())

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -750,6 +750,7 @@ mod tests {
         // Clean outdated meta.
         manager_ctx.remove_outdated_meta(Duration::from_millis(1));
         assert!(manager_ctx.state(procedure_id).is_none());
+        assert!(manager_ctx.finished_procedures.lock().unwrap().is_empty());
         for child_id in children_ids {
             assert!(manager_ctx.state(child_id).is_none());
         }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -150,7 +150,19 @@ impl Runner {
         // If this is the root procedure, clean up message cache.
         if self.meta.parent_id.is_none() {
             let procedure_ids = self.manager_ctx.procedures_in_tree(&self.meta);
-            self.manager_ctx.remove_messages(&procedure_ids);
+            // Clean resources.
+            self.manager_ctx.on_procedures_finish(&procedure_ids);
+            for id in procedure_ids {
+                if let Err(e) = self.store.delete_procedure(id).await {
+                    logging::error!(
+                        e;
+                        "Runner {}-{} failed to delete procedure {}",
+                        self.procedure.type_name(),
+                        self.meta.id,
+                        id,
+                    );
+                }
+            }
         }
 
         logging::info!(

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -31,6 +31,14 @@ pub mod state_store;
 /// Key prefix of procedure store.
 pub(crate) const PROC_PATH: &str = "procedure/";
 
+/// Constructs a path for procedure store.
+macro_rules! proc_path {
+    ($fmt:expr) => { format!("{}{}", $crate::store::PROC_PATH, format_args!($fmt)) };
+    ($fmt:expr, $($args:tt)*) => { format!("{}{}", $crate::store::PROC_PATH, format_args!($fmt, $($args)*)) };
+}
+
+pub(crate) use proc_path;
+
 /// Serialized data of a procedure.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProcedureMessage {
@@ -264,11 +272,6 @@ mod tests {
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
         ProcedureStore::from(object_store)
-    }
-
-    macro_rules! proc_path {
-        ($fmt:expr) => { format!("{}{}", PROC_PATH, format_args!($fmt)) };
-        ($fmt:expr, $($args:tt)*) => { format!("{}{}", PROC_PATH, format_args!($fmt, $($args)*)) };
     }
 
     #[test]

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -92,9 +92,7 @@ impl StateStore for ObjectStateStore {
                     StatusCode::StorageUnavailable,
                 ))
             })
-            .with_context(|_| ListStateSnafu {
-                path: path_string.clone(),
-            })?;
+            .context(ListStateSnafu { path })?;
 
         let store = self.store.clone();
 

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -84,8 +84,6 @@ impl StateStore for ObjectStateStore {
     }
 
     async fn walk_top_down(&self, path: &str) -> Result<KeyValueStream> {
-        let path_string = path.to_string();
-
         let mut lister = self
             .store
             .scan(path)
@@ -100,6 +98,7 @@ impl StateStore for ObjectStateStore {
 
         let store = self.store.clone();
 
+        let path_string = path.to_string();
         let stream = try_stream!({
             while let Some(res) = lister.next().await {
                 let entry = res

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -45,7 +45,11 @@ pub trait StateStore: Send + Sync {
     async fn walk_top_down(&self, path: &str) -> Result<KeyValueStream>;
 
     /// Deletes key-value pairs by `keys`.
-    async fn delete(&self, keys: &[String]) -> Result<()>;
+    async fn batch_delete(&self, keys: &[String]) -> Result<()>;
+
+    /// Deletes one key-value pair by `key`. Return `Ok` if the key
+    /// does not exist.
+    async fn delete(&self, key: &str) -> Result<()>;
 }
 
 /// Reference counted pointer to [StateStore].
@@ -136,13 +140,22 @@ impl StateStore for ObjectStateStore {
         Ok(Box::pin(stream))
     }
 
-    async fn delete(&self, keys: &[String]) -> Result<()> {
-        for key in keys {
-            self.store
-                .delete(key)
-                .await
-                .context(DeleteStateSnafu { key })?;
-        }
+    async fn batch_delete(&self, keys: &[String]) -> Result<()> {
+        self.store
+            .remove(keys.to_vec())
+            .await
+            .with_context(|_| DeleteStateSnafu {
+                key: format!("{:?}", keys),
+            })?;
+
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        self.store
+            .delete(key)
+            .await
+            .with_context(|_| DeleteStateSnafu { key })?;
 
         Ok(())
     }
@@ -213,7 +226,7 @@ mod tests {
         );
 
         state_store
-            .delete(&["a/2".to_string(), "b/1".to_string()])
+            .batch_delete(&["a/2".to_string(), "b/1".to_string()])
             .await
             .unwrap();
         let mut data: Vec<_> = state_store
@@ -225,5 +238,41 @@ mod tests {
             .unwrap();
         data.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         assert_eq!(vec![("a/1".to_string(), b"v1".to_vec()),], data);
+    }
+
+    #[tokio::test]
+    async fn test_object_state_store_delete() {
+        let dir = create_temp_dir("state_store_list");
+        let store_dir = dir.path().to_str().unwrap();
+        let mut builder = Builder::default();
+        builder.root(store_dir);
+
+        let object_store = ObjectStore::new(builder).unwrap().finish();
+        let state_store = ObjectStateStore::new(object_store);
+
+        state_store.put("a/1", b"v1".to_vec()).await.unwrap();
+        state_store.put("a/2", b"v2".to_vec()).await.unwrap();
+        state_store.put("b/1", b"v3".to_vec()).await.unwrap();
+
+        state_store.delete("b/1").await.unwrap();
+
+        let mut data: Vec<_> = state_store
+            .walk_top_down("a/")
+            .await
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        data.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            vec![
+                ("a/1".to_string(), b"v1".to_vec()),
+                ("a/2".to_string(), b"v2".to_vec()),
+            ],
+            data
+        );
+
+        // Delete returns Ok even the key doesn't exist.
+        state_store.delete("b/1").await.unwrap();
     }
 }

--- a/src/meta-srv/src/procedure/state_store.rs
+++ b/src/meta-srv/src/procedure/state_store.rs
@@ -109,7 +109,7 @@ impl StateStore for MetaStateStore {
         Ok(Box::pin(stream))
     }
 
-    async fn delete(&self, keys: &[String]) -> Result<()> {
+    async fn batch_delete(&self, keys: &[String]) -> Result<()> {
         let _ = self
             .kv_store
             .batch_delete(BatchDeleteRequest {
@@ -125,6 +125,10 @@ impl StateStore for MetaStateStore {
                 keys: format!("{:?}", keys.to_vec()),
             })?;
         Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<()> {
+        self.batch_delete(&[key.to_string()]).await
     }
 }
 
@@ -184,7 +188,7 @@ mod tests {
         );
 
         store
-            .delete(&["a/2".to_string(), "b/1".to_string()])
+            .batch_delete(&["a/2".to_string(), "b/1".to_string()])
             .await
             .unwrap();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR cleans the procedure's state in `ProcedureStore` and memory after it is done
- Add `delete_procedure()` method to `ProcedureStore`
- After a root procedure is done, the runner cleans all the state files related to this procedure and its children
- Removes the metadata in memory after `META_TTL`. When we submit a procedure to the manager or query a procedure's state, the manager tries to clean the outdated metadata
- Cleans finished procedures during recovery

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1509 