### PR TITLE
fix: compile issue on develop and workaround to fix failing tests cau…

### DIFF
--- a/src/storage/src/region/tests/compact.rs
+++ b/src/storage/src/region/tests/compact.rs
@@ -262,7 +262,7 @@ impl CompactionTester {
             MockFilePurgeHandler::default(),
         ));
 
-        //FIXME(hl): find out which component prevents logstore from being dropped.
+        // FIXME(hl): find out which component prevents logstore from being dropped.
         tokio::time::sleep(Duration::from_millis(100)).await;
         let Some(region) = RegionImpl::open(REGION_NAME.to_string(), store_config, &OpenOptions::default()).await? else {
             return Ok(false);

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -102,7 +102,7 @@ impl FlushTester {
         )
         .await;
         store_config.flush_strategy = self.flush_strategy.clone();
-        //FIXME(hl): find out which component prevents logstore from being dropped.
+        // FIXME(hl): find out which component prevents logstore from being dropped.
         tokio::time::sleep(Duration::from_millis(100)).await;
         let opts = OpenOptions::default();
         let region = RegionImpl::open(REGION_NAME.to_string(), store_config, &opts)

--- a/src/storage/src/region/tests/flush.rs
+++ b/src/storage/src/region/tests/flush.rs
@@ -102,6 +102,8 @@ impl FlushTester {
         )
         .await;
         store_config.flush_strategy = self.flush_strategy.clone();
+        //FIXME(hl): find out which component prevents logstore from being dropped.
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let opts = OpenOptions::default();
         let region = RegionImpl::open(REGION_NAME.to_string(), store_config, &opts)
             .await


### PR DESCRIPTION
…sed by logstore file lock

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Fix compile issue on develop branch and add some sleep between region reopen in unit tests to avoid concurrently opeing two raft-engine instances, which will panic.

This is a workaround and we will keep track of the root cause in #1772

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
