### PR TITLE
chore: bump greptimedb version 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -199,7 +199,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arrow-flight",
  "common-base",
@@ -831,9 +831,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bcder"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69dfb7dc0d4aee3f8c723c43553b55662badf692b541ff8e4426df75dae8da9a"
+checksum = "ab26f019795af36086f2ca879aeeaae7566bdfd2fe0821a0328d3fdd9d1da2d9"
 dependencies = [
  "bytes",
  "smallvec",
@@ -841,10 +841,10 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
- "clap 4.3.0",
+ "clap 4.3.1",
  "client",
  "indicatif",
  "itertools",
@@ -1224,7 +1224,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1445,20 +1445,20 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.0",
+ "clap_derive 4.3.1",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "72394f3339a76daf211e57d4bcb374410f3965dcc606dd0e03738c7888766980"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1509,7 +1509,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "client"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1534,7 +1534,7 @@ dependencies = [
  "prost",
  "rand",
  "snafu",
- "substrait 0.2.0",
+ "substrait 0.4.0",
  "substrait 0.7.5",
  "tokio",
  "tokio-stream",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anymap",
  "build-data",
@@ -1601,7 +1601,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.2.0",
+ "substrait 0.4.0",
  "temp-env",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
@@ -1634,7 +1634,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "snafu",
  "strum",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "chrono-tz 0.6.3",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "common-function-macro"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "backtrace",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "common-error",
  "snafu",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "chrono",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "common-error",
  "datafusion",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "once_cell",
  "rand",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "chrono-tz 0.8.2",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-compat",
@@ -2622,7 +2622,7 @@ dependencies = [
  "sql",
  "storage",
  "store-api",
- "substrait 0.2.0",
+ "substrait 0.4.0",
  "table",
  "table-procedure",
  "tokio",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "file-table-engine"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "common-catalog",
@@ -3114,9 +3114,9 @@ checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "flatbuffers"
-version = "23.1.21"
+version = "23.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f5399c2c9c50ae9418e522842ad362f61ee48b346ac106807bd355a8a7c619"
+checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version 0.4.0",
@@ -3159,7 +3159,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-compat",
@@ -3213,7 +3213,7 @@ dependencies = [
  "storage",
  "store-api",
  "strfmt",
- "substrait 0.2.0",
+ "substrait 0.4.0",
  "table",
  "tokio",
  "toml",
@@ -4385,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db45317f37ef454e6519b6c3ed7d377e5f23346f0823f86e65ca36912d1d0ef8"
+checksum = "8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057"
 dependencies = [
  "console",
  "instant",
@@ -4699,9 +4699,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
 
 [[package]]
 name = "libgit2-sys"
@@ -4801,7 +4801,7 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "log-store"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anymap",
  "api",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anymap",
  "arc-swap",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5782,9 +5782,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6677,7 +6677,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "ahash 0.8.3",
  "approx_eq",
@@ -6981,7 +6981,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.2.0",
+ "substrait 0.4.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -7179,7 +7179,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -8139,7 +8139,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "script"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "aide",
  "api",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "common-catalog",
@@ -8751,7 +8751,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "common-base",
@@ -8797,7 +8797,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "client",
@@ -8972,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9132,7 +9132,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "table-procedure"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "catalog",
@@ -9393,7 +9393,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "api",
  "async-trait",
@@ -11072,9 +11072,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR bumps greptimedb project version from 0.2.0 to 0.4.0

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
