### PR TITLE
fix: abort parquet writer 

### DIFF
--- a/src/common/datasource/src/buffered_writer.rs
+++ b/src/common/datasource/src/buffered_writer.rs
@@ -47,7 +47,7 @@ pub trait ArrowWriterCloser {
 impl<
         T: AsyncWrite + Send + Unpin,
         U: DfRecordBatchEncoder + ArrowWriterCloser,
-        F: FnMut(&str) -> Fut,
+        F: FnMut(String) -> Fut,
         Fut: Future<Output = Result<T>>,
     > LazyBufferedWriter<T, U, F>
 {
@@ -73,7 +73,7 @@ impl<
 impl<
         T: AsyncWrite + Send + Unpin,
         U: DfRecordBatchEncoder,
-        F: FnMut(&str) -> Fut,
+        F: FnMut(String) -> Fut,
         Fut: Future<Output = Result<T>>,
     > LazyBufferedWriter<T, U, F>
 {
@@ -144,9 +144,9 @@ impl<
     /// Only initiates underlying file writer when rows have been written.
     async fn maybe_init_writer(&mut self) -> Result<&mut T> {
         if let Some(ref mut writer) = self.writer {
-            return Ok(writer);
+            Ok(writer)
         } else {
-            let writer = (self.writer_factory)(&self.path).await?;
+            let writer = (self.writer_factory)(self.path.clone()).await?;
             Ok(self.writer.insert(writer))
         }
     }

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -201,7 +201,6 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
 
     // Flushes all pending writes
     writer.try_flush(true).await?;
-
     writer.close().await?;
 
     Ok(rows)

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -199,7 +199,7 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
 
     // Flushes all pending writes
     writer.try_flush(true).await?;
-    writer.close().await?;
+    writer.close_inner_writer().await?;
 
     Ok(rows)
 }

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -182,14 +182,11 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
 ) -> Result<usize> {
     let buffer = SharedBuffer::with_capacity(threshold);
     let encoder = encoder_factory(buffer.clone());
-    let mut writer = LazyBufferedWriter::new(threshold, buffer, encoder, path, |path| {
-        let path = path.to_string();
-        async {
-            store
-                .writer(&path)
-                .await
-                .context(error::WriteObjectSnafu { path })
-        }
+    let mut writer = LazyBufferedWriter::new(threshold, buffer, encoder, path, |path| async {
+        store
+            .writer(&path)
+            .await
+            .context(error::WriteObjectSnafu { path })
     });
 
     let mut rows = 0;

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -27,7 +27,7 @@ use arrow_array::{
 use async_compat::CompatExt;
 use async_stream::try_stream;
 use async_trait::async_trait;
-use common_telemetry::{error, info};
+use common_telemetry::{debug, error};
 use common_time::range::TimestampRange;
 use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
@@ -132,15 +132,8 @@ impl<'a> ParquetWriter<'a> {
         }
 
         if rows_written == 0 {
-            info!("No data written, try abort writer");
-            // if the source does not contain any batch, we skip writing an empty parquet file.
-            // if !buffered_writer.abort().await {
-            //     common_telemetry::warn!(
-            //         "Partial file {} has been uploaded to remote storage",
-            //         self.file_path
-            //     );
-            // }
-            buffered_writer.close().await.unwrap();
+            debug!("No data written, try abort writer: {}", self.file_path);
+            buffered_writer.close().await?;
             return Ok(None);
         }
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -674,11 +674,11 @@ mod tests {
             rows_written += keys.len();
         }
 
-        let dir = create_temp_dir("write_parquet");
+        let dir = create_temp_dir("write_large_parquet");
         let path = dir.path().to_str().unwrap();
 
         let object_store = create_object_store(path);
-        let sst_file_name = "test-flush.parquet";
+        let sst_file_name = "test-large.parquet";
         let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
 
@@ -1004,12 +1004,12 @@ mod tests {
         let schema = memtable_tests::schema_for_test();
         let memtable = DefaultMemtableBuilder::default().build(schema.clone());
 
-        let dir = create_temp_dir("read-parquet-by-range");
+        let dir = create_temp_dir("write-empty-file");
         let path = dir.path().to_str().unwrap();
         let mut builder = Fs::default();
         builder.root(path);
         let object_store = ObjectStore::new(builder).unwrap().finish();
-        let sst_file_name = "test-read.parquet";
+        let sst_file_name = "test-empty.parquet";
         let iter = memtable.iter(IterContext::default()).unwrap();
         let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
 

--- a/src/storage/src/sst/parquet.rs
+++ b/src/storage/src/sst/parquet.rs
@@ -27,7 +27,7 @@ use arrow_array::{
 use async_compat::CompatExt;
 use async_stream::try_stream;
 use async_trait::async_trait;
-use common_telemetry::{error, warn};
+use common_telemetry::{error, info};
 use common_time::range::TimestampRange;
 use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
@@ -132,13 +132,15 @@ impl<'a> ParquetWriter<'a> {
         }
 
         if rows_written == 0 {
+            info!("No data written, try abort writer");
             // if the source does not contain any batch, we skip writing an empty parquet file.
-            if !buffered_writer.abort().await {
-                warn!(
-                    "Partial file {} has been uploaded to remote storage",
-                    self.file_path
-                );
-            }
+            // if !buffered_writer.abort().await {
+            //     common_telemetry::warn!(
+            //         "Partial file {} has been uploaded to remote storage",
+            //         self.file_path
+            //     );
+            // }
+            buffered_writer.close().await.unwrap();
             return Ok(None);
         }
 
@@ -547,8 +549,10 @@ impl BatchReader for ChunkStream {
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
     use std::sync::Arc;
 
+    use common_base::readable_size::ReadableSize;
     use common_test_util::temp_dir::create_temp_dir;
     use datatypes::arrow::array::{Array, UInt64Array, UInt8Array};
     use datatypes::prelude::{ScalarVector, Vector};
@@ -651,6 +655,44 @@ mod tests {
             &(Arc::new(UInt8Array::from(vec![1; 5])) as Arc<dyn Array>),
             chunk.column(4)
         );
+    }
+
+    #[tokio::test]
+    async fn test_write_large_data() {
+        common_telemetry::init_default_ut_logging();
+        let schema = memtable_tests::schema_for_test();
+        let memtable = DefaultMemtableBuilder::default().build(schema);
+
+        let mut rows_written = 0;
+        for i in 0..16 {
+            let range: Range<i64> = i * 1024..(i + 1) * 1024;
+            let keys = range.clone().collect::<Vec<_>>();
+            let values = range
+                .map(|idx| (Some(idx as u64), Some(idx as u64)))
+                .collect::<Vec<_>>();
+            memtable_tests::write_kvs(&*memtable, i as u64, OpType::Put, &keys, &values);
+            rows_written += keys.len();
+        }
+
+        let dir = create_temp_dir("write_parquet");
+        let path = dir.path().to_str().unwrap();
+
+        let object_store = create_object_store(path);
+        let sst_file_name = "test-flush.parquet";
+        let iter = memtable.iter(IterContext::default()).unwrap();
+        let writer = ParquetWriter::new(sst_file_name, Source::Iter(iter), object_store.clone());
+
+        let sst_info = writer
+            .write_sst(&sst::WriteOptions {
+                sst_write_buffer_size: ReadableSize::kb(4),
+            })
+            .await
+            .unwrap()
+            .unwrap();
+        let file_meta = object_store.stat(sst_file_name).await.unwrap();
+        assert!(file_meta.is_file());
+        assert_eq!(sst_info.file_size, file_meta.content_length());
+        assert_eq!(rows_written, sst_info.num_rows);
     }
 
     #[tokio::test]
@@ -975,8 +1017,9 @@ mod tests {
             .write_sst(&sst::WriteOptions::default())
             .await
             .unwrap();
-
         assert!(sst_info_opt.is_none());
+        // The file should not exist when no row has been written.
+        assert!(!object_store.is_exist(sst_file_name).await.unwrap());
     }
 
     #[test]

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -108,7 +108,7 @@ impl BufferedWriter {
         Ok(())
     }
 
-    /// Close parquet writer and ensure all buffered data are written into underlying storage.
+    /// Close parquet writer.
     pub async fn close(self) -> error::Result<(FileMetaData, u64)> {
         self.inner
             .close_with_arrow_writer()

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -40,7 +40,7 @@ type InnerBufferedWriter = DatasourceBufferedWriter<
     ArrowWriter<SharedBuffer>,
     Box<
         dyn FnMut(
-                &str,
+                String,
             ) -> Pin<
                 Box<
                     dyn Future<Output = common_datasource::error::Result<object_store::Writer>>
@@ -63,16 +63,14 @@ impl BufferedWriter {
 
         let arrow_writer = ArrowWriter::try_new(buffer.clone(), arrow_schema.clone(), props)
             .context(WriteParquetSnafu)?;
-        let store = store.clone();
 
         Ok(Self {
             inner: DatasourceBufferedWriter::new(
                 buffer_threshold,
-                buffer.clone(),
+                buffer,
                 arrow_writer,
                 &path,
-                Box::new(move |path: &str| {
-                    let path = path.to_string();
+                Box::new(move |path| {
                     let store = store.clone();
                     Box::pin(async move {
                         store

--- a/src/storage/src/sst/stream_writer.rs
+++ b/src/storage/src/sst/stream_writer.rs
@@ -92,13 +92,6 @@ impl BufferedWriter {
         Ok(())
     }
 
-    /// Abort writer.
-    pub async fn abort(self) -> bool {
-        // TODO(hl): Currently we can do nothing if file's parts have been uploaded to remote storage
-        // on abortion, we need to find a way to abort the upload. see https://help.aliyun.com/document_detail/31996.htm?spm=a2c4g.11186623.0.0.3eb42cb7b2mwUz#reference-txp-bvx-wdb
-        !self.inner.flushed()
-    }
-
     /// Close parquet writer and ensure all buffered data are written into underlying storage.
     pub async fn close(self) -> error::Result<(FileMetaData, u64)> {
         self.inner


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR fixes two issues:
- `ParquetWriter::close` returns the bytes during last flush attempt when closing underlying writer instead of the size of whole file: https://github.com/GreptimeTeam/greptimedb/pull/1785/files#diff-051f815e4fa71f86735dd28136c0d475fa75dceb4903a7ab47c93b60576ad970L56
- [`stream_to_file`](https://github.com/GreptimeTeam/greptimedb/pull/1785/files#diff-423117cc93ea8a8d6deed211495ad49b92650c130e6932d1d9282c4eff8b52c9L184-L188) and [`BufferedWriter::try_new`](https://github.com/GreptimeTeam/greptimedb/pull/1785/files#diff-23b04e5dea6eef5d5101622d0d8d2046da2f0331c97474c484cc647ddaf6f4dfL50-L53) eagerly create underlying files even if there's no row has been written. This PR tries to fix this issue by lazily creating files upon first flush.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Fixes #1786 and  #1787
