### PR TITLE
fix: wal replay ignore manifest entries

### DIFF
--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -67,6 +67,19 @@ pub enum Error {
         source: raft_engine::Error,
         location: Location,
     },
+
+    #[snafu(display(
+        "Cannot override compacted entry, namespace: {}, first index: {}, attempt index: {}",
+        namespace,
+        first_index,
+        attempt_index
+    ))]
+    OverrideCompactedEntry {
+        namespace: u64,
+        first_index: u64,
+        attempt_index: u64,
+        location: Location,
+    },
 }
 
 impl ErrorExt for Error {

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use common_telemetry::logging;
+use common_telemetry::{info, logging};
 use common_time::util;
 use metrics::{decrement_gauge, increment_gauge};
 use snafu::ResultExt;
@@ -319,6 +319,12 @@ impl<S: LogStore> RegionImpl<S> {
 
         let wal = Wal::new(metadata.id(), store_config.log_store);
         wal.obsolete(flushed_sequence).await?;
+        info!(
+            "Obsolete WAL entries on startup, region: {}, flushed sequence: {}",
+            metadata.id(),
+            flushed_sequence
+        );
+
         let shared = Arc::new(SharedData {
             id: metadata.id(),
             name,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

During WAL replay, manifest entries in WAL are ignored, so sequences may jump backward by 1. This PR fixes this issue so that region sequence can be recovered to the correct value.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
