### PR TITLE
feat: Add FlushPicker to flush regions periodically

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -52,6 +52,15 @@ gc_duration = '30s'
 # Whether to try creating a manifest checkpoint on region opening
 checkpoint_on_startup = false
 
+# Storage flush options
+[storage.flush]
+# Max inflight flush tasks.
+max_flush_tasks = 8
+# Default write buffer size for a region.
+region_write_buffer_size = "32MB"
+# Interval to auto flush a region if it has not flushed yet.
+auto_flush_interval = "1h"
+
 # Procedure storage options, see `standalone.example.toml`.
 [procedure]
 max_retry_times = 3

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -117,6 +117,15 @@ gc_duration = '30s'
 # Whether to try creating a manifest checkpoint on region opening
 checkpoint_on_startup = false
 
+# Storage flush options
+[storage.flush]
+# Max inflight flush tasks.
+max_flush_tasks = 8
+# Default write buffer size for a region.
+region_write_buffer_size = "32MB"
+# Interval to auto flush a region if it has not flushed yet.
+auto_flush_interval = "1h"
+
 # Procedure storage options.
 [procedure]
 # Procedure max retry time.

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -509,7 +509,8 @@ mod tests {
                 Arc::new(NoopLogStore::default()),
                 object_store.clone(),
                 noop_compaction_scheduler,
-            ),
+            )
+            .unwrap(),
             object_store,
         ));
         (dir, table_engine)

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -23,7 +23,10 @@ use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 use servers::http::HttpOptions;
 use servers::Mode;
-use storage::config::EngineConfig as StorageEngineConfig;
+use storage::config::{
+    EngineConfig as StorageEngineConfig, DEFAULT_AUTO_FLUSH_INTERVAL, DEFAULT_MAX_FLUSH_TASKS,
+    DEFAULT_REGION_WRITE_BUFFER_SIZE,
+};
 use storage::scheduler::SchedulerConfig;
 
 use crate::error::Result;
@@ -49,6 +52,7 @@ pub struct StorageConfig {
     pub store: ObjectStoreConfig,
     pub compaction: CompactionConfig,
     pub manifest: RegionManifestConfig,
+    pub flush: FlushConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Default, Deserialize)]
@@ -203,6 +207,28 @@ impl Default for CompactionConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(default)]
+pub struct FlushConfig {
+    /// Max inflight flush tasks.
+    pub max_flush_tasks: usize,
+    /// Default write buffer size for a region.
+    pub region_write_buffer_size: ReadableSize,
+    /// Interval to auto flush a region if it has not flushed yet.
+    #[serde(with = "humantime_serde")]
+    pub auto_flush_interval: Duration,
+}
+
+impl Default for FlushConfig {
+    fn default() -> Self {
+        Self {
+            max_flush_tasks: DEFAULT_MAX_FLUSH_TASKS,
+            region_write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE,
+            auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
+        }
+    }
+}
+
 impl From<&DatanodeOptions> for SchedulerConfig {
     fn from(value: &DatanodeOptions) -> Self {
         Self {
@@ -220,6 +246,9 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
             max_files_in_l0: value.storage.compaction.max_files_in_level0,
             max_purge_tasks: value.storage.compaction.max_purge_tasks,
             sst_write_buffer_size: value.storage.compaction.sst_write_buffer_size,
+            max_flush_tasks: value.storage.flush.max_flush_tasks,
+            region_write_buffer_size: value.storage.flush.region_write_buffer_size,
+            auto_flush_interval: value.storage.flush.auto_flush_interval,
         }
     }
 }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -25,7 +25,7 @@ use servers::http::HttpOptions;
 use servers::Mode;
 use storage::config::{
     EngineConfig as StorageEngineConfig, DEFAULT_AUTO_FLUSH_INTERVAL, DEFAULT_MAX_FLUSH_TASKS,
-    DEFAULT_REGION_WRITE_BUFFER_SIZE,
+    DEFAULT_PICKER_SCHEDULE_INTERVAL, DEFAULT_REGION_WRITE_BUFFER_SIZE,
 };
 use storage::scheduler::SchedulerConfig;
 
