### PR TITLE
fix:  unwrap() `None` in NULL value exist multi-field table during prometheus `query_range`

### DIFF
--- a/src/servers/src/prom.rs
+++ b/src/servers/src/prom.rs
@@ -350,12 +350,10 @@ impl PromJsonResponse {
                 let timestamp = timestamp_millis as f64 / 1000.0;
 
                 // retrieve value
-                let value = match field_column.get_data(row_index) {
-                    Some(v) => Into::<f64>::into(v).to_string(),
-                    None => "NULL".to_string(),
+                if let Some(v) = field_column.get_data(row_index) {
+                    let value = Into::<f64>::into(v).to_string();
+                    buffer.entry(tags).or_default().push((timestamp, value));
                 };
-
-                buffer.entry(tags).or_default().push((timestamp, value));
             }
         }
 

--- a/src/servers/src/prom.rs
+++ b/src/servers/src/prom.rs
@@ -350,8 +350,10 @@ impl PromJsonResponse {
                 let timestamp = timestamp_millis as f64 / 1000.0;
 
                 // retrieve value
-                let value =
-                    Into::<f64>::into(field_column.get_data(row_index).unwrap()).to_string();
+                let value = match field_column.get_data(row_index) {
+                    Some(v) => Into::<f64>::into(v).to_string(),
+                    None => "NULL".to_string(),
+                };
 
                 buffer.entry(tags).or_default().push((timestamp, value));
             }

--- a/src/servers/src/prom.rs
+++ b/src/servers/src/prom.rs
@@ -351,8 +351,10 @@ impl PromJsonResponse {
 
                 // retrieve value
                 if let Some(v) = field_column.get_data(row_index) {
-                    let value = Into::<f64>::into(v).to_string();
-                    buffer.entry(tags).or_default().push((timestamp, value));
+                    buffer
+                        .entry(tags)
+                        .or_default()
+                        .push((timestamp, Into::<f64>::into(v).to_string()));
                 };
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When I use  `curl '127.0.0.1:4004/api/v1/query_range?query=up&start=0&end=100&step=10s'` query a multi-field table which have NULL value. I get a error of `unwrap()` a `Option`. the table look like
```
mysql> select * from up;
+------+------+--------+---------------------+
| host | cpu  | memory | ts                  |
+------+------+--------+---------------------+
| h1   | 66.6 |   1024 | 1970-01-01 08:00:00 |
| h1   | 66.6 |   2048 | 1970-01-01 08:00:02 |
| h1   | 66.6 |   4096 | 1970-01-01 08:00:05 |
| h3   | NULL | 8764.8 | 1970-01-01 08:00:15 |
| h3   | NULL | 754.99 | 1970-01-01 08:00:20 |
| h3   | NULL |   64.8 | 1970-01-01 08:00:30 |
+------+------+--------+---------------------+
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
