### PR TITLE
refactor: remove version column

### DIFF
--- a/src/storage/benches/memtable/util/mod.rs
+++ b/src/storage/benches/memtable/util/mod.rs
@@ -27,7 +27,6 @@ pub const TIMESTAMP_NAME: &str = "timestamp";
 
 pub fn schema_for_test() -> RegionSchemaRef {
     let desc = RegionDescBuilder::new("bench")
-        .enable_version_column(true)
         .push_field_column(("v1", LogicalTypeId::UInt64, true))
         .push_field_column(("v2", LogicalTypeId::String, true))
         .build();

--- a/src/storage/benches/memtable/util/regiondesc_util.rs
+++ b/src/storage/benches/memtable/util/regiondesc_util.rs
@@ -49,11 +49,6 @@ impl RegionDescBuilder {
         }
     }
 
-    pub fn enable_version_column(mut self, enable: bool) -> Self {
-        self.key_builder = self.key_builder.enable_version_column(enable);
-        self
-    }
-
     pub fn push_field_column(mut self, column_def: ColumnDef) -> Self {
         let column = self.new_column(column_def);
         self.default_cf_builder = self.default_cf_builder.push_column(column);

--- a/src/storage/benches/wal/util/mod.rs
+++ b/src/storage/benches/wal/util/mod.rs
@@ -25,13 +25,12 @@ use datatypes::vectors::{
 use rand::Rng;
 use storage::proto;
 use storage::write_batch::WriteBatch;
-use store_api::storage::{consts, WriteRequest};
+use store_api::storage::WriteRequest;
 
 pub fn new_test_batch() -> WriteBatch {
     write_batch_util::new_write_batch(
         &[
             ("k1", LogicalTypeId::UInt64, false),
-            (consts::VERSION_COLUMN_NAME, LogicalTypeId::UInt64, false),
             ("ts", LogicalTypeId::TimestampMillisecond, false),
             ("v1", LogicalTypeId::Boolean, true),
             ("4", LogicalTypeId::Float64, false),
@@ -78,7 +77,6 @@ pub fn gen_new_batch_and_types(putdate_nums: usize) -> (WriteBatch, Vec<i32>) {
         let svs = Arc::new(StringVector::from_slice(&svs)) as VectorRef;
         let mut put_data = HashMap::with_capacity(11);
         put_data.insert("k1".to_string(), intv.clone());
-        put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         put_data.insert("v1".to_string(), boolv);
         put_data.insert("ts".to_string(), tsv.clone());
         put_data.insert("4".to_string(), fvs.clone());

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -110,7 +110,6 @@ mod tests {
     fn schema_for_test() -> RegionSchemaRef {
         // Just build a region desc and use its columns metadata.
         let desc = RegionDescBuilder::new("test")
-            .enable_version_column(false)
             .push_field_column(("v", LogicalTypeId::UInt64, true))
             .build();
         let metadata: RegionMetadata = desc.try_into().unwrap();

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -139,7 +139,7 @@ mod tests {
             &*memtable,
             10,
             OpType::Put,
-            &[(1, 1), (2, 2)],
+            &[1, 2],
             &[(Some(1), Some(1)), (Some(2), Some(2))],
         );
 

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -48,7 +48,6 @@ pub struct RawColumnsMetadata {
     pub columns: Vec<ColumnMetadata>,
     pub row_key_end: usize,
     pub timestamp_key_index: usize,
-    pub enable_version_column: bool,
     pub user_column_end: usize,
 }
 
@@ -365,7 +364,6 @@ mod tests {
     #[test]
     fn test_region_manifest_builder() {
         let desc = RegionDescBuilder::new("test_region_manifest_builder")
-            .enable_version_column(true)
             .push_field_column(("v0", LogicalTypeId::Int64, true))
             .build();
         let region_metadata: RegionMetadata = desc.try_into().unwrap();

--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -355,7 +355,9 @@ impl<'a> Iterator for IterRow<'a> {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct InnerKey {
+    /// User defined primary keys
     row_key: Vec<Value>,
+    /// Sequence number of row
     sequence: SequenceNumber,
     index_in_batch: usize,
     op_type: OpType,

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -151,7 +151,6 @@ mod tests {
         let desc = RegionDescBuilder::new("test")
             .timestamp(("ts", LogicalTypeId::TimestampMillisecond, false))
             .push_field_column(("value", LogicalTypeId::Int64, true))
-            .enable_version_column(false)
             .build();
         let metadata: RegionMetadata = desc.try_into().unwrap();
 

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -35,7 +35,7 @@ use object_store::services::Fs;
 use object_store::ObjectStore;
 use store_api::manifest::MAX_VERSION;
 use store_api::storage::{
-    consts, Chunk, ChunkReader, RegionMeta, ScanRequest, SequenceNumber, Snapshot, WriteRequest,
+    Chunk, ChunkReader, RegionMeta, ScanRequest, SequenceNumber, Snapshot, WriteRequest,
 };
 
 use super::*;
@@ -50,9 +50,8 @@ use crate::test_util::descriptor_util::RegionDescBuilder;
 use crate::test_util::{self, config_util, schema_util, write_batch_util};
 
 /// Create metadata of a region with schema: (timestamp, v0).
-pub fn new_metadata(region_name: &str, enable_version_column: bool) -> RegionMetadata {
+pub fn new_metadata(region_name: &str) -> RegionMetadata {
     let desc = RegionDescBuilder::new(region_name)
-        .enable_version_column(enable_version_column)
         .push_field_column(("v0", LogicalTypeId::Int64, true))
         .build();
     desc.try_into().unwrap()
@@ -195,7 +194,6 @@ fn new_write_batch_for_test(enable_version_column: bool) -> WriteBatch {
                     LogicalTypeId::TimestampMillisecond,
                     false,
                 ),
-                (consts::VERSION_COLUMN_NAME, LogicalTypeId::UInt64, false),
                 ("v0", LogicalTypeId::Int64, true),
             ],
             Some(0),
@@ -267,7 +265,6 @@ fn append_chunk_to(chunk: &Chunk, dst: &mut Vec<(i64, Option<i64>)>) {
 async fn test_new_region() {
     let region_name = "region-0";
     let desc = RegionDescBuilder::new(region_name)
-        .enable_version_column(true)
         .push_key_column(("k1", LogicalTypeId::Int32, false))
         .push_field_column(("v0", LogicalTypeId::Float32, true))
         .build();
@@ -294,7 +291,6 @@ async fn test_new_region() {
                 LogicalTypeId::TimestampMillisecond,
                 false,
             ),
-            (consts::VERSION_COLUMN_NAME, LogicalTypeId::UInt64, false),
             ("v0", LogicalTypeId::Float32, true),
         ],
         Some(1),

--- a/src/storage/src/region/tests/alter.rs
+++ b/src/storage/src/region/tests/alter.rs
@@ -36,7 +36,7 @@ const REGION_NAME: &str = "region-alter-0";
 
 async fn create_region_for_alter(store_dir: &str) -> RegionImpl<RaftEngineLogStore> {
     // Always disable version column in this test.
-    let metadata = tests::new_metadata(REGION_NAME, false);
+    let metadata = tests::new_metadata(REGION_NAME);
 
     let store_config = config_util::new_store_config(REGION_NAME, store_dir).await;
 

--- a/src/storage/src/region/tests/basic.rs
+++ b/src/storage/src/region/tests/basic.rs
@@ -30,12 +30,9 @@ const REGION_NAME: &str = "region-basic-0";
 async fn create_region_for_basic(
     region_name: &str,
     store_dir: &str,
-    enable_version_column: bool,
 ) -> RegionImpl<RaftEngineLogStore> {
-    let metadata = tests::new_metadata(region_name, enable_version_column);
-
+    let metadata = tests::new_metadata(region_name);
     let store_config = config_util::new_store_config(region_name, store_dir).await;
-
     RegionImpl::create(metadata, store_config).await.unwrap()
 }
 
@@ -48,7 +45,7 @@ struct Tester {
 
 impl Tester {
     async fn new(region_name: &str, store_dir: &str) -> Tester {
-        let region = create_region_for_basic(region_name, store_dir, false).await;
+        let region = create_region_for_basic(region_name, store_dir).await;
 
         Tester {
             region_name: region_name.to_string(),

--- a/src/storage/src/region/tests/close.rs
+++ b/src/storage/src/region/tests/close.rs
@@ -38,10 +38,9 @@ struct CloseTester {
 /// Create a new region for flush test
 async fn create_region_for_close(
     store_dir: &str,
-    enable_version_column: bool,
     flush_strategy: FlushStrategyRef,
 ) -> RegionImpl<RaftEngineLogStore> {
-    let metadata = tests::new_metadata(REGION_NAME, enable_version_column);
+    let metadata = tests::new_metadata(REGION_NAME);
 
     let mut store_config = config_util::new_store_config(REGION_NAME, store_dir).await;
     store_config.flush_strategy = flush_strategy;
@@ -51,7 +50,7 @@ async fn create_region_for_close(
 
 impl CloseTester {
     async fn new(store_dir: &str, flush_strategy: FlushStrategyRef) -> CloseTester {
-        let region = create_region_for_close(store_dir, false, flush_strategy.clone()).await;
+        let region = create_region_for_close(store_dir, flush_strategy.clone()).await;
 
         CloseTester {
             base: Some(FileTesterBase::with_region(region)),

--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -70,13 +70,12 @@ async fn create_region_for_compaction<
     H: Handler<Request = FilePurgeRequest> + Send + Sync + 'static,
 >(
     store_dir: &str,
-    enable_version_column: bool,
     engine_config: EngineConfig,
     purge_handler: H,
     flush_strategy: FlushStrategyRef,
     s3_bucket: Option<String>,
 ) -> (RegionImpl<RaftEngineLogStore>, ObjectStore) {
-    let metadata = tests::new_metadata(REGION_NAME, enable_version_column);
+    let metadata = tests::new_metadata(REGION_NAME);
 
     let object_store = new_object_store(store_dir, s3_bucket);
 
@@ -163,7 +162,6 @@ impl CompactionTester {
         let purge_handler = MockFilePurgeHandler::default();
         let (region, object_store) = create_region_for_compaction(
             store_dir,
-            false,
             engine_config.clone(),
             purge_handler.clone(),
             flush_strategy,

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -32,10 +32,9 @@ const REGION_NAME: &str = "region-flush-0";
 /// Create a new region for flush test
 async fn create_region_for_flush(
     store_dir: &str,
-    enable_version_column: bool,
     flush_strategy: FlushStrategyRef,
 ) -> RegionImpl<RaftEngineLogStore> {
-    let metadata = tests::new_metadata(REGION_NAME, enable_version_column);
+    let metadata = tests::new_metadata(REGION_NAME);
 
     let mut store_config = config_util::new_store_config(REGION_NAME, store_dir).await;
     store_config.flush_strategy = flush_strategy;
@@ -52,7 +51,7 @@ struct FlushTester {
 
 impl FlushTester {
     async fn new(store_dir: &str, flush_strategy: FlushStrategyRef) -> FlushTester {
-        let region = create_region_for_flush(store_dir, false, flush_strategy.clone()).await;
+        let region = create_region_for_flush(store_dir, flush_strategy.clone()).await;
 
         FlushTester {
             base: Some(FileTesterBase::with_region(region)),

--- a/src/storage/src/test_util/descriptor_util.rs
+++ b/src/storage/src/test_util/descriptor_util.rs
@@ -65,11 +65,6 @@ impl RegionDescBuilder {
         self
     }
 
-    pub fn enable_version_column(mut self, enable: bool) -> Self {
-        self.key_builder = self.key_builder.enable_version_column(enable);
-        self
-    }
-
     pub fn push_key_column(mut self, column_def: ColumnDef) -> Self {
         let column = self.new_column(column_def);
         self.key_builder = self.key_builder.push_column(column);

--- a/src/storage/src/test_util/read_util.rs
+++ b/src/storage/src/test_util/read_util.rs
@@ -30,7 +30,6 @@ use crate::test_util::descriptor_util::RegionDescBuilder;
 /// Create a new region schema (timestamp, v0).
 fn new_region_schema() -> RegionSchemaRef {
     let desc = RegionDescBuilder::new("read-util")
-        .enable_version_column(false)
         .push_field_column(("v0", LogicalTypeId::Int64, true))
         .build();
     let metadata: RegionMetadata = desc.try_into().unwrap();

--- a/src/storage/src/version.rs
+++ b/src/storage/src/version.rs
@@ -313,9 +313,7 @@ mod tests {
     use crate::test_util::descriptor_util::RegionDescBuilder;
 
     fn new_version_control() -> VersionControl {
-        let desc = RegionDescBuilder::new("version-test")
-            .enable_version_column(false)
-            .build();
+        let desc = RegionDescBuilder::new("version-test").build();
         let metadata: RegionMetadataRef = Arc::new(desc.try_into().unwrap());
         let memtable = DefaultMemtableBuilder::default().build(metadata.schema().clone());
 

--- a/src/storage/src/write_batch.rs
+++ b/src/storage/src/write_batch.rs
@@ -330,19 +330,17 @@ impl NameToVector {
 #[cfg(test)]
 pub(crate) fn new_test_batch() -> WriteBatch {
     use datatypes::type_id::LogicalTypeId;
-    use store_api::storage::consts;
 
     use crate::test_util::write_batch_util;
 
     write_batch_util::new_write_batch(
         &[
             ("k1", LogicalTypeId::UInt64, false),
-            (consts::VERSION_COLUMN_NAME, LogicalTypeId::UInt64, false),
             ("ts", LogicalTypeId::TimestampMillisecond, false),
             ("v1", LogicalTypeId::Boolean, true),
         ],
-        Some(2),
-        3,
+        Some(1),
+        2,
     )
 }
 
@@ -357,7 +355,6 @@ mod tests {
     use datatypes::vectors::{
         BooleanVector, Int32Vector, Int64Vector, TimestampMillisecondVector, UInt64Vector,
     };
-    use store_api::storage::consts;
 
     use super::*;
     use crate::test_util::write_batch_util;
@@ -368,11 +365,9 @@ mod tests {
         assert!(columns.is_empty());
 
         let vector1 = Arc::new(Int32Vector::from_slice([1, 2, 3, 4, 5])) as VectorRef;
-        let vector2 = Arc::new(UInt64Vector::from_slice([0, 2, 4, 6, 8])) as VectorRef;
 
         let mut put_data = HashMap::with_capacity(3);
         put_data.insert("k1".to_string(), vector1.clone());
-        put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), vector2);
         put_data.insert("v1".to_string(), vector1);
 
         let columns = NameToVector::new(put_data).unwrap();
@@ -399,7 +394,6 @@ mod tests {
 
         let mut put_data = HashMap::with_capacity(4);
         put_data.insert("k1".to_string(), intv.clone());
-        put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         put_data.insert("v1".to_string(), boolv);
         put_data.insert("ts".to_string(), tsv);
 
@@ -442,7 +436,6 @@ mod tests {
 
         let mut put_data = HashMap::new();
         put_data.insert("k1".to_string(), intv.clone());
-        put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         put_data.insert("v1".to_string(), boolv.clone());
         put_data.insert("ts".to_string(), tsv);
 
@@ -482,7 +475,7 @@ mod tests {
     #[test]
     fn test_put_missing_column() {
         let boolv = Arc::new(BooleanVector::from(vec![true, false, true])) as VectorRef;
-        let tsv = Arc::new(Int64Vector::from_slice([0, 0, 0])) as VectorRef;
+        let tsv = Arc::new(TimestampMillisecondVector::from_slice([0, 0, 0])) as VectorRef;
 
         let mut put_data = HashMap::new();
         put_data.insert("v1".to_string(), boolv);
@@ -501,7 +494,6 @@ mod tests {
 
         let mut put_data = HashMap::new();
         put_data.insert("k1".to_string(), intv.clone());
-        put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         put_data.insert("v1".to_string(), boolv.clone());
         put_data.insert("ts".to_string(), tsv);
         put_data.insert("v2".to_string(), boolv);
@@ -532,7 +524,6 @@ mod tests {
 
         let mut keys = HashMap::with_capacity(3);
         keys.insert("k1".to_string(), intv.clone());
-        keys.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         keys.insert("ts".to_string(), tsv);
 
         let mut batch = new_test_batch();
@@ -540,7 +531,7 @@ mod tests {
 
         let record_batch = &batch.payload().mutations[0].record_batch;
         assert_eq!(3, record_batch.num_rows());
-        assert_eq!(4, record_batch.num_columns());
+        assert_eq!(3, record_batch.num_columns());
         let v1 = record_batch.column_by_name("v1").unwrap();
         assert!(v1.only_null());
     }
@@ -551,7 +542,6 @@ mod tests {
 
         let mut keys = HashMap::with_capacity(3);
         keys.insert("k1".to_string(), intv.clone());
-        keys.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
 
         let mut batch = new_test_batch();
         let err = batch.delete(keys).unwrap_err();
@@ -565,7 +555,6 @@ mod tests {
 
         let mut keys = HashMap::with_capacity(3);
         keys.insert("k1".to_string(), intv.clone());
-        keys.insert(consts::VERSION_COLUMN_NAME.to_string(), intv.clone());
         keys.insert("ts".to_string(), tsv);
         keys.insert("v2".to_string(), intv);
 
@@ -581,7 +570,6 @@ mod tests {
 
         let mut keys = HashMap::with_capacity(3);
         keys.insert("k1".to_string(), intv.clone());
-        keys.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
         keys.insert("ts".to_string(), boolv);
 
         let mut batch = new_test_batch();

--- a/src/storage/src/write_batch/codec.rs
+++ b/src/storage/src/write_batch/codec.rs
@@ -133,7 +133,7 @@ mod tests {
     use std::sync::Arc;
 
     use datatypes::vectors::{BooleanVector, TimestampMillisecondVector, UInt64Vector, VectorRef};
-    use store_api::storage::{consts, WriteRequest};
+    use store_api::storage::WriteRequest;
 
     use super::*;
     use crate::write_batch::WriteBatch;
@@ -149,7 +149,6 @@ mod tests {
 
             let mut put_data = HashMap::new();
             put_data.insert("k1".to_string(), intv.clone());
-            put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
             put_data.insert("v1".to_string(), boolv);
             put_data.insert("ts".to_string(), tsv);
 
@@ -186,7 +185,6 @@ mod tests {
 
             let mut put_data = HashMap::with_capacity(3);
             put_data.insert("k1".to_string(), intv.clone());
-            put_data.insert(consts::VERSION_COLUMN_NAME.to_string(), intv);
             put_data.insert("ts".to_string(), tsv);
 
             batch.put(put_data).unwrap();

--- a/src/store-api/src/storage/consts.rs
+++ b/src/store-api/src/storage/consts.rs
@@ -72,9 +72,6 @@ impl ReservedColumnId {
 
 // ---------- Names reserved for internal columns and engine -------------------
 
-/// Name of version column.
-pub const VERSION_COLUMN_NAME: &str = "__version";
-
 /// Names for default column family.
 pub const DEFAULT_CF_NAME: &str = "default";
 

--- a/src/store-api/src/storage/descriptors.rs
+++ b/src/store-api/src/storage/descriptors.rs
@@ -114,11 +114,6 @@ pub struct RowKeyDescriptor {
     pub columns: Vec<ColumnDescriptor>,
     /// Timestamp key column.
     pub timestamp: ColumnDescriptor,
-    /// Enable version column in row key if this field is true.
-    ///
-    /// The default value is false.
-    #[builder(default = "false")]
-    pub enable_version_column: bool,
 }
 
 /// A [ColumnFamilyDescriptor] contains information to create a column family.
@@ -263,7 +258,6 @@ mod tests {
             .build()
             .unwrap();
         assert!(desc.columns.is_empty());
-        assert!(!desc.enable_version_column);
 
         let desc = RowKeyDescriptorBuilder::new(timestamp.clone())
             .columns_capacity(1)
@@ -280,14 +274,9 @@ mod tests {
             .build()
             .unwrap();
         assert_eq!(2, desc.columns.len());
-        assert!(!desc.enable_version_column);
 
-        let desc = RowKeyDescriptorBuilder::new(timestamp)
-            .enable_version_column(false)
-            .build()
-            .unwrap();
+        let desc = RowKeyDescriptorBuilder::new(timestamp).build().unwrap();
         assert!(desc.columns.is_empty());
-        assert!(!desc.enable_version_column);
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR removes the reserved column `__version` so that we can always assume the timestamp index is the last column of row key. 

The `__version` column is now only used in tests and users cannot enable this column when creating tables, so it's not a breaking change and shall not cause data corruption.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #233 