### PR TITLE
fix: order by optimization

### DIFF
--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::{Debug, Display, Formatter};
+
 use crate::timestamp::TimeUnit;
 use crate::timestamp_millis::TimestampMillis;
 use crate::Timestamp;
@@ -192,6 +194,21 @@ impl<T: PartialOrd> GenericRange<T> {
 }
 
 pub type TimestampRange = GenericRange<Timestamp>;
+
+impl Display for TimestampRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let start = self
+            .start
+            .map(|t| format!("{}{}", t.value(), t.unit().short_name()))
+            .unwrap_or("#".to_string());
+
+        let end = self
+            .end
+            .map(|t| format!("{}{}", t.value(), t.unit().short_name()))
+            .unwrap_or("#".to_string());
+        write!(f, "TimestampRange{{[{},{})}}", start, end)
+    }
+}
 
 impl TimestampRange {
     /// Create a TimestampRange with optional inclusive end timestamp.

--- a/src/common/time/src/range.rs
+++ b/src/common/time/src/range.rs
@@ -197,16 +197,33 @@ pub type TimestampRange = GenericRange<Timestamp>;
 
 impl Display for TimestampRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let start = self
-            .start
-            .map(|t| format!("{}{}", t.value(), t.unit().short_name()))
-            .unwrap_or("#".to_string());
-
-        let end = self
-            .end
-            .map(|t| format!("{}{}", t.value(), t.unit().short_name()))
-            .unwrap_or("#".to_string());
-        write!(f, "TimestampRange{{[{},{})}}", start, end)
+        let s = match (&self.start, &self.end) {
+            (Some(start), Some(end)) => {
+                format!(
+                    "TimestampRange{{[{}{},{}{})}}",
+                    start.value(),
+                    start.unit().short_name(),
+                    end.value(),
+                    end.unit().short_name()
+                )
+            }
+            (Some(start), None) => {
+                format!(
+                    "TimestampRange{{[{}{},#)}}",
+                    start.value(),
+                    start.unit().short_name()
+                )
+            }
+            (None, Some(end)) => {
+                format!(
+                    "TimestampRange{{[#,{}{})}}",
+                    end.value(),
+                    end.unit().short_name()
+                )
+            }
+            (None, None) => "TimestampRange{{[#,#)}}".to_string(),
+        };
+        f.write_str(&s)
     }
 }
 

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -336,6 +336,15 @@ impl TimeUnit {
             TimeUnit::Nanosecond => 1,
         }
     }
+
+    pub(crate) fn short_name(&self) -> &'static str {
+        match self {
+            TimeUnit::Second => "s",
+            TimeUnit::Millisecond => "ms",
+            TimeUnit::Microsecond => "us",
+            TimeUnit::Nanosecond => "ns",
+        }
+    }
 }
 
 impl PartialOrd for Timestamp {

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -73,7 +73,7 @@ snap = "1"
 sql = { path = "../sql" }
 strum = { version = "0.24", features = ["derive"] }
 table = { path = "../table" }
-tikv-jemalloc-ctl = "0.5"
+tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -274,9 +274,7 @@ pub enum Error {
         source: common_pprof::Error,
     },
 
-    #[snafu(display(
-        "Failed to update jemalloc metrics, source: {source:?}, location: {location}"
-    ))]
+    #[snafu(display("Failed to update jemalloc metrics, source: {source}, location: {location}"))]
     UpdateJemallocMetrics {
         source: tikv_jemalloc_ctl::Error,
         location: Location,

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -274,7 +274,9 @@ pub enum Error {
         source: common_pprof::Error,
     },
 
-    #[snafu(display("Failed to update jemalloc metrics, source: {source}, location: {location}"))]
+    #[snafu(display(
+        "Failed to update jemalloc metrics, source: {source:?}, location: {location}"
+    ))]
     UpdateJemallocMetrics {
         source: tikv_jemalloc_ctl::Error,
         location: Location,

--- a/src/storage/benches/memtable/util/bench_context.rs
+++ b/src/storage/benches/memtable/util/bench_context.rs
@@ -41,7 +41,7 @@ impl BenchContext {
             batch_size,
             ..Default::default()
         };
-        let iter = self.memtable.iter(&iter_ctx).unwrap();
+        let iter = self.memtable.iter(iter_ctx).unwrap();
         for batch in iter {
             batch.unwrap();
             read_count += batch_size;

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_query::logical_plan::Expr;
 use common_recordbatch::OrderOption;
-use common_telemetry::debug;
+use common_telemetry::{debug, info};
 use common_time::range::TimestampRange;
 use snafu::ResultExt;
 use store_api::storage::{Chunk, ChunkReader, SchemaRef, SequenceNumber};
@@ -255,6 +255,7 @@ impl ChunkReaderBuilder {
         let mut output_ordering = None;
         let reader = if let Some(ordering) = self.output_ordering.take() &&
             let Some(windows) = self.infer_time_windows(&ordering) {
+                info!("Building windowed reader: {:?}", windows);
                 output_ordering = Some(ordering.clone());
                 self.build_windowed(&schema, &time_range_predicate, windows, ordering)
                     .await?

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -220,7 +220,9 @@ impl ChunkReaderBuilder {
             .batch_size(self.iter_ctx.batch_size);
 
         for mem in &self.memtables {
-            let iter = mem.iter(&self.iter_ctx)?;
+            let mut iter_ctx = self.iter_ctx.clone();
+            iter_ctx.time_range = Some(*time_range);
+            let iter = mem.iter(iter_ctx)?;
             reader_builder = reader_builder.push_batch_iter(iter);
         }
 

--- a/src/storage/src/chunk.rs
+++ b/src/storage/src/chunk.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_query::logical_plan::Expr;
 use common_recordbatch::OrderOption;
-use common_telemetry::{debug, info};
+use common_telemetry::debug;
 use common_time::range::TimestampRange;
 use snafu::ResultExt;
 use store_api::storage::{Chunk, ChunkReader, SchemaRef, SequenceNumber};
@@ -255,7 +255,6 @@ impl ChunkReaderBuilder {
         let mut output_ordering = None;
         let reader = if let Some(ordering) = self.output_ordering.take() &&
             let Some(windows) = self.infer_time_windows(&ordering) {
-                info!("Building windowed reader: {:?}", windows);
                 output_ordering = Some(ordering.clone());
                 self.build_windowed(&schema, &time_range_predicate, windows, ordering)
                     .await?

--- a/src/storage/src/compaction/writer.rs
+++ b/src/storage/src/compaction/writer.rs
@@ -217,7 +217,7 @@ mod tests {
             seq.fetch_add(1, Ordering::Relaxed);
         }
 
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let file_path = sst_file_id.as_parquet();
         let writer = ParquetWriter::new(&file_path, Source::Iter(iter), object_store.clone());
 

--- a/src/storage/src/file_purger.rs
+++ b/src/storage/src/file_purger.rs
@@ -143,7 +143,7 @@ mod tests {
             &[(Some(1), Some(1)), (Some(2), Some(2))],
         );
 
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let sst_path = "table1";
         let layer = Arc::new(FsAccessLayer::new(sst_path, os.clone()));
         let sst_info = layer

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -267,7 +267,7 @@ impl<S: LogStore> FlushJob<S> {
 
             let file_id = FileId::random();
             // TODO(hl): Check if random file name already exists in meta.
-            let iter = m.iter(&iter_ctx)?;
+            let iter = m.iter(iter_ctx.clone())?;
             let sst_layer = self.sst_layer.clone();
             let write_options = WriteOptions {
                 sst_write_buffer_size: self.engine_config.sst_write_buffer_size,

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -73,7 +73,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     fn write(&self, kvs: &KeyValues) -> Result<()>;
 
     /// Iterates the memtable.
-    fn iter(&self, ctx: &IterContext) -> Result<BoxedBatchIterator>;
+    fn iter(&self, ctx: IterContext) -> Result<BoxedBatchIterator>;
 
     /// Returns the estimated bytes allocated by this memtable from heap. Result
     /// of this method may be larger than the estimated based on [`num_rows`] because

--- a/src/storage/src/memtable/btree.rs
+++ b/src/storage/src/memtable/btree.rs
@@ -145,10 +145,10 @@ impl Memtable for BTreeMemtable {
         Ok(())
     }
 
-    fn iter(&self, ctx: &IterContext) -> Result<BoxedBatchIterator> {
+    fn iter(&self, ctx: IterContext) -> Result<BoxedBatchIterator> {
         assert!(ctx.batch_size > 0);
 
-        let iter = BTreeIterator::new(ctx.clone(), self.schema.clone(), self.map.clone())?;
+        let iter = BTreeIterator::new(ctx, self.schema.clone(), self.map.clone())?;
 
         Ok(Box::new(iter))
     }

--- a/src/storage/src/memtable/inserter.rs
+++ b/src/storage/src/memtable/inserter.rs
@@ -179,7 +179,7 @@ mod tests {
         max_ts: i64,
         min_ts: i64,
     ) {
-        let iter = mem.iter(&IterContext::default()).unwrap();
+        let iter = mem.iter(IterContext::default()).unwrap();
         assert_eq!(min_ts, mem.stats().min_timestamp.value());
         assert_eq!(max_ts, mem.stats().max_timestamp.value());
 

--- a/src/storage/src/memtable/tests.rs
+++ b/src/storage/src/memtable/tests.rs
@@ -440,7 +440,7 @@ fn test_sequence_visibility() {
                 time_range: None,
             };
 
-            let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[], // keys

--- a/src/storage/src/memtable/tests.rs
+++ b/src/storage/src/memtable/tests.rs
@@ -196,7 +196,7 @@ struct TestContext {
 
 fn write_iter_memtable_case(ctx: &TestContext) {
     // Test iterating an empty memtable.
-    let mut iter = ctx.memtable.iter(&IterContext::default()).unwrap();
+    let mut iter = ctx.memtable.iter(IterContext::default()).unwrap();
     assert!(iter.next().is_none());
     // Poll the empty iterator again.
     assert!(iter.next().is_none());
@@ -234,7 +234,7 @@ fn write_iter_memtable_case(ctx: &TestContext) {
             batch_size,
             ..Default::default()
         };
-        let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+        let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
         assert_eq!(
             ctx.schema.user_schema(),
             iter.schema().projected_user_schema()
@@ -322,7 +322,7 @@ fn test_iter_batch_size() {
                 ..Default::default()
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
             check_iter_batch_size(&mut *iter, total, batch_size);
         }
     });
@@ -355,7 +355,7 @@ fn test_duplicate_key_across_batch() {
                 ..Default::default()
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[1000, 1001, 2000, 2001], // keys
@@ -391,7 +391,7 @@ fn test_duplicate_key_in_batch() {
                 ..Default::default()
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[1000, 1001, 2001],                               // keys
@@ -440,7 +440,7 @@ fn test_sequence_visibility() {
                 time_range: None,
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx.clone()).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[], // keys
@@ -459,7 +459,7 @@ fn test_sequence_visibility() {
                 time_range: None,
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[1000],                     // keys
@@ -478,7 +478,7 @@ fn test_sequence_visibility() {
                 time_range: None,
             };
 
-            let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+            let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
             check_iter_content(
                 &mut *iter,
                 &[1000],                     // keys
@@ -507,7 +507,7 @@ fn test_iter_after_none() {
             ..Default::default()
         };
 
-        let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+        let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
         assert!(iter.next().is_some());
         assert!(iter.next().is_none());
         assert!(iter.next().is_none());
@@ -538,7 +538,7 @@ fn test_filter_memtable() {
             ..Default::default()
         };
 
-        let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+        let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
         let batch = iter.next().unwrap().unwrap();
         assert_eq!(5, batch.columns.len());
         assert_eq!(
@@ -574,7 +574,7 @@ fn test_memtable_projection() {
             ..Default::default()
         };
 
-        let mut iter = ctx.memtable.iter(&iter_ctx).unwrap();
+        let mut iter = ctx.memtable.iter(iter_ctx).unwrap();
         let batch = iter.next().unwrap().unwrap();
         assert!(iter.next().is_none());
 

--- a/src/storage/src/metrics.rs
+++ b/src/storage/src/metrics.rs
@@ -38,3 +38,7 @@ pub const WRITE_BUFFER_BYTES: &str = "storage.write_buffer_bytes";
 pub const MEMTABLE_WRITE_ELAPSED: &str = "storage.memtable.write.elapsed";
 /// Elapsed time of preprocessing write batch.
 pub const PREPROCESS_ELAPSED: &str = "storage.write.preprocess.elapsed";
+/// Elapsed time for windowed scan
+pub const WINDOW_SCAN_ELAPSED: &str = "query.scan.window_scan.elapsed";
+/// Rows per window during window scan
+pub const WINDOW_SCAN_ROWS_PER_WINDOW: &str = "query.scan.window_scan.window_row_size";

--- a/src/storage/src/read/windowed.rs
+++ b/src/storage/src/read/windowed.rs
@@ -62,7 +62,7 @@ where
     R: BatchReader,
 {
     async fn next_batch(&mut self) -> Result<Option<Batch>> {
-        let _window_scan_elapsed = timer!("query.scan.window_scan.elapsed");
+        let _window_scan_elapsed = timer!(crate::metrics::WINDOW_SCAN_ELAPSED);
         let Some(mut reader) = self.readers.pop() else { return Ok(None); };
 
         let store_schema = self.schema.schema_to_read();
@@ -94,7 +94,7 @@ where
                 .push(arrow::compute::concat(&columns).context(error::ConvertColumnsToRowsSnafu)?);
         }
         if let Some(v) = vectors_in_batch.get(0) {
-            histogram!("query.scan.window_scan.window_row_size", v.len() as f64);
+            histogram!(crate::metrics::WINDOW_SCAN_ROWS_PER_WINDOW, v.len() as f64);
         }
         let sorted = sort_by_rows(&self.schema, vectors_in_batch, &self.order_options)?;
         let vectors = sorted

--- a/src/storage/src/read/windowed.rs
+++ b/src/storage/src/read/windowed.rs
@@ -78,6 +78,8 @@ where
         }
 
         let Some(num_columns) = batches.get(0).map(|b| b.len()) else {
+            // the reader does not yield data, a batch of empty vectors must be returned instead of 
+            // an empty batch without any column.
             let empty_columns = store_schema.columns().iter().map(|s| {
                 s.desc.data_type.create_mutable_vector(0).to_vector()
             }).collect();

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -291,6 +291,7 @@ impl ParquetReader {
             .build()
             .context(ReadParquetSnafu { file: &file_path })?;
 
+        let time_range = self.time_range.clone();
         let chunk_stream = try_stream!({
             while let Some(res) = stream.next().await {
                 yield res.context(ReadParquetSnafu { file: &file_path })?
@@ -579,7 +580,7 @@ mod tests {
 
         let object_store = create_object_store(path);
         let sst_file_name = "test-flush.parquet";
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
 
         writer
@@ -663,7 +664,7 @@ mod tests {
         let object_store = create_object_store(path);
         let sst_file_handle = new_file_handle(FileId::random());
         let sst_file_name = sst_file_handle.file_name();
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(&sst_file_name, Source::Iter(iter), object_store.clone());
 
         let SstInfo {
@@ -749,7 +750,7 @@ mod tests {
         let object_store = create_object_store(path);
         let file_handle = new_file_handle(FileId::random());
         let sst_file_name = file_handle.file_name();
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(&sst_file_name, Source::Iter(iter), object_store.clone());
 
         let SstInfo {
@@ -855,7 +856,7 @@ mod tests {
         let object_store = create_object_store(path);
         let sst_file_handle = new_file_handle(FileId::random());
         let sst_file_name = sst_file_handle.file_name();
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(&sst_file_name, Source::Iter(iter), object_store.clone());
 
         let SstInfo {
@@ -950,7 +951,7 @@ mod tests {
         builder.root(path);
         let object_store = ObjectStore::new(builder).unwrap().finish();
         let sst_file_name = "test-read.parquet";
-        let iter = memtable.iter(&IterContext::default()).unwrap();
+        let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
 
         let sst_info_opt = writer

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -291,7 +291,6 @@ impl ParquetReader {
             .build()
             .context(ReadParquetSnafu { file: &file_path })?;
 
-        let time_range = self.time_range.clone();
         let chunk_stream = try_stream!({
             while let Some(res) = stream.next().await {
                 yield res.context(ReadParquetSnafu { file: &file_path })?

--- a/src/storage/src/window_infer.rs
+++ b/src/storage/src/window_infer.rs
@@ -299,7 +299,6 @@ mod tests {
         );
 
         let mut expect = (0..=61)
-            .into_iter()
             .map(|s| TimestampRange::with_unit(s, s + 1, TimeUnit::Second).unwrap())
             .collect::<Vec<_>>();
         expect.push(TimestampRange::with_unit(60 * 60, 60 * 60 + 1, TimeUnit::Second).unwrap());

--- a/src/storage/src/window_infer.rs
+++ b/src/storage/src/window_infer.rs
@@ -23,10 +23,11 @@ use crate::memtable::MemtableStats;
 use crate::sst::FileMeta;
 
 /// A set of predefined time windows.
-const TIME_WINDOW_SIZE: [i64; 9] = [
+const TIME_WINDOW_SIZE: [i64; 10] = [
+    1,                // 1 second
     60,               // 1 minute
-    60 * 10,          // 10 minute
-    60 * 30,          // 30 minute
+    60 * 10,          // 10 minutes
+    60 * 30,          // 30 minutes
     60 * 60,          // 1 hour
     2 * 60 * 60,      // 2 hours
     6 * 60 * 60,      // 6 hours

--- a/src/storage/src/window_infer.rs
+++ b/src/storage/src/window_infer.rs
@@ -161,11 +161,12 @@ mod tests {
 
     #[test]
     fn test_get_time_window_size() {
-        assert_eq!(60, min_duration_to_window_size(0));
+        assert_eq!(1, min_duration_to_window_size(0));
         for window in TIME_WINDOW_SIZE {
             assert_eq!(window, min_duration_to_window_size(window));
         }
-        assert_eq!(60, min_duration_to_window_size(1));
+        assert_eq!(1, min_duration_to_window_size(1));
+        assert_eq!(60, min_duration_to_window_size(60));
         assert_eq!(60 * 10, min_duration_to_window_size(100));
         assert_eq!(60 * 30, min_duration_to_window_size(1800));
         assert_eq!(60 * 60, min_duration_to_window_size(3000));
@@ -245,7 +246,7 @@ mod tests {
             true,
         );
         assert_eq!(
-            vec![TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap()],
+            vec![TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap(),],
             res
         );
 
@@ -296,14 +297,15 @@ mod tests {
             }],
             true,
         );
-        assert_eq!(
-            vec![
-                TimestampRange::with_unit(0, 60, TimeUnit::Second).unwrap(),
-                TimestampRange::with_unit(60, 120, TimeUnit::Second).unwrap(),
-                TimestampRange::with_unit(60 * 60, 61 * 60, TimeUnit::Second).unwrap(),
-            ],
-            res
-        );
+
+        let mut expect = (0..=61)
+            .into_iter()
+            .map(|s| TimestampRange::with_unit(s, s + 1, TimeUnit::Second).unwrap())
+            .collect::<Vec<_>>();
+        expect.push(TimestampRange::with_unit(60 * 60, 60 * 60 + 1, TimeUnit::Second).unwrap());
+        expect.push(TimestampRange::with_unit(60 * 60 + 1, 60 * 60 + 2, TimeUnit::Second).unwrap());
+
+        assert_eq!(expect, res);
 
         let res = window_inference.infer_window(
             &[

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -63,16 +63,13 @@ async fn test_create_database_and_insert_query(instance: Arc<dyn MockInstance>) 
     .await;
     assert!(matches!(output, Output::AffectedRows(2)));
 
-    let query_output = execute_sql(&instance, "select ts from test.demo order by ts").await;
+    let query_output = execute_sql(&instance, "select ts from test.demo order by ts limit 1").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
             assert_eq!(1, batches[0].num_columns());
             assert_eq!(
-                Arc::new(Int64Vector::from_vec(vec![
-                    1655276557000_i64,
-                    1655276558000_i64
-                ])) as VectorRef,
+                Arc::new(Int64Vector::from_vec(vec![1655276557000_i64])) as VectorRef,
                 *batches[0].column(0)
             );
         }
@@ -193,7 +190,7 @@ async fn test_issue477_same_table_name_in_different_databases(instance: Arc<dyn 
     // Query data and assert
     assert_query_result(
         &instance,
-        "select host,ts from a.demo order by ts",
+        "select host,ts from a.demo order by ts limit 1",
         1655276557000,
         "host1",
     )
@@ -329,32 +326,27 @@ async fn test_execute_insert_query_with_i64_timestamp(instance: Arc<dyn MockInst
     .await;
     assert!(matches!(output, Output::AffectedRows(2)));
 
-    let query_output = execute_sql(&instance, "select ts from demo order by ts").await;
+    let query_output = execute_sql(&instance, "select ts from demo order by ts limit 1").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
             assert_eq!(1, batches[0].num_columns());
             assert_eq!(
-                Arc::new(Int64Vector::from_vec(vec![
-                    1655276557000_i64,
-                    1655276558000_i64
-                ])) as VectorRef,
+                Arc::new(Int64Vector::from_vec(vec![1655276557000_i64,])) as VectorRef,
                 *batches[0].column(0)
             );
         }
         _ => unreachable!(),
     }
 
-    let query_output = execute_sql(&instance, "select ts as time from demo order by ts").await;
+    let query_output =
+        execute_sql(&instance, "select ts as time from demo order by ts limit 1").await;
     match query_output {
         Output::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
             assert_eq!(1, batches[0].num_columns());
             assert_eq!(
-                Arc::new(Int64Vector::from_vec(vec![
-                    1655276557000_i64,
-                    1655276558000_i64
-                ])) as VectorRef,
+                Arc::new(Int64Vector::from_vec(vec![1655276557000_i64,])) as VectorRef,
                 *batches[0].column(0)
             );
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

This PR fixes issues related to order-by rule.
- avoid actual IO during plan stage by wrap `ParquetReader` with a `LazyParquetReader`
- when time windows does not yield a valid record batch, replace it with a record batch of empty vectors to avoid panic.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1750 
