### PR TITLE
fix(storage): Use region_write_buffer_size as default value

### DIFF
--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -575,6 +575,10 @@ impl<S: LogStore> RegionImpl<S> {
 
         inner.writer.replay(recovered_metadata, writer_ctx).await
     }
+
+    pub(crate) async fn write_buffer_size(&self) -> usize {
+        self.inner.writer.write_buffer_size().await
+    }
 }
 
 /// Shared data of region.

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -390,6 +390,14 @@ impl RegionWriter {
     }
 }
 
+// Methods for tests.
+#[cfg(test)]
+impl RegionWriter {
+    pub(crate) async fn write_buffer_size(&self) -> usize {
+        self.inner.lock().await.write_buffer_size
+    }
+}
+
 pub struct WriterContext<'a, S: LogStore> {
     pub shared: &'a SharedDataRef,
     pub flush_strategy: &'a FlushStrategyRef,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Respect `EngineConfig::region_write_buffer_size` instead of the constant `DEFAULT_REGION_WRITE_BUFFER_SIZE`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
