### PR TITLE
fix: jemalloc error does not implement Error

### DIFF
--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -73,7 +73,7 @@ snap = "1"
 sql = { path = "../sql" }
 strum = { version = "0.24", features = ["derive"] }
 table = { path = "../table" }
-tikv-jemalloc-ctl = "0.5"
+tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR fixes the error that complains jemallocs's Error does not implement `std::Error`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
