### PR TITLE
chore: bump orc-rust to 0319acd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5994,8 +5994,7 @@ checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 [[package]]
 name = "orc-rust"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e15d3f67795da54d9526e46b7808181ce6236d518f56ca1ee556d3a3fdd77c66"
+source = "git+https://github.com/WenyXu/orc-rs.git?rev=0319acd32456e403c20f135cc012441a76852605#0319acd32456e403c20f135cc012441a76852605"
 dependencies = [
  "arrow",
  "bytes",
@@ -6010,6 +6009,7 @@ dependencies = [
  "snafu",
  "tokio",
  "zigzag",
+ "zstd 0.12.3+zstd.1.5.2",
 ]
 
 [[package]]

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -24,7 +24,7 @@ datafusion.workspace = true
 derive_builder = "0.12"
 futures.workspace = true
 object-store = { path = "../../object-store" }
-orc-rust = "0.2.3"
+orc-rust = { git = "https://github.com/WenyXu/orc-rs.git", rev = "0319acd32456e403c20f135cc012441a76852605" }
 regex = "1.7"
 snafu.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Support to read the orc format files with the zstd compression.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
