### PR TITLE
fix(table-procedure): Open table in RegisterCatalog state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8688,6 +8688,7 @@ dependencies = [
  "common-catalog",
  "common-error",
  "common-procedure",
+ "common-procedure-test",
  "common-telemetry",
  "common-test-util",
  "datatypes",

--- a/src/common/procedure-test/src/lib.rs
+++ b/src/common/procedure-test/src/lib.rs
@@ -94,7 +94,7 @@ pub async fn execute_procedure_once(
 /// Executes a procedure until it returns [Status::Suspended] or [Status::Done].
 ///
 /// Returns `Some` if it returns [Status::Suspended] or `None` if it returns [Status::Done].
-pub async fn execute_parent_procedure(
+pub async fn execute_until_suspended_or_done(
     procedure_id: ProcedureId,
     provider: MockContextProvider,
     procedure: &mut dyn Procedure,

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -97,6 +97,25 @@ pub trait Procedure: Send + Sync {
     fn lock_key(&self) -> LockKey;
 }
 
+#[async_trait]
+impl<T: Procedure + ?Sized> Procedure for Box<T> {
+    fn type_name(&self) -> &str {
+        (**self).type_name()
+    }
+
+    async fn execute(&mut self, ctx: &Context) -> Result<Status> {
+        (**self).execute(ctx).await
+    }
+
+    fn dump(&self) -> Result<String> {
+        (**self).dump()
+    }
+
+    fn lock_key(&self) -> LockKey {
+        (**self).lock_key()
+    }
+}
+
 /// Keys to identify required locks.
 ///
 /// [LockKey] always sorts keys lexicographically so that they can be acquired

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -152,7 +152,7 @@ impl<S: StorageEngine> CreateMitoTable<S> {
     async fn on_engine_create_table(&mut self) -> Result<Status> {
         // In this state, we can ensure we are able to create a new table.
         let table_ref = self.creator.data.table_ref();
-        logging::info!("on engine create table {}", table_ref);
+        logging::debug!("on engine create table {}", table_ref);
 
         let _lock = self
             .creator
@@ -216,7 +216,7 @@ impl<S: StorageEngine> TableCreator<S> {
             return Ok(table.clone());
         }
 
-        logging::info!("Creator create table {}", table_ref);
+        logging::debug!("Creator create table {}", table_ref);
 
         self.create_regions(&table_dir).await?;
 
@@ -301,7 +301,7 @@ impl<S: StorageEngine> TableCreator<S> {
                     .map_err(Error::from_error_ext)?
             };
 
-            logging::info!(
+            logging::debug!(
                 "Create region {} for table {}, region_id: {}",
                 number,
                 self.data.request.table_ref(),

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -456,8 +456,13 @@ impl<R: Region> MitoTable<R> {
         object_store: ObjectStore,
         compress_type: CompressionType,
     ) -> Result<MitoTable<R>> {
-        let manifest =
-            TableManifest::create(&table_manifest_dir(table_dir), object_store, compress_type);
+        let manifest_dir = table_manifest_dir(table_dir);
+        let manifest = TableManifest::create(&manifest_dir, object_store, compress_type);
+        logging::info!(
+            "Create table manifest at {}, table_name: {}",
+            manifest_dir,
+            table_name
+        );
 
         let _timer =
             common_telemetry::timer!(crate::metrics::MITO_CREATE_TABLE_UPDATE_MANIFEST_ELAPSED);

--- a/src/table-procedure/Cargo.toml
+++ b/src/table-procedure/Cargo.toml
@@ -18,6 +18,7 @@ table = { path = "../table" }
 
 [dev-dependencies]
 common-catalog = { path = "../common/catalog" }
+common-procedure-test = { path = "../common/procedure-test" }
 common-test-util = { path = "../common/test-util" }
 log-store = { path = "../log-store" }
 mito = { path = "../mito" }

--- a/src/table-procedure/src/create.rs
+++ b/src/table-procedure/src/create.rs
@@ -322,7 +322,7 @@ mod tests {
     use std::collections::HashMap;
 
     use common_procedure_test::{
-        execute_parent_procedure, execute_procedure_once, execute_procedure_until_done,
+        execute_procedure_once, execute_procedure_until_done, execute_until_suspended_or_done,
         MockContextProvider,
     };
     use table::engine::{EngineContext, TableEngine};
@@ -404,10 +404,13 @@ mod tests {
         let mut procedure = Box::new(procedure);
         // Execute until suspended. We use an empty provider so the parent can submit
         // a new subprocedure as the it can't find the subprocedure.
-        let mut subprocedures =
-            execute_parent_procedure(procedure_id, MockContextProvider::default(), &mut procedure)
-                .await
-                .unwrap();
+        let mut subprocedures = execute_until_suspended_or_done(
+            procedure_id,
+            MockContextProvider::default(),
+            &mut procedure,
+        )
+        .await
+        .unwrap();
         assert_eq!(1, subprocedures.len());
         // Execute the subprocedure.
         let mut subprocedure = subprocedures.pop().unwrap();

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -46,6 +46,10 @@ pub struct TestEnv {
 impl TestEnv {
     pub fn new(prefix: &str) -> TestEnv {
         let dir = create_temp_dir(prefix);
+        TestEnv::from_temp_dir(dir)
+    }
+
+    pub fn from_temp_dir(dir: TempDir) -> TestEnv {
         let store_dir = format!("{}/db", dir.path().to_string_lossy());
         let mut builder = Fs::default();
         builder.root(&store_dir);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Open the created table in the `CreateTable::RegisterCatalog` state so the procedure can execute correctly after recovery.

To test this case, it adds the following helper functions to execute the procedure without the procedure manager
- execute_parent_procedure
- execute_procedure_once

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fix #1614 