### PR TITLE
chore: remove useless Option type in plugins

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -155,7 +155,8 @@ impl Instance {
             query_engine.clone(),
             dist_instance.clone(),
         ));
-        plugins.insert::<Option<StatementExecutorRef>>(Some(statement_executor.clone()));
+
+        plugins.insert::<StatementExecutorRef>(statement_executor.clone());
 
         Ok(Instance {
             catalog_manager,

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -181,9 +181,8 @@ impl Services {
             http_server_builder.with_metrics_handler(MetricsHandler);
             http_server_builder.with_script_handler(instance.clone());
 
-            if let Some(configurator) = plugins.get::<Option<ConfiguratorRef>>() {
-                http_server_builder.with_configurator(configurator);
-            }
+            http_server_builder.with_configurator(plugins.get::<ConfiguratorRef>());
+
             let http_server = http_server_builder.build();
             result.push((Box::new(http_server), http_addr));
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* Remove useless Option types

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
