### PR TITLE
feat: memtable stats

### DIFF
--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -48,7 +48,7 @@ impl Timestamp {
     /// The result time unit remains unchanged even if `duration` has a different unit with `self`.
     /// For example, a timestamp with value 1 and time unit second, subtracted by 1 millisecond
     /// and the result is still 1 second.
-    pub fn sub(&self, duration: Duration) -> error::Result<Self> {
+    pub fn sub_duration(&self, duration: Duration) -> error::Result<Self> {
         let duration: i64 = match self.unit {
             TimeUnit::Second => {
                 i64::try_from(duration.as_secs()).context(TimestampOverflowSnafu)?
@@ -77,6 +77,13 @@ impl Timestamp {
             value,
             unit: self.unit,
         })
+    }
+
+    /// Subtracts current timestamp with another timestamp, yielding a duration.
+    pub fn sub(&self, rhs: Self) -> Option<chrono::Duration> {
+        let lhs = self.to_chrono_datetime()?;
+        let rhs = rhs.to_chrono_datetime()?;
+        Some(lhs - rhs)
     }
 
     pub fn new(value: i64, unit: TimeUnit) -> Self {
@@ -863,19 +870,19 @@ mod tests {
     #[test]
     fn test_timestamp_sub() {
         let res = Timestamp::new(1, TimeUnit::Second)
-            .sub(Duration::from_secs(1))
+            .sub_duration(Duration::from_secs(1))
             .unwrap();
         assert_eq!(0, res.value);
         assert_eq!(TimeUnit::Second, res.unit);
 
         let res = Timestamp::new(0, TimeUnit::Second)
-            .sub(Duration::from_secs(1))
+            .sub_duration(Duration::from_secs(1))
             .unwrap();
         assert_eq!(-1, res.value);
         assert_eq!(TimeUnit::Second, res.unit);
 
         let res = Timestamp::new(1, TimeUnit::Second)
-            .sub(Duration::from_millis(1))
+            .sub_duration(Duration::from_millis(1))
             .unwrap();
         assert_eq!(1, res.value);
         assert_eq!(TimeUnit::Second, res.unit);

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -921,4 +921,17 @@ mod tests {
             Timestamp::new(1, TimeUnit::Second).to_local_string()
         );
     }
+
+    #[test]
+    fn test_subtract_timestamp() {
+        assert_eq!(
+            Some(chrono::Duration::milliseconds(42)),
+            Timestamp::new_millisecond(100).sub(Timestamp::new_millisecond(58))
+        );
+
+        assert_eq!(
+            Some(chrono::Duration::milliseconds(-42)),
+            Timestamp::new_millisecond(58).sub(Timestamp::new_millisecond(100))
+        );
+    }
 }

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -250,6 +250,15 @@ impl Value {
 
         Ok(scalar_value)
     }
+
+    /// Casts Value to [Timestamp]. Returns None if it's not a valid timestamp value.
+    pub fn as_timestamp(&self) -> Option<Timestamp> {
+        match self {
+            Value::Int64(v) => Some(Timestamp::new_millisecond(*v)),
+            Value::Timestamp(t) => Some(*t),
+            _ => None,
+        }
+    }
 }
 
 fn to_null_value(output_type: &ConcreteDataType) -> ScalarValue {

--- a/src/storage/benches/memtable/mod.rs
+++ b/src/storage/benches/memtable/mod.rs
@@ -78,10 +78,8 @@ fn kvs_with_index(
         key_builders.0.push(Some(TimestampMillisecond::from(key.0)));
         key_builders.1.push(Some(key.1));
     }
-    let row_keys = vec![
-        Arc::new(key_builders.0.finish()) as _,
-        Arc::new(key_builders.1.finish()) as _,
-    ];
+    let row_keys = vec![Arc::new(key_builders.1.finish()) as _];
+
     let mut value_builders = (
         UInt64VectorBuilder::with_capacity(values.len()),
         StringVectorBuilder::with_capacity(values.len()),
@@ -100,6 +98,7 @@ fn kvs_with_index(
         start_index_in_batch,
         keys: row_keys,
         values: row_values,
+        timestamp: Some(Arc::new(key_builders.0.finish()) as _),
     }
 }
 

--- a/src/storage/src/compaction/picker.rs
+++ b/src/storage/src/compaction/picker.rs
@@ -82,7 +82,7 @@ impl<S> SimplePicker<S> {
         let Some(ttl) = ttl else { return Ok(vec![]); };
 
         let expire_time = Timestamp::current_millis()
-            .sub(ttl)
+            .sub_duration(ttl)
             .context(TtlCalculationSnafu)?;
 
         let mut expired_ssts = vec![];

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -140,8 +140,7 @@ mod tests {
         for key in ts {
             key_builders.push(Some(*key));
         }
-        let row_keys = vec![Arc::new(key_builders.finish()) as _];
-
+        let ts_col = Arc::new(key_builders.finish()) as _;
         let mut value_builders = UInt64VectorBuilder::with_capacity(values.len());
 
         for value in values {
@@ -153,8 +152,9 @@ mod tests {
             sequence,
             op_type,
             start_index_in_batch,
-            keys: row_keys,
+            keys: vec![],
             values: row_values,
+            timestamp: Some(ts_col),
         };
 
         assert_eq!(ts.len(), kvs.len());

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -18,7 +18,7 @@ mod inserter;
 pub mod tests;
 mod version;
 
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use datatypes::vectors::VectorRef;
@@ -33,6 +33,35 @@ use crate::schema::{ProjectedSchemaRef, RegionSchemaRef};
 
 /// Unique id for memtables under same region.
 pub type MemtableId = u32;
+
+#[derive(Debug)]
+pub struct MemtableStats {
+    /// The  estimated bytes allocated by this memtable from heap. Result
+    /// of this method may be larger than the estimated based on [`num_rows`] because
+    /// of the implementor's pre-alloc behavior.
+    estimated_bytes: AtomicUsize,
+    /// The max timestamp that this memtable contains.
+    max_timestamp: AtomicI64,
+    /// The min timestamp that this memtable contains.
+    min_timestamp: AtomicI64,
+}
+
+impl MemtableStats {
+    pub fn bytes_allocated(&self) -> usize {
+        self.estimated_bytes
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+impl Default for MemtableStats {
+    fn default() -> Self {
+        Self {
+            estimated_bytes: AtomicUsize::default(),
+            max_timestamp: AtomicI64::new(i64::MIN),
+            min_timestamp: AtomicI64::new(i64::MAX),
+        }
+    }
+}
 
 /// In memory storage.
 pub trait Memtable: Send + Sync + std::fmt::Debug {
@@ -54,10 +83,10 @@ pub trait Memtable: Send + Sync + std::fmt::Debug {
     /// Returns the estimated bytes allocated by this memtable from heap. Result
     /// of this method may be larger than the estimated based on [`num_rows`] because
     /// of the implementor's pre-alloc behavior.
-    fn bytes_allocated(&self) -> usize;
-
-    /// Return the number of rows contained in this memtable.
     fn num_rows(&self) -> usize;
+
+    /// Returns stats of this memtable.
+    fn stats(&self) -> &MemtableStats;
 }
 
 pub type MemtableRef = Arc<dyn Memtable>;
@@ -125,7 +154,6 @@ pub trait MemtableBuilder: Send + Sync + std::fmt::Debug {
 
 pub type MemtableBuilderRef = Arc<dyn MemtableBuilder>;
 
-// TODO(yingwen): Maybe use individual vector for timestamp and version.
 /// Key-value pairs in columnar format.
 pub struct KeyValues {
     pub sequence: SequenceNumber,
@@ -135,6 +163,7 @@ pub struct KeyValues {
     pub start_index_in_batch: usize,
     pub keys: Vec<VectorRef>,
     pub values: Vec<VectorRef>,
+    pub timestamp: Option<VectorRef>,
 }
 
 impl KeyValues {
@@ -144,10 +173,11 @@ impl KeyValues {
         self.start_index_in_batch = index_in_batch;
         self.keys.clear();
         self.values.clear();
+        self.timestamp = None;
     }
 
     pub fn len(&self) -> usize {
-        self.keys.first().map(|v| v.len()).unwrap_or_default()
+        self.timestamp.as_ref().map(|v| v.len()).unwrap_or_default()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -157,6 +187,11 @@ impl KeyValues {
     pub fn estimated_memory_size(&self) -> usize {
         self.keys.iter().fold(0, |acc, v| acc + v.memory_size())
             + self.values.iter().fold(0, |acc, v| acc + v.memory_size())
+            + self
+                .timestamp
+                .as_ref()
+                .map(|t| t.memory_size())
+                .unwrap_or_default()
     }
 }
 

--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -60,11 +60,10 @@ impl BTreeMemtable {
     /// This function is guarded by `BTreeMemtable::map` so that store-after-load is safe.
     fn update_stats(&self, min: Option<Value>, max: Option<Value>) {
         if let Some(min) = min {
-            let min_val = match min {
-                Value::Int64(v) => v,
-                Value::Timestamp(t) => t.value(),
-                _ => unreachable!(),
-            };
+            let min_val = min
+                .as_timestamp()
+                .expect("Min timestamp must be a valid timestamp value")
+                .value();
             let cur_min = self.stats.min_timestamp.load(AtomicOrdering::Relaxed);
             if min_val < cur_min {
                 self.stats
@@ -75,11 +74,10 @@ impl BTreeMemtable {
 
         if let Some(max) = max {
             let cur_max = self.stats.max_timestamp.load(AtomicOrdering::Relaxed);
-            let max_val = match max {
-                Value::Int64(v) => v,
-                Value::Timestamp(t) => t.value(),
-                _ => unreachable!(),
-            };
+            let max_val = max
+                .as_timestamp()
+                .expect("Max timestamp must be a valid timestamp value")
+                .value();
             if max_val > cur_max {
                 self.stats
                     .max_timestamp

--- a/src/storage/src/memtable/tests.rs
+++ b/src/storage/src/memtable/tests.rs
@@ -52,7 +52,7 @@ fn kvs_for_test_with_index(
     for key in keys {
         key_builders.push(Some(*key));
     }
-    let row_keys = vec![Arc::new(key_builders.finish()) as _];
+    let ts_col = Arc::new(key_builders.finish()) as _;
 
     let mut value_builders = (
         UInt64VectorBuilder::with_capacity(values.len()),
@@ -71,8 +71,9 @@ fn kvs_for_test_with_index(
         sequence,
         op_type,
         start_index_in_batch,
-        keys: row_keys,
+        keys: vec![],
         values: row_values,
+        timestamp: Some(ts_col),
     };
 
     assert_eq!(keys.len(), kvs.len());
@@ -198,7 +199,7 @@ fn write_iter_memtable_case(ctx: &TestContext) {
     assert!(iter.next().is_none());
     // Poll the empty iterator again.
     assert!(iter.next().is_none());
-    assert_eq!(0, ctx.memtable.bytes_allocated());
+    assert_eq!(0, ctx.memtable.stats().bytes_allocated());
 
     // Init test data.
     write_kvs(
@@ -224,7 +225,7 @@ fn write_iter_memtable_case(ctx: &TestContext) {
     );
 
     // 9 key value pairs (6 + 3).
-    assert_eq!(576, ctx.memtable.bytes_allocated());
+    assert_eq!(576, ctx.memtable.stats().bytes_allocated());
 
     let batch_sizes = [1, 4, 8, consts::READ_BATCH_SIZE];
     for batch_size in batch_sizes {

--- a/src/storage/src/memtable/version.rs
+++ b/src/storage/src/memtable/version.rs
@@ -64,15 +64,15 @@ impl MemtableVersion {
     }
 
     pub fn mutable_bytes_allocated(&self) -> usize {
-        self.mutable.bytes_allocated()
+        self.mutable.stats().bytes_allocated()
     }
 
     pub fn total_bytes_allocated(&self) -> usize {
         self.immutables
             .iter()
-            .map(|m| m.bytes_allocated())
+            .map(|m| m.stats().bytes_allocated())
             .sum::<usize>()
-            + self.mutable.bytes_allocated()
+            + self.mutable.stats().bytes_allocated()
     }
 
     /// Creates a new `MemtableVersion` that removes immutable memtables

--- a/src/storage/src/schema/region.rs
+++ b/src/storage/src/schema/region.rs
@@ -131,6 +131,11 @@ impl RegionSchema {
     }
 
     #[inline]
+    pub(crate) fn timestamp_index(&self) -> usize {
+        self.store_schema.timestamp_index()
+    }
+
+    #[inline]
     pub(crate) fn value_indices(&self) -> impl Iterator<Item = usize> {
         self.store_schema.value_indices()
     }

--- a/src/storage/src/schema/store.rs
+++ b/src/storage/src/schema/store.rs
@@ -156,6 +156,11 @@ impl StoreSchema {
     }
 
     #[inline]
+    pub(crate) fn timestamp_index(&self) -> usize {
+        self.row_key_end - 1
+    }
+
+    #[inline]
     pub(crate) fn row_key_indices(&self) -> impl Iterator<Item = usize> {
         0..self.row_key_end
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR:
- add `stats` method to `Memtable` trait to retrieve memtable's statistical info
- add `timestamp_index` method to `RegionSchema` and `StoreSchema`, these two schema should by all means be aware of timestamp column index, which is the last column in the row key
- for `KeyValues` struct, move timestamp out of `row_key` field to a separate field.

This is a prerequisite work for infering time windows from memtables and SST files so that we can precisely determine the scan window in TopK scenario.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
