### PR TITLE
feat: update table metadata in lock

### DIFF
--- a/src/meta-srv/src/lock.rs
+++ b/src/meta-srv/src/lock.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod etcd;
+pub(crate) mod memory;
 
 use std::sync::Arc;
 
@@ -26,6 +27,14 @@ pub struct Opts {
     // If the expiration time is exceeded and currently holds the lock, the lock is
     // automatically released.
     pub expire_secs: Option<u64>,
+}
+
+impl Default for Opts {
+    fn default() -> Self {
+        Opts {
+            expire_secs: Some(DEFAULT_EXPIRE_TIME_SECS),
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/src/meta-srv/src/lock.rs
+++ b/src/meta-srv/src/lock.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod etcd;
+pub(crate) mod keys;
 pub(crate) mod memory;
 
 use std::sync::Arc;

--- a/src/meta-srv/src/lock/keys.rs
+++ b/src/meta-srv/src/lock/keys.rs
@@ -1,0 +1,28 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! All keys used for distributed locking in the Metasrv.
+//! Place them in this unified module for better maintenance.
+
+use common_meta::RegionIdent;
+
+use crate::lock::Key;
+
+pub(crate) fn table_metadata_lock_key(region: &RegionIdent) -> Key {
+    format!(
+        "table_metadata_lock_({}-{}.{}.{}-{})",
+        region.cluster_id, region.catalog, region.schema, region.table, region.table_id,
+    )
+    .into_bytes()
+}

--- a/src/meta-srv/src/lock/memory.rs
+++ b/src/meta-srv/src/lock/memory.rs
@@ -1,0 +1,117 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+use crate::error::Result;
+use crate::lock::{DistLock, Key, Opts};
+
+#[derive(Default)]
+pub(crate) struct MemLock {
+    mutexes: Arc<Mutex<HashMap<Key, Arc<Mutex<()>>>>>,
+    guards: Arc<Mutex<HashMap<Key, OwnedMutexGuard<()>>>>,
+}
+
+#[async_trait]
+impl DistLock for MemLock {
+    async fn lock(&self, name: Vec<u8>, _opts: Opts) -> Result<Key> {
+        let key = name;
+
+        let mutex = {
+            let mut mutexes = self.mutexes.lock().await;
+            mutexes
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+
+        let guard = mutex.lock_owned().await;
+
+        let mut guards = self.guards.lock().await;
+        guards.insert(key.clone(), guard);
+        Ok(key)
+    }
+
+    async fn unlock(&self, key: Vec<u8>) -> Result<()> {
+        let mut guards = self.guards.lock().await;
+        // drop the guard, so that the mutex can be unlocked,
+        // effectively make the `mutex.lock_owned` in `lock` method to proceed
+        guards.remove(&key);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use rand::seq::SliceRandom;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_mem_lock_concurrently() {
+        let lock = Arc::new(MemLock::default());
+
+        let keys = (0..10)
+            .map(|i| format!("my-lock-{i}").into_bytes())
+            .collect::<Vec<Key>>();
+        let counters: [(Key, AtomicU32); 10] = keys
+            .iter()
+            .map(|x| (x.clone(), AtomicU32::new(0)))
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        let counters = Arc::new(HashMap::from(counters));
+
+        let tasks = (0..100)
+            .map(|_| {
+                let mut keys = keys.clone();
+                keys.shuffle(&mut rand::thread_rng());
+
+                let lock_clone = lock.clone();
+                let counters_clone = counters.clone();
+                tokio::spawn(async move {
+                    // every key counter will be added by 1 for 10 times
+                    for i in 0..100 {
+                        let key = &keys[i % keys.len()];
+                        lock_clone
+                            .lock(key.clone(), Opts { expire_secs: None })
+                            .await
+                            .unwrap();
+
+                        // Intentionally create a critical section:
+                        // if our MemLock is flawed, the resulting counter is wrong.
+                        //
+                        // Note that AtomicU32 is only used to enable the updates from multiple tasks,
+                        // does not make any guarantee about the correctness of the result.
+
+                        let counter = counters_clone.get(key).unwrap();
+                        let v = counter.load(Ordering::Relaxed);
+                        counter.store(v + 1, Ordering::Relaxed);
+
+                        lock_clone.unlock(key.clone()).await.unwrap();
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        futures::future::join_all(tasks).await;
+
+        assert!(counters.values().all(|x| x.load(Ordering::Relaxed) == 1000));
+    }
+}

--- a/src/meta-srv/src/lock/memory.rs
+++ b/src/meta-srv/src/lock/memory.rs
@@ -29,9 +29,7 @@ pub(crate) struct MemLock {
 
 #[async_trait]
 impl DistLock for MemLock {
-    async fn lock(&self, name: Vec<u8>, _opts: Opts) -> Result<Key> {
-        let key = name;
-
+    async fn lock(&self, key: Vec<u8>, _opts: Opts) -> Result<Key> {
         let mutex = self
             .mutexes
             .entry(key.clone())

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -120,7 +120,7 @@ pub struct MetaSrv {
     handler_group: HeartbeatHandlerGroup,
     election: Option<ElectionRef>,
     meta_peer_client: Option<MetaPeerClient>,
-    lock: Option<DistLockRef>,
+    lock: DistLockRef,
     procedure_manager: ProcedureManagerRef,
     metadata_service: MetadataServiceRef,
     mailbox: MailboxRef,
@@ -244,8 +244,8 @@ impl MetaSrv {
     }
 
     #[inline]
-    pub fn lock(&self) -> Option<DistLockRef> {
-        self.lock.clone()
+    pub fn lock(&self) -> &DistLockRef {
+        &self.lock
     }
 
     #[inline]

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -25,6 +25,7 @@ use crate::handler::{
     KeepLeaseHandler, OnLeaderStartHandler, PersistStatsHandler, Pushers, RegionFailureHandler,
     ResponseHeaderHandler,
 };
+use crate::lock::memory::MemLock;
 use crate::lock::DistLockRef;
 use crate::metadata_service::{DefaultMetadataService, MetadataServiceRef};
 use crate::metasrv::{
@@ -140,6 +141,8 @@ impl MetaSrvBuilder {
         let state_store = Arc::new(MetaStateStore::new(kv_store.clone()));
         let procedure_manager = Arc::new(LocalManager::new(ManagerConfig::default(), state_store));
 
+        let lock = lock.unwrap_or_else(|| Arc::new(MemLock::default()));
+
         let handler_group = match handler_group {
             Some(handler_group) => handler_group,
             None => {
@@ -154,6 +157,7 @@ impl MetaSrvBuilder {
                         catalog: None,
                         schema: None,
                     },
+                    lock.clone(),
                 ));
 
                 let region_failure_handler =

--- a/src/meta-srv/src/procedure/region_failover/failover_start.rs
+++ b/src/meta-srv/src/procedure/region_failover/failover_start.rs
@@ -101,30 +101,27 @@ impl State for RegionFailoverStart {
 
 #[cfg(test)]
 mod tests {
-    use super::super::tests::{TestingEnv, TestingEnvBuilder};
+    use super::super::tests::TestingEnvBuilder;
     use super::*;
 
     #[tokio::test]
     async fn test_choose_failover_candidate() {
         common_telemetry::init_default_ut_logging();
 
-        let TestingEnv {
-            context,
-            failed_region,
-            heartbeat_receivers: _,
-        } = TestingEnvBuilder::new().build().await;
+        let env = TestingEnvBuilder::new().build().await;
+        let failed_region = env.failed_region(1).await;
 
         let mut state = RegionFailoverStart::new();
         assert!(state.failover_candidate.is_none());
 
         let candidate = state
-            .choose_candidate(&context, &failed_region)
+            .choose_candidate(&env.context, &failed_region)
             .await
             .unwrap();
         assert_ne!(candidate.id, failed_region.datanode_id);
 
         let candidate_again = state
-            .choose_candidate(&context, &failed_region)
+            .choose_candidate(&env.context, &failed_region)
             .await
             .unwrap();
         assert_eq!(candidate, candidate_again);

--- a/src/meta-srv/src/procedure/region_failover/update_metadata.rs
+++ b/src/meta-srv/src/procedure/region_failover/update_metadata.rs
@@ -29,7 +29,8 @@ use crate::error::{
     TableRouteConversionSnafu,
 };
 use crate::keys::TableRouteKey;
-use crate::lock::{Key, Opts};
+use crate::lock::keys::table_metadata_lock_key;
+use crate::lock::Opts;
 use crate::table_routes;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -213,14 +214,6 @@ impl State for UpdateRegionMetadata {
             })?;
         Ok(Box::new(RegionFailoverEnd))
     }
-}
-
-fn table_metadata_lock_key(region: &RegionIdent) -> Key {
-    format!(
-        "table_metadata_lock_({}-{}.{}.{}-{})",
-        region.cluster_id, region.catalog, region.schema, region.table, region.table_id,
-    )
-    .into_bytes()
 }
 
 #[cfg(test)]

--- a/src/meta-srv/src/service/lock.rs
+++ b/src/meta-srv/src/service/lock.rs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 use api::v1::meta::{lock_server, LockRequest, LockResponse, UnlockRequest, UnlockResponse};
-use snafu::OptionExt;
 use tonic::{Request, Response};
 
 use super::GrpcResult;
-use crate::error;
 use crate::lock::Opts;
 use crate::metasrv::MetaSrv;
 
@@ -29,8 +27,7 @@ impl lock_server::Lock for MetaSrv {
         } = request.into_inner();
         let expire_secs = Some(expire_secs as u64);
 
-        let lock = self.lock().context(error::LockNotConfigSnafu)?;
-        let key = lock.lock(name, Opts { expire_secs }).await?;
+        let key = self.lock().lock(name, Opts { expire_secs }).await?;
 
         let resp = LockResponse {
             key,
@@ -43,8 +40,7 @@ impl lock_server::Lock for MetaSrv {
     async fn unlock(&self, request: Request<UnlockRequest>) -> GrpcResult<UnlockResponse> {
         let UnlockRequest { key, .. } = request.into_inner();
 
-        let lock = self.lock().context(error::LockNotConfigSnafu)?;
-        let _ = lock.unlock(key).await?;
+        let _ = self.lock().unlock(key).await?;
 
         let resp = UnlockResponse {
             ..Default::default()

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_procedure::local::{LocalManager, ManagerConfig};
 
 use crate::handler::{HeartbeatMailbox, Pushers};
+use crate::lock::memory::MemLock;
 use crate::metasrv::SelectorContext;
 use crate::procedure::region_failover::RegionFailoverManager;
 use crate::procedure::state_store::MetaStateStore;
@@ -48,5 +49,6 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
         procedure_manager,
         selector,
         selector_ctx,
+        Arc::new(MemLock::default()),
     ))
 }

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -134,6 +134,7 @@ async fn run_region_failover_procedure(cluster: &GreptimeDbCluster, failed_regio
                 catalog: None,
                 schema: None,
             },
+            dist_lock: meta_srv.lock().clone(),
         },
     );
     let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Using distributed lock to guard against the concurrent updating of table metadatas in region failover procedure.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#1126 