### PR TITLE
feat: make jemalloc the default allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ name = "benchmarks"
 version = "0.4.0"
 dependencies = [
  "arrow",
- "clap 4.3.1",
+ "clap 4.3.2",
  "client",
  "indicatif",
  "itertools",
@@ -1445,12 +1445,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.1",
+ "clap_derive 4.3.2",
  "once_cell",
 ]
 
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1603,7 +1603,6 @@ dependencies = [
  "snafu",
  "substrait 0.4.0",
  "temp-env",
- "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "toml",
@@ -2380,7 +2379,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -3141,9 +3140,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -4348,9 +4347,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -4785,9 +4784,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -5734,9 +5733,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -6025,7 +6024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -6044,18 +6043,18 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
  "libc",
  "petgraph",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
  "thread-id",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -6195,9 +6194,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -7175,9 +7174,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
@@ -8462,6 +8461,7 @@ dependencies = [
  "sql",
  "strum",
  "table",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
@@ -10493,9 +10493,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -41,7 +41,7 @@ servers = { path = "../servers" }
 session = { path = "../session" }
 snafu.workspace = true
 substrait = { path = "../common/substrait" }
-tikv-jemallocator = { version = "0.5" }
+tikv-jemallocator = "0.5"
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -10,7 +10,6 @@ name = "greptime"
 path = "src/bin/greptime.rs"
 
 [features]
-mem-prof = ["tikv-jemallocator", "tikv-jemalloc-ctl"]
 tokio-console = ["common-telemetry/tokio-console"]
 
 [dependencies]
@@ -42,8 +41,7 @@ servers = { path = "../servers" }
 session = { path = "../session" }
 snafu.workspace = true
 substrait = { path = "../common/substrait" }
-tikv-jemalloc-ctl = { version = "0.5", optional = true }
-tikv-jemallocator = { version = "0.5", optional = true }
+tikv-jemallocator = { version = "0.5" }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -180,7 +180,6 @@ fn full_version() -> &'static str {
     )
 }
 
-#[cfg(feature = "mem-prof")]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -71,6 +71,7 @@ snap = "1"
 sql = { path = "../sql" }
 strum = { version = "0.24", features = ["derive"] }
 table = { path = "../table" }
+tikv-jemalloc-ctl = "0.5"
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -267,9 +267,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(
-        "Failed to update jemalloc metrics, source: {source:?}, location: {location:?}"
-    ))]
+    #[snafu(display("Failed to update jemalloc metrics, source: {source}, location: {location}"))]
     UpdateJemallocMetrics {
         source: tikv_jemalloc_ctl::Error,
         location: Location,

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -266,6 +266,14 @@ pub enum Error {
         source: tokio::task::JoinError,
         location: Location,
     },
+
+    #[snafu(display(
+        "Failed to update jemalloc metrics, source: {source:?}, location: {location:?}"
+    ))]
+    UpdateJemallocMetrics {
+        source: tikv_jemalloc_ctl::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -341,6 +349,7 @@ impl ErrorExt for Error {
                     StatusCode::Unknown
                 }
             }
+            UpdateJemallocMetrics { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use session::context::UserInfo;
 
 use crate::http::{ApiState, JsonResponse};
-use crate::metrics::PROCESS_COLLECTOR;
+use crate::metrics::{JEMALLOC_COLLECTOR, PROCESS_COLLECTOR};
 use crate::metrics_handler::MetricsHandler;
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -137,7 +137,7 @@ pub async fn metrics(
 ) -> String {
     // Collect process metrics.
     PROCESS_COLLECTOR.collect();
-
+    JEMALLOC_COLLECTOR.as_ref().map(|c| c.update());
     state.render()
 }
 

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -19,7 +19,7 @@ use aide::transform::TransformOperation;
 use axum::extract::{Json, Query, State};
 use axum::{Extension, Form};
 use common_error::status_code::StatusCode;
-use common_telemetry::timer;
+use common_telemetry::{error, timer};
 use query::parser::PromQuery;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -137,7 +137,11 @@ pub async fn metrics(
 ) -> String {
     // Collect process metrics.
     PROCESS_COLLECTOR.collect();
-    JEMALLOC_COLLECTOR.as_ref().map(|c| c.update());
+    if let Some(c) = JEMALLOC_COLLECTOR.as_ref() {
+        if let Err(e) = c.update() {
+            error!(e; "Failed to update jemalloc metrics");
+        }
+    }
     state.render()
 }
 

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -67,6 +67,8 @@ pub(crate) const METRIC_GRPC_REQUESTS_ELAPSED: &str = "servers.grpc_requests_ela
 pub(crate) const METRIC_METHOD_LABEL: &str = "method";
 pub(crate) const METRIC_PATH_LABEL: &str = "path";
 pub(crate) const METRIC_STATUS_LABEL: &str = "status";
+pub(crate) const METRIC_JEMALLOC_RESIDENT: &str = "sys.jemalloc.resident";
+pub(crate) const METRIC_JEMALLOC_ALLOCATED: &str = "sys.jemalloc.allocated";
 
 /// Prometheus style process metrics collector.
 pub(crate) static PROCESS_COLLECTOR: Lazy<Collector> = Lazy::new(|| {
@@ -113,8 +115,8 @@ impl JemallocCollector {
         self.epoch.advance().context(UpdateJemallocMetricsSnafu)?;
         let allocated = self.allocated.read().context(UpdateJemallocMetricsSnafu)?;
         let resident = self.resident.read().context(UpdateJemallocMetricsSnafu)?;
-        gauge!("sys.jemalloc.allocated", allocated as f64);
-        gauge!("sys.jemalloc.resident", resident as f64);
+        gauge!(METRIC_JEMALLOC_ALLOCATED, allocated as f64);
+        gauge!(METRIC_JEMALLOC_RESIDENT, resident as f64);
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR makes jemalloc as the default memory allocator for GreptimeDB. Also it adds two jemalloc metrics:
- `greptime_sys_jemalloc_allocated`: the memory footprint in bytes allocated by jemalloc
- `greptime_sys_jemalloc_resident`: the resident set of allocated memory 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
