### PR TITLE
feat: add keep lease handler for frontend node

### DIFF
--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -183,18 +183,18 @@ impl HeartbeatHandlerGroup {
     ) -> Result<HeartbeatResponse> {
         let mut acc = HeartbeatAccumulator::default();
         let handlers = self.handlers.read().await;
+        let role = req
+            .header
+            .as_ref()
+            .and_then(|h| Role::from_i32(h.role))
+            .context(error::InvalidArgumentsSnafu {
+                err_msg: format!("invalid role: {:?}", req.header),
+            })?;
+
         for h in handlers.iter() {
             if ctx.is_skip_all() {
                 break;
             }
-
-            let role = req
-                .header
-                .as_ref()
-                .and_then(|h| Role::from_i32(h.role))
-                .context(error::InvalidArgumentsSnafu {
-                    err_msg: format!("invalid role: {:?}", req.header),
-                })?;
 
             if h.is_acceptable(role) {
                 h.handle(&req, &mut ctx, &mut acc).await?;

--- a/src/meta-srv/src/lease.rs
+++ b/src/meta-srv/src/lease.rs
@@ -15,7 +15,7 @@
 use api::v1::meta::RangeRequest;
 
 use crate::error::Result;
-use crate::keys::{LeaseKey, LeaseValue, DN_LEASE_PREFIX};
+use crate::keys::{DnLeaseKey, LeaseValue, DN_LEASE_PREFIX};
 use crate::service::store::kv::KvStoreRef;
 use crate::util;
 
@@ -23,9 +23,9 @@ pub async fn alive_datanodes<P>(
     cluster_id: u64,
     kv_store: &KvStoreRef,
     predicate: P,
-) -> Result<Vec<(LeaseKey, LeaseValue)>>
+) -> Result<Vec<(DnLeaseKey, LeaseValue)>>
 where
-    P: Fn(&LeaseKey, &LeaseValue) -> bool,
+    P: Fn(&DnLeaseKey, &LeaseValue) -> bool,
 {
     let key = get_lease_prefix(cluster_id);
     let range_end = util::get_prefix_end_key(&key);
@@ -40,7 +40,7 @@ where
     let kvs = res.kvs;
     let mut lease_kvs = vec![];
     for kv in kvs {
-        let lease_key: LeaseKey = kv.key.try_into()?;
+        let lease_key: DnLeaseKey = kv.key.try_into()?;
         let lease_value: LeaseValue = kv.value.try_into()?;
         if !predicate(&lease_key, &lease_value) {
             continue;

--- a/src/meta-srv/src/selector/lease_based.rs
+++ b/src/meta-srv/src/selector/lease_based.rs
@@ -16,7 +16,7 @@ use api::v1::meta::Peer;
 use common_time::util as time_util;
 
 use crate::error::Result;
-use crate::keys::{LeaseKey, LeaseValue};
+use crate::keys::{DnLeaseKey, LeaseValue};
 use crate::lease;
 use crate::metasrv::SelectorContext;
 use crate::selector::{Namespace, Selector};
@@ -30,7 +30,7 @@ impl Selector for LeaseBasedSelector {
 
     async fn select(&self, ns: Namespace, ctx: &Self::Context) -> Result<Self::Output> {
         // filter out the nodes out lease
-        let lease_filter = |_: &LeaseKey, v: &LeaseValue| {
+        let lease_filter = |_: &DnLeaseKey, v: &LeaseValue| {
             time_util::current_time_millis() - v.timestamp_millis < ctx.datanode_lease_secs * 1000
         };
         let mut lease_kvs = lease::alive_datanodes(ns, &ctx.kv_store, lease_filter).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Rename `LeaseKey` to `DnLeaseKey`.
2. Add keep lease handler for frontend nodes.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
