### PR TITLE
feat: support user config manifest compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,6 +5003,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "common-catalog",
+ "common-datasource",
  "common-error",
  "common-procedure",
  "common-procedure-test",

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -236,7 +236,7 @@ mod tests {
             checkpoint_margin = 9
             gc_duration = '7s'
             checkpoint_on_startup = true
-            use_compress = true
+            compress = true
 
             [logging]
             level = "debug"
@@ -296,7 +296,7 @@ mod tests {
                 checkpoint_margin: Some(9),
                 gc_duration: Some(Duration::from_secs(7)),
                 checkpoint_on_startup: true,
-                use_compress: true
+                compress: true
             },
             options.storage.manifest,
         );

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -236,6 +236,7 @@ mod tests {
             checkpoint_margin = 9
             gc_duration = '7s'
             checkpoint_on_startup = true
+            use_compress = true
 
             [logging]
             level = "debug"
@@ -295,6 +296,7 @@ mod tests {
                 checkpoint_margin: Some(9),
                 gc_duration: Some(Duration::from_secs(7)),
                 checkpoint_on_startup: true,
+                use_compress: true
             },
             options.storage.manifest,
         );

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -167,7 +167,7 @@ pub struct RegionManifestConfig {
     /// Whether to try creating a manifest checkpoint on region opening
     pub checkpoint_on_startup: bool,
     /// Whether to compress manifest and checkpoint file by gzip
-    pub use_compress: bool,
+    pub compress: bool,
 }
 
 impl Default for RegionManifestConfig {
@@ -176,7 +176,7 @@ impl Default for RegionManifestConfig {
             checkpoint_margin: Some(10u16),
             gc_duration: Some(Duration::from_secs(30)),
             checkpoint_on_startup: false,
-            use_compress: false,
+            compress: false,
         }
     }
 }
