### PR TITLE
feat(copy_to): add initial avro support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ async-stream = "0.3"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 # TODO(ruihang): use arrow-datafusion when it contains https://github.com/apache/arrow-datafusion/pull/6032
-datafusion = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" , features = ["avro"]}
-datafusion-common = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
+datafusion = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793"}
+datafusion-common = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793", features = ["avro"] }
 datafusion-expr = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
 datafusion-optimizer = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
 datafusion-physical-expr = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ async-stream = "0.3"
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 # TODO(ruihang): use arrow-datafusion when it contains https://github.com/apache/arrow-datafusion/pull/6032
-datafusion = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
+datafusion = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" , features = ["avro"]}
 datafusion-common = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
 datafusion-expr = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }
 datafusion-optimizer = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "b14f7a9ffe91257fc3d2a5d654f2a1a14a8fc793" }

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -116,7 +116,7 @@ pub enum Error {
     #[snafu(display("Failed to convert avro to schema: {}", source))]
     AvroToSchema {
         location: Location,
-        source: arrow_schema::ArrowError, // TODO use an Arrow specific error here
+        source: datafusion::error::DataFusionError,
     },
 
     #[snafu(display("Failed to infer schema from file, source: {}", source))]
@@ -181,6 +181,7 @@ impl ErrorExt for Error {
             | EmptyHostPath { .. }
             | InvalidPath { .. }
             | InferSchema { .. }
+            | AvroToSchema { .. }
             | ReadParquetSnafu { .. }
             | ParquetToSchema { .. }
             | ParseFormat { .. }
@@ -208,6 +209,7 @@ impl ErrorExt for Error {
             ListObjects { location, .. } => Some(*location),
             InferSchema { location, .. } => Some(*location),
             ReadParquetSnafu { location, .. } => Some(*location),
+            AvroToSchema { location, .. } => Some(*location),
             ParquetToSchema { location, .. } => Some(*location),
             Decompression { location, .. } => Some(*location),
             JoinHandle { location, .. } => Some(*location),

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -113,6 +113,12 @@ pub enum Error {
         source: datafusion::parquet::errors::ParquetError,
     },
 
+    #[snafu(display("Failed to convert avro to schema: {}", source))]
+    AvroToSchema {
+        location: Location,
+        source: arrow_schema::ArrowError, // TODO use an Arrow specific error here
+    },
+
     #[snafu(display("Failed to infer schema from file, source: {}", source))]
     InferSchema {
         location: Location,

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -38,6 +38,7 @@ use object_store::ObjectStore;
 use snafu::ResultExt;
 use tokio_util::compat::FuturesAsyncWriteCompatExt;
 
+use self::avro::AvroFormat;
 use self::csv::CsvFormat;
 use self::json::JsonFormat;
 use self::parquet::ParquetFormat;
@@ -55,6 +56,7 @@ pub const FILE_PATTERN: &str = "pattern";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Format {
+    Avro(AvroFormat),
     Csv(CsvFormat),
     Json(JsonFormat),
     Parquet(ParquetFormat),

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod avro;
 pub mod csv;
 pub mod json;
 pub mod parquet;

--- a/src/common/datasource/src/file_format/avro.rs
+++ b/src/common/datasource/src/file_format/avro.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow_schema::Schema;
+use async_trait::async_trait;
+use datafusion::avro_to_arrow;
+use object_store::{ObjectStore, Reader};
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+use crate::file_format::FileFormat;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct AvroFormat {}
+
+#[async_trait]
+impl FileFormat for AvroFormat {
+
+    async fn infer_schema(&self, store: &ObjectStore, path: &str) -> Result<Schema> {
+        let mut reader: Reader = store
+            .reader(path)
+            .await
+            .context(error::ReadObjectSnafu { path })?;
+
+        let schema = avro_to_arrow::read_avro_schema_from_reader(&mut reader)
+            .context(error::ParquetToSchemaSnafu)?;
+        Ok(schema)
+    }
+}

--- a/src/frontend/src/statement/copy_table_from.rs
+++ b/src/frontend/src/statement/copy_table_from.rs
@@ -84,7 +84,13 @@ impl StatementExecutor {
         object_store: ObjectStore,
         path: &str,
     ) -> Result<SchemaRef> {
-        match format {
+        match format {            
+            Format::Avro(format) => Ok(Arc::new(
+                format
+                    .infer_schema(&object_store, path)
+                    .await
+                    .context(error::InferSchemaSnafu { path })?,
+            )),
             Format::Csv(format) => Ok(Arc::new(
                 format
                     .infer_schema(&object_store, path)
@@ -149,6 +155,7 @@ impl StatementExecutor {
         projection: Vec<usize>,
     ) -> Result<DfSendableRecordBatchStream> {
         match format {
+            Format::Avro(_) => todo!(),
             Format::Csv(format) => {
                 let csv_conf = CsvConfigBuilder::default()
                     .batch_size(DEFAULT_BATCH_SIZE)

--- a/src/frontend/src/statement/copy_table_to.rs
+++ b/src/frontend/src/statement/copy_table_to.rs
@@ -42,6 +42,7 @@ impl StatementExecutor {
         let threshold = ReadableSize::mb(4).as_bytes() as usize;
 
         match format {
+            Format::Avro(_) => todo!(),
             Format::Csv(_) => stream_to_csv(
                 Box::pin(DfRecordBatchStreamAdapter::new(stream)),
                 object_store,

--- a/src/frontend/src/statement/copy_table_to.rs
+++ b/src/frontend/src/statement/copy_table_to.rs
@@ -27,6 +27,7 @@ use storage::sst::SstInfo;
 use storage::{ParquetWriter, Source};
 use table::engine::TableReference;
 use table::requests::CopyTableRequest;
+use apache_avro::Writer;
 
 use crate::error::{self, Result, WriteParquetSnafu};
 use crate::statement::StatementExecutor;

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -331,6 +331,7 @@ fn parse_immutable_file_table_format(
 ) -> Result<Box<dyn FileFormat>> {
     Ok(
         match Format::try_from(options).context(error::ParseFileFormatSnafu)? {
+            Format::Avro(format) => Box::new(format),
             Format::Csv(format) => Box::new(format),
             Format::Json(format) => Box::new(format),
             Format::Parquet(format) => Box::new(format),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

API improvement; extend `COPY TO` command to support ORC and AVRO formats.


Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link:
https://github.com/GreptimeTeam/greptimedb/issues/1550