### PR TITLE
feat: support cross compilation to aarch64 linux

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+[build]
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt update && apt install -y unzip zlib1g-dev:$CROSS_DEB_ARCH",
+    "curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip && unzip protoc-3.15.8-linux-x86_64.zip -d /usr/",
+    "chmod a+x /usr/bin/protoc && chmod -R a+rx /usr/include/google",
+]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add support for cross compilation targeting aarch64-unknown-linux-gnu, thanks to [cross-rs(https://github.com/cross-rs/cross).

You can produce a GreptimeDB binary for aarch-unknown-linux-gnu by following steps:
- Install docker
- Install cross-rs by `cargo install cross --git https://github.com/cross-rs/cross`
- Under GreptimeDB repository, run `cross build --target aarch64-unknown-linux-gnu`


## Note

Honestly I really don't suggest cross compilation on macOS in that it uses QEMU to run containers, which will make the compilation painfully slow.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
