### PR TITLE
feat: Trigger flush based on global write buffer size

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -58,9 +58,12 @@ checkpoint_on_startup = false
 max_flush_tasks = 8
 # Default write buffer size for a region.
 region_write_buffer_size = "32MB"
+# Interval to check whether a region needs flush.
+picker_schedule_interval = "5m"
 # Interval to auto flush a region if it has not flushed yet.
 auto_flush_interval = "1h"
-# TODO schedule_interval/buffer_size
+# Global write buffer size for all regions.
+global_write_buffer_size = "1GB"
 
 # Procedure storage options, see `standalone.example.toml`.
 [procedure]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -60,6 +60,7 @@ max_flush_tasks = 8
 region_write_buffer_size = "32MB"
 # Interval to auto flush a region if it has not flushed yet.
 auto_flush_interval = "1h"
+# TODO schedule_interval/buffer_size
 
 # Procedure storage options, see `standalone.example.toml`.
 [procedure]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -125,6 +125,7 @@ max_flush_tasks = 8
 region_write_buffer_size = "32MB"
 # Interval to auto flush a region if it has not flushed yet.
 auto_flush_interval = "1h"
+# TODO schedule_interval/buffer_size
 
 # Procedure storage options.
 [procedure]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -123,9 +123,12 @@ checkpoint_on_startup = false
 max_flush_tasks = 8
 # Default write buffer size for a region.
 region_write_buffer_size = "32MB"
+# Interval to check whether a region needs flush.
+picker_schedule_interval = "5m"
 # Interval to auto flush a region if it has not flushed yet.
 auto_flush_interval = "1h"
-# TODO schedule_interval/buffer_size
+# Global write buffer size for all regions.
+global_write_buffer_size = "1GB"
 
 # Procedure storage options.
 [procedure]

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -223,6 +223,8 @@ pub struct FlushConfig {
     /// Interval to auto flush a region if it has not flushed yet.
     #[serde(with = "humantime_serde")]
     pub auto_flush_interval: Duration,
+    /// Global write buffer size for all regions.
+    pub global_write_buffer_size: Option<ReadableSize>,
 }
 
 impl Default for FlushConfig {
@@ -234,6 +236,7 @@ impl Default for FlushConfig {
                 DEFAULT_PICKER_SCHEDULE_INTERVAL.into(),
             ),
             auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
+            global_write_buffer_size: None,
         }
     }
 }
@@ -260,6 +263,7 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
             region_write_buffer_size: value.storage.flush.region_write_buffer_size,
             picker_schedule_interval: value.storage.flush.picker_schedule_interval,
             auto_flush_interval: value.storage.flush.auto_flush_interval,
+            global_write_buffer_size: value.storage.flush.global_write_buffer_size,
         }
     }
 }

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -44,6 +44,8 @@ pub struct EngineConfig {
     pub picker_schedule_interval: Duration,
     /// Interval to auto flush a region if it has not flushed yet.
     pub auto_flush_interval: Duration,
+    /// Limit for global write buffer size. Disabled by default.
+    pub global_write_buffer_size: Option<ReadableSize>,
 }
 
 impl Default for EngineConfig {
@@ -62,6 +64,7 @@ impl Default for EngineConfig {
                 DEFAULT_PICKER_SCHEDULE_INTERVAL.into(),
             ),
             auto_flush_interval: Duration::from_millis(DEFAULT_AUTO_FLUSH_INTERVAL.into()),
+            global_write_buffer_size: None,
         }
     }
 }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -462,6 +462,7 @@ impl<S: LogStore> EngineInner<S> {
         );
         manifest.start().await?;
 
+        // FIXME(yingwen): Always use the global flush strategy.
         let flush_strategy = write_buffer_size
             .map(|size| Arc::new(SizeBasedStrategy::new(size)) as Arc<_>)
             .unwrap_or_else(|| self.flush_strategy.clone());

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -288,7 +288,7 @@ impl<S: LogStore> RegionMap<S> {
     }
 
     /// Clear the region map.
