### PR TITLE
test: add write test for region failover

### DIFF
--- a/src/catalog/src/remote.rs
+++ b/src/catalog/src/remote.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -70,6 +71,8 @@ pub trait KvBackend: Send + Sync {
         }
         return Ok(None);
     }
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 pub type KvBackendRef = Arc<dyn KvBackend>;
@@ -120,6 +123,10 @@ mod tests {
 
         async fn delete_range(&self, _key: &[u8], _end: &[u8]) -> Result<(), Error> {
             unimplemented!()
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
         }
     }
 

--- a/src/catalog/src/remote/client.rs
+++ b/src/catalog/src/remote/client.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -32,9 +33,10 @@ const CACHE_MAX_CAPACITY: u64 = 10000;
 const CACHE_TTL_SECOND: u64 = 10 * 60;
 const CACHE_TTI_SECOND: u64 = 5 * 60;
 
+pub type CacheBackendRef = Arc<Cache<Vec<u8>, Option<Kv>>>;
 pub struct CachedMetaKvBackend {
     kv_backend: KvBackendRef,
-    cache: Arc<Cache<Vec<u8>, Option<Kv>>>,
+    cache: CacheBackendRef,
 }
 
 #[async_trait::async_trait]
@@ -98,6 +100,10 @@ impl KvBackend for CachedMetaKvBackend {
 
         ret
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 #[async_trait::async_trait]
@@ -129,6 +135,10 @@ impl CachedMetaKvBackend {
         );
 
         Self { kv_backend, cache }
+    }
+
+    pub fn cache(&self) -> &CacheBackendRef {
+        &self.cache
     }
 }
 
@@ -213,5 +223,9 @@ impl KvBackend for MetaKvBackend {
         } else {
             Ok(Err(response.take_prev_kv().map(|v| v.value().to_vec())))
         }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }

--- a/src/catalog/tests/mock.rs
+++ b/src/catalog/tests/mock.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Formatter};
@@ -150,6 +151,10 @@ impl KvBackend for MockKvBackend {
             map.retain(|k, _| !range.contains(k));
         }
         Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/datanode/src/heartbeat/handler/close_region.rs
+++ b/src/datanode/src/heartbeat/handler/close_region.rs
@@ -192,6 +192,7 @@ impl CloseRegionHandler {
                         schema_name: table_ref.schema.to_string(),
                         table_name: table_ref.table.to_string(),
                         region_numbers: region_numbers.clone(),
+                        flush: true,
                     },
                 )
                 .await

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -51,7 +51,7 @@ use crate::table::DistTable;
 #[derive(Clone)]
 pub struct FrontendCatalogManager {
     backend: KvBackendRef,
-    backend_cache_invalidtor: KvCacheInvalidatorRef,
+    backend_cache_invalidator: KvCacheInvalidatorRef,
     partition_manager: PartitionRuleManagerRef,
     datanode_clients: Arc<DatanodeClients>,
 
@@ -65,13 +65,13 @@ pub struct FrontendCatalogManager {
 impl FrontendCatalogManager {
     pub fn new(
         backend: KvBackendRef,
-        backend_cache_invalidtor: KvCacheInvalidatorRef,
+        backend_cache_invalidator: KvCacheInvalidatorRef,
         partition_manager: PartitionRuleManagerRef,
         datanode_clients: Arc<DatanodeClients>,
     ) -> Self {
         Self {
             backend,
-            backend_cache_invalidtor,
+            backend_cache_invalidator,
             partition_manager,
             datanode_clients,
             dist_instance: None,
@@ -103,7 +103,7 @@ impl FrontendCatalogManager {
 
         let key = schema_key.as_bytes();
 
-        self.backend_cache_invalidtor.invalidate_key(key).await;
+        self.backend_cache_invalidator.invalidate_key(key).await;
     }
 
     pub async fn invalidate_table(&self, catalog: &str, schema: &str, table: &str) {
@@ -116,7 +116,7 @@ impl FrontendCatalogManager {
 
         let tg_key = tg_key.as_bytes();
 
-        self.backend_cache_invalidtor.invalidate_key(tg_key).await;
+        self.backend_cache_invalidator.invalidate_key(tg_key).await;
     }
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -98,7 +98,7 @@ pub trait FrontendInstance:
     + Sync
     + 'static
 {
-    async fn start(&mut self) -> Result<()>;
+    async fn start(&self) -> Result<()>;
 }
 
 pub type FrontendInstanceRef = Arc<dyn FrontendInstance>;
@@ -433,7 +433,7 @@ impl Instance {
 
 #[async_trait]
 impl FrontendInstance for Instance {
-    async fn start(&mut self) -> Result<()> {
+    async fn start(&self) -> Result<()> {
         // TODO(hl): Frontend init should move to here
 
         if let Some(heartbeat_task) = &self.heartbeat_task {

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -592,6 +592,10 @@ mod test {
 
     #[async_trait]
     impl KvBackend for DummyKvBackend {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
         fn range<'a, 'b>(&'a self, _key: &[u8]) -> ValueIter<'b, catalog::error::Error>
         where
             'a: 'b,

--- a/src/meta-srv/src/procedure/region_failover/invalidate_cache.rs
+++ b/src/meta-srv/src/procedure/region_failover/invalidate_cache.rs
@@ -16,6 +16,7 @@ use api::v1::meta::MailboxMessage;
 use async_trait::async_trait;
 use common_meta::instruction::{Instruction, TableIdent};
 use common_meta::RegionIdent;
+use common_telemetry::info;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
@@ -61,6 +62,10 @@ impl State for InvalidateCache {
         failed_region: &RegionIdent,
     ) -> Result<Box<dyn State>> {
         let table_ident = TableIdent::from(failed_region.clone());
+        info!(
+            "Broadcast invalidate table({}) cache message to frontend",
+            table_ident
+        );
         self.broadcast_invalidate_table_cache_messages(ctx, &table_ident)
             .await?;
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -373,6 +373,7 @@ impl<R: Region> Table for MitoTable<R> {
             .map(|wait| FlushContext {
                 wait,
                 reason: FlushReason::Manually,
+                ..Default::default()
             })
             .unwrap_or_default();
         let regions = self.regions.load();

--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -26,9 +26,9 @@ use datatypes::schema::{ColumnSchema, Schema};
 use storage::metadata::{RegionMetaImpl, RegionMetadata};
 use storage::write_batch::WriteBatch;
 use store_api::storage::{
-    AlterRequest, Chunk, ChunkReader, CreateOptions, EngineContext, FlushContext, GetRequest,
-    GetResponse, OpenOptions, ReadContext, Region, RegionDescriptor, RegionId, ScanRequest,
-    ScanResponse, SchemaRef, Snapshot, StorageEngine, WriteContext, WriteResponse,
+    AlterRequest, Chunk, ChunkReader, CloseOptions, CreateOptions, EngineContext, FlushContext,
+    GetRequest, GetResponse, OpenOptions, ReadContext, Region, RegionDescriptor, RegionId,
+    ScanRequest, ScanResponse, SchemaRef, Snapshot, StorageEngine, WriteContext, WriteResponse,
 };
 
 pub type Result<T> = std::result::Result<T, MockError>;
@@ -291,7 +291,12 @@ impl StorageEngine for MockEngine {
         return Ok(None);
     }
 
-    async fn close_region(&self, _ctx: &EngineContext, name: &str) -> Result<()> {
+    async fn close_region(
+        &self,
+        _ctx: &EngineContext,
+        name: &str,
+        _opts: &CloseOptions,
+    ) -> Result<()> {
         let mut regions = self.regions.lock().unwrap();
 
         if let Some(region) = regions.opened_regions.remove(name) {

--- a/src/partition/src/route.rs
+++ b/src/partition/src/route.rs
@@ -25,10 +25,12 @@ use snafu::{ensure, ResultExt};
 use crate::error::{self, Result};
 use crate::metrics;
 
+type TableRouteCache = Cache<TableName, Arc<TableRoute>>;
+
 pub struct TableRoutes {
     meta_client: Arc<MetaClient>,
     // TODO(LFC): Use table id as cache key, then remove all the manually invoked cache invalidations.
-    cache: Cache<TableName, Arc<TableRoute>>,
+    cache: TableRouteCache,
 }
 
 // TODO(hl): maybe periodically refresh table route cache?
@@ -83,5 +85,9 @@ impl TableRoutes {
 
     pub async fn invalidate_table_route(&self, table_name: &TableName) {
         self.cache.invalidate(table_name).await
+    }
+
+    pub fn cache(&self) -> &TableRouteCache {
+        &self.cache
     }
 }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -23,7 +23,8 @@ use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::manifest::Manifest;
 use store_api::storage::{
-    CreateOptions, EngineContext, OpenOptions, Region, RegionDescriptor, StorageEngine,
+    CloseContext, CloseOptions, CreateOptions, EngineContext, OpenOptions, Region,
+    RegionDescriptor, StorageEngine,
 };
 
 use crate::compaction::CompactionSchedulerRef;
@@ -68,8 +69,13 @@ impl<S: LogStore> StorageEngine for EngineImpl<S> {
         self.inner.open_region(name, opts).await
     }
 
-    async fn close_region(&self, _ctx: &EngineContext, name: &str) -> Result<()> {
-        self.inner.close_region(name).await
+    async fn close_region(
+        &self,
+        _ctx: &EngineContext,
+        name: &str,
+        opts: &CloseOptions,
+    ) -> Result<()> {
+        self.inner.close_region(name, opts).await
     }
 
     async fn create_region(
@@ -362,9 +368,10 @@ impl<S: LogStore> EngineInner<S> {
         })
     }
 
-    async fn close_region(&self, name: &str) -> Result<()> {
+    async fn close_region(&self, name: &str, opts: &CloseOptions) -> Result<()> {
         if let Some(region) = self.get_region(name) {
-            region.close().await?;
+            let ctx = CloseContext { flush: opts.flush };
+            region.close(&ctx).await?;
         }
 
         self.regions.remove(name);
@@ -502,9 +509,10 @@ impl<S: LogStore> EngineInner<S> {
 
     async fn close(&self) -> Result<()> {
         let regions = self.regions.list_regions();
+        let ctx = CloseContext::default();
         for region in regions {
             // Tolerate failure during closing regions.
-            if let Err(e) = region.close().await {
+            if let Err(e) = region.close(&ctx).await {
                 logging::error!(e; "Failed to close region {}", region.id());
             }
         }
@@ -637,7 +645,10 @@ mod tests {
 
         // Flush memtable to sst.
         region.flush(&FlushContext::default()).await.unwrap();
-        engine.close_region(&ctx, region.name()).await.unwrap();
+        engine
+            .close_region(&ctx, region.name(), &CloseOptions::default())
+            .await
+            .unwrap();
 
         let dir_path = dir.path().join(region_name);
 

--- a/src/storage/src/flush/picker.rs
+++ b/src/storage/src/flush/picker.rs
@@ -137,6 +137,7 @@ impl<S: LogStore> FlushItem for RegionImpl<S> {
         let ctx = FlushContext {
             wait: false,
             reason,
+            ..Default::default()
         };
 
         if let Err(e) = self.flush(&ctx).await {

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -602,6 +602,7 @@ impl WindowedReaderTester {
                 .flush(&FlushContext {
                     wait: true,
                     reason: FlushReason::Others,
+                    ..Default::default()
                 })
                 .await
                 .unwrap();

--- a/src/storage/src/region/tests/alter.rs
+++ b/src/storage/src/region/tests/alter.rs
@@ -122,6 +122,7 @@ impl AlterTester {
             .map(|wait| FlushContext {
                 wait,
                 reason: FlushReason::Manually,
+                ..Default::default()
             })
             .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();

--- a/src/storage/src/region/tests/close.rs
+++ b/src/storage/src/region/tests/close.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 
 use common_test_util::temp_dir::create_temp_dir;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
-use store_api::storage::{AlterOperation, AlterRequest, Region, RegionMeta, WriteResponse};
+use store_api::storage::{
+    AlterOperation, AlterRequest, CloseContext, Region, RegionMeta, WriteResponse,
+};
 
 use crate::engine;
 use crate::error::Error;
@@ -92,7 +94,12 @@ async fn test_close_basic() {
     let flush_switch = Arc::new(FlushSwitch::default());
     let tester = CloseTester::new(store_dir, flush_switch).await;
 
-    tester.base().region.close().await.unwrap();
+    tester
+        .base()
+        .region
+        .close(&CloseContext::default())
+        .await
+        .unwrap();
 
     let data = [(1000, Some(100))];
 
@@ -140,7 +147,7 @@ async fn test_close_wait_flush_done() {
     assert!(!has_parquet_file(&sst_dir));
 
     // Close should cancel the flush.
-    tester.base().region.close().await.unwrap();
+    tester.base().region.close(&CloseContext::default()).await.unwrap();
 
     assert!(!has_parquet_file(&sst_dir));
 }

--- a/src/storage/src/region/tests/close.rs
+++ b/src/storage/src/region/tests/close.rs
@@ -147,7 +147,12 @@ async fn test_close_wait_flush_done() {
     assert!(!has_parquet_file(&sst_dir));
 
     // Close should cancel the flush.
-    tester.base().region.close(&CloseContext::default()).await.unwrap();
+    tester
+        .base()
+        .region
+        .close(&CloseContext::default())
+        .await
+        .unwrap();
 
     assert!(!has_parquet_file(&sst_dir));
 }

--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -195,6 +195,7 @@ impl CompactionTester {
             .map(|wait| FlushContext {
                 wait,
                 reason: FlushReason::Manually,
+                ..Default::default()
             })
             .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -106,6 +106,7 @@ impl FlushTester {
             .map(|wait| FlushContext {
                 wait,
                 reason: FlushReason::Manually,
+                ..Default::default()
             })
             .unwrap_or_default();
         self.base().region.flush(&ctx).await.unwrap();

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -348,7 +348,9 @@ impl RegionWriter {
     ) -> Result<()> {
         let mut inner = self.inner.lock().await;
 
-        ensure!(!inner.is_closed(), error::ClosedRegionSnafu);
+        if !ctx.force {
+            ensure!(!inner.is_closed(), error::ClosedRegionSnafu);
+        }
 
         inner.manual_flush(writer_ctx, ctx.reason).await?;
 

--- a/src/store-api/src/storage.rs
+++ b/src/store-api/src/storage.rs
@@ -32,9 +32,9 @@ pub use datatypes::schema::{
 
 pub use self::chunk::{Chunk, ChunkReader};
 pub use self::descriptors::*;
-pub use self::engine::{CreateOptions, EngineContext, OpenOptions, StorageEngine};
+pub use self::engine::{CloseOptions, CreateOptions, EngineContext, OpenOptions, StorageEngine};
 pub use self::metadata::RegionMeta;
-pub use self::region::{FlushContext, FlushReason, Region, RegionStat, WriteContext};
+pub use self::region::{CloseContext, FlushContext, FlushReason, Region, RegionStat, WriteContext};
 pub use self::requests::{
     AddColumn, AlterOperation, AlterRequest, GetRequest, ScanRequest, WriteRequest,
 };

--- a/src/store-api/src/storage/engine.rs
+++ b/src/store-api/src/storage/engine.rs
@@ -41,7 +41,12 @@ pub trait StorageEngine: Send + Sync + Clone + 'static {
     ) -> Result<Option<Self::Region>, Self::Error>;
 
     /// Closes given region.
-    async fn close_region(&self, ctx: &EngineContext, name: &str) -> Result<(), Self::Error>;
+    async fn close_region(
+        &self,
+        ctx: &EngineContext,
+        name: &str,
+        opts: &CloseOptions,
+    ) -> Result<(), Self::Error>;
 
     /// Creates and returns the created region.
     ///
@@ -100,4 +105,11 @@ pub struct OpenOptions {
     /// Region SST files TTL
     pub ttl: Option<Duration>,
     pub compaction_time_window: Option<i64>,
+}
+
+/// Options to close a region.
+#[derive(Debug, Clone, Default)]
+pub struct CloseOptions {
+    /// Flush region
+    pub flush: bool,
 }

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -104,6 +104,12 @@ impl From<&OpenOptions> for WriteContext {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct CloseContext {
+    /// If true, flush the closing region.
+    pub flush: bool,
+}
+
 /// Context for flush operations.
 #[derive(Debug, Clone)]
 pub struct FlushContext {
@@ -112,6 +118,8 @@ pub struct FlushContext {
     pub wait: bool,
     /// Flush reason.
     pub reason: FlushReason,
+    /// If true, allows to flush a closed region
+    pub force: bool,
 }
 
 impl Default for FlushContext {
@@ -119,6 +127,7 @@ impl Default for FlushContext {
         FlushContext {
             wait: true,
             reason: FlushReason::Others,
+            force: false,
         }
     }
 }

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -185,7 +185,7 @@ pub fn region_id(table_id: TableId, region_number: RegionNumber) -> RegionId {
 /// Retrieve the table id from specific `region_id`.
 #[inline]
 pub fn table_id(region_id: RegionId) -> TableId {
-    (region_id >> 32) as RegionNumber
+    (region_id >> 32) as TableId
 }
 
 /// Retrieve the region_number from specific `region_id`.

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -242,6 +242,8 @@ pub struct CloseTableRequest {
     pub table_name: String,
     /// Do nothing if region_numbers is empty
     pub region_numbers: Vec<RegionNumber>,
+    /// flush regions
+    pub flush: bool,
 }
 
 impl CloseTableRequest {

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -28,7 +28,7 @@ use common_test_util::temp_dir::create_temp_dir;
 use datanode::datanode::{DatanodeOptions, ObjectStoreConfig};
 use datanode::instance::Instance as DatanodeInstance;
 use frontend::datanode::DatanodeClients;
-use frontend::instance::Instance as FrontendInstance;
+use frontend::instance::{FrontendInstance, Instance as FeInstance};
 use meta_client::client::MetaClientBuilder;
 use meta_srv::metasrv::{MetaSrv, MetaSrvOptions};
 use meta_srv::mocks::MockInfo;
@@ -51,7 +51,7 @@ pub struct GreptimeDbCluster {
     pub datanode_instances: HashMap<DatanodeId, Arc<DatanodeInstance>>,
     pub kv_store: KvStoreRef,
     pub meta_srv: MetaSrv,
-    pub frontend: Arc<FrontendInstance>,
+    pub frontend: Arc<FeInstance>,
 }
 
 pub struct GreptimeDbClusterBuilder {
@@ -96,6 +96,8 @@ impl GreptimeDbClusterBuilder {
         let frontend = self
             .build_frontend(meta_srv.clone(), datanode_clients)
             .await;
+
+        frontend.start().await.unwrap();
 
         GreptimeDbCluster {
             storage_guards,
@@ -197,7 +199,7 @@ impl GreptimeDbClusterBuilder {
         &self,
         meta_srv: MockInfo,
         datanode_clients: Arc<DatanodeClients>,
-    ) -> Arc<FrontendInstance> {
+    ) -> Arc<FeInstance> {
         let mut meta_client = MetaClientBuilder::new(1000, 0, Role::Frontend)
             .enable_router()
             .enable_store()
@@ -208,7 +210,7 @@ impl GreptimeDbClusterBuilder {
         let meta_client = Arc::new(meta_client);
 
         Arc::new(
-            FrontendInstance::try_new_distributed_with(
+            FeInstance::try_new_distributed_with(
                 meta_client,
                 datanode_clients,
                 Arc::new(Plugins::default()),

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -201,6 +201,7 @@ impl GreptimeDbClusterBuilder {
         let mut meta_client = MetaClientBuilder::new(1000, 0, Role::Frontend)
             .enable_router()
             .enable_store()
+            .enable_heartbeat()
             .channel_manager(meta_srv.channel_manager)
             .build();
         meta_client.start(&[&meta_srv.server_addr]).await.unwrap();

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -27,9 +27,10 @@ use rstest_reuse::apply;
 use servers::query_handler::sql::SqlQueryHandler;
 use session::context::{QueryContext, QueryContextRef};
 
+use crate::test_util::check_output_stream;
 use crate::tests::test_util::{
-    both_instances_cases, check_output_stream, check_unordered_output_stream, distributed,
-    get_data_dir, standalone, standalone_instance_case, MockInstance,
+    both_instances_cases, check_unordered_output_stream, distributed, get_data_dir, standalone,
+    standalone_instance_case, MockInstance,
 };
 
 #[apply(both_instances_cases)]

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -88,16 +88,6 @@ pub(crate) fn standalone_instance_case(
 ) {
 }
 
-pub(crate) async fn check_output_stream(output: Output, expected: &str) {
-    let recordbatches = match output {
-        Output::Stream(stream) => util::collect_batches(stream).await.unwrap(),
-        Output::RecordBatches(recordbatches) => recordbatches,
-        _ => unreachable!(),
-    };
-    let pretty_print = recordbatches.pretty_print().unwrap();
-    assert_eq!(pretty_print, expected, "actual: \n{}", pretty_print);
-}
-
 pub(crate) async fn check_unordered_output_stream(output: Output, expected: &str) {
     let sort_table = |table: &str| -> String {
         let replaced = table.replace("\\n", "\n");

--- a/tests-integration/tests/main.rs
+++ b/tests-integration/tests/main.rs
@@ -17,5 +17,9 @@ mod grpc;
 #[macro_use]
 mod http;
 
-grpc_tests!(File, S3, S3WithCache, Oss, Azblob);
-http_tests!(File, S3, S3WithCache, Oss, Azblob);
+#[macro_use]
+mod region_failover;
+
+grpc_tests!(File, S3, S3WithCache, Oss);
+http_tests!(File, S3, S3WithCache, Oss);
+region_failover_tests!(File, S3, S3WithCache, Oss);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Test datanode nodes writing after region failover

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1126
