### PR TITLE
fix: clippy warning

### DIFF
--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -629,6 +629,8 @@ impl WindowedReaderTester {
                     sequence: None,
                     projection: None,
                     filters: vec![],
+                    limit: None,
+                    output_ordering: None,
                 },
                 windows,
             )

--- a/tests/cases/distributed/common
+++ b/tests/cases/distributed/common
@@ -1,0 +1,1 @@
+../standalone/common


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- CI breaks due to #1639 
- Restore the removed symlink to sqlness common cases in #1577


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
