### PR TITLE
chore: Log version and arguments

### DIFF
--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -180,14 +180,19 @@ fn full_version() -> &'static str {
     )
 }
 
+fn log_env_flags() {
+    info!("command line arguments");
+    for argument in std::env::args() {
+        info!("argument: {}", argument);
+    }
+}
+
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cmd = Command::parse();
-    // TODO(dennis):
-    // 1. adds ip/port to app
     let app_name = &cmd.subcmd.to_string();
 
     let opts = cmd.load_options()?;
@@ -203,6 +208,14 @@ async fn main() -> Result<()> {
 
     // Report app version as gauge.
     gauge!("app_version", 1.0, "short_version" => short_version(), "version" => full_version());
+
+    // Log version and argument flags.
+    info!(
+        "short_version: {}, full_version: {}",
+        short_version(),
+        full_version()
+    );
+    log_env_flags();
 
     let mut app = cmd.build(opts).await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Log binary version and command line arguments
```
2023-06-08T03:38:50.237197Z  INFO greptime: short_version: 0.4.0, full_version: greptimedb-chore/log-version-4e71ce4
2023-06-08T03:38:50.237461Z  INFO greptime: command line arguments
2023-06-08T03:38:50.237518Z  INFO greptime: argument: target/debug/greptime
2023-06-08T03:38:50.237593Z  INFO greptime: argument: standalone
2023-06-08T03:38:50.237666Z  INFO greptime: argument: start
2023-06-08T03:38:50.237703Z  INFO greptime: argument: --config-file=./config/standalone.example.toml
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
