### PR TITLE
fix: avoid writing manifest and wal if no files are actually flushed

### DIFF
--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 use std::fmt::{Debug, Formatter};
 
 use common_base::readable_size::ReadableSize;
-use common_telemetry::{debug, error, timer};
+use common_telemetry::{debug, error, info, timer};
 use store_api::logstore::LogStore;
 use store_api::storage::RegionId;
 
@@ -148,6 +148,7 @@ impl<S: LogStore> CompactionTask for CompactionTaskImpl<S> {
             e
         })?;
         compacted.extend(self.expired_ssts.iter().map(FileHandle::meta));
+        info!("Compacting SST files, input: {compacted:?}, output: {output:?}");
         self.write_manifest_and_apply(output, compacted)
             .await
             .map_err(|e| {

--- a/src/storage/src/compaction/task.rs
+++ b/src/storage/src/compaction/task.rs
@@ -148,7 +148,10 @@ impl<S: LogStore> CompactionTask for CompactionTaskImpl<S> {
             e
         })?;
         compacted.extend(self.expired_ssts.iter().map(FileHandle::meta));
-        info!("Compacting SST files, input: {compacted:?}, output: {output:?}");
+
+        let input_ids = compacted.iter().map(|f| f.file_id).collect::<Vec<_>>();
+        let output_ids = output.iter().map(|f| f.file_id).collect::<Vec<_>>();
+        info!("Compacting SST files, input: {input_ids:?}, output: {output_ids:?}");
         self.write_manifest_and_apply(output, compacted)
             .await
             .map_err(|e| {

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -239,6 +239,10 @@ impl<S: LogStore> FlushJob<S> {
         let _timer = timer!(FLUSH_ELAPSED);
 
         let file_metas = self.write_memtables_to_layer().await?;
+        if file_metas.is_empty() {
+            // skip writing manifest and wal if no files are flushed.
+            return Ok(());
+        }
         self.write_manifest_and_apply(&file_metas).await?;
 
         Ok(())
@@ -293,7 +297,7 @@ impl<S: LogStore> FlushJob<S> {
             .flatten()
             .collect();
 
-        logging::info!("Successfully flush memtables to files: {:?}", metas);
+        logging::info!("Successfully flush memtables, region:{region_id}, files: {metas:?}");
         Ok(metas)
     }
 

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -291,13 +291,14 @@ impl<S: LogStore> FlushJob<S> {
             });
         }
 
-        let metas = futures_util::future::try_join_all(futures)
+        let metas: Vec<_> = futures_util::future::try_join_all(futures)
             .await?
             .into_iter()
             .flatten()
             .collect();
 
-        logging::info!("Successfully flush memtables, region:{region_id}, files: {metas:?}");
+        let file_ids = metas.iter().map(|f| f.file_id).collect::<Vec<_>>();
+        logging::info!("Successfully flush memtables, region:{region_id}, files: {file_ids:?}");
         Ok(metas)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR avoids manifest and wal writes when no files are flushed so that meaningless sequence bumping is prevented.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