@@ -217,7 +217,7 @@ impl From<&DatanodeOptions> for SchedulerConfig {
 impl From<&DatanodeOptions> for StorageEngineConfig {
     fn from(value: &DatanodeOptions) -> Self {
         Self {
-            manifest_use_compress: value.storage.manifest.use_compress,
+            compress_manifest: value.storage.manifest.compress,
             manifest_checkpoint_on_startup: value.storage.manifest.checkpoint_on_startup,
             manifest_checkpoint_margin: value.storage.manifest.checkpoint_margin,
             manifest_gc_duration: value.storage.manifest.gc_duration,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -166,6 +166,8 @@ pub struct RegionManifestConfig {
     pub gc_duration: Option<Duration>,
     /// Whether to try creating a manifest checkpoint on region opening
     pub checkpoint_on_startup: bool,
+    /// Whether to compress manifest and checkpoint file by gzip
+    pub use_compress: bool,
 }
 
 impl Default for RegionManifestConfig {
@@ -174,6 +176,7 @@ impl Default for RegionManifestConfig {
             checkpoint_margin: Some(10u16),
             gc_duration: Some(Duration::from_secs(30)),
             checkpoint_on_startup: false,
+            use_compress: false,
         }
     }
 }
@@ -214,6 +217,7 @@ impl From<&DatanodeOptions> for SchedulerConfig {
 impl From<&DatanodeOptions> for StorageEngineConfig {
     fn from(value: &DatanodeOptions) -> Self {
         Self {
+            manifest_use_compress: value.storage.manifest.use_compress,
             manifest_checkpoint_on_startup: value.storage.manifest.checkpoint_on_startup,
             manifest_checkpoint_margin: value.storage.manifest.checkpoint_margin,
             manifest_gc_duration: value.storage.manifest.gc_duration,

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -114,7 +114,9 @@ impl Instance {
         let log_store = Arc::new(create_log_store(&opts.wal).await?);
 
         let mito_engine = Arc::new(DefaultEngine::new(
-            TableEngineConfig::default(),
+            TableEngineConfig {
+                manifest_use_compress: opts.storage.manifest.use_compress,
+            },
             EngineImpl::new(
                 StorageEngineConfig::from(opts),
                 log_store.clone(),

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -115,7 +115,7 @@ impl Instance {
 
         let mito_engine = Arc::new(DefaultEngine::new(
             TableEngineConfig {
-                manifest_use_compress: opts.storage.manifest.use_compress,
+                compress_manifest: opts.storage.manifest.compress,
             },
             EngineImpl::new(
                 StorageEngineConfig::from(opts),

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -19,6 +19,7 @@ common-error = { path = "../common/error" }
 common-procedure = { path = "../common/procedure" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
+common-datasource = { path = "../common/datasource" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
 dashmap = "5.4"

--- a/src/mito/src/config.rs
+++ b/src/mito/src/config.rs
@@ -15,4 +15,6 @@
 //! Table Engine config
 
 #[derive(Debug, Clone, Default)]
-pub struct EngineConfig {}
+pub struct EngineConfig {
+    pub manifest_use_compress: bool,
+}

--- a/src/mito/src/config.rs
+++ b/src/mito/src/config.rs
@@ -16,5 +16,5 @@
 
 #[derive(Debug, Clone, Default)]
 pub struct EngineConfig {
-    pub manifest_use_compress: bool,
+    pub compress_manifest: bool,
 }

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -558,7 +558,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             tables: DashMap::new(),
             storage_engine,
             object_store,
-            compress_type: manifest_compress_type(config.manifest_use_compress),
+            compress_type: manifest_compress_type(config.compress_manifest),
             table_mutex: Arc::new(KeyLock::new()),
         }
     }

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -367,6 +367,7 @@ impl<S: StorageEngine> TableCreator<S> {
             table_info,
             self.regions.clone(),
             self.engine_inner.object_store.clone(),
+            self.engine_inner.compress_type,
         )
         .await?;
 

--- a/src/mito/src/manifest.rs
+++ b/src/mito/src/manifest.rs
@@ -46,6 +46,7 @@ pub type TableManifest = ManifestImpl<NoopCheckpoint, TableMetaActionList>;
 
 #[cfg(test)]
 mod tests {
+    use common_datasource::compression::CompressionType;
     use storage::manifest::MetaActionIteratorImpl;
     use store_api::manifest::action::ProtocolAction;
     use store_api::manifest::{Manifest, MetaActionIterator};
@@ -80,7 +81,8 @@ mod tests {
     async fn test_table_manifest() {
         let (_dir, object_store) = test_util::new_test_object_store("test_table_manifest").await;
 
-        let manifest = TableManifest::create("manifest/", object_store);
+        let manifest =
+            TableManifest::create("manifest/", object_store, CompressionType::Uncompressed);
 
         let mut iter = manifest.scan(0, 100).await.unwrap();
         assert!(iter.next_action().await.unwrap().is_none());

--- a/src/mito/src/manifest.rs
+++ b/src/mito/src/manifest.rs
@@ -46,8 +46,7 @@ pub type TableManifest = ManifestImpl<NoopCheckpoint, TableMetaActionList>;
 
 #[cfg(test)]
 mod tests {
-    use common_datasource::compression::CompressionType;
-    use storage::manifest::MetaActionIteratorImpl;
+    use storage::manifest::{manifest_compress_type, MetaActionIteratorImpl};
     use store_api::manifest::action::ProtocolAction;
     use store_api::manifest::{Manifest, MetaActionIterator};
     use table::metadata::{RawTableInfo, TableInfo};
@@ -78,11 +77,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_table_manifest() {
+    async fn test_table_manifest_compress() {
+        test_table_manifest(true).await
+    }
+
+    #[tokio::test]
+    async fn test_table_manifest_uncompress() {
+        test_table_manifest(false).await
+    }
+
+    async fn test_table_manifest(compress: bool) {
         let (_dir, object_store) = test_util::new_test_object_store("test_table_manifest").await;
 
         let manifest =
-            TableManifest::create("manifest/", object_store, CompressionType::Uncompressed);
+            TableManifest::create("manifest/", object_store, manifest_compress_type(compress));
 
         let mut iter = manifest.scan(0, 100).await.unwrap();
         assert!(iter.next_action().await.unwrap().is_none());

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
+use common_datasource::compression::CompressionType;
 use common_error::ext::BoxedError;
 use common_query::logical_plan::Expr;
 use common_query::physical_plan::PhysicalPlanRef;
@@ -436,8 +437,10 @@ impl<R: Region> MitoTable<R> {
         table_info: TableInfo,
         regions: HashMap<RegionNumber, R>,
         object_store: ObjectStore,
+        compress_type: CompressionType,
     ) -> Result<MitoTable<R>> {
-        let manifest = TableManifest::create(&table_manifest_dir(table_dir), object_store);
+        let manifest =
+            TableManifest::create(&table_manifest_dir(table_dir), object_store, compress_type);
 
         let _timer =
             common_telemetry::timer!(crate::metrics::MITO_CREATE_TABLE_UPDATE_MANIFEST_ELAPSED);
@@ -454,8 +457,12 @@ impl<R: Region> MitoTable<R> {
         Ok(MitoTable::new(table_info, regions, manifest))
     }
 
-    pub(crate) fn build_manifest(table_dir: &str, object_store: ObjectStore) -> TableManifest {
-        TableManifest::create(&table_manifest_dir(table_dir), object_store)
+    pub(crate) fn build_manifest(
+        table_dir: &str,
+        object_store: ObjectStore,
+        compress_type: CompressionType,
+    ) -> TableManifest {
+        TableManifest::create(&table_manifest_dir(table_dir), object_store, compress_type)
     }
 
     pub(crate) async fn recover_table_info(

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -21,7 +21,7 @@ use common_base::readable_size::ReadableSize;
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
     pub manifest_checkpoint_on_startup: bool,
-    pub manifest_use_compress: bool,
+    pub compress_manifest: bool,
     pub manifest_checkpoint_margin: Option<u16>,
     pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
@@ -33,7 +33,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             manifest_checkpoint_on_startup: false,
-            manifest_use_compress: false,
+            compress_manifest: false,
             manifest_checkpoint_margin: Some(10),
             manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -21,6 +21,7 @@ use common_base::readable_size::ReadableSize;
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
     pub manifest_checkpoint_on_startup: bool,
+    pub manifest_use_compress: bool,
     pub manifest_checkpoint_margin: Option<u16>,
     pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
@@ -32,6 +33,7 @@ impl Default for EngineConfig {
     fn default() -> Self {
         Self {
             manifest_checkpoint_on_startup: false,
+            manifest_use_compress: false,
             manifest_checkpoint_margin: Some(10),
             manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -405,7 +405,7 @@ impl<S: LogStore> EngineInner<S> {
         let manifest = RegionManifest::with_checkpointer(
             &manifest_dir,
             self.object_store.clone(),
-            manifest_compress_type(config.manifest_use_compress),
+            manifest_compress_type(config.compress_manifest),
             config.manifest_checkpoint_margin,
             config.manifest_gc_duration,
         );

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -32,6 +32,7 @@ use crate::error::{self, Error, Result};
 use crate::file_purger::{FilePurgeHandler, FilePurgerRef};
 use crate::flush::{FlushScheduler, FlushSchedulerRef, FlushStrategyRef, SizeBasedStrategy};
 use crate::manifest::region::RegionManifest;
+use crate::manifest::storage::manifest_compress_type;
 use crate::memtable::{DefaultMemtableBuilder, MemtableBuilderRef};
 use crate::metadata::RegionMetadata;
 use crate::region::{RegionImpl, StoreConfig};
@@ -404,6 +405,7 @@ impl<S: LogStore> EngineInner<S> {
         let manifest = RegionManifest::with_checkpointer(
             &manifest_dir,
             self.object_store.clone(),
+            manifest_compress_type(config.manifest_use_compress),
             config.manifest_checkpoint_margin,
             config.manifest_gc_duration,
         );

--- a/src/storage/src/manifest.rs
+++ b/src/storage/src/manifest.rs
@@ -23,3 +23,4 @@ pub(crate) mod storage;
 pub mod test_utils;
 
 pub use self::impl_::*;
+pub use self::storage::manifest_compress_type;

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -189,12 +189,22 @@ mod tests {
     use store_api::manifest::{Manifest, MetaActionIterator, MAX_VERSION};
 
     use super::*;
+    use crate::manifest::manifest_compress_type;
     use crate::manifest::test_utils::*;
     use crate::metadata::RegionMetadata;
     use crate::sst::FileId;
 
     #[tokio::test]
-    async fn test_region_manifest() {
+    async fn test_region_manifest_compress() {
+        test_region_manifest(true).await
+    }
+
+    #[tokio::test]
+    async fn test_region_manifest_uncompress() {
+        test_region_manifest(false).await
+    }
+
+    async fn test_region_manifest(compress: bool) {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_region_manifest");
         let mut builder = Fs::default();
@@ -204,7 +214,7 @@ mod tests {
         let manifest = RegionManifest::with_checkpointer(
             "/manifest/",
             object_store,
-            CompressionType::Uncompressed,
+            manifest_compress_type(compress),
             None,
             None,
         );
@@ -315,7 +325,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_region_manifest_checkpoint() {
+    async fn test_region_manifest_checkpoint_compress() {
+        test_region_manifest_checkpoint(true).await
+    }
+
+    #[tokio::test]
+    async fn test_region_manifest_checkpoint_uncompress() {
+        test_region_manifest_checkpoint(false).await
+    }
+
+    async fn test_region_manifest_checkpoint(compress: bool) {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_region_manifest_checkpoint");
         let mut builder = Fs::default();
@@ -325,7 +344,7 @@ mod tests {
         let manifest = RegionManifest::with_checkpointer(
             "/manifest/",
             object_store,
-            CompressionType::Uncompressed,
+            manifest_compress_type(compress),
             None,
             Some(Duration::from_millis(50)),
         );

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common_datasource::compression::CompressionType;
 use common_telemetry::{info, warn};
 use object_store::ObjectStore;
 use store_api::manifest::action::ProtocolAction;
@@ -148,12 +149,14 @@ impl RegionManifest {
     pub fn with_checkpointer(
         manifest_dir: &str,
         object_store: ObjectStore,
+        compress_type: CompressionType,
         checkpoint_actions_margin: Option<u16>,
         gc_duration: Option<Duration>,
     ) -> Self {
         Self::new(
             manifest_dir,
             object_store,
+            compress_type,
             checkpoint_actions_margin,
             gc_duration,
             Some(Arc::new(RegionManifestCheckpointer {
@@ -198,7 +201,13 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer("/manifest/", object_store, None, None);
+        let manifest = RegionManifest::with_checkpointer(
+            "/manifest/",
+            object_store,
+            CompressionType::Uncompressed,
+            None,
+            None,
+        );
         manifest.start().await.unwrap();
 
         let region_meta = Arc::new(build_region_meta());
@@ -316,6 +325,7 @@ mod tests {
         let manifest = RegionManifest::with_checkpointer(
             "/manifest/",
             object_store,
+            CompressionType::Uncompressed,
             None,
             Some(Duration::from_millis(50)),
         );

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -45,8 +45,8 @@ const DEFAULT_MANIFEST_COMPRESSION_TYPE: CompressionType = CompressionType::Gzip
 const FALL_BACK_COMPRESS_TYPE: CompressionType = CompressionType::Uncompressed;
 
 #[inline]
-pub const fn manifest_compress_type(use_compress: bool) -> CompressionType {
-    if use_compress {
+pub const fn manifest_compress_type(compress: bool) -> CompressionType {
+    if compress {
         DEFAULT_MANIFEST_COMPRESSION_TYPE
     } else {
         FALL_BACK_COMPRESS_TYPE

--- a/src/storage/src/manifest/storage.rs
+++ b/src/storage/src/manifest/storage.rs
@@ -39,10 +39,19 @@ lazy_static! {
 }
 
 const LAST_CHECKPOINT_FILE: &str = "_last_checkpoint";
-const DEFAULT_MANIFEST_COMPRESSION_TYPE: CompressionType = CompressionType::Uncompressed;
+const DEFAULT_MANIFEST_COMPRESSION_TYPE: CompressionType = CompressionType::Gzip;
 /// Due to backward compatibility, it is possible that the user's manifest file has not been compressed.
 /// So when we encounter problems, we need to fall back to `FALL_BACK_COMPRESS_TYPE` for processing.
 const FALL_BACK_COMPRESS_TYPE: CompressionType = CompressionType::Uncompressed;
+
+#[inline]
+pub const fn manifest_compress_type(use_compress: bool) -> CompressionType {
+    if use_compress {
+        DEFAULT_MANIFEST_COMPRESSION_TYPE
+    } else {
+        FALL_BACK_COMPRESS_TYPE
+    }
+}
 
 #[inline]
 pub fn delta_file(version: ManifestVersion) -> String {
@@ -133,11 +142,10 @@ pub struct ManifestObjectStore {
 }
 
 impl ManifestObjectStore {
-    pub fn new(path: &str, object_store: ObjectStore) -> Self {
+    pub fn new(path: &str, object_store: ObjectStore, compress_type: CompressionType) -> Self {
         Self {
             object_store,
-            //TODO: make it configurable
-            compress_type: DEFAULT_MANIFEST_COMPRESSION_TYPE,
+            compress_type,
             path: util::normalize_dir(path),
         }
     }
@@ -528,7 +536,7 @@ mod tests {
         let mut builder = Fs::default();
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
-        ManifestObjectStore::new("/", object_store)
+        ManifestObjectStore::new("/", object_store, CompressionType::Uncompressed)
     }
 
     #[test]

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -23,6 +23,7 @@ mod projection;
 
 use std::collections::{HashMap, HashSet};
 
+use common_datasource::compression::CompressionType;
 use common_telemetry::logging;
 use common_test_util::temp_dir::create_temp_dir;
 use datatypes::prelude::{ScalarVector, WrapperType};
@@ -314,8 +315,13 @@ async fn test_recover_region_manifets() {
     builder.root(&tmp_dir.path().to_string_lossy());
     let object_store = ObjectStore::new(builder).unwrap().finish();
 
-    let manifest =
-        RegionManifest::with_checkpointer("/manifest/", object_store.clone(), None, None);
+    let manifest = RegionManifest::with_checkpointer(
+        "/manifest/",
+        object_store.clone(),
+        CompressionType::Uncompressed,
+        None,
+        None,
+    );
     let region_meta = Arc::new(build_region_meta());
 
     let sst_layer = Arc::new(FsAccessLayer::new("sst", object_store)) as _;

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use common_datasource::compression::CompressionType;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use log_store::LogConfig;
 use object_store::services::Fs;
@@ -57,7 +58,13 @@ pub async fn new_store_config_with_object_store(
     let manifest_dir = engine::region_manifest_dir(parent_dir, region_name);
 
     let sst_layer = Arc::new(FsAccessLayer::new(&sst_dir, object_store.clone()));
-    let manifest = RegionManifest::with_checkpointer(&manifest_dir, object_store, None, None);
+    let manifest = RegionManifest::with_checkpointer(
+        &manifest_dir,
+        object_store,
+        CompressionType::Uncompressed,
+        None,
+        None,
+    );
     manifest.start().await.unwrap();
     let log_config = LogConfig {
         log_file_dir: log_store_dir(store_dir),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Expose ManifestLogStorage compress configuration to user

Manifest log now supports compression but it is not enabled by default. I hope to expose the option to users whether to enable Manifest log compression.

expose a config `use_compress` to user whether to use Manifest log compression.

```toml
[storage.manifest]
checkpoint_on_startup = true
use_compress = true # false by default
```

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/1394
Follow-up of https://github.com/GreptimeTeam/greptimedb/pull/1497
