### PR TITLE
feat: time_zone variable for mysql connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,7 @@ name = "common-time"
 version = "0.2.0"
 dependencies = [
  "chrono",
+ "chrono-tz 0.8.2",
  "common-error",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7994,6 +7994,7 @@ dependencies = [
  "arc-swap",
  "common-catalog",
  "common-telemetry",
+ "common-time",
 ]
 
 [[package]]

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 chrono.workspace = true
+chrono-tz = "0.8.2"
 common-error = { path = "../error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/common/time/src/timezone.rs
+++ b/src/common/time/src/timezone.rs
@@ -12,26 +12,113 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{FixedOffset, Offset};
+use std::str::FromStr;
 
-#[derive(Debug, Clone)]
-pub struct TimeZone {
-    offset_secs: i32,
+use chrono::FixedOffset;
+use chrono_tz::Tz;
+use snafu::{OptionExt, ResultExt};
+
+use crate::error::{
+    InvalidTimeZoneOffsetSnafu, ParseOffsetStrSnafu, ParseTimeZoneNameSnafu, Result,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimeZone {
+    Offset(FixedOffset),
+    Named(Tz),
 }
 
 impl TimeZone {
-    pub fn new(offset_hours: i32, offset_mins: u32) -> Self {
+    /// Compute timezone from given offset hours and minutes
+    /// Return `None` if given offset exceeds scope
+    pub fn hours_mins_opt(offset_hours: i32, offset_mins: u32) -> Result<Self> {
         let offset_secs = if offset_hours > 0 {
             offset_hours * 3600 + offset_mins as i32 * 60
         } else {
             offset_hours * 3600 - offset_mins as i32 * 60
         };
-        Self { offset_secs }
+
+        FixedOffset::east_opt(offset_secs)
+            .map(Self::Offset)
+            .context(InvalidTimeZoneOffsetSnafu {
+                hours: offset_hours,
+                minutes: offset_mins,
+            })
+    }
+
+    /// Parse timezone offset string and return None if given offset exceeds
+    /// scope.
+    ///
+    /// String examples are available as described in
+    /// https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html
+    ///
+    /// - `SYSTEM`
+    /// - Offset to UTC: `+08:00` , `-11:30`
+    /// - Named zones: `Asia/Shanghai`, `Europe/Berlin`
+    pub fn from_tz_string(tz_string: &str) -> Result<Option<Self>> {
+        // Use system timezone
+        if tz_string.eq_ignore_ascii_case("SYSTEM") {
+            Ok(None)
+        } else if let Some((hrs, mins)) = tz_string.split_once(':') {
+            let hrs = hrs
+                .parse::<i32>()
+                .context(ParseOffsetStrSnafu { raw: tz_string })?;
+            let mins = mins
+                .parse::<u32>()
+                .context(ParseOffsetStrSnafu { raw: tz_string })?;
+            Self::hours_mins_opt(hrs, mins).map(Some)
+        } else if let Ok(tz) = Tz::from_str(tz_string) {
+            Ok(Some(Self::Named(tz)))
+        } else {
+            ParseTimeZoneNameSnafu { raw: tz_string }.fail()
+        }
     }
 }
 
-impl Offset for TimeZone {
-    fn fix(&self) -> FixedOffset {
-        FixedOffset::east_opt(self.offset_secs).unwrap()
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_tz_string() {
+        assert_eq!(None, TimeZone::from_tz_string("SYSTEM").unwrap());
+
+        let utc_plus_8 = Some(TimeZone::Offset(FixedOffset::east_opt(3600 * 8).unwrap()));
+        assert_eq!(utc_plus_8, TimeZone::from_tz_string("+8:00").unwrap());
+        assert_eq!(utc_plus_8, TimeZone::from_tz_string("+08:00").unwrap());
+        assert_eq!(utc_plus_8, TimeZone::from_tz_string("08:00").unwrap());
+
+        let utc_minus_8 = Some(TimeZone::Offset(FixedOffset::west_opt(3600 * 8).unwrap()));
+        assert_eq!(utc_minus_8, TimeZone::from_tz_string("-08:00").unwrap());
+        assert_eq!(utc_minus_8, TimeZone::from_tz_string("-8:00").unwrap());
+
+        let utc_minus_8_5 = Some(TimeZone::Offset(
+            FixedOffset::west_opt(3600 * 8 + 60 * 30).unwrap(),
+        ));
+        assert_eq!(utc_minus_8_5, TimeZone::from_tz_string("-8:30").unwrap());
+
+        let utc_plus_max = Some(TimeZone::Offset(FixedOffset::east_opt(3600 * 14).unwrap()));
+        assert_eq!(utc_plus_max, TimeZone::from_tz_string("14:00").unwrap());
+
+        let utc_minus_max = Some(TimeZone::Offset(
+            FixedOffset::west_opt(3600 * 13 + 60 * 59).unwrap(),
+        ));
+        assert_eq!(utc_minus_max, TimeZone::from_tz_string("-13:59").unwrap());
+
+        assert_eq!(
+            Some(TimeZone::Named(Tz::Asia__Shanghai)),
+            TimeZone::from_tz_string("Asia/Shanghai").unwrap()
+        );
+        assert_eq!(
+            Some(TimeZone::Named(Tz::UTC)),
+            TimeZone::from_tz_string("UTC").unwrap()
+        );
+
+        assert!(TimeZone::from_tz_string("WORLD_PEACE").is_err());
+        assert!(TimeZone::from_tz_string("A0:01").is_err());
+        assert!(TimeZone::from_tz_string("20:0A").is_err());
+        assert!(TimeZone::from_tz_string(":::::").is_err());
+        assert!(TimeZone::from_tz_string("Asia/London").is_err());
+        assert!(TimeZone::from_tz_string("Unknown").is_err());
     }
 }

--- a/src/common/time/src/timezone.rs
+++ b/src/common/time/src/timezone.rs
@@ -14,7 +14,7 @@
 
 use std::str::FromStr;
 
-use chrono::FixedOffset;
+use chrono::{FixedOffset, Local};
 use chrono_tz::Tz;
 use snafu::{OptionExt, ResultExt};
 
@@ -73,6 +73,19 @@ impl TimeZone {
             ParseTimeZoneNameSnafu { raw: tz_string }.fail()
         }
     }
+}
+
+impl ToString for TimeZone {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Named(tz) => tz.name().to_owned(),
+            Self::Offset(offset) => offset.to_string(),
+        }
+    }
+}
+
+pub fn system_time_zone_name() -> String {
+    Local::now().offset().to_string()
 }
 
 #[cfg(test)]

--- a/src/common/time/src/timezone.rs
+++ b/src/common/time/src/timezone.rs
@@ -12,18 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod date;
-pub mod datetime;
-pub mod error;
-pub mod range;
-pub mod timestamp;
-pub mod timestamp_millis;
-pub mod timezone;
-pub mod util;
+use chrono::{FixedOffset, Offset};
 
-pub use date::Date;
-pub use datetime::DateTime;
-pub use range::RangeMillis;
-pub use timestamp::Timestamp;
-pub use timestamp_millis::TimestampMillis;
-pub use timezone::TimeZone;
+#[derive(Debug, Clone)]
+pub struct TimeZone {
+    offset_secs: i32,
+}
+
+impl TimeZone {
+    pub fn new(offset_hours: i32, offset_mins: u32) -> Self {
+        let offset_secs = if offset_hours > 0 {
+            offset_hours * 3600 + offset_mins as i32 * 60
+        } else {
+            offset_hours * 3600 - offset_mins as i32 * 60
+        };
+        Self { offset_secs }
+    }
+}
+
+impl Offset for TimeZone {
+    fn fix(&self) -> FixedOffset {
+        FixedOffset::east_opt(self.offset_secs).unwrap()
+    }
+}

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -20,6 +20,8 @@ use std::sync::Arc;
 
 use common_query::Output;
 use common_recordbatch::RecordBatches;
+use common_time::timezone::system_time_zone_name;
+use common_time::TimeZone;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::StringVector;
@@ -53,6 +55,10 @@ static SELECT_TIME_DIFF_FUNC_PATTERN: Lazy<Regex> =
 // sqlalchemy < 1.4.30
 static SHOW_SQL_MODE_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(SHOW VARIABLES LIKE 'sql_mode'(.*))").unwrap());
+
+// Time zone settings
+static SET_TIME_ZONE_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)^SET TIME_ZONE\s*=\s*'(\S+)'").unwrap());
 
 static OTHER_NOT_SUPPORTED_STMT: Lazy<RegexSet> = Lazy::new(|| {
     RegexSet::new([
@@ -124,8 +130,6 @@ static VAR_VALUES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
         ("transaction_isolation", "REPEATABLE-READ"),
         ("session.transaction_isolation", "REPEATABLE-READ"),
         ("session.transaction_read_only", "0"),
-        ("time_zone", "UTC"),
-        ("system_time_zone", "UTC"),
         ("max_allowed_packet", "134217728"),
         ("interactive_timeout", "31536000"),
         ("wait_timeout", "31536000"),
@@ -168,7 +172,7 @@ fn show_variables(name: &str, value: &str) -> RecordBatches {
         .unwrap()
 }
 
-fn select_variable(query: &str) -> Option<Output> {
+fn select_variable(query: &str, query_context: QueryContextRef) -> Option<Output> {
     let mut fields = vec![];
     let mut values = vec![];
 
@@ -191,12 +195,24 @@ fn select_variable(query: &str) -> Option<Output> {
                     .unwrap_or("")
             })
             .collect();
+
+        // get value of variables from known sources or fallback to defaults
+        let value = match var_as[0] {
+            "time_zone" => query_context
+                .time_zone()
+                .map(|tz| tz.to_string())
+                .unwrap_or_else(|| "".to_owned()),
+            "system_time_zone" => system_time_zone_name(),
+            _ => VAR_VALUES
+                .get(var_as[0])
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "0".to_owned()),
+        };
+
+        values.push(Arc::new(StringVector::from(vec![value])) as _);
         match var_as.len() {
             1 => {
                 // @@aa
-                let value = VAR_VALUES.get(var_as[0]).unwrap_or(&"0");
-                values.push(Arc::new(StringVector::from(vec![*value])) as _);
-
                 // field is '@@aa'
                 fields.push(ColumnSchema::new(
                     &format!("@@{}", var_as[0]),
@@ -207,9 +223,6 @@ fn select_variable(query: &str) -> Option<Output> {
             2 => {
                 // @@bb as cc:
                 // var is 'bb'.
-                let value = VAR_VALUES.get(var_as[0]).unwrap_or(&"0");
-                values.push(Arc::new(StringVector::from(vec![*value])) as _);
-
                 // field is 'cc'.
                 fields.push(ColumnSchema::new(
                     var_as[1],
@@ -227,12 +240,12 @@ fn select_variable(query: &str) -> Option<Output> {
     Some(Output::RecordBatches(batches))
 }
 
-fn check_select_variable(query: &str) -> Option<Output> {
+fn check_select_variable(query: &str, query_context: QueryContextRef) -> Option<Output> {
     if vec![&SELECT_VAR_PATTERN, &MYSQL_CONN_JAVA_PATTERN]
         .iter()
         .any(|r| r.is_match(query))
     {
-        select_variable(query)
+        select_variable(query, query_context)
     } else {
         None
     }
@@ -249,6 +262,20 @@ fn check_show_variables(query: &str) -> Option<Output> {
         None
     };
     recordbatches.map(Output::RecordBatches)
+}
+
+// TODO(sunng87): extract this to use sqlparser for more variables
+fn check_set_variables(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
+    if let Some(captures) = SET_TIME_ZONE_PATTERN.captures(query) {
+        // get the capture
+        let tz = captures.get(1).unwrap();
+        if let Ok(timezone) = TimeZone::from_tz_string(tz.as_str()) {
+            query_ctx.set_time_zone(timezone);
+            return Some(Output::AffectedRows(0));
+        }
+    }
+
+    None
 }
 
 // Check for SET or others query, this is the final check of the federated query.
@@ -283,19 +310,12 @@ pub(crate) fn check(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
     }
 
     // First to check the query is like "select @@variables".
-    let output = check_select_variable(query);
-    if output.is_some() {
-        return output;
-    }
-
-    // Then to check "show variables like ...".
-    let output = check_show_variables(query);
-    if output.is_some() {
-        return output;
-    }
-
-    // Last check.
-    check_others(query, query_ctx)
+    check_select_variable(query, query_ctx.clone())
+        // Then to check "show variables like ...".
+        .or_else(|| check_show_variables(query))
+        .or_else(|| check_set_variables(query, query_ctx.clone()))
+        // Last check
+        .or_else(|| check_others(query, query_ctx))
 }
 
 #[cfg(test)]

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -231,7 +231,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         log::debug!("execute replaced query: {}", query);
 
         let outputs = self.do_query(&query).await;
-        writer::write_output(w, &query, outputs).await?;
+        writer::write_output(w, &query, self.session.context(), outputs).await?;
 
         Ok(())
     }
@@ -263,7 +263,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
             ]
         );
         let outputs = self.do_query(query).await;
-        writer::write_output(writer, query, outputs).await?;
+        writer::write_output(writer, query, self.session.context(), outputs).await?;
         Ok(())
     }
 

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::ops::Deref;
+use std::sync::Arc;
 
 use common_query::Output;
 use common_recordbatch::{util, RecordBatch};
@@ -22,6 +23,7 @@ use datatypes::schema::{ColumnSchema, SchemaRef};
 use opensrv_mysql::{
     Column, ColumnFlags, ColumnType, ErrorKind, OkResponse, QueryResultWriter, RowWriter,
 };
+use session::context::QueryContext;
 use snafu::prelude::*;
 use tokio::io::AsyncWrite;
 
@@ -31,9 +33,10 @@ use crate::error::{self, Error, Result};
 pub async fn write_output<'a, W: AsyncWrite + Send + Sync + Unpin>(
     w: QueryResultWriter<'a, W>,
     query: &str,
+    query_context: Arc<QueryContext>,
     outputs: Vec<Result<Output>>,
 ) -> Result<()> {
-    let mut writer = Some(MysqlResultWriter::new(w));
+    let mut writer = Some(MysqlResultWriter::new(w, query_context.clone()));
     for output in outputs {
         let result_writer = writer.take().context(error::InternalSnafu {
             err_msg: "Sending multiple result set is unsupported",
@@ -54,11 +57,18 @@ struct QueryResult {
 
 pub struct MysqlResultWriter<'a, W: AsyncWrite + Unpin> {
     writer: QueryResultWriter<'a, W>,
+    query_context: Arc<QueryContext>,
 }
 
 impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
-    pub fn new(writer: QueryResultWriter<'a, W>) -> MysqlResultWriter<'a, W> {
-        MysqlResultWriter::<'a, W> { writer }
+    pub fn new(
+        writer: QueryResultWriter<'a, W>,
+        query_context: Arc<QueryContext>,
+    ) -> MysqlResultWriter<'a, W> {
+        MysqlResultWriter::<'a, W> {
+            writer,
+            query_context,
+        }
     }
 
     /// Try to write one result set. If there are more than one result set, return `Some`.
@@ -80,18 +90,23 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                         recordbatches,
                         schema,
                     };
-                    Self::write_query_result(query, query_result, self.writer).await?;
+                    Self::write_query_result(query, query_result, self.writer, self.query_context)
+                        .await?;
                 }
                 Output::RecordBatches(recordbatches) => {
                     let query_result = QueryResult {
                         schema: recordbatches.schema(),
                         recordbatches: recordbatches.take(),
                     };
-                    Self::write_query_result(query, query_result, self.writer).await?;
+                    Self::write_query_result(query, query_result, self.writer, self.query_context)
+                        .await?;
                 }
                 Output::AffectedRows(rows) => {
                     let next_writer = Self::write_affected_rows(self.writer, rows).await?;
-                    return Ok(Some(MysqlResultWriter::new(next_writer)));
+                    return Ok(Some(MysqlResultWriter::new(
+                        next_writer,
+                        self.query_context,
+                    )));
                 }
             },
             Err(error) => Self::write_query_error(query, error, self.writer).await?,
@@ -122,6 +137,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
         query: &str,
         query_result: QueryResult,
         writer: QueryResultWriter<'a, W>,
+        query_context: Arc<QueryContext>,
     ) -> Result<()> {
         match create_mysql_column_def(&query_result.schema) {
             Ok(column_def) => {
@@ -129,7 +145,8 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                 // to return a new QueryResultWriter.
                 let mut row_writer = writer.start(&column_def).await?;
                 for recordbatch in &query_result.recordbatches {
-                    Self::write_recordbatch(&mut row_writer, recordbatch).await?;
+                    Self::write_recordbatch(&mut row_writer, recordbatch, query_context.clone())
+                        .await?;
                 }
                 row_writer.finish().await?;
                 Ok(())
@@ -141,6 +158,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
     async fn write_recordbatch(
         row_writer: &mut RowWriter<'_, W>,
         recordbatch: &RecordBatch,
+        query_context: Arc<QueryContext>,
     ) -> Result<()> {
         for row in recordbatch.rows() {
             for value in row.into_iter() {
@@ -161,7 +179,8 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                     Value::Binary(v) => row_writer.write_col(v.deref())?,
                     Value::Date(v) => row_writer.write_col(v.val())?,
                     Value::DateTime(v) => row_writer.write_col(v.val())?,
-                    Value::Timestamp(v) => row_writer.write_col(v.to_local_string())?,
+                    Value::Timestamp(v) => row_writer
+                        .write_col(v.to_timezone_aware_string(query_context.time_zone()))?,
                     Value::List(_) => {
                         return Err(Error::Internal {
                             err_msg: format!(

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -8,3 +8,4 @@ license.workspace = true
 arc-swap = "1.5"
 common-catalog = { path = "../common/catalog" }
 common-telemetry = { path = "../common/telemetry" }
+common-time = { path = "../common/time"}

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -108,8 +108,8 @@ impl QueryContext {
         self.time_zone.load().as_ref().clone()
     }
 
-    pub fn set_time_zone(&self, tz: TimeZone) {
-        self.time_zone.swap(Arc::new(Some(tz)));
+    pub fn set_time_zone(&self, tz: Option<TimeZone>) {
+        self.time_zone.swap(Arc::new(tz));
     }
 }
 

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -20,6 +20,7 @@ use arc_swap::ArcSwap;
 use common_catalog::build_db_string;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_telemetry::debug;
+use common_time::TimeZone;
 
 pub type QueryContextRef = Arc<QueryContext>;
 pub type ConnInfoRef = Arc<ConnInfo>;
@@ -28,6 +29,7 @@ pub type ConnInfoRef = Arc<ConnInfo>;
 pub struct QueryContext {
     current_catalog: ArcSwap<String>,
     current_schema: ArcSwap<String>,
+    time_zone: ArcSwap<Option<TimeZone>>,
 }
 
 impl Default for QueryContext {
@@ -56,6 +58,7 @@ impl QueryContext {
         Self {
             current_catalog: ArcSwap::new(Arc::new(DEFAULT_CATALOG_NAME.to_string())),
             current_schema: ArcSwap::new(Arc::new(DEFAULT_SCHEMA_NAME.to_string())),
+            time_zone: ArcSwap::new(Arc::new(None)),
         }
     }
 
@@ -63,6 +66,7 @@ impl QueryContext {
         Self {
             current_catalog: ArcSwap::new(Arc::new(catalog.to_string())),
             current_schema: ArcSwap::new(Arc::new(schema.to_string())),
+            time_zone: ArcSwap::new(Arc::new(None)),
         }
     }
 
@@ -98,6 +102,14 @@ impl QueryContext {
         let catalog = self.current_catalog();
         let schema = self.current_schema();
         build_db_string(&catalog, &schema)
+    }
+
+    pub fn time_zone(&self) -> Option<TimeZone> {
+        self.time_zone.load().as_ref().clone()
+    }
+
+    pub fn set_time_zone(&self, tz: TimeZone) {
+        self.time_zone.swap(Arc::new(Some(tz)));
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Probably the last step to enable Grafana mysql visualization plugin on greptimedb: the session timezone.

Grafana has [its confusion with its time zone handling on timestamp data type](https://www.google.com/search?q=grafana+mysql+timezone&sxsrf=APwXEdflcH1NAr06uCp_XNCkwiSpprhC8A%3A1684390655218&source=hp&ei=_8JlZImKC7yu2roP--WTiAY&iflsig=AOEireoAAAAAZGXRD02Isc8b9dd2XEo1f-wLxsTIQBX-&ved=0ahUKEwjJhamVnP7-AhU8l1YBHfvyBGEQ4dUDCAo&uact=5&oq=grafana+mysql+timezone&gs_lcp=Cgdnd3Mtd2l6EAMyBQgAEIAEMgYIABAWEB4yBggAEBYQHjIGCAAQFhAeMgYIABAWEB4yCAgAEIYDEIsDMggIABCGAxCLAzIICAAQhgMQiwM6BAgjECc6BwgjEIoFECc6EQguEIAEELEDEIMBEMcBENEDOgsIABCABBCxAxCDAToRCC4QgwEQxwEQsQMQ0QMQgAQ6FAguEIAEELEDEIMBEMcBENEDENQCOhEILhCABBCxAxDHARCvARDUAjoLCAAQigUQsQMQgwE6BQguEIAEOggIABCABBCxAzoLCC4QgAQQxwEQrwE6EQguEMcBENQCELEDENEDEIAEUABY2ihg4SpoAHAAeAGAAawGiAGkP5IBCTMtNC44LjQuMZgBAKABAbgBAQ&sclient=gws-wiz). In order to make it work, we will need to specify mysql's session time zone to `UTC`.

This patch adds session variable `time_zone` for our mysql channel:

- read/write `time_zone` variable via sql: `SET time_zone = 'UTC'`/`SELECT @@time_zone`.
- apply current time zone variable for mysql timestamp output

### Future work

The `time_zone` variable read/write is implemented within of `mysql/federated.rs`. The structure of this module cannot hold complex logic. We will need to refactor it and implement our own session/system variable system for query and modification.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
