### PR TITLE
feat: change default selector in meta from "LeaseBased" to "LoadBased"

### DIFF
--- a/src/meta-srv/src/selector.rs
+++ b/src/meta-srv/src/selector.rs
@@ -32,8 +32,8 @@ pub trait Selector: Send + Sync {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum SelectorType {
-    LoadBased,
     #[default]
+    LoadBased,
     LeaseBased,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly change default selector in meta from "LeaseBased" to "LoadBased".

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
