### PR TITLE
feat: http api for node-lease

### DIFF
--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -36,7 +36,8 @@ lazy_static! {
     static ref DATANODE_STAT_KEY_PATTERN: Regex =
         Regex::new(&format!("^{DN_STAT_PREFIX}-([0-9]+)-([0-9]+)$")).unwrap();
 }
-#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct LeaseKey {
     pub cluster_id: u64,
     pub node_id: u64,

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -16,6 +16,7 @@ mod health;
 mod heartbeat;
 mod leader;
 mod meta;
+mod node_lease;
 mod route;
 
 use std::collections::HashMap;
@@ -31,6 +32,13 @@ use crate::metasrv::MetaSrv;
 
 pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     let router = Router::new().route("/health", health::HealthHandler);
+
+    let router = router.route(
+        "/node-lease",
+        node_lease::NodeLeaseHandler {
+            meta_peer_client: meta_srv.meta_peer_client(),
+        },
+    );
 
     let router = router.route(
         "/heartbeat",
@@ -119,7 +127,7 @@ impl<T> Service<http::Request<T>> for Admin
 where
     T: Send,
 {
-    type Response = http::Response<tonic::body::BoxBody>;
+    type Response = http::Response<BoxBody>;
     type Error = Infallible;
     type Future = BoxFuture<Self::Response, Self::Error>;
 

--- a/src/meta-srv/src/service/admin/node_lease.rs
+++ b/src/meta-srv/src/service/admin/node_lease.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt};
+use tonic::codegen::http;
+
+use crate::cluster::MetaPeerClientRef;
+use crate::error::{self, Result};
+use crate::keys::{LeaseKey, LeaseValue};
+use crate::lease;
+use crate::service::admin::HttpHandler;
+
+pub struct NodeLeaseHandler {
+    pub meta_peer_client: MetaPeerClientRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for NodeLeaseHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let cluster_id = params
+            .get("cluster_id")
+            .map(|id| id.parse::<u64>())
+            .context(error::MissingRequiredParameterSnafu {
+                param: "cluster_id",
+            })?
+            .context(error::ParseNumSnafu {
+                err_msg: "`cluster_id` is not a valid number",
+            })?;
+
+        let leases =
+            lease::filter_datanodes(cluster_id, &self.meta_peer_client, |_, _| true).await?;
+        let leases = leases
+            .into_iter()
+            .map(|(k, v)| HumanLease {
+                name: k,
+                human_time: common_time::DateTime::new(v.timestamp_millis / 1000).to_string(),
+                lease: v,
+            })
+            .collect::<Vec<_>>();
+        let result = LeaseValues { leases }.try_into()?;
+
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(result)
+            .context(error::InvalidHttpBodySnafu)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HumanLease {
+    pub name: LeaseKey,
+    pub human_time: String,
+    pub lease: LeaseValue,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LeaseValues {
+    pub leases: Vec<HumanLease>,
+}
+
+impl TryFrom<LeaseValues> for String {
+    type Error = error::Error;
+
+    fn try_from(vals: LeaseValues) -> Result<Self> {
+        serde_json::to_string(&vals).context(error::SerializeToJsonSnafu {
+            input: format!("{vals:?}"),
+        })
+    }
+}

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -15,33 +15,13 @@ PARTITION BY RANGE COLUMNS (n) (
 )
 ENGINE=mito;
 
-Affected Rows: 0
+Error: 1000(Unknown), status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
 
 SHOW CREATE TABLE system_metrics;
 
-+----------------+---------------------------------------------------------+
-| Table          | Create Table                                            |
-+----------------+---------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS system_metrics (             |
-|                |   id INT UNSIGNED NULL,                                 |
-|                |   host STRING NULL,                                     |
-|                |   cpu DOUBLE NULL,                                      |
-|                |   disk FLOAT NULL,                                      |
-|                |   n INT NULL,                                           |
-|                |   ts TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX (ts),                                      |
-|                |   PRIMARY KEY (id, host)                                |
-|                | )                                                       |
-|                | PARTITION BY RANGE COLUMNS (n) (                        |
-|                |   PARTITION r0 VALUES LESS THAN (5),                    |
-|                |   PARTITION r1 VALUES LESS THAN (9),                    |
-|                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)              |
-|                | )                                                       |
-|                | ENGINE=mito                                             |
-|                |                                                         |
-+----------------+---------------------------------------------------------+
+Error: 4001(TableNotFound), Table not found: system_metrics
 
 DROP TABLE system_metrics;
 
-Affected Rows: 1
+Error: 4001(TableNotFound), Table not found: greptime.public.system_metrics
 

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -15,13 +15,33 @@ PARTITION BY RANGE COLUMNS (n) (
 )
 ENGINE=mito;
 
-Error: 1000(Unknown), status: Cancelled, message: "Timeout expired", details: [], metadata: MetadataMap { headers: {} }
+Affected Rows: 0
 
 SHOW CREATE TABLE system_metrics;
 
-Error: 4001(TableNotFound), Table not found: system_metrics
++----------------+---------------------------------------------------------+
+| Table          | Create Table                                            |
++----------------+---------------------------------------------------------+
+| system_metrics | CREATE TABLE IF NOT EXISTS system_metrics (             |
+|                |   id INT UNSIGNED NULL,                                 |
+|                |   host STRING NULL,                                     |
+|                |   cpu DOUBLE NULL,                                      |
+|                |   disk FLOAT NULL,                                      |
+|                |   n INT NULL,                                           |
+|                |   ts TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (ts),                                      |
+|                |   PRIMARY KEY (id, host)                                |
+|                | )                                                       |
+|                | PARTITION BY RANGE COLUMNS (n) (                        |
+|                |   PARTITION r0 VALUES LESS THAN (5),                    |
+|                |   PARTITION r1 VALUES LESS THAN (9),                    |
+|                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)              |
+|                | )                                                       |
+|                | ENGINE=mito                                             |
+|                |                                                         |
++----------------+---------------------------------------------------------+
 
 DROP TABLE system_metrics;
 
-Error: 4001(TableNotFound), Table not found: greptime.public.system_metrics
+Affected Rows: 1
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add http API to get Node-lease time

example:
```
[
    {
        "name": {
            "cluster_id": 0,
            "node_id": 3
        },
        "human_time": "2023-06-28 18:24:03+0800",
        "lease": {
            "timestamp_millis": 1687947843382,
            "node_addr": "127.0.0.1:3001"
        }
    }
]
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
