### PR TITLE
feat: Add app version metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,6 +1587,7 @@ dependencies = [
  "futures",
  "meta-client",
  "meta-srv",
+ "metrics",
  "nu-ansi-term",
  "partition",
  "query",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -32,6 +32,7 @@ frontend = { path = "../frontend" }
 futures.workspace = true
 meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv" }
+metrics.workspace = true
 nu-ansi-term = "0.46"
 partition = { path = "../partition" }
 query = { path = "../query" }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -19,6 +19,10 @@ fn main() {
         build_data::get_git_commit().unwrap_or_else(|_| DEFAULT_VALUE.to_string())
     );
     println!(
+        "cargo:rustc-env=GIT_COMMIT_SHORT={}",
+        build_data::get_git_commit_short().unwrap_or_else(|_| DEFAULT_VALUE.to_string())
+    );
+    println!(
         "cargo:rustc-env=GIT_BRANCH={}",
         build_data::get_git_branch().unwrap_or_else(|_| DEFAULT_VALUE.to_string())
     );

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -173,7 +173,7 @@ fn short_version() -> &'static str {
 // version so the full version doesn't concat the short version explicitly.
 fn full_version() -> &'static str {
     concat!(
-        "greptime-",
+        "greptimedb-",
         env!("GIT_BRANCH"),
         "-",
         env!("GIT_COMMIT_SHORT")

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -21,6 +21,7 @@ use cmd::error::Result;
 use cmd::options::{Options, TopLevelOptions};
 use cmd::{cli, datanode, frontend, metasrv, standalone};
 use common_telemetry::logging::{error, info, TracingOptions};
+use metrics::gauge;
 
 #[derive(Parser)]
 #[clap(name = "greptimedb", version = print_version())]
@@ -163,6 +164,22 @@ fn print_version() -> &'static str {
     )
 }
 
+fn short_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+// {app_name}-{branch_name}-{commit_short}
+// The branch name (tag) of a release build should already contain the short
+// version so the full version doesn't concat the short version explicitly.
+fn full_version() -> &'static str {
+    concat!(
+        "greptime-",
+        env!("GIT_BRANCH"),
+        "-",
+        env!("GIT_COMMIT_SHORT")
+    )
+}
+
 #[cfg(feature = "mem-prof")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -184,6 +201,9 @@ async fn main() -> Result<()> {
     common_telemetry::set_panic_hook();
     common_telemetry::init_default_metrics_recorder();
     let _guard = common_telemetry::init_global_logging(app_name, logging_opts, tracing_opts);
+
+    // Report app version as gauge.
+    gauge!("app_version", 1.0, "short_version" => short_version(), "version" => full_version());
 
     let mut app = cmd.build(opts).await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Adds metric `greptime_app_version`
```
# TYPE greptime_app_version gauge
greptime_app_version{short_version="0.2.0",version="greptimedb-feat/more-metrics-fc623b5"} 1
```

The version contains the app name, the branch name, and the git commit. The example above doesn't have a short version. But in our formal release build, the branch (tag) name will contain a short version.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
