### PR TITLE
chore: initialize mito2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5390,6 +5390,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mito2"
+version = "0.4.0"
+
+[[package]]
 name = "moka"
 version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "src/meta-client",
     "src/meta-srv",
     "src/mito",
+    "src/mito2",
     "src/object-store",
     "src/partition",
     "src/promql",

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "mito2"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]

--- a/src/mito2/README.md
+++ b/src/mito2/README.md
@@ -1,0 +1,9 @@
+# Mito
+
+Mito is GreptimeDB's default region engine.
+
+## About Mito
+The Alfa Romeo [MiTo](https://en.wikipedia.org/wiki/Alfa_Romeo_MiTo) is a front-wheel drive, three-door supermini designed by Centro Stile Alfa Romeo.
+
+> "You can't be a true petrolhead until you've owned an Alfa Romeo."
+> <div align="right">-- by Jeremy Clarkson</div>

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Region engine implementation for timeseries data.
+#[derive(Clone)]
+pub struct MitoEngine {}

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod engine;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR is a part of #1869. It initializes a new crate `mito2` to experiment with refactoring the old `mito` engine to a region engine.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 
