### PR TITLE
fix: return err msg if use wrong database in MySQL

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -355,11 +355,6 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                 .map_err(|e| e.into());
         }
 
-        ensure!(
-            self.query_handler.is_valid_schema(catalog, schema).await?,
-            error::DatabaseNotFoundSnafu { catalog, schema }
-        );
-
         let user_info = &self.session.user_info();
 
         if let Some(schema_validator) = &self.user_provider {

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -344,6 +344,17 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
 
     async fn on_init<'a>(&'a mut self, database: &'a str, w: InitWriter<'a, W>) -> Result<()> {
         let (catalog, schema) = crate::parse_catalog_and_schema_from_client_database_name(database);
+
+        if !self.query_handler.is_valid_schema(catalog, schema).await? {
+            return w
+                .error(
+                    ErrorKind::ER_WRONG_DB_NAME,
+                    format!("Unknown database '{}'", database).as_bytes(),
+                )
+                .await
+                .map_err(|e| e.into());
+        }
+
         ensure!(
             self.query_handler.is_valid_schema(catalog, schema).await?,
             error::DatabaseNotFoundSnafu { catalog, schema }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly changes from suspending MySQL session to returning an error msg if user tries to switch to an invalid database using `use` syntax.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
