### PR TITLE
fix: refreshing Dashboard returns 404

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -520,10 +520,13 @@ impl HttpServer {
                 info!("Enable dashboard service at '/dashboard'");
                 router = router.nest("/dashboard", dashboard::dashboard());
 
-                // "/dashboard" and "/dashboard/" are two different path in Axum.
+                // "/dashboard" and "/dashboard/" are two different paths in Axum.
                 // We cannot nest "/dashboard/", because we already mapping "/dashboard/*x" while nesting "/dashboard".
                 // So we explicitly route "/dashboard/" here.
-                router = router.route("/dashboard/", routing::get(dashboard::static_handler));
+                router = router.route(
+                    "/dashboard/",
+                    routing::get(dashboard::static_handler).post(dashboard::static_handler),
+                );
             }
         }
         router

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -519,6 +519,11 @@ impl HttpServer {
             if !self.options.disable_dashboard {
                 info!("Enable dashboard service at '/dashboard'");
                 router = router.nest("/dashboard", dashboard::dashboard());
+
+                // "/dashboard" and "/dashboard/" are two different path in Axum.
+                // We cannot nest "/dashboard/", because we already mapping "/dashboard/*x" while nesting "/dashboard".
+                // So we explicitly route "/dashboard/" here.
+                router = router.route("/dashboard/", routing::get(dashboard::static_handler));
             }
         }
         router

--- a/src/servers/src/http/dashboard.rs
+++ b/src/servers/src/http/dashboard.rs
@@ -29,8 +29,8 @@ pub struct Assets;
 
 pub(crate) fn dashboard() -> Router {
     Router::new()
-        .route("/", routing::get(static_handler))
-        .route("/*x", routing::get(static_handler))
+        .route("/", routing::get(static_handler).post(static_handler))
+        .route("/*x", routing::get(static_handler).post(static_handler))
 }
 
 #[axum_macros::debug_handler]

--- a/src/servers/src/http/dashboard.rs
+++ b/src/servers/src/http/dashboard.rs
@@ -14,7 +14,8 @@
 
 use axum::body::{boxed, Full};
 use axum::http::{header, StatusCode, Uri};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
+use axum::routing;
 use axum::routing::Router;
 use common_telemetry::debug;
 use rust_embed::RustEmbed;
@@ -27,11 +28,13 @@ use crate::error::{BuildHttpResponseSnafu, Result};
 pub struct Assets;
 
 pub(crate) fn dashboard() -> Router {
-    Router::new().fallback(static_handler)
+    Router::new()
+        .route("/", routing::get(static_handler))
+        .route("/*x", routing::get(static_handler))
 }
 
 #[axum_macros::debug_handler]
-async fn static_handler(uri: Uri) -> Result<impl IntoResponse> {
+pub async fn static_handler(uri: Uri) -> Result<Response> {
     debug!("[dashboard] requesting: {}", uri.path());
 
     let mut path = uri.path().trim_start_matches('/');
@@ -39,6 +42,18 @@ async fn static_handler(uri: Uri) -> Result<impl IntoResponse> {
         path = "index.html";
     }
 
+    match get_assets(path) {
+        Ok(response) if response.status() == StatusCode::NOT_FOUND => index_page(),
+        Ok(response) => Ok(response),
+        Err(e) => Err(e),
+    }
+}
+
+fn index_page() -> Result<Response> {
+    get_assets("index.html")
+}
+
+fn get_assets(path: &str) -> Result<Response> {
     match Assets::get(path) {
         Some(content) => {
             let body = boxed(Full::from(content.data));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix #1552 

Now "/dashboard", "/dashboard/" and "/dashboard/query" all works as expected. However, "/dashboard/not/existed" still returns 404.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
