### PR TITLE
fix: parquet time range predicate panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,7 @@ name = "benchmarks"
 version = "0.4.0"
 dependencies = [
  "arrow",
- "clap 4.3.1",
+ "clap 4.3.2",
  "client",
  "indicatif",
  "itertools",
@@ -1445,12 +1445,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ed2379f8603fa2b7509891660e802b88c70a79a6427a70abb5968054de2c28"
+checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.1",
+ "clap_derive 4.3.2",
  "once_cell",
 ]
 
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e9ef9a08ee1c0e1f2e162121665ac45ac3783b0f897db7244ae75ad9a8f65b"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2380,7 +2380,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -3141,9 +3141,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -4348,9 +4348,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -4785,9 +4785,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -5734,9 +5734,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr",
 ]
@@ -6025,7 +6025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -6044,18 +6044,18 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
  "libc",
  "petgraph",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec",
  "thread-id",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -6195,9 +6195,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
@@ -7175,9 +7175,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick 1.0.2",
  "memchr",
@@ -10493,9 +10493,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/src/storage/src/region/tests/alter.rs
+++ b/src/storage/src/region/tests/alter.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use common_test_util::temp_dir::create_temp_dir;
 use datatypes::prelude::*;
 use datatypes::timestamp::TimestampMillisecond;
-use datatypes::vectors::{Int64Vector, TimestampMillisecondVector, VectorRef};
+use datatypes::vectors::{Int64Vector, StringVector, TimestampMillisecondVector, VectorRef};
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use store_api::storage::{
     AddColumn, AlterOperation, AlterRequest, Chunk, ChunkReader, ColumnDescriptor,
@@ -53,18 +53,22 @@ struct AlterTester {
 struct DataRow {
     key: Option<i64>,
     ts: TimestampMillisecond,
-    v0: Option<i64>,
+    v0: Option<String>,
     v1: Option<i64>,
 }
 
 impl DataRow {
-    fn new(key: Option<i64>, ts: i64, v0: Option<i64>, v1: Option<i64>) -> Self {
+    fn new_with_string(key: Option<i64>, ts: i64, v0: Option<String>, v1: Option<i64>) -> Self {
         DataRow {
             key,
             ts: ts.into(),
             v0,
             v1,
         }
+    }
+
+    fn new(key: Option<i64>, ts: i64, v0: Option<i64>, v1: Option<i64>) -> Self {
+        Self::new_with_string(key, ts, v0.map(|s| s.to_string()), v1)
     }
 }
 
@@ -76,7 +80,7 @@ fn new_put_data(data: &[DataRow]) -> HashMap<String, VectorRef> {
             .map(|v| Some(v.ts.into_native()))
             .collect::<Vec<_>>(),
     );
-    let values1 = Int64Vector::from(data.iter().map(|kv| kv.v0).collect::<Vec<_>>());
+    let values1 = StringVector::from(data.iter().map(|v| v.v0.clone()).collect::<Vec<_>>());
     let values2 = Int64Vector::from(data.iter().map(|kv| kv.v1).collect::<Vec<_>>());
 
     put_data.insert("k0".to_string(), Arc::new(keys) as VectorRef);
@@ -158,13 +162,21 @@ impl AlterTester {
     /// Put data with initial schema.
     async fn put_with_init_schema(&self, data: &[(i64, Option<i64>)]) {
         // put of FileTesterBase always use initial schema version.
-        self.base().put(data).await;
+        let data = data
+            .iter()
+            .map(|(ts, v0)| (*ts, v0.map(|v| v.to_string())))
+            .collect::<Vec<_>>();
+        self.base().put(&data).await;
     }
 
     /// Put data to inner writer with initial schema.
     async fn put_inner_with_init_schema(&self, data: &[(i64, Option<i64>)]) {
+        let data = data
+            .iter()
+            .map(|(ts, v0)| (*ts, v0.map(|v| v.to_string())))
+            .collect::<Vec<_>>();
         // put of FileTesterBase always use initial schema version.
-        self.base().put_inner(data).await;
+        self.base().put_inner(&data).await;
     }
 
     async fn alter(&self, mut req: AlterRequest) {
@@ -179,7 +191,7 @@ impl AlterTester {
         metadata.version()
     }
 
-    async fn full_scan_with_init_schema(&self) -> Vec<(i64, Option<i64>)> {
+    async fn full_scan_with_init_schema(&self) -> Vec<(i64, Option<String>)> {
         self.base().full_scan().await
     }
 
@@ -219,17 +231,17 @@ fn append_chunk_to(chunk: &Chunk, dst: &mut Vec<DataRow>) {
         .unwrap();
     let v0_vector = chunk.columns[2]
         .as_any()
-        .downcast_ref::<Int64Vector>()
+        .downcast_ref::<StringVector>()
         .unwrap();
     let v1_vector = chunk.columns[3]
         .as_any()
         .downcast_ref::<Int64Vector>()
         .unwrap();
     for i in 0..k0_vector.len() {
-        dst.push(DataRow::new(
+        dst.push(DataRow::new_with_string(
             k0_vector.get_data(i),
             ts_vector.get_data(i).unwrap().into(),
-            v0_vector.get_data(i),
+            v0_vector.get_data(i).map(|s| s.to_string()),
             v1_vector.get_data(i),
         ));
     }

--- a/src/storage/src/region/tests/close.rs
+++ b/src/storage/src/region/tests/close.rs
@@ -65,11 +65,19 @@ impl CloseTester {
     }
 
     async fn put(&self, data: &[(i64, Option<i64>)]) -> WriteResponse {
-        self.base().put(data).await
+        let data = data
+            .iter()
+            .map(|(ts, v0)| (*ts, v0.map(|v| v.to_string())))
+            .collect::<Vec<_>>();
+        self.base().put(&data).await
     }
 
     async fn try_put(&self, data: &[(i64, Option<i64>)]) -> Result<WriteResponse, Error> {
-        self.base().try_put(data).await
+        let data = data
+            .iter()
+            .map(|(ts, v0)| (*ts, v0.map(|v| v.to_string())))
+            .collect::<Vec<_>>();
+        self.base().try_put(&data).await
     }
 
     async fn try_alter(&self, mut req: AlterRequest) -> Result<(), Error> {

--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -187,7 +187,11 @@ impl CompactionTester {
     }
 
     async fn put(&self, data: &[(i64, Option<i64>)]) -> WriteResponse {
-        self.base().put(data).await
+        let data = data
+            .iter()
+            .map(|(ts, v0)| (*ts, v0.map(|v| v.to_string())))
+            .collect::<Vec<_>>();
+        self.base().put(&data).await
     }
 
     async fn flush(&self, wait: Option<bool>) {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixes panics when building time range predicate in parquet reader.

This PR also changes the `TesterBase`'s region schema to `[Timestamp, String, Int64]` which is more generic.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

fixes #1640
