### PR TITLE
feat: make grpc insert requests in a batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backoff",
+ "catalog",
  "chrono",
  "common-catalog",
  "common-error",
@@ -4054,7 +4055,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ff0a47b6462bf196cbcd01b589c5dddfa6bfbc45#ff0a47b6462bf196cbcd01b589c5dddfa6bfbc45"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=4398d20c56d5f7939cc2960789cb1fa7dd18e6fe#4398d20c56d5f7939cc2960789cb1fa7dd18e6fe"
 dependencies = [
  "prost",
  "serde",
@@ -6116,6 +6117,7 @@ dependencies = [
 name = "partition"
 version = "0.2.0"
 dependencies = [
+ "api",
  "async-trait",
  "common-catalog",
  "common-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8426,6 +8426,7 @@ dependencies = [
  "humantime-serde",
  "hyper",
  "influxdb_line_protocol",
+ "itertools",
  "metrics",
  "metrics-process",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ datafusion-sql = { git = "https://github.com/waynexia/arrow-datafusion.git", rev
 datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ff0a47b6462bf196cbcd01b589c5dddfa6bfbc45" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "4398d20c56d5f7939cc2960789cb1fa7dd18e6fe" }
 itertools = "0.10"
 parquet = "40.0"
 paste = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 futures = "0.3"
 futures-util = "0.3"
 greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ff0a47b6462bf196cbcd01b589c5dddfa6bfbc45" }
+itertools = "0.10"
 parquet = "40.0"
 paste = "1.0"
 prost = "0.11"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,6 +9,6 @@ arrow.workspace = true
 clap = { version = "4.0", features = ["derive"] }
 client = { path = "../src/client" }
 indicatif = "0.17.1"
-itertools = "0.10.5"
+itertools.workspace = true
 parquet.workspace = true
 tokio.workspace = true

--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -26,7 +26,9 @@ use arrow::datatypes::{DataType, Float64Type, Int64Type};
 use arrow::record_batch::RecordBatch;
 use clap::Parser;
 use client::api::v1::column::Values;
-use client::api::v1::{Column, ColumnDataType, ColumnDef, CreateTableExpr, InsertRequest};
+use client::api::v1::{
+    Column, ColumnDataType, ColumnDef, CreateTableExpr, InsertRequest, InsertRequests,
+};
 use client::{Client, Database, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -107,8 +109,12 @@ async fn write_data(
             columns,
             row_count,
         };
+        let requests = InsertRequests {
+            inserts: vec![request],
+        };
+
         let now = Instant::now();
-        db.insert(request).await.unwrap();
+        db.insert(requests).await.unwrap();
         let elapsed = now.elapsed();
         total_rpc_elapsed_ms += elapsed.as_millis();
         progress_bar.inc(row_count as _);

--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -231,7 +231,7 @@ pub fn push_vals(column: &mut Column, origin_count: usize, vector: VectorRef) {
 /// Returns the type name of the [Request].
 pub fn request_type(request: &Request) -> &'static str {
     match request {
-        Request::Insert(_) => "insert",
+        Request::Inserts(_) => "inserts",
         Request::Query(query_req) => query_request_type(query_req),
         Request::Ddl(ddl_req) => ddl_request_type(ddl_req),
         Request::Delete(_) => "delete",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+testing = []
+
 [dependencies]
 api = { path = "../api" }
 arc-swap = "1.0"
@@ -42,6 +45,7 @@ table = { path = "../table" }
 tokio.workspace = true
 
 [dev-dependencies]
+catalog = { path = ".", features = ["testing"] }
 common-test-util = { path = "../common/test-util" }
 chrono.workspace = true
 log-store = { path = "../log-store" }

--- a/src/catalog/src/remote.rs
+++ b/src/catalog/src/remote.rs
@@ -27,6 +27,9 @@ use crate::error::Error;
 mod client;
 mod manager;
 
+#[cfg(feature = "testing")]
+pub mod mock;
+
 #[derive(Debug, Clone)]
 pub struct Kv(pub Vec<u8>, pub Vec<u8>);
 

--- a/src/catalog/src/remote/mock.rs
+++ b/src/catalog/src/remote/mock.rs
@@ -20,9 +20,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_stream::stream;
-use catalog::error::Error;
-use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
-use catalog::remote::{Kv, KvBackend, ValueIter};
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_recordbatch::RecordBatch;
 use common_telemetry::logging::info;
@@ -36,6 +33,10 @@ use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, O
 use table::test_util::MemTable;
 use table::TableRef;
 use tokio::sync::RwLock;
+
+use crate::error::Error;
+use crate::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
+use crate::remote::{Kv, KvBackend, ValueIter};
 
 pub struct MockKvBackend {
     map: RwLock<BTreeMap<Vec<u8>, Vec<u8>>>,

--- a/src/catalog/tests/remote_catalog_tests.rs
+++ b/src/catalog/tests/remote_catalog_tests.rs
@@ -14,8 +14,6 @@
 
 #![feature(assert_matches)]
 
-mod mock;
-
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
@@ -23,6 +21,7 @@ mod tests {
     use std::sync::Arc;
 
     use catalog::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
+    use catalog::remote::mock::{MockKvBackend, MockTableEngine};
     use catalog::remote::{
         CachedMetaKvBackend, KvBackend, KvBackendRef, RemoteCatalogManager, RemoteCatalogProvider,
         RemoteSchemaProvider,
@@ -34,8 +33,6 @@ mod tests {
     use table::engine::manager::{MemoryTableEngineManager, TableEngineManagerRef};
     use table::engine::{EngineContext, TableEngineRef};
     use table::requests::CreateTableRequest;
-
-    use crate::mock::{MockKvBackend, MockTableEngine};
 
     #[tokio::test]
     async fn test_backend() {

--- a/src/client/src/client_manager.rs
+++ b/src/client/src/client_manager.rs
@@ -16,7 +16,8 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use common_grpc::channel_manager::ChannelManager;
+use client::Client;
+use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
 use common_meta::peer::Peer;
 use common_telemetry::info;
 use moka::future::{Cache, CacheBuilder};
@@ -31,8 +32,11 @@ pub struct DatanodeClients {
 
 impl Default for DatanodeClients {
     fn default() -> Self {
+        // TODO(LFC): Make this channel config configurable.
+        let config = ChannelConfig::new().timeout(Duration::from_secs(8));
+
         Self {
-            channel_manager: ChannelManager::new(),
+            channel_manager: ChannelManager::with_config(config),
             clients: CacheBuilder::new(1024)
                 .time_to_live(Duration::from_secs(30 * 60))
                 .time_to_idle(Duration::from_secs(5 * 60))

--- a/src/client/src/client_manager.rs
+++ b/src/client/src/client_manager.rs
@@ -16,7 +16,6 @@ use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use client::Client;
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
 use common_meta::peer::Peer;
 use common_telemetry::info;

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -18,7 +18,7 @@ use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use api::v1::{
     greptime_response, AffectedRows, AlterExpr, AuthHeader, CreateTableExpr, DdlRequest,
-    DeleteRequest, DropTableExpr, FlushTableExpr, GreptimeRequest, InsertRequest, PromRangeQuery,
+    DeleteRequest, DropTableExpr, FlushTableExpr, GreptimeRequest, InsertRequests, PromRangeQuery,
     QueryRequest, RequestHeader,
 };
 use arrow_flight::{FlightData, Ticket};
@@ -109,9 +109,9 @@ impl Database {
         });
     }
 
-    pub async fn insert(&self, request: InsertRequest) -> Result<u32> {
+    pub async fn insert(&self, requests: InsertRequests) -> Result<u32> {
         let _timer = timer!(metrics::METRIC_GRPC_INSERT);
-        self.handle(Request::Insert(request)).await
+        self.handle(Request::Inserts(requests)).await
     }
 
     pub async fn delete(&self, request: DeleteRequest) -> Result<u32> {

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -28,7 +28,7 @@ use tower::make::MakeConnection;
 use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
-const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 8;
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 2;
 
 #[derive(Clone, Debug)]
 pub struct ChannelManager {
@@ -237,7 +237,6 @@ pub struct ChannelConfig {
 impl Default for ChannelConfig {
     fn default() -> Self {
         Self {
-            // TODO(LFC): Make this channel config configurable.
             timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
             connect_timeout: Some(Duration::from_secs(4)),
             concurrency_limit: None,

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -28,6 +28,7 @@ use tower::make::MakeConnection;
 use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 8;
 
 #[derive(Clone, Debug)]
 pub struct ChannelManager {
@@ -236,7 +237,8 @@ pub struct ChannelConfig {
 impl Default for ChannelConfig {
     fn default() -> Self {
         Self {
-            timeout: Some(Duration::from_secs(2)),
+            // TODO(LFC): Make this channel config configurable.
+            timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
             connect_timeout: Some(Duration::from_secs(4)),
             concurrency_limit: None,
             rate_limit: None,
@@ -497,7 +499,7 @@ mod tests {
         let default_cfg = ChannelConfig::new();
         assert_eq!(
             ChannelConfig {
-                timeout: Some(Duration::from_secs(2)),
+                timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
                 connect_timeout: Some(Duration::from_secs(4)),
                 concurrency_limit: None,
                 rate_limit: None,

--- a/src/common/meta/src/rpc/router.rs
+++ b/src/common/meta/src/rpc/router.rs
@@ -22,6 +22,7 @@ use api::v1::meta::{
 };
 use serde::{Deserialize, Serialize, Serializer};
 use snafu::{OptionExt, ResultExt};
+use store_api::storage::RegionNumber;
 use store_api::storage::RegionId;
 use table::metadata::RawTableInfo;
 
@@ -266,6 +267,13 @@ impl TableRoute {
                 None
             })
             .collect()
+    }
+
+    pub fn find_region_leader(&self, region_number: RegionNumber) -> Option<Peer> {
+        self.region_routes
+            .iter()
+            .find(|x| x.region.id == region_number as u64)
+            .and_then(|x| x.leader_peer.clone())
     }
 }
 

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -65,6 +65,7 @@ tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
+catalog = { path = "../catalog", features = ["testing"] }
 common-test-util = { path = "../common/test-util" }
 datanode = { path = "../datanode" }
 futures = "0.3"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -37,7 +37,7 @@ datatypes = { path = "../datatypes" }
 file-table-engine = { path = "../file-table-engine" }
 futures = "0.3"
 futures-util.workspace = true
-itertools = "0.10"
+itertools.workspace = true
 meta-client = { path = "../meta-client" }
 meter-core.workspace = true
 meter-macros.workspace = true

--- a/src/frontend/src/heartbeat/handler.rs
+++ b/src/frontend/src/heartbeat/handler.rs
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 pub mod invalidate_table_cache;
+
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/src/frontend/src/heartbeat/handler/tests.rs
+++ b/src/frontend/src/heartbeat/handler/tests.rs
@@ -30,6 +30,7 @@ use tokio::sync::mpsc;
 
 use super::invalidate_table_cache::InvalidateTableCacheHandler;
 
+#[derive(Default)]
 pub struct MockKvCacheInvalidator {
     inner: Mutex<HashMap<Vec<u8>, i32>>,
 }

--- a/src/frontend/src/instance/distributed/inserter.rs
+++ b/src/frontend/src/instance/distributed/inserter.rs
@@ -23,15 +23,15 @@ use common_meta::peer::Peer;
 use common_meta::table_name::TableName;
 use futures::future;
 use metrics::counter;
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt};
 use table::metadata::TableInfoRef;
 use table::meter_insert_request;
 use table::requests::InsertRequest;
 
 use crate::catalog::FrontendCatalogManager;
 use crate::error::{
-    CatalogSnafu, FindDatanodeSnafu, FindTableRouteSnafu, JoinTaskSnafu, NotSupportedSnafu,
-    RequestDatanodeSnafu, Result, SplitInsertSnafu, TableNotFoundSnafu, ToTableInsertRequestSnafu,
+    CatalogSnafu, FindDatanodeSnafu, FindTableRouteSnafu, JoinTaskSnafu, RequestDatanodeSnafu,
+    Result, SplitInsertSnafu, TableNotFoundSnafu, ToTableInsertRequestSnafu,
 };
 use crate::table::insert::to_grpc_insert_request;
 
@@ -76,14 +76,9 @@ impl DistInserter {
     }
 
     pub(crate) async fn insert(&self, requests: Vec<InsertRequest>) -> Result<u32> {
-        ensure!(
-            requests
-                .iter()
-                .all(|x| x.catalog_name == self.catalog && x.schema_name == self.schema),
-            NotSupportedSnafu {
-                feat: "insert requests with different catalog or schema",
-            }
-        );
+        debug_assert!(requests
+            .iter()
+            .all(|x| x.catalog_name == self.catalog && x.schema_name == self.schema));
 
         let inserts = self.split_inserts(requests).await?;
 

--- a/src/frontend/src/instance/distributed/inserter.rs
+++ b/src/frontend/src/instance/distributed/inserter.rs
@@ -181,6 +181,7 @@ mod tests {
     };
     use catalog::remote::mock::MockKvBackend;
     use catalog::remote::{KvBackend, KvBackendRef};
+    use client::client_manager::DatanodeClients;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::prelude::{ConcreteDataType, VectorRef};
     use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, Schema};
@@ -188,7 +189,6 @@ mod tests {
     use table::metadata::{TableInfoBuilder, TableMetaBuilder};
 
     use super::*;
-    use crate::datanode::DatanodeClients;
     use crate::heartbeat::handler::tests::MockKvCacheInvalidator;
     use crate::table::test::create_partition_rule_manager;
 

--- a/src/frontend/src/instance/distributed/inserter.rs
+++ b/src/frontend/src/instance/distributed/inserter.rs
@@ -1,0 +1,385 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use api::v1::InsertRequests;
+use catalog::CatalogManager;
+use client::Database;
+use common_grpc_expr::insert::to_table_insert_request;
+use common_meta::peer::Peer;
+use common_meta::table_name::TableName;
+use futures::future;
+use metrics::counter;
+use snafu::{ensure, OptionExt, ResultExt};
+use table::metadata::TableInfoRef;
+use table::meter_insert_request;
+use table::requests::InsertRequest;
+
+use crate::catalog::FrontendCatalogManager;
+use crate::error::{
+    CatalogSnafu, FindDatanodeSnafu, FindTableRouteSnafu, JoinTaskSnafu, NotSupportedSnafu,
+    RequestDatanodeSnafu, Result, SplitInsertSnafu, TableNotFoundSnafu, ToTableInsertRequestSnafu,
+};
+use crate::table::insert::to_grpc_insert_request;
+
+/// A distributed inserter. It ingests GRPC [InsertRequests] or table [InsertRequest] (so it can be
+/// used in protocol handlers or table insertion API).
+///
+/// Table data partitioning and Datanode requests batching are handled inside.
+///
+/// Note that the inserter is confined to a single catalog and schema. I.e., it cannot handle
+/// multiple insert requests with different catalog or schema (will throw "NotSupported" error).
+/// This is because we currently do not have this kind of requirements. Let's keep it simple for now.
+pub(crate) struct DistInserter {
+    catalog: String,
+    schema: String,
+    catalog_manager: Arc<FrontendCatalogManager>,
+}
+
+impl DistInserter {
+    pub(crate) fn new(
+        catalog: String,
+        schema: String,
+        catalog_manager: Arc<FrontendCatalogManager>,
+    ) -> Self {
+        Self {
+            catalog,
+            schema,
+            catalog_manager,
+        }
+    }
+
+    pub(crate) async fn grpc_insert(&self, requests: InsertRequests) -> Result<u32> {
+        let inserts = requests
+            .inserts
+            .into_iter()
+            .map(|x| {
+                to_table_insert_request(&self.catalog, &self.schema, x)
+                    .context(ToTableInsertRequestSnafu)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.insert(inserts).await
+    }
+
+    pub(crate) async fn insert(&self, requests: Vec<InsertRequest>) -> Result<u32> {
+        ensure!(
+            requests
+                .iter()
+                .all(|x| x.catalog_name == self.catalog && x.schema_name == self.schema),
+            NotSupportedSnafu {
+                feat: "insert requests with different catalog or schema",
+            }
+        );
+
+        let inserts = self.split_inserts(requests).await?;
+
+        self.request_datanodes(inserts).await
+    }
+
+    /// Splits multiple table [InsertRequest]s into multiple GRPC [InsertRequests]s, each of which
+    /// is grouped by the peer of Datanode, so we can batch them together when invoking gRPC write
+    /// method in Datanode.
+    async fn split_inserts(
+        &self,
+        requests: Vec<InsertRequest>,
+    ) -> Result<HashMap<Peer, InsertRequests>> {
+        let partition_manager = self.catalog_manager.partition_manager();
+
+        let mut inserts = HashMap::new();
+
+        for request in requests {
+            meter_insert_request!(request);
+
+            let table_name = TableName::new(&self.catalog, &self.schema, &request.table_name);
+            let table_info = self.find_table_info(&request.table_name).await?;
+            let table_meta = &table_info.meta;
+
+            let split = partition_manager
+                .split_insert_request(&table_name, request, table_meta.schema.as_ref())
+                .await
+                .context(SplitInsertSnafu)?;
+
+            let table_route = partition_manager
+                .find_table_route(&table_name)
+                .await
+                .with_context(|_| FindTableRouteSnafu {
+                    table_name: table_name.to_string(),
+                })?;
+
+            for (region_number, insert) in split {
+                let datanode =
+                    table_route
+                        .find_region_leader(region_number)
+                        .context(FindDatanodeSnafu {
+                            region: region_number,
+                        })?;
+
+                let insert = to_grpc_insert_request(table_meta, region_number, insert)?;
+
+                inserts
+                    .entry(datanode.clone())
+                    .or_insert_with(|| InsertRequests { inserts: vec![] })
+                    .inserts
+                    .push(insert);
+            }
+        }
+        Ok(inserts)
+    }
+
+    async fn find_table_info(&self, table_name: &str) -> Result<TableInfoRef> {
+        let table = self
+            .catalog_manager
+            .table(&self.catalog, &self.schema, table_name)
+            .await
+            .context(CatalogSnafu)?
+            .with_context(|| TableNotFoundSnafu {
+                table_name: common_catalog::format_full_table_name(
+                    &self.catalog,
+                    &self.schema,
+                    table_name,
+                ),
+            })?;
+        Ok(table.table_info())
+    }
+
+    async fn request_datanodes(&self, inserts: HashMap<Peer, InsertRequests>) -> Result<u32> {
+        let results = future::try_join_all(inserts.into_iter().map(|(peer, inserts)| {
+            let datanode_clients = self.catalog_manager.datanode_clients();
+            let catalog = self.catalog.clone();
+            let schema = self.schema.clone();
+
+            common_runtime::spawn_write(async move {
+                let client = datanode_clients.get_client(&peer).await;
+                let database = Database::new(&catalog, &schema, client);
+                database.insert(inserts).await.context(RequestDatanodeSnafu)
+            })
+        }))
+        .await
+        .context(JoinTaskSnafu)?;
+
+        let affected_rows = results.into_iter().sum::<Result<u32>>()?;
+        counter!(crate::metrics::DIST_INGEST_ROW_COUNT, affected_rows as u64);
+        Ok(affected_rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use api::v1::column::{SemanticType, Values};
+    use api::v1::{Column, ColumnDataType, InsertRequest as GrpcInsertRequest};
+    use catalog::helper::{
+        CatalogKey, CatalogValue, SchemaKey, SchemaValue, TableGlobalKey, TableGlobalValue,
+    };
+    use catalog::remote::mock::MockKvBackend;
+    use catalog::remote::{KvBackend, KvBackendRef};
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use datatypes::prelude::{ConcreteDataType, VectorRef};
+    use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, Schema};
+    use datatypes::vectors::Int32Vector;
+    use table::metadata::{TableInfoBuilder, TableMetaBuilder};
+
+    use super::*;
+    use crate::datanode::DatanodeClients;
+    use crate::heartbeat::handler::tests::MockKvCacheInvalidator;
+    use crate::table::test::create_partition_rule_manager;
+
+    async fn prepare_mocked_backend() -> KvBackendRef {
+        let backend = Arc::new(MockKvBackend::default());
+
+        let default_catalog = CatalogKey {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        }
+        .to_string();
+        backend
+            .set(
+                default_catalog.as_bytes(),
+                CatalogValue.as_bytes().unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let default_schema = SchemaKey {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+        }
+        .to_string();
+        backend
+            .set(
+                default_schema.as_bytes(),
+                SchemaValue.as_bytes().unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        backend
+    }
+
+    async fn create_testing_table(backend: &KvBackendRef, table_name: &str) {
+        let table_global_key = TableGlobalKey {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: table_name.to_string(),
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("ts", ConcreteDataType::int64_datatype(), false)
+                .with_time_index(true)
+                .with_default_constraint(Some(ColumnDefaultConstraint::Function(
+                    "current_timestamp()".to_string(),
+                )))
+                .unwrap(),
+            ColumnSchema::new("a", ConcreteDataType::int32_datatype(), true),
+        ]));
+
+        let mut builder = TableMetaBuilder::default();
+        builder.schema(schema);
+        builder.primary_key_indices(vec![]);
+        builder.next_column_id(1);
+        let table_meta = builder.build().unwrap();
+
+        let table_info = TableInfoBuilder::new(table_name, table_meta)
+            .build()
+            .unwrap();
+
+        let table_global_value = TableGlobalValue {
+            node_id: 1,
+            regions_id_map: HashMap::from([(1, vec![1]), (2, vec![2]), (3, vec![3])]),
+            table_info: table_info.into(),
+        };
+
+        backend
+            .set(
+                table_global_key.to_string().as_bytes(),
+                table_global_value.as_bytes().unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_split_inserts() {
+        let backend = prepare_mocked_backend().await;
+
+        let table_name = "one_column_partitioning_table";
+        create_testing_table(&backend, table_name).await;
+
+        let catalog_manager = Arc::new(FrontendCatalogManager::new(
+            backend,
+            Arc::new(MockKvCacheInvalidator::default()),
+            create_partition_rule_manager().await,
+            Arc::new(DatanodeClients::default()),
+        ));
+
+        let inserter = DistInserter::new(
+            DEFAULT_CATALOG_NAME.to_string(),
+            DEFAULT_SCHEMA_NAME.to_string(),
+            catalog_manager,
+        );
+
+        let new_insert_request = |vector: VectorRef| -> InsertRequest {
+            InsertRequest {
+                catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+                table_name: table_name.to_string(),
+                columns_values: HashMap::from([("a".to_string(), vector)]),
+                region_number: 0,
+            }
+        };
+        let requests = vec![
+            new_insert_request(Arc::new(Int32Vector::from(vec![
+                Some(1),
+                None,
+                Some(11),
+                Some(101),
+            ]))),
+            new_insert_request(Arc::new(Int32Vector::from(vec![
+                Some(2),
+                Some(12),
+                None,
+                Some(102),
+            ]))),
+        ];
+
+        let mut inserts = inserter.split_inserts(requests).await.unwrap();
+        assert_eq!(inserts.len(), 3);
+
+        let new_grpc_insert_request = |column_values: Vec<i32>,
+                                       null_mask: Vec<u8>,
+                                       row_count: u32,
+                                       region_number: u32|
+         -> GrpcInsertRequest {
+            GrpcInsertRequest {
+                table_name: table_name.to_string(),
+                columns: vec![Column {
+                    column_name: "a".to_string(),
+                    semantic_type: SemanticType::Field as i32,
+                    values: Some(Values {
+                        i32_values: column_values,
+                        ..Default::default()
+                    }),
+                    null_mask,
+                    datatype: ColumnDataType::Int32 as i32,
+                }],
+                row_count,
+                region_number,
+            }
+        };
+
+        // region to datanode placement:
+        // 1 -> 1
+        // 2 -> 2
+        // 3 -> 3
+        //
+        // region value ranges:
+        // 1 -> [50, max)
+        // 2 -> [10, 50)
+        // 3 -> (min, 10)
+
+        let datanode_inserts = inserts.remove(&Peer::new(1, "")).unwrap().inserts;
+        assert_eq!(datanode_inserts.len(), 2);
+        assert_eq!(
+            datanode_inserts[0],
+            new_grpc_insert_request(vec![101], vec![0], 1, 1)
+        );
+        assert_eq!(
+            datanode_inserts[1],
+            new_grpc_insert_request(vec![102], vec![0], 1, 1)
+        );
+
+        let datanode_inserts = inserts.remove(&Peer::new(2, "")).unwrap().inserts;
+        assert_eq!(datanode_inserts.len(), 2);
+        assert_eq!(
+            datanode_inserts[0],
+            new_grpc_insert_request(vec![11], vec![0], 1, 2)
+        );
+        assert_eq!(
+            datanode_inserts[1],
+            new_grpc_insert_request(vec![12], vec![0], 1, 2)
+        );
+
+        let datanode_inserts = inserts.remove(&Peer::new(3, "")).unwrap().inserts;
+        assert_eq!(datanode_inserts.len(), 2);
+        assert_eq!(
+            datanode_inserts[0],
+            new_grpc_insert_request(vec![1], vec![2], 2, 3)
+        );
+        assert_eq!(
+            datanode_inserts[1],
+            new_grpc_insert_request(vec![2], vec![2], 2, 3)
+        );
+    }
+}

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -36,7 +36,7 @@ impl GrpcQueryHandler for Instance {
         interceptor.pre_execute(&request, ctx.clone())?;
 
         let output = match request {
-            Request::Insert(request) => self.handle_insert(request, ctx.clone()).await?,
+            Request::Inserts(requests) => self.handle_inserts(requests, ctx.clone()).await?,
             Request::Query(query_request) => {
                 let query = query_request.query.context(IncompleteGrpcResultSnafu {
                     err_msg: "Missing field 'QueryRequest.query'",

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use api::v1::InsertRequests;
 use async_trait::async_trait;
 use common_error::prelude::BoxedError;
 use servers::error as server_error;
@@ -25,8 +26,10 @@ use crate::instance::Instance;
 #[async_trait]
 impl OpentsdbProtocolHandler for Instance {
     async fn exec(&self, data_point: &DataPoint, ctx: QueryContextRef) -> server_error::Result<()> {
-        let request = data_point.as_grpc_insert();
-        self.handle_insert(request, ctx)
+        let requests = InsertRequests {
+            inserts: vec![data_point.as_grpc_insert()],
+        };
+        self.handle_inserts(requests, ctx)
             .await
             .map_err(BoxedError::new)
             .with_context(|_| server_error::ExecuteQuerySnafu {

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -108,13 +108,7 @@ impl Instance {
 #[async_trait]
 impl PrometheusProtocolHandler for Instance {
     async fn write(&self, request: WriteRequest, ctx: QueryContextRef) -> ServerResult<()> {
-        let samples = request
-            .timeseries
-            .iter()
-            .map(|x| x.samples.len())
-            .sum::<usize>();
-
-        let requests = prometheus::to_grpc_insert_requests(request)?;
+        let (requests, samples) = prometheus::to_grpc_insert_requests(request)?;
         self.handle_inserts(requests, ctx)
             .await
             .map_err(BoxedError::new)

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -21,6 +21,7 @@ use common_error::prelude::BoxedError;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
 use common_telemetry::logging;
+use metrics::counter;
 use prost::Message;
 use servers::error::{self, Result as ServerResult};
 use servers::prometheus::{self, Metrics};
@@ -30,6 +31,7 @@ use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
 
 use crate::instance::Instance;
+use crate::metrics::PROMETHEUS_REMOTE_WRITE_SAMPLES;
 
 const SAMPLES_RESPONSE_TYPE: i32 = ResponseType::Samples as i32;
 
@@ -106,11 +108,19 @@ impl Instance {
 #[async_trait]
 impl PrometheusProtocolHandler for Instance {
     async fn write(&self, request: WriteRequest, ctx: QueryContextRef) -> ServerResult<()> {
-        let requests = prometheus::to_grpc_insert_requests(request.clone())?;
+        let samples = request
+            .timeseries
+            .iter()
+            .map(|x| x.samples.len())
+            .sum::<usize>();
+
+        let requests = prometheus::to_grpc_insert_requests(request)?;
         self.handle_inserts(requests, ctx)
             .await
             .map_err(BoxedError::new)
             .context(error::ExecuteGrpcQuerySnafu)?;
+
+        counter!(PROMETHEUS_REMOTE_WRITE_SAMPLES, samples as u64);
         Ok(())
     }
 

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -22,3 +22,6 @@ pub const DIST_CREATE_TABLE: &str = "frontend.dist.create_table";
 pub const DIST_CREATE_TABLE_IN_META: &str = "frontend.dist.create_table.update_meta";
 pub const DIST_CREATE_TABLE_IN_DATANODE: &str = "frontend.dist.create_table.invoke_datanode";
 pub const DIST_INGEST_ROW_COUNT: &str = "frontend.dist.ingest_rows";
+
+/// The samples count of Prometheus remote write.
+pub const PROMETHEUS_REMOTE_WRITE_SAMPLES: &str = "frontend.prometheus.remote_write.samples";

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -360,7 +360,8 @@ impl DistTable {
         }
         .key();
 
-        self.backend
+        self.catalog_manager
+            .backend()
             .move_value(old_key.as_bytes(), new_key.as_bytes())
             .await
             .context(error::CatalogSnafu)?;

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -45,7 +45,7 @@ use datafusion::physical_plan::{
 use datafusion_common::DataFusionError;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use futures_util::{Stream, StreamExt};
-use partition::manager::{PartitionRuleManagerRef, TableRouteCacheInvalidator};
+use partition::manager::TableRouteCacheInvalidator;
 use partition::splitter::WriteSplitter;
 use snafu::prelude::*;
 use store_api::storage::{RegionNumber, ScanRequest};
@@ -366,7 +366,8 @@ impl DistTable {
             .await
             .context(error::CatalogSnafu)?;
 
-        self.partition_manager
+        self.catalog_manager
+            .partition_manager()
             .invalidate_table_route(&TableName {
                 catalog_name: catalog_name.to_string(),
                 schema_name: schema_name.to_string(),

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -20,8 +20,6 @@ use std::sync::Arc;
 use api::v1::AlterExpr;
 use async_trait::async_trait;
 use catalog::helper::{TableGlobalKey, TableGlobalValue};
-use catalog::remote::KvBackendRef;
-use client::client_manager::DatanodeClients;
 use client::Database;
 use common_error::prelude::BoxedError;
 use common_meta::key::TableRouteKey;
@@ -503,7 +501,7 @@ impl DistTable {
         let datanode_clients = self.catalog_manager.datanode_clients();
         let mut instances = Vec::with_capacity(datanodes.len());
         for datanode in datanodes {
-            let client = datanode_clients.get_client(&datanode).await;
+            let client = datanode_clients.get_client(datanode).await;
             let db = Database::new(&table_name.catalog_name, &table_name.schema_name, client);
             instances.push(DatanodeInstance::new(Arc::new(self.clone()) as _, db));
         }
@@ -661,13 +659,13 @@ pub(crate) mod test {
             DEFAULT_SCHEMA_NAME,
             "one_column_partitioning_table",
         );
-        let table_route = TableRoute {
-            table: Table {
+        let table_route = TableRoute::new(
+            Table {
                 id: 1,
                 table_name: table_name.clone(),
                 table_schema: vec![],
             },
-            region_routes: vec![
+            vec![
                 RegionRoute {
                     region: Region {
                         id: 3,
@@ -720,7 +718,7 @@ pub(crate) mod test {
                     follower_peers: vec![],
                 },
             ],
-        };
+        );
         table_routes
             .insert_table_route(table_name.clone(), Arc::new(table_route))
             .await;
@@ -730,13 +728,13 @@ pub(crate) mod test {
             DEFAULT_SCHEMA_NAME,
             "two_column_partitioning_table",
         );
-        let table_route = TableRoute {
-            table: Table {
+        let table_route = TableRoute::new(
+            Table {
                 id: 1,
                 table_name: table_name.clone(),
                 table_schema: vec![],
             },
-            region_routes: vec![
+            vec![
                 RegionRoute {
                     region: Region {
                         id: 1,
@@ -795,7 +793,7 @@ pub(crate) mod test {
                     follower_peers: vec![],
                 },
             ],
-        };
+        );
         table_routes
             .insert_table_route(table_name.clone(), Arc::new(table_route))
             .await;

--- a/src/frontend/src/table/insert.rs
+++ b/src/frontend/src/table/insert.rs
@@ -15,49 +15,18 @@
 use std::collections::HashMap;
 
 use api::helper::{push_vals, ColumnDataTypeWrapper};
-use api::v1::column::SemanticType;
+use api::v1::column::{SemanticType, Values};
 use api::v1::{Column, InsertRequest as GrpcInsertRequest};
-use common_query::Output;
-use datatypes::prelude::{ConcreteDataType, VectorRef};
-use futures::future;
-use metrics::counter;
-use snafu::{ensure, ResultExt};
+use datatypes::prelude::*;
+use snafu::{ensure, OptionExt, ResultExt};
 use store_api::storage::RegionNumber;
+use table::metadata::TableMeta;
 use table::requests::InsertRequest;
 
-use super::DistTable;
-use crate::error;
-use crate::error::{JoinTaskSnafu, RequestDatanodeSnafu, Result};
-
-impl DistTable {
-    pub async fn dist_insert(&self, inserts: Vec<GrpcInsertRequest>) -> Result<Output> {
-        let regions = inserts.iter().map(|x| x.region_number).collect::<Vec<_>>();
-        let instances = self.find_datanode_instances(&regions).await?;
-
-        let results = future::try_join_all(instances.into_iter().zip(inserts.into_iter()).map(
-            |(instance, request)| {
-                common_runtime::spawn_write(async move {
-                    instance
-                        .grpc_insert(request)
-                        .await
-                        .context(RequestDatanodeSnafu)
-                })
-            },
-        ))
-        .await
-        .context(JoinTaskSnafu)?;
-
-        let affected_rows = results.into_iter().sum::<Result<u32>>()?;
-        counter!(crate::metrics::DIST_INGEST_ROW_COUNT, affected_rows as u64);
-        Ok(Output::AffectedRows(affected_rows as _))
-    }
-}
-
-pub fn insert_request_to_insert_batch(insert: &InsertRequest) -> Result<(Vec<Column>, u32)> {
-    to_grpc_columns(&insert.columns_values)
-}
+use crate::error::{self, ColumnDataTypeSnafu, Result, VectorToGrpcColumnSnafu};
 
 pub(crate) fn to_grpc_columns(
+    table_meta: &TableMeta,
     columns_values: &HashMap<String, VectorRef>,
 ) -> Result<(Vec<Column>, u32)> {
     let mut row_count = None;
@@ -76,27 +45,7 @@ pub(crate) fn to_grpc_columns(
                 None => row_count = Some(vector.len()),
             }
 
-            let datatype: ColumnDataTypeWrapper = vector
-                .data_type()
-                .try_into()
-                .context(error::ColumnDataTypeSnafu)?;
-
-            // TODO(hl): need refactor
-            let semantic_type =
-                if vector.data_type() == ConcreteDataType::timestamp_millisecond_datatype() {
-                    SemanticType::Timestamp
-                } else {
-                    SemanticType::Field
-                };
-
-            let mut column = Column {
-                column_name: column_name.clone(),
-                semantic_type: semantic_type.into(),
-                datatype: datatype.datatype() as i32,
-                ..Default::default()
-            };
-
-            push_vals(&mut column, 0, vector.clone());
+            let column = vector_to_grpc_column(table_meta, column_name, vector.clone())?;
             Ok(column)
         })
         .collect::<Result<Vec<_>>>()?;
@@ -107,11 +56,12 @@ pub(crate) fn to_grpc_columns(
 }
 
 pub(crate) fn to_grpc_insert_request(
+    table_meta: &TableMeta,
     region_number: RegionNumber,
     insert: InsertRequest,
 ) -> Result<GrpcInsertRequest> {
     let table_name = insert.table_name.clone();
-    let (columns, row_count) = insert_request_to_insert_batch(&insert)?;
+    let (columns, row_count) = to_grpc_columns(table_meta, &insert.columns_values)?;
     Ok(GrpcInsertRequest {
         table_name,
         region_number,
@@ -120,23 +70,136 @@ pub(crate) fn to_grpc_insert_request(
     })
 }
 
+fn vector_to_grpc_column(
+    table_meta: &TableMeta,
+    column_name: &str,
+    vector: VectorRef,
+) -> Result<Column> {
+    // Safety: timestamp column has to be existed in a table.
+    let semantic_type = if column_name == table_meta.schema.timestamp_column().unwrap().name {
+        SemanticType::Timestamp
+    } else {
+        let column_index = table_meta
+            .schema
+            .column_index_by_name(column_name)
+            .context(VectorToGrpcColumnSnafu {
+                reason: format!("unable to find column {column_name} in table schema"),
+            })?;
+        if table_meta.primary_key_indices.contains(&column_index) {
+            SemanticType::Tag
+        } else {
+            SemanticType::Field
+        }
+    };
+
+    let datatype: ColumnDataTypeWrapper =
+        vector.data_type().try_into().context(ColumnDataTypeSnafu)?;
+
+    let mut column = Column {
+        column_name: column_name.to_string(),
+        semantic_type: semantic_type as i32,
+        null_mask: vec![],
+        datatype: datatype.datatype() as i32,
+        values: Some(Values::default()), // vector values will be pushed into it below
+    };
+    push_vals(&mut column, 0, vector);
+    Ok(column)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use api::v1::ColumnDataType;
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::prelude::ScalarVectorBuilder;
-    use datatypes::vectors::{Int16VectorBuilder, MutableVector, StringVectorBuilder};
+    use datatypes::schema::{ColumnSchema, Schema};
+    use datatypes::vectors::{
+        Int16VectorBuilder, Int32Vector, Int64Vector, MutableVector, StringVector,
+        StringVectorBuilder,
+    };
+    use table::metadata::TableMetaBuilder;
     use table::requests::InsertRequest;
 
     use super::*;
 
     #[test]
-    fn test_to_grpc_insert_request() {
-        let insert_request = mock_insert_request();
+    fn test_vector_to_grpc_column() {
+        let schema = Arc::new(Schema::new(vec![
+            ColumnSchema::new("ts", ConcreteDataType::int64_datatype(), false)
+                .with_time_index(true),
+            ColumnSchema::new("k", ConcreteDataType::int32_datatype(), false),
+            ColumnSchema::new("v", ConcreteDataType::string_datatype(), true),
+        ]));
 
-        let request = to_grpc_insert_request(12, insert_request).unwrap();
+        let mut builder = TableMetaBuilder::default();
+        builder.schema(schema);
+        builder.primary_key_indices(vec![1]);
+        builder.next_column_id(3);
+        let table_meta = builder.build().unwrap();
+
+        let column = vector_to_grpc_column(
+            &table_meta,
+            "ts",
+            Arc::new(Int64Vector::from_slice([1, 2, 3])),
+        )
+        .unwrap();
+        assert_eq!(column.column_name, "ts");
+        assert_eq!(column.semantic_type, SemanticType::Timestamp as i32);
+        assert_eq!(column.values.unwrap().i64_values, vec![1, 2, 3]);
+        assert_eq!(column.null_mask, vec![0]);
+        assert_eq!(column.datatype, ColumnDataType::Int64 as i32);
+
+        let column = vector_to_grpc_column(
+            &table_meta,
+            "k",
+            Arc::new(Int32Vector::from_slice([3, 2, 1])),
+        )
+        .unwrap();
+        assert_eq!(column.column_name, "k");
+        assert_eq!(column.semantic_type, SemanticType::Tag as i32);
+        assert_eq!(column.values.unwrap().i32_values, vec![3, 2, 1]);
+        assert_eq!(column.null_mask, vec![0]);
+        assert_eq!(column.datatype, ColumnDataType::Int32 as i32);
+
+        let column = vector_to_grpc_column(
+            &table_meta,
+            "v",
+            Arc::new(StringVector::from(vec![
+                Some("hello"),
+                None,
+                Some("greptime"),
+            ])),
+        )
+        .unwrap();
+        assert_eq!(column.column_name, "v");
+        assert_eq!(column.semantic_type, SemanticType::Field as i32);
+        assert_eq!(
+            column.values.unwrap().string_values,
+            vec!["hello", "greptime"]
+        );
+        assert_eq!(column.null_mask, vec![2]);
+        assert_eq!(column.datatype, ColumnDataType::String as i32);
+    }
+
+    #[test]
+    fn test_to_grpc_insert_request() {
+        let schema = Schema::new(vec![
+            ColumnSchema::new("ts", ConcreteDataType::int64_datatype(), false)
+                .with_time_index(true),
+            ColumnSchema::new("id", ConcreteDataType::int16_datatype(), false),
+            ColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+        ]);
+
+        let mut builder = TableMetaBuilder::default();
+        builder.schema(Arc::new(schema));
+        builder.primary_key_indices(vec![]);
+        builder.next_column_id(3);
+
+        let table_meta = builder.build().unwrap();
+        let insert_request = mock_insert_request();
+        let request = to_grpc_insert_request(&table_meta, 12, insert_request).unwrap();
 
         verify_grpc_insert_request(request);
     }

--- a/src/frontend/src/table/scan.rs
+++ b/src/frontend/src/table/scan.rs
@@ -15,7 +15,7 @@
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use api::v1::{DeleteRequest, InsertRequest};
+use api::v1::DeleteRequest;
 use client::Database;
 use common_meta::table_name::TableName;
 use common_query::prelude::Expr;
@@ -45,10 +45,6 @@ impl std::fmt::Debug for DatanodeInstance {
 impl DatanodeInstance {
     pub(crate) fn new(table: TableRef, db: Database) -> Self {
         Self { table, db }
-    }
-
-    pub(crate) async fn grpc_insert(&self, request: InsertRequest) -> client::Result<u32> {
-        self.db.insert(request).await
     }
 
     pub(crate) async fn grpc_delete(&self, request: DeleteRequest) -> client::Result<u32> {

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -33,6 +33,7 @@ use tonic::transport::server::Router;
 use crate::cluster::MetaPeerClientBuilder;
 use crate::election::etcd::EtcdElection;
 use crate::lock::etcd::EtcdLock;
+use crate::lock::memory::MemLock;
 use crate::metasrv::builder::MetaSrvBuilder;
 use crate::metasrv::{MetaSrv, MetaSrvOptions, SelectorRef};
 use crate::selector::lease_based::LeaseBasedSelector;
@@ -152,7 +153,11 @@ pub fn router(meta_srv: MetaSrv) -> Router {
 
 pub async fn build_meta_srv(opts: &MetaSrvOptions) -> Result<MetaSrv> {
     let (kv_store, election, lock) = if opts.use_memory_store {
-        (Arc::new(MemStore::new()) as _, None, None)
+        (
+            Arc::new(MemStore::new()) as _,
+            None,
+            Some(Arc::new(MemLock::default()) as _),
+        )
     } else {
         let etcd_endpoints = [&opts.store_addr];
         let etcd_client = Client::connect(etcd_endpoints, None)

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -283,6 +283,12 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Table already exists: {table_name}"))]
+    TableAlreadyExists {
+        table_name: String,
+        location: Location,
+    },
+
     #[snafu(display("Pusher not found: {pusher_id}"))]
     PusherNotFound {
         pusher_id: String,
@@ -394,6 +400,7 @@ impl ErrorExt for Error {
             | Error::SendShutdownSignal { .. }
             | Error::ParseAddr { .. }
             | Error::SchemaAlreadyExists { .. }
+            | Error::TableAlreadyExists { .. }
             | Error::PusherNotFound { .. }
             | Error::PushMessage { .. }
             | Error::MailboxClosed { .. }

--- a/src/meta-srv/src/lock/keys.rs
+++ b/src/meta-srv/src/lock/keys.rs
@@ -15,6 +15,7 @@
 //! All keys used for distributed locking in the Metasrv.
 //! Place them in this unified module for better maintenance.
 
+use common_meta::table_name::TableName;
 use common_meta::RegionIdent;
 
 use crate::lock::Key;
@@ -29,4 +30,8 @@ pub(crate) fn table_metadata_lock_key(region: &RegionIdent) -> Key {
         region.table_ident.table_id,
     )
     .into_bytes()
+}
+
+pub(crate) fn table_creation_lock_key(table_name: &TableName) -> Key {
+    format!("table_creation_lock_({})", table_name).into_bytes()
 }

--- a/src/meta-srv/src/service/router.rs
+++ b/src/meta-srv/src/service/router.rs
@@ -164,7 +164,7 @@ async fn handle_create(
         return Ok(RouteResponse {
             header: Some(ResponseHeader::failed(
                 cluster_id,
-                Error::not_enough_active_datanodes(peers.len() as _),
+                Error::not_enough_available_datanodes(partitions.len(), peers.len()),
             )),
             ..Default::default()
         });

--- a/src/meta-srv/src/service/router.rs
+++ b/src/meta-srv/src/service/router.rs
@@ -29,7 +29,6 @@ use tonic::{Request, Response};
 
 use crate::error;
 use crate::error::Result;
-use crate::keys::TableRouteKey;
 use crate::lock::{keys, DistLockRef, Key, Opts};
 use crate::metasrv::{Context, MetaSrv, SelectorContext, SelectorRef};
 use crate::metrics::METRIC_META_ROUTE_REQUEST;

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+api = { path = "../api" }
 async-trait = "0.1"
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -94,7 +94,7 @@ impl PartitionRuleManager {
                     region: *region,
                 })?;
             datanodes
-                .entry(datanode)
+                .entry(datanode.clone())
                 .or_insert_with(Vec::new)
                 .push(*region);
         }

--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -88,15 +88,7 @@ impl PartitionRuleManager {
         let mut datanodes = HashMap::with_capacity(regions.len());
         for region in regions.iter() {
             let datanode = route
-                .region_routes
-                .iter()
-                .find_map(|x| {
-                    if x.region.id == *region as RegionId {
-                        x.leader_peer.clone()
-                    } else {
-                        None
-                    }
-                })
+                .find_region_leader(*region)
                 .context(error::FindDatanodeSnafu {
                     table: table.to_string(),
                     region: *region,

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -39,6 +39,7 @@ http-body = "0.4"
 humantime-serde = "1.1"
 hyper = { version = "0.14", features = ["full"] }
 influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", branch = "feat/line-protocol" }
+itertools.workspace = true
 metrics.workspace = true
 # metrics-process 1.0.10 depends on metrics-0.21 but opendal depends on metrics-0.20.1
 metrics-process = "<1.0.10"

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -109,7 +109,7 @@ impl GrpcServer {
                       or we have already waited for the serve result before.",
         })?;
         let Ok(result) = rx.await else {
-            warn!("Background gRPC serving task is quit before we can receive the serve result.");
+            warn!("Background gRPC serving task is quited before we can receive the serve result.");
             return Ok(());
         };
         if let Err(e) = result {

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -28,10 +28,11 @@ use arrow_flight::flight_service_server::{FlightService, FlightServiceServer};
 use async_trait::async_trait;
 use common_runtime::Runtime;
 use common_telemetry::logging::info;
+use common_telemetry::{error, warn};
 use futures::FutureExt;
-use snafu::{ensure, ResultExt};
+use snafu::{ensure, OptionExt, ResultExt};
 use tokio::net::TcpListener;
-use tokio::sync::oneshot::{self, Sender};
+use tokio::sync::oneshot::{self, Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
@@ -39,7 +40,8 @@ use tonic::{Request, Response, Status};
 use self::prom_query_gateway::PrometheusGatewayService;
 use crate::auth::UserProviderRef;
 use crate::error::{
-    AlreadyStartedSnafu, GrpcReflectionServiceSnafu, Result, StartGrpcSnafu, TcpBindSnafu,
+    AlreadyStartedSnafu, GrpcReflectionServiceSnafu, InternalSnafu, Result, StartGrpcSnafu,
+    TcpBindSnafu,
 };
 use crate::grpc::database::DatabaseService;
 use crate::grpc::flight::FlightHandler;
@@ -55,6 +57,10 @@ pub struct GrpcServer {
     request_handler: Arc<GreptimeRequestHandler>,
     /// Handler for Prometheus-compatible PromQL queries. Only present for frontend server.
     promql_handler: Option<PromHandlerRef>,
+
+    /// gRPC serving state receiver. Only present if the gRPC server is started.
+    /// Used to wait for the server to stop, performing the old blocking fashion.
+    serve_state: Mutex<Option<Receiver<Result<()>>>>,
 }
 
 impl GrpcServer {
@@ -73,6 +79,7 @@ impl GrpcServer {
             shutdown_tx: Mutex::new(None),
             request_handler,
             promql_handler,
+            serve_state: Mutex::new(None),
         }
     }
 
@@ -93,6 +100,22 @@ impl GrpcServer {
         handler: PromHandlerRef,
     ) -> PrometheusGatewayServer<impl PrometheusGateway> {
         PrometheusGatewayServer::new(PrometheusGatewayService::new(handler))
+    }
+
+    pub async fn wait_for_serve(&self) -> Result<()> {
+        let mut serve_state = self.serve_state.lock().await;
+        let rx = serve_state.take().context(InternalSnafu {
+            err_msg: "gRPC serving state is unknown, maybe the server is not started, \
+                      or we have already waited for the serve result before.",
+        })?;
+        let Ok(result) = rx.await else {
+            warn!("Background gRPC serving task is quit before we can receive the serve result.");
+            return Ok(());
+        };
+        if let Err(e) = result {
+            error!(e; "GRPC serve error");
+        }
+        Ok(())
     }
 }
 
@@ -151,7 +174,6 @@ impl Server for GrpcServer {
             .build()
             .context(GrpcReflectionServiceSnafu)?;
 
-        // Would block to serve requests.
         let mut builder = tonic::transport::Server::builder()
             .add_service(self.create_flight_service())
             .add_service(self.create_database_service())
@@ -160,12 +182,19 @@ impl Server for GrpcServer {
             builder =
                 builder.add_service(self.create_prom_query_gateway_service(promql_handler.clone()))
         }
-        builder
-            .add_service(reflection_service)
-            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), rx.map(drop))
-            .await
-            .context(StartGrpcSnafu)?;
+        let builder = builder.add_service(reflection_service);
 
+        let (serve_state_tx, serve_state_rx) = oneshot::channel();
+        let mut serve_state = self.serve_state.lock().await;
+        *serve_state = Some(serve_state_rx);
+
+        common_runtime::spawn_bg(async move {
+            let result = builder
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), rx.map(drop))
+                .await
+                .context(StartGrpcSnafu);
+            serve_state_tx.send(result)
+        });
         Ok(addr)
     }
 

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use api::v1::greptime_request::Request;
-use api::v1::InsertRequest;
+use api::v1::InsertRequests;
 use async_trait::async_trait;
 use axum::{http, Router};
 use axum_test_helper::TestClient;
@@ -54,9 +54,8 @@ impl GrpcQueryHandler for DummyInstance {
 #[async_trait]
 impl InfluxdbLineProtocolHandler for DummyInstance {
     async fn exec(&self, request: &InfluxdbRequest, ctx: QueryContextRef) -> Result<()> {
-        let requests: Vec<InsertRequest> = request.try_into()?;
-
-        for expr in requests {
+        let requests: InsertRequests = request.try_into()?;
+        for expr in requests.inserts {
             let _ = self.tx.send((ctx.current_schema(), expr.table_name)).await;
         }
 

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -154,7 +154,7 @@ impl GrpcQueryHandler for DummyInstance {
         ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error> {
         let output = match request {
-            Request::Insert(_) | Request::Delete(_) => unimplemented!(),
+            Request::Inserts(_) | Request::Delete(_) => unimplemented!(),
             Request::Query(query_request) => {
                 let query = query_request.query.unwrap();
                 match query {

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -15,7 +15,7 @@ common-time = { path = "../common/time" }
 datafusion-sql.workspace = true
 datatypes = { path = "../datatypes" }
 hex = "0.4"
-itertools = "0.10"
+itertools.workspace = true
 mito = { path = "../mito" }
 once_cell = "1.10"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -25,7 +25,7 @@ datafusion-common.workspace = true
 datafusion-expr.workspace = true
 futures.workspace = true
 futures-util.workspace = true
-itertools = "0.10"
+itertools.workspace = true
 lazy_static = "1.4"
 metrics.workspace = true
 object-store = { path = "../object-store" }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -61,7 +61,7 @@ uuid.workspace = true
 common-procedure = { path = "../src/common/procedure" }
 datafusion.workspace = true
 datafusion-expr.workspace = true
-itertools = "0.10"
+itertools.workspace = true
 partition = { path = "../src/partition" }
 paste.workspace = true
 prost.workspace = true

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -23,7 +23,7 @@ mod test {
     use api::v1::{
         alter_expr, AddColumn, AddColumns, AlterExpr, Column, ColumnDataType, ColumnDef,
         CreateDatabaseExpr, CreateTableExpr, DdlRequest, DeleteRequest, DropTableExpr,
-        FlushTableExpr, InsertRequest, QueryRequest,
+        FlushTableExpr, InsertRequest, InsertRequests, QueryRequest,
     };
     use catalog::helper::{TableGlobalKey, TableGlobalValue};
     use common_catalog::consts::MITO_ENGINE;
@@ -482,7 +482,13 @@ CREATE TABLE {table_name} (
             row_count: 16,
             ..Default::default()
         };
-        let output = query(instance, Request::Insert(insert)).await;
+        let output = query(
+            instance,
+            Request::Inserts(InsertRequests {
+                inserts: vec![insert],
+            }),
+        )
+        .await;
         assert!(matches!(output, Output::AffectedRows(16)));
 
         let request = Request::Query(QueryRequest {
@@ -670,7 +676,9 @@ CREATE TABLE {table_name} (
         };
 
         // Test auto create not existed table upon insertion.
-        let request = Request::Insert(insert);
+        let request = Request::Inserts(InsertRequests {
+            inserts: vec![insert],
+        });
         let output = query(instance, request).await;
         assert!(matches!(output, Output::AffectedRows(3)));
 
@@ -703,7 +711,9 @@ CREATE TABLE {table_name} (
         };
 
         // Test auto add not existed column upon insertion.
-        let request = Request::Insert(insert);
+        let request = Request::Inserts(InsertRequests {
+            inserts: vec![insert],
+        });
         let output = query(instance, request).await;
         assert!(matches!(output, Output::AffectedRows(3)));
 
@@ -829,7 +839,9 @@ CREATE TABLE {table_name} (
             ..Default::default()
         };
 
-        let request = Request::Insert(insert);
+        let request = Request::Inserts(InsertRequests {
+            inserts: vec![insert],
+        });
         let output = query(instance, request).await;
         assert!(matches!(output, Output::AffectedRows(8)));
 

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -421,8 +421,6 @@ pub async fn setup_grpc_server(
             .unwrap(),
     );
 
-    let fe_grpc_addr = format!("127.0.0.1:{}", ports::get_port());
-
     let fe_instance = FeInstance::try_new_standalone(instance.clone())
         .await
         .unwrap();
@@ -434,13 +432,13 @@ pub async fn setup_grpc_server(
         None,
         runtime,
     ));
-    let grpc_server_clone = fe_grpc_server.clone();
 
-    let fe_grpc_addr_clone = fe_grpc_addr.clone();
-    tokio::spawn(async move {
-        let addr = fe_grpc_addr_clone.parse::<SocketAddr>().unwrap();
-        grpc_server_clone.start(addr).await.unwrap()
-    });
+    let fe_grpc_addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+    let fe_grpc_addr = fe_grpc_server
+        .start(fe_grpc_addr)
+        .await
+        .unwrap()
+        .to_string();
 
     // wait for GRPC server to start
     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -17,7 +17,8 @@ use api::v1::column::SemanticType;
 use api::v1::promql_request::Promql;
 use api::v1::{
     column, AddColumn, AddColumns, AlterExpr, Column, ColumnDataType, ColumnDef, CreateTableExpr,
-    InsertRequest, PromInstantQuery, PromRangeQuery, PromqlRequest, RequestHeader, TableId,
+    InsertRequest, InsertRequests, PromInstantQuery, PromRangeQuery, PromqlRequest, RequestHeader,
+    TableId,
 };
 use client::{Client, Database, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::consts::{MIN_USER_TABLE_ID, MITO_ENGINE};
@@ -86,7 +87,11 @@ pub async fn test_invalid_dbname(store_type: StorageType) {
         ],
         row_count: 4,
     };
-    let result = db.insert(request).await;
+    let result = db
+        .insert(InsertRequests {
+            inserts: vec![request],
+        })
+        .await;
     assert!(result.is_err());
 
     let _ = fe_grpc_server.shutdown().await;
@@ -230,7 +235,11 @@ async fn insert_and_assert(db: &Database) {
         ],
         row_count: 4,
     };
-    let result = db.insert(request).await;
+    let result = db
+        .insert(InsertRequests {
+            inserts: vec![request],
+        })
+        .await;
     assert_eq!(result.unwrap(), 4);
 
     let result = db


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Trying to optimize Prometheus remote write.

Now the remote write path is like this:

```txt
remote write     ->    grpc insert     ->   `DistInserter`(splits inserts here)      -> Datanodes
(single request)     (single request)       (multiple batching requests)                (parallel)
                                            (other protocols insertions all go here)
```

Before:

```txt
remote write     ->    grpc insert     ->   `DistTable::insert`(splits inserts here) -> Datanodes
(single request)     (multiple requests,    (single request)                         (single request)
                      for each table)
```

This PR also:

- makes the inserts in Datanode GRPC interface parallel.
- makes the table "create-on-insert" parallel (we have to add a distributed lock in Metasrv)
  - will be changed to use procedure soon
- makes the gRPC server no longer blocks

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
