### PR TITLE
refactor!: Uses table id to locate tables in table engines

### DIFF
--- a/src/catalog/src/helper.rs
+++ b/src/catalog/src/helper.rs
@@ -197,12 +197,11 @@ impl TableRegionalKey {
     }
 }
 
-// FIXME(yingwen): TableRegionalValue doesn't contains table id. We have to get it from the global
-// table value if we need to access the table id.
 /// Regional table info of specific datanode, including table version on that datanode and
 /// region ids allocated by metasrv.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TableRegionalValue {
+    pub table_id: Option<TableId>,
     pub version: TableVersion,
     pub regions_ids: Vec<u32>,
     pub engine_name: Option<String>,

--- a/src/catalog/src/helper.rs
+++ b/src/catalog/src/helper.rs
@@ -197,6 +197,8 @@ impl TableRegionalKey {
     }
 }
 
+// FIXME(yingwen): TableRegionalValue doesn't contains table id. We have to get it from the global
+// table value if we need to access the table id.
 /// Regional table info of specific datanode, including table version on that datanode and
 /// region ids allocated by metasrv.
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/catalog/src/helper.rs
+++ b/src/catalog/src/helper.rs
@@ -201,6 +201,8 @@ impl TableRegionalKey {
 /// region ids allocated by metasrv.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TableRegionalValue {
+    // We can remove the `Option` from the table id once all regional values
+    // stored in meta have table ids.
     pub table_id: Option<TableId>,
     pub version: TableVersion,
     pub regions_ids: Vec<u32>,

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -1010,18 +1010,19 @@ impl SchemaProvider for RemoteSchemaProvider {
                 let TableRegionalValue { engine_name, .. } =
                     TableRegionalValue::parse(String::from_utf8_lossy(&v))
                         .context(InvalidCatalogValueSnafu)?;
-                let reference = TableReference {
-                    catalog: &self.catalog_name,
-                    schema: &self.schema_name,
-                    table: name,
-                };
+
                 let engine_name = engine_name.as_deref().unwrap_or(MITO_ENGINE);
                 let engine = self
                     .engine_manager
                     .engine(engine_name)
                     .context(TableEngineNotFoundSnafu { engine_name })?;
+                let reference = TableReference {
+                    catalog: &self.catalog_name,
+                    schema: &self.schema_name,
+                    table: name,
+                };
                 let table = engine
-                    .get_table(&EngineContext {}, &reference, global_value.table_id())
+                    .get_table(&EngineContext {}, global_value.table_id())
                     .with_context(|_| OpenTableSnafu {
                         table_info: reference.to_string(),
                     })?;
@@ -1117,7 +1118,7 @@ impl SchemaProvider for RemoteSchemaProvider {
             .engine_manager
             .engine(engine_name)
             .context(TableEngineNotFoundSnafu { engine_name })?
-            .get_table(&EngineContext {}, &reference, global_value.table_id())
+            .get_table(&EngineContext {}, global_value.table_id())
             .with_context(|_| OpenTableSnafu {
                 table_info: reference.to_string(),
             })?;

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -992,6 +992,7 @@ impl SchemaProvider for RemoteSchemaProvider {
                     .context(InvalidCatalogValueSnafu)?;
 
                 let Some(table_id) = table_id else {
+                    warn!("Cannot find table id for {key}, the value has an old format");
                     return Ok(None);
                 };
                 let engine_name = engine_name.as_deref().unwrap_or(MITO_ENGINE);
@@ -1090,7 +1091,6 @@ impl SchemaProvider for RemoteSchemaProvider {
 
         let Some((engine_name, table_id)) = engine_opt else {
             warn!("Cannot find table id and engine name for {table_key}");
-            // If table
             return Ok(None);
         };
         let reference = TableReference {

--- a/src/catalog/src/remote/mock.rs
+++ b/src/catalog/src/remote/mock.rs
@@ -181,9 +181,6 @@ impl TableEngine for MockTableEngine {
         _ctx: &EngineContext,
         request: CreateTableRequest,
     ) -> table::Result<TableRef> {
-        let table_name = request.table_name.clone();
-        let catalog_name = request.catalog_name.clone();
-        let schema_name = request.schema_name.clone();
         let table_id = request.id;
 
         let schema = Arc::new(Schema::new(vec![ColumnSchema::new(
@@ -195,11 +192,11 @@ impl TableEngine for MockTableEngine {
         let data = vec![Arc::new(StringVector::from(vec!["a", "b", "c"])) as _];
         let record_batch = RecordBatch::new(schema, data).unwrap();
         let table: TableRef = Arc::new(MemTable::new_with_catalog(
-            &table_name,
+            &request.table_name,
             record_batch,
             table_id,
-            catalog_name,
-            schema_name,
+            request.catalog_name,
+            request.schema_name,
             vec![0],
         )) as Arc<_>;
 

--- a/src/catalog/src/remote/mock.rs
+++ b/src/catalog/src/remote/mock.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Display, Formatter};
-use std::str::FromStr;
 use std::sync::{Arc, RwLock as StdRwLock};
 
 use async_stream::stream;
@@ -27,7 +26,7 @@ use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
 use datatypes::vectors::StringVector;
 use serde::Serializer;
-use table::engine::{CloseTableResult, EngineContext, TableEngine, TableReference};
+use table::engine::{CloseTableResult, EngineContext, TableEngine};
 use table::metadata::TableId;
 use table::requests::{
     AlterTableRequest, CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest,

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -500,7 +500,7 @@ mod test {
     use common_meta::heartbeat::mailbox::HeartbeatMailbox;
     use datatypes::schema::RawSchema;
     use table::engine::manager::MemoryTableEngineManager;
-    use table::engine::{TableEngine, TableReference};
+    use table::engine::TableEngine;
     use table::requests::{CreateTableRequest, TableOptions};
     use table::test_util::EmptyTable;
 

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -754,7 +754,7 @@ mod test {
         let table = "my_table";
         let table_id = 1;
         let request = CreateTableRequest {
-            id: 1,
+            id: table_id,
             catalog_name: catalog.to_string(),
             schema_name: schema.to_string(),
             table_name: table.to_string(),
@@ -770,7 +770,6 @@ mod test {
             table_options: TableOptions::default(),
             engine: "mito".to_string(),
         };
-        let table_ref = TableReference::full(catalog, schema, table);
 
         let table_engine = Arc::new(MockTableEngine::default());
         table_engine.create_table(ctx, request).await.unwrap();
@@ -815,9 +814,9 @@ mod test {
         .unwrap();
 
         // assert the table is closed after deadline is reached
-        assert!(table_engine.table_exists(ctx, &table_ref, table_id));
+        assert!(table_engine.table_exists(ctx, table_id));
         // spare 500ms for the task to close the table
         tokio::time::sleep(Duration::from_millis(2000)).await;
-        assert!(!table_engine.table_exists(ctx, &table_ref, table_id));
+        assert!(!table_engine.table_exists(ctx, table_id));
     }
 }

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -475,6 +475,7 @@ impl CountdownTask {
                 catalog_name: table_ident.catalog.clone(),
                 schema_name: table_ident.schema.clone(),
                 table_name: table_ident.table.clone(),
+                table_id: table_ident.table_id,
                 region_numbers: vec![region],
                 flush: true,
             };

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -751,6 +751,7 @@ mod test {
         let catalog = "my_catalog";
         let schema = "my_schema";
         let table = "my_table";
+        let table_id = 1;
         let request = CreateTableRequest {
             id: 1,
             catalog_name: catalog.to_string(),
@@ -777,7 +778,7 @@ mod test {
             catalog: catalog.to_string(),
             schema: schema.to_string(),
             table: table.to_string(),
-            table_id: 1024,
+            table_id,
             engine: "mito".to_string(),
         };
         let (tx, rx) = mpsc::channel(10);
@@ -813,9 +814,9 @@ mod test {
         .unwrap();
 
         // assert the table is closed after deadline is reached
-        assert!(table_engine.table_exists(ctx, &table_ref));
+        assert!(table_engine.table_exists(ctx, &table_ref, table_id));
         // spare 500ms for the task to close the table
         tokio::time::sleep(Duration::from_millis(2000)).await;
-        assert!(!table_engine.table_exists(ctx, &table_ref));
+        assert!(!table_engine.table_exists(ctx, &table_ref, table_id));
     }
 }

--- a/src/common/grpc-expr/src/alter.rs
+++ b/src/common/grpc-expr/src/alter.rs
@@ -34,7 +34,7 @@ const LOCATION_TYPE_FIRST: i32 = LocationType::First as i32;
 const LOCATION_TYPE_AFTER: i32 = LocationType::After as i32;
 
 /// Convert an [`AlterExpr`] to an [`AlterTableRequest`]
-pub fn alter_expr_to_request(expr: AlterExpr) -> Result<AlterTableRequest> {
+pub fn alter_expr_to_request(table_id: TableId, expr: AlterExpr) -> Result<AlterTableRequest> {
     let catalog_name = expr.catalog_name;
     let schema_name = expr.schema_name;
     let kind = expr.kind.context(MissingFieldSnafu { field: "kind" })?;
@@ -69,6 +69,7 @@ pub fn alter_expr_to_request(expr: AlterExpr) -> Result<AlterTableRequest> {
                 catalog_name,
                 schema_name,
                 table_name: expr.table_name,
+                table_id,
                 alter_kind,
             };
             Ok(request)
@@ -82,6 +83,7 @@ pub fn alter_expr_to_request(expr: AlterExpr) -> Result<AlterTableRequest> {
                 catalog_name,
                 schema_name,
                 table_name: expr.table_name,
+                table_id,
                 alter_kind,
             };
             Ok(request)
@@ -92,6 +94,7 @@ pub fn alter_expr_to_request(expr: AlterExpr) -> Result<AlterTableRequest> {
                 catalog_name,
                 schema_name,
                 table_name: expr.table_name,
+                table_id,
                 alter_kind,
             };
             Ok(request)
@@ -239,7 +242,7 @@ mod tests {
             })),
         };
 
-        let alter_request = alter_expr_to_request(expr).unwrap();
+        let alter_request = alter_expr_to_request(1, expr).unwrap();
         assert_eq!(alter_request.catalog_name, "");
         assert_eq!(alter_request.schema_name, "");
         assert_eq!("monitor".to_string(), alter_request.table_name);
@@ -296,7 +299,7 @@ mod tests {
             })),
         };
 
-        let alter_request = alter_expr_to_request(expr).unwrap();
+        let alter_request = alter_expr_to_request(1, expr).unwrap();
         assert_eq!(alter_request.catalog_name, "");
         assert_eq!(alter_request.schema_name, "");
         assert_eq!("monitor".to_string(), alter_request.table_name);
@@ -344,7 +347,7 @@ mod tests {
             })),
         };
 
-        let alter_request = alter_expr_to_request(expr).unwrap();
+        let alter_request = alter_expr_to_request(1, expr).unwrap();
         assert_eq!(alter_request.catalog_name, "test_catalog");
         assert_eq!(alter_request.schema_name, "test_schema");
         assert_eq!("monitor".to_string(), alter_request.table_name);

--- a/src/datanode/src/heartbeat/handler/close_region.rs
+++ b/src/datanode/src/heartbeat/handler/close_region.rs
@@ -164,7 +164,7 @@ impl CloseRegionHandler {
         }
 
         if engine
-            .get_table(&ctx, table_ref, region_ident.table_ident.table_id)
+            .get_table(&ctx, region_ident.table_ident.table_id)
             .with_context(|_| error::GetTableSnafu {
                 table_name: table_ref.to_string(),
             })?

--- a/src/datanode/src/heartbeat/handler/close_region.rs
+++ b/src/datanode/src/heartbeat/handler/close_region.rs
@@ -178,6 +178,7 @@ impl CloseRegionHandler {
                         schema_name: table_ref.schema.to_string(),
                         table_name: table_ref.table.to_string(),
                         region_numbers: region_numbers.clone(),
+                        table_id: region_ident.table_ident.table_id,
                         flush: true,
                     },
                 )

--- a/src/datanode/src/heartbeat/handler/close_region.rs
+++ b/src/datanode/src/heartbeat/handler/close_region.rs
@@ -164,7 +164,7 @@ impl CloseRegionHandler {
         }
 
         if engine
-            .get_table(&ctx, table_ref)
+            .get_table(&ctx, table_ref, region_ident.table_ident.table_id)
             .with_context(|_| error::GetTableSnafu {
                 table_name: table_ref.to_string(),
             })?

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -106,7 +106,13 @@ impl Instance {
                 let name = alter_table.table_name().clone();
                 let (catalog, schema, table) = table_idents_to_full_name(&name, query_ctx.clone())?;
                 let table_ref = TableReference::full(&catalog, &schema, &table);
-                let req = SqlHandler::alter_to_request(alter_table, table_ref)?;
+                // Currently, we have to get the table multiple times. Consider remove the sql handler in the future.
+                let table = self.sql_handler.get_table(&table_ref).await?;
+                let req = SqlHandler::alter_to_request(
+                    alter_table,
+                    table_ref,
+                    table.table_info().ident.table_id,
+                )?;
                 self.sql_handler
                     .execute(SqlRequest::Alter(req), query_ctx)
                     .await

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -120,10 +120,13 @@ impl Instance {
             Statement::DropTable(drop_table) => {
                 let (catalog_name, schema_name, table_name) =
                     table_idents_to_full_name(drop_table.table_name(), query_ctx.clone())?;
+                let table_ref = TableReference::full(&catalog_name, &schema_name, &table_name);
+                let table = self.sql_handler.get_table(&table_ref).await?;
                 let req = DropTableRequest {
                     catalog_name,
                     schema_name,
                     table_name,
+                    table_id: table.table_info().ident.table_id,
                 };
                 self.sql_handler
                     .execute(SqlRequest::DropTable(req), query_ctx)

--- a/src/datanode/src/sql/alter.rs
+++ b/src/datanode/src/sql/alter.rs
@@ -19,6 +19,7 @@ use snafu::prelude::*;
 use sql::statements::alter::{AlterTable, AlterTableOperation};
 use sql::statements::column_def_to_schema;
 use table::engine::TableReference;
+use table::metadata::TableId;
 use table::requests::{AddColumnRequest, AlterKind, AlterTableRequest};
 use table_procedure::AlterTableProcedure;
 
@@ -60,6 +61,7 @@ impl SqlHandler {
     pub(crate) fn alter_to_request(
         alter_table: AlterTable,
         table_ref: TableReference,
+        table_id: TableId,
     ) -> Result<AlterTableRequest> {
         let alter_kind = match &alter_table.alter_operation() {
             AlterTableOperation::AddConstraint(table_constraint) => {
@@ -91,6 +93,7 @@ impl SqlHandler {
             catalog_name: table_ref.catalog.to_string(),
             schema_name: table_ref.schema.to_string(),
             table_name: table_ref.table.to_string(),
+            table_id,
             alter_kind,
         })
     }
@@ -128,6 +131,7 @@ mod tests {
         let req = SqlHandler::alter_to_request(
             alter_table,
             TableReference::full("greptime", "public", "my_metric_1"),
+            1,
         )
         .unwrap();
         assert_eq!(req.catalog_name, "greptime");
@@ -154,6 +158,7 @@ mod tests {
         let req = SqlHandler::alter_to_request(
             alter_table,
             TableReference::full("greptime", "public", "test_table"),
+            1,
         )
         .unwrap();
         assert_eq!(req.catalog_name, "greptime");

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -25,7 +25,7 @@ use object_store::ObjectStore;
 use snafu::ResultExt;
 use table::engine::{table_dir, EngineContext, TableEngine, TableEngineProcedure, TableReference};
 use table::error::TableOperationSnafu;
-use table::metadata::{TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
+use table::metadata::{TableId, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
 use table::{error as table_error, Result as TableResult, Table, TableRef};
 use tokio::sync::Mutex;
@@ -92,11 +92,17 @@ impl TableEngine for ImmutableFileTableEngine {
         &self,
         _ctx: &EngineContext,
         table_ref: &TableReference,
+        _table_id: TableId,
     ) -> TableResult<Option<TableRef>> {
         Ok(self.inner.get_table(table_ref))
     }
 
-    fn table_exists(&self, _ctx: &EngineContext, table_ref: &TableReference) -> bool {
+    fn table_exists(
+        &self,
+        _ctx: &EngineContext,
+        table_ref: &TableReference,
+        _table_id: TableId,
+    ) -> bool {
         self.inner.get_table(table_ref).is_some()
     }
 

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -88,21 +88,11 @@ impl TableEngine for ImmutableFileTableEngine {
         .fail()
     }
 
-    fn get_table(
-        &self,
-        _ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> TableResult<Option<TableRef>> {
+    fn get_table(&self, _ctx: &EngineContext, table_id: TableId) -> TableResult<Option<TableRef>> {
         Ok(self.inner.get_table(table_id))
     }
 
-    fn table_exists(
-        &self,
-        _ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> bool {
+    fn table_exists(&self, _ctx: &EngineContext, table_id: TableId) -> bool {
         self.inner.get_table(table_id).is_some()
     }
 

--- a/src/file-table-engine/src/engine/procedure/create.rs
+++ b/src/file-table-engine/src/engine/procedure/create.rs
@@ -92,17 +92,13 @@ impl CreateImmutableFileTable {
 
     fn on_prepare(&mut self) -> Result<Status> {
         let engine_ctx = EngineContext::default();
-        let table_ref = self.data.table_ref();
         // Safety: Current get_table implementation always returns Ok.
-        if self
-            .engine
-            .table_exists(&engine_ctx, &table_ref, self.data.request.id)
-        {
+        if self.engine.table_exists(&engine_ctx, self.data.request.id) {
             // The table already exists.
             ensure!(
                 self.data.request.create_if_not_exists,
                 TableExistsSnafu {
-                    table_name: table_ref.to_string(),
+                    table_name: self.data.table_ref().to_string(),
                 }
             );
 
@@ -116,11 +112,7 @@ impl CreateImmutableFileTable {
 
     async fn on_create_table(&mut self) -> Result<Status> {
         let engine_ctx = EngineContext::default();
-        let table_ref = self.data.table_ref();
-        if self
-            .engine
-            .table_exists(&engine_ctx, &table_ref, self.data.request.id)
-        {
+        if self.engine.table_exists(&engine_ctx, self.data.request.id) {
             // Table already created. We don't need to check create_if_not_exists as
             // we have checked it in prepare state.
             return Ok(Status::Done);

--- a/src/file-table-engine/src/engine/procedure/create.rs
+++ b/src/file-table-engine/src/engine/procedure/create.rs
@@ -94,7 +94,10 @@ impl CreateImmutableFileTable {
         let engine_ctx = EngineContext::default();
         let table_ref = self.data.table_ref();
         // Safety: Current get_table implementation always returns Ok.
-        if self.engine.table_exists(&engine_ctx, &table_ref) {
+        if self
+            .engine
+            .table_exists(&engine_ctx, &table_ref, self.data.request.id)
+        {
             // The table already exists.
             ensure!(
                 self.data.request.create_if_not_exists,
@@ -114,7 +117,10 @@ impl CreateImmutableFileTable {
     async fn on_create_table(&mut self) -> Result<Status> {
         let engine_ctx = EngineContext::default();
         let table_ref = self.data.table_ref();
-        if self.engine.table_exists(&engine_ctx, &table_ref) {
+        if self
+            .engine
+            .table_exists(&engine_ctx, &table_ref, self.data.request.id)
+        {
             // Table already created. We don't need to check create_if_not_exists as
             // we have checked it in prepare state.
             return Ok(Status::Done);

--- a/src/file-table-engine/src/engine/tests.rs
+++ b/src/file-table-engine/src/engine/tests.rs
@@ -16,7 +16,7 @@ use std::assert_matches::assert_matches;
 use std::sync::Arc;
 
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, IMMUTABLE_FILE_ENGINE};
-use table::engine::{EngineContext, TableEngine, TableEngineProcedure, TableReference};
+use table::engine::{EngineContext, TableEngine, TableEngineProcedure};
 use table::requests::{AlterKind, AlterTableRequest, DropTableRequest, OpenTableRequest};
 use table::{error as table_error, Table};
 
@@ -57,12 +57,6 @@ async fn test_open_table() {
         // the test table id is 1
         table_id,
         region_numbers: vec![0],
-    };
-
-    let table_ref = TableReference {
-        catalog: DEFAULT_CATALOG_NAME,
-        schema: DEFAULT_SCHEMA_NAME,
-        table: test_util::TEST_TABLE_NAME,
     };
 
     let TestEngineComponents {

--- a/src/file-table-engine/src/engine/tests.rs
+++ b/src/file-table-engine/src/engine/tests.rs
@@ -35,18 +35,9 @@ async fn test_get_table() {
         ..
     } = test_util::setup_test_engine_and_table("test_get_table").await;
     let table_info = table.table_info();
-    let table_ref = TableReference {
-        catalog: &table_info.catalog_name,
-        schema: &table_info.schema_name,
-        table: &table_info.name,
-    };
 
     let got = table_engine
-        .get_table(
-            &EngineContext::default(),
-            &table_ref,
-            table_info.ident.table_id,
-        )
+        .get_table(&EngineContext::default(), table_info.ident.table_id)
         .unwrap()
         .unwrap();
 
@@ -107,12 +98,6 @@ async fn test_open_table() {
 async fn test_close_all_table() {
     common_telemetry::init_default_ut_logging();
 
-    let table_ref = TableReference {
-        catalog: DEFAULT_CATALOG_NAME,
-        schema: DEFAULT_SCHEMA_NAME,
-        table: test_util::TEST_TABLE_NAME,
-    };
-
     let TestEngineComponents {
         table_engine,
         dir: _dir,
@@ -123,7 +108,7 @@ async fn test_close_all_table() {
     table_engine.close().await.unwrap();
 
     let table_id = table.table_info().ident.table_id;
-    let exist = table_engine.table_exists(&EngineContext::default(), &table_ref, table_id);
+    let exist = table_engine.table_exists(&EngineContext::default(), table_id);
 
     assert!(!exist);
 }
@@ -171,11 +156,6 @@ async fn test_drop_table() {
     } = test_util::setup_test_engine_and_table("test_drop_table").await;
 
     let table_info = table.table_info();
-    let table_ref = TableReference {
-        catalog: &table_info.catalog_name,
-        schema: &table_info.schema_name,
-        table: &table_info.name,
-    };
 
     let drop_req = DropTableRequest {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
@@ -190,11 +170,7 @@ async fn test_drop_table() {
 
     assert!(dropped);
 
-    let exist = table_engine.table_exists(
-        &EngineContext::default(),
-        &table_ref,
-        table_info.ident.table_id,
-    );
+    let exist = table_engine.table_exists(&EngineContext::default(), table_info.ident.table_id);
     assert!(!exist);
 
     // check table_dir manifest
@@ -224,7 +200,7 @@ async fn test_create_drop_table_procedure() {
     common_procedure_test::execute_procedure_until_done(&mut procedure).await;
 
     assert!(table_engine
-        .get_table(&engine_ctx, &create_request.table_ref(), table_id)
+        .get_table(&engine_ctx, table_id)
         .unwrap()
         .is_some());
 
@@ -241,7 +217,7 @@ async fn test_create_drop_table_procedure() {
     common_procedure_test::execute_procedure_until_done(&mut procedure).await;
 
     assert!(table_engine
-        .get_table(&engine_ctx, &create_request.table_ref(), table_id)
+        .get_table(&engine_ctx, table_id)
         .unwrap()
         .is_none());
 }

--- a/src/file-table-engine/src/engine/tests.rs
+++ b/src/file-table-engine/src/engine/tests.rs
@@ -159,12 +159,6 @@ async fn test_alter_table() {
 async fn test_drop_table() {
     common_telemetry::init_default_ut_logging();
 
-    let drop_req = DropTableRequest {
-        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
-        schema_name: DEFAULT_SCHEMA_NAME.to_string(),
-        table_name: TEST_TABLE_NAME.to_string(),
-    };
-
     let TestEngineComponents {
         table_engine,
         object_store,
@@ -181,6 +175,12 @@ async fn test_drop_table() {
         table: &table_info.name,
     };
 
+    let drop_req = DropTableRequest {
+        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+        table_name: TEST_TABLE_NAME.to_string(),
+        table_id: table_info.ident.table_id,
+    };
     let dropped = table_engine
         .drop_table(&EngineContext::default(), drop_req)
         .await
@@ -231,6 +231,7 @@ async fn test_create_drop_table_procedure() {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TEST_TABLE_NAME.to_string(),
+        table_id,
     };
     let mut procedure = table_engine
         .drop_table_procedure(&engine_ctx, drop_request)

--- a/src/file-table-engine/src/engine/tests.rs
+++ b/src/file-table-engine/src/engine/tests.rs
@@ -57,12 +57,14 @@ async fn test_get_table() {
 async fn test_open_table() {
     common_telemetry::init_default_ut_logging();
     let ctx = EngineContext::default();
+    // the test table id is 1
+    let table_id = 1;
     let open_req = OpenTableRequest {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: test_util::TEST_TABLE_NAME.to_string(),
         // the test table id is 1
-        table_id: 1,
+        table_id,
         region_numbers: vec![0],
     };
 
@@ -81,7 +83,7 @@ async fn test_open_table() {
 
     assert_eq!(IMMUTABLE_FILE_ENGINE, table_engine.name());
 
-    table_engine.close_table(&table_ref).await.unwrap();
+    table_engine.close_table(table_id).await.unwrap();
 
     let reopened = table_engine
         .open_table(&ctx, open_req.clone())

--- a/src/file-table-engine/src/engine/tests.rs
+++ b/src/file-table-engine/src/engine/tests.rs
@@ -132,6 +132,7 @@ async fn test_alter_table() {
     let TestEngineComponents {
         table_engine,
         dir: _dir,
+        table_ref,
         ..
     } = test_util::setup_test_engine_and_table("test_alter_table").await;
 
@@ -139,6 +140,7 @@ async fn test_alter_table() {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TEST_TABLE_NAME.to_string(),
+        table_id: table_ref.table_info().ident.table_id,
         alter_kind: AlterKind::RenameTable {
             new_table_name: "foo".to_string(),
         },

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -543,8 +543,11 @@ impl DistInstance {
                 table_name: format_full_table_name(catalog_name, schema_name, table_name),
             })?;
 
-        let request = common_grpc_expr::alter_expr_to_request(expr.clone())
-            .context(AlterExprToRequestSnafu)?;
+        let request = common_grpc_expr::alter_expr_to_request(
+            table.table_info().ident.table_id,
+            expr.clone(),
+        )
+        .context(AlterExprToRequestSnafu)?;
 
         let mut context = AlterContext::with_capacity(1);
 

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -382,6 +382,7 @@ impl DistTable {
             schema_name,
             table_name,
             alter_kind,
+            table_id: _table_id,
         } = request;
 
         let alter_expr = context

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -159,21 +159,11 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
             .context(table_error::TableOperationSnafu)
     }
 
-    fn get_table(
-        &self,
-        _ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> TableResult<Option<TableRef>> {
+    fn get_table(&self, _ctx: &EngineContext, table_id: TableId) -> TableResult<Option<TableRef>> {
         Ok(self.inner.get_table(table_id))
     }
 
-    fn table_exists(
-        &self,
-        _ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> bool {
+    fn table_exists(&self, _ctx: &EngineContext, table_id: TableId) -> bool {
         self.inner.get_table(table_id).is_some()
     }
 
@@ -244,7 +234,7 @@ impl<S: StorageEngine> TableEngineProcedure for MitoEngine<S> {
 }
 
 pub(crate) struct MitoEngineInner<S: StorageEngine> {
-    /// All tables opened by the engine. Map key is formatted [TableReference].
+    /// All tables opened by the engine.
     ///
     /// Writing to `tables` should also hold the `table_mutex`.
     tables: DashMap<TableId, Arc<MitoTable<S::Region>>>,

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -179,11 +179,17 @@ impl<S: StorageEngine> TableEngine for MitoEngine<S> {
         &self,
         _ctx: &EngineContext,
         table_ref: &TableReference,
+        _table_id: TableId,
     ) -> TableResult<Option<TableRef>> {
         Ok(self.inner.get_table(table_ref))
     }
 
-    fn table_exists(&self, _ctx: &EngineContext, table_ref: &TableReference) -> bool {
+    fn table_exists(
+        &self,
+        _ctx: &EngineContext,
+        table_ref: &TableReference,
+        _table_id: TableId,
+    ) -> bool {
         self.inner.get_table(table_ref).is_some()
     }
 

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -369,13 +369,14 @@ mod tests {
             table: &request.table_name,
         };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, request.id)
             .unwrap()
             .unwrap();
         let old_info = table.table_info();
         let old_meta = &old_info.meta;
 
         // Alter the table.
+        let table_id = request.id;
         let request = new_add_columns_req();
         let mut procedure = table_engine
             .alter_table_procedure(&engine_ctx, request.clone())
@@ -384,7 +385,7 @@ mod tests {
 
         // Validate.
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, table_id)
             .unwrap()
             .unwrap();
         let new_info = table.table_info();
@@ -413,7 +414,7 @@ mod tests {
 
         // Validate.
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, table_id)
             .unwrap()
             .unwrap();
         let new_info = table.table_info();
@@ -456,6 +457,7 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // Add columns.
+        let table_id = request.id;
         let request = new_add_columns_req();
         let mut procedure = table_engine
             .alter_table_procedure(&engine_ctx, request.clone())
@@ -469,7 +471,7 @@ mod tests {
             table: &request.table_name,
         };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, table_id)
             .unwrap()
             .unwrap();
         let old_info = table.table_info();
@@ -527,7 +529,7 @@ mod tests {
             table: &create_request.table_name,
         };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, create_request.id)
             .unwrap()
             .unwrap();
 
@@ -546,12 +548,12 @@ mod tests {
         let info = table.table_info();
         assert_eq!(new_name, info.name);
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, create_request.id)
             .unwrap()
             .is_none());
         table_ref.table = &new_name;
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, create_request.id)
             .unwrap()
             .is_some());
     }

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -406,7 +406,7 @@ mod tests {
             ConcreteDataType::string_datatype(),
             true,
         );
-        let request = new_add_columns_req_with_location(&new_tag, &new_field);
+        let request = new_add_columns_req_with_location(table_id, &new_tag, &new_field);
         let mut procedure = table_engine
             .alter_table_procedure(&engine_ctx, request.clone())
             .unwrap();

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -29,9 +29,7 @@ use table::requests::{AlterKind, AlterTableRequest};
 use table::{Table, TableRef};
 
 use crate::engine::MitoEngineInner;
-use crate::error::{
-    TableExistsSnafu, TableNotFoundSnafu, UpdateTableManifestSnafu, VersionChangedSnafu,
-};
+use crate::error::{TableNotFoundSnafu, UpdateTableManifestSnafu, VersionChangedSnafu};
 use crate::manifest::action::{TableChange, TableMetaAction, TableMetaActionList};
 use crate::metrics;
 use crate::table::MitoTable;
@@ -39,7 +37,6 @@ use crate::table::MitoTable;
 /// Procedure to alter a [MitoTable].
 pub(crate) struct AlterMitoTable<S: StorageEngine> {
     data: AlterTableData,
-    engine_inner: Arc<MitoEngineInner<S>>,
     table: Arc<MitoTable<S::Region>>,
     /// The table info after alteration.
     new_info: Option<TableInfo>,
@@ -117,7 +114,6 @@ impl<S: StorageEngine> AlterMitoTable<S> {
 
         Ok(AlterMitoTable {
             data,
-            engine_inner,
             table,
             new_info: None,
             alter_op: None,
@@ -155,7 +151,6 @@ impl<S: StorageEngine> AlterMitoTable<S> {
 
         Ok(AlterMitoTable {
             data,
-            engine_inner,
             table,
             new_info: None,
             alter_op: None,

--- a/src/mito/src/engine/procedure/alter.rs
+++ b/src/mito/src/engine/procedure/alter.rs
@@ -336,13 +336,8 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // Get metadata of the created table.
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref, request.id)
+            .get_table(&engine_ctx, request.id)
             .unwrap()
             .unwrap();
         let old_info = table.table_info();
@@ -358,7 +353,7 @@ mod tests {
 
         // Validate.
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref, table_id)
+            .get_table(&engine_ctx, table_id)
             .unwrap()
             .unwrap();
         let new_info = table.table_info();
@@ -387,7 +382,7 @@ mod tests {
 
         // Validate.
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref, table_id)
+            .get_table(&engine_ctx, table_id)
             .unwrap()
             .unwrap();
         let new_info = table.table_info();
@@ -438,13 +433,8 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // Get metadata.
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref, table_id)
+            .get_table(&engine_ctx, table_id)
             .unwrap()
             .unwrap();
         let old_info = table.table_info();
@@ -496,13 +486,8 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // Get metadata of the created table.
-        let mut table_ref = TableReference {
-            catalog: &create_request.catalog_name,
-            schema: &create_request.schema_name,
-            table: &create_request.table_name,
-        };
         let table = table_engine
-            .get_table(&engine_ctx, &table_ref, create_request.id)
+            .get_table(&engine_ctx, create_request.id)
             .unwrap()
             .unwrap();
 
@@ -521,12 +506,7 @@ mod tests {
         let info = table.table_info();
         assert_eq!(new_name, info.name);
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, create_request.id)
-            .unwrap()
-            .is_none());
-        table_ref.table = &new_name;
-        assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, create_request.id)
+            .get_table(&engine_ctx, create_request.id)
             .unwrap()
             .is_some());
     }

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -438,7 +438,7 @@ mod tests {
             table: &request.table_name,
         };
         assert!(table_engine
-            .get_table(&EngineContext::default(), &table_ref)
+            .get_table(&EngineContext::default(), &table_ref, request.id)
             .unwrap()
             .is_some());
     }

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -131,7 +131,12 @@ impl<S: StorageEngine> CreateMitoTable<S> {
         let table_ref = self.creator.data.table_ref();
         logging::debug!("on prepare create table {}", table_ref);
 
-        if self.creator.engine_inner.get_table(&table_ref).is_some() {
+        if self
+            .creator
+            .engine_inner
+            .get_table(self.creator.data.request.id)
+            .is_some()
+        {
             // If the table already exists.
             ensure!(
                 self.creator.data.request.create_if_not_exists,
@@ -152,14 +157,14 @@ impl<S: StorageEngine> CreateMitoTable<S> {
     async fn on_engine_create_table(&mut self) -> Result<Status> {
         // In this state, we can ensure we are able to create a new table.
         let table_ref = self.creator.data.table_ref();
-        logging::debug!("on engine create table {}", table_ref);
+        let table_id = self.creator.data.request.id;
+        logging::debug!(
+            "on engine create table {}, table_id: {}",
+            table_ref,
+            table_id
+        );
 
-        let _lock = self
-            .creator
-            .engine_inner
-            .table_mutex
-            .lock(table_ref.to_string())
-            .await;
+        let _lock = self.creator.engine_inner.table_mutex.lock(table_id).await;
         self.creator.create_table().await?;
 
         Ok(Status::Done)
@@ -209,14 +214,13 @@ impl<S: StorageEngine> TableCreator<S> {
             self.data.request.id,
         );
 
-        let table_ref = self.data.table_ref();
         // It is possible that the procedure retries `CREATE TABLE` many times, so we
         // return the table if it exists.
-        if let Some(table) = self.engine_inner.get_table(&table_ref) {
+        if let Some(table) = self.engine_inner.get_table(self.data.request.id) {
             return Ok(table.clone());
         }
 
-        logging::debug!("Creator create table {}", table_ref);
+        logging::debug!("Creator create table {}", self.data.table_ref());
 
         self.create_regions(&table_dir).await?;
 
@@ -313,7 +317,6 @@ impl<S: StorageEngine> TableCreator<S> {
     /// Writes metadata to the table manifest.
     async fn write_table_manifest(&mut self, table_dir: &str) -> Result<TableRef> {
         // Try to open the table first, as the table manifest might already exist.
-        let table_ref = self.data.table_ref();
         if let Some((manifest, table_info)) = self
             .engine_inner
             .recover_table_manifest_and_info(&self.data.request.table_name, table_dir)
@@ -323,7 +326,7 @@ impl<S: StorageEngine> TableCreator<S> {
 
             self.engine_inner
                 .tables
-                .insert(table_ref.to_string(), table.clone());
+                .insert(self.data.request.id, table.clone());
             return Ok(table);
         }
 
@@ -333,7 +336,7 @@ impl<S: StorageEngine> TableCreator<S> {
 
         self.engine_inner
             .tables
-            .insert(table_ref.to_string(), table.clone());
+            .insert(self.data.request.id, table.clone());
 
         Ok(table)
     }

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -435,13 +435,8 @@ mod tests {
             .unwrap();
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         assert!(table_engine
-            .get_table(&EngineContext::default(), &table_ref, request.id)
+            .get_table(&EngineContext::default(), request.id)
             .unwrap()
             .is_some());
     }

--- a/src/mito/src/engine/procedure/drop.rs
+++ b/src/mito/src/engine/procedure/drop.rs
@@ -188,13 +188,8 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // The table is dropped.
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, table_id)
+            .get_table(&engine_ctx, table_id)
             .unwrap()
             .is_none());
     }

--- a/src/mito/src/engine/procedure/drop.rs
+++ b/src/mito/src/engine/procedure/drop.rs
@@ -182,6 +182,7 @@ mod tests {
         procedure_test_util::execute_procedure_until_done(&mut procedure).await;
 
         // Drop the table.
+        let table_id = request.id;
         let request = test_util::new_drop_request();
         let mut procedure = table_engine
             .drop_table_procedure(&engine_ctx, request.clone())
@@ -195,7 +196,7 @@ mod tests {
             table: &request.table_name,
         };
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, table_id)
             .unwrap()
             .is_none());
     }

--- a/src/mito/src/engine/procedure/drop.rs
+++ b/src/mito/src/engine/procedure/drop.rs
@@ -84,8 +84,7 @@ impl<S: StorageEngine> DropMitoTable<S> {
             state: DropTableState::Prepare,
             request,
         };
-        let table_ref = data.table_ref();
-        let table = engine_inner.get_mito_table(&table_ref);
+        let table = engine_inner.get_mito_table(data.request.table_id);
 
         Ok(DropMitoTable {
             data,
@@ -115,8 +114,7 @@ impl<S: StorageEngine> DropMitoTable<S> {
     /// Recover the procedure from json.
     fn from_json(json: &str, engine_inner: Arc<MitoEngineInner<S>>) -> Result<Self> {
         let data: DropTableData = serde_json::from_str(json).context(FromJsonSnafu)?;
-        let table_ref = data.table_ref();
-        let table = engine_inner.get_mito_table(&table_ref);
+        let table = engine_inner.get_mito_table(data.request.table_id);
 
         Ok(DropMitoTable {
             data,

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -800,8 +800,9 @@ async fn test_drop_table() {
         table: &table_info.name,
     };
 
+    let table_id = 1;
     let create_table_request = CreateTableRequest {
-        id: 1,
+        id: table_id,
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: table_info.name.to_string(),
@@ -819,7 +820,7 @@ async fn test_drop_table() {
         .await
         .unwrap();
     assert_eq!(table_info, created_table.table_info());
-    assert!(table_engine.table_exists(&engine_ctx, &table_reference));
+    assert!(table_engine.table_exists(&engine_ctx, &table_reference, table_id));
 
     let drop_table_request = DropTableRequest {
         catalog_name: table_reference.catalog.to_string(),
@@ -831,11 +832,12 @@ async fn test_drop_table() {
         .await
         .unwrap();
     assert!(table_dropped);
-    assert!(!table_engine.table_exists(&engine_ctx, &table_reference));
+    assert!(!table_engine.table_exists(&engine_ctx, &table_reference, table_id));
 
     // should be able to re-create
+    let table_id = 2;
     let request = CreateTableRequest {
-        id: 2,
+        id: table_id,
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: table_info.name.to_string(),
@@ -848,7 +850,7 @@ async fn test_drop_table() {
         engine: MITO_ENGINE.to_string(),
     };
     table_engine.create_table(&ctx, request).await.unwrap();
-    assert!(table_engine.table_exists(&engine_ctx, &table_reference));
+    assert!(table_engine.table_exists(&engine_ctx, &table_reference, table_id));
 }
 
 #[tokio::test]

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -40,7 +40,7 @@ use table::Table;
 
 use super::*;
 use crate::table::test_util::{
-    self, new_insert_request, schema_for_test, setup_table, TestEngineComponents, TABLE_NAME,
+    self, new_insert_request, setup_table, TestEngineComponents, TABLE_NAME,
 };
 
 pub fn has_parquet_file(sst_dir: &str) -> bool {

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -838,6 +838,7 @@ async fn test_drop_table() {
         catalog_name: table_reference.catalog.to_string(),
         schema_name: table_reference.schema.to_string(),
         table_name: table_reference.table.to_string(),
+        table_id,
     };
     let table_dropped = table_engine
         .drop_table(&engine_ctx, drop_table_request)

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -28,7 +28,7 @@ use storage::compaction::noop::NoopCompactionScheduler;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;
 use table::engine::{EngineContext, TableEngine};
-use table::metadata::{TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
+use table::metadata::{TableId, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::requests::{
     AlterKind, AlterTableRequest, CreateTableRequest, DropTableRequest, InsertRequest, TableOptions,
 };
@@ -39,6 +39,7 @@ use crate::engine::{MitoEngine, MITO_ENGINE};
 pub use crate::table::test_util::mock_engine::{MockEngine, MockRegion};
 
 pub const TABLE_NAME: &str = "demo";
+pub const TABLE_ID: TableId = 1;
 
 /// Create a InsertRequest with default catalog and schema.
 pub fn new_insert_request(
@@ -107,7 +108,7 @@ pub async fn new_test_object_store(prefix: &str) -> (TempDir, ObjectStore) {
 
 pub fn new_create_request(schema: SchemaRef) -> CreateTableRequest {
     CreateTableRequest {
-        id: 1,
+        id: TABLE_ID,
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TABLE_NAME.to_string(),
@@ -126,6 +127,7 @@ pub fn new_alter_request(alter_kind: AlterKind) -> AlterTableRequest {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TABLE_NAME.to_string(),
+        table_id: TABLE_ID,
         alter_kind,
     }
 }

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -137,6 +137,7 @@ pub fn new_drop_request() -> DropTableRequest {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TABLE_NAME.to_string(),
+        table_id: TABLE_ID,
     }
 }
 

--- a/src/table-procedure/src/alter.rs
+++ b/src/table-procedure/src/alter.rs
@@ -315,13 +315,14 @@ mod tests {
     async fn test_alter_table_procedure_rename() {
         let env = TestEnv::new("rename");
         let table_name = "test_old";
-        env.create_table(table_name).await;
+        let table_id = env.create_table(table_name).await;
 
         let new_table_name = "test_new";
         let request = AlterTableRequest {
             catalog_name: DEFAULT_CATALOG_NAME.to_string(),
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: table_name.to_string(),
+            table_id,
             alter_kind: AlterKind::RenameTable {
                 new_table_name: new_table_name.to_string(),
             },

--- a/src/table-procedure/src/create.rs
+++ b/src/table-procedure/src/create.rs
@@ -356,7 +356,7 @@ mod tests {
         };
         let engine_ctx = EngineContext::default();
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, request.id)
             .unwrap()
             .is_none());
 
@@ -365,7 +365,7 @@ mod tests {
         watcher.changed().await.unwrap();
 
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, request.id)
             .unwrap()
             .is_some());
     }
@@ -397,7 +397,7 @@ mod tests {
         };
         let engine_ctx = EngineContext::default();
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, request.id)
             .unwrap()
             .is_none());
 
@@ -452,7 +452,7 @@ mod tests {
 
         // The table is created.
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref)
+            .get_table(&engine_ctx, &table_ref, request.id)
             .unwrap()
             .is_some());
     }

--- a/src/table-procedure/src/create.rs
+++ b/src/table-procedure/src/create.rs
@@ -349,14 +349,9 @@ mod tests {
             table_engine.clone(),
         );
 
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         let engine_ctx = EngineContext::default();
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, request.id)
+            .get_table(&engine_ctx, request.id)
             .unwrap()
             .is_none());
 
@@ -365,7 +360,7 @@ mod tests {
         watcher.changed().await.unwrap();
 
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, request.id)
+            .get_table(&engine_ctx, request.id)
             .unwrap()
             .is_some());
     }
@@ -390,14 +385,9 @@ mod tests {
             table_engine.clone(),
         );
 
-        let table_ref = TableReference {
-            catalog: &request.catalog_name,
-            schema: &request.schema_name,
-            table: &request.table_name,
-        };
         let engine_ctx = EngineContext::default();
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, request.id)
+            .get_table(&engine_ctx, request.id)
             .unwrap()
             .is_none());
 
@@ -452,7 +442,7 @@ mod tests {
 
         // The table is created.
         assert!(table_engine
-            .get_table(&engine_ctx, &table_ref, request.id)
+            .get_table(&engine_ctx, request.id)
             .unwrap()
             .is_some());
     }

--- a/src/table-procedure/src/drop.rs
+++ b/src/table-procedure/src/drop.rs
@@ -283,6 +283,7 @@ mod tests {
             catalog_name: DEFAULT_CATALOG_NAME.to_string(),
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: table_name.to_string(),
+            table_id,
         };
         let TestEnv {
             dir: _dir,

--- a/src/table-procedure/src/drop.rs
+++ b/src/table-procedure/src/drop.rs
@@ -277,7 +277,7 @@ mod tests {
     async fn test_drop_table_procedure() {
         let env = TestEnv::new("drop");
         let table_name = "test_drop";
-        env.create_table(table_name).await;
+        let table_id = env.create_table(table_name).await;
 
         let request = DropTableRequest {
             catalog_name: DEFAULT_CATALOG_NAME.to_string(),
@@ -311,7 +311,8 @@ mod tests {
                 catalog: DEFAULT_CATALOG_NAME,
                 schema: DEFAULT_SCHEMA_NAME,
                 table: table_name,
-            }
+            },
+            table_id,
         ));
     }
 }

--- a/src/table-procedure/src/drop.rs
+++ b/src/table-procedure/src/drop.rs
@@ -306,14 +306,6 @@ mod tests {
         let schema = catalog.schema(DEFAULT_SCHEMA_NAME).await.unwrap().unwrap();
         assert!(schema.table(table_name).await.unwrap().is_none());
         let ctx = EngineContext::default();
-        assert!(!table_engine.table_exists(
-            &ctx,
-            &TableReference {
-                catalog: DEFAULT_CATALOG_NAME,
-                schema: DEFAULT_SCHEMA_NAME,
-                table: table_name,
-            },
-            table_id,
-        ));
+        assert!(!table_engine.table_exists(&ctx, table_id,));
     }
 }

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -32,6 +32,7 @@ use object_store::ObjectStore;
 use storage::compaction::noop::NoopCompactionScheduler;
 use storage::config::EngineConfig as StorageEngineConfig;
 use storage::EngineImpl;
+use table::metadata::TableId;
 use table::requests::CreateTableRequest;
 
 use crate::CreateTableProcedure;
@@ -92,8 +93,9 @@ impl TestEnv {
         }
     }
 
-    pub async fn create_table(&self, table_name: &str) {
+    pub async fn create_table(&self, table_name: &str) -> TableId {
         let request = new_create_request(table_name);
+        let table_id = request.id;
         let procedure = CreateTableProcedure::new(
             request,
             self.catalog_manager.clone(),
@@ -108,6 +110,8 @@ impl TestEnv {
             .await
             .unwrap();
         watcher.changed().await.unwrap();
+
+        table_id
     }
 }
 

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -112,10 +112,16 @@ pub trait TableEngine: Send + Sync {
         &self,
         ctx: &EngineContext,
         table_ref: &TableReference,
+        table_id: TableId,
     ) -> Result<Option<TableRef>>;
 
     /// Returns true when the given table is exists.
-    fn table_exists(&self, ctx: &EngineContext, table_ref: &TableReference) -> bool;
+    fn table_exists(
+        &self,
+        ctx: &EngineContext,
+        table_ref: &TableReference,
+        table_id: TableId,
+    ) -> bool;
 
     /// Drops the given table. Return true if the table is dropped, or false if the table doesn't exist.
     async fn drop_table(&self, ctx: &EngineContext, request: DropTableRequest) -> Result<bool>;

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -108,20 +108,10 @@ pub trait TableEngine: Send + Sync {
     ) -> Result<TableRef>;
 
     /// Returns the table by it's name.
-    fn get_table(
-        &self,
-        ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> Result<Option<TableRef>>;
+    fn get_table(&self, ctx: &EngineContext, table_id: TableId) -> Result<Option<TableRef>>;
 
     /// Returns true when the given table is exists.
-    fn table_exists(
-        &self,
-        ctx: &EngineContext,
-        table_ref: &TableReference,
-        table_id: TableId,
-    ) -> bool;
+    fn table_exists(&self, ctx: &EngineContext, table_id: TableId) -> bool;
 
     /// Drops the given table. Return true if the table is dropped, or false if the table doesn't exist.
     async fn drop_table(&self, ctx: &EngineContext, request: DropTableRequest) -> Result<bool>;

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -220,6 +220,7 @@ pub struct CloseTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
+    pub table_id: TableId,
     /// Do nothing if region_numbers is empty
     pub region_numbers: Vec<RegionNumber>,
     /// flush regions

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -201,6 +201,7 @@ pub struct DropTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
+    pub table_id: TableId,
 }
 
 impl DropTableRequest {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -162,6 +162,7 @@ pub struct AlterTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
+    pub table_id: TableId,
     pub alter_kind: AlterKind,
 }
 

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -87,21 +87,11 @@ impl TableEngine for MockTableEngine {
         unimplemented!()
     }
 
-    fn get_table(
-        &self,
-        _ctx: &EngineContext,
-        _ref: &TableReference,
-        _table_id: TableId,
-    ) -> Result<Option<TableRef>> {
+    fn get_table(&self, _ctx: &EngineContext, _table_id: TableId) -> Result<Option<TableRef>> {
         unimplemented!()
     }
 
-    fn table_exists(
-        &self,
-        _ctx: &EngineContext,
-        _name: &TableReference,
-        _table_id: TableId,
-    ) -> bool {
+    fn table_exists(&self, _ctx: &EngineContext, _table_id: TableId) -> bool {
         unimplemented!()
     }
 

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -20,6 +20,7 @@ use common_procedure::BoxedProcedure;
 use tokio::sync::Mutex;
 
 use crate::engine::{EngineContext, TableEngine, TableEngineProcedure, TableReference};
+use crate::metadata::TableId;
 use crate::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
 use crate::test_util::EmptyTable;
 use crate::{Result, TableRef};
@@ -86,11 +87,21 @@ impl TableEngine for MockTableEngine {
         unimplemented!()
     }
 
-    fn get_table(&self, _ctx: &EngineContext, _ref: &TableReference) -> Result<Option<TableRef>> {
+    fn get_table(
+        &self,
+        _ctx: &EngineContext,
+        _ref: &TableReference,
+        _table_id: TableId,
+    ) -> Result<Option<TableRef>> {
         unimplemented!()
     }
 
-    fn table_exists(&self, _ctx: &EngineContext, _name: &TableReference) -> bool {
+    fn table_exists(
+        &self,
+        _ctx: &EngineContext,
+        _name: &TableReference,
+        _table_id: TableId,
+    ) -> bool {
         unimplemented!()
     }
 

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use common_procedure::BoxedProcedure;
 use tokio::sync::Mutex;
 
-use crate::engine::{EngineContext, TableEngine, TableEngineProcedure, TableReference};
+use crate::engine::{EngineContext, TableEngine, TableEngineProcedure};
 use crate::metadata::TableId;
 use crate::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
 use crate::test_util::EmptyTable;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR uses table id instead of the table name to index tables in table engines. It adds the table id to table requests so engines can use it to locate the table.

### Breaking Changes
The remote catalog manager doesn't store a table id in the `TableRegionalValue` so we add an `Option<TableId>` to the `TableRegionValue`. Then we can use the table id to find the table. This might be a breaking change.
```rust
pub struct TableRegionalValue {
    pub table_id: Option<TableId>,
    pub version: TableVersion,
    pub regions_ids: Vec<u32>,
    pub engine_name: Option<String>,
}
```

However, the remote catalog always registers the table to the `RemoteSchemaProvider` in `initiate_tables()`
https://github.com/GreptimeTeam/greptimedb/blob/5ab074709206c539657d91ac8766065addd3b084/src/catalog/src/remote/manager.rs#L426-L434

The `RemoteSchemaProvider` then updates the value so we might fix the regional value after the process restarts.
https://github.com/GreptimeTeam/greptimedb/blob/5ab074709206c539657d91ac8766065addd3b084/src/catalog/src/remote/manager.rs#L1013-L1027

We can remove `RemoteSchemaProvider` after #1803 is merged.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