@@ -214,6 +214,9 @@ pub struct FlushConfig {
     pub max_flush_tasks: usize,
     /// Default write buffer size for a region.
     pub region_write_buffer_size: ReadableSize,
+    /// Interval to schedule auto flush picker to find region to flush.
+    #[serde(with = "humantime_serde")]
+    pub picker_schedule_interval: Duration,
     /// Interval to auto flush a region if it has not flushed yet.
     #[serde(with = "humantime_serde")]
     pub auto_flush_interval: Duration,
@@ -224,6 +227,9 @@ impl Default for FlushConfig {
         Self {
             max_flush_tasks: DEFAULT_MAX_FLUSH_TASKS,
             region_write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE,
+            picker_schedule_interval: Duration::from_millis(
+                DEFAULT_PICKER_SCHEDULE_INTERVAL.into(),
+            ),
             auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
         }
     }
@@ -248,6 +254,7 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
             sst_write_buffer_size: value.storage.compaction.sst_write_buffer_size,
             max_flush_tasks: value.storage.flush.max_flush_tasks,
             region_write_buffer_size: value.storage.flush.region_write_buffer_size,
+            picker_schedule_interval: value.storage.flush.picker_schedule_interval,
             auto_flush_interval: value.storage.flush.auto_flush_interval,
         }
     }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -120,7 +120,8 @@ impl Instance {
                 log_store.clone(),
                 object_store.clone(),
                 compaction_scheduler,
-            ),
+            )
+            .unwrap(),
             object_store.clone(),
         ));
 

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -669,6 +669,12 @@ impl<S: StorageEngine> MitoEngineInner<S> {
         .map_err(BoxedError::new)
         .context(table_error::TableOperationSnafu)?;
 
+        self.storage_engine
+            .close(&StorageEngineContext::default())
+            .await
+            .map_err(BoxedError::new)
+            .context(table_error::TableOperationSnafu)?;
+
         Ok(())
     }
 }

--- a/src/mito/src/engine/procedure.rs
+++ b/src/mito/src/engine/procedure.rs
@@ -66,7 +66,8 @@ mod procedure_test_util {
             Arc::new(NoopLogStore::default()),
             object_store.clone(),
             compaction_scheduler,
-        );
+        )
+        .unwrap();
         let table_engine = MitoEngine::new(EngineConfig::default(), storage_engine, object_store);
 
         TestEnv { table_engine, dir }

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -83,7 +83,8 @@ async fn setup_table_with_column_default_constraint() -> (TempDir, String, Table
             Arc::new(NoopLogStore::default()),
             object_store.clone(),
             compaction_scheduler,
-        ),
+        )
+        .unwrap(),
         object_store,
     );
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -35,8 +35,8 @@ use object_store::ObjectStore;
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::manifest::{self, Manifest, ManifestVersion, MetaActionIterator};
 use store_api::storage::{
-    AddColumn, AlterOperation, AlterRequest, ChunkReader, FlushContext, ReadContext, Region,
-    RegionMeta, RegionNumber, ScanRequest, SchemaRef, Snapshot, WriteContext, WriteRequest,
+    AddColumn, AlterOperation, AlterRequest, ChunkReader, FlushContext, FlushReason, ReadContext,
+    Region, RegionMeta, RegionNumber, ScanRequest, SchemaRef, Snapshot, WriteContext, WriteRequest,
 };
 use table::error::{
     InvalidTableSnafu, RegionSchemaMismatchSnafu, Result as TableResult, TableOperationSnafu,
@@ -294,7 +294,12 @@ impl<R: Region> Table for MitoTable<R> {
         region_number: Option<RegionNumber>,
         wait: Option<bool>,
     ) -> TableResult<()> {
-        let flush_ctx = wait.map(|wait| FlushContext { wait }).unwrap_or_default();
+        let flush_ctx = wait
+            .map(|wait| FlushContext {
+                wait,
+                reason: FlushReason::Manually,
+            })
+            .unwrap_or_default();
         if let Some(region_number) = region_number {
             if let Some(region) = self.regions.get(&region_number) {
                 region

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -155,7 +155,8 @@ pub async fn setup_test_engine_and_table() -> TestEngineComponents {
         Arc::new(NoopLogStore::default()),
         object_store.clone(),
         compaction_scheduler,
-    );
+    )
+    .unwrap();
     let table_engine = MitoEngine::new(
         EngineConfig::default(),
         storage_engine.clone(),

--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -326,4 +326,8 @@ impl StorageEngine for MockEngine {
         let regions = self.regions.lock().unwrap();
         Ok(regions.opened_regions.get(name).cloned())
     }
+
+    async fn close(&self, _ctx: &EngineContext) -> Result<()> {
+        Ok(())
+    }
 }

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -160,7 +160,8 @@ mod tests {
                 Arc::new(log_store),
                 object_store.clone(),
                 compaction_scheduler,
-            ),
+            )
+            .unwrap(),
             object_store,
         ));
         let engine_manager = Arc::new(MemoryTableEngineManager::new(mock_engine.clone()));

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -18,6 +18,13 @@ use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 
+/// Default max flush tasks.
+pub const DEFAULT_MAX_FLUSH_TASKS: usize = 8;
+/// Default region write buffer size.
+pub const DEFAULT_REGION_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(32);
+/// Default interval to trigger auto flush in millis.
+pub const DEFAULT_AUTO_FLUSH_INTERVAL: u32 = 60 * 60 * 1000;
+
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
     pub manifest_checkpoint_on_startup: bool,
