### PR TITLE
feat: improve influxdb v2 api compability

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -599,6 +599,7 @@ impl HttpServer {
     fn route_influxdb<S>(&self, influxdb_handler: InfluxdbLineProtocolHandlerRef) -> Router<S> {
         Router::new()
             .route("/write", routing::post(influxdb_write))
+            .route("/api/v2/write", routing::post(influxdb_write))
             .route("/ping", routing::get(influxdb_ping))
             .route("/health", routing::get(influxdb_health))
             .with_state(influxdb_handler)

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -59,7 +59,7 @@ use tower_http::auth::AsyncRequireAuthorizationLayer;
 use tower_http::trace::TraceLayer;
 
 use self::authorize::HttpAuth;
-use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write};
+use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb_write_v2};
 use crate::auth::UserProviderRef;
 use crate::configurator::ConfiguratorRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
@@ -598,8 +598,8 @@ impl HttpServer {
 
     fn route_influxdb<S>(&self, influxdb_handler: InfluxdbLineProtocolHandlerRef) -> Router<S> {
         Router::new()
-            .route("/write", routing::post(influxdb_write))
-            .route("/api/v2/write", routing::post(influxdb_write))
+            .route("/write", routing::post(influxdb_write_v1))
+            .route("/api/v2/write", routing::post(influxdb_write_v2))
             .route("/ping", routing::get(influxdb_ping))
             .route("/health", routing::get(influxdb_health))
             .with_state(influxdb_handler)

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -46,13 +46,17 @@ pub async fn influxdb_write(
     Query(mut params): Query<HashMap<String, String>>,
     lines: String,
 ) -> Result<impl IntoResponse> {
-    let db = params
-        .remove("db")
-        .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
+    let db = params.remove("db").unwrap_or_else(|| {
+        params
+            .remove("bucket")
+            .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string())
+    });
+
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_INFLUXDB_WRITE_ELAPSED,
         &[(crate::metrics::METRIC_DB_LABEL, db.clone())]
     );
+
     let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
     let ctx = Arc::new(QueryContext::with(catalog, schema));
 
@@ -60,16 +64,22 @@ pub async fn influxdb_write(
         .get("precision")
         .map(|val| parse_time_precision(val))
         .transpose()?;
+
     let request = InfluxdbRequest { precision, lines };
 
     handler.exec(&request, ctx).await?;
+
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
 fn parse_time_precision(value: &str) -> Result<Precision> {
+    // Precision conversion needs to be compatible with influxdb v1 v2 api.
+    // For details, see the Influxdb documents.
+    // https://docs.influxdata.com/influxdb/v1.8/tools/api/#apiv2write-http-endpoint
+    // https://docs.influxdata.com/influxdb/v1.8/tools/api/#write-http-endpoint
     match value {
-        "n" => Ok(Precision::Nanosecond),
-        "u" => Ok(Precision::Microsecond),
+        "n" | "ns" => Ok(Precision::Nanosecond),
+        "u" | "us" => Ok(Precision::Microsecond),
         "ms" => Ok(Precision::Millisecond),
         "s" => Ok(Precision::Second),
         "m" => Ok(Precision::Minute),
@@ -90,7 +100,9 @@ mod tests {
     #[test]
     fn test_parse_time_precision() {
         assert_eq!(Precision::Nanosecond, parse_time_precision("n").unwrap());
+        assert_eq!(Precision::Nanosecond, parse_time_precision("ns").unwrap());
         assert_eq!(Precision::Microsecond, parse_time_precision("u").unwrap());
+        assert_eq!(Precision::Microsecond, parse_time_precision("us").unwrap());
         assert_eq!(Precision::Millisecond, parse_time_precision("ms").unwrap());
         assert_eq!(Precision::Second, parse_time_precision("s").unwrap());
         assert_eq!(Precision::Minute, parse_time_precision("m").unwrap());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly improve influxdb v2 api compability.

- Write using the curl command as shown below
    ```shell
    curl -i -XPOST "http://localhost:4000/v1/influxdb/api/v2/write?bucket=public&precision=ms" \
    --data-binary \
    'monitor,host=127.0.0.1 cpu=0.1,memory=0.4 1667446797450
     monitor,host=127.0.0.2 cpu=0.2,memory=0.3 1667446798450
     monitor,host=127.0.0.1 cpu=0.5,memory=0.2 1667446798450'
    ```
- Write using Go sdk, an example [here](https://github.com/Fengys123/influxdb_write_example/blob/main/main.go)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fix https://github.com/GreptimeTeam/greptimedb/issues/1815