### PR TITLE
feat: Add request type and result code to grpc metrics

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -33,6 +33,8 @@ pub enum StatusCode {
     Internal = 1003,
     /// Invalid arguments.
     InvalidArguments = 1004,
+    /// The task is cancelled.
+    Cancelled = 1005,
     // ====== End of common status code ================
 
     // ====== Begin of SQL related status code =========
@@ -100,6 +102,7 @@ impl StatusCode {
             | StatusCode::Unsupported
             | StatusCode::Unexpected
             | StatusCode::InvalidArguments
+            | StatusCode::Cancelled
             | StatusCode::InvalidSyntax
             | StatusCode::PlanQuery
             | StatusCode::EngineExecuteQuery
@@ -125,6 +128,7 @@ impl StatusCode {
             | StatusCode::Unsupported
             | StatusCode::Unexpected
             | StatusCode::Internal
+            | StatusCode::Cancelled
             | StatusCode::PlanQuery
             | StatusCode::EngineExecuteQuery
             | StatusCode::StorageUnavailable

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -614,6 +614,7 @@ impl HttpServer {
 /// A middleware to record metrics for HTTP.
 // Based on https://github.com/tokio-rs/axum/blob/axum-v0.6.16/examples/prometheus-metrics/src/main.rs
 pub(crate) async fn track_metrics<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
+    let _timer = common_telemetry::timer!("http_track_metrics", &[("tag", "value")]);
     let start = Instant::now();
     let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
         matched_path.as_str().to_owned()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `type` and `status` to `greptime_servers_grpc_db_request_elapsed` metric
```
# TYPE greptime_servers_grpc_db_request_elapsed summary
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0"} 0.001190166
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0.5"} 0.0011901213200353528
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0.9"} 0.0011901213200353528
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0.95"} 0.0011901213200353528
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0.99"} 0.0011901213200353528
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="0.999"} 0.0011901213200353528
greptime_servers_grpc_db_request_elapsed{code="public",type="query.sql",status="Success",quantile="1"} 0.002327333
greptime_servers_grpc_db_request_elapsed_sum{code="public",type="query.sql",status="Success"} 0.0035174990000000003
greptime_servers_grpc_db_request_elapsed_count{code="public",type="query.sql",status="Success"} 2
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
