### PR TITLE
feat: add metrics for ingested row count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3118,6 +3118,7 @@ dependencies = [
  "meta-srv",
  "meter-core",
  "meter-macros",
+ "metrics",
  "mito",
  "moka 0.9.7",
  "object-store",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -41,6 +41,7 @@ itertools = "0.10"
 meta-client = { path = "../meta-client" }
 meter-core.workspace = true
 meter-macros.workspace = true
+metrics.workspace = true
 mito = { path = "../mito", features = ["test"] }
 moka = { version = "0.9", features = ["future"] }
 object-store = { path = "../object-store" }

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -21,3 +21,4 @@ pub(crate) const METRIC_RUN_SCRIPT_ELAPSED: &str = "frontend.run_script_elapsed"
 pub const DIST_CREATE_TABLE: &str = "frontend.dist.create_table";
 pub const DIST_CREATE_TABLE_IN_META: &str = "frontend.dist.create_table.update_meta";
 pub const DIST_CREATE_TABLE_IN_DATANODE: &str = "frontend.dist.create_table.invoke_datanode";
+pub const DIST_INGEST_ROW_COUNT: &str = "frontend.dist.ingest_rows";

--- a/src/frontend/src/table/insert.rs
+++ b/src/frontend/src/table/insert.rs
@@ -20,6 +20,7 @@ use api::v1::{Column, InsertRequest as GrpcInsertRequest};
 use common_query::Output;
 use datatypes::prelude::{ConcreteDataType, VectorRef};
 use futures::future;
+use metrics::counter;
 use snafu::{ensure, ResultExt};
 use store_api::storage::RegionNumber;
 use table::requests::InsertRequest;
@@ -47,6 +48,7 @@ impl DistTable {
         .context(JoinTaskSnafu)?;
 
         let affected_rows = results.into_iter().sum::<Result<u32>>()?;
+        counter!(crate::metrics::DIST_INGEST_ROW_COUNT, affected_rows as u64);
         Ok(Output::AffectedRows(affected_rows as _))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add a counter to track ingested rows

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
