### PR TITLE
refactor: replace `#[snafu(backtrace)]` with `Location`

### DIFF
--- a/src/api/src/error.rs
+++ b/src/api/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
     ))]
     ConvertColumnDefaultConstraint {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -52,7 +52,7 @@ pub enum Error {
     ))]
     InvalidColumnDefaultConstraint {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 }

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -32,18 +32,18 @@ pub enum Error {
         source
     ))]
     CompileScriptInternal {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
     #[snafu(display("Failed to open system catalog table, source: {}", source))]
     OpenSystemCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
     #[snafu(display("Failed to create system catalog table, source: {}", source))]
     CreateSystemCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -54,7 +54,7 @@ pub enum Error {
     ))]
     CreateTable {
         table_info: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -94,7 +94,7 @@ pub enum Error {
     #[snafu(display("Table engine not found: {}, source: {}", engine_name, source))]
     TableEngineNotFound {
         engine_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -132,7 +132,7 @@ pub enum Error {
     #[snafu(display("Failed to open table, table info: {}, source: {}", table_info, source))]
     OpenTable {
         table_info: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -147,13 +147,13 @@ pub enum Error {
 
     #[snafu(display("Failed to read system catalog table records"))]
     ReadSystemCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to create recordbatch, source: {}", source))]
     CreateRecordBatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
@@ -162,7 +162,7 @@ pub enum Error {
         source
     ))]
     InsertCatalogRecord {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -173,7 +173,7 @@ pub enum Error {
     ))]
     DeregisterTable {
         request: DeregisterTableRequest,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -182,36 +182,36 @@ pub enum Error {
 
     #[snafu(display("Failed to scan system catalog table, source: {}", source))]
     SystemCatalogTableScan {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
     #[snafu(display("{source}"))]
     Internal {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Failed to execute system catalog table scan, source: {}", source))]
     SystemCatalogTableScanExec {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_query::error::Error,
     },
     #[snafu(display("Cannot parse catalog value, source: {}", source))]
     InvalidCatalogValue {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_catalog::error::Error,
     },
 
     #[snafu(display("Failed to perform metasrv operation, source: {}", source))]
     MetaSrv {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_client::error::Error,
     },
 
     #[snafu(display("Invalid table info in catalog, source: {}", source))]
     InvalidTableInfoInCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -230,7 +230,7 @@ pub enum Error {
 
     #[snafu(display("Table schema mismatch, source: {}", source))]
     TableSchemaMismatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -258,7 +258,7 @@ impl ErrorExt for Error {
 
             Error::Generic { .. } | Error::SystemCatalogTypeMismatch { .. } => StatusCode::Internal,
 
-            Error::ReadSystemCatalog { source, .. } | Error::CreateRecordBatch { source } => {
+            Error::ReadSystemCatalog { source, .. } | Error::CreateRecordBatch { source, .. } => {
                 source.status_code()
             }
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
@@ -275,14 +275,14 @@ impl ErrorExt for Error {
             | Error::OpenTable { source, .. }
             | Error::CreateTable { source, .. }
             | Error::DeregisterTable { source, .. }
-            | Error::TableSchemaMismatch { source } => source.status_code(),
+            | Error::TableSchemaMismatch { source, .. } => source.status_code(),
 
             Error::MetaSrv { source, .. } => source.status_code(),
-            Error::SystemCatalogTableScan { source } => source.status_code(),
-            Error::SystemCatalogTableScanExec { source } => source.status_code(),
-            Error::InvalidTableInfoInCatalog { source } => source.status_code(),
+            Error::SystemCatalogTableScan { source, .. } => source.status_code(),
+            Error::SystemCatalogTableScanExec { source, .. } => source.status_code(),
+            Error::InvalidTableInfoInCatalog { source, .. } => source.status_code(),
 
-            Error::CompileScriptInternal { source } | Error::Internal { source } => {
+            Error::CompileScriptInternal { source, .. } | Error::Internal { source, .. } => {
                 source.status_code()
             }
 

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -34,13 +34,13 @@ pub enum Error {
 
     #[snafu(display("Failed to convert FlightData, source: {}", source))]
     ConvertFlightData {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::Error,
     },
 
     #[snafu(display("Column datatype error, source: {}", source))]
     ColumnDataType {
-        #[snafu(backtrace)]
+        location: Location,
         source: api::error::Error,
     },
 
@@ -57,7 +57,7 @@ pub enum Error {
     ))]
     CreateChannel {
         addr: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::error::Error,
     },
 
@@ -85,7 +85,7 @@ impl ErrorExt for Error {
 
             Error::Server { code, .. } => *code,
             Error::FlightGet { source, .. } => source.status_code(),
-            Error::CreateChannel { source, .. } | Error::ConvertFlightData { source } => {
+            Error::CreateChannel { source, .. } | Error::ConvertFlightData { source, .. } => {
                 source.status_code()
             }
             Error::IllegalGrpcClientState { .. } => StatusCode::Unexpected,

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -24,43 +24,43 @@ use snafu::Location;
 pub enum Error {
     #[snafu(display("Failed to start datanode, source: {}", source))]
     StartDatanode {
-        #[snafu(backtrace)]
+        location: Location,
         source: datanode::error::Error,
     },
 
     #[snafu(display("Failed to shutdown datanode, source: {}", source))]
     ShutdownDatanode {
-        #[snafu(backtrace)]
+        location: Location,
         source: datanode::error::Error,
     },
 
     #[snafu(display("Failed to start frontend, source: {}", source))]
     StartFrontend {
-        #[snafu(backtrace)]
+        location: Location,
         source: frontend::error::Error,
     },
 
     #[snafu(display("Failed to shutdown frontend, source: {}", source))]
     ShutdownFrontend {
-        #[snafu(backtrace)]
+        location: Location,
         source: frontend::error::Error,
     },
 
     #[snafu(display("Failed to build meta server, source: {}", source))]
     BuildMetaServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_srv::error::Error,
     },
 
     #[snafu(display("Failed to start meta server, source: {}", source))]
     StartMetaServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_srv::error::Error,
     },
 
     #[snafu(display("Failed to shutdown meta server, source: {}", source))]
     ShutdownMetaServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_srv::error::Error,
     },
 
@@ -72,14 +72,14 @@ pub enum Error {
 
     #[snafu(display("Illegal auth config: {}", source))]
     IllegalAuthConfig {
-        #[snafu(backtrace)]
+        location: Location,
         source: servers::auth::Error,
     },
 
     #[snafu(display("Unsupported selector type, {} source: {}", selector_type, source))]
     UnsupportedSelectorType {
         selector_type: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_srv::error::Error,
     },
 
@@ -101,44 +101,44 @@ pub enum Error {
     #[snafu(display("Failed to request database, sql: {sql}, source: {source}"))]
     RequestDatabase {
         sql: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: client::Error,
     },
 
     #[snafu(display("Failed to collect RecordBatches, source: {source}"))]
     CollectRecordBatches {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to pretty print Recordbatches, source: {source}"))]
     PrettyPrintRecordBatches {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to start Meta client, source: {}", source))]
     StartMetaClient {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_client::error::Error,
     },
 
     #[snafu(display("Failed to parse SQL: {}, source: {}", sql, source))]
     ParseSql {
         sql: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to plan statement, source: {}", source))]
     PlanStatement {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to encode logical plan in substrait, source: {}", source))]
     SubstraitEncodeLogicalPlan {
-        #[snafu(backtrace)]
+        location: Location,
         source: substrait::error::Error,
     },
 
@@ -150,7 +150,7 @@ pub enum Error {
 
     #[snafu(display("Failed to start catalog manager, source: {}", source))]
     StartCatalogManager {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 }
@@ -160,13 +160,13 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            Error::StartDatanode { source } => source.status_code(),
-            Error::StartFrontend { source } => source.status_code(),
-            Error::ShutdownDatanode { source } => source.status_code(),
-            Error::ShutdownFrontend { source } => source.status_code(),
-            Error::StartMetaServer { source } => source.status_code(),
-            Error::ShutdownMetaServer { source } => source.status_code(),
-            Error::BuildMetaServer { source } => source.status_code(),
+            Error::StartDatanode { source, .. } => source.status_code(),
+            Error::StartFrontend { source, .. } => source.status_code(),
+            Error::ShutdownDatanode { source, .. } => source.status_code(),
+            Error::ShutdownFrontend { source, .. } => source.status_code(),
+            Error::StartMetaServer { source, .. } => source.status_code(),
+            Error::ShutdownMetaServer { source, .. } => source.status_code(),
+            Error::BuildMetaServer { source, .. } => source.status_code(),
             Error::UnsupportedSelectorType { source, .. } => source.status_code(),
             Error::MissingConfig { .. }
             | Error::LoadLayeredConfig { .. }
@@ -175,15 +175,14 @@ impl ErrorExt for Error {
             | Error::IllegalAuthConfig { .. } => StatusCode::InvalidArguments,
             Error::ReplCreation { .. } | Error::Readline { .. } => StatusCode::Internal,
             Error::RequestDatabase { source, .. } => source.status_code(),
-            Error::CollectRecordBatches { source } | Error::PrettyPrintRecordBatches { source } => {
+            Error::CollectRecordBatches { source, .. }
+            | Error::PrettyPrintRecordBatches { source, .. } => source.status_code(),
+            Error::StartMetaClient { source, .. } => source.status_code(),
+            Error::ParseSql { source, .. } | Error::PlanStatement { source, .. } => {
                 source.status_code()
             }
-            Error::StartMetaClient { source } => source.status_code(),
-            Error::ParseSql { source, .. } | Error::PlanStatement { source } => {
-                source.status_code()
-            }
-            Error::SubstraitEncodeLogicalPlan { source } => source.status_code(),
-            Error::StartCatalogManager { source } => source.status_code(),
+            Error::SubstraitEncodeLogicalPlan { source, .. } => source.status_code(),
+            Error::StartCatalogManager { source, .. } => source.status_code(),
         }
     }
 

--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -32,7 +32,7 @@ pub enum Error {
 
     #[snafu(display("Column datatype error, source: {}", source))]
     ColumnDataType {
-        #[snafu(backtrace)]
+        location: Location,
         source: api::error::Error,
     },
 
@@ -54,7 +54,7 @@ pub enum Error {
     InvalidColumnProto { err_msg: String, location: Location },
     #[snafu(display("Failed to create vector, source: {}", source))]
     CreateVector {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -68,13 +68,13 @@ pub enum Error {
     ))]
     InvalidColumnDef {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: api::error::Error,
     },
 
     #[snafu(display("Unrecognized table option: {}", source))]
     UnrecognizedTableOption {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 

--- a/src/common/grpc/src/error.rs
+++ b/src/common/grpc/src/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create RecordBatch, source: {}", source))]
     CreateRecordBatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
@@ -71,7 +71,7 @@ pub enum Error {
 
     #[snafu(display("Failed to convert Arrow Schema, source: {}", source))]
     ConvertArrowSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 }
@@ -88,8 +88,8 @@ impl ErrorExt for Error {
             | Error::Conversion { .. }
             | Error::DecodeFlightData { .. } => StatusCode::Internal,
 
-            Error::CreateRecordBatch { source } => source.status_code(),
-            Error::ConvertArrowSchema { source } => source.status_code(),
+            Error::CreateRecordBatch { source, .. } => source.status_code(),
+            Error::ConvertArrowSchema { source, .. } => source.status_code(),
         }
     }
 

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -29,10 +29,7 @@ pub enum Error {
         "Failed to execute procedure due to external error, source: {}",
         source
     ))]
-    External {
-        #[snafu(backtrace)]
-        source: BoxedError,
-    },
+    External { source: BoxedError },
 
     #[snafu(display("Loader {} is already registered", name))]
     LoaderConflict { name: String, location: Location },
@@ -52,7 +49,7 @@ pub enum Error {
     #[snafu(display("Failed to put state, key: '{key}', source: {source}"))]
     PutState {
         key: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -65,14 +62,14 @@ pub enum Error {
     #[snafu(display("Failed to delete keys: '{keys}', source: {source}"))]
     DeleteStates {
         keys: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Failed to list state, path: '{path}', source: {source}"))]
     ListState {
         path: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -83,10 +80,7 @@ pub enum Error {
     },
 
     #[snafu(display("Procedure exec failed, source: {}", source))]
-    RetryLater {
-        #[snafu(backtrace)]
-        source: BoxedError,
-    },
+    RetryLater { source: BoxedError },
 
     #[snafu(display("Procedure panics, procedure_id: {}", procedure_id))]
     ProcedurePanic { procedure_id: ProcedureId },

--- a/src/common/recordbatch/src/adapter.rs
+++ b/src/common/recordbatch/src/adapter.rs
@@ -225,6 +225,7 @@ mod test {
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use datatypes::vectors::Int32Vector;
+    use snafu::IntoError;
 
     use super::*;
     use crate::RecordBatches;
@@ -296,9 +297,8 @@ mod test {
 
         let poll_err_stream = new_future_stream(Ok(vec![
             Ok(batch1.clone()),
-            Err(error::Error::External {
-                source: BoxedError::new(MockError::new(StatusCode::Unknown)),
-            }),
+            Err(error::ExternalSnafu
+                .into_error(BoxedError::new(MockError::new(StatusCode::Unknown)))),
         ]));
         let adapter = AsyncRecordBatchStreamAdapter::new(schema.clone(), poll_err_stream);
         let result = RecordBatches::try_collect(Box::pin(adapter)).await;
@@ -307,9 +307,9 @@ mod test {
             "Failed to poll stream, source: External error: External error, source: Unknown"
         );
 
-        let failed_to_init_stream = new_future_stream(Err(error::Error::External {
-            source: BoxedError::new(MockError::new(StatusCode::Internal)),
-        }));
+        let failed_to_init_stream =
+            new_future_stream(Err(error::ExternalSnafu
+                .into_error(BoxedError::new(MockError::new(StatusCode::Internal)))));
         let adapter = AsyncRecordBatchStreamAdapter::new(schema.clone(), failed_to_init_stream);
         let result = RecordBatches::try_collect(Box::pin(adapter)).await;
         assert_eq!(

--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -33,13 +33,13 @@ pub enum Error {
 
     #[snafu(display("Data types error, source: {}", source))]
     DataTypes {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("External error, source: {}", source))]
     External {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -99,7 +99,7 @@ pub enum Error {
     CastVector {
         from_type: ConcreteDataType,
         to_type: ConcreteDataType,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 }
@@ -117,7 +117,7 @@ impl ErrorExt for Error {
             | Error::ColumnNotExists { .. }
             | Error::ProjectArrowRecordBatch { .. } => StatusCode::Internal,
 
-            Error::External { source } => source.status_code(),
+            Error::External { source, .. } => source.status_code(),
 
             Error::SchemaConversion { source, .. } | Error::CastVector { source, .. } => {
                 source.status_code()

--- a/src/common/substrait/src/error.rs
+++ b/src/common/substrait/src/error.rs
@@ -74,7 +74,7 @@ pub enum Error {
 
     #[snafu(display("Internal error: {}", source))]
     Internal {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -96,14 +96,14 @@ pub enum Error {
 
     #[snafu(display("Failed to convert DataFusion schema, source: {}", source))]
     ConvertDfSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("Unable to resolve table: {table_name}, error: {source}"))]
     ResolveTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
@@ -141,7 +141,7 @@ impl ErrorExt for Error {
             | Error::Internal { .. }
             | Error::EncodeDfPlan { .. }
             | Error::DecodeDfPlan { .. } => StatusCode::Internal,
-            Error::ConvertDfSchema { source } => source.status_code(),
+            Error::ConvertDfSchema { source, .. } => source.status_code(),
             Error::ResolveTable { source, .. } => source.status_code(),
         }
     }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -27,14 +27,14 @@ use table::error::Error as TableError;
 pub enum Error {
     #[snafu(display("Failed to access catalog, source: {}", source))]
     AccessCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
     #[snafu(display("Failed to deregister table: {}, source: {}", table_name, source))]
     DeregisterTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
@@ -48,7 +48,7 @@ pub enum Error {
     #[snafu(display("Failed to open table: {}, source: {}", table_name, source))]
     OpenTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
@@ -68,7 +68,7 @@ pub enum Error {
     CloseTable {
         table_name: String,
         region_numbers: Vec<RegionNumber>,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
@@ -93,31 +93,31 @@ pub enum Error {
 
     #[snafu(display("Failed to execute sql, source: {}", source))]
     ExecuteSql {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to plan statement, source: {}", source))]
     PlanStatement {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to execute statement, source: {}", source))]
     ExecuteStatement {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to execute logical plan, source: {}", source))]
     ExecuteLogicalPlan {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to decode logical plan, source: {}", source))]
     DecodeLogicalPlan {
-        #[snafu(backtrace)]
+        location: Location,
         source: substrait::error::Error,
     },
 
@@ -126,7 +126,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create catalog list, source: {}", source))]
     NewCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
@@ -139,21 +139,21 @@ pub enum Error {
     #[snafu(display("Failed to create table: {}, source: {}", table_name, source))]
     CreateTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
     #[snafu(display("Failed to drop table {}, source: {}", table_name, source))]
     DropTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Table engine not found: {}, source: {}", engine_name, source))]
     TableEngineNotFound {
         engine_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -164,7 +164,7 @@ pub enum Error {
     ))]
     EngineProcedureNotFound {
         engine_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -192,7 +192,7 @@ pub enum Error {
 
     #[snafu(display("Failed to parse sql value, source: {}", source))]
     ParseSqlValue {
-        #[snafu(backtrace)]
+        location: Location,
         source: sql::error::Error,
     },
 
@@ -202,7 +202,7 @@ pub enum Error {
     #[snafu(display("Failed to insert value to table: {}, source: {}", table_name, source))]
     Insert {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
@@ -213,20 +213,20 @@ pub enum Error {
     ))]
     Delete {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
     #[snafu(display("Failed to flush table: {}, source: {}", table_name, source))]
     FlushTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: TableError,
     },
 
     #[snafu(display("Failed to start server, source: {}", source))]
     StartServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: servers::error::Error,
     },
 
@@ -250,8 +250,8 @@ pub enum Error {
 
     #[snafu(display("Failed to open log store, source: {}", source))]
     OpenLogStore {
-        #[snafu(backtrace)]
-        source: log_store::error::Error,
+        location: Location,
+        source: Box<log_store::error::Error>,
     },
 
     #[snafu(display("Failed to init backend, source: {}", source))]
@@ -262,7 +262,7 @@ pub enum Error {
 
     #[snafu(display("Runtime resource error, source: {}", source))]
     RuntimeResource {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_runtime::error::Error,
     },
 
@@ -289,7 +289,7 @@ pub enum Error {
 
     #[snafu(display("Failed to register a new schema, source: {}", source))]
     RegisterSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
@@ -298,25 +298,25 @@ pub enum Error {
 
     #[snafu(display("Failed to convert alter expr to request: {}", source))]
     AlterExprToRequest {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc_expr::error::Error,
     },
 
     #[snafu(display("Failed to convert create expr to request: {}", source))]
     CreateExprToRequest {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc_expr::error::Error,
     },
 
     #[snafu(display("Failed to convert delete expr to request: {}", source))]
     DeleteExprToRequest {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc_expr::error::Error,
     },
 
     #[snafu(display("Failed to parse SQL, source: {}", source))]
     ParseSql {
-        #[snafu(backtrace)]
+        location: Location,
         source: sql::error::Error,
     },
 
@@ -327,38 +327,38 @@ pub enum Error {
     ))]
     ParseTimestamp {
         raw: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: common_time::error::Error,
     },
 
     #[snafu(display("Failed to prepare immutable table: {}", source))]
     PrepareImmutableTable {
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
     #[snafu(display("Failed to access catalog, source: {}", source))]
     Catalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
     #[snafu(display("Failed to find table {} from catalog, source: {}", table_name, source))]
     FindTable {
         table_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
     #[snafu(display("Failed to initialize meta client, source: {}", source))]
     MetaClientInit {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_client::error::Error,
     },
 
     #[snafu(display("Failed to insert data, source: {}", source))]
     InsertData {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc_expr::error::Error,
     },
 
@@ -369,7 +369,7 @@ pub enum Error {
 
     #[snafu(display("Failed to bump table id, source: {}", source))]
     BumpTableId {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
@@ -392,7 +392,7 @@ pub enum Error {
     ))]
     ColumnDefaultValue {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -404,45 +404,45 @@ pub enum Error {
 
     #[snafu(display("Unrecognized table option: {}", source))]
     UnrecognizedTableOption {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::error::Error,
     },
 
     #[snafu(display("Failed to recover procedure, source: {}", source))]
     RecoverProcedure {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_procedure::error::Error,
     },
 
     #[snafu(display("Failed to submit procedure {}, source: {}", procedure_id, source))]
     SubmitProcedure {
         procedure_id: ProcedureId,
-        #[snafu(backtrace)]
+        location: Location,
         source: common_procedure::error::Error,
     },
 
     #[snafu(display("Failed to wait procedure {} done, source: {}", procedure_id, source))]
     WaitProcedure {
         procedure_id: ProcedureId,
-        #[snafu(backtrace)]
+        location: Location,
         source: common_procedure::error::Error,
     },
 
     #[snafu(display("Failed to close table engine, source: {}", source))]
     CloseTableEngine {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Failed to shutdown server, source: {}", source))]
     ShutdownServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: servers::error::Error,
     },
 
     #[snafu(display("Failed to shutdown instance, source: {}", source))]
     ShutdownInstance {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -487,15 +487,15 @@ impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         use Error::*;
         match self {
-            ExecuteSql { source }
-            | PlanStatement { source }
-            | ExecuteStatement { source }
-            | ExecuteLogicalPlan { source } => source.status_code(),
+            ExecuteSql { source, .. }
+            | PlanStatement { source, .. }
+            | ExecuteStatement { source, .. }
+            | ExecuteLogicalPlan { source, .. } => source.status_code(),
 
             HandleHeartbeatResponse { source, .. } => source.status_code(),
 
-            DecodeLogicalPlan { source } => source.status_code(),
-            NewCatalog { source } | RegisterSchema { source } => source.status_code(),
+            DecodeLogicalPlan { source, .. } => source.status_code(),
+            NewCatalog { source, .. } | RegisterSchema { source, .. } => source.status_code(),
             FindTable { source, .. } => source.status_code(),
             CreateTable { source, .. } => source.status_code(),
             DropTable { source, .. } => source.status_code(),
@@ -512,9 +512,9 @@ impl ErrorExt for Error {
             ParseSqlValue { source, .. } | ParseSql { source, .. } => source.status_code(),
 
             AlterExprToRequest { source, .. }
-            | CreateExprToRequest { source }
-            | DeleteExprToRequest { source }
-            | InsertData { source } => source.status_code(),
+            | CreateExprToRequest { source, .. }
+            | DeleteExprToRequest { source, .. }
+            | InsertData { source, .. } => source.status_code(),
 
             ColumnValuesNumberMismatch { .. }
             | InvalidSql { .. }
@@ -559,13 +559,13 @@ impl ErrorExt for Error {
             | CloseTableEngine { .. }
             | JoinTask { .. } => StatusCode::Internal,
 
-            StartServer { source }
-            | ShutdownServer { source }
+            StartServer { source, .. }
+            | ShutdownServer { source, .. }
             | WaitForGrpcServing { source, .. } => source.status_code(),
 
             InitBackend { .. } => StatusCode::StorageUnavailable,
 
-            OpenLogStore { source } => source.status_code(),
+            OpenLogStore { source, .. } => source.status_code(),
             RuntimeResource { .. } => StatusCode::RuntimeResourcesExhausted,
             MetaClientInit { source, .. } => source.status_code(),
             TableIdProviderNotFound { .. } => StatusCode::Unsupported,

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -421,6 +421,7 @@ pub(crate) async fn create_log_store(
 
     let logstore = RaftEngineLogStore::try_new(log_config)
         .await
+        .map_err(Box::new)
         .context(OpenLogStoreSnafu)?;
     Ok(logstore)
 }

--- a/src/file-table-engine/src/error.rs
+++ b/src/file-table-engine/src/error.rs
@@ -115,13 +115,13 @@ pub enum Error {
         source
     ))]
     ConvertRaw {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::metadata::ConvertError,
     },
 
     #[snafu(display("Invalid schema, source: {}", source))]
     InvalidRawSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -130,7 +130,7 @@ pub enum Error {
 
     #[snafu(display("Failed to build backend, source: {}", source))]
     BuildBackend {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_datasource::error::Error,
     },
 
@@ -154,13 +154,13 @@ pub enum Error {
 
     #[snafu(display("Failed to build stream adapter: {}", source))]
     BuildStreamAdapter {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to parse file format: {}", source))]
     ParseFileFormat {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_datasource::error::Error,
     },
 

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -23,13 +23,13 @@ use snafu::Location;
 pub enum Error {
     #[snafu(display("Failed to start log store gc task, source: {}", source))]
     StartGcTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 
     #[snafu(display("Failed to stop log store gc task, source: {}", source))]
     StopGcTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create gRPC channel, source: {}", source))]
     CreateChannel {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::error::Error,
     },
 
@@ -50,19 +50,19 @@ pub enum Error {
 
     #[snafu(display("Invalid response header, source: {}", source))]
     InvalidResponseHeader {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_meta::error::Error,
     },
 
     #[snafu(display("Failed to convert Metasrv request, source: {}", source))]
     ConvertMetaRequest {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_meta::error::Error,
     },
 
     #[snafu(display("Failed to convert Metasrv response, source: {}", source))]
     ConvertMetaResponse {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_meta::error::Error,
     },
 }
@@ -86,9 +86,9 @@ impl ErrorExt for Error {
             | Error::CreateHeartbeatStream { .. }
             | Error::CreateChannel { .. } => StatusCode::Internal,
 
-            Error::InvalidResponseHeader { source }
-            | Error::ConvertMetaRequest { source }
-            | Error::ConvertMetaResponse { source } => source.status_code(),
+            Error::InvalidResponseHeader { source, .. }
+            | Error::ConvertMetaRequest { source, .. }
+            | Error::ConvertMetaResponse { source, .. } => source.status_code(),
         }
     }
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
 
     #[snafu(display("Failed to shutdown {} server, source: {}", server, source))]
     ShutdownServer {
-        #[snafu(backtrace)]
+        location: Location,
         source: servers::error::Error,
         server: String,
     },
@@ -60,7 +60,7 @@ pub enum Error {
     },
     #[snafu(display("Failed to start http server, source: {}", source))]
     StartHttp {
-        #[snafu(backtrace)]
+        location: Location,
         source: servers::error::Error,
     },
     #[snafu(display("Failed to parse address {}, source: {}", addr, source))]
@@ -130,7 +130,7 @@ pub enum Error {
 
     #[snafu(display("Cannot parse catalog value, source: {}", source))]
     InvalidCatalogValue {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_catalog::error::Error,
     },
 
@@ -190,7 +190,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create gRPC channel, source: {}", source))]
     CreateChannel {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::error::Error,
     },
 
@@ -273,7 +273,7 @@ pub enum Error {
 
     #[snafu(display("Failed to recover procedure, source: {source}"))]
     RecoverProcedure {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_procedure::Error,
     },
 
@@ -321,7 +321,7 @@ pub enum Error {
     ))]
     RegisterProcedureLoader {
         type_name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: common_procedure::error::Error,
     },
 
@@ -350,7 +350,7 @@ pub enum Error {
 
     #[snafu(display("Failed to convert table route, source: {}", source))]
     TableRouteConversion {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_meta::error::Error,
     },
 
@@ -434,15 +434,15 @@ impl ErrorExt for Error {
             | Error::Unexpected { .. } => StatusCode::Unexpected,
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidCatalogValue { source, .. } => source.status_code(),
-            Error::RecoverProcedure { source } => source.status_code(),
-            Error::ShutdownServer { source, .. } | Error::StartHttp { source } => {
+            Error::RecoverProcedure { source, .. } => source.status_code(),
+            Error::ShutdownServer { source, .. } | Error::StartHttp { source, .. } => {
                 source.status_code()
             }
 
             Error::RegionFailoverCandidatesNotFound { .. } => StatusCode::RuntimeResourcesExhausted,
 
             Error::RegisterProcedureLoader { source, .. } => source.status_code(),
-            Error::TableRouteConversion { source } => source.status_code(),
+            Error::TableRouteConversion { source, .. } => source.status_code(),
             Error::Other { source, .. } => source.status_code(),
         }
     }

--- a/src/mito/src/error.rs
+++ b/src/mito/src/error.rs
@@ -107,7 +107,7 @@ pub enum Error {
         source,
     ))]
     UpdateTableManifest {
-        #[snafu(backtrace)]
+        location: Location,
         source: storage::error::Error,
         table_name: String,
     },
@@ -118,7 +118,7 @@ pub enum Error {
         source,
     ))]
     ScanTableManifest {
-        #[snafu(backtrace)]
+        location: Location,
         source: storage::error::Error,
         table_name: String,
     },
@@ -149,7 +149,7 @@ pub enum Error {
         source
     ))]
     ConvertRaw {
-        #[snafu(backtrace)]
+        location: Location,
         source: table::metadata::ConvertError,
     },
 

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
 
     #[snafu(display("Failed to request Meta, source: {}", source))]
     RequestMeta {
-        #[snafu(backtrace)]
+        location: Location,
         source: meta_client::error::Error,
     },
 
@@ -75,7 +75,7 @@ pub enum Error {
     ))]
     CreateDefaultToRead {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -128,7 +128,7 @@ pub enum Error {
     ))]
     ConvertScalarValue {
         value: ScalarValue,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 

--- a/src/query/src/datafusion/error.rs
+++ b/src/query/src/datafusion/error.rs
@@ -34,7 +34,7 @@ pub enum InnerError {
 
     #[snafu(display("Fail to convert arrow schema, source: {}", source))]
     ConvertSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -43,13 +43,13 @@ pub enum InnerError {
         source
     ))]
     ConvertDfRecordBatchStream {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to execute physical plan, source: {}", source))]
     ExecutePhysicalPlan {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_query::error::Error,
     },
 }
@@ -62,8 +62,8 @@ impl ErrorExt for InnerError {
             // TODO(yingwen): Further categorize datafusion error.
             Datafusion { .. } => StatusCode::EngineExecuteQuery,
             PhysicalPlanDowncast { .. } | ConvertSchema { .. } => StatusCode::Unexpected,
-            ConvertDfRecordBatchStream { source } => source.status_code(),
-            ExecutePhysicalPlan { source } => source.status_code(),
+            ConvertDfRecordBatchStream { source, .. } => source.status_code(),
+            ExecutePhysicalPlan { source, .. } => source.status_code(),
         }
     }
 

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -35,13 +35,13 @@ pub(crate) fn ret_other_error_with(reason: String) -> OtherSnafu<String> {
 pub enum Error {
     #[snafu(display("Datatype error: {}", source))]
     TypeCast {
-        #[snafu(backtrace)]
+        location: SnafuLocation,
         source: DataTypeError,
     },
 
     #[snafu(display("Failed to query, source: {}", source))]
     DatabaseQuery {
-        #[snafu(backtrace)]
+        location: SnafuLocation,
         source: QueryError,
     },
 
@@ -105,24 +105,24 @@ pub enum Error {
 
     #[snafu(display("Failed to retrieve record batches, source: {}", source))]
     RecordBatch {
-        #[snafu(backtrace)]
+        location: SnafuLocation,
         source: common_recordbatch::error::Error,
     },
 
     #[snafu(display("Failed to create record batch, source: {}", source))]
     NewRecordBatch {
-        #[snafu(backtrace)]
+        location: SnafuLocation,
         source: common_recordbatch::error::Error,
     },
     #[snafu(display("Failed to create tokio task, source: {}", source))]
     TokioJoin { source: tokio::task::JoinError },
 }
 
-impl From<QueryError> for Error {
-    fn from(source: QueryError) -> Self {
-        Self::DatabaseQuery { source }
-    }
-}
+// impl From<QueryError> for Error {
+//     fn from(source: QueryError) -> Self {
+//         Self::DatabaseQuery { source }
+//     }
+// }
 
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
@@ -133,11 +133,11 @@ impl ErrorExt for Error {
             | Error::TokioJoin { .. }
             | Error::Other { .. } => StatusCode::Internal,
 
-            Error::RecordBatch { source } | Error::NewRecordBatch { source } => {
+            Error::RecordBatch { source, .. } | Error::NewRecordBatch { source, .. } => {
                 source.status_code()
             }
-            Error::DatabaseQuery { source } => source.status_code(),
-            Error::TypeCast { source } => source.status_code(),
+            Error::DatabaseQuery { source, .. } => source.status_code(),
+            Error::TypeCast { source, .. } => source.status_code(),
 
             Error::PyParse { .. }
             | Error::PyCompile { .. }
@@ -151,11 +151,11 @@ impl ErrorExt for Error {
     }
 }
 // impl from for those error so one can use question mark and implicitly cast into `CoprError`
-impl From<DataTypeError> for Error {
-    fn from(e: DataTypeError) -> Self {
-        Self::TypeCast { source: e }
-    }
-}
+// impl From<DataTypeError> for Error {
+//     fn from(e: DataTypeError) -> Self {
+//         Self::TypeCast { source: e }
+//     }
+// }
 
 /// pretty print [`Error`] in given script,
 /// basically print a arrow which point to where error occurs(if possible to get a location)

--- a/src/script/src/python/error.rs
+++ b/src/script/src/python/error.rs
@@ -118,12 +118,6 @@ pub enum Error {
     TokioJoin { source: tokio::task::JoinError },
 }
 
-// impl From<QueryError> for Error {
-//     fn from(source: QueryError) -> Self {
-//         Self::DatabaseQuery { source }
-//     }
-// }
-
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
@@ -150,12 +144,6 @@ impl ErrorExt for Error {
         self
     }
 }
-// impl from for those error so one can use question mark and implicitly cast into `CoprError`
-// impl From<DataTypeError> for Error {
-//     fn from(e: DataTypeError) -> Self {
-//         Self::TypeCast { source: e }
-//     }
-// }
 
 /// pretty print [`Error`] in given script,
 /// basically print a arrow which point to where error occurs(if possible to get a location)

--- a/src/servers/src/auth.rs
+++ b/src/servers/src/auth.rs
@@ -111,7 +111,7 @@ pub enum Error {
 
     #[snafu(display("Auth failed, source: {}", source))]
     AuthBackend {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -409,12 +409,6 @@ impl From<std::io::Error> for Error {
     }
 }
 
-// impl From<auth::Error> for Error {
-//     fn from(e: auth::Error) -> Self {
-//         Error::Auth { source: e }
-//     }
-// }
-
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -49,7 +49,7 @@ pub enum Error {
 
     #[snafu(display("Failed to collect recordbatch, source: {}", source))]
     CollectRecordbatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
@@ -71,19 +71,19 @@ pub enum Error {
     #[snafu(display("Failed to execute query: {}, source: {}", query, source))]
     ExecuteQuery {
         query: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("{source}"))]
     ExecuteGrpcQuery {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Failed to check database validity, source: {}", source))]
     CheckDatabaseValidity {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -93,14 +93,14 @@ pub enum Error {
     #[snafu(display("Failed to insert script with name: {}, source: {}", name, source))]
     InsertScript {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
     #[snafu(display("Failed to execute script by name: {}, source: {}", name, source))]
     ExecuteScript {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -112,19 +112,19 @@ pub enum Error {
 
     #[snafu(display("Failed to parse InfluxDB line protocol, source: {}", source))]
     InfluxdbLineProtocol {
-        #[snafu(backtrace)]
+        location: Location,
         source: influxdb_line_protocol::Error,
     },
 
     #[snafu(display("Failed to write InfluxDB line protocol, source: {}", source))]
     InfluxdbLinesWrite {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::error::Error,
     },
 
     #[snafu(display("Failed to write prometheus series, source: {}", source))]
     PromSeriesWrite {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_grpc::error::Error,
     },
 
@@ -178,7 +178,7 @@ pub enum Error {
 
     #[snafu(display("Failed to get user info, source: {}", source))]
     Auth {
-        #[snafu(backtrace)]
+        location: Location,
         source: auth::Error,
     },
 
@@ -221,7 +221,7 @@ pub enum Error {
     #[cfg(feature = "mem-prof")]
     #[snafu(display("Failed to dump profile data, source: {}", source))]
     DumpProfileData {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_mem_prof::error::Error,
     },
 
@@ -246,7 +246,7 @@ pub enum Error {
     #[snafu(display("Failed to parse PromQL: {query:?}, source: {source}"))]
     ParsePromQL {
         query: PromQuery,
-        #[snafu(backtrace)]
+        location: Location,
         source: query::error::Error,
     },
 
@@ -409,11 +409,11 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<auth::Error> for Error {
-    fn from(e: auth::Error) -> Self {
-        Error::Auth { source: e }
-    }
-}
+// impl From<auth::Error> for Error {
+//     fn from(e: auth::Error) -> Self {
+//         Error::Auth { source: e }
+//     }
+// }
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {

--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -29,8 +29,8 @@ use snafu::{OptionExt, ResultExt};
 use tonic::Status;
 
 use crate::auth::{Identity, Password, UserProviderRef};
-use crate::error::Error::{Auth, UnsupportedAuthScheme};
-use crate::error::{InvalidQuerySnafu, JoinTaskSnafu, NotFoundAuthHeaderSnafu};
+use crate::error::Error::UnsupportedAuthScheme;
+use crate::error::{AuthSnafu, InvalidQuerySnafu, JoinTaskSnafu, NotFoundAuthHeaderSnafu};
 use crate::grpc::TonicResult;
 use crate::metrics::{
     METRIC_AUTH_FAILURE, METRIC_CODE_LABEL, METRIC_SERVER_GRPC_DB_REQUEST_TIMER,
@@ -123,7 +123,7 @@ impl GreptimeRequestHandler {
                     &query_ctx.current_schema(),
                 )
                 .await
-                .map_err(|e| Auth { source: e }),
+                .context(AuthSnafu),
             AuthScheme::Token(_) => Err(UnsupportedAuthScheme {
                 name: "Token AuthScheme".to_string(),
             }),

--- a/src/servers/src/postgres/auth_handler.rs
+++ b/src/servers/src/postgres/auth_handler.rs
@@ -26,10 +26,11 @@ use pgwire::messages::startup::Authentication;
 use pgwire::messages::{PgWireBackendMessage, PgWireFrontendMessage};
 use session::context::UserInfo;
 use session::Session;
+use snafu::IntoError;
 
 use super::PostgresServerHandler;
 use crate::auth::{Identity, Password, UserProviderRef};
-use crate::error::Result;
+use crate::error::{AuthSnafu, Result};
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
 pub(crate) struct PgLoginVerifier {
@@ -106,7 +107,7 @@ impl PgLoginVerifier {
                     format!("{}", e.status_code())
                 )]
             );
-            Err(e.into())
+            Err(AuthSnafu.into_error(e))
         } else {
             Ok(true)
         }

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -98,13 +98,13 @@ pub enum Error {
     #[snafu(display("Invalid default constraint, column: {}, source: {}", column, source))]
     InvalidDefault {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("Failed to serialize column default constraint, source: {}", source))]
     SerializeColumnDefaultConstraint {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -113,7 +113,7 @@ pub enum Error {
         source
     ))]
     ConvertToGrpcDataType {
-        #[snafu(backtrace)]
+        location: Location,
         source: api::error::Error,
     },
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[snafu(display("Invalid region descriptor, region: {}, source: {}", region, source))]
     InvalidRegionDesc {
         region: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
@@ -53,7 +53,7 @@ pub enum Error {
 
     #[snafu(display("Failed to write to buffer, source: {}", source))]
     WriteBuffer {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_datasource::error::Error,
     },
 
@@ -147,7 +147,7 @@ pub enum Error {
     ))]
     WriteWal {
         region_id: RegionId,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -218,7 +218,7 @@ pub enum Error {
     #[snafu(display("Failed to read WAL, region_id: {}, source: {}", region_id, source))]
     ReadWal {
         region_id: RegionId,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -229,7 +229,7 @@ pub enum Error {
     ))]
     MarkWalObsolete {
         region_id: u64,
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -265,14 +265,14 @@ pub enum Error {
     #[snafu(display("Failed to convert store schema, file: {}, source: {}", file, source))]
     ConvertStoreSchema {
         file: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
     #[snafu(display("Invalid raw region metadata, region: {}, source: {}", region, source))]
     InvalidRawRegion {
         region: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
@@ -281,13 +281,13 @@ pub enum Error {
 
     #[snafu(display("Invalid projection, source: {}", source))]
     InvalidProjection {
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
     #[snafu(display("Failed to push data to batch builder, source: {}", source))]
     PushBatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -297,19 +297,19 @@ pub enum Error {
     #[snafu(display("Failed to filter column {}, source: {}", name, source))]
     FilterColumn {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("Invalid alter request, source: {}", source))]
     InvalidAlterRequest {
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
     #[snafu(display("Failed to alter metadata, source: {}", source))]
     AlterMetadata {
-        #[snafu(backtrace)]
+        location: Location,
         source: MetadataError,
     },
 
@@ -320,7 +320,7 @@ pub enum Error {
     ))]
     CreateDefault {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -353,7 +353,7 @@ pub enum Error {
     ))]
     CreateDefaultToRead {
         column: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -367,7 +367,7 @@ pub enum Error {
     ))]
     ConvertChunk {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -376,7 +376,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create record batch for write batch, source:{}", source))]
     CreateRecordBatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_recordbatch::error::Error,
     },
 
@@ -451,13 +451,13 @@ pub enum Error {
 
     #[snafu(display("Failed to start manifest gc task: {}", source))]
     StartManifestGcTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 
     #[snafu(display("Failed to stop manifest gc task: {}", source))]
     StopManifestGcTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 
@@ -475,7 +475,7 @@ pub enum Error {
 
     #[snafu(display("Failed to calculate SST expire time, source: {}", source))]
     TtlCalculation {
-        #[snafu(backtrace)]
+        location: Location,
         source: common_time::error::Error,
     },
 
@@ -501,13 +501,13 @@ pub enum Error {
 
     #[snafu(display("Failed to start picking task for flush: {}", source))]
     StartPickTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 
     #[snafu(display("Failed to stop picking task for flush: {}", source))]
     StopPickTask {
-        #[snafu(backtrace)]
+        location: Location,
         source: RuntimeError,
     },
 

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -51,7 +51,7 @@ pub enum Error {
 
     #[snafu(display("Failed to build schema, source: {}", source))]
     InvalidSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -86,7 +86,7 @@ pub enum Error {
     // End of variants for validating `AlterRequest`.
     #[snafu(display("Failed to convert to column schema, source: {}", source))]
     ToColumnSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -113,7 +113,7 @@ pub enum Error {
 
     #[snafu(display("Failed to convert from arrow schema, source: {}", source))]
     ConvertArrowSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
@@ -127,13 +127,13 @@ pub enum Error {
     ))]
     ConvertChunk {
         name: String,
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("Failed to convert schema, source: {}", source))]
     ConvertSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 

--- a/src/storage/src/wal.rs
+++ b/src/storage/src/wal.rs
@@ -19,7 +19,7 @@ use common_error::prelude::BoxedError;
 use common_telemetry::timer;
 use futures::{stream, Stream, TryStreamExt};
 use prost::Message;
-use snafu::{ensure, ResultExt};
+use snafu::{ensure, Location, ResultExt};
 use store_api::logstore::entry::{Entry, Id};
 use store_api::logstore::LogStore;
 use store_api::storage::{RegionId, SequenceNumber};
@@ -157,6 +157,7 @@ impl<S: LogStore> Wal<S> {
             .map_err(|e| Error::ReadWal {
                 region_id: self.region_id(),
                 source: BoxedError::new(e),
+                location: Location::default(),
             })
             .and_then(|entries| async {
                 let iter = entries.into_iter().map(|x| self.decode_entry(x));

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -34,13 +34,13 @@ pub enum Error {
 
     #[snafu(display("Invalid raw schema, source: {}", source))]
     InvalidRawSchema {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
     },
 
     #[snafu(display("Failed to access catalog, source: {}", source))]
     AccessCatalog {
-        #[snafu(backtrace)]
+        location: Location,
         source: catalog::error::Error,
     },
 
@@ -66,7 +66,7 @@ impl ErrorExt for Error {
         match self {
             SerializeProcedure { .. } | DeserializeProcedure { .. } => StatusCode::Internal,
             InvalidRawSchema { source, .. } => source.status_code(),
-            AccessCatalog { source } => source.status_code(),
+            AccessCatalog { source, .. } => source.status_code(),
             CatalogNotFound { .. } | SchemaNotFound { .. } | TableExists { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/table/src/error.rs
+++ b/src/table/src/error.rs
@@ -15,7 +15,6 @@
 use std::any::Any;
 
 use common_error::prelude::*;
-use common_recordbatch::error::Error as RecordBatchError;
 use datafusion::error::DataFusionError;
 use datatypes::arrow::error::ArrowError;
 use snafu::Location;
@@ -54,7 +53,7 @@ pub enum Error {
 
     #[snafu(display("Failed to create record batch for Tables, source: {}", source))]
     TablesRecordBatch {
-        #[snafu(backtrace)]
+        location: Location,
         source: BoxedError,
     },
 
@@ -67,7 +66,7 @@ pub enum Error {
 
     #[snafu(display("Failed to build schema, msg: {}, source: {}", msg, source))]
     SchemaBuild {
-        #[snafu(backtrace)]
+        location: Location,
         source: datatypes::error::Error,
         msg: String,
     },
@@ -171,13 +170,5 @@ impl ErrorExt for Error {
 impl From<Error> for DataFusionError {
     fn from(e: Error) -> DataFusionError {
         DataFusionError::External(Box::new(e))
-    }
-}
-
-impl From<Error> for RecordBatchError {
-    fn from(e: Error) -> RecordBatchError {
-        RecordBatchError::External {
-            source: BoxedError::new(e),
-        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

replace `#[snafu(backtrace)]` with `Location` in all places except in frontend. Theoretically, location is also enough for external error because we don't care about the internal stack trace of dependencies.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
