### PR TITLE
feat!: reorganize the storage layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,8 @@ dependencies = [
 name = "common-test-util"
 version = "0.2.0"
 dependencies = [
+ "once_cell",
+ "rand",
  "tempfile",
 ]
 

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -24,7 +24,6 @@ tcp_nodelay = true
 
 # WAL options, see `standalone.example.toml`.
 [wal]
-dir = "/tmp/greptimedb/wal"
 file_size = "1GB"
 purge_threshold = "50GB"
 purge_interval = "10m"
@@ -34,7 +33,7 @@ sync_write = false
 # Storage options, see `standalone.example.toml`.
 [storage]
 type = "File"
-data_dir = "/tmp/greptimedb/data/"
+data_home = "/tmp/greptimedb/"
 
 # Compaction options, see `standalone.example.toml`.
 [storage.compaction]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -24,6 +24,8 @@ tcp_nodelay = true
 
 # WAL options, see `standalone.example.toml`.
 [wal]
+# WAL data directory
+# dir = "/tmp/greptimedb/wal"
 file_size = "1GB"
 purge_threshold = "50GB"
 purge_interval = "10m"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -78,8 +78,8 @@ addr = "127.0.0.1:4004"
 
 # WAL options.
 [wal]
-# WAL data directory.
-dir = "/tmp/greptimedb/wal"
+# WAL data directory
+# dir = "/tmp/greptimedb/wal"
 # WAL file size in bytes.
 file_size = "1GB"
 # WAL purge threshold in bytes.
@@ -96,7 +96,7 @@ sync_write = false
 # Storage type.
 type = "File"
 # Data directory, "/tmp/greptimedb/data" by default.
-data_dir = "/tmp/greptimedb/data/"
+data_home = "/tmp/greptimedb/"
 
 # Compaction options.
 [storage.compaction]

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -91,7 +91,7 @@ struct StartCommand {
     #[clap(short, long)]
     config_file: Option<String>,
     #[clap(long)]
-    data_dir: Option<String>,
+    data_home: Option<String>,
     #[clap(long)]
     wal_dir: Option<String>,
     #[clap(long)]
@@ -147,9 +147,9 @@ impl StartCommand {
             .fail();
         }
 
-        if let Some(data_dir) = &self.data_dir {
+        if let Some(data_home) = &self.data_home {
             opts.storage.store = ObjectStoreConfig::File(FileConfig {
-                data_dir: data_dir.clone(),
+                data_home: data_home.clone(),
             });
         }
 
@@ -223,7 +223,7 @@ mod tests {
 
             [storage]
             type = "File"
-            data_dir = "/tmp/greptimedb/data/"
+            data_home = "/tmp/greptimedb/data/"
 
             [storage.compaction]
             max_inflight_tasks = 3
@@ -273,8 +273,8 @@ mod tests {
         assert!(tcp_nodelay);
 
         match &options.storage.store {
-            ObjectStoreConfig::File(FileConfig { data_dir, .. }) => {
-                assert_eq!("/tmp/greptimedb/data/", data_dir)
+            ObjectStoreConfig::File(FileConfig { data_home, .. }) => {
+                assert_eq!("/tmp/greptimedb/data/", data_home)
             }
             ObjectStoreConfig::S3 { .. } => unreachable!(),
             ObjectStoreConfig::Oss { .. } => unreachable!(),
@@ -383,7 +383,7 @@ mod tests {
 
             [storage]
             type = "File"
-            data_dir = "/tmp/greptimedb/data/"
+            data_home = "/tmp/greptimedb/data/"
 
             [storage.compaction]
             max_inflight_tasks = 3

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -214,7 +214,7 @@ mod tests {
             tcp_nodelay = true
 
             [wal]
-            dir = "/tmp/greptimedb/wal"
+            dir = "/other/wal"
             file_size = "1GB"
             purge_threshold = "50GB"
             purge_interval = "10m"
@@ -255,6 +255,7 @@ mod tests {
         assert_eq!(2, options.mysql_runtime_size);
         assert_eq!(Some(42), options.node_id);
 
+        assert_eq!("/other/wal", options.wal.dir);
         assert_eq!(Duration::from_secs(600), options.wal.purge_interval);
         assert_eq!(1024 * 1024 * 1024, options.wal.file_size.0);
         assert_eq!(1024 * 1024 * 1024 * 50, options.wal.purge_threshold.0);

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -154,7 +154,7 @@ impl StartCommand {
         }
 
         if let Some(wal_dir) = &self.wal_dir {
-            opts.wal.dir = wal_dir.clone();
+            opts.wal.dir = Some(wal_dir.clone());
         }
 
         if let Some(http_addr) = &self.http_addr {
@@ -255,7 +255,7 @@ mod tests {
         assert_eq!(2, options.mysql_runtime_size);
         assert_eq!(Some(42), options.node_id);
 
-        assert_eq!("/other/wal", options.wal.dir);
+        assert_eq!("/other/wal", options.wal.dir.unwrap());
         assert_eq!(Duration::from_secs(600), options.wal.purge_interval);
         assert_eq!(1024 * 1024 * 1024, options.wal.file_size.0);
         assert_eq!(1024 * 1024 * 1024 * 50, options.wal.purge_threshold.0);
@@ -465,7 +465,7 @@ mod tests {
                 assert_eq!(opts.storage.compaction.max_purge_tasks, 32);
 
                 // Should be read from cli, cli > config file > env > default values.
-                assert_eq!(opts.wal.dir, "/other/wal/dir");
+                assert_eq!(opts.wal.dir.unwrap(), "/other/wal/dir");
 
                 // Should be default value.
                 assert_eq!(

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -223,7 +223,7 @@ mod tests {
 
             [storage]
             type = "File"
-            data_home = "/tmp/greptimedb/data/"
+            data_home = "/tmp/greptimedb/"
 
             [storage.compaction]
             max_inflight_tasks = 3
@@ -275,7 +275,7 @@ mod tests {
 
         match &options.storage.store {
             ObjectStoreConfig::File(FileConfig { data_home, .. }) => {
-                assert_eq!("/tmp/greptimedb/data/", data_home)
+                assert_eq!("/tmp/greptimedb/", data_home)
             }
             ObjectStoreConfig::S3 { .. } => unreachable!(),
             ObjectStoreConfig::Oss { .. } => unreachable!(),
@@ -375,7 +375,6 @@ mod tests {
             tcp_nodelay = true
 
             [wal]
-            dir = "/tmp/greptimedb/wal"
             file_size = "1GB"
             purge_threshold = "50GB"
             purge_interval = "10m"
@@ -384,7 +383,7 @@ mod tests {
 
             [storage]
             type = "File"
-            data_home = "/tmp/greptimedb/data/"
+            data_home = "/tmp/greptimedb/"
 
             [storage.compaction]
             max_inflight_tasks = 3

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -264,7 +264,7 @@ mod tests {
                 );
 
                 // Should be the values from config file, not environment variables.
-                assert_eq!(opts.wal.dir, "/tmp/greptimedb/wal".to_string());
+                assert_eq!(opts.wal.dir.unwrap(), "/tmp/greptimedb/wal");
 
                 // Should be default values.
                 assert_eq!(opts.node_id, None);

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -449,7 +449,7 @@ mod tests {
         );
         assert!(fe_opts.influxdb_options.as_ref().unwrap().enable);
 
-        assert_eq!("/tmp/greptimedb/test/wal", dn_opts.wal.dir);
+        assert_eq!("/tmp/greptimedb/test/wal", dn_opts.wal.dir.unwrap());
         match &dn_opts.storage.store {
             datanode::datanode::ObjectStoreConfig::S3(s3_config) => {
                 assert_eq!(

--- a/src/cmd/tests/cli.rs
+++ b/src/cmd/tests/cli.rs
@@ -51,7 +51,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_repl() {
-        let data_dir = create_temp_dir("data");
+        let data_home = create_temp_dir("data");
         let wal_dir = create_temp_dir("wal");
 
         let mut bin_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -65,7 +65,7 @@ mod tests {
                 "start",
                 "--rpc-addr=0.0.0.0:4321",
                 "--node-id=1",
-                &format!("--data-dir={}", data_dir.path().display()),
+                &format!("--data-home={}", data_home.path().display()),
                 &format!("--wal-dir={}", wal_dir.path().display()),
             ])
             .stdout(Stdio::null())

--- a/src/common/base/src/lib.rs
+++ b/src/common/base/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod bit_vec;
 pub mod buffer;
 pub mod bytes;
+pub mod paths;
 #[allow(clippy::all)]
 pub mod readable_size;
 

--- a/src/common/base/src/paths.rs
+++ b/src/common/base/src/paths.rs
@@ -1,0 +1,25 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Path constants for table engines, cluster states and WAL
+/// All paths relative to data_home(file storage) or root path(S3, OSS etc).
+
+/// WAL dir for local file storage
+pub const WAL_DIR: &str = "wal/";
+
+/// Data dir for table engines
+pub const DATA_DIR: &str = "data/";
+
+/// Cluster state dir
+pub const CLUSTER_DIR: &str = "cluster/";

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -684,7 +684,7 @@ mod tests {
     fn test_register_loader() {
         let dir = create_temp_dir("register");
         let config = ManagerConfig {
-            parent_path: "".to_string(),
+            parent_path: "data/".to_string(),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
             ..Default::default()
@@ -755,7 +755,7 @@ mod tests {
     async fn test_submit_procedure() {
         let dir = create_temp_dir("submit");
         let config = ManagerConfig {
-            parent_path: "".to_string(),
+            parent_path: "data/".to_string(),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
             ..Default::default()
@@ -805,7 +805,7 @@ mod tests {
     async fn test_state_changed_on_err() {
         let dir = create_temp_dir("on_err");
         let config = ManagerConfig {
-            parent_path: "".to_string(),
+            parent_path: "data/".to_string(),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
             ..Default::default()
@@ -868,7 +868,7 @@ mod tests {
         let dir = create_temp_dir("remove_outdated_meta_task");
         let object_store = test_util::new_object_store(&dir);
         let config = ManagerConfig {
-            parent_path: "".to_string(),
+            parent_path: "data/".to_string(),
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
             remove_outdated_meta_task_interval: Duration::from_millis(1),

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -14,30 +14,20 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::Arc;
 
 use common_telemetry::logging;
 use futures::TryStreamExt;
-use object_store::ObjectStore;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
 use crate::error::{Result, ToJsonSnafu};
-pub(crate) use crate::store::state_store::{ObjectStateStore, StateStoreRef};
+pub(crate) use crate::store::state_store::StateStoreRef;
 use crate::{BoxedProcedure, ProcedureId};
 
 pub mod state_store;
 
 /// Key prefix of procedure store.
 pub(crate) const PROC_PATH: &str = "procedure/";
-
-/// Constructs a path for procedure store.
-macro_rules! proc_path {
-    ($fmt:expr) => { format!("{}{}", $crate::store::PROC_PATH, format_args!($fmt)) };
-    ($fmt:expr, $($args:tt)*) => { format!("{}{}", $crate::store::PROC_PATH, format_args!($fmt, $($args)*)) };
-}
-
-pub(crate) use proc_path;
 
 /// Serialized data of a procedure.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -55,12 +45,22 @@ pub struct ProcedureMessage {
 
 /// Procedure storage layer.
 #[derive(Clone)]
-pub(crate) struct ProcedureStore(StateStoreRef);
+pub(crate) struct ProcedureStore {
+    proc_path: String,
+    store: StateStoreRef,
+}
 
 impl ProcedureStore {
     /// Creates a new [ProcedureStore] from specific [StateStoreRef].
-    pub(crate) fn new(state_store: StateStoreRef) -> ProcedureStore {
-        ProcedureStore(state_store)
+    pub(crate) fn new(parent_path: &str, store: StateStoreRef) -> ProcedureStore {
+        let proc_path = format!("{}{PROC_PATH}", parent_path);
+        logging::info!("The procedure state store path is: {}", &proc_path);
+        ProcedureStore { proc_path, store }
+    }
+
+    #[inline]
+    pub(crate) fn proc_path_with(&self, path: &str) -> String {
+        format!("{}{path}", self.proc_path)
     }
 
     /// Dump the `procedure` to the storage.
@@ -81,6 +81,7 @@ impl ProcedureStore {
             step,
         };
         let key = ParsedKey {
+            parent_path: self.proc_path.to_string(),
             procedure_id,
             step,
             key_type: KeyType::Step,
@@ -88,7 +89,7 @@ impl ProcedureStore {
         .to_string();
         let value = serde_json::to_string(&message).context(ToJsonSnafu)?;
 
-        self.0.put(&key, value.into_bytes()).await?;
+        self.store.put(&key, value.into_bytes()).await?;
 
         Ok(())
     }
@@ -100,12 +101,13 @@ impl ProcedureStore {
         step: u32,
     ) -> Result<()> {
         let key = ParsedKey {
+            parent_path: self.proc_path.to_string(),
             procedure_id,
             step,
             key_type: KeyType::Commit,
         }
         .to_string();
-        self.0.put(&key, Vec::new()).await?;
+        self.store.put(&key, Vec::new()).await?;
 
         Ok(())
     }
@@ -117,26 +119,27 @@ impl ProcedureStore {
         step: u32,
     ) -> Result<()> {
         let key = ParsedKey {
+            parent_path: self.proc_path.to_string(),
             procedure_id,
             step,
             key_type: KeyType::Rollback,
         }
         .to_string();
-        self.0.put(&key, Vec::new()).await?;
+        self.store.put(&key, Vec::new()).await?;
 
         Ok(())
     }
 
     /// Delete states of procedure from the storage.
     pub(crate) async fn delete_procedure(&self, procedure_id: ProcedureId) -> Result<()> {
-        let path = proc_path!("{procedure_id}/");
+        let path = self.proc_path_with(&format!("{procedure_id}/"));
         // TODO(yingwen): We can optimize this to avoid reading the value.
-        let mut key_values = self.0.walk_top_down(&path).await?;
+        let mut key_values = self.store.walk_top_down(&path).await?;
         // 8 should be enough for most procedures.
         let mut step_keys = Vec::with_capacity(8);
         let mut finish_keys = Vec::new();
         while let Some((key, _)) = key_values.try_next().await? {
-            let Some(curr_key) = ParsedKey::parse_str(&key) else {
+            let Some(curr_key) = ParsedKey::parse_str(&self.proc_path, &key) else {
                 logging::warn!("Unknown key while deleting procedures, key: {}", key);
                 continue;
             };
@@ -155,11 +158,11 @@ impl ProcedureStore {
             finish_keys
         );
         // We delete all step keys first.
-        self.0.batch_delete(step_keys.as_slice()).await?;
+        self.store.batch_delete(step_keys.as_slice()).await?;
         // Then we delete the finish keys, to ensure
-        self.0.batch_delete(finish_keys.as_slice()).await?;
+        self.store.batch_delete(finish_keys.as_slice()).await?;
         // Finally we remove the directory itself.
-        self.0.delete(&path).await?;
+        self.store.delete(&path).await?;
         // Maybe we could use procedure_id.commit/rollback as the file name so we could
         // use remove_all to remove the directory and then remove the commit/rollback file.
 
@@ -175,9 +178,9 @@ impl ProcedureStore {
         let mut procedure_key_values: HashMap<_, (ParsedKey, Vec<u8>)> = HashMap::new();
 
         // Scan all procedures.
-        let mut key_values = self.0.walk_top_down(PROC_PATH).await?;
+        let mut key_values = self.store.walk_top_down(&self.proc_path).await?;
         while let Some((key, value)) = key_values.try_next().await? {
-            let Some(curr_key) = ParsedKey::parse_str(&key) else {
+            let Some(curr_key) = ParsedKey::parse_str(&self.proc_path, &key) else {
                 logging::warn!("Unknown key while loading procedures, key: {}", key);
                 continue;
             };
@@ -221,14 +224,6 @@ impl ProcedureStore {
     }
 }
 
-impl From<ObjectStore> for ProcedureStore {
-    fn from(store: ObjectStore) -> ProcedureStore {
-        let state_store = ObjectStateStore::new(store);
-
-        ProcedureStore::new(Arc::new(state_store))
-    }
-}
-
 /// Suffix type of the key.
 #[derive(Debug, PartialEq, Eq)]
 enum KeyType {
@@ -259,6 +254,7 @@ impl KeyType {
 /// Key to refer the procedure in the [ProcedureStore].
 #[derive(Debug, PartialEq, Eq)]
 struct ParsedKey {
+    parent_path: String,
     procedure_id: ProcedureId,
     step: u32,
     key_type: KeyType,
@@ -269,7 +265,7 @@ impl fmt::Display for ParsedKey {
         write!(
             f,
             "{}{}/{:010}.{}",
-            PROC_PATH,
+            self.parent_path,
             self.procedure_id,
             self.step,
             self.key_type.as_str(),
@@ -279,8 +275,8 @@ impl fmt::Display for ParsedKey {
 
 impl ParsedKey {
     /// Try to parse the key from specific `input`.
-    fn parse_str(input: &str) -> Option<ParsedKey> {
-        let input = input.strip_prefix(PROC_PATH)?;
+    fn parse_str(parent_path: &str, input: &str) -> Option<ParsedKey> {
+        let input = input.strip_prefix(parent_path)?;
         let mut iter = input.rsplit('/');
         let name = iter.next()?;
         let id_str = iter.next()?;
@@ -294,6 +290,7 @@ impl ParsedKey {
         let step = step_str.parse().ok()?;
 
         Some(ParsedKey {
+            parent_path: parent_path.to_string(),
             procedure_id,
             step,
             key_type,
@@ -303,6 +300,20 @@ impl ParsedKey {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use object_store::ObjectStore;
+
+    use crate::store::state_store::ObjectStateStore;
+
+    impl ProcedureStore {
+        pub(crate) fn from_object_store(store: ObjectStore) -> ProcedureStore {
+            let state_store = ObjectStateStore::new(store);
+
+            ProcedureStore::new("data/", Arc::new(state_store))
+        }
+    }
+
     use async_trait::async_trait;
     use common_test_util::temp_dir::{create_temp_dir, TempDir};
     use object_store::services::Fs as Builder;
@@ -316,73 +327,91 @@ mod tests {
         builder.root(store_dir);
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        ProcedureStore::from(object_store)
+        ProcedureStore::from_object_store(object_store)
     }
 
     #[test]
     fn test_parsed_key() {
+        let dir = create_temp_dir("store_procedure");
+        let store = procedure_store_for_test(&dir);
+
         let procedure_id = ProcedureId::random();
         let key = ParsedKey {
+            parent_path: store.proc_path.to_string(),
             procedure_id,
             step: 2,
             key_type: KeyType::Step,
         };
         assert_eq!(
-            proc_path!("{procedure_id}/0000000002.step"),
+            store.proc_path_with(&format!("{procedure_id}/0000000002.step")),
             key.to_string()
         );
-        assert_eq!(key, ParsedKey::parse_str(&key.to_string()).unwrap());
+        assert_eq!(
+            key,
+            ParsedKey::parse_str(&store.proc_path, &key.to_string()).unwrap()
+        );
 
         let key = ParsedKey {
+            parent_path: store.proc_path.to_string(),
             procedure_id,
             step: 2,
             key_type: KeyType::Commit,
         };
         assert_eq!(
-            proc_path!("{procedure_id}/0000000002.commit"),
+            store.proc_path_with(&format!("{procedure_id}/0000000002.commit")),
             key.to_string()
         );
-        assert_eq!(key, ParsedKey::parse_str(&key.to_string()).unwrap());
+        assert_eq!(
+            key,
+            ParsedKey::parse_str(&store.proc_path, &key.to_string()).unwrap()
+        );
 
         let key = ParsedKey {
+            parent_path: store.proc_path.to_string(),
             procedure_id,
             step: 2,
             key_type: KeyType::Rollback,
         };
         assert_eq!(
-            proc_path!("{procedure_id}/0000000002.rollback"),
+            store.proc_path_with(&format!("{procedure_id}/0000000002.rollback")),
             key.to_string()
         );
-        assert_eq!(key, ParsedKey::parse_str(&key.to_string()).unwrap());
+        assert_eq!(
+            key,
+            ParsedKey::parse_str(&store.proc_path, &key.to_string()).unwrap()
+        );
     }
 
     #[test]
     fn test_parse_invalid_key() {
-        assert!(ParsedKey::parse_str("").is_none());
-        assert!(ParsedKey::parse_str("invalidprefix").is_none());
-        assert!(ParsedKey::parse_str("procedu/0000000003.step").is_none());
-        assert!(ParsedKey::parse_str("procedure-0000000003.step").is_none());
+        let dir = create_temp_dir("store_procedure");
+        let store = procedure_store_for_test(&dir);
+
+        assert!(ParsedKey::parse_str(&store.proc_path, "").is_none());
+        assert!(ParsedKey::parse_str(&store.proc_path, "invalidprefix").is_none());
+        assert!(ParsedKey::parse_str(&store.proc_path, "procedu/0000000003.step").is_none());
+        assert!(ParsedKey::parse_str(&store.proc_path, "procedure-0000000003.step").is_none());
 
         let procedure_id = ProcedureId::random();
-        let input = proc_path!("{procedure_id}");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}"));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
 
-        let input = proc_path!("{procedure_id}/");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}"));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
 
-        let input = proc_path!("{procedure_id}/0000000003");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}/0000000003"));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
 
-        let input = proc_path!("{procedure_id}/0000000003.");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}/0000000003."));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
 
-        let input = proc_path!("{procedure_id}/0000000003.other");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}/0000000003.other"));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
 
-        assert!(ParsedKey::parse_str("12345/0000000003.step").is_none());
+        assert!(ParsedKey::parse_str(&store.proc_path, "12345/0000000003.step").is_none());
 
-        let input = proc_path!("{procedure_id}-0000000003.commit");
-        assert!(ParsedKey::parse_str(&input).is_none());
+        let input = store.proc_path_with(&format!("{procedure_id}-0000000003.commit"));
+        assert!(ParsedKey::parse_str(&store.proc_path, &input).is_none());
     }
 
     #[test]

--- a/src/common/test-util/Cargo.toml
+++ b/src/common/test-util/Cargo.toml
@@ -5,4 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+once_cell = "1.16"
 tempfile.workspace = true
+rand.workspace = true

--- a/src/common/test-util/Cargo.toml
+++ b/src/common/test-util/Cargo.toml
@@ -6,5 +6,5 @@ license.workspace = true
 
 [dependencies]
 once_cell = "1.16"
-tempfile.workspace = true
 rand.workspace = true
+tempfile.workspace = true

--- a/src/common/test-util/src/lib.rs
+++ b/src/common/test-util/src/lib.rs
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod ports;
 pub mod temp_dir;

--- a/src/common/test-util/src/ports.rs
+++ b/src/common/test-util/src/ports.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::sync::atomic::{AtomicUsize, Ordering};
+
 use once_cell::sync::OnceCell;
 use rand::Rng;
 

--- a/src/common/test-util/src/ports.rs
+++ b/src/common/test-util/src/ports.rs
@@ -1,0 +1,24 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::sync::atomic::{AtomicUsize, Ordering};
+static PORTS: OnceCell<AtomicUsize> = OnceCell::new();
+use once_cell::sync::OnceCell;
+use rand::Rng;
+
+/// Return a unique port(in runtime) for test
+pub fn get_port() -> usize {
+    PORTS
+        .get_or_init(|| AtomicUsize::new(rand::thread_rng().gen_range(3000..3800)))
+        .fetch_add(1, Ordering::Relaxed)
+}

--- a/src/common/test-util/src/ports.rs
+++ b/src/common/test-util/src/ports.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::sync::atomic::{AtomicUsize, Ordering};
-static PORTS: OnceCell<AtomicUsize> = OnceCell::new();
 use once_cell::sync::OnceCell;
 use rand::Rng;
+
+static PORTS: OnceCell<AtomicUsize> = OnceCell::new();
 
 /// Return a unique port(in runtime) for test
 pub fn get_port() -> usize {

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -17,7 +17,6 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use common_base::paths::WAL_DIR;
 use common_base::readable_size::ReadableSize;
 use common_telemetry::info;
 use common_telemetry::logging::LoggingOptions;
@@ -40,12 +39,6 @@ pub const DEFAULT_OBJECT_STORE_CACHE_SIZE: ReadableSize = ReadableSize(1024);
 
 /// Default data home in file storage
 const DEFAULT_DATA_HOME: &str = "/tmp/greptimedb";
-
-/// Returns the default wal dir in file storage
-#[inline]
-fn default_wal_dir() -> String {
-    format!("{DEFAULT_DATA_HOME}/{WAL_DIR}")
-}
 
 /// Object storage config
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,7 +136,7 @@ impl Default for ObjectStoreConfig {
 #[serde(default)]
 pub struct WalConfig {
     // wal directory
-    pub dir: String,
+    pub dir: Option<String>,
     // wal file size in bytes
     pub file_size: ReadableSize,
     // wal purge threshold in bytes
@@ -160,7 +153,7 @@ pub struct WalConfig {
 impl Default for WalConfig {
     fn default() -> Self {
         Self {
-            dir: default_wal_dir(),
+            dir: None,
             file_size: ReadableSize::gb(1),        // log file size 1G
             purge_threshold: ReadableSize::gb(50), // purge threshold 50G
             purge_interval: Duration::from_secs(600),

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use common_base::paths::WAL_DIR;
 use common_base::readable_size::ReadableSize;
 use common_telemetry::info;
 use common_telemetry::logging::LoggingOptions;
@@ -43,7 +44,7 @@ const DEFAULT_DATA_HOME: &str = "/tmp/greptimedb";
 /// Returns the default wal dir in file storage
 #[inline]
 fn default_wal_dir() -> String {
-    format!("{DEFAULT_DATA_HOME}/wal")
+    format!("{DEFAULT_DATA_HOME}/{WAL_DIR}")
 }
 
 /// Object storage config
@@ -353,7 +354,7 @@ pub struct Datanode {
 
 impl Datanode {
     pub async fn new(opts: DatanodeOptions) -> Result<Datanode> {
-        let instance = Arc::new(Instance::new(&opts).await?);
+        let instance = Arc::new(Instance::with_opts(&opts).await?);
         let services = match opts.mode {
             Mode::Distributed => Some(Services::try_new(instance.clone(), &opts).await?),
             Mode::Standalone => None,

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -37,15 +37,13 @@ use crate::server::Services;
 
 pub const DEFAULT_OBJECT_STORE_CACHE_SIZE: ReadableSize = ReadableSize(1024);
 
+/// Default data home in file storage
 const DEFAULT_DATA_HOME: &str = "/tmp/greptimedb";
 
+/// Returns the default wal dir in file storage
 #[inline]
 fn default_wal_dir() -> String {
     format!("{DEFAULT_DATA_HOME}/wal")
-}
-#[inline]
-fn default_data_dir() -> String {
-    format!("{DEFAULT_DATA_HOME}/data")
 }
 
 /// Object storage config
@@ -71,7 +69,7 @@ pub struct StorageConfig {
 #[derive(Debug, Clone, Serialize, Default, Deserialize)]
 #[serde(default)]
 pub struct FileConfig {
-    pub data_dir: String,
+    pub data_home: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -135,7 +133,7 @@ impl Default for OssConfig {
 impl Default for ObjectStoreConfig {
     fn default() -> Self {
         ObjectStoreConfig::File(FileConfig {
-            data_dir: default_data_dir(),
+            data_home: DEFAULT_DATA_HOME.to_string(),
         })
     }
 }
@@ -304,7 +302,6 @@ impl Default for ProcedureConfig {
 #[serde(default)]
 pub struct DatanodeOptions {
     pub mode: Mode,
-    pub data_home: String,
     pub enable_memory_catalog: bool,
     pub node_id: Option<u64>,
     pub rpc_addr: String,
@@ -324,7 +321,6 @@ impl Default for DatanodeOptions {
     fn default() -> Self {
         Self {
             mode: Mode::Standalone,
-            data_home: DEFAULT_DATA_HOME.to_string(),
             enable_memory_catalog: false,
             node_id: None,
             rpc_addr: "127.0.0.1:3001".to_string(),

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Datanode configurations
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -34,6 +36,17 @@ use crate::instance::{Instance, InstanceRef};
 use crate::server::Services;
 
 pub const DEFAULT_OBJECT_STORE_CACHE_SIZE: ReadableSize = ReadableSize(1024);
+
+const DEFAULT_DATA_HOME: &str = "/tmp/greptimedb";
+
+#[inline]
+fn default_wal_dir() -> String {
+    format!("{DEFAULT_DATA_HOME}/wal")
+}
+#[inline]
+fn default_data_dir() -> String {
+    format!("{DEFAULT_DATA_HOME}/data")
+}
 
 /// Object storage config
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -122,7 +135,7 @@ impl Default for OssConfig {
 impl Default for ObjectStoreConfig {
     fn default() -> Self {
         ObjectStoreConfig::File(FileConfig {
-            data_dir: "/tmp/greptimedb/data/".to_string(),
+            data_dir: default_data_dir(),
         })
     }
 }
@@ -148,7 +161,7 @@ pub struct WalConfig {
 impl Default for WalConfig {
     fn default() -> Self {
         Self {
-            dir: "/tmp/greptimedb/wal".to_string(),
+            dir: default_wal_dir(),
             file_size: ReadableSize::gb(1),        // log file size 1G
             purge_threshold: ReadableSize::gb(50), // purge threshold 50G
             purge_interval: Duration::from_secs(600),
@@ -291,6 +304,7 @@ impl Default for ProcedureConfig {
 #[serde(default)]
 pub struct DatanodeOptions {
     pub mode: Mode,
+    pub data_home: String,
     pub enable_memory_catalog: bool,
     pub node_id: Option<u64>,
     pub rpc_addr: String,
@@ -310,6 +324,7 @@ impl Default for DatanodeOptions {
     fn default() -> Self {
         Self {
             mode: Mode::Standalone,
+            data_home: DEFAULT_DATA_HOME.to_string(),
             enable_memory_catalog: false,
             node_id: None,
             rpc_addr: "127.0.0.1:3001".to_string(),

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -429,6 +429,9 @@ pub enum Error {
     StopProcedureManager {
         source: common_procedure::error::Error,
     },
+
+    #[snafu(display("Missing WAL dir config"))]
+    MissingWalDirConfig { location: Location },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -483,6 +486,7 @@ impl ErrorExt for Error {
             | MissingNodeId { .. }
             | MissingMetasrvOpts { .. }
             | ColumnNoneDefaultValue { .. }
+            | MissingWalDirConfig { .. }
             | PrepareImmutableTable { .. } => StatusCode::InvalidArguments,
 
             EncodeJson { .. } | DecodeJson { .. } | PayloadNotExist { .. } => {

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -23,5 +23,6 @@ pub mod metrics;
 mod mock;
 pub mod server;
 pub mod sql;
+mod store;
 #[cfg(test)]
 mod tests;

--- a/src/datanode/src/mock.rs
+++ b/src/datanode/src/mock.rs
@@ -32,7 +32,7 @@ impl Instance {
     pub async fn with_mock_meta_server(opts: &DatanodeOptions, meta_srv: MockInfo) -> Result<Self> {
         let meta_client = Arc::new(mock_meta_client(meta_srv, opts.node_id.unwrap_or(42)).await);
         let compaction_scheduler = Arc::new(NoopCompactionScheduler::default());
-        Instance::new_with(opts, Some(meta_client), compaction_scheduler).await
+        Instance::new(opts, Some(meta_client), compaction_scheduler).await
     }
 }
 

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -1,0 +1,176 @@
+use std::sync::Arc;
+use std::{fs, path};
+
+use common_base::readable_size::ReadableSize;
+use common_telemetry::logging::info;
+use object_store::cache_policy::LruCacheLayer;
+use object_store::layers::{LoggingLayer, MetricsLayer, RetryLayer, TracingLayer};
+use object_store::services::{Fs as FsBuilder, Oss as OSSBuilder, S3 as S3Builder};
+use object_store::{util, ObjectStore, ObjectStoreBuilder};
+use secrecy::ExposeSecret;
+use snafu::prelude::*;
+
+use crate::datanode::{ObjectStoreConfig, DEFAULT_OBJECT_STORE_CACHE_SIZE};
+use crate::error::{self, Result};
+
+pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
+    let object_store = match store_config {
+        ObjectStoreConfig::File { .. } => new_fs_object_store(store_config).await,
+        ObjectStoreConfig::S3 { .. } => new_s3_object_store(store_config).await,
+        ObjectStoreConfig::Oss { .. } => new_oss_object_store(store_config).await,
+    };
+
+    // Don't enable retry layer when using local file backend.
+    let object_store = if !matches!(store_config, ObjectStoreConfig::File(..)) {
+        object_store.map(|object_store| object_store.layer(RetryLayer::new().with_jitter()))
+    } else {
+        object_store
+    };
+
+    object_store.map(|object_store| {
+        object_store
+            .layer(MetricsLayer)
+            .layer(
+                LoggingLayer::default()
+                    // Print the expected error only in DEBUG level.
+                    // See https://docs.rs/opendal/latest/opendal/layers/struct.LoggingLayer.html#method.with_error_level
+                    .with_error_level(Some(log::Level::Debug)),
+            )
+            .layer(TracingLayer)
+    })
+}
+
+pub(crate) async fn new_oss_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
+    let oss_config = match store_config {
+        ObjectStoreConfig::Oss(config) => config,
+        _ => unreachable!(),
+    };
+
+    let root = util::normalize_dir(&oss_config.root);
+    info!(
+        "The oss storage bucket is: {}, root is: {}",
+        oss_config.bucket, &root
+    );
+
+    let mut builder = OSSBuilder::default();
+    builder
+        .root(&root)
+        .bucket(&oss_config.bucket)
+        .endpoint(&oss_config.endpoint)
+        .access_key_id(oss_config.access_key_id.expose_secret())
+        .access_key_secret(oss_config.access_key_secret.expose_secret());
+
+    let object_store = ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish();
+
+    create_object_store_with_cache(object_store, store_config).await
+}
+
+async fn create_object_store_with_cache(
+    object_store: ObjectStore,
+    store_config: &ObjectStoreConfig,
+) -> Result<ObjectStore> {
+    let (cache_path, cache_capacity) = match store_config {
+        ObjectStoreConfig::S3(s3_config) => {
+            let path = s3_config.cache_path.as_ref();
+            let capacity = s3_config
+                .cache_capacity
+                .unwrap_or(DEFAULT_OBJECT_STORE_CACHE_SIZE);
+            (path, capacity)
+        }
+        ObjectStoreConfig::Oss(oss_config) => {
+            let path = oss_config.cache_path.as_ref();
+            let capacity = oss_config
+                .cache_capacity
+                .unwrap_or(DEFAULT_OBJECT_STORE_CACHE_SIZE);
+            (path, capacity)
+        }
+        _ => (None, ReadableSize(0)),
+    };
+
+    if let Some(path) = cache_path {
+        let atomic_temp_dir = format!("{path}/.tmp/");
+        clean_temp_dir(&atomic_temp_dir)?;
+        let cache_store = FsBuilder::default()
+            .root(path)
+            .atomic_write_dir(&atomic_temp_dir)
+            .build()
+            .context(error::InitBackendSnafu)?;
+
+        let cache_layer = LruCacheLayer::new(Arc::new(cache_store), cache_capacity.0 as usize)
+            .await
+            .context(error::InitBackendSnafu)?;
+        Ok(object_store.layer(cache_layer))
+    } else {
+        Ok(object_store)
+    }
+}
+
+pub(crate) async fn new_s3_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
+    let s3_config = match store_config {
+        ObjectStoreConfig::S3(config) => config,
+        _ => unreachable!(),
+    };
+
+    let root = util::normalize_dir(&s3_config.root);
+    info!(
+        "The s3 storage bucket is: {}, root is: {}",
+        s3_config.bucket, &root
+    );
+
+    let mut builder = S3Builder::default();
+    builder
+        .root(&root)
+        .bucket(&s3_config.bucket)
+        .access_key_id(s3_config.access_key_id.expose_secret())
+        .secret_access_key(s3_config.secret_access_key.expose_secret());
+
+    if s3_config.endpoint.is_some() {
+        builder.endpoint(s3_config.endpoint.as_ref().unwrap());
+    }
+    if s3_config.region.is_some() {
+        builder.region(s3_config.region.as_ref().unwrap());
+    }
+
+    create_object_store_with_cache(
+        ObjectStore::new(builder)
+            .context(error::InitBackendSnafu)?
+            .finish(),
+        store_config,
+    )
+    .await
+}
+
+fn clean_temp_dir(dir: &str) -> Result<()> {
+    if path::Path::new(&dir).exists() {
+        info!("Begin to clean temp storage directory: {}", dir);
+        fs::remove_dir_all(dir).context(error::RemoveDirSnafu { dir })?;
+        info!("Cleaned temp storage directory: {}", dir);
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
+    let file_config = match store_config {
+        ObjectStoreConfig::File(config) => config,
+        _ => unreachable!(),
+    };
+    let data_dir = util::normalize_dir(&file_config.data_dir);
+    fs::create_dir_all(path::Path::new(&data_dir))
+        .context(error::CreateDirSnafu { dir: &data_dir })?;
+    info!("The file storage directory is: {}", &data_dir);
+
+    let atomic_write_dir = format!("{data_dir}/.tmp/");
+    clean_temp_dir(&atomic_write_dir)?;
+
+    let mut builder = FsBuilder::default();
+    builder.root(&data_dir).atomic_write_dir(&atomic_write_dir);
+
+    let object_store = ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish();
+
+    Ok(object_store)
+}

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -13,15 +13,19 @@
 // limitations under the License.
 
 //! object storage utilities
+
+mod fs;
+mod oss;
+mod s3;
+
+use std::path;
 use std::sync::Arc;
-use std::{fs, path};
 
 use common_base::readable_size::ReadableSize;
 use common_telemetry::logging::info;
 use object_store::layers::{LoggingLayer, LruCacheLayer, MetricsLayer, RetryLayer, TracingLayer};
-use object_store::services::{Fs as FsBuilder, Oss as OSSBuilder, S3 as S3Builder};
-use object_store::{util, ObjectStore, ObjectStoreBuilder};
-use secrecy::ExposeSecret;
+use object_store::services::Fs as FsBuilder;
+use object_store::{ObjectStore, ObjectStoreBuilder};
 use snafu::prelude::*;
 
 use crate::datanode::{ObjectStoreConfig, DEFAULT_OBJECT_STORE_CACHE_SIZE};
@@ -29,56 +33,28 @@ use crate::error::{self, Result};
 
 pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
     let object_store = match store_config {
-        ObjectStoreConfig::File { .. } => new_fs_object_store(store_config).await,
-        ObjectStoreConfig::S3 { .. } => new_s3_object_store(store_config).await,
-        ObjectStoreConfig::Oss { .. } => new_oss_object_store(store_config).await,
-    };
+        ObjectStoreConfig::File(file_config) => fs::new_fs_object_store(file_config).await,
+        ObjectStoreConfig::S3(s3_config) => s3::new_s3_object_store(s3_config).await,
+        ObjectStoreConfig::Oss(oss_config) => oss::new_oss_object_store(oss_config).await,
+    }?;
 
-    // Don't enable retry layer when using local file backend.
+    // Enable retry layer and cache layer for non-fs object storages
     let object_store = if !matches!(store_config, ObjectStoreConfig::File(..)) {
-        object_store.map(|object_store| object_store.layer(RetryLayer::new().with_jitter()))
+        let object_store = create_object_store_with_cache(object_store, store_config).await?;
+        object_store.layer(RetryLayer::new().with_jitter())
     } else {
         object_store
     };
 
-    object_store.map(|object_store| {
-        object_store
-            .layer(MetricsLayer)
-            .layer(
-                LoggingLayer::default()
-                    // Print the expected error only in DEBUG level.
-                    // See https://docs.rs/opendal/latest/opendal/layers/struct.LoggingLayer.html#method.with_error_level
-                    .with_error_level(Some(log::Level::Debug)),
-            )
-            .layer(TracingLayer)
-    })
-}
-
-pub(crate) async fn new_oss_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
-    let oss_config = match store_config {
-        ObjectStoreConfig::Oss(config) => config,
-        _ => unreachable!(),
-    };
-
-    let root = util::normalize_dir(&oss_config.root);
-    info!(
-        "The oss storage bucket is: {}, root is: {}",
-        oss_config.bucket, &root
-    );
-
-    let mut builder = OSSBuilder::default();
-    builder
-        .root(&root)
-        .bucket(&oss_config.bucket)
-        .endpoint(&oss_config.endpoint)
-        .access_key_id(oss_config.access_key_id.expose_secret())
-        .access_key_secret(oss_config.access_key_secret.expose_secret());
-
-    let object_store = ObjectStore::new(builder)
-        .context(error::InitBackendSnafu)?
-        .finish();
-
-    create_object_store_with_cache(object_store, store_config).await
+    Ok(object_store
+        .layer(MetricsLayer)
+        .layer(
+            LoggingLayer::default()
+                // Print the expected error only in DEBUG level.
+                // See https://docs.rs/opendal/latest/opendal/layers/struct.LoggingLayer.html#method.with_error_level
+                .with_error_level(Some(log::Level::Debug)),
+        )
+        .layer(TracingLayer))
 }
 
 async fn create_object_store_with_cache(
@@ -121,70 +97,12 @@ async fn create_object_store_with_cache(
     }
 }
 
-pub(crate) async fn new_s3_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
-    let s3_config = match store_config {
-        ObjectStoreConfig::S3(config) => config,
-        _ => unreachable!(),
-    };
-
-    let root = util::normalize_dir(&s3_config.root);
-    info!(
-        "The s3 storage bucket is: {}, root is: {}",
-        s3_config.bucket, &root
-    );
-
-    let mut builder = S3Builder::default();
-    builder
-        .root(&root)
-        .bucket(&s3_config.bucket)
-        .access_key_id(s3_config.access_key_id.expose_secret())
-        .secret_access_key(s3_config.secret_access_key.expose_secret());
-
-    if s3_config.endpoint.is_some() {
-        builder.endpoint(s3_config.endpoint.as_ref().unwrap());
-    }
-    if s3_config.region.is_some() {
-        builder.region(s3_config.region.as_ref().unwrap());
-    }
-
-    create_object_store_with_cache(
-        ObjectStore::new(builder)
-            .context(error::InitBackendSnafu)?
-            .finish(),
-        store_config,
-    )
-    .await
-}
-
-fn clean_temp_dir(dir: &str) -> Result<()> {
+pub(crate) fn clean_temp_dir(dir: &str) -> Result<()> {
     if path::Path::new(&dir).exists() {
         info!("Begin to clean temp storage directory: {}", dir);
-        fs::remove_dir_all(dir).context(error::RemoveDirSnafu { dir })?;
+        std::fs::remove_dir_all(dir).context(error::RemoveDirSnafu { dir })?;
         info!("Cleaned temp storage directory: {}", dir);
     }
 
     Ok(())
-}
-
-pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
-    let file_config = match store_config {
-        ObjectStoreConfig::File(config) => config,
-        _ => unreachable!(),
-    };
-    let data_home = util::normalize_dir(&file_config.data_home);
-    fs::create_dir_all(path::Path::new(&data_home))
-        .context(error::CreateDirSnafu { dir: &data_home })?;
-    info!("The file storage home is: {}", &data_home);
-
-    let atomic_write_dir = format!("{data_home}/.tmp/");
-    clean_temp_dir(&atomic_write_dir)?;
-
-    let mut builder = FsBuilder::default();
-    builder.root(&data_home).atomic_write_dir(&atomic_write_dir);
-
-    let object_store = ObjectStore::new(builder)
-        .context(error::InitBackendSnafu)?
-        .finish();
-
-    Ok(object_store)
 }

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -174,7 +174,7 @@ pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Res
     let data_home = util::normalize_dir(&file_config.data_home);
     fs::create_dir_all(path::Path::new(&data_home))
         .context(error::CreateDirSnafu { dir: &data_home })?;
-    info!("The file storage directory is: {}", &data_home);
+    info!("The file storage home is: {}", &data_home);
 
     let atomic_write_dir = format!("{data_home}/.tmp/");
     clean_temp_dir(&atomic_write_dir)?;

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -18,8 +18,7 @@ use std::{fs, path};
 
 use common_base::readable_size::ReadableSize;
 use common_telemetry::logging::info;
-use object_store::cache_policy::LruCacheLayer;
-use object_store::layers::{LoggingLayer, MetricsLayer, RetryLayer, TracingLayer};
+use object_store::layers::{LoggingLayer, LruCacheLayer, MetricsLayer, RetryLayer, TracingLayer};
 use object_store::services::{Fs as FsBuilder, Oss as OSSBuilder, S3 as S3Builder};
 use object_store::{util, ObjectStore, ObjectStoreBuilder};
 use secrecy::ExposeSecret;

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -1,3 +1,18 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! object storage utilities
 use std::sync::Arc;
 use std::{fs, path};
 
@@ -157,16 +172,16 @@ pub(crate) async fn new_fs_object_store(store_config: &ObjectStoreConfig) -> Res
         ObjectStoreConfig::File(config) => config,
         _ => unreachable!(),
     };
-    let data_dir = util::normalize_dir(&file_config.data_dir);
-    fs::create_dir_all(path::Path::new(&data_dir))
-        .context(error::CreateDirSnafu { dir: &data_dir })?;
-    info!("The file storage directory is: {}", &data_dir);
+    let data_home = util::normalize_dir(&file_config.data_home);
+    fs::create_dir_all(path::Path::new(&data_home))
+        .context(error::CreateDirSnafu { dir: &data_home })?;
+    info!("The file storage directory is: {}", &data_home);
 
-    let atomic_write_dir = format!("{data_dir}/.tmp/");
+    let atomic_write_dir = format!("{data_home}/.tmp/");
     clean_temp_dir(&atomic_write_dir)?;
 
     let mut builder = FsBuilder::default();
-    builder.root(&data_dir).atomic_write_dir(&atomic_write_dir);
+    builder.root(&data_home).atomic_write_dir(&atomic_write_dir);
 
     let object_store = ObjectStore::new(builder)
         .context(error::InitBackendSnafu)?

--- a/src/datanode/src/store/fs.rs
+++ b/src/datanode/src/store/fs.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{fs, path};
+
+use common_telemetry::logging::info;
+use object_store::services::Fs as FsBuilder;
+use object_store::{util, ObjectStore};
+use snafu::prelude::*;
+
+use crate::datanode::FileConfig;
+use crate::error::{self, Result};
+use crate::store;
+
+pub(crate) async fn new_fs_object_store(file_config: &FileConfig) -> Result<ObjectStore> {
+    let data_home = util::normalize_dir(&file_config.data_home);
+    fs::create_dir_all(path::Path::new(&data_home))
+        .context(error::CreateDirSnafu { dir: &data_home })?;
+    info!("The file storage home is: {}", &data_home);
+
+    let atomic_write_dir = format!("{data_home}/.tmp/");
+    store::clean_temp_dir(&atomic_write_dir)?;
+
+    let mut builder = FsBuilder::default();
+    builder.root(&data_home).atomic_write_dir(&atomic_write_dir);
+
+    let object_store = ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish();
+
+    Ok(object_store)
+}

--- a/src/datanode/src/store/oss.rs
+++ b/src/datanode/src/store/oss.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_telemetry::logging::info;
+use object_store::services::Oss as OSSBuilder;
+use object_store::{util, ObjectStore};
+use secrecy::ExposeSecret;
+use snafu::prelude::*;
+
+use crate::datanode::OssConfig;
+use crate::error::{self, Result};
+
+pub(crate) async fn new_oss_object_store(oss_config: &OssConfig) -> Result<ObjectStore> {
+    let root = util::normalize_dir(&oss_config.root);
+    info!(
+        "The oss storage bucket is: {}, root is: {}",
+        oss_config.bucket, &root
+    );
+
+    let mut builder = OSSBuilder::default();
+    builder
+        .root(&root)
+        .bucket(&oss_config.bucket)
+        .endpoint(&oss_config.endpoint)
+        .access_key_id(oss_config.access_key_id.expose_secret())
+        .access_key_secret(oss_config.access_key_secret.expose_secret());
+
+    Ok(ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish())
+}

--- a/src/datanode/src/store/s3.rs
+++ b/src/datanode/src/store/s3.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_telemetry::logging::info;
+use object_store::services::S3 as S3Builder;
+use object_store::{util, ObjectStore};
+use secrecy::ExposeSecret;
+use snafu::prelude::*;
+
+use crate::datanode::S3Config;
+use crate::error::{self, Result};
+
+pub(crate) async fn new_s3_object_store(s3_config: &S3Config) -> Result<ObjectStore> {
+    let root = util::normalize_dir(&s3_config.root);
+
+    info!(
+        "The s3 storage bucket is: {}, root is: {}",
+        s3_config.bucket, &root
+    );
+
+    let mut builder = S3Builder::default();
+    builder
+        .root(&root)
+        .bucket(&s3_config.bucket)
+        .access_key_id(s3_config.access_key_id.expose_secret())
+        .secret_access_key(s3_config.secret_access_key.expose_secret());
+
+    if s3_config.endpoint.is_some() {
+        builder.endpoint(s3_config.endpoint.as_ref().unwrap());
+    }
+    if s3_config.region.is_some() {
+        builder.region(s3_config.region.as_ref().unwrap());
+    }
+
+    Ok(ObjectStore::new(builder)
+        .context(error::InitBackendSnafu)?
+        .finish())
+}

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -59,7 +59,7 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
     let data_tmp_dir = create_temp_dir(&format!("gt_data_{name}"));
     let opts = DatanodeOptions {
         wal: WalConfig {
-            dir: wal_tmp_dir.path().to_str().unwrap().to_string(),
+            dir: Some(wal_tmp_dir.path().to_str().unwrap().to_string()),
             ..Default::default()
         },
         storage: StorageConfig {

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -64,7 +64,7 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
         },
         storage: StorageConfig {
             store: ObjectStoreConfig::File(FileConfig {
-                data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+                data_home: data_tmp_dir.path().to_str().unwrap().to_string(),
             }),
             ..Default::default()
         },

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -181,11 +181,11 @@ fn test_region_name() {
 #[test]
 fn test_table_dir() {
     assert_eq!(
-        "greptime/public/1024/",
+        "data/greptime/public/1024/",
         table_dir("greptime", "public", 1024)
     );
     assert_eq!(
-        "0x4354a1/prometheus/1024/",
+        "data/0x4354a1/prometheus/1024/",
         table_dir("0x4354a1", "prometheus", 1024)
     );
 }

--- a/src/object-store/src/layers.rs
+++ b/src/object-store/src/layers.rs
@@ -1,0 +1,4 @@
+mod lru_cache;
+
+pub use lru_cache::*;
+pub use opendal::layers::*;

--- a/src/object-store/src/layers.rs
+++ b/src/object-store/src/layers.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod lru_cache;
 
 pub use lru_cache::*;

--- a/src/object-store/src/layers/lru_cache.rs
+++ b/src/object-store/src/layers/lru_cache.rs
@@ -73,7 +73,7 @@ impl<I: Accessor, C: Accessor> Layer<I> for LruCacheLayer<C> {
 
     fn layer(&self, inner: I) -> Self::LayeredAccessor {
         LruCacheAccessor {
-            inner: Arc::new(inner),
+            inner,
             cache: self.cache.clone(),
             lru_cache: self.lru_cache.clone(),
         }
@@ -82,7 +82,7 @@ impl<I: Accessor, C: Accessor> Layer<I> for LruCacheLayer<C> {
 
 #[derive(Debug)]
 pub struct LruCacheAccessor<I, C> {
-    inner: Arc<I>,
+    inner: I,
     cache: Arc<C>,
     lru_cache: Arc<Mutex<LruCache<String, ()>>>,
 }

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -15,11 +15,11 @@
 pub use opendal::raw::normalize_path as raw_normalize_path;
 pub use opendal::raw::oio::Pager;
 pub use opendal::{
-    layers, services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
+    services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Metakey,
     Operator as ObjectStore, Reader, Result, Writer,
 };
 
-pub mod cache_policy;
+pub mod layers;
 mod metrics;
 pub mod test_util;
 pub mod util;

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use common_telemetry::{logging, metric};
 use common_test_util::temp_dir::create_temp_dir;
-use object_store::cache_policy::LruCacheLayer;
+use object_store::layers::LruCacheLayer;
 use object_store::services::{Fs, S3};
 use object_store::test_util::TempFolder;
 use object_store::{util, ObjectStore, ObjectStoreBuilder};

--- a/src/servers/tests/http/http_test.rs
+++ b/src/servers/tests/http/http_test.rs
@@ -14,13 +14,19 @@
 
 use axum::Router;
 use axum_test_helper::TestClient;
+use common_test_util::ports;
 use servers::http::{HttpOptions, HttpServerBuilder};
 use table::test_util::MemTable;
 
 use crate::{create_testing_grpc_query_handler, create_testing_sql_query_handler};
 
 fn make_test_app() -> Router {
-    let server = HttpServerBuilder::new(HttpOptions::default())
+    let http_opts = HttpOptions {
+        addr: format!("127.0.0.1:{}", ports::get_port()),
+        ..Default::default()
+    };
+
+    let server = HttpServerBuilder::new(http_opts)
         .with_sql_handler(create_testing_sql_query_handler(
             MemTable::default_numbers_table(),
         ))

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use axum::{http, Router};
 use axum_test_helper::TestClient;
 use common_query::Output;
+use common_test_util::ports;
 use datatypes::schema::Schema;
 use query::parser::PromQuery;
 use servers::error::{Error, Result};
@@ -93,8 +94,13 @@ impl SqlQueryHandler for DummyInstance {
 }
 
 fn make_test_app(tx: Arc<mpsc::Sender<(String, String)>>, db_name: Option<&str>) -> Router {
+    let http_opts = HttpOptions {
+        addr: format!("127.0.0.1:{}", ports::get_port()),
+        ..Default::default()
+    };
+
     let instance = Arc::new(DummyInstance { tx });
-    let mut server_builder = HttpServerBuilder::new(HttpOptions::default());
+    let mut server_builder = HttpServerBuilder::new(http_opts);
     server_builder.with_sql_handler(instance.clone());
     server_builder.with_grpc_handler(instance.clone());
     let mut user_provider = MockUserProvider::default();

--- a/src/servers/tests/http/opentsdb_test.rs
+++ b/src/servers/tests/http/opentsdb_test.rs
@@ -19,6 +19,7 @@ use async_trait::async_trait;
 use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
+use common_test_util::ports;
 use datatypes::schema::Schema;
 use query::parser::PromQuery;
 use servers::error::{self, Result};
@@ -91,8 +92,13 @@ impl SqlQueryHandler for DummyInstance {
 }
 
 fn make_test_app(tx: mpsc::Sender<String>) -> Router {
+    let http_opts = HttpOptions {
+        addr: format!("127.0.0.1:{}", ports::get_port()),
+        ..Default::default()
+    };
+
     let instance = Arc::new(DummyInstance { tx });
-    let server = HttpServerBuilder::new(HttpOptions::default())
+    let server = HttpServerBuilder::new(http_opts)
         .with_grpc_handler(instance.clone())
         .with_sql_handler(instance.clone())
         .with_opentsdb_handler(instance)

--- a/src/servers/tests/http/prometheus_test.rs
+++ b/src/servers/tests/http/prometheus_test.rs
@@ -22,6 +22,7 @@ use async_trait::async_trait;
 use axum::Router;
 use axum_test_helper::TestClient;
 use common_query::Output;
+use common_test_util::ports;
 use datatypes::schema::Schema;
 use prost::Message;
 use query::parser::PromQuery;
@@ -116,8 +117,13 @@ impl SqlQueryHandler for DummyInstance {
 }
 
 fn make_test_app(tx: mpsc::Sender<(String, Vec<u8>)>) -> Router {
+    let http_opts = HttpOptions {
+        addr: format!("127.0.0.1:{}", ports::get_port()),
+        ..Default::default()
+    };
+
     let instance = Arc::new(DummyInstance { tx });
-    let server = HttpServerBuilder::new(HttpOptions::default())
+    let server = HttpServerBuilder::new(http_opts)
         .with_grpc_handler(instance.clone())
         .with_sql_handler(instance.clone())
         .with_prom_handler(instance)

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -15,6 +15,7 @@
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
+use common_base::paths::DATA_DIR;
 use common_procedure::BoxedProcedure;
 use store_api::storage::RegionId;
 
@@ -153,7 +154,7 @@ pub fn region_id(table_id: TableId, n: u32) -> RegionId {
 
 #[inline]
 pub fn table_dir(catalog_name: &str, schema_name: &str, table_id: TableId) -> String {
-    format!("{catalog_name}/{schema_name}/{table_id}/")
+    format!("{DATA_DIR}{catalog_name}/{schema_name}/{table_id}/")
 }
 
 #[cfg(test)]

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -210,7 +210,7 @@ pub fn create_tmp_dir_and_datanode_opts(
 pub fn create_datanode_opts(store: ObjectStoreConfig, wal_dir: String) -> DatanodeOptions {
     DatanodeOptions {
         wal: WalConfig {
-            dir: Some(wal_tmp_dir.path().to_str().unwrap().to_string()),
+            dir: Some(wal_dir),
             ..Default::default()
         },
         storage: StorageConfig {

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -167,7 +167,7 @@ pub fn get_test_store_config(
 
             (
                 ObjectStoreConfig::File(FileConfig {
-                    data_dir: data_tmp_dir.path().to_str().unwrap().to_string(),
+                    data_home: data_tmp_dir.path().to_str().unwrap().to_string(),
                 }),
                 TempDirGuard::File(data_tmp_dir),
             )

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -63,9 +63,11 @@ impl MockStandaloneInstance {
     }
 }
 
-pub async fn create_standalone_instance(test_name: &str) -> MockStandaloneInstance {
-    let (opts, guard) = create_tmp_dir_and_datanode_opts(StorageType::File, test_name);
-    let dn_instance = Arc::new(DatanodeInstance::new(&opts).await.unwrap());
+
+pub(crate) async fn create_standalone_instance(test_name: &str) -> MockStandaloneInstance {
+    let (opts, guard) = create_tmp_dir_and_datanode_opts(test_name);
+    let dn_instance = Arc::new(DatanodeInstance::with_opts(&opts).await.unwrap());
+
     let frontend_instance = Instance::try_new_standalone(dn_instance.clone())
         .await
         .unwrap();

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -63,9 +63,8 @@ impl MockStandaloneInstance {
     }
 }
 
-
 pub(crate) async fn create_standalone_instance(test_name: &str) -> MockStandaloneInstance {
-    let (opts, guard) = create_tmp_dir_and_datanode_opts(test_name);
+    let (opts, guard) = create_tmp_dir_and_datanode_opts(StorageType::File, test_name);
     let dn_instance = Arc::new(DatanodeInstance::with_opts(&opts).await.unwrap());
 
     let frontend_instance = Instance::try_new_standalone(dn_instance.clone())

--- a/tests/conf/datanode-test.toml.template
+++ b/tests/conf/datanode-test.toml.template
@@ -5,7 +5,6 @@ rpc_hostname = '127.0.0.1'
 rpc_runtime_size = 8
 
 [wal]
-dir = '{wal_dir}'
 file_size = '1GB'
 purge_interval = '10m'
 purge_threshold = '50GB'
@@ -14,7 +13,7 @@ sync_write = false
 
 [storage]
 type = 'File'
-data_dir = '{data_dir}'
+data_home = '{data_home}'
 
 [meta_client_options]
 metasrv_addrs = ['127.0.0.1:3002']
@@ -22,8 +21,6 @@ timeout_millis = 3000
 connect_timeout_millis = 5000
 tcp_nodelay = false
 
-[procedure.store]
-type = "File"
-data_dir = "{procedure_dir}"
+[procedure]
 max_retry_times = 3
 retry_delay = "500ms"

--- a/tests/conf/standalone-test.toml.template
+++ b/tests/conf/standalone-test.toml.template
@@ -2,7 +2,6 @@ mode = 'standalone'
 enable_memory_catalog = false
 
 [wal]
-dir = '{wal_dir}'
 file_size = '1GB'
 purge_interval = '10m'
 purge_threshold = '50GB'
@@ -11,14 +10,12 @@ sync_write = false
 
 [storage]
 type = 'File'
-data_dir = '{data_dir}'
+data_home = '{data_home}'
 
 [grpc_options]
 addr = '127.0.0.1:4001'
 runtime_size = 8
 
-[procedure.store]
-type = "File"
-data_dir = "{procedure_dir}"
+[procedure]
 max_retry_times = 3
 retry_delay = "500ms"

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -218,7 +218,7 @@ impl Env {
         let greptimedb_dir = format!("/tmp/greptimedb-{subcommand}-{}", db_ctx.time);
         let ctx = Context {
             wal_dir: format!("{greptimedb_dir}/wal/"),
-            data_home: format!("{greptimedb_dir}/data/"),
+            data_home: format!("{greptimedb_dir}/"),
             procedure_dir: format!("{greptimedb_dir}/procedure/"),
         };
         let rendered = tt.render(subcommand, &ctx).unwrap();

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -211,14 +211,14 @@ impl Env {
         #[derive(Serialize)]
         struct Context {
             wal_dir: String,
-            data_dir: String,
+            data_home: String,
             procedure_dir: String,
         }
 
         let greptimedb_dir = format!("/tmp/greptimedb-{subcommand}-{}", db_ctx.time);
         let ctx = Context {
             wal_dir: format!("{greptimedb_dir}/wal/"),
-            data_dir: format!("{greptimedb_dir}/data/"),
+            data_home: format!("{greptimedb_dir}/data/"),
             procedure_dir: format!("{greptimedb_dir}/procedure/"),
         };
         let rendered = tt.render(subcommand, &ctx).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:
1. Use `data_home` instead of `data_dir` in `FileConfig`.
2. Make `dir` in `WalConfig` to be an option. When using file storage, it will be generated by `{data_home}/wal`. Otherwise, it must be specified in the config file.
3. Reorganize the storage layout as below:

```
├── cluster
│   └── dn-0
│       └── procedure
├── data
│   ├── greptime
│   │   └── public
│   │       ├── 1
│   │       │   ├── 1_0000000000
│   │       │   │   └── manifest
│   │       │   │       └── 00000000000000000000.json
│   │       │   └── manifest
│   │       │       └── 00000000000000000000.json
│   │       └── 1024
│   │           ├── 1024_0000000000
│   │           │   └── manifest
│   │           │       └── 00000000000000000000.json
│   │           └── manifest
│   │               └── 00000000000000000000.json
│   └── system
│       └── information_schema
│           └── 0
│               ├── 0_0000000000
│               │   └── manifest
│               │       └── 00000000000000000000.json
│               └── manifest
│                   └── 00000000000000000000.json 
└── wal
    ├── 0000000000000001.raftlog
    ├── 0000000000000001.rewrite
    └── LOCK
```

* Adds `cluster` folder to keep internal data such as procedure states, and organize the data grouped by datanode id. The datanode internal data are stored in `cluster/dn-{datanode id}` folder.
* Refactor some code

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Close #1526