### PR TITLE
feat: ignore mailbox message into stat

### DIFF
--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -34,6 +34,12 @@ impl HeartbeatHandler for CollectStatsHandler {
         _ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
+        if req.mailbox_message.is_some() {
+            // If the heartbeat is a mailbox message, it may have no other valid information,
+            // so we don't need to collect stats.
+            return Ok(());
+        }
+
         match Stat::try_from(req.clone()) {
             Ok(stat) => {
                 let _ = acc.stat.insert(stat);

--- a/src/meta-srv/src/handler/persist_stats_handler.rs
+++ b/src/meta-srv/src/handler/persist_stats_handler.rs
@@ -55,7 +55,6 @@ impl HeartbeatHandler for PersistStatsHandler {
         }
 
         let stats = stats.drain(..).collect();
-
         let val = StatValue { stats };
 
         let put = PutRequest {

--- a/src/meta-srv/src/handler/response_header_handler.rs
+++ b/src/meta-srv/src/handler/response_header_handler.rs
@@ -40,6 +40,7 @@ impl HeartbeatHandler for ResponseHeaderHandler {
             ..Default::default()
         };
         acc.header = Some(res_header);
+
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

If the heartbeat is a mailbox message, it may have no other valid information, so we don't need to collect stats.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
