### PR TITLE
chore: check catalog deregister result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8520,6 +8520,7 @@ dependencies = [
  "axum-macros",
  "axum-test-helper",
  "base64 0.13.1",
+ "build-data",
  "bytes",
  "catalog",
  "chrono",

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -467,10 +467,7 @@ impl CatalogManager for LocalCatalogManager {
                 .ident
                 .table_id;
 
-            if !self.system.deregister_table(&request, table_id).await? {
-                return Ok(false);
-            }
-
+            self.system.deregister_table(&request, table_id).await?;
             self.catalogs.deregister_table(request).await
         }
     }

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -662,7 +662,7 @@ impl CatalogManager for RemoteCatalogManager {
                 .await;
         }
 
-        Ok(result.is_none())
+        Ok(true)
     }
 
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool> {

--- a/src/catalog/src/tables.rs
+++ b/src/catalog/src/tables.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_catalog::consts::{INFORMATION_SCHEMA_NAME, SYSTEM_CATALOG_TABLE_NAME};
+use common_telemetry::logging;
 use snafu::ResultExt;
 use table::metadata::TableId;
 use table::{Table, TableRef};
@@ -96,7 +97,20 @@ impl SystemCatalog {
             .system
             .delete(build_table_deletion_request(request, table_id))
             .await
-            .map(|x| x == 1)
+            .map(|x| {
+                if x != 1 {
+                    let table = common_catalog::format_full_table_name(
+                        &request.catalog,
+                        &request.schema,
+                        &request.table_name
+                    );
+                    logging::warn!("Failed to delete table record from information_schema, unexpected returned result: {x}, table: {table}");
+                }
+
+                // Returns true even though the returned result is unexpected.
+                // If there are no IO or other unexpected errors, the `deregister_table` is idempotent.
+                true
+            })
             .with_context(|_| error::DeregisterTableSnafu {
                 request: request.clone(),
             })

--- a/src/catalog/src/tables.rs
+++ b/src/catalog/src/tables.rs
@@ -92,7 +92,7 @@ impl SystemCatalog {
         &self,
         request: &DeregisterTableRequest,
         table_id: TableId,
-    ) -> CatalogResult<bool> {
+    ) -> CatalogResult<()> {
         self.information_schema
             .system
             .delete(build_table_deletion_request(request, table_id))
@@ -106,10 +106,6 @@ impl SystemCatalog {
                     );
                     logging::warn!("Failed to delete table record from information_schema, unexpected returned result: {x}, table: {table}");
                 }
-
-                // Returns true even though the returned result is unexpected.
-                // If there are no IO or other unexpected errors, the `deregister_table` is idempotent.
-                true
             })
             .with_context(|_| error::DeregisterTableSnafu {
                 request: request.clone(),

--- a/src/table-procedure/src/drop.rs
+++ b/src/table-procedure/src/drop.rs
@@ -168,8 +168,7 @@ impl DropTableProcedure {
                 return DeregisterTableSnafu {
                     name: request.table_ref().to_string(),
                 }
-                .fail()
-                .map_err(|e| e.into());
+                .fail()?;
             }
         }
 

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
 
     #[snafu(display("Table already exists: {}", name))]
     TableExists { name: String },
+
+    #[snafu(display("Failed to deregister table: {}", name))]
+    DeregisterTable { name: String },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -64,7 +67,9 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            SerializeProcedure { .. } | DeserializeProcedure { .. } => StatusCode::Internal,
+            DeregisterTable { .. } | SerializeProcedure { .. } | DeserializeProcedure { .. } => {
+                StatusCode::Internal
+            }
             InvalidRawSchema { source, .. } => source.status_code(),
             AccessCatalog { source, .. } => source.status_code(),
             CatalogNotFound { .. } | SchemaNotFound { .. } | TableExists { .. } => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds result check when invoking `CatalogManager::deregister_table`. We should remove the return value of this API in #1803 .


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
