### PR TITLE
feat: add information_schema as exception of cross schema check

### DIFF
--- a/src/query/src/lib.rs
+++ b/src/query/src/lib.rs
@@ -25,10 +25,11 @@ pub mod plan;
 pub mod planner;
 pub mod query_engine;
 pub mod sql;
-#[cfg(test)]
-mod tests;
 
 pub use crate::datafusion::DfContextProviderAdapter;
 pub use crate::query_engine::{
     QueryEngine, QueryEngineContext, QueryEngineFactory, QueryEngineRef,
 };
+
+#[cfg(test)]
+mod tests;

--- a/src/query/src/query_engine/options.rs
+++ b/src/query/src/query_engine/options.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_catalog::consts::INFORMATION_SCHEMA_NAME;
 use session::context::QueryContextRef;
 use snafu::ensure;
 
@@ -28,6 +29,11 @@ pub fn validate_catalog_and_schema(
     schema: &str,
     query_ctx: &QueryContextRef,
 ) -> Result<()> {
+    // information_schema is an exception
+    if schema.eq_ignore_ascii_case(INFORMATION_SCHEMA_NAME) {
+        return Ok(());
+    }
+
     ensure!(
         catalog == query_ctx.current_catalog() && schema == query_ctx.current_schema(),
         QueryAccessDeniedSnafu {
@@ -59,5 +65,7 @@ mod tests {
         assert!(re.is_err());
         let re = validate_catalog_and_schema("wrong_catalog", "wrong_schema", &context);
         assert!(re.is_err());
+
+        assert!(validate_catalog_and_schema("greptime", "information_schema", &context).is_ok());
     }
 }

--- a/src/table-procedure/src/lib.rs
+++ b/src/table-procedure/src/lib.rs
@@ -18,8 +18,6 @@ mod alter;
 mod create;
 mod drop;
 pub mod error;
-#[cfg(test)]
-mod test_util;
 
 pub use alter::AlterTableProcedure;
 use catalog::CatalogManagerRef;
@@ -52,3 +50,6 @@ pub fn register_procedure_loaders(
     );
     DropTableProcedure::register_loader(catalog_manager, engine_procedure, procedure_manager);
 }
+
+#[cfg(test)]
+mod test_util;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch allows cross schema query on information_schema.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