-    fn clear(&self) {
+    pub(crate) fn clear(&self) {
         self.0.write().unwrap().clear();
     }
 }

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -49,7 +49,7 @@ pub struct RegionStatus {
 }
 
 /// Type of flush request to send.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushType {
     /// Flush current region.
     Region,

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -104,7 +104,7 @@ impl SizeBasedStrategy {
 
     /// Returns whether to trigger an engine level flush.
     ///
-    /// Insipired by RocksDB's WriteBufferManager.
+    /// Inspired by RocksDB's WriteBufferManager.
     /// https://github.com/facebook/rocksdb/blob/main/include/rocksdb/write_buffer_manager.h#L94
     fn should_flush_engine(&self) -> bool {
         // We only check global limit when it is Some.

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -89,6 +89,11 @@ impl FlushPicker {
             .filter(|region| region.mutable_memtable_usage() > 0)
             .min_by_key(|region| region.last_flush_time());
         if let Some(region) = target {
+            logging::debug!(
+                "Request flush for region {} due to global buffer is full",
+                region.item_id()
+            );
+
             region.request_flush(FlushReason::GlobalBufferFull).await;
         }
     }
@@ -133,6 +138,7 @@ impl<S: LogStore> FlushItem for RegionImpl<S> {
             wait: false,
             reason,
         };
+
         if let Err(e) = self.flush(&ctx).await {
             logging::error!(e; "Failed to flush region {}", self.id());
         }

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -216,7 +216,7 @@ impl fmt::Debug for AllocTracker {
 
 impl AllocTracker {
     /// Returns a new [AllocTracker].
-    fn new(flush_strategy: Option<FlushStrategyRef>) -> AllocTracker {
+    pub fn new(flush_strategy: Option<FlushStrategyRef>) -> AllocTracker {
         AllocTracker {
             flush_strategy,
             bytes_allocated: AtomicUsize::new(0),
@@ -225,7 +225,7 @@ impl AllocTracker {
     }
 
     /// Tracks `bytes` memory is allocated.
-    fn on_allocate(&self, bytes: usize) {
+    pub(crate) fn on_allocate(&self, bytes: usize) {
         self.bytes_allocated.fetch_add(bytes, Ordering::Relaxed);
         if let Some(flush_strategy) = &self.flush_strategy {
             flush_strategy.reserve_mem(bytes);
@@ -236,7 +236,7 @@ impl AllocTracker {
     /// the write buffer's limit.
     ///
     /// The region MUST ensure that it calls this method inside the region writer's write lock.
-    fn done_allocating(&self) {
+    pub(crate) fn done_allocating(&self) {
         if let Some(flush_strategy) = &self.flush_strategy {
             if self
                 .is_done_allocating
@@ -249,7 +249,7 @@ impl AllocTracker {
     }
 
     /// Returns bytes allocated.
-    fn bytes_allocated(&self) -> usize {
+    pub(crate) fn bytes_allocated(&self) -> usize {
         self.bytes_allocated.load(Ordering::Relaxed)
     }
 }

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -267,10 +267,24 @@ impl Drop for AllocTracker {
     }
 }
 
+/// Default memtable builder that builds [BTreeMemtable].
 #[derive(Debug, Default)]
 pub struct DefaultMemtableBuilder {
     memtable_id: AtomicU32,
     flush_strategy: Option<FlushStrategyRef>,
+}
+
+impl DefaultMemtableBuilder {
+    /// Returns a new [DefaultMemtableBuilder] with specific `flush_strategy`.
+    ///
+    /// If `flush_strategy` is `Some`, the memtable will report its memory usage
+    /// to the `flush_strategy`.
+    pub fn with_flush_strategy(flush_strategy: Option<FlushStrategyRef>) -> Self {
+        Self {
+            memtable_id: AtomicU32::new(0),
+            flush_strategy,
+        }
+    }
 }
 
 impl MemtableBuilder for DefaultMemtableBuilder {

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -122,7 +122,6 @@ struct SliceIndex {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::atomic::Ordering;
     use std::sync::Arc;
 
     use common_time::timestamp::Timestamp;
@@ -178,8 +177,8 @@ mod tests {
         min_ts: i64,
     ) {
         let iter = mem.iter(&IterContext::default()).unwrap();
-        assert_eq!(min_ts, mem.stats().min_timestamp.load(Ordering::Relaxed));
-        assert_eq!(max_ts, mem.stats().max_timestamp.load(Ordering::Relaxed));
+        assert_eq!(min_ts, mem.stats().min_timestamp);
+        assert_eq!(max_ts, mem.stats().max_timestamp);
 
         let mut index = 0;
         for batch in iter {

--- a/src/storage/src/memtable/version.rs
+++ b/src/storage/src/memtable/version.rs
@@ -53,8 +53,14 @@ impl MemtableVersion {
 
     /// Clone current memtable version and freeze its mutable memtables, which moves
     /// all mutable memtables to immutable memtable list.
+    ///
+    /// This method also calls [Memtable::mark_immutable()](crate::memtable::Memtable::mark_immutable()) to
+    /// mark the mutable memtable as immutable.
     pub fn freeze_mutable(&self, new_mutable: MemtableRef) -> MemtableVersion {
         let mut immutables = self.immutables.clone();
+        // Marks the mutable memtable as immutable so it can free the memory usage from our
+        // soft limit.
+        self.mutable.mark_immutable();
         immutables.push(self.mutable.clone());
 
         MemtableVersion {

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -30,3 +30,5 @@ pub const REGION_COUNT: &str = "storage.region_count";
 pub const LOG_STORE_WRITE_ELAPSED: &str = "storage.logstore.write.elapsed";
 /// Elapsed time of a compact job.
 pub const COMPACT_ELAPSED: &str = "storage.compact.elapsed";
+/// Global write buffer size in bytes.
+pub const WRITE_BUFFER_BYTES: &str = "storage.write_buffer_bytes";

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -166,6 +166,7 @@ pub struct StoreConfig<S: LogStore> {
     pub file_purger: FilePurgerRef,
     pub ttl: Option<Duration>,
     pub compaction_time_window: Option<i64>,
+    pub write_buffer_size: usize,
 }
 
 pub type RecoverdMetadata = (SequenceNumber, (ManifestVersion, RawRegionMetadata));
@@ -249,6 +250,7 @@ impl<S: LogStore> RegionImpl<S> {
                 store_config.engine_config.clone(),
                 store_config.ttl,
                 store_config.compaction_time_window,
+                store_config.write_buffer_size,
             )),
             wal,
             flush_strategy: store_config.flush_strategy,
@@ -333,6 +335,7 @@ impl<S: LogStore> RegionImpl<S> {
             store_config.engine_config.clone(),
             store_config.ttl,
             compaction_time_window,
+            store_config.write_buffer_size,
         ));
         let writer_ctx = WriterContext {
             shared: &shared,

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -379,8 +379,13 @@ impl<S: LogStore> RegionImpl<S> {
     }
 
     /// Returns last flush timestamp in millis.
-    pub fn last_flush_millis(&self) -> i64 {
+    pub(crate) fn last_flush_millis(&self) -> i64 {
         self.inner.shared.last_flush_millis()
+    }
+
+    /// Returns the [VersionControl] of the region.
+    pub(crate) fn version_control(&self) -> &VersionControl {
+        self.inner.version_control()
     }
 
     fn create_version_with_checkpoint(

--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -79,7 +79,7 @@ async fn create_region_for_compaction<
 
     let object_store = new_object_store(store_dir, s3_bucket);
 
-    let mut store_config = config_util::new_store_config_with_object_store(
+    let (mut store_config, _) = config_util::new_store_config_with_object_store(
         REGION_NAME,
         store_dir,
         object_store.clone(),

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -15,13 +15,14 @@
 //! Region flush tests.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_test_util::temp_dir::create_temp_dir;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use store_api::storage::{FlushContext, FlushReason, OpenOptions, Region, WriteResponse};
 
-use crate::engine;
-use crate::flush::FlushStrategyRef;
+use crate::engine::{self, RegionMap};
+use crate::flush::{FlushStrategyRef, FlushType};
 use crate::region::tests::{self, FileTesterBase};
 use crate::region::RegionImpl;
 use crate::test_util::config_util;
@@ -33,13 +34,20 @@ const REGION_NAME: &str = "region-flush-0";
 async fn create_region_for_flush(
     store_dir: &str,
     flush_strategy: FlushStrategyRef,
-) -> RegionImpl<RaftEngineLogStore> {
+) -> (
+    RegionImpl<RaftEngineLogStore>,
+    Arc<RegionMap<RaftEngineLogStore>>,
+) {
     let metadata = tests::new_metadata(REGION_NAME);
 
-    let mut store_config = config_util::new_store_config(REGION_NAME, store_dir).await;
+    let (mut store_config, regions) =
+        config_util::new_store_config_and_region_map(REGION_NAME, store_dir).await;
     store_config.flush_strategy = flush_strategy;
 
-    RegionImpl::create(metadata, store_config).await.unwrap()
+    (
+        RegionImpl::create(metadata, store_config).await.unwrap(),
+        regions,
+    )
 }
 
 /// Tester for region flush.
@@ -47,20 +55,23 @@ struct FlushTester {
     base: Option<FileTesterBase>,
     store_dir: String,
     flush_strategy: FlushStrategyRef,
+    regions: Arc<RegionMap<RaftEngineLogStore>>,
 }
 
 impl FlushTester {
     async fn new(store_dir: &str, flush_strategy: FlushStrategyRef) -> FlushTester {
-        let region = create_region_for_flush(store_dir, flush_strategy.clone()).await;
+        let (region, regions) = create_region_for_flush(store_dir, flush_strategy.clone()).await;
 
         FlushTester {
             base: Some(FileTesterBase::with_region(region)),
             store_dir: store_dir.to_string(),
             flush_strategy: flush_strategy.clone(),
+            regions,
         }
     }
 
     async fn reopen(&mut self) {
+        self.regions.clear();
         // Close the old region.
         if let Some(base) = self.base.as_ref() {
             base.close().await;
@@ -98,6 +109,12 @@ impl FlushTester {
             })
             .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();
+    }
+}
+
+impl Drop for FlushTester {
+    fn drop(&mut self) {
+        self.regions.clear();
     }
 }
 
@@ -254,4 +271,42 @@ async fn test_merge_read_after_flush() {
     // Scan after reopen.
     let output = tester.full_scan().await;
     assert_eq!(expect, output);
+}
+
+#[tokio::test]
+async fn test_schedule_engine_flush() {
+    common_telemetry::init_default_ut_logging();
+
+    let dir = create_temp_dir("engine-flush");
+    let store_dir = dir.path().to_str().unwrap();
+
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let tester = FlushTester::new(store_dir, flush_switch.clone()).await;
+    assert_eq!(0, tester.base().region.last_flush_millis());
+
+    // Insert the region to the region map.
+    tester.regions.get_or_occupy_slot(
+        REGION_NAME,
+        engine::RegionSlot::Ready(tester.base().region.clone()),
+    );
+
+    // Put elements so we have content to flush.
+    tester.put(&[(1000, Some(100))]).await;
+    tester.put(&[(2000, Some(200))]).await;
+
+    flush_switch.set_flush_type(FlushType::Engine);
+
+    // Put element and trigger an engine level flush.
+    tester.put(&[(3000, Some(300))]).await;
+
+    // Wait for flush.
+    let mut count = 0;
+    while tester.base().region.last_flush_millis() == 0 && count < 50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        count += 1;
+    }
+
+    // Check parquet files.
+    let sst_dir = format!("{}/{}", store_dir, engine::region_sst_dir("", REGION_NAME));
+    assert!(has_parquet_file(&sst_dir));
 }

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -736,6 +736,9 @@ impl WriterInner {
         let (max_memtable_id, mem_to_flush) = current_version.memtables().memtables_to_flush();
 
         if max_memtable_id.is_none() {
+            // We still update the flush time to avoid the picker picks this region again.
+            ctx.shared.update_flush_millis();
+
             logging::info!("No memtables to flush in region: {}", ctx.shared.name);
             return Ok(());
         }

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -30,7 +30,9 @@ use tokio::sync::{oneshot, Mutex};
 use crate::compaction::{CompactionRequestImpl, CompactionSchedulerRef};
 use crate::config::EngineConfig;
 use crate::error::{self, Result};
-use crate::flush::{FlushHandle, FlushRequest, FlushSchedulerRef, FlushStrategyRef};
+use crate::flush::{
+    FlushHandle, FlushRegionRequest, FlushSchedulerRef, FlushStrategyRef, FlushType, RegionStatus,
+};
 use crate::manifest::action::{
     RawRegionMetadata, RegionChange, RegionEdit, RegionMetaAction, RegionMetaActionList,
     RegionRemove,
@@ -71,6 +73,7 @@ impl RegionWriter {
         config: Arc<EngineConfig>,
         ttl: Option<Duration>,
         compaction_time_window: Option<i64>,
+        write_buffer_size: usize,
     ) -> RegionWriter {
         RegionWriter {
             inner: Mutex::new(WriterInner::new(
@@ -78,6 +81,7 @@ impl RegionWriter {
                 config,
                 ttl,
                 compaction_time_window,
+                write_buffer_size,
             )),
             version_mutex: Mutex::new(()),
         }
@@ -434,6 +438,8 @@ struct WriterInner {
     engine_config: Arc<EngineConfig>,
     ttl: Option<Duration>,
     compaction_time_window: Option<i64>,
+    /// Size in bytes to freeze the mutable memtable.
+    write_buffer_size: usize,
 }
 
 impl WriterInner {
@@ -442,6 +448,7 @@ impl WriterInner {
         engine_config: Arc<EngineConfig>,
         ttl: Option<Duration>,
         compaction_time_window: Option<i64>,
+        write_buffer_size: usize,
     ) -> WriterInner {
         WriterInner {
             memtable_builder,
@@ -450,6 +457,7 @@ impl WriterInner {
             closed: false,
             ttl,
             compaction_time_window,
+            write_buffer_size,
         }
     }
 
@@ -654,13 +662,24 @@ impl WriterInner {
         let version_control = writer_ctx.version_control();
         // Check whether memtable is full or flush should be triggered. We need to do this first since
         // switching memtables will clear all mutable memtables.
-        if self.should_flush(
+        if let Some(flush_type) = self.should_flush(
             writer_ctx.shared,
             version_control,
             writer_ctx.flush_strategy,
         ) {
-            self.trigger_flush(writer_ctx, FlushReason::MemtableFull)
-                .await?;
+            // Trigger flush according to the flush type.
+            match flush_type {
+                FlushType::Region => {
+                    // Trigger flush for current region.
+                    self.trigger_flush(writer_ctx, FlushReason::MemtableFull)
+                        .await?;
+                }
+                FlushType::Engine => {
+                    // Trigger engine level flush. This wakeup the flush handler
+                    // to pick region to flush.
+                    writer_ctx.flush_scheduler.schedule_engine_flush()?;
+                }
+            }
         }
 
         Ok(())
@@ -677,12 +696,15 @@ impl WriterInner {
         shared: &SharedDataRef,
         version_control: &VersionControlRef,
         flush_strategy: &FlushStrategyRef,
-    ) -> bool {
+    ) -> Option<FlushType> {
         let current = version_control.current();
         let memtables = current.memtables();
-        let mutable_bytes_allocated = memtables.mutable_bytes_allocated();
-        let total_bytes_allocated = memtables.total_bytes_allocated();
-        flush_strategy.should_flush(shared, mutable_bytes_allocated, total_bytes_allocated)
+        let status = RegionStatus {
+            region_id: shared.id(),
+            bytes_mutable: memtables.mutable_bytes_allocated(),
+            write_buffer_size: self.write_buffer_size,
+        };
+        flush_strategy.should_flush(status)
     }
 
     async fn trigger_flush<S: LogStore>(
@@ -718,7 +740,7 @@ impl WriterInner {
             return Ok(());
         }
 
-        let flush_req = FlushRequest {
+        let flush_req = FlushRegionRequest {
             max_memtable_id: max_memtable_id.unwrap(),
             memtables: mem_to_flush,
             // In write thread, safe to use current committed sequence.
@@ -729,15 +751,17 @@ impl WriterInner {
             wal: ctx.wal.clone(),
             manifest: ctx.manifest.clone(),
             engine_config: self.engine_config.clone(),
-            sender: None,
             ttl: self.ttl,
             compaction_time_window: self.compaction_time_window,
         };
 
-        let flush_handle = ctx.flush_scheduler.schedule_flush(flush_req).map_err(|e| {
-            logging::error!(e; "Failed to schedule flush request");
-            e
-        })?;
+        let flush_handle = ctx
+            .flush_scheduler
+            .schedule_region_flush(flush_req)
+            .map_err(|e| {
+                logging::error!(e; "Failed to schedule flush request");
+                e
+            })?;
         self.flush_handle = Some(flush_handle);
 
         Ok(())

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -22,6 +22,7 @@ use object_store::ObjectStore;
 use store_api::manifest::Manifest;
 
 use crate::compaction::noop::NoopCompactionScheduler;
+use crate::config::DEFAULT_REGION_WRITE_BUFFER_SIZE;
 use crate::engine::{self, RegionMap};
 use crate::file_purger::noop::NoopFilePurgeHandler;
 use crate::flush::{FlushScheduler, PickerConfig, SizeBasedStrategy};
@@ -98,5 +99,6 @@ pub async fn new_store_config_with_object_store(
         file_purger,
         ttl: None,
         compaction_time_window: None,
+        write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE.as_bytes() as usize,
     }
 }

--- a/src/storage/src/test_util/config_util.rs
+++ b/src/storage/src/test_util/config_util.rs
@@ -45,6 +45,23 @@ pub async fn new_store_config(
     builder.root(store_dir);
     let object_store = ObjectStore::new(builder).unwrap().finish();
 
+    new_store_config_with_object_store(region_name, store_dir, object_store)
+        .await
+        .0
+}
+
+/// Create a new StoreConfig and region map for test.
+pub async fn new_store_config_and_region_map(
+    region_name: &str,
+    store_dir: &str,
+) -> (
+    StoreConfig<RaftEngineLogStore>,
+    Arc<RegionMap<RaftEngineLogStore>>,
+) {
+    let mut builder = Fs::default();
+    builder.root(store_dir);
+    let object_store = ObjectStore::new(builder).unwrap().finish();
+
     new_store_config_with_object_store(region_name, store_dir, object_store).await
 }
 
@@ -53,7 +70,10 @@ pub async fn new_store_config_with_object_store(
     region_name: &str,
     store_dir: &str,
     object_store: ObjectStore,
-) -> StoreConfig<RaftEngineLogStore> {
+) -> (
+    StoreConfig<RaftEngineLogStore>,
+    Arc<RegionMap<RaftEngineLogStore>>,
+) {
     let parent_dir = "";
     let sst_dir = engine::region_sst_dir(parent_dir, region_name);
     let manifest_dir = engine::region_manifest_dir(parent_dir, region_name);
@@ -74,11 +94,12 @@ pub async fn new_store_config_with_object_store(
     let log_store = Arc::new(RaftEngineLogStore::try_new(log_config).await.unwrap());
     let compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
     // We use an empty region map so actually the background worker of the picker is disabled.
+    let regions = Arc::new(RegionMap::new());
     let flush_scheduler = Arc::new(
         FlushScheduler::new(
             SchedulerConfig::default(),
             compaction_scheduler.clone(),
-            Arc::new(RegionMap::new()),
+            regions.clone(),
             PickerConfig::default(),
         )
         .unwrap(),
@@ -87,18 +108,21 @@ pub async fn new_store_config_with_object_store(
         SchedulerConfig::default(),
         NoopFilePurgeHandler,
     ));
-    StoreConfig {
-        log_store,
-        sst_layer,
-        manifest,
-        memtable_builder: Arc::new(DefaultMemtableBuilder::default()),
-        flush_scheduler,
-        flush_strategy: Arc::new(SizeBasedStrategy::default()),
-        compaction_scheduler,
-        engine_config: Default::default(),
-        file_purger,
-        ttl: None,
-        compaction_time_window: None,
-        write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE.as_bytes() as usize,
-    }
+    (
+        StoreConfig {
+            log_store,
+            sst_layer,
+            manifest,
+            memtable_builder: Arc::new(DefaultMemtableBuilder::default()),
+            flush_scheduler,
+            flush_strategy: Arc::new(SizeBasedStrategy::default()),
+            compaction_scheduler,
+            engine_config: Default::default(),
+            file_purger,
+            ttl: None,
+            compaction_time_window: None,
+            write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE.as_bytes() as usize,
+        },
+        regions,
+    )
 }

--- a/src/storage/src/test_util/flush_switch.rs
+++ b/src/storage/src/test_util/flush_switch.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
 use crate::flush::{FlushStrategy, FlushType, RegionStatus};
 
@@ -20,22 +20,26 @@ use crate::flush::{FlushStrategy, FlushType, RegionStatus};
 /// Disable flush by default.
 #[derive(Debug, Default)]
 pub struct FlushSwitch {
-    should_flush: AtomicBool,
+    flush_type: Mutex<Option<FlushType>>,
 }
 
 impl FlushSwitch {
     pub fn set_should_flush(&self, should_flush: bool) {
-        self.should_flush.store(should_flush, Ordering::Relaxed);
+        if should_flush {
+            *self.flush_type.lock().unwrap() = Some(FlushType::Region);
+        } else {
+            *self.flush_type.lock().unwrap() = None;
+        }
+    }
+
+    pub fn set_flush_type(&self, flush_type: FlushType) {
+        *self.flush_type.lock().unwrap() = Some(flush_type);
     }
 }
 
 impl FlushStrategy for FlushSwitch {
     fn should_flush(&self, _status: RegionStatus) -> Option<FlushType> {
-        if self.should_flush.load(Ordering::Relaxed) {
-            Some(FlushType::Region)
-        } else {
-            None
-        }
+        *self.flush_type.lock().unwrap()
     }
 
     fn reserve_mem(&self, _mem: usize) {}

--- a/src/storage/src/test_util/flush_switch.rs
+++ b/src/storage/src/test_util/flush_switch.rs
@@ -14,8 +14,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::flush::FlushStrategy;
-use crate::region::SharedDataRef;
+use crate::flush::{FlushStrategy, FlushType, RegionStatus};
 
 /// Controls whether to flush a region while writing the region.
 /// Disable flush by default.
@@ -31,13 +30,12 @@ impl FlushSwitch {
 }
 
 impl FlushStrategy for FlushSwitch {
-    fn should_flush(
-        &self,
-        _shared: &SharedDataRef,
-        _bytes_mutable: usize,
-        _bytes_total: usize,
-    ) -> bool {
-        self.should_flush.load(Ordering::Relaxed)
+    fn should_flush(&self, _status: RegionStatus) -> Option<FlushType> {
+        if self.should_flush.load(Ordering::Relaxed) {
+            Some(FlushType::Region)
+        } else {
+            None
+        }
     }
 
     fn reserve_mem(&self, _mem: usize) {}

--- a/src/storage/src/test_util/flush_switch.rs
+++ b/src/storage/src/test_util/flush_switch.rs
@@ -39,6 +39,12 @@ impl FlushStrategy for FlushSwitch {
     ) -> bool {
         self.should_flush.load(Ordering::Relaxed)
     }
+
+    fn reserve_mem(&self, _mem: usize) {}
+
+    fn schedule_free_mem(&self, _mem: usize) {}
+
+    fn free_mem(&self, _mem: usize) {}
 }
 
 pub fn has_parquet_file(sst_dir: &str) -> bool {

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -136,6 +136,8 @@ pub enum FlushReason {
     Manually,
     /// Auto flush periodically.
     Periodically,
+    /// Global write buffer is full.
+    GlobalBufferFull,
 }
 
 impl FlushReason {
@@ -146,6 +148,7 @@ impl FlushReason {
             FlushReason::MemtableFull => "memtable_full",
             FlushReason::Manually => "manually",
             FlushReason::Periodically => "periodically",
+            FlushReason::GlobalBufferFull => "global_buffer_full",
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a new option `global_write_buffer_size` that triggers flush when the write buffer size of all regions is larger than it. This feature is disabled by default.

The whole design is similar to RocksDB's [WriteBufferManager](https://github.com/facebook/rocksdb/blob/5fc57eec2b44337289f25c1b5687beb54ad709a2/include/rocksdb/write_buffer_manager.h#L37), except that we don't stall the write thread when the global write buffer is full.

It adds some methods to `FlushStrategy` so the strategy can track the total memory usage. The `should_flush` method returns whether we should flush the current region or other regions in the engine.
```rust
pub trait FlushStrategy: Send + Sync + std::fmt::Debug {
    /// Returns whether to trigger a flush operation.
    fn should_flush(&self, status: RegionStatus) -> Option<FlushType>;

    /// Reserves `mem` bytes.
    fn reserve_mem(&self, mem: usize);

    /// Tells the strategy we are freeing `mem` bytes.
    ///
    /// We are in the process of freeing `mem` bytes, so it is not considered
    /// when checking the soft limit.
    fn schedule_free_mem(&self, mem: usize);

    /// We have freed `mem` bytes.
    fn free_mem(&self, mem: usize);
}
```

The memtable uses `AllocTracker` to track its memory usage and update the total memory usage in `FlushStrategy`.

The `FlushRequest` now becomes an enum. We schedule a `FlushRequest::Engine` to the `FlushScheduler` when we want to ask the engine to pick some regions to flush.
```rust
pub enum FlushRequest<S: LogStore> {
    /// Flush the engine.
    Engine,
    /// Flush a region.
    Region {
        /// Region flush request.
        req: FlushRegionRequest<S>,
        /// Flush result sender.
        sender: Sender<Result<()>>,
    },
}
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1462 