### PR TITLE
fix: invalidate table route cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,6 +5943,7 @@ dependencies = [
 name = "partition"
 version = "0.2.0"
 dependencies = [
+ "async-trait",
  "common-catalog",
  "common-error",
  "common-meta",

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -147,7 +147,7 @@ impl Instance {
         let mut catalog_manager = FrontendCatalogManager::new(
             meta_backend.clone(),
             meta_backend.clone(),
-            partition_manager,
+            partition_manager.clone(),
             datanode_clients.clone(),
         );
 
@@ -178,7 +178,10 @@ impl Instance {
 
         let handlers_executor = HandlerGroupExecutor::new(vec![
             Arc::new(ParseMailboxMessageHandler::default()),
-            Arc::new(InvalidateTableCacheHandler::new(meta_backend)),
+            Arc::new(InvalidateTableCacheHandler::new(
+                meta_backend,
+                partition_manager,
+            )),
         ]);
 
         let heartbeat_task = Some(HeartbeatTask::new(

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-query = { path = "../common/query" }

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -34,6 +34,13 @@ use crate::route::TableRoutes;
 use crate::splitter::{InsertRequestSplit, WriteSplitter};
 use crate::{error, PartitionRuleRef};
 
+#[async_trait::async_trait]
+pub trait TableRouteCacheInvalidator: Send + Sync {
+    async fn invalidate_table_route(&self, table: &TableName);
+}
+
+pub type TableRouteCacheInvalidatorRef = Arc<dyn TableRouteCacheInvalidator>;
+
 pub type PartitionRuleManagerRef = Arc<PartitionRuleManager>;
 
 /// PartitionRuleManager manages the table routes and partition rules.
@@ -48,6 +55,13 @@ pub struct PartitionRuleManager {
 pub struct PartitionInfo {
     pub id: RegionId,
     pub partition: PartitionDef,
+}
+
+#[async_trait::async_trait]
+impl TableRouteCacheInvalidator for PartitionRuleManager {
+    async fn invalidate_table_route(&self, table: &TableName) {
+        self.table_routes.invalidate_table_route(table).await
+    }
 }
 
 impl PartitionRuleManager {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Invalidate table route's cache

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
