### PR TITLE
feat:make version() show greptime info.

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -31,9 +31,6 @@ use regex::bytes::RegexSet;
 use regex::Regex;
 use session::context::QueryContextRef;
 
-// TODO(LFC): Include GreptimeDB's version and git commit tag etc.
-// const MYSQL_VERSION: &str = "8.0.26";
-
 static SELECT_VAR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new("(?i)^(SELECT @@(.*))").unwrap());
 static MYSQL_CONN_JAVA_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(/\\* mysql-connector-j(.*))").unwrap());
@@ -328,7 +325,6 @@ fn get_version() -> String {
 }
 #[cfg(test)]
 mod test {
-    use std::fmt::Write;
 
     use session::context::QueryContext;
 
@@ -355,20 +351,15 @@ mod test {
         }
 
         let query = "select version()";
-        let mut buffer = String::new();
-        write!(
-            &mut buffer,
-            "\
-+----------------+
+        let expected = format!(
+            r#"+----------------+
 | version()      |
 +----------------+
 | {}-greptime |
-+----------------+",
++----------------+"#,
             env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string())
-        )
-        .expect("failed to write to buffer");
-        let expected = buffer.as_str();
-        test(query, expected);
+        );
+        test(query, &expected);
 
         let query = "SELECT @@version_comment LIMIT 1";
         let expected = "\


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Please explain IN DETAIL what the changes are in this PR and why they are needed:

make `select version()` show greptime info.
just like this.
```
mysql> select version();
+----------------+
| version()      |
+----------------+
| 0.4.0-greptime |
+----------------+
1 row in set (0.04 sec)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close https://github.com/GreptimeTeam/greptimedb/issues/1711