### PR TITLE
feat: exists API for KVStore

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -188,13 +188,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Invalid KVs length, expected: {}, actual: {}", expected, actual))]
-    InvalidKvsLength {
-        expected: usize,
-        actual: usize,
-        location: Location,
-    },
-
     #[snafu(display("Failed to create gRPC channel, source: {}", source))]
     CreateChannel {
         #[snafu(backtrace)]
@@ -428,7 +421,6 @@ impl ErrorExt for Error {
             | Error::NextSequence { .. }
             | Error::SequenceOutOfRange { .. }
             | Error::MoveValue { .. }
-            | Error::InvalidKvsLength { .. }
             | Error::InvalidTxnResult { .. }
             | Error::InvalidUtf8Value { .. }
             | Error::UnexpectedInstructionReply { .. }

--- a/src/meta-srv/src/service/store/ext.rs
+++ b/src/meta-srv/src/service/store/ext.rs
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 use api::v1::meta::{KeyValue, RangeRequest};
-use snafu::ensure;
 
-use crate::error::{self, Result};
+use crate::error::Result;
 use crate::service::store::kv::KvStore;
 
 #[async_trait::async_trait]
 pub trait KvStoreExt {
+    /// Get the value by the given key.
     async fn get(&self, key: Vec<u8>) -> Result<Option<KeyValue>>;
+
+    /// Check if a key exists, it does not return the value.
+    async fn exists(&self, key: Vec<u8>) -> Result<bool>;
 }
 
 #[async_trait::async_trait]
@@ -36,20 +39,19 @@ where
 
         let mut kvs = self.range(req).await?.kvs;
 
-        if kvs.is_empty() {
-            return Ok(None);
-        }
+        Ok(kvs.pop())
+    }
 
-        ensure!(
-            kvs.len() == 1,
-            error::InvalidKvsLengthSnafu {
-                expected: 1_usize,
-                actual: kvs.len(),
-            }
-        );
+    async fn exists(&self, key: Vec<u8>) -> Result<bool> {
+        let req = RangeRequest {
+            key,
+            keys_only: true,
+            ..Default::default()
+        };
 
-        // Safety: the length check has been performed before using unwrap()
-        Ok(Some(kvs.pop().unwrap()))
+        let kvs = self.range(req).await?.kvs;
+
+        Ok(!kvs.is_empty())
     }
 }
 
@@ -90,6 +92,26 @@ mod tests {
         let may_kv = in_mem.get("test_key3".as_bytes().to_vec()).await.unwrap();
 
         assert!(may_kv.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let mut in_mem = Arc::new(MemStore::new()) as KvStoreRef;
+
+        put_stats_to_store(&mut in_mem).await;
+
+        assert!(in_mem
+            .exists("test_key1".as_bytes().to_vec())
+            .await
+            .unwrap());
+        assert!(in_mem
+            .exists("test_key2".as_bytes().to_vec())
+            .await
+            .unwrap());
+        assert!(!in_mem
+            .exists("test_key3".as_bytes().to_vec())
+            .await
+            .unwrap());
     }
 
     async fn put_stats_to_store(store: &mut KvStoreRef) {

--- a/src/meta-srv/src/service/store/ext.rs
+++ b/src/meta-srv/src/service/store/ext.rs
@@ -112,6 +112,7 @@ mod tests {
             .exists("test_key3".as_bytes().to_vec())
             .await
             .unwrap());
+        assert!(!in_mem.exists("test_key".as_bytes().to_vec()).await.unwrap());
     }
 
     async fn put_stats_to_store(store: &mut KvStoreRef) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `exists` API for KVStore to check if a key exists, it does not return the value.
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
