### PR TITLE
fix: use mark-deletion for system catalog

### DIFF
--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -243,9 +243,12 @@ impl LocalCatalogManager {
                     info!("Registered schema: {:?}", s);
                 }
                 Entry::Table(t) => {
+                    max_table_id = max_table_id.max(t.table_id);
+                    if t.is_deleted {
+                        continue;
+                    }
                     self.open_and_register_table(&t).await?;
                     info!("Registered table: {:?}", t);
-                    max_table_id = max_table_id.max(t.table_id);
                 }
             }
         }
@@ -602,6 +605,7 @@ mod tests {
                 table_name: "T1".to_string(),
                 table_id: 1,
                 engine: MITO_ENGINE.to_string(),
+                is_deleted: false,
             }),
             Entry::Catalog(CatalogEntry {
                 catalog_name: "C2".to_string(),
@@ -623,6 +627,7 @@ mod tests {
                 table_name: "T2".to_string(),
                 table_id: 2,
                 engine: MITO_ENGINE.to_string(),
+                is_deleted: false,
             }),
         ];
         let res = LocalCatalogManager::sort_entries(vec);

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -414,7 +414,7 @@ pub struct TableEntryValue {
     #[serde(default = "mito_engine")]
     pub engine: String,
 
-    #[serde(default = "present")]
+    #[serde(default = "not_deleted")]
     pub is_deleted: bool,
 }
 
@@ -422,8 +422,8 @@ fn mito_engine() -> String {
     MITO_ENGINE.to_string()
 }
 
-fn present() -> bool {
-    true
+fn not_deleted() -> bool {
+    false
 }
 
 #[cfg(test)]

--- a/src/catalog/src/tables.rs
+++ b/src/catalog/src/tables.rs
@@ -69,7 +69,7 @@ impl SystemCatalog {
     ) -> CatalogResult<()> {
         self.information_schema
             .system
-            .delete(build_table_deletion_request(request, table_id))
+            .insert(build_table_deletion_request(request, table_id))
             .await
             .map(|x| {
                 if x != 1 {

--- a/tests/cases/standalone/common/tql/operator.result
+++ b/tests/cases/standalone/common/tql/operator.result
@@ -51,3 +51,15 @@ tql eval (300, 300, '1s') 10 atan2 NaN;
 | 1970-01-01T00:05:00 | NaN   |
 +---------------------+-------+
 
+drop table trigx;
+
+Affected Rows: 1
+
+drop table trigy;
+
+Affected Rows: 1
+
+drop table trignan;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/tql/operator.sql
+++ b/tests/cases/standalone/common/tql/operator.sql
@@ -33,3 +33,9 @@ tql eval (300, 300, '1s') 10 atan2 20;
 -- eval instant at 5m 10 atan2 NaN
 --     NaN
 tql eval (300, 300, '1s') 10 atan2 NaN;
+
+drop table trigx;
+
+drop table trigy;
+
+drop table trignan;

--- a/tests/cases/standalone/create/recover_created.result
+++ b/tests/cases/standalone/create/recover_created.result
@@ -1,0 +1,42 @@
+create table t1 (a timestamp time index);
+
+Affected Rows: 0
+
+create table t2 (b timestamp time index);
+
+Affected Rows: 0
+
+drop table t1;
+
+Affected Rows: 1
+
+drop table t2;
+
+Affected Rows: 1
+
+-- SQLNESS ARG restart=true
+show tables;
+
++---------+
+| Tables  |
++---------+
+| numbers |
+| scripts |
++---------+
+
+create table t3 (c timestamp time index);
+
+Affected Rows: 0
+
+desc table t3;
+
++-------+----------------------+------+---------+---------------+
+| Field | Type                 | Null | Default | Semantic Type |
++-------+----------------------+------+---------+---------------+
+| c     | TimestampMillisecond | NO   |         | TIME INDEX    |
++-------+----------------------+------+---------+---------------+
+
+drop table t3;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/create/recover_created.sql
+++ b/tests/cases/standalone/create/recover_created.sql
@@ -1,0 +1,16 @@
+create table t1 (a timestamp time index);
+
+create table t2 (b timestamp time index);
+
+drop table t1;
+
+drop table t2;
+
+-- SQLNESS ARG restart=true
+show tables;
+
+create table t3 (c timestamp time index);
+
+desc table t3;
+
+drop table t3;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change system catalog's behavior on deleting table. It will remove the entire entry in previous, which may cause "jump back" of max table id. This pr changes it to mark-deletion, thus the allocated table id would never disappear.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #1797