### PR TITLE
docs: add tsbs benchmark result of v0.3.2

### DIFF
--- a/docs/benchmarks/tsbs/v0.3.2.md
+++ b/docs/benchmarks/tsbs/v0.3.2.md
@@ -1,0 +1,41 @@
+# TSBS benchmark - v0.3.2
+
+## Environment
+
+|     |     |
+| --- | --- |
+| CPU | AMD Ryzen 7 7735HS (8 core 3.2GHz) |
+| Memory | 32GB |
+| Disk | SOLIDIGM SSDPFKNU010TZ |
+| OS | Ubuntu 22.04.2 LTS |
+
+
+## Write performance
+
+|     |     |
+| --- | --- |
+| Write buffer size | （rows/s） |
+| 512M | 139583.04 |
+| 32M | 279250.52 |
+
+
+## Query performance
+
+|     |     |     |     |
+| --- | --- | --- | --- |
+| Query type  | v0.3.2 write buffer 32M (ms) | v0.3.2 write buffer 512M (ms) | v0.3.1 write buffer 32M (ms) |
+| cpu-max-all-1 | 921.12 | 241.23 | 553.63 |
+| cpu-max-all-8 | 2657.66 | 502.78 | 3308.41 |
+| double-groupby-1 | 28238.85 | 27367.42 | 52148.22 |
+| double-groupby-5 | 33094.65 | 32421.89 | 56762.37 |
+| double-groupby-all | 38565.89 | 38635.52 | 59596.80 |
+| groupby-orderby-limit | 23321.60 | 22423.55 | 53983.23 |
+| high-cpu-1 | 1167.04 | 254.15 | 832.41 |
+| high-cpu-all | 32814.08 | 29906.94 | 62853.12 |
+| lastpoint | 192045.05 | 153575.42 | NA   |
+| single-groupby-1-1-1 | 63.97 | 87.35 | 92.66 |
+| single-groupby-1-1-12 | 666.24 | 326.98 | 781.50 |
+| single-groupby-1-8-1 | 225.29 | 137.97 |281.95 |
+| single-groupby-5-1-1 | 70.40 | 81.64 | 86.15 |
+| single-groupby-5-1-12 | 722.75 | 356.01 | 805.18 |
+| single-groupby-5-8-1 | 285.60 | 115.88 | 326.29 |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Add TSBS benchmark result of v0.3.2 release

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
