### PR TITLE
refactor: remove unnecessary async from RepeatedTask::start

### DIFF
--- a/src/common/runtime/src/error.rs
+++ b/src/common/runtime/src/error.rs
@@ -28,7 +28,8 @@ pub enum Error {
         source: std::io::Error,
         location: Location,
     },
-    #[snafu(display("Repeated task {} not started yet", name))]
+
+    #[snafu(display("Repeated task {} is already started", name))]
     IllegalState { name: String, location: Location },
 
     #[snafu(display(

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -24,5 +24,5 @@ pub use global::{
     spawn_read, spawn_write, write_runtime,
 };
 
-pub use crate::repeated_task::{RepeatedTask, TaskFunction, TaskFunctionRef};
+pub use crate::repeated_task::{BoxedTaskFunction, RepeatedTask, TaskFunction};
 pub use crate::runtime::{Builder, JoinError, JoinHandle, Runtime};

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -51,7 +51,7 @@ impl TaskFunction<Error> for PurgeExpiredFilesFunction {
         "RaftEngineLogStore-gc-task"
     }
 
-    async fn call(&self) -> Result<(), Error> {
+    async fn call(&mut self) -> Result<(), Error> {
         match self.engine.purge_expired_files().context(RaftEngineSnafu) {
             Ok(res) => {
                 // TODO(hl): the retval of purge_expired_files indicates the namespaces need to be compact,
@@ -84,7 +84,7 @@ impl RaftEngineLogStore {
         let engine = Arc::new(Engine::open(raft_engine_config).context(RaftEngineSnafu)?);
         let gc_task = RepeatedTask::new(
             config.purge_interval,
-            Arc::new(PurgeExpiredFilesFunction {
+            Box::new(PurgeExpiredFilesFunction {
                 engine: engine.clone(),
             }),
         );
@@ -94,7 +94,7 @@ impl RaftEngineLogStore {
             engine,
             gc_task,
         };
-        log_store.start().await?;
+        log_store.start()?;
         Ok(log_store)
     }
 
@@ -102,10 +102,9 @@ impl RaftEngineLogStore {
         self.gc_task.started()
     }
 
-    async fn start(&self) -> Result<(), Error> {
+    fn start(&self) -> Result<(), Error> {
         self.gc_task
             .start(common_runtime::bg_runtime())
-            .await
             .context(StartGcTaskSnafu)
     }
 }
@@ -337,7 +336,7 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
         let namespaces = logstore.list_namespaces().await.unwrap();
         assert_eq!(0, namespaces.len());
     }
@@ -351,7 +350,7 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
         assert!(logstore.list_namespaces().await.unwrap().is_empty());
 
         logstore
@@ -378,7 +377,7 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
 
         let namespace = Namespace::with_id(1);
         let cnt = 1024;
@@ -440,7 +439,7 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
 
         let entries =
             collect_entries(logstore.read(&Namespace::with_id(1), 1).await.unwrap()).await;
@@ -480,7 +479,7 @@ mod tests {
         };
 
         let logstore = RaftEngineLogStore::try_new(config).await.unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..4096 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());
@@ -513,7 +512,7 @@ mod tests {
         };
 
         let logstore = RaftEngineLogStore::try_new(config).await.unwrap();
-        logstore.start().await.unwrap();
+        logstore.start().unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..1024 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -336,7 +336,6 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().unwrap();
         let namespaces = logstore.list_namespaces().await.unwrap();
         assert_eq!(0, namespaces.len());
     }
@@ -350,7 +349,6 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().unwrap();
         assert!(logstore.list_namespaces().await.unwrap().is_empty());
 
         logstore
@@ -377,7 +375,6 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().unwrap();
 
         let namespace = Namespace::with_id(1);
         let cnt = 1024;
@@ -439,7 +436,6 @@ mod tests {
         })
         .await
         .unwrap();
-        logstore.start().unwrap();
 
         let entries =
             collect_entries(logstore.read(&Namespace::with_id(1), 1).await.unwrap()).await;
@@ -479,7 +475,6 @@ mod tests {
         };
 
         let logstore = RaftEngineLogStore::try_new(config).await.unwrap();
-        logstore.start().unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..4096 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());
@@ -512,7 +507,6 @@ mod tests {
         };
 
         let logstore = RaftEngineLogStore::try_new(config).await.unwrap();
-        logstore.start().unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..1024 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Some refactor:
- Remove async from start(), also make start() concurrent safe
- Cancel task in drop
- Allow TaskFunction::call taking `&mut self` so we could maintain state in the TaskFunction

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
