### PR TITLE
feat: acquire table_id from region_id

### DIFF
--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 use common_catalog::consts::MITO_ENGINE;
 use common_meta::instruction::TableIdent;
 use common_meta::RegionIdent;
+use table::engine::table_id;
 
 use crate::error::Result;
 use crate::handler::failure_handler::runner::{FailureDetectControl, FailureDetectRunner};
@@ -90,9 +91,7 @@ impl HeartbeatHandler for RegionFailureHandler {
                         catalog: x.catalog.clone(),
                         schema: x.schema.clone(),
                         table: x.table.clone(),
-
-                        // TODO(#1566): Use the real table id.
-                        table_id: 0,
+                        table_id: table_id(x.id),
                         // TODO(#1583): Use the actual table engine.
                         engine: MITO_ENGINE.to_string(),
                     },

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -182,6 +182,11 @@ pub fn region_id(table_id: TableId, n: u32) -> RegionId {
 }
 
 #[inline]
+pub fn table_id(region_id: RegionId) -> TableId {
+    (region_id >> 32) as u32
+}
+
+#[inline]
 pub fn table_dir(catalog_name: &str, schema_name: &str, table_id: TableId) -> String {
     format!("{DATA_DIR}{catalog_name}/{schema_name}/{table_id}/")
 }
@@ -199,5 +204,12 @@ mod tests {
         };
 
         assert_eq!("greptime.public.test", table_ref.to_string());
+    }
+
+    #[test]
+    fn test_table_id() {
+        let region_id = region_id(u32::MAX, 1);
+        let table_id = table_id(region_id);
+        assert_eq!(u32::MAX, table_id);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Acquire `table_id` from `region_id`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1566