### PR TITLE
chore: add boxed error for custom error map

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::string::FromUtf8Error;
-
 use common_error::prelude::*;
 use snafu::Location;
 use tokio::sync::mpsc::error::SendError;
 use tonic::codegen::http;
-use tonic::{Code, Status};
+use tonic::Code;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
@@ -273,7 +271,7 @@ pub enum Error {
 
     #[snafu(display("Invalid utf-8 value, source: {:?}", source))]
     InvalidUtf8Value {
-        source: FromUtf8Error,
+        source: std::string::FromUtf8Error,
         location: Location,
     },
 
@@ -353,13 +351,20 @@ pub enum Error {
         #[snafu(backtrace)]
         source: common_meta::error::Error,
     },
+
+    #[allow(dead_code)]
+    #[snafu(display("Meta Internal error, source: {}", source))]
+    MetaInternal {
+        source: BoxedError,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-impl From<Error> for Status {
+impl From<Error> for tonic::Status {
     fn from(err: Error) -> Self {
-        Status::new(Code::Internal, err.to_string())
+        tonic::Status::new(Code::Internal, err.to_string())
     }
 }
 
@@ -433,14 +438,14 @@ impl ErrorExt for Error {
             Error::RegionFailoverCandidatesNotFound { .. } => StatusCode::RuntimeResourcesExhausted,
 
             Error::RegisterProcedureLoader { source, .. } => source.status_code(),
-
             Error::TableRouteConversion { source } => source.status_code(),
+            Error::MetaInternal { source, .. } => source.status_code(),
         }
     }
 }
 
 // for form tonic
-pub(crate) fn match_for_io_error(err_status: &Status) -> Option<&std::io::Error> {
+pub(crate) fn match_for_io_error(err_status: &tonic::Status) -> Option<&std::io::Error> {
     let mut err: &(dyn std::error::Error + 'static) = err_status;
 
     loop {

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -352,8 +352,10 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
+    // this error is used for custom error mapping
+    // please do not delete it
     #[allow(dead_code)]
-    #[snafu(display("Meta internal error, source: {}", source))]
+    #[snafu(display("Internal error, source: {}", source))]
     MetaInternal {
         source: BoxedError,
         location: Location,

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -353,7 +353,7 @@ pub enum Error {
     },
 
     #[allow(dead_code)]
-    #[snafu(display("Meta Internal error, source: {}", source))]
+    #[snafu(display("Meta internal error, source: {}", source))]
     MetaInternal {
         source: BoxedError,
         location: Location,

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -354,9 +354,8 @@ pub enum Error {
 
     // this error is used for custom error mapping
     // please do not delete it
-    #[allow(dead_code)]
-    #[snafu(display("Internal error, source: {}", source))]
-    MetaInternal {
+    #[snafu(display("Other error, source: {}", source))]
+    Other {
         source: BoxedError,
         location: Location,
     },
@@ -441,7 +440,7 @@ impl ErrorExt for Error {
 
             Error::RegisterProcedureLoader { source, .. } => source.status_code(),
             Error::TableRouteConversion { source } => source.status_code(),
-            Error::MetaInternal { source, .. } => source.status_code(),
+            Error::Other { source, .. } => source.status_code(),
         }
     }
 }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -246,8 +246,10 @@ pub enum Error {
     #[snafu(display("{}", reason))]
     UnexpectedResult { reason: String, location: Location },
 
+    // this error is used for custom error mapping
+    // please do not delete it
     #[allow(dead_code)]
-    #[snafu(display("Servers internal error, source: {}", source))]
+    #[snafu(display("Internal error, source: {}", source))]
     ServersInternal {
         source: BoxedError,
         location: Location,

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -247,7 +247,7 @@ pub enum Error {
     UnexpectedResult { reason: String, location: Location },
 
     #[allow(dead_code)]
-    #[snafu(display("Servers Internal error, source: {}", source))]
+    #[snafu(display("Servers internal error, source: {}", source))]
     ServersInternal {
         source: BoxedError,
         location: Location,

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -245,6 +245,13 @@ pub enum Error {
 
     #[snafu(display("{}", reason))]
     UnexpectedResult { reason: String, location: Location },
+
+    #[allow(dead_code)]
+    #[snafu(display("Servers Internal error, source: {}", source))]
+    ServersInternal {
+        source: BoxedError,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -305,6 +312,7 @@ impl ErrorExt for Error {
             InvalidFlushArgument { .. } => StatusCode::InvalidArguments,
 
             ParsePromQL { source, .. } => source.status_code(),
+            ServersInternal { source, .. } => source.status_code(),
 
             UnexpectedResult { .. } => StatusCode::Unexpected,
         }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -248,9 +248,8 @@ pub enum Error {
 
     // this error is used for custom error mapping
     // please do not delete it
-    #[allow(dead_code)]
-    #[snafu(display("Internal error, source: {}", source))]
-    ServersInternal {
+    #[snafu(display("Other error, source: {}", source))]
+    Other {
         source: BoxedError,
         location: Location,
     },
@@ -314,7 +313,7 @@ impl ErrorExt for Error {
             InvalidFlushArgument { .. } => StatusCode::InvalidArguments,
 
             ParsePromQL { source, .. } => source.status_code(),
-            ServersInternal { source, .. } => source.status_code(),
+            Other { source, .. } => source.status_code(),
 
             UnexpectedResult { .. } => StatusCode::Unexpected,
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

#1624 removes some of the error we use for custom error map. This pr mainly adds two error back with `#[allow(dead_code)]` to prevent future mis-delete.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
