### PR TITLE
feat: support where in show

### DIFF
--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -51,9 +51,9 @@ use table::TableRef;
 use crate::dataframe::DataFrame;
 pub use crate::datafusion::planner::DfContextProviderAdapter;
 use crate::error::{
-    CatalogNotFoundSnafu, CatalogSnafu, CreateRecordBatchSnafu, CreateSchemaSnafu, DataFusionSnafu,
-    MissingTimestampColumnSnafu, QueryExecutionSnafu, Result, SchemaNotFoundSnafu,
-    TableNotFoundSnafu, UnsupportedExprSnafu,
+    CatalogSnafu, CreateRecordBatchSnafu, CreateSchemaSnafu, DataFusionSnafu,
+    MissingTimestampColumnSnafu, QueryExecutionSnafu, Result, TableNotFoundSnafu,
+    UnsupportedExprSnafu,
 };
 use crate::executor::QueryExecutor;
 use crate::logical_optimizer::LogicalOptimizer;
@@ -442,12 +442,11 @@ mod tests {
     use datatypes::types::StringType;
     use datatypes::vectors::{Helper, StringVectorBuilder, UInt32Vector, UInt64Vector, VectorRef};
     use session::context::QueryContext;
-    use table::table::numbers::{NumbersTable, NUMBERS_TABLE_NAME};
     use sql::dialect::GreptimeDbDialect;
     use sql::parser::ParserContext;
     use sql::statements::show::{ShowKind, ShowTables};
     use sql::statements::statement::Statement;
-    use table::table::numbers::NumbersTable;
+    use table::table::numbers::{NumbersTable, NUMBERS_TABLE_NAME};
 
     use super::*;
     use crate::parser::QueryLanguageParser;
@@ -593,7 +592,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_show_() {
+    async fn test_show_tables() {
         // No filter
         let column_schemas = vec![ColumnSchema::new(
             "tables",

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -60,6 +60,12 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to create Schema, source: {}", source))]
+    CreateSchema {
+        source: datatypes::error::Error,
+        location: Location,
+    },
+
     #[snafu(display("Failure during query execution, source: {}", source))]
     QueryExecution {
         source: BoxedError,
@@ -258,6 +264,7 @@ impl ErrorExt for Error {
             ConvertSqlType { source, .. } | ConvertSqlValue { source, .. } => source.status_code(),
             RemoteRequest { source, .. } => source.status_code(),
             UnexpectedOutputKind { .. } => StatusCode::Unexpected,
+            CreateSchema { source, .. } => source.status_code(),
         }
     }
 

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -46,7 +46,7 @@ use crate::datafusion::execute_show_with_filter;
 use crate::error::{self, Result};
 
 const SCHEMAS_COLUMN: &str = "Schemas";
-const TABLES_COLUMN: &str = "tables";
+const TABLES_COLUMN: &str = "Tables";
 const COLUMN_NAME_COLUMN: &str = "Field";
 const COLUMN_TYPE_COLUMN: &str = "Type";
 const COLUMN_NULLABLE_COLUMN: &str = "Null";
@@ -163,8 +163,7 @@ pub async fn show_tables(
             let columns = vec![Arc::new(StringVector::from(tables)) as _];
             let record_batch =
                 RecordBatch::new(schema, columns).context(error::CreateRecordBatchSnafu)?;
-            let result =
-                execute_show_with_filter(record_batch, Some(filter), "tables".to_string()).await?;
+            let result = execute_show_with_filter(record_batch, Some(filter)).await?;
             Ok(result)
         }
         ShowKind::Like(ident) => {

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -410,7 +410,7 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
 
     let expected = "\
 +---------+
-| Tables  |
+| tables  |
 +---------+
 | numbers |
 | scripts |
@@ -427,7 +427,7 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
     let output = execute_sql(&instance, "show tables").await;
     let expected = "\
 +---------+
-| Tables  |
+| tables  |
 +---------+
 | demo    |
 | numbers |
@@ -785,7 +785,7 @@ async fn test_rename_table(instance: Arc<dyn MockInstance>) {
     let output = execute_sql_with(&instance, "show tables", query_ctx.clone()).await;
     let expect = "\
 +------------+
-| Tables     |
+| tables     |
 +------------+
 | test_table |
 +------------+";
@@ -852,7 +852,7 @@ async fn test_create_table_after_rename_table(instance: Arc<dyn MockInstance>) {
 
     let expect = "\
 +------------+
-| Tables     |
+| tables     |
 +------------+
 | demo       |
 | test_table |
@@ -1011,7 +1011,7 @@ async fn test_use_database(instance: Arc<dyn MockInstance>) {
     let output = execute_sql_with(&instance, "show tables", query_ctx.clone()).await;
     let expected = "\
 +--------+
-| Tables |
+| tables |
 +--------+
 | tb1    |
 +--------+";

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -410,7 +410,7 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
 
     let expected = "\
 +---------+
-| tables  |
+| Tables  |
 +---------+
 | numbers |
 | scripts |
@@ -427,7 +427,7 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
     let output = execute_sql(&instance, "show tables").await;
     let expected = "\
 +---------+
-| tables  |
+| Tables  |
 +---------+
 | demo    |
 | numbers |
@@ -785,7 +785,7 @@ async fn test_rename_table(instance: Arc<dyn MockInstance>) {
     let output = execute_sql_with(&instance, "show tables", query_ctx.clone()).await;
     let expect = "\
 +------------+
-| tables     |
+| Tables     |
 +------------+
 | test_table |
 +------------+";
@@ -852,7 +852,7 @@ async fn test_create_table_after_rename_table(instance: Arc<dyn MockInstance>) {
 
     let expect = "\
 +------------+
-| tables     |
+| Tables     |
 +------------+
 | demo       |
 | test_table |
@@ -1011,7 +1011,7 @@ async fn test_use_database(instance: Arc<dyn MockInstance>) {
     let output = execute_sql_with(&instance, "show tables", query_ctx.clone()).await;
     let expected = "\
 +--------+
-| tables |
+| Tables |
 +--------+
 | tb1    |
 +--------+";

--- a/tests/cases/standalone/common/catalog/schema.result
+++ b/tests/cases/standalone/common/catalog/schema.result
@@ -39,7 +39,7 @@ Affected Rows: 0
 SHOW TABLES FROM test_public_schema;
 
 +--------+
-| Tables |
+| tables |
 +--------+
 | hello  |
 +--------+
@@ -47,7 +47,7 @@ SHOW TABLES FROM test_public_schema;
 SHOW TABLES FROM public;
 
 +---------+
-| Tables  |
+| tables  |
 +---------+
 | numbers |
 | scripts |
@@ -70,7 +70,7 @@ SELECT * FROM hello;
 SHOW TABLES;
 
 +--------+
-| Tables |
+| tables |
 +--------+
 | hello  |
 +--------+
@@ -86,17 +86,25 @@ Error: 4001(TableNotFound), Table not found: greptime.test_public_schema.hello
 SHOW TABLES FROM test_public_schema;
 
 +--------+
-| Tables |
+| tables |
 +--------+
 +--------+
 
 SHOW TABLES FROM public;
 
 +---------+
-| Tables  |
+| tables  |
 +---------+
 | numbers |
 | scripts |
++---------+
+
+SHOW TABLES FROM public WHERE tables='numbers';
+
++---------+
+| tables  |
++---------+
+| numbers |
 +---------+
 
 DROP SCHEMA test_public_schema;

--- a/tests/cases/standalone/common/catalog/schema.result
+++ b/tests/cases/standalone/common/catalog/schema.result
@@ -39,7 +39,7 @@ Affected Rows: 0
 SHOW TABLES FROM test_public_schema;
 
 +--------+
-| tables |
+| Tables |
 +--------+
 | hello  |
 +--------+
@@ -47,7 +47,7 @@ SHOW TABLES FROM test_public_schema;
 SHOW TABLES FROM public;
 
 +---------+
-| tables  |
+| Tables  |
 +---------+
 | numbers |
 | scripts |
@@ -70,7 +70,7 @@ SELECT * FROM hello;
 SHOW TABLES;
 
 +--------+
-| tables |
+| Tables |
 +--------+
 | hello  |
 +--------+
@@ -86,23 +86,23 @@ Error: 4001(TableNotFound), Table not found: greptime.test_public_schema.hello
 SHOW TABLES FROM test_public_schema;
 
 +--------+
-| tables |
+| Tables |
 +--------+
 +--------+
 
 SHOW TABLES FROM public;
 
 +---------+
-| tables  |
+| Tables  |
 +---------+
 | numbers |
 | scripts |
 +---------+
 
-SHOW TABLES FROM public WHERE tables='numbers';
+SHOW TABLES FROM public WHERE Tables='numbers';
 
 +---------+
-| tables  |
+| Tables  |
 +---------+
 | numbers |
 +---------+

--- a/tests/cases/standalone/common/catalog/schema.sql
+++ b/tests/cases/standalone/common/catalog/schema.sql
@@ -32,7 +32,7 @@ SHOW TABLES FROM test_public_schema;
 
 SHOW TABLES FROM public;
 
-SHOW TABLES FROM public WHERE tables='numbers';
+SHOW TABLES FROM public WHERE Tables='numbers';
 
 DROP SCHEMA test_public_schema;
 

--- a/tests/cases/standalone/common/catalog/schema.sql
+++ b/tests/cases/standalone/common/catalog/schema.sql
@@ -32,6 +32,8 @@ SHOW TABLES FROM test_public_schema;
 
 SHOW TABLES FROM public;
 
+SHOW TABLES FROM public WHERE tables='numbers';
+
 DROP SCHEMA test_public_schema;
 
 SELECT * FROM test_public_schema.hello;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds support for executing `SHOW TABLES WHERE ~`:

```sql
SHOW TABLES WHERE tables='monitor'
```
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

close #1722