### PR TITLE
fix: Print source error in subprocedure failure message

### DIFF
--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -127,6 +127,13 @@ pub enum Error {
         source: common_runtime::error::Error,
         location: Location,
     },
+
+    #[snafu(display("Subprocedure {} failed, source: {}", subprocedure_id, source))]
+    SubprocedureFailed {
+        subprocedure_id: ProcedureId,
+        source: Arc<Error>,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -134,7 +141,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            Error::External { source }
+            Error::External { source, .. }
             | Error::PutState { source, .. }
             | Error::DeleteStates { source, .. }
             | Error::ListState { source, .. } => source.status_code(),
@@ -152,6 +159,8 @@ impl ErrorExt for Error {
             Error::ProcedureExec { source, .. } => source.status_code(),
             Error::StartRemoveOutdatedMetaTask { source, .. }
             | Error::StopRemoveOutdatedMetaTask { source, .. } => source.status_code(),
+
+            Error::SubprocedureFailed { source, .. } => source.status_code(),
         }
     }
 

--- a/src/table-procedure/src/alter.rs
+++ b/src/table-procedure/src/alter.rs
@@ -16,6 +16,7 @@
 
 use async_trait::async_trait;
 use catalog::{CatalogManagerRef, RenameTableRequest};
+use common_procedure::error::SubprocedureFailedSnafu;
 use common_procedure::{
     Context, Error, LockKey, Procedure, ProcedureId, ProcedureManager, ProcedureState,
     ProcedureWithId, Result, Status,
@@ -29,7 +30,7 @@ use table::requests::{AlterKind, AlterTableRequest};
 
 use crate::error::{
     AccessCatalogSnafu, CatalogNotFoundSnafu, DeserializeProcedureSnafu, SchemaNotFoundSnafu,
-    SerializeProcedureSnafu, SubprocedureFailedSnafu, TableExistsSnafu, TableNotFoundSnafu,
+    SerializeProcedureSnafu, TableExistsSnafu, TableNotFoundSnafu,
 };
 
 /// Procedure to alter a table.

--- a/src/table-procedure/src/create.rs
+++ b/src/table-procedure/src/create.rs
@@ -16,6 +16,7 @@
 
 use async_trait::async_trait;
 use catalog::{CatalogManagerRef, RegisterTableRequest};
+use common_procedure::error::SubprocedureFailedSnafu;
 use common_procedure::{
     Context, Error, LockKey, Procedure, ProcedureId, ProcedureManager, ProcedureState,
     ProcedureWithId, Result, Status,
@@ -28,7 +29,7 @@ use table::requests::{CreateTableRequest, OpenTableRequest};
 
 use crate::error::{
     AccessCatalogSnafu, CatalogNotFoundSnafu, DeserializeProcedureSnafu, SchemaNotFoundSnafu,
-    SerializeProcedureSnafu, SubprocedureFailedSnafu,
+    SerializeProcedureSnafu,
 };
 
 /// Procedure to create a table.

--- a/src/table-procedure/src/drop.rs
+++ b/src/table-procedure/src/drop.rs
@@ -16,6 +16,7 @@
 
 use async_trait::async_trait;
 use catalog::{CatalogManagerRef, DeregisterTableRequest};
+use common_procedure::error::SubprocedureFailedSnafu;
 use common_procedure::{
     Context, Error, LockKey, Procedure, ProcedureId, ProcedureManager, ProcedureState,
     ProcedureWithId, Result, Status,
@@ -27,8 +28,7 @@ use table::engine::{EngineContext, TableEngineProcedureRef, TableReference};
 use table::requests::DropTableRequest;
 
 use crate::error::{
-    AccessCatalogSnafu, DeserializeProcedureSnafu, SerializeProcedureSnafu,
-    SubprocedureFailedSnafu, TableNotFoundSnafu,
+    AccessCatalogSnafu, DeserializeProcedureSnafu, SerializeProcedureSnafu, TableNotFoundSnafu,
 };
 
 /// Procedure to drop a table.

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 use std::any::Any;
-use std::sync::Arc;
 
 use common_error::prelude::*;
-use common_procedure::ProcedureId;
 use snafu::Location;
 
 #[derive(Debug, Snafu)]
@@ -55,13 +53,6 @@ pub enum Error {
     #[snafu(display("Table {} not found", name))]
     TableNotFound { name: String },
 
-    #[snafu(display("Subprocedure {} failed, source: {}", subprocedure_id, source))]
-    SubprocedureFailed {
-        subprocedure_id: ProcedureId,
-        source: Arc<common_procedure::Error>,
-        location: Location,
-    },
-
     #[snafu(display("Table already exists: {}", name))]
     TableExists { name: String },
 }
@@ -74,7 +65,6 @@ impl ErrorExt for Error {
 
         match self {
             SerializeProcedure { .. } | DeserializeProcedure { .. } => StatusCode::Internal,
-            SubprocedureFailed { source, .. } => source.status_code(),
             InvalidRawSchema { source, .. } => source.status_code(),
             AccessCatalog { source } => source.status_code(),
             CatalogNotFound { .. } | SchemaNotFound { .. } | TableExists { .. } => {

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
     #[snafu(display("Table {} not found", name))]
     TableNotFound { name: String },
 
-    #[snafu(display("Subprocedure {} failed", subprocedure_id))]
+    #[snafu(display("Subprocedure {} failed, source: {}", subprocedure_id, source))]
     SubprocedureFailed {
         subprocedure_id: ProcedureId,
         source: Arc<common_procedure::Error>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR prints the source error in the error variant `SubprocedureFailed`. It also moves this variant to `common_procedure::error::Error` and shortens the final error message.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
