### PR TITLE
feat: add route admin api in metasrv

### DIFF
--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -16,6 +16,7 @@ mod health;
 mod heartbeat;
 mod leader;
 mod meta;
+mod route;
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -70,6 +71,13 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         "/leader",
         leader::LeaderHandler {
             election: meta_srv.election(),
+        },
+    );
+
+    let router = router.route(
+        "/route",
+        route::RouteHandler {
+            kv_store: meta_srv.kv_store(),
         },
     );
 

--- a/src/meta-srv/src/service/admin/route.rs
+++ b/src/meta-srv/src/service/admin/route.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::HashMap;
 
 use api::v1::meta::{RangeRequest, RangeResponse, TableRouteValue};


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Since the table route stored in etcd is encoded by protobuf, it is difficult to understand. 

So this pr provides an api to query table route information.

for example: 
```shell
curl "localhost:3002/admin/route?full_table_name=greptime.public.dist_table"
```


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
