### PR TITLE
feat: support building binary for centos7

### DIFF
--- a/docker/Dockerfile-centos7-builder
+++ b/docker/Dockerfile-centos7-builder
@@ -1,0 +1,29 @@
+FROM centos:7
+
+ENV LANG en_US.utf8
+WORKDIR /greptimedb
+
+RUN sed -e 's|^mirrorlist=|#mirrorlist=|g' \
+             -e 's|^#baseurl=http://mirror.centos.org/centos|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos|g' \
+             -i.bak \
+             /etc/yum.repos.d/CentOS-*.repo
+
+# Install dependencies
+RUN RUN ulimit -n 1024000 && yum groupinstall -y 'Development Tools'
+RUN yum install -y epel-release  \
+    openssl \
+    openssl-devel  \
+    centos-release-scl  \
+    rh-python38  \
+    rh-python38-python-devel
+
+# Install protoc
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip
+RUN unzip protoc-3.15.8-linux-x86_64.zip -d /usr/local/
+
+# Install Rust
+SHELL ["/bin/bash", "-c"]
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --no-modify-path --default-toolchain none -y
+ENV PATH /opt/rh/rh-python38/root/usr/bin:/usr/local/bin:/root/.cargo/bin/:$PATH
+
+CMD ["cargo", "build", "--release"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds a dockerfile to support compilation to CentoOS 7 machines that only have glibc 2.17

To build CentOS 7 compatible binaries:
- `docker buildx build -f ./docker/Dockerfile-centos7 -t greptime-centos7-builder .` to build a builder image
- `docker run --rm -v .:/greptimedb greptime-centos7-builder` using that builder image to build binaries.

<img width="1157" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/6406592/f677a707-eae5-46f2-959f-d23d8d078c42">

### Known caveat
GreptimeDB requires Python >= 3.8. For CentOS 7 platform, we need to install extra dependencies like

```bash
$ yum install -y centos-release-scl rh-python38 rh-python38-python-devel
$ source /opt/rh/rh-python38/enable
```

And then GreptimeDB built with PyO3 backend should now work.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#1271