### PR TITLE
fix: sequence out of range

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -154,6 +154,14 @@ pub enum Error {
     #[snafu(display("Failed to get sequence: {}", err_msg))]
     NextSequence { err_msg: String, location: Location },
 
+    #[snafu(display("Sequence out of range: {}, start={}, step={}", name, start, step))]
+    SequenceOutOfRange {
+        name: String,
+        start: u64,
+        step: u64,
+        location: Location,
+    },
+
     #[snafu(display("MetaSrv has no leader at this moment"))]
     NoLeader { location: Location },
 
@@ -379,6 +387,7 @@ impl ErrorExt for Error {
             | Error::UnexceptedSequenceValue { .. }
             | Error::TableRouteNotFound { .. }
             | Error::NextSequence { .. }
+            | Error::SequenceOutOfRange { .. }
             | Error::MoveValue { .. }
             | Error::InvalidKvsLength { .. }
             | Error::InvalidTxnResult { .. }

--- a/src/meta-srv/src/handler/check_leader_handler.rs
+++ b/src/meta-srv/src/handler/check_leader_handler.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use api::v1::meta::{Error, HeartbeatRequest, Role};
+use common_telemetry::warn;
 
 use crate::error::Result;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
@@ -29,7 +30,7 @@ impl HeartbeatHandler for CheckLeaderHandler {
 
     async fn handle(
         &self,
-        _req: &HeartbeatRequest,
+        req: &HeartbeatRequest,
         ctx: &mut Context,
         acc: &mut HeartbeatAccumulator,
     ) -> Result<()> {
@@ -40,6 +41,7 @@ impl HeartbeatHandler for CheckLeaderHandler {
             if let Some(header) = &mut acc.header {
                 header.error = Some(Error::is_not_leader());
                 ctx.set_skip_all();
+                warn!("Received a heartbeat {:?}, but the current node is not the leader, so the heartbeat will be ignored.", req.header);
             }
         }
         Ok(())

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -161,7 +161,7 @@ impl MetaSrvBuilder {
         let metadata_service = metadata_service
             .unwrap_or_else(|| Arc::new(DefaultMetadataService::new(kv_store.clone())));
 
-        let mailbox_sequence = Sequence::new("heartbeat_mailbox", 0, 100, kv_store.clone());
+        let mailbox_sequence = Sequence::new("heartbeat_mailbox", 1, 100, kv_store.clone());
         let mailbox = HeartbeatMailbox::create(handler_group.pushers(), mailbox_sequence);
 
         MetaSrv {

--- a/src/meta-srv/src/sequence.rs
+++ b/src/meta-srv/src/sequence.rs
@@ -16,7 +16,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use api::v1::meta::CompareAndPutRequest;
-use snafu::ensure;
+use snafu::{ensure, OptionExt};
 use tokio::sync::Mutex;
 
 use crate::error::{self, Result};
@@ -106,7 +106,15 @@ impl Inner {
             } else {
                 u64::to_le_bytes(start).to_vec()
             };
-            let value = u64::to_le_bytes(start + self.step);
+
+            let value = start
+                .checked_add(self.step)
+                .context(error::SequenceOutOfRangeSnafu {
+                    name: &self.name,
+                    start,
+                    step: self.step,
+                })?;
+            let value = u64::to_le_bytes(value);
 
             let req = CompareAndPutRequest {
                 key: key.to_vec(),
@@ -170,7 +178,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sequence_fouce_quit() {
+    async fn test_sequence_out_of_rage() {
+        let kv_store = Arc::new(MemStore::new());
+        let initial = u64::MAX - 10;
+        let seq = Sequence::new("test_seq", initial, 10, kv_store);
+
+        for _ in 0..10 {
+            let _ = seq.next().await.unwrap();
+        }
+
+        let res = seq.next().await;
+        assert!(res.is_err());
+        assert!(matches!(
+            res.unwrap_err(),
+            error::Error::SequenceOutOfRange { .. }
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_sequence_force_quit() {
         struct Noop;
 
         #[async_trait::async_trait]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Out of range checking in Sequence
2. use `message_id = 0` to mark a Message as a one-way call
3. Add log in CheckLeaderHandler

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