@@ -26,6 +33,12 @@ pub struct EngineConfig {
     pub max_files_in_l0: usize,
     pub max_purge_tasks: usize,
     pub sst_write_buffer_size: ReadableSize,
+    /// Max inflight flush tasks.
+    pub max_flush_tasks: usize,
+    /// Default write buffer size for a region.
+    pub region_write_buffer_size: ReadableSize,
+    /// Interval to auto flush a region if it has not flushed yet.
+    pub auto_flush_interval: Duration,
 }
 
 impl Default for EngineConfig {
@@ -37,6 +50,9 @@ impl Default for EngineConfig {
             max_files_in_l0: 8,
             max_purge_tasks: 32,
             sst_write_buffer_size: ReadableSize::mb(8),
+            max_flush_tasks: DEFAULT_MAX_FLUSH_TASKS,
+            region_write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE,
+            auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
         }
     }
 }

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -24,6 +24,8 @@ pub const DEFAULT_MAX_FLUSH_TASKS: usize = 8;
 pub const DEFAULT_REGION_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(32);
 /// Default interval to trigger auto flush in millis.
 pub const DEFAULT_AUTO_FLUSH_INTERVAL: u32 = 60 * 60 * 1000;
+/// Default interval to schedule the picker to flush automatically in millis.
+pub const DEFAULT_PICKER_SCHEDULE_INTERVAL: u32 = 5 * 60 * 1000;
 
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
@@ -37,6 +39,8 @@ pub struct EngineConfig {
     pub max_flush_tasks: usize,
     /// Default write buffer size for a region.
     pub region_write_buffer_size: ReadableSize,
+    /// Interval to schedule the auto flush picker.
+    pub picker_schedule_interval: Duration,
     /// Interval to auto flush a region if it has not flushed yet.
     pub auto_flush_interval: Duration,
 }
