### PR TITLE
fix: break CI again 🥲

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,5 +13,4 @@ rustflags = [
     "-Wclippy::print_stderr",
     "-Wclippy::implicit_clone",
     "-Aclippy::items_after_test_module",
-    "-Wunused_results",
 ]

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -3,8 +3,7 @@ database my_db;
 
 Affected Rows: 1
 
-use
-my_db;
+use my_db;
 
 ++
 ++
@@ -51,8 +50,7 @@ order by table_schema, table_name;
 | greptime      | my_db        | foo        | ts          | Int64     | TIME INDEX    |
 +---------------+--------------+------------+-------------+-----------+---------------+
 
-use
-public;
+use public;
 
 ++
 ++

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -1,8 +1,7 @@
 create
 database my_db;
 
-use
-my_db;
+use my_db;
 
 create table foo
 (
@@ -26,5 +25,4 @@ where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-use
-public;
+use public;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


- fix Sqlness CI caused by #1858
  - that pr is auto merged before I push 2ea71568c77bf3c5adcc481eab57646055f7e5e1 😵‍💫
- remove flag `-Wunused_results` introduced in #1825
  - `let _` may lead to other errors like forgetting to `.await` a future etc

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
