### PR TITLE
fix: uses nextest in the Release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.arch }}
-
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
       - name: Output package versions
         run: protoc --version ; cargo version ; rustc --version ; gcc --version ; g++ --version
 
@@ -200,7 +201,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.arch }}
-
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
       - name: Output package versions
         run: protoc --version ; cargo version ; rustc --version ; gcc --version ; g++ --version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run tests
         if: env.DISABLE_RUN_TESTS == 'false'
-        run: make nextest sqlness-test
+        run: make test sqlness-test
 
       - name: Run cargo build
         if: contains(matrix.arch, 'darwin') || contains(matrix.opts, 'pyo3_backend') == false
@@ -208,7 +208,7 @@ jobs:
 
       - name: Run tests
         if: env.DISABLE_RUN_TESTS == 'false'
-        run: make nextest sqlness-test
+        run: make test sqlness-test
 
       - name: Run cargo build
         if: contains(matrix.arch, 'darwin') || contains(matrix.opts, 'pyo3_backend') == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,9 +88,9 @@ jobs:
       - name: Output package versions
         run: protoc --version ; cargo version ; rustc --version ; gcc --version ; g++ --version
 
-      # - name: Run tests
-      #   if: env.DISABLE_RUN_TESTS == 'false'
-      #   run: make unit-test integration-test sqlness-test
+      - name: Run tests
+        if: env.DISABLE_RUN_TESTS == 'false'
+        run: make nextest sqlness-test
 
       - name: Run cargo build
         if: contains(matrix.arch, 'darwin') || contains(matrix.opts, 'pyo3_backend') == false
@@ -206,7 +206,7 @@ jobs:
 
       - name: Run tests
         if: env.DISABLE_RUN_TESTS == 'false'
-        run: make unit-test integration-test sqlness-test
+        run: make nextest sqlness-test
 
       - name: Run cargo build
         if: contains(matrix.arch, 'darwin') || contains(matrix.opts, 'pyo3_backend') == false

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,12 @@ docker-image: ## Build docker image.
 
 ##@ Test
 
-.PHONY: nextest
+tests: nextest ## Run unit and integration tests.
+	cargo nextest run
+
+.PHONY: nextest ## Install nextest tools.
+nextest:
+	cargo --list | grep nextest || cargo install cargo-nextest --locked
 nextest: ## Run unit and integration tests.
 	cargo nextest run
 

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,9 @@ docker-image: ## Build docker image.
 
 ##@ Test
 
-.PHONY: unit-test
-unit-test: ## Run unit test.
-	cargo test --workspace
-
-.PHONY: integration-test
-integration-test: ## Run integation test.
-	cargo test integration
+.PHONY: nextest
+nextest: ## Run unit and integration tests.
+	cargo nextest run
 
 .PHONY: sqlness-test
 sqlness-test: ## Run sqlness test.

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,12 @@ docker-image: ## Build docker image.
 
 ##@ Test
 
-tests: nextest ## Run unit and integration tests.
+test: nextest ## Run unit and integration tests.
 	cargo nextest run
 
 .PHONY: nextest ## Install nextest tools.
 nextest:
 	cargo --list | grep nextest || cargo install cargo-nextest --locked
-nextest: ## Run unit and integration tests.
-	cargo nextest run
 
 .PHONY: sqlness-test
 sqlness-test: ## Run sqlness test.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

I noticed from the discussion on https://github.com/GreptimeTeam/greptimedb/discussions/1570 that this could be the cause of the test failure in the release CI. This PR
- Change Makefile to use nextest
- Install nextest in corresponding jobs

I'm afraid our unit test can only run by nextest for now, due to those global variables.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
