### PR TITLE
ci: fix using env in job.if context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,6 @@ env:
   # Controls whether to run tests, include unit-test, integration-test and sqlness.
   DISABLE_RUN_TESTS: ${{ github.event.inputs.skip_test || false }}
 
-  DRY_RUN: ${{ github.event.inputs.dry_run || false }}
-
 jobs:
   build-macos:
     name: Build macOS binary
@@ -292,7 +290,7 @@ jobs:
     name: Build docker image
     needs: [build-linux, build-macos]
     runs-on: ubuntu-latest
-    if: github.repository == 'GreptimeTeam/greptimedb' && !env.DRY_RUN
+    if: github.repository == 'GreptimeTeam/greptimedb' && !(github.event.inputs.dry_run || false)
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -378,7 +376,7 @@ jobs:
     # Release artifacts only when all the artifacts are built successfully.
     needs: [build-linux, build-macos, docker]
     runs-on: ubuntu-latest
-    if: github.repository == 'GreptimeTeam/greptimedb' && !env.DRY_RUN
+    if: github.repository == 'GreptimeTeam/greptimedb' && !(github.event.inputs.dry_run || false)
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -437,7 +435,7 @@ jobs:
     name: Push docker image to alibaba cloud container registry
     needs: [docker]
     runs-on: ubuntu-latest
-    if: github.repository == 'GreptimeTeam/greptimedb' && !env.DRY_RUN
+    if: github.repository == 'GreptimeTeam/greptimedb' && !(github.event.inputs.dry_run || false)
     continue-on-error: true
     steps:
       - name: Checkout sources


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Followup for #1746 as github doesn't allow `env` in `jobs.<id>.if` context: https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
