### PR TITLE
fix: enable region failover test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9381,6 +9381,7 @@ name = "tests-integration"
 version = "0.2.0"
 dependencies = [
  "api",
+ "async-trait",
  "axum",
  "axum-test-helper",
  "catalog",

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -375,21 +375,6 @@ mod tests {
         }
     }
 
-    // The "foreign" means the Datanode is not containing any regions to the table before.
-    pub struct ForeignNodeSelector {
-        pub foreign: Peer,
-    }
-
-    #[async_trait]
-    impl Selector for ForeignNodeSelector {
-        type Context = SelectorContext;
-        type Output = Vec<Peer>;
-
-        async fn select(&self, _ns: Namespace, _ctx: &Self::Context) -> Result<Self::Output> {
-            Ok(vec![self.foreign.clone()])
-        }
-    }
-
     pub struct TestingEnv {
         pub context: RegionFailoverContext,
         pub heartbeat_receivers: HashMap<DatanodeId, Receiver<tonic::Result<HeartbeatResponse>>>,

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -11,6 +11,7 @@ dashboard = []
 api = { path = "../src/api" }
 axum = "0.6"
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
+async-trait = "0.1"
 catalog = { path = "../src/catalog" }
 client = { path = "../src/client" }
 common-base = { path = "../src/common/base" }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Enable the disabled region failover tests(#1660). 

In #1660 introduces a limitation, if a table in the datanode contains multiple regions, then the scan will lead to an incorrect result, Which means we can only tolerate `n` node failures in an `m` nodes cluster, and the number of regions the table contains should be less than or equal `m-n`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1660