### PR TITLE
refactor: support parsing env list

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -86,8 +86,8 @@ struct StartCommand {
     rpc_hostname: Option<String>,
     #[clap(long)]
     mysql_addr: Option<String>,
-    #[clap(long)]
-    metasrv_addr: Option<String>,
+    #[clap(long, multiple = true, value_delimiter = ',')]
+    metasrv_addr: Option<Vec<String>>,
     #[clap(short, long)]
     config_file: Option<String>,
     #[clap(long)]
@@ -133,15 +133,10 @@ impl StartCommand {
             opts.node_id = Some(node_id);
         }
 
-        if let Some(meta_addr) = &self.metasrv_addr {
+        if let Some(metasrv_addrs) = &self.metasrv_addr {
             opts.meta_client_options
                 .get_or_insert_with(MetaClientOptions::default)
-                .metasrv_addrs = meta_addr
-                .clone()
-                .split(',')
-                .map(&str::trim)
-                .map(&str::to_string)
-                .collect::<_>();
+                .metasrv_addrs = metasrv_addrs.clone();
             opts.mode = Mode::Distributed;
         }
 
@@ -317,7 +312,7 @@ mod tests {
 
         if let Options::Datanode(opt) = (StartCommand {
             node_id: Some(42),
-            metasrv_addr: Some("127.0.0.1:3002".to_string()),
+            metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
         .load_options(TopLevelOptions::default())
@@ -327,7 +322,7 @@ mod tests {
         }
 
         assert!((StartCommand {
-            metasrv_addr: Some("127.0.0.1:3002".to_string()),
+            metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
         .load_options(TopLevelOptions::default())

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -102,8 +102,8 @@ pub struct StartCommand {
     config_file: Option<String>,
     #[clap(short, long)]
     influxdb_enable: Option<bool>,
-    #[clap(long)]
-    metasrv_addr: Option<String>,
+    #[clap(long, multiple = true, value_delimiter = ',')]
+    metasrv_addr: Option<Vec<String>>,
     #[clap(long)]
     tls_mode: Option<TlsMode>,
     #[clap(long)]
@@ -185,15 +185,10 @@ impl StartCommand {
             opts.influxdb_options = Some(InfluxdbOptions { enable });
         }
 
-        if let Some(metasrv_addr) = &self.metasrv_addr {
+        if let Some(metasrv_addrs) = &self.metasrv_addr {
             opts.meta_client_options
                 .get_or_insert_with(MetaClientOptions::default)
-                .metasrv_addrs = metasrv_addr
-                .clone()
-                .split(',')
-                .map(&str::trim)
-                .map(&str::to_string)
-                .collect::<Vec<_>>();
+                .metasrv_addrs = metasrv_addrs.clone();
             opts.mode = Mode::Distributed;
         }
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -120,8 +120,11 @@ pub struct StartCommand {
 
 impl StartCommand {
     fn load_options(&self, top_level_opts: TopLevelOptions) -> Result<Options> {
-        let mut opts: FrontendOptions =
-            Options::load_layered_options(self.config_file.as_deref(), self.env_prefix.as_ref())?;
+        let mut opts: FrontendOptions = Options::load_layered_options(
+            self.config_file.as_deref(),
+            self.env_prefix.as_ref(),
+            FrontendOptions::env_list_keys(),
+        )?;
 
         if let Some(dir) = top_level_opts.log_dir {
             opts.logging.dir = dir;
@@ -374,6 +377,11 @@ mod tests {
             [http_options]
             addr = "127.0.0.1:4000"
             
+            [meta_client_options]
+            timeout_millis = 3000
+            connect_timeout_millis = 5000
+            tcp_nodelay = true
+
             [mysql_options]
             addr = "127.0.0.1:4002"
         "#;
@@ -412,6 +420,16 @@ mod tests {
                     .join(ENV_VAR_SEP),
                     Some("127.0.0.1:24000"),
                 ),
+                (
+                    // meta_client_options.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
+                    vec![
+                        env_prefix.to_string(),
+                        "meta_client_options".to_uppercase(),
+                        "metasrv_addrs".to_uppercase(),
+                    ]
+                    .join(ENV_VAR_SEP),
+                    Some("127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003"),
+                ),
             ],
             || {
                 let command = StartCommand {
@@ -430,6 +448,14 @@ mod tests {
 
                 // Should be read from env, env > default values.
                 assert_eq!(fe_opts.mysql_options.as_ref().unwrap().runtime_size, 11);
+                assert_eq!(
+                    fe_opts.meta_client_options.unwrap().metasrv_addrs,
+                    vec![
+                        "127.0.0.1:3001".to_string(),
+                        "127.0.0.1:3002".to_string(),
+                        "127.0.0.1:3003".to_string()
+                    ]
+                );
 
                 // Should be read from config file, config file > env > default values.
                 assert_eq!(

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -102,8 +102,11 @@ struct StartCommand {
 
 impl StartCommand {
     fn load_options(&self, top_level_opts: TopLevelOptions) -> Result<Options> {
-        let mut opts: MetaSrvOptions =
-            Options::load_layered_options(self.config_file.as_deref(), self.env_prefix.as_ref())?;
+        let mut opts: MetaSrvOptions = Options::load_layered_options(
+            self.config_file.as_deref(),
+            self.env_prefix.as_ref(),
+            None,
+        )?;
 
         if let Some(dir) = top_level_opts.log_dir {
             opts.logging.dir = dir;

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -217,8 +217,11 @@ struct StartCommand {
 
 impl StartCommand {
     fn load_options(&self, top_level_options: TopLevelOptions) -> Result<Options> {
-        let mut opts: StandaloneOptions =
-            Options::load_layered_options(self.config_file.as_deref(), self.env_prefix.as_ref())?;
+        let mut opts: StandaloneOptions = Options::load_layered_options(
+            self.config_file.as_deref(),
+            self.env_prefix.as_ref(),
+            None,
+        )?;
 
         opts.enable_memory_catalog = self.enable_memory_catalog;
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -283,6 +283,12 @@ impl Default for DatanodeOptions {
     }
 }
 
+impl DatanodeOptions {
+    pub fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["meta_client_options.metasrv_addrs"])
+    }
+}
+
 /// Datanode service.
 pub struct Datanode {
     opts: DatanodeOptions,

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -60,6 +60,12 @@ impl Default for FrontendOptions {
     }
 }
 
+impl FrontendOptions {
+    pub fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["meta_client_options.metasrv_addrs"])
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Use `config-rs` to support parsing env list, for example, `GREPTIMEDB_METASRV__META_CLIENT_OPTIONS__METASRV_ADDRS=127.0.0.1:3001,127.0.0.1:3002`;

   Passing [`list_parse_keys`](https://github.com/zyy17/greptimedb/blob/refactor/support-parse-env-list/src/datanode/src/datanode.rs#L286) seems ugly since config-rs limit it. Using some derive will be better. I will try to add the function to upstream later.

3. Use `multiple = true` in clap derive and remove duplicated string list parsing;
   (btw, maybe the name `metasrv_addrs` is better than `metasrv_addr` in cli options.)


Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