@@ -52,6 +56,9 @@ impl Default for EngineConfig {
             sst_write_buffer_size: ReadableSize::mb(8),
             max_flush_tasks: DEFAULT_MAX_FLUSH_TASKS,
             region_write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE,
+            picker_schedule_interval: Duration::from_millis(
+                DEFAULT_PICKER_SCHEDULE_INTERVAL.into(),
+            ),
             auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
         }
     }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -323,6 +323,7 @@ impl<S: LogStore> EngineInner<S> {
             compaction_scheduler.clone(),
             regions.clone(),
             PickerConfig {
+                schedule_interval: config.picker_schedule_interval,
                 auto_flush_interval: config.auto_flush_interval,
             },
         )?);

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -137,7 +137,7 @@ pub fn region_manifest_dir(parent_dir: &str, region_name: &str) -> String {
 /// Also used as a placeholder in the region map when the region isn't ready, e.g. during
 /// creating/opening.
 #[derive(Debug)]
-enum RegionSlot<S: LogStore> {
+pub(crate) enum RegionSlot<S: LogStore> {
     /// The region is during creation.
     Creating,
     /// The region is during opening.
@@ -231,7 +231,11 @@ impl<S: LogStore> RegionMap<S> {
 
     /// Returns the `Some(slot)` if there is existing slot with given `name`, or insert
     /// given `slot` and returns `None`.
-    fn get_or_occupy_slot(&self, name: &str, slot: RegionSlot<S>) -> Option<RegionSlot<S>> {
+    pub(crate) fn get_or_occupy_slot(
+        &self,
+        name: &str,
+        slot: RegionSlot<S>,
+    ) -> Option<RegionSlot<S>> {
         {
             // Try to get the region under read lock.
             let regions = self.0.read().unwrap();

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -487,6 +487,12 @@ pub enum Error {
         sequence: SequenceNumber,
         location: Location,
     },
+
+    #[snafu(display("Failed to start pick task for flush: {}", source))]
+    StartPickTask {
+        #[snafu(backtrace)]
+        source: RuntimeError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -579,7 +585,8 @@ impl ErrorExt for Error {
             StartManifestGcTask { .. }
             | StopManifestGcTask { .. }
             | IllegalSchedulerState { .. }
-            | DuplicateFlush { .. } => StatusCode::Unexpected,
+            | DuplicateFlush { .. }
+            | StartPickTask { .. } => StatusCode::Unexpected,
 
             TtlCalculation { source, .. } => source.status_code(),
         }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -488,13 +488,13 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to start pick task for flush: {}", source))]
+    #[snafu(display("Failed to start picking task for flush: {}", source))]
     StartPickTask {
         #[snafu(backtrace)]
         source: RuntimeError,
     },
 
-    #[snafu(display("Failed to stop pick task for flush: {}", source))]
+    #[snafu(display("Failed to stop picking task for flush: {}", source))]
     StopPickTask {
         #[snafu(backtrace)]
         source: RuntimeError,

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -493,6 +493,12 @@ pub enum Error {
         #[snafu(backtrace)]
         source: RuntimeError,
     },
+
+    #[snafu(display("Failed to stop pick task for flush: {}", source))]
+    StopPickTask {
+        #[snafu(backtrace)]
+        source: RuntimeError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -586,7 +592,8 @@ impl ErrorExt for Error {
             | StopManifestGcTask { .. }
             | IllegalSchedulerState { .. }
             | DuplicateFlush { .. }
-            | StartPickTask { .. } => StatusCode::Unexpected,
+            | StartPickTask { .. }
+            | StopPickTask { .. } => StatusCode::Unexpected,
 
             TtlCalculation { source, .. } => source.status_code(),
         }

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -24,7 +24,7 @@ use store_api::logstore::LogStore;
 use store_api::storage::consts::WRITE_ROW_GROUP_SIZE;
 use store_api::storage::SequenceNumber;
 
-use crate::config::EngineConfig;
+use crate::config::{EngineConfig, DEFAULT_REGION_WRITE_BUFFER_SIZE};
 use crate::error::Result;
 use crate::manifest::action::*;
 use crate::manifest::region::RegionManifest;
@@ -33,9 +33,6 @@ use crate::metrics::FLUSH_ELAPSED;
 use crate::region::{RegionWriterRef, SharedDataRef};
 use crate::sst::{AccessLayerRef, FileId, FileMeta, Source, SstInfo, WriteOptions};
 use crate::wal::Wal;
-
-/// Default write buffer size (32M).
-const DEFAULT_WRITE_BUFFER_SIZE: usize = 32 * 1024 * 1024;
 
 pub trait FlushStrategy: Send + Sync + std::fmt::Debug {
     fn should_flush(
@@ -74,7 +71,7 @@ fn get_mutable_limitation(max_write_buffer_size: usize) -> usize {
 
 impl Default for SizeBasedStrategy {
     fn default() -> Self {
-        let max_write_buffer_size = DEFAULT_WRITE_BUFFER_SIZE;
+        let max_write_buffer_size = DEFAULT_REGION_WRITE_BUFFER_SIZE.as_bytes() as usize;
         Self {
             max_write_buffer_size,
             mutable_limitation: get_mutable_limitation(max_write_buffer_size),

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod picker;
 mod scheduler;
 
 use std::sync::Arc;
 
 use common_telemetry::{logging, timer};
+pub use picker::{FlushPicker, PickerConfig};
 pub use scheduler::{FlushHandle, FlushRequest, FlushScheduler, FlushSchedulerRef};
 use store_api::logstore::LogStore;
 use store_api::storage::consts::WRITE_ROW_GROUP_SIZE;

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -23,12 +23,10 @@ use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::storage::{FlushContext, FlushReason, Region};
 
+use crate::config::DEFAULT_AUTO_FLUSH_INTERVAL;
 use crate::engine::RegionMap;
 use crate::error::{Error, Result, StartPickTaskSnafu, StopPickTaskSnafu};
 use crate::region::RegionImpl;
-
-/// Default interval to trigger auto flush in millis.
-const DEFAULT_AUTO_FLUSH_INTERVAL: u32 = 60 * 60 * 1000;
 
 /// Config for [FlushPicker].
 pub struct PickerConfig {

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -1,0 +1,140 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common_runtime::{RepeatedTask, TaskFunction};
+use common_telemetry::logging;
+use common_time::util;
+use snafu::ResultExt;
+use store_api::logstore::LogStore;
+use store_api::storage::{FlushContext, Region};
+
+use crate::engine::RegionMap;
+use crate::error::{Error, Result, StartPickTaskSnafu};
+use crate::region::RegionImpl;
+
+/// Default interval to trigger auto flush in millis.
+const DEFAULT_AUTO_FLUSH_INTERVAL: u32 = 60 * 60 * 1000;
+
+/// Config for [FlushPicker].
+pub struct PickerConfig {
+    /// Interval to auto flush a region if it has not flushed yet.
+    pub auto_flush_interval: Duration,
+}
+
+impl PickerConfig {
+    /// Returns the interval to pick regions.
+    fn picker_schedule_interval(&self) -> Duration {
+        self.auto_flush_interval / 2
+    }
+
+    /// Returns the auto flush interval in millis.
+    fn auto_flush_interval_millis(&self) -> i64 {
+        self.auto_flush_interval
+            .as_millis()
+            .try_into()
+            .unwrap_or(DEFAULT_AUTO_FLUSH_INTERVAL.into())
+    }
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        PickerConfig {
+            auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
+        }
+    }
+}
+
+/// Flush task picker.
+pub struct FlushPicker<S: LogStore> {
+    /// Regions of the engine.
+    regions: Arc<RegionMap<S>>,
+    /// Background repeated pick task.
+    pick_task: RepeatedTask<Error>,
+}
+
+impl<S: LogStore> FlushPicker<S> {
+    /// Returns a new FlushPicker.
+    pub fn new(regions: Arc<RegionMap<S>>, config: PickerConfig) -> Result<Self> {
+        let task_fn = PickTaskFunction {
+            regions: regions.clone(),
+            auto_flush_interval_millis: config.auto_flush_interval_millis(),
+        };
+        let pick_task = RepeatedTask::new(config.picker_schedule_interval(), Box::new(task_fn));
+        // Start the background task.
+        pick_task
+            .start(common_runtime::bg_runtime())
+            .context(StartPickTaskSnafu)?;
+
+        Ok(Self { regions, pick_task })
+    }
+}
+
+/// Task function to pick regions to flush.
+struct PickTaskFunction<S: LogStore> {
+    /// Regions of the engine.
+    regions: Arc<RegionMap<S>>,
+    /// Interval to flush a region automatically.
+    auto_flush_interval_millis: i64,
+}
+
+impl<S: LogStore> PickTaskFunction<S> {
+    /// Auto flush regions based on last flush time.
+    async fn auto_flush_regions(&self, regions: &[RegionImpl<S>], earliest_flush_millis: i64) {
+        for region in regions {
+            if region.last_flush_millis() < earliest_flush_millis {
+                logging::debug!(
+                    "Auto flush region {} due to last flush time ({} < {})",
+                    region.id(),
+                    region.last_flush_millis(),
+                    earliest_flush_millis,
+                );
+
+                Self::flush_region(&region).await;
+                unimplemented!();
+            }
+        }
+    }
+
+    /// Try to flush region.
+    async fn flush_region(region: &RegionImpl<S>) {
+        let ctx = FlushContext { wait: false };
+        if let Err(e) = region.flush(&ctx).await {
+            logging::error!(e; "Failed to flush region {}", region.id());
+        }
+    }
+}
+
+#[async_trait]
+impl<S: LogStore> TaskFunction<Error> for PickTaskFunction<S> {
+    async fn call(&mut self) -> Result<()> {
+        // Get all regions.
+        let regions = self.regions.list_regions();
+        let now = util::current_time_millis();
+        // Flush regions by interval.
+        if let Some(earliest_flush_millis) = now.checked_sub(self.auto_flush_interval_millis) {
+            self.auto_flush_regions(&regions, earliest_flush_millis)
+                .await;
+        }
+
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "FlushPicker-pick-task"
+    }
+}

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -19,12 +19,14 @@ use async_trait::async_trait;
 use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::logging;
 use common_time::util;
+use metrics::counter;
 use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::storage::{FlushContext, Region};
 
 use crate::engine::RegionMap;
 use crate::error::{Error, Result, StartPickTaskSnafu, StopPickTaskSnafu};
+use crate::metrics::FLUSH_AUTO_FLUSH_TOTAL;
 use crate::region::RegionImpl;
 
 /// Default interval to trigger auto flush in millis.
@@ -98,6 +100,7 @@ struct PickTaskFunction<S: LogStore> {
 impl<S: LogStore> PickTaskFunction<S> {
     /// Auto flush regions based on last flush time.
     async fn auto_flush_regions(&self, regions: &[RegionImpl<S>], earliest_flush_millis: i64) {
+        let mut count = 0;
         for region in regions {
             if region.last_flush_millis() < earliest_flush_millis {
                 logging::debug!(
@@ -107,9 +110,12 @@ impl<S: LogStore> PickTaskFunction<S> {
                     earliest_flush_millis,
                 );
 
+                count += 1;
                 Self::flush_region(region).await;
             }
         }
+
+        counter!(FLUSH_AUTO_FLUSH_TOTAL, count);
     }
 
     /// Try to flush region.

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -60,16 +60,16 @@ impl Default for PickerConfig {
 }
 
 /// Flush task picker.
-pub struct FlushPicker<S: LogStore> {
+pub struct FlushPicker {
     /// Background repeated pick task.
     pick_task: RepeatedTask<Error>,
 }
 
-impl<S: LogStore> FlushPicker<S> {
+impl FlushPicker {
     /// Returns a new FlushPicker.
-    pub fn new(regions: Arc<RegionMap<S>>, config: PickerConfig) -> Result<Self> {
+    pub fn new<S: LogStore>(regions: Arc<RegionMap<S>>, config: PickerConfig) -> Result<Self> {
         let task_fn = PickTaskFunction {
-            regions: regions.clone(),
+            regions,
             auto_flush_interval_millis: config.auto_flush_interval_millis(),
         };
         let pick_task = RepeatedTask::new(config.picker_schedule_interval(), Box::new(task_fn));
@@ -107,8 +107,7 @@ impl<S: LogStore> PickTaskFunction<S> {
                     earliest_flush_millis,
                 );
 
-                Self::flush_region(&region).await;
-                unimplemented!();
+                Self::flush_region(region).await;
             }
         }
     }

--- a/src/storage/src/flush/scheduler.rs
+++ b/src/storage/src/flush/scheduler.rs
@@ -169,7 +169,7 @@ impl<S: LogStore> FlushScheduler<S> {
         let handler = FlushHandler {
             compaction_scheduler,
         };
-        let task_interval = picker_config.picker_schedule_interval();
+        let task_interval = picker_config.schedule_interval;
         let picker = FlushPicker::new(picker_config);
         let task_fn = AutoFlushFunction { regions, picker };
         let auto_flush_task = RepeatedTask::new(task_interval, Box::new(task_fn));

--- a/src/storage/src/flush/scheduler.rs
+++ b/src/storage/src/flush/scheduler.rs
@@ -198,6 +198,14 @@ impl<S: LogStore> FlushScheduler<S> {
             receiver,
         })
     }
+
+    /// Stop the scheduler.
+    pub async fn stop(&self) -> Result<()> {
+        self.picker.stop().await?;
+        self.scheduler.stop(true).await?;
+
+        Ok(())
+    }
 }
 
 struct FlushHandler<S: LogStore> {

--- a/src/storage/src/flush/scheduler.rs
+++ b/src/storage/src/flush/scheduler.rs
@@ -29,7 +29,7 @@ use crate::error::{DuplicateFlushSnafu, Result, WaitFlushSnafu};
 use crate::flush::{FlushJob, FlushPicker};
 use crate::manifest::region::RegionManifest;
 use crate::memtable::{MemtableId, MemtableRef};
-use crate::metrics::{FLUSH_ERRORS_TOTAL, FLUSH_REQUESTS_TOTAL};
+use crate::metrics::FLUSH_ERRORS_TOTAL;
 use crate::region;
 use crate::region::{RegionWriterRef, SharedDataRef};
 use crate::scheduler::rate_limit::BoxedRateLimitToken;
@@ -190,8 +190,6 @@ impl<S: LogStore> FlushScheduler<S> {
                 sequence,
             }
         );
-
-        increment_counter!(FLUSH_REQUESTS_TOTAL);
 
         Ok(FlushHandle {
             region_id,

--- a/src/storage/src/flush/scheduler.rs
+++ b/src/storage/src/flush/scheduler.rs
@@ -148,7 +148,7 @@ pub struct FlushScheduler<S: LogStore> {
     /// Flush task scheduler.
     scheduler: LocalScheduler<FlushRequest<S>>,
     /// Flush picker.
-    picker: FlushPicker<S>,
+    picker: FlushPicker,
 }
 
 pub type FlushSchedulerRef<S> = Arc<FlushScheduler<S>>;
@@ -157,7 +157,7 @@ impl<S: LogStore> FlushScheduler<S> {
     /// Returns a new [FlushScheduler].
     pub fn new(
         config: SchedulerConfig,
-        picker: FlushPicker<S>,
+        picker: FlushPicker,
         compaction_scheduler: CompactionSchedulerRef<S>,
     ) -> Self {
         let handler = FlushHandler {

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -22,6 +22,8 @@ pub const FLUSH_REQUESTS_TOTAL: &str = "storage.flush.requests_total";
 pub const FLUSH_ERRORS_TOTAL: &str = "storage.flush.errors_total";
 /// Elapsed time of a flush job.
 pub const FLUSH_ELAPSED: &str = "storage.flush.elapsed";
+/// Reason to flush.
+pub const FLUSH_REASON: &str = "reason";
 /// Counter of auto flushed regions.
 pub const FLUSH_AUTO_FLUSH_TOTAL: &str = "storage.flush.auto_flush_total";
 /// Gauge for open regions

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -24,8 +24,6 @@ pub const FLUSH_ERRORS_TOTAL: &str = "storage.flush.errors_total";
 pub const FLUSH_ELAPSED: &str = "storage.flush.elapsed";
 /// Reason to flush.
 pub const FLUSH_REASON: &str = "reason";
-/// Counter of auto flushed regions.
-pub const FLUSH_AUTO_FLUSH_TOTAL: &str = "storage.flush.auto_flush_total";
 /// Gauge for open regions
 pub const REGION_COUNT: &str = "storage.region_count";
 /// Timer for logstore write

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -22,6 +22,8 @@ pub const FLUSH_REQUESTS_TOTAL: &str = "storage.flush.requests_total";
 pub const FLUSH_ERRORS_TOTAL: &str = "storage.flush.errors_total";
 /// Elapsed time of a flush job.
 pub const FLUSH_ELAPSED: &str = "storage.flush.elapsed";
+/// Counter of auto flushed regions.
+pub const FLUSH_AUTO_FLUSH_TOTAL: &str = "storage.flush.auto_flush_total";
 /// Gauge for open regions
 pub const REGION_COUNT: &str = "storage.region_count";
 /// Timer for logstore write

--- a/src/storage/src/region/tests/alter.rs
+++ b/src/storage/src/region/tests/alter.rs
@@ -22,8 +22,8 @@ use datatypes::vectors::{Int64Vector, TimestampMillisecondVector, VectorRef};
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use store_api::storage::{
     AddColumn, AlterOperation, AlterRequest, Chunk, ChunkReader, ColumnDescriptor,
-    ColumnDescriptorBuilder, ColumnId, FlushContext, Region, RegionMeta, ScanRequest, SchemaRef,
-    Snapshot, WriteRequest, WriteResponse,
+    ColumnDescriptorBuilder, ColumnId, FlushContext, FlushReason, Region, RegionMeta, ScanRequest,
+    SchemaRef, Snapshot, WriteRequest, WriteResponse,
 };
 
 use crate::region::tests::{self, FileTesterBase};
@@ -118,7 +118,12 @@ impl AlterTester {
     }
 
     async fn flush(&self, wait: Option<bool>) {
-        let ctx = wait.map(|wait| FlushContext { wait }).unwrap_or_default();
+        let ctx = wait
+            .map(|wait| FlushContext {
+                wait,
+                reason: FlushReason::Manually,
+            })
+            .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();
     }
 

--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -23,7 +23,7 @@ use common_test_util::temp_dir::create_temp_dir;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use object_store::services::{Fs, S3};
 use object_store::ObjectStore;
-use store_api::storage::{FlushContext, Region, WriteResponse};
+use store_api::storage::{FlushContext, FlushReason, Region, WriteResponse};
 use tokio::sync::Notify;
 
 use crate::compaction::{CompactionHandler, SimplePicker};
@@ -191,7 +191,12 @@ impl CompactionTester {
     }
 
     async fn flush(&self, wait: Option<bool>) {
-        let ctx = wait.map(|wait| FlushContext { wait }).unwrap_or_default();
+        let ctx = wait
+            .map(|wait| FlushContext {
+                wait,
+                reason: FlushReason::Manually,
+            })
+            .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();
     }
 

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use common_test_util::temp_dir::create_temp_dir;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
-use store_api::storage::{FlushContext, OpenOptions, Region, WriteResponse};
+use store_api::storage::{FlushContext, FlushReason, OpenOptions, Region, WriteResponse};
 use tokio::time;
 
 use crate::engine::{self, RegionMap, RegionSlot};
@@ -93,7 +93,12 @@ impl FlushTester {
     }
 
     async fn flush(&self, wait: Option<bool>) {
-        let ctx = wait.map(|wait| FlushContext { wait }).unwrap_or_default();
+        let ctx = wait
+            .map(|wait| FlushContext {
+                wait,
+                reason: FlushReason::Manually,
+            })
+            .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();
     }
 }

--- a/src/storage/src/scheduler.rs
+++ b/src/storage/src/scheduler.rs
@@ -124,6 +124,9 @@ where
         self.state.store(STATE_STOP, Ordering::Relaxed);
 
         self.cancel_token.cancel();
+
+        // Clear all requests
+        self.request_queue.write().unwrap().clear();
     }
 }
 

--- a/src/storage/src/scheduler/dedup_deque.rs
+++ b/src/storage/src/scheduler/dedup_deque.rs
@@ -76,6 +76,12 @@ impl<K: Eq + Hash + Clone, V> DedupDeque<K, V> {
     pub fn is_empty(&self) -> bool {
         self.deque.is_empty()
     }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.deque.clear();
+        self.existing.clear();
+    }
 }
 
 impl<K, V> Debug for DedupDeque<K, V>
@@ -111,5 +117,8 @@ mod tests {
         assert!(deque.push_back(1, "hello".to_string()));
         assert!(!deque.push_back(1, "world".to_string()));
         assert_eq!((1, "hello".to_string()), deque.pop_front().unwrap());
+
+        deque.clear();
+        assert!(deque.is_empty());
     }
 }

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -21,9 +21,9 @@ use object_store::ObjectStore;
 use store_api::manifest::Manifest;
 
 use crate::compaction::noop::NoopCompactionScheduler;
-use crate::engine;
+use crate::engine::{self, RegionMap};
 use crate::file_purger::noop::NoopFilePurgeHandler;
-use crate::flush::{FlushScheduler, SizeBasedStrategy};
+use crate::flush::{FlushPicker, FlushScheduler, PickerConfig, SizeBasedStrategy};
 use crate::manifest::region::RegionManifest;
 use crate::memtable::DefaultMemtableBuilder;
 use crate::region::StoreConfig;
@@ -65,8 +65,11 @@ pub async fn new_store_config_with_object_store(
     };
     let log_store = Arc::new(RaftEngineLogStore::try_new(log_config).await.unwrap());
     let compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
+    // We use an empty region map so actually the background worker of the picker is disabled.
+    let picker = FlushPicker::new(Arc::new(RegionMap::new()), PickerConfig::default()).unwrap();
     let flush_scheduler = Arc::new(FlushScheduler::new(
         SchedulerConfig::default(),
+        picker,
         compaction_scheduler.clone(),
     ));
     let file_purger = Arc::new(LocalScheduler::new(

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -66,7 +66,11 @@ pub async fn new_store_config_with_object_store(
     let log_store = Arc::new(RaftEngineLogStore::try_new(log_config).await.unwrap());
     let compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
     // We use an empty region map so actually the background worker of the picker is disabled.
-    let picker = FlushPicker::new(Arc::new(RegionMap::new()), PickerConfig::default()).unwrap();
+    let picker = FlushPicker::new(
+        Arc::new(RegionMap::<RaftEngineLogStore>::new()),
+        PickerConfig::default(),
+    )
+    .unwrap();
     let flush_scheduler = Arc::new(FlushScheduler::new(
         SchedulerConfig::default(),
         picker,

--- a/src/storage/src/test_util/flush_switch.rs
+++ b/src/storage/src/test_util/flush_switch.rs
@@ -17,6 +17,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::flush::FlushStrategy;
 use crate::region::SharedDataRef;
 
+/// Controls whether to flush a region while writing the region.
+/// Disable flush by default.
 #[derive(Debug, Default)]
 pub struct FlushSwitch {
     should_flush: AtomicBool,

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -34,7 +34,7 @@ pub use self::chunk::{Chunk, ChunkReader};
 pub use self::descriptors::*;
 pub use self::engine::{CreateOptions, EngineContext, OpenOptions, StorageEngine};
 pub use self::metadata::RegionMeta;
-pub use self::region::{FlushContext, Region, RegionStat, WriteContext};
+pub use self::region::{FlushContext, FlushReason, Region, RegionStat, WriteContext};
 pub use self::requests::{
     AddColumn, AlterOperation, AlterRequest, GetRequest, ScanRequest, WriteRequest,
 };

--- a/src/store-api/src/storage/engine.rs
+++ b/src/store-api/src/storage/engine.rs
@@ -73,6 +73,9 @@ pub trait StorageEngine: Send + Sync + Clone + 'static {
         ctx: &EngineContext,
         name: &str,
     ) -> Result<Option<Self::Region>, Self::Error>;
+
+    /// Close the engine.
+    async fn close(&self, ctx: &EngineContext) -> Result<(), Self::Error>;
 }
 
 /// Storage engine context.

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -118,7 +118,7 @@ impl Default for FlushContext {
     fn default() -> FlushContext {
         FlushContext {
             wait: true,
-            reason: FlushReason::Unknown,
+            reason: FlushReason::Others,
         }
     }
 }
@@ -126,8 +126,8 @@ impl Default for FlushContext {
 /// Reason of flush operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushReason {
-    /// Unknown reason.
-    Unknown,
+    /// Other reasons.
+    Others,
     /// Memtable is full.
     MemtableFull,
     /// Flush manually.
@@ -140,7 +140,7 @@ impl FlushReason {
     /// Returns reason as `str`.
     pub fn as_str(&self) -> &'static str {
         match self {
-            FlushReason::Unknown => "unknown",
+            FlushReason::Others => "others",
             FlushReason::MemtableFull => "memtable_full",
             FlushReason::Manually => "manually",
             FlushReason::Periodically => "periodically",

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -124,7 +124,7 @@ impl Default for FlushContext {
 }
 
 /// Reason of flush operation.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushReason {
     /// Unknown reason.
     Unknown,

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -110,10 +110,40 @@ pub struct FlushContext {
     /// If true, the flush will wait until the flush is done.
     /// Default: true
     pub wait: bool,
+    /// Flush reason.
+    pub reason: FlushReason,
 }
 
 impl Default for FlushContext {
     fn default() -> FlushContext {
-        FlushContext { wait: true }
+        FlushContext {
+            wait: true,
+            reason: FlushReason::Unknown,
+        }
+    }
+}
+
+/// Reason of flush operation.
+#[derive(Debug, Clone, Copy)]
+pub enum FlushReason {
+    /// Unknown reason.
+    Unknown,
+    /// Memtable is full.
+    MemtableFull,
+    /// Flush manually.
+    Manually,
+    /// Auto flush periodically.
+    Periodically,
+}
+
+impl FlushReason {
+    /// Returns reason as `str`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FlushReason::Unknown => "unknown",
+            FlushReason::MemtableFull => "memtable_full",
+            FlushReason::Manually => "manually",
+            FlushReason::Periodically => "periodically",
+        }
     }
 }

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -57,7 +57,8 @@ impl TestEnv {
             Arc::new(NoopLogStore::default()),
             object_store.clone(),
             compaction_scheduler,
-        );
+        )
+        .unwrap();
         let table_engine = Arc::new(MitoEngine::new(
             EngineConfig::default(),
             storage_engine,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Adds FlushPicker that picks region to flush periodically.
- The FlushPicker picks and flushes regions that have not been flushed before.
- The FlushScheduler starts a `RepeatedTask` to pick regions.
  - The default flush interval `1h` takes from HBase's [optionalcacheflushinterval](https://github.com/apache/hbase/blob/5cea8112fde64c019e7c9ed8f9a4220834276eda/hbase-common/src/main/resources/hbase-default.xml#L314-L318)
- Adds the `close()` method to the `StorageEngine` to stop background schedulers.
- Adds metrics about the flush reason.
- Exposes flush-related config.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1462 