### PR TITLE
feat: disable_region_failover option for metasrv

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -93,6 +93,8 @@ struct StartCommand {
     #[clap(long)]
     use_memory_store: bool,
     #[clap(long)]
+    disable_region_failover: bool,
+    #[clap(long)]
     http_addr: Option<String>,
     #[clap(long)]
     http_timeout: Option<u64>,
@@ -134,9 +136,9 @@ impl StartCommand {
                 .context(error::UnsupportedSelectorTypeSnafu { selector_type })?;
         }
 
-        if self.use_memory_store {
-            opts.use_memory_store = true;
-        }
+        opts.use_memory_store = self.use_memory_store;
+
+        opts.disable_region_failover = self.disable_region_failover;
 
         if let Some(http_addr) = &self.http_addr {
             opts.http_opts.addr = http_addr.clone();

--- a/src/meta-srv/src/handler/collect_stats_handler.rs
+++ b/src/meta-srv/src/handler/collect_stats_handler.rs
@@ -20,6 +20,7 @@ use crate::error::Result;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
 
+#[derive(Default)]
 pub struct CollectStatsHandler;
 
 #[async_trait::async_trait]

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -49,6 +49,7 @@ pub struct MetaSrvOptions {
     pub datanode_lease_secs: i64,
     pub selector: SelectorType,
     pub use_memory_store: bool,
+    pub disable_region_failover: bool,
     pub http_opts: HttpOptions,
     pub logging: LoggingOptions,
 }
@@ -62,6 +63,7 @@ impl Default for MetaSrvOptions {
             datanode_lease_secs: 15,
             selector: SelectorType::default(),
             use_memory_store: false,
+            disable_region_failover: false,
             http_opts: HttpOptions::default(),
             logging: LoggingOptions::default(),
         }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -146,24 +146,29 @@ impl MetaSrvBuilder {
         let handler_group = match handler_group {
             Some(handler_group) => handler_group,
             None => {
-                let region_failover_manager = Arc::new(RegionFailoverManager::new(
-                    mailbox.clone(),
-                    procedure_manager.clone(),
-                    selector.clone(),
-                    SelectorContext {
-                        server_addr: options.server_addr.clone(),
-                        datanode_lease_secs: options.datanode_lease_secs,
-                        kv_store: kv_store.clone(),
-                        catalog: None,
-                        schema: None,
-                        table: None,
-                    },
-                    lock.clone(),
-                ));
+                let region_failover_handler = if options.disable_region_failover {
+                    None
+                } else {
+                    let region_failover_manager = Arc::new(RegionFailoverManager::new(
+                        mailbox.clone(),
+                        procedure_manager.clone(),
+                        selector.clone(),
+                        SelectorContext {
+                            server_addr: options.server_addr.clone(),
+                            datanode_lease_secs: options.datanode_lease_secs,
+                            kv_store: kv_store.clone(),
+                            catalog: None,
+                            schema: None,
+                            table: None,
+                        },
+                        lock.clone(),
+                    ));
 
-                let region_failure_handler =
-                    RegionFailureHandler::try_new(election.clone(), region_failover_manager)
-                        .await?;
+                    Some(
+                        RegionFailureHandler::try_new(election.clone(), region_failover_manager)
+                            .await?,
+                    )
+                };
 
                 let group = HeartbeatHandlerGroup::new(pushers);
                 let keep_lease_handler = KeepLeaseHandler::new(kv_store.clone());
@@ -174,9 +179,11 @@ impl MetaSrvBuilder {
                 group.add_handler(keep_lease_handler).await;
                 group.add_handler(CheckLeaderHandler::default()).await;
                 group.add_handler(OnLeaderStartHandler::default()).await;
-                group.add_handler(CollectStatsHandler).await;
-                group.add_handler(MailboxHandler).await;
-                group.add_handler(region_failure_handler).await;
+                group.add_handler(CollectStatsHandler::default()).await;
+                group.add_handler(MailboxHandler::default()).await;
+                if let Some(region_failover_handler) = region_failover_handler {
+                    group.add_handler(region_failover_handler).await;
+                }
                 group.add_handler(PersistStatsHandler::default()).await;
                 group
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

In some scenarios, we don't need to enable region failover, such as when the data is stored on local disks and we don't currently support data migration. If a failover occurs, it will result in data loss, so region failover should be disabled in this case.
I added a startup option called `disable_region_failover`, which defaults to false(enable region failover) and allows users to choose to turn it on(disable region failover).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
