### PR TITLE
fix: remove region number validation

### DIFF
--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -450,7 +450,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             table_id, table_info
         );
 
-        // Fixme: We cannot trust the region numbers in the manifest because other datanodes might overwrite the manifest.
+        // FIXME: We cannot trust the region numbers in the manifest because other datanodes might overwrite the manifest.
 
         let mut regions = HashMap::with_capacity(table_info.meta.region_numbers.len());
 

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -450,15 +450,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
             table_id, table_info
         );
 
-        for target_region in &request.region_numbers {
-            if !table_info.meta.region_numbers.contains(target_region) {
-                table_error::RegionNotFoundSnafu {
-                    table: table_ref.to_string(),
-                    region: *target_region,
-                }
-                .fail()?
-            }
-        }
+        // Fixme: We cannot trust the region numbers in the manifest because other datanodes might overwrite the manifest.
 
         let mut regions = HashMap::with_capacity(table_info.meta.region_numbers.len());
 

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -460,7 +460,7 @@ async fn test_open_table_with_region_number() {
         .err()
         .unwrap();
 
-    assert_eq!(region_not_found.to_string(), "Failed to operate table, source: Cannot find region, table: greptime.public.demo, region: 1");
+    assert_eq!(region_not_found.to_string(), "Failed to operate table, source: Failed to operate table, source: Cannot find region, table: greptime.public.demo, region: 1");
 
     let reopened = table_engine
         .open_table(&ctx, open_req.clone())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove region number validation. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
