### PR TITLE
fix: deregister table may fail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8520,6 +8520,7 @@ dependencies = [
  "axum-macros",
  "axum-test-helper",
  "base64 0.13.1",
+ "build-data",
  "bytes",
  "catalog",
  "chrono",

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -26,8 +26,8 @@ tcp_nodelay = true
 [wal]
 # WAL data directory
 # dir = "/tmp/greptimedb/wal"
-file_size = "1GB"
-purge_threshold = "50GB"
+file_size = "256m"
+purge_threshold = "4GB"
 purge_interval = "10m"
 read_batch_size = 128
 sync_write = false

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -81,9 +81,9 @@ addr = "127.0.0.1:4004"
 # WAL data directory
 # dir = "/tmp/greptimedb/wal"
 # WAL file size in bytes.
-file_size = "1GB"
+file_size = "256m"
 # WAL purge threshold in bytes.
-purge_threshold = "50GB"
+purge_threshold = "4GB"
 # WAL purge interval in seconds.
 purge_interval = "10m"
 # WAL read batch size.

--- a/src/catalog/src/tables.rs
+++ b/src/catalog/src/tables.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_catalog::consts::{INFORMATION_SCHEMA_NAME, SYSTEM_CATALOG_TABLE_NAME};
+use common_telemetry::logging;
 use snafu::ResultExt;
 use table::metadata::TableId;
 use table::{Table, TableRef};
@@ -96,7 +97,19 @@ impl SystemCatalog {
             .system
             .delete(build_table_deletion_request(request, table_id))
             .await
-            .map(|x| x == 1)
+            .map(|x| {
+                if x !=1 {
+                    logging::warn!("Failed to delete table record from information_schema, unexpected returned result: {}, table: {}", x, common_catalog::format_full_table_name(
+                        &request.catalog,
+                        &request.schema,
+                        &request.table_name
+                    ));
+                }
+
+                // Returns true even though the returned result is unexpected.
+                // If there are no IO or other unexpected errors, the `deregister_table` is idempotent.
+                true
+            })
             .with_context(|_| error::DeregisterTableSnafu {
                 request: request.clone(),
             })

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -192,8 +192,8 @@ impl Default for WalConfig {
     fn default() -> Self {
         Self {
             dir: None,
-            file_size: ReadableSize::gb(1),        // log file size 1G
-            purge_threshold: ReadableSize::gb(50), // purge threshold 50G
+            file_size: ReadableSize::mb(256), // log file size 256M
+            purge_threshold: ReadableSize::gb(4), // purge threshold 4G
             purge_interval: Duration::from_secs(600),
             read_batch_size: 128,
             sync_write: false,

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
 
     #[snafu(display("Table already exists: {}", name))]
     TableExists { name: String },
+
+    #[snafu(display("Failed to deregister table: {}", name))]
+    DeregisterTable { name: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -64,7 +67,9 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            SerializeProcedure { .. } | DeserializeProcedure { .. } => StatusCode::Internal,
+            DeregisterTable { .. } | SerializeProcedure { .. } | DeserializeProcedure { .. } => {
+                StatusCode::Internal
+            }
             InvalidRawSchema { source, .. } => source.status_code(),
             AccessCatalog { source, .. } => source.status_code(),
             CatalogNotFound { .. } | SchemaNotFound { .. } | TableExists { .. } => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* `deregister_table` may fail in CatalogManager, the procedure should take care of it.
*  Always returning true when deleting table records from `information_schema`, but log the unexpected result.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
