### PR TITLE
refactor: implement Display for TableRouteKey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arrow-flight",
  "common-base",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "clap 4.3.2",
@@ -1224,7 +1224,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1509,7 +1509,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "client"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1535,7 +1535,7 @@ dependencies = [
  "prost",
  "rand",
  "snafu",
- "substrait 0.4.0",
+ "substrait 0.3.2",
  "substrait 0.7.5",
  "tokio",
  "tokio-stream",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anymap",
  "build-data",
@@ -1602,7 +1602,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.4.0",
+ "substrait 0.3.2",
  "temp-env",
  "tikv-jemallocator",
  "tokio",
@@ -1634,7 +1634,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "snafu",
  "strum",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "chrono-tz 0.6.3",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "common-function-macro"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "backtrace",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "common-error",
  "snafu",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-stream",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "common-pprof"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "common-error",
  "pprof",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "common-error",
  "datafusion",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "once_cell",
  "rand",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "chrono-tz 0.8.2",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-compat",
@@ -2646,7 +2646,7 @@ dependencies = [
  "sql",
  "storage",
  "store-api",
- "substrait 0.4.0",
+ "substrait 0.3.2",
  "table",
  "table-procedure",
  "tokio",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "file-table-engine"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "common-catalog",
@@ -3210,7 +3210,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-compat",
@@ -3265,7 +3265,7 @@ dependencies = [
  "storage",
  "store-api",
  "strfmt",
- "substrait 0.4.0",
+ "substrait 0.3.2",
  "table",
  "tokio",
  "toml",
@@ -4871,7 +4871,7 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "log-store"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-trait",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anymap",
  "api",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anymap",
  "arc-swap",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.4.0"
+version = "0.3.2"
 
 [[package]]
 name = "moka"
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6223,7 +6223,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7060,7 +7060,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "ahash 0.8.3",
  "approx_eq",
@@ -7114,7 +7114,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.4.0",
+ "substrait 0.3.2",
  "table",
  "tokio",
  "tokio-stream",
@@ -8290,7 +8290,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "script"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -8545,7 +8545,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "aide",
  "api",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "common-catalog",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "common-base",
@@ -8954,7 +8954,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "client",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "arc-swap",
  "arrow",
@@ -9189,7 +9189,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9459,7 +9459,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9495,7 +9495,7 @@ dependencies = [
 
 [[package]]
 name = "table-procedure"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "catalog",
@@ -9588,7 +9588,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.4.0"
+version = "0.3.2"
 dependencies = [
  "api",
  "async-trait",

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+
 use api::v1::meta::TableName;
 
 use crate::key::to_removed_key;
@@ -42,12 +44,14 @@ impl<'a> TableRouteKey<'a> {
         )
     }
 
-    pub fn key(&self) -> String {
-        format!("{}-{}", self.prefix(), self.table_id)
-    }
-
     pub fn removed_key(&self) -> String {
-        to_removed_key(&self.key())
+        to_removed_key(&self.to_string())
+    }
+}
+
+impl<'a> Display for TableRouteKey<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}", self.prefix(), self.table_id)
     }
 }
 
@@ -69,7 +73,7 @@ mod tests {
         let prefix = key.prefix();
         assert_eq!("__meta_table_route-greptime-public-demo", prefix);
 
-        let key_string = key.key();
+        let key_string = key.to_string();
         assert_eq!("__meta_table_route-greptime-public-demo-123", key_string);
 
         let removed = key.removed_key();

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -301,7 +301,7 @@ impl DistTable {
             schema_name,
             table_name: old_table_name,
         }
-        .key();
+        .to_string();
 
         let new_key = TableRouteKey {
             table_id: table_id.into(),
@@ -309,7 +309,7 @@ impl DistTable {
             schema_name,
             table_name: new_table_name,
         }
-        .key();
+        .to_string();
 
         self.catalog_manager
             .backend()

--- a/src/meta-srv/src/procedure/region_failover/update_metadata.rs
+++ b/src/meta-srv/src/procedure/region_failover/update_metadata.rs
@@ -121,7 +121,7 @@ impl UpdateRegionMetadata {
         let table_route = value
             .table_route
             .with_context(|| CorruptedTableRouteSnafu {
-                key: key.key(),
+                key: key.to_string(),
                 reason: "'table_route' is empty",
             })?;
         let mut table_route = TableRoute::try_from_raw(&value.peers, table_route)
@@ -177,7 +177,7 @@ fn pretty_log_table_route_change(
     info!(
         "Updating region routes in table route value (key = '{}') to [{}]. \
         Failed region {} was on Datanode {}.",
-        key.key(),
+        key.to_string(),
         region_routes.join(", "),
         failed_region.region_number,
         failed_region.datanode_id,

--- a/src/meta-srv/src/service/router.rs
+++ b/src/meta-srv/src/service/router.rs
@@ -182,7 +182,7 @@ async fn handle_create(
     table_info.ident.table_id = id as u32;
 
     let table_route_key = TableRouteKey::with_table_name(id, &table_name)
-        .key()
+        .to_string()
         .into_bytes();
 
     let table = Table {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

implement `Display` for `TableRouteKey`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
