### PR TITLE
ci: allow update release (except release note) if it already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,7 +459,8 @@ jobs:
           name: "${{ github.ref_name }}"
           prerelease: ${{ env.prerelease }}
           makeLatest: ${{ env.makeLatest }}
-          generateReleaseNotes: true
+          generateReleaseNotes: false
+          allowUpdates: true
           artifacts: |
             **/greptime-*
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Sets `allowUpdates` to `true` and disable release note generation when the release ci is triggered manually.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
