### PR TITLE
feat: Adds some metrics for write path and flush

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,7 @@ dependencies = [
  "futures",
  "key-lock",
  "log-store",
+ "metrics",
  "object-store",
  "serde",
  "serde_json",

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -21,6 +21,7 @@ common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-datasource = { path = "../common/datasource" }
 common-telemetry = { path = "../common/telemetry" }
+common-test-util = { path = "../common/test-util", optional = true }
 common-time = { path = "../common/time" }
 dashmap = "5.4"
 datafusion.workspace = true
@@ -29,6 +30,7 @@ datatypes = { path = "../datatypes" }
 futures.workspace = true
 key-lock = "0.1"
 log-store = { path = "../log-store" }
+metrics.workspace = true
 object-store = { path = "../object-store" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -36,7 +38,6 @@ snafu.workspace = true
 storage = { path = "../storage" }
 store-api = { path = "../store-api" }
 table = { path = "../table" }
-common-test-util = { path = "../common/test-util", optional = true }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/mito/src/metrics.rs
+++ b/src/mito/src/metrics.rs
@@ -25,3 +25,7 @@ pub const MITO_CREATE_TABLE_UPDATE_MANIFEST_ELAPSED: &str =
 pub const MITO_OPEN_TABLE_ELAPSED: &str = "datanode.mito.open_table";
 /// Elapsed time of altering tables
 pub const MITO_ALTER_TABLE_ELAPSED: &str = "datanode.mito.alter_table";
+/// Elapsed time of insertion
+pub const MITO_INSERT_ELAPSED: &str = "datanode.mito.insert";
+/// Insert batch size.
+pub const MITO_INSERT_BATCH_SIZE: &str = "datanode.mito.insert_batch_size";

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -341,12 +341,13 @@ mod tests {
         builder.root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
+        let test_gc_duration = Duration::from_millis(50);
         let manifest = RegionManifest::with_checkpointer(
             "/manifest/",
             object_store,
             manifest_compress_type(compress),
             None,
-            Some(Duration::from_millis(50)),
+            Some(test_gc_duration),
         );
         manifest.start().await.unwrap();
 
@@ -492,7 +493,7 @@ mod tests {
         );
 
         // wait for gc
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        tokio::time::sleep(test_gc_duration * 3).await;
 
         for v in checkpoint_versions {
             if v < 4 {

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -17,6 +17,7 @@ use store_api::storage::{OpType, SequenceNumber};
 use super::MemtableRef;
 use crate::error::Result;
 use crate::memtable::KeyValues;
+use crate::metrics::MEMTABLE_WRITE_ELAPSED;
 use crate::write_batch::{Mutation, Payload};
 
 /// Wraps logic of inserting key/values in [WriteBatch] to [Memtable].
@@ -40,6 +41,8 @@ impl Inserter {
     /// Won't do schema validation if not configured. Caller (mostly the [`RegionWriter`]) should ensure the
     /// schemas of `memtable` are consistent with `payload`'s.
     pub fn insert_memtable(&mut self, payload: &Payload, memtable: &MemtableRef) -> Result<()> {
+        let _timer = common_telemetry::timer!(MEMTABLE_WRITE_ELAPSED);
+
         if payload.is_empty() {
             return Ok(());
         }

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -36,3 +36,5 @@ pub const COMPACT_ELAPSED: &str = "storage.compact.elapsed";
 pub const WRITE_BUFFER_BYTES: &str = "storage.write_buffer_bytes";
 /// Elapsed time of inserting memtable.
 pub const MEMTABLE_WRITE_ELAPSED: &str = "storage.memtable.write.elapsed";
+/// Elapsed time of preprocessing write batch.
+pub const PREPROCESS_ELAPSED: &str = "storage.write.preprocess";

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -22,6 +22,8 @@ pub const FLUSH_REQUESTS_TOTAL: &str = "storage.flush.requests_total";
 pub const FLUSH_ERRORS_TOTAL: &str = "storage.flush.errors_total";
 /// Elapsed time of a flush job.
 pub const FLUSH_ELAPSED: &str = "storage.flush.elapsed";
+/// Counter of flushed bytes.
+pub const FLUSH_BYTES_TOTAL: &str = "storage.flush.bytes_total";
 /// Reason to flush.
 pub const FLUSH_REASON: &str = "reason";
 /// Gauge for open regions
@@ -32,3 +34,5 @@ pub const LOG_STORE_WRITE_ELAPSED: &str = "storage.logstore.write.elapsed";
 pub const COMPACT_ELAPSED: &str = "storage.compact.elapsed";
 /// Global write buffer size in bytes.
 pub const WRITE_BUFFER_BYTES: &str = "storage.write_buffer_bytes";
+/// Elapsed time of inserting memtable.
+pub const MEMTABLE_WRITE_ELAPSED: &str = "storage.memtable.write.elapsed";

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -37,4 +37,4 @@ pub const WRITE_BUFFER_BYTES: &str = "storage.write_buffer_bytes";
 /// Elapsed time of inserting memtable.
 pub const MEMTABLE_WRITE_ELAPSED: &str = "storage.memtable.write.elapsed";
 /// Elapsed time of preprocessing write batch.
-pub const PREPROCESS_ELAPSED: &str = "storage.write.preprocess";
+pub const PREPROCESS_ELAPSED: &str = "storage.write.preprocess.elapsed";

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -39,7 +39,7 @@ use crate::manifest::action::{
 };
 use crate::memtable::{Inserter, MemtableBuilderRef, MemtableId, MemtableRef};
 use crate::metadata::RegionMetadataRef;
-use crate::metrics::{FLUSH_REASON, FLUSH_REQUESTS_TOTAL};
+use crate::metrics::{FLUSH_REASON, FLUSH_REQUESTS_TOTAL, PREPROCESS_ELAPSED};
 use crate::proto::wal::WalHeader;
 use crate::region::{
     CompactContext, RecoverdMetadata, RecoveredMetadataMap, RegionManifest, SharedDataRef,
@@ -670,6 +670,8 @@ impl WriterInner {
         &mut self,
         writer_ctx: &WriterContext<'_, S>,
     ) -> Result<()> {
+        let _timer = common_telemetry::timer!(PREPROCESS_ELAPSED);
+
         let version_control = writer_ctx.version_control();
         // Check whether memtable is full or flush should be triggered. We need to do this first since
         // switching memtables will clear all mutable memtables.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds the following metrics
- write elapsed time of a mito table
- write batch size of a mito table
- memtable/preprocess elapsed time
- flushed bytes

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
