### PR TITLE
feat: make RepeatedTask invoke remove_outdated_meta method

### DIFF
--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -128,7 +128,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Faield to stop the remove_outdated_meta method"))]
+    #[snafu(display("Failed to stop the remove_outdated_meta method"))]
     StopRemoveOutdatedMetaTask {
         source: common_runtime::error::Error,
         location: Location,

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -122,13 +122,13 @@ pub enum Error {
     #[snafu(display("Corrupted data, error: {source}"))]
     CorruptedData { source: FromUtf8Error },
 
-    #[snafu(display("Failed to start the remove_outdated_meta method"))]
+    #[snafu(display("Failed to start the remove_outdated_meta method, error: {}", source))]
     StartRemoveOutdatedMetaTask {
         source: common_runtime::error::Error,
         location: Location,
     },
 
-    #[snafu(display("Failed to stop the remove_outdated_meta method"))]
+    #[snafu(display("Failed to stop the remove_outdated_meta method, error: {}", source))]
     StopRemoveOutdatedMetaTask {
         source: common_runtime::error::Error,
         location: Location,

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -121,6 +121,18 @@ pub enum Error {
 
     #[snafu(display("Corrupted data, error: {source}"))]
     CorruptedData { source: FromUtf8Error },
+
+    #[snafu(display("Failed to start the remove_outdated_meta method"))]
+    StartRemoveOutdatedMetaTask {
+        source: common_runtime::error::Error,
+        location: Location,
+    },
+
+    #[snafu(display("Faield to stop the remove_outdated_meta method"))]
+    StopRemoveOutdatedMetaTask {
+        source: common_runtime::error::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -145,6 +157,8 @@ impl ErrorExt for Error {
             }
             Error::ProcedurePanic { .. } | Error::CorruptedData { .. } => StatusCode::Unexpected,
             Error::ProcedureExec { source, .. } => source.status_code(),
+            Error::StartRemoveOutdatedMetaTask { source, .. }
+            | Error::StopRemoveOutdatedMetaTask { source, .. } => source.status_code(),
         }
     }
 

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -21,14 +21,14 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use backon::ExponentialBuilder;
-use common_runtime::RepeatedTask;
+use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::logging;
 use snafu::{ensure, ResultExt};
 use tokio::sync::watch::{self, Receiver, Sender};
 use tokio::sync::Notify;
 
 use crate::error::{
-    DuplicateProcedureSnafu, LoaderConflictSnafu, Result, StartRemoveOutdatedMetaTaskSnafu,
+    DuplicateProcedureSnafu, Error, LoaderConflictSnafu, Result, StartRemoveOutdatedMetaTaskSnafu,
     StopRemoveOutdatedMetaTaskSnafu,
 };
 use crate::local::lock::LockMap;
@@ -530,10 +530,6 @@ struct RemoveOutdatedMetaFunction {
     ttl: Duration,
 }
 
-use common_runtime::TaskFunction;
-
-use crate::error::Error;
-
 #[async_trait::async_trait]
 impl TaskFunction<Error> for RemoveOutdatedMetaFunction {
     fn name(&self) -> &str {
@@ -892,7 +888,7 @@ mod tests {
             .unwrap()
             .is_none());
 
-        //The remove_outdated_meta method has been stopped, so any procedure meta-data will not be automatically removed.
+        // The remove_outdated_meta method has been stopped, so any procedure meta-data will not be automatically removed.
         manager.stop().await.unwrap();
         let mut procedure = ProcedureToLoad::new("submit");
         procedure.lock_key = LockKey::single("test.submit");

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -260,6 +260,10 @@ pub trait ProcedureManager: Send + Sync + 'static {
     /// Registers loader for specific procedure type `name`.
     fn register_loader(&self, name: &str, loader: BoxedProcedureLoader) -> Result<()>;
 
+    fn start(&self) -> Result<()>;
+
+    async fn stop(&self) -> Result<()>;
+
     /// Submits a procedure to execute.
     ///
     /// Returns a [Watcher] to watch the created procedure.

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -453,6 +453,16 @@ pub enum Error {
 
     #[snafu(display("Payload not exist"))]
     PayloadNotExist { location: Location },
+
+    #[snafu(display("Failed to start the procedure manager"))]
+    StartProcedureManager {
+        source: common_procedure::error::Error,
+    },
+
+    #[snafu(display("Failed to stop the procedure manager"))]
+    StopProcedureManager {
+        source: common_procedure::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -548,6 +558,9 @@ impl ErrorExt for Error {
                 source.status_code()
             }
             WaitProcedure { source, .. } => source.status_code(),
+            StartProcedureManager { source } | StopProcedureManager { source } => {
+                source.status_code()
+            }
         }
     }
 

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -72,6 +72,7 @@ impl TestEnv {
         let config = ManagerConfig {
             max_retry_times: 3,
             retry_delay: Duration::from_secs(500),
+            ..Default::default()
         };
         let state_store = Arc::new(ObjectStateStore::new(object_store));
         let procedure_manager = Arc::new(LocalManager::new(config, state_store));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR makes a `RepeatedTask` invoke the `remove_outdated_meta` method.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#1509