### PR TITLE
chore: add feature for metrics-process, default enable

### DIFF
--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -10,7 +10,9 @@ name = "greptime"
 path = "src/bin/greptime.rs"
 
 [features]
+default = ["metrics-process"]
 tokio-console = ["common-telemetry/tokio-console"]
+metrics-process = ["servers/metrics-process"]
 
 [dependencies]
 anymap = "1.0.0-beta.2"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -5,9 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-pprof = ["dep:common-pprof"]
-mem-prof = ["dep:common-mem-prof"]
 dashboard = []
+mem-prof = ["dep:common-mem-prof"]
+pprof = ["dep:common-pprof"]
 
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
@@ -48,7 +48,7 @@ influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", bran
 itertools.workspace = true
 metrics.workspace = true
 # metrics-process 1.0.10 depends on metrics-0.21 but opendal depends on metrics-0.20.1
-metrics-process = "<1.0.10"
+metrics-process = { version = "<1.0.10", optional = true }
 mime_guess = "2.0"
 num_cpus = "1.13"
 once_cell = "1.16"

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use session::context::UserInfo;
 
 use crate::http::{ApiState, JsonResponse};
-use crate::metrics::{JEMALLOC_COLLECTOR, PROCESS_COLLECTOR};
+use crate::metrics::JEMALLOC_COLLECTOR;
 use crate::metrics_handler::MetricsHandler;
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -137,7 +137,9 @@ pub async fn metrics(
     Query(_params): Query<HashMap<String, String>>,
 ) -> String {
     // Collect process metrics.
-    PROCESS_COLLECTOR.collect();
+    #[cfg(feature = "metrics-process")]
+    crate::metrics::PROCESS_COLLECTOR.collect();
+
     if let Some(c) = JEMALLOC_COLLECTOR.as_ref() {
         if let Err(e) = c.update() {
             error!(e; "Failed to update jemalloc metrics");

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -18,7 +18,6 @@ use std::time::Instant;
 use common_telemetry::error;
 use hyper::Body;
 use metrics::gauge;
-use metrics_process::Collector;
 use once_cell::sync::Lazy;
 use snafu::ResultExt;
 use tikv_jemalloc_ctl::stats::{allocated_mib, resident_mib};
@@ -71,8 +70,9 @@ pub(crate) const METRIC_JEMALLOC_RESIDENT: &str = "sys.jemalloc.resident";
 pub(crate) const METRIC_JEMALLOC_ALLOCATED: &str = "sys.jemalloc.allocated";
 
 /// Prometheus style process metrics collector.
-pub(crate) static PROCESS_COLLECTOR: Lazy<Collector> = Lazy::new(|| {
-    let collector = Collector::default();
+#[cfg(feature = "metrics-process")]
+pub(crate) static PROCESS_COLLECTOR: Lazy<metrics_process::Collector> = Lazy::new(|| {
+    let collector = metrics_process::Collector::default();
     // Describe collector.
     collector.describe();
     collector


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr add feature for metrics-process crate, default enable. Since the [metrics-process](https://github.com/lambdalisue/rs-metrics-process) crate does not support the android platform.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/1766