### PR TITLE
feat: window inferer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8517,6 +8517,7 @@ dependencies = [
  "datatypes",
  "futures",
  "futures-util",
+ "itertools",
  "lazy_static",
  "log-store",
  "metrics",

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -221,6 +221,7 @@ impl TimestampRange {
     }
 
     /// Shortcut method to create a timestamp range with given start/end value and time unit.
+    /// Returns empty iff `start` > `end`.
     pub fn with_unit(start: i64, end: i64, unit: TimeUnit) -> Option<Self> {
         let start = Timestamp::new(start, unit);
         let end = Timestamp::new(end, unit);

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -81,7 +81,7 @@ impl Timestamp {
     }
 
     /// Subtracts current timestamp with another timestamp, yielding a duration.
-    pub fn sub(&self, rhs: Self) -> Option<chrono::Duration> {
+    pub fn sub(&self, rhs: &Self) -> Option<chrono::Duration> {
         let lhs = self.to_chrono_datetime()?;
         let rhs = rhs.to_chrono_datetime()?;
         Some(lhs - rhs)
@@ -943,12 +943,12 @@ mod tests {
     fn test_subtract_timestamp() {
         assert_eq!(
             Some(chrono::Duration::milliseconds(42)),
-            Timestamp::new_millisecond(100).sub(Timestamp::new_millisecond(58))
+            Timestamp::new_millisecond(100).sub(&Timestamp::new_millisecond(58))
         );
 
         assert_eq!(
             Some(chrono::Duration::milliseconds(-42)),
-            Timestamp::new_millisecond(58).sub(Timestamp::new_millisecond(100))
+            Timestamp::new_millisecond(58).sub(&Timestamp::new_millisecond(100))
         );
     }
 

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -170,6 +170,17 @@ impl ConcreteDataType {
             _ => None,
         }
     }
+
+    /// Try to cast data type as a [`TimestampType`].
+    pub fn as_timestamp(&self) -> Option<TimestampType> {
+        match self {
+            ConcreteDataType::Int64(_) => {
+                Some(TimestampType::Millisecond(TimestampMillisecondType))
+            }
+            ConcreteDataType::Timestamp(t) => Some(*t),
+            _ => None,
+        }
+    }
 }
 
 impl TryFrom<&ArrowDataType> for ConcreteDataType {

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -47,7 +47,7 @@ const MILLISECOND_VARIATION: u64 = 3;
 const MICROSECOND_VARIATION: u64 = 6;
 const NANOSECOND_VARIATION: u64 = 9;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[enum_dispatch(DataType)]
 pub enum TimestampType {
     Second(TimestampSecondType),
@@ -92,6 +92,10 @@ impl TimestampType {
         }
     }
 
+    pub fn create_timestamp(&self, val: i64) -> Timestamp {
+        Timestamp::new(val, self.unit())
+    }
+
     pub fn precision(&self) -> u64 {
         match self {
             TimestampType::Second(_) => SECOND_VARIATION,
@@ -105,7 +109,7 @@ impl TimestampType {
 macro_rules! impl_data_type_for_timestamp {
     ($unit: ident) => {
         paste! {
-            #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
             pub struct [<Timestamp $unit Type>];
 
             impl DataType for [<Timestamp $unit Type>] {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -25,6 +25,7 @@ datafusion-common.workspace = true
 datafusion-expr.workspace = true
 futures.workspace = true
 futures-util.workspace = true
+itertools = "0.10"
 lazy_static = "1.4"
 metrics.workspace = true
 object-store = { path = "../object-store" }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -41,6 +41,7 @@ pub mod write_batch;
 pub use engine::EngineImpl;
 mod file_purger;
 mod metrics;
+mod window_infer;
 
 pub use sst::parquet::ParquetWriter;
 pub use sst::Source;

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use common_time::range::TimestampRange;
+use common_time::Timestamp;
 use datatypes::vectors::VectorRef;
 use metrics::{decrement_gauge, increment_gauge};
 use store_api::storage::{consts, OpType, SequenceNumber};
@@ -39,16 +40,16 @@ use crate::schema::{ProjectedSchemaRef, RegionSchemaRef};
 /// Unique id for memtables under same region.
 pub type MemtableId = u32;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MemtableStats {
     /// The  estimated bytes allocated by this memtable from heap. Result
     /// of this method may be larger than the estimated based on [`num_rows`] because
     /// of the implementor's pre-alloc behavior.
-    estimated_bytes: usize,
+    pub estimated_bytes: usize,
     /// The max timestamp that this memtable contains.
-    pub max_timestamp: i64,
+    pub max_timestamp: Timestamp,
     /// The min timestamp that this memtable contains.
-    pub min_timestamp: i64,
+    pub min_timestamp: Timestamp,
 }
 
 impl MemtableStats {

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -177,8 +177,8 @@ mod tests {
         min_ts: i64,
     ) {
         let iter = mem.iter(&IterContext::default()).unwrap();
-        assert_eq!(min_ts, mem.stats().min_timestamp);
-        assert_eq!(max_ts, mem.stats().max_timestamp);
+        assert_eq!(min_ts, mem.stats().min_timestamp.value());
+        assert_eq!(max_ts, mem.stats().max_timestamp.value());
 
         let mut index = 0;
         for batch in iter {

--- a/src/storage/src/read/windowed.rs
+++ b/src/storage/src/read/windowed.rs
@@ -33,6 +33,11 @@ pub struct WindowedReader<R> {
 }
 
 impl<R> WindowedReader<R> {
+    /// Creates a new [WindowedReader] from given schema and a set of boxed readers.
+    ///
+    /// ### Note
+    /// [WindowedReader] always reads the readers in a reverse order. The last reader in `readers`
+    /// gets polled first.
     pub fn new(schema: ProjectedSchemaRef, readers: Vec<R>) -> Self {
         Self { schema, readers }
     }

--- a/src/storage/src/window_infer.rs
+++ b/src/storage/src/window_infer.rs
@@ -1,0 +1,274 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use common_time::range::TimestampRange;
+use common_time::timestamp::TimeUnit;
+use common_time::timestamp_millis::BucketAligned;
+use itertools::Itertools;
+
+use crate::memtable::MemtableStats;
+use crate::sst::FileMeta;
+
+/// A set of predefined time windows.
+const TIME_WINDOW_SIZE: [i64; 10] = [
+    60,                 // 1 minute
+    60 * 10,            // 10 minute
+    60 * 30,            // 30 minute
+    60 * 60,            // 1 hour
+    2 * 60 * 60,        // 2 hours
+    6 * 60 * 60,        // 6 hours
+    12 * 60 * 60,       // 12 hours
+    24 * 60 * 60,       // 1 day
+    7 * 24 * 60 * 60,   // 1 week
+    365 * 24 * 60 * 60, // 1 year
+];
+
+/// [WindowInfer] infers the time windows that can be used to optimize table scans ordered by
+/// timestamp column or have explicit time windows. By splitting time spans of tables into
+/// time windows, we can scan entries window by window.
+pub(crate) trait WindowInfer {
+    /// Infers time windows according to the SST files and memtables.
+    ///
+    /// ### Note
+    /// The order of returned vector defines how records are yielded.
+    fn infer_window(&self, files: &[FileMeta], mem_tables: &[MemtableStats])
+        -> Vec<TimestampRange>;
+}
+
+/// [PlainWindowInference] simply finds the minimum time span within all SST files and memtables,
+/// matches that time span into a set of predefined time windows.
+pub struct PlainWindowInference;
+
+impl WindowInfer for PlainWindowInference {
+    fn infer_window(
+        &self,
+        files: &[FileMeta],
+        mem_tables: &[MemtableStats],
+    ) -> Vec<TimestampRange> {
+        let mut min_duration_sec = i64::MAX;
+        let mut durations = Vec::with_capacity(files.len() + mem_tables.len());
+
+        for meta in files {
+            if let Some((start, end)) = &meta.time_range {
+                // unwrap safety: converting timestamps with any unit to seconds won't overflow.
+                let start_sec = start.convert_to(TimeUnit::Second).unwrap().value();
+                let end_sec = end.convert_to_ceil(TimeUnit::Second).unwrap().value();
+                debug_assert!(end_sec >= start_sec);
+                min_duration_sec = min_duration_sec.min(end_sec - start_sec);
+                durations.push((start_sec, end_sec));
+            }
+        }
+
+        for stats in mem_tables {
+            // unwrap safety: converting timestamps with any unit to seconds won't overflow.
+            let start_sec = stats
+                .min_timestamp
+                .convert_to(TimeUnit::Second)
+                .unwrap()
+                .value();
+            let end_sec = stats
+                .max_timestamp
+                .convert_to_ceil(TimeUnit::Second)
+                .unwrap()
+                .value();
+            min_duration_sec = min_duration_sec.min(end_sec - start_sec);
+            durations.push((start_sec, end_sec));
+        }
+
+        let window_size = min_duration_to_window_size(min_duration_sec);
+        align_durations_to_windows(&durations, window_size)
+            .into_iter()
+            .sorted_by(|(l_start, _), (r_start, _)| r_start.cmp(l_start)) // sort time windows in descending order
+            // unwrap safety: we ensure that end>=start so that TimestampRange::with_unit won't return None
+            .map(|(start, end)| TimestampRange::with_unit(start, end, TimeUnit::Second).unwrap())
+            .collect()
+    }
+}
+
+fn align_durations_to_windows(durations: &[(i64, i64)], min_duration: i64) -> HashSet<(i64, i64)> {
+    let mut res = HashSet::new();
+    for (start, end) in durations {
+        let mut next = *start;
+        while next <= *end {
+            let next_aligned = next.align_by_bucket(min_duration).unwrap_or(i64::MIN);
+            if let Some(next_end_aligned) = next_aligned.checked_add(min_duration) {
+                res.insert((next_aligned, next_end_aligned));
+                next = next_end_aligned;
+            } else {
+                // arithmetic overflow, clamp to i64::MAX and break the loop.
+                res.insert((next_aligned, i64::MAX));
+                break;
+            }
+        }
+    }
+    res
+}
+
+fn min_duration_to_window_size(min_duration: i64) -> i64 {
+    for window in TIME_WINDOW_SIZE {
+        if window >= min_duration {
+            return window;
+        }
+    }
+    return TIME_WINDOW_SIZE.last().copied().unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use common_time::Timestamp;
+
+    use super::*;
+
+    #[test]
+    fn test_get_time_window_size() {
+        assert_eq!(60, min_duration_to_window_size(1));
+        assert_eq!(60 * 10, min_duration_to_window_size(100));
+        assert_eq!(60 * 30, min_duration_to_window_size(1800));
+        assert_eq!(60 * 60, min_duration_to_window_size(3000));
+        assert_eq!(2 * 60 * 60, min_duration_to_window_size(4000));
+        assert_eq!(6 * 60 * 60, min_duration_to_window_size(21599));
+        assert_eq!(12 * 60 * 60, min_duration_to_window_size(21601));
+        assert_eq!(24 * 60 * 60, min_duration_to_window_size(43201));
+        assert_eq!(7 * 24 * 60 * 60, min_duration_to_window_size(604799));
+        assert_eq!(365 * 24 * 60 * 60, min_duration_to_window_size(31535999));
+        assert_eq!(365 * 24 * 60 * 60, min_duration_to_window_size(i64::MAX));
+    }
+
+    fn check_align_durations_to_windows(
+        durations: &[(i64, i64)],
+        min_duration: i64,
+        expected: &[(i64, i64)],
+    ) {
+        let res = align_durations_to_windows(durations, min_duration);
+        let expected = expected.iter().copied().collect::<HashSet<_>>();
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_duration_to_windows() {
+        check_align_durations_to_windows(&[(0, 1)], 2, &[(0, 2)]);
+        check_align_durations_to_windows(&[(-3, 1)], 2, &[(-4, -2), (-2, 0), (0, 2)]);
+        check_align_durations_to_windows(&[(1, 3)], 2, &[(0, 2), (2, 4)]);
+        check_align_durations_to_windows(
+            &[(i64::MIN, i64::MIN + 3)],
+            2,
+            &[(i64::MIN, i64::MIN + 2), (i64::MIN + 2, i64::MIN + 4)],
+        );
+
+        check_align_durations_to_windows(
+            &[(i64::MAX - 3, i64::MAX)],
+            2,
+            &[(i64::MAX - 3, i64::MAX - 1), (i64::MAX - 1, i64::MAX)],
+        );
+
+        check_align_durations_to_windows(&[(-3, 10)], 7, &[(-7, 0), (0, 7), (7, 14)]);
+    }
+
+    #[test]
+    fn test_multiple_duration_to_windows() {
+        check_align_durations_to_windows(&[(0, 1), (1, 3)], 3, &[(0, 3), (3, 6)]);
+        check_align_durations_to_windows(&[(0, 1), (1, 2), (7, 11)], 3, &[(0, 3), (6, 9), (9, 12)]);
+
+        check_align_durations_to_windows(
+            &[(-2, 1), (i64::MAX - 2, i64::MAX)],
+            3,
+            &[
+                (-3, 0),
+                (0, 3),
+                (i64::MAX - 4, i64::MAX - 1),
+                (i64::MAX - 1, i64::MAX),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_plain_window_inference() {
+        let window_inference = PlainWindowInference {};
+
+        let res = window_inference.infer_window(
+            &[FileMeta {
+                time_range: Some((
+                    Timestamp::new(1000, TimeUnit::Millisecond),
+                    Timestamp::new(3000, TimeUnit::Millisecond),
+                )),
+                ..Default::default()
+            }],
+            &[MemtableStats {
+                max_timestamp: Timestamp::new(3001, TimeUnit::Millisecond),
+                min_timestamp: Timestamp::new(2001, TimeUnit::Millisecond),
+                ..Default::default()
+            }],
+        );
+        assert_eq!(
+            vec![TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap()],
+            res
+        );
+
+        let res = window_inference.infer_window(
+            &[FileMeta {
+                time_range: Some((
+                    Timestamp::new(0, TimeUnit::Millisecond),
+                    Timestamp::new(60 * 1000 + 1, TimeUnit::Millisecond),
+                )),
+                ..Default::default()
+            }],
+            &[MemtableStats {
+                max_timestamp: Timestamp::new(3001, TimeUnit::Millisecond),
+                min_timestamp: Timestamp::new(2001, TimeUnit::Millisecond),
+                ..Default::default()
+            }],
+        );
+        assert_eq!(
+            vec![
+                TimestampRange::with_unit(60, 120, TimeUnit::Second).unwrap(),
+                TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap(),
+            ],
+            res
+        );
+
+        let res = window_inference.infer_window(
+            &[
+                FileMeta {
+                    time_range: Some((
+                        Timestamp::new(0, TimeUnit::Millisecond),
+                        Timestamp::new(60 * 1000 + 1, TimeUnit::Millisecond),
+                    )),
+                    ..Default::default()
+                },
+                FileMeta {
+                    time_range: Some((
+                        Timestamp::new(60 * 60 * 1000, TimeUnit::Millisecond),
+                        Timestamp::new(60 * 60 * 1000 + 1, TimeUnit::Millisecond),
+                    )),
+                    ..Default::default()
+                },
+            ],
+            &[MemtableStats {
+                max_timestamp: Timestamp::new(3001, TimeUnit::Millisecond),
+                min_timestamp: Timestamp::new(2001, TimeUnit::Millisecond),
+                ..Default::default()
+            }],
+        );
+        assert_eq!(
+            vec![
+                TimestampRange::with_unit(60 * 60, 61 * 60, TimeUnit::Second).unwrap(),
+                TimestampRange::with_unit(60, 120, TimeUnit::Second).unwrap(),
+                TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap(),
+            ],
+            res
+        );
+    }
+}

--- a/src/storage/src/window_infer.rs
+++ b/src/storage/src/window_infer.rs
@@ -92,7 +92,7 @@ impl WindowInfer for PlainWindowInference {
         }
 
         let window_size = min_duration_to_window_size(min_duration_sec);
-        align_durations_to_windows(&durations, window_size)
+        align_time_spans_to_windows(&durations, window_size)
             .into_iter()
             .sorted_by(|(l_start, _), (r_start, _)| r_start.cmp(l_start)) // sort time windows in descending order
             // unwrap safety: we ensure that end>=start so that TimestampRange::with_unit won't return None
@@ -107,7 +107,7 @@ impl WindowInfer for PlainWindowInference {
 /// For example, given time span `[1, 6)` and duration 5, the span can be aligned and split to
 /// two windows with length 5: `[0, 5)` and `[5, 10]`, and these two windows can cover the original
 /// span `[1, 6)`.
-fn align_durations_to_windows(durations: &[(i64, i64)], min_duration: i64) -> HashSet<(i64, i64)> {
+fn align_time_spans_to_windows(durations: &[(i64, i64)], min_duration: i64) -> HashSet<(i64, i64)> {
     let mut res = HashSet::new();
     for (start, end) in durations {
         let mut next = *start;
@@ -149,6 +149,7 @@ mod tests {
 
     #[test]
     fn test_get_time_window_size() {
+        assert_eq!(60, min_duration_to_window_size(0));
         for window in TIME_WINDOW_SIZE {
             assert_eq!(window, min_duration_to_window_size(window));
         }
@@ -170,7 +171,7 @@ mod tests {
         min_duration: i64,
         expected: &[(i64, i64)],
     ) {
-        let res = align_durations_to_windows(durations, min_duration);
+        let res = align_time_spans_to_windows(durations, min_duration);
         let expected = expected.iter().copied().collect::<HashSet<_>>();
         assert_eq!(res, expected);
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Window inferer is used to infer a set of time windows that can be used to optimize queries if:
- timestamp column is the left-most column in ORDER-BY clause
- queries have explicit time window selection.


This PR defines a `WindowInference` trait and add a plain implementation that simply find the minimum time span of all SST files and memtables, matches that window into a set of predefined orthodox time windows and generate time windows for all SST files and memtables according to the infered time window.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
