### PR TITLE
feat: add rows counter metric for frontend inserts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,7 @@ dependencies = [
  "meta-srv",
  "meter-core",
  "meter-macros",
+ "metrics",
  "mito",
  "moka",
  "object-store",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -40,6 +40,7 @@ itertools = "0.10"
 meta-client = { path = "../meta-client" }
 meter-core.workspace = true
 meter-macros.workspace = true
+metrics.workspace = true
 mito = { path = "../mito", features = ["test"] }
 moka = { version = "0.9", features = ["future"] }
 object-store = { path = "../object-store" }

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -15,6 +15,7 @@
 pub(crate) const METRIC_HANDLE_SQL_ELAPSED: &str = "frontend.handle_sql_elapsed";
 pub(crate) const METRIC_HANDLE_SCRIPTS_ELAPSED: &str = "frontend.handle_scripts_elapsed";
 pub(crate) const METRIC_RUN_SCRIPT_ELAPSED: &str = "frontend.run_script_elapsed";
+pub(crate) const METRIC_INSERT_ROWS_COUNTER: &str = "frontend.dist.insert_rows";
 
 /// frontend metrics
 /// Metrics for creating table in dist mode.

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -36,6 +36,7 @@ use datafusion::physical_plan::{
 use datafusion_common::DataFusionError;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use meta_client::rpc::TableName;
+use metrics::counter;
 use partition::manager::PartitionRuleManagerRef;
 use partition::splitter::WriteSplitter;
 use snafu::prelude::*;
@@ -82,6 +83,10 @@ impl Table for DistTable {
 
     async fn insert(&self, request: InsertRequest) -> table::Result<usize> {
         meter_insert_request!(request);
+        counter!(
+            crate::metrics::METRIC_INSERT_ROWS_COUNTER,
+            request.rows() as u64
+        );
 
         let splits = self
             .partition_manager

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -243,6 +243,17 @@ pub struct InsertRequest {
     pub region_number: RegionNumber,
 }
 
+impl InsertRequest {
+    /// Returns rows that the insert request contains
+    pub fn rows(&self) -> usize {
+        if let Some(vector) = self.columns_values.values().next() {
+            vector.len()
+        } else {
+            0
+        }
+    }
+}
+
 /// Delete (by primary key) request
 #[derive(Debug)]
 pub struct DeleteRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds a counter to track how many rows in insert requests issued from frontend.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
