### PR TITLE
feat(servers): Add metrics based on axum's example

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -22,6 +22,7 @@ use axum::{http, Json};
 use base64::DecodeError;
 use catalog;
 use common_error::prelude::*;
+use common_telemetry::logging;
 use query::parser::PromQuery;
 use serde_json::json;
 use snafu::Location;
@@ -358,7 +359,11 @@ impl IntoResponse for Error {
             | Error::InvalidPromRemoteRequest { .. }
             | Error::InvalidQuery { .. }
             | Error::TimePrecision { .. } => (HttpStatusCode::BAD_REQUEST, self.to_string()),
-            _ => (HttpStatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            _ => {
+                logging::error!(self; "Failed to handle HTTP request");
+
+                (HttpStatusCode::INTERNAL_SERVER_ERROR, self.to_string())
+            }
         };
         let body = Json(json!({
             "error": error_message,

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -41,3 +41,9 @@ pub(crate) const METRIC_POSTGRES_PREPARED_COUNT: &str = "servers.postgres_prepar
 
 pub(crate) const METRIC_SERVER_GRPC_DB_REQUEST_TIMER: &str = "servers.grpc.db_request_elapsed";
 pub(crate) const METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: &str = "servers.grpc.prom_request_elapsed";
+
+pub(crate) const METRIC_HTTP_REQUESTS_TOTAL: &str = "servers.http_requests_total";
+pub(crate) const METRIC_HTTP_REQUESTS_ELAPSED: &str = "servers.http_requests_elapsed";
+pub(crate) const METRIC_METHOD_LABEL: &str = "method";
+pub(crate) const METRIC_PATH_LABEL: &str = "path";
+pub(crate) const METRIC_STATUS_LABEL: &str = "status";

--- a/src/servers/src/prom.rs
+++ b/src/servers/src/prom.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use axum::body::BoxBody;
 use axum::extract::{Path, Query, State};
-use axum::{routing, Form, Json, Router};
+use axum::{middleware, routing, Form, Json, Router};
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_error::prelude::ErrorExt;
 use common_error::status_code::StatusCode;
@@ -56,6 +56,7 @@ use crate::error::{
     StartHttpSnafu, UnexpectedResultSnafu,
 };
 use crate::http::authorize::HttpAuth;
+use crate::http::track_metrics;
 use crate::prometheus::{FIELD_COLUMN_NAME, TIMESTAMP_COLUMN_NAME};
 use crate::server::Server;
 
@@ -114,6 +115,9 @@ impl PromServer {
                         HttpAuth::<BoxBody>::new(self.user_provider.clone()),
                     )),
             )
+            // We need to register the metrics layer again since start a new http server
+            // for the PromServer.
+            .route_layer(middleware::from_fn(track_metrics))
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR
- Adds a common metrics layer for HTTP servers
- log error returned by HTTP handlers

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
