### PR TITLE
fix: the latest number of regions

### DIFF
--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -251,9 +251,9 @@ pub struct StatValue {
 }
 
 impl StatValue {
-    /// Get the region number from stat value.
+    /// Get the latest number of regions.
     pub fn region_num(&self) -> Option<u64> {
-        for stat in self.stats.iter() {
+        for stat in self.stats.iter().rev() {
             match stat.region_num {
                 Some(region_num) => return Some(region_num),
                 None => continue,

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -402,7 +402,7 @@ mod tests {
             ],
         };
         let region_num = stat_val.region_num().unwrap();
-        assert_eq!(1, region_num);
+        assert_eq!(2, region_num);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

We have cached the latest 10 heartbeat messages for each node as Stat. When we need to obtain the most accurate information, we should retrieve it from the newest Stat.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
