### PR TITLE
fix: docker build for aarch64

### DIFF
--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     protobuf-compiler \
     curl \
+    git \
     build-essential \
     pkg-config \
     wget


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
The similar change that was done in https://github.com/greptimeTeam/greptimedb/pull/1822 to add `git` command that is required for build info

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/greptimeTeam/greptimedb/pull/1822
https://github.com/GreptimeTeam/greptimedb/pull/1685