### PR TITLE
fix: docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,3 @@ out/
 
 # Rust
 target/
-
-# Git
-.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     protobuf-compiler \
     curl \
+    git \
     build-essential \
     pkg-config \
     python3 \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
#1685 introduced build info which requires git command and `.git` directory to be present during compile time. But the default base image does not have a built in git command, and the `.git` directory is intentionally ignored when copying files into container.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
