### PR TITLE
fix: resolve catalog and schema in dist planner

### DIFF
--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -26,6 +26,7 @@ use futures_util::StreamExt;
 use snafu::ResultExt;
 use store_api::storage::ScanRequest;
 use table::error::{SchemaConversionSnafu, TablesRecordBatchSnafu};
+use table::metadata::TableType;
 use table::{Result as TableResult, Table, TableRef};
 
 use self::columns::InformationSchemaColumns;
@@ -100,6 +101,10 @@ impl Table for InformationTable {
 
     fn table_info(&self) -> table::metadata::TableInfoRef {
         unreachable!("Should not call table_info() of InformationTable directly")
+    }
+
+    fn table_type(&self) -> table::metadata::TableType {
+        TableType::View
     }
 
     async fn scan_to_stream(&self, request: ScanRequest) -> TableResult<SendableRecordBatchStream> {

--- a/src/common/substrait/src/df_substrait.rs
+++ b/src/common/substrait/src/df_substrait.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::{Buf, Bytes, BytesMut};
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use datafusion::catalog::catalog::CatalogList;
 use datafusion::execution::context::SessionState;
 use datafusion::execution::runtime_env::RuntimeEnv;
@@ -51,7 +50,6 @@ impl SubstraitPlan for DFLogicalSubstraitConvertor {
         let mut context = SessionContext::with_state(state);
         context.register_catalog_list(catalog_list);
         let plan = Plan::decode(message).context(DecodeRelSnafu)?;
-        println!("plan: {:?}", plan);
         let df_plan = from_substrait_plan(&mut context, &plan)
             .await
             .context(DecodeDfPlanSnafu)?;

--- a/src/common/substrait/src/df_substrait.rs
+++ b/src/common/substrait/src/df_substrait.rs
@@ -43,13 +43,15 @@ impl SubstraitPlan for DFLogicalSubstraitConvertor {
         &self,
         message: B,
         catalog_list: Arc<dyn CatalogList>,
+        catalog: &str,
+        schema: &str,
     ) -> Result<Self::Plan, Self::Error> {
-        let state_config = SessionConfig::new()
-            .with_default_catalog_and_schema(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let state_config = SessionConfig::new().with_default_catalog_and_schema(catalog, schema);
         let state = SessionState::with_config_rt(state_config, Arc::new(RuntimeEnv::default()));
         let mut context = SessionContext::with_state(state);
         context.register_catalog_list(catalog_list);
         let plan = Plan::decode(message).context(DecodeRelSnafu)?;
+        println!("plan: {:?}", plan);
         let df_plan = from_substrait_plan(&mut context, &plan)
             .await
             .context(DecodeDfPlanSnafu)?;

--- a/src/common/substrait/src/lib.rs
+++ b/src/common/substrait/src/lib.rs
@@ -36,6 +36,8 @@ pub trait SubstraitPlan {
         &self,
         message: B,
         catalog_list: Arc<dyn CatalogList>,
+        catalog: &str,
+        schema: &str,
     ) -> Result<Self::Plan, Self::Error>;
 
     fn encode(&self, plan: Self::Plan) -> Result<Bytes, Self::Error>;

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -74,7 +74,12 @@ impl Instance {
         .await?;
 
         let logical_plan = DFLogicalSubstraitConvertor
-            .decode(plan_bytes.as_slice(), Arc::new(catalog_list) as Arc<_>)
+            .decode(
+                plan_bytes.as_slice(),
+                Arc::new(catalog_list) as Arc<_>,
+                &ctx.current_catalog(),
+                &ctx.current_schema(),
+            )
             .await
             .context(DecodeLogicalPlanSnafu)?;
 

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -94,8 +94,6 @@ impl Instance {
                 table_name: format_full_table_name(catalog_name, schema_name, table_name),
             })?;
 
-        println!("table name: {:?}", table.table_info().name);
-
         let dataframe = self
             .query_engine
             .read_table(table)
@@ -128,13 +126,8 @@ impl Instance {
         let catalog_name = ctx.current_catalog();
         let schema_name = ctx.current_schema();
 
-        println!("catalog name: {catalog_name}, schema name: {schema_name}");
-        println!("queries: {:?}", queries);
-
         for query in queries {
             let table_name = prometheus::table_name(query)?;
-
-            println!("table name: {table_name}");
 
             let output = self
                 .handle_remote_query(&ctx, &catalog_name, &schema_name, &table_name, query)

--- a/src/frontend/src/instance/prometheus.rs
+++ b/src/frontend/src/instance/prometheus.rs
@@ -94,6 +94,8 @@ impl Instance {
                 table_name: format_full_table_name(catalog_name, schema_name, table_name),
             })?;
 
+        println!("table name: {:?}", table.table_info().name);
+
         let dataframe = self
             .query_engine
             .read_table(table)
@@ -126,8 +128,13 @@ impl Instance {
         let catalog_name = ctx.current_catalog();
         let schema_name = ctx.current_schema();
 
+        println!("catalog name: {catalog_name}, schema name: {schema_name}");
+        println!("queries: {:?}", queries);
+
         for query in queries {
             let table_name = prometheus::table_name(query)?;
+
+            println!("table name: {table_name}");
 
             let output = self
                 .handle_remote_query(&ctx, &catalog_name, &schema_name, &table_name, query)

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -85,15 +85,12 @@ impl ExtensionPlanner for DistExtensionPlanner {
                         .map(Some);
                 };
                 let input_schema = input_plan.schema().clone();
-                println!("input plan: {:?}", input_plan);
                 let input_plan = self.set_table_name(&table_name, input_plan.clone())?;
-                println!("resolved input plan: {:?}", input_plan);
                 let substrait_plan: Bytes = DFLogicalSubstraitConvertor
                     .encode(input_plan.clone())
                     .context(error::EncodeSubstraitLogicalPlanSnafu)?
                     .into();
                 let peers = self.get_peers(&table_name).await;
-                println!("peers: {:?}", peers);
                 match peers {
                     Ok(peers) => {
                         let exec = MergeScanExec::new(
@@ -129,7 +126,7 @@ impl DistExtensionPlanner {
     /// Set the fully resolved table name to TableScan plan
     fn set_table_name(&self, name: &TableName, plan: LogicalPlan) -> Result<LogicalPlan> {
         // let mut rewriter
-        plan.transform(&|plan| TableNameRewriter::rewrite_table_name(plan, &name))
+        plan.transform(&|plan| TableNameRewriter::rewrite_table_name(plan, name))
     }
 
     async fn get_peers(&self, table_name: &TableName) -> Result<Vec<Peer>> {
@@ -155,23 +152,19 @@ impl TreeNodeVisitor for TableNameExtractor {
     fn pre_visit(&mut self, node: &Self::N) -> Result<VisitRecursion> {
         match node {
             LogicalPlan::TableScan(scan) => {
-                println!("table name in scan: {:?}", scan.table_name);
                 if let Some(source) = scan.source.as_any().downcast_ref::<DefaultTableSource>() {
                     if let Some(provider) = source
                         .table_provider
                         .as_any()
                         .downcast_ref::<DfTableProviderAdapter>()
                     {
-                        println!("downcast success");
                         if provider.table().table_type() == TableType::Base {
-                            println!("is base table");
                             let info = provider.table().table_info();
                             self.table_name = Some(TableName::new(
                                 info.catalog_name.clone(),
                                 info.schema_name.clone(),
                                 info.name.clone(),
                             ));
-                            println!("table name: {:?}", self.table_name);
                             return Ok(VisitRecursion::Stop);
                         }
                     }

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -76,9 +76,7 @@ impl ExtensionPlanner for DistExtensionPlanner {
             } else {
                 // TODO(ruihang): generate different execution plans for different variant merge operation
                 let input_plan = merge_scan.input();
-                println!("input: {:?}", input_plan);
                 let Some(table_name) = self.get_table_name(input_plan)? else {
-                    println!("table name not found, ignore this merge scan");
                     // no relation found in input plan, going to execute them locally 
                     return planner
                         .create_physical_plan(input_plan, session_state)
@@ -158,11 +156,9 @@ impl TreeNodeVisitor for TableNameExtractor {
                             info.schema_name.clone(),
                             info.name.clone(),
                         ));
-                        println!("retrieved table name: {:?}", self.table_name);
                         return Ok(VisitRecursion::Stop);
                     }
                 }
-                println!("downcast failed");
                 match &scan.table_name {
                     TableReference::Full {
                         catalog,

--- a/tests/cases/standalone/common/create/upper_case_table_name.result
+++ b/tests/cases/standalone/common/create/upper_case_table_name.result
@@ -1,0 +1,39 @@
+create database upper_case_table_name;
+
+Affected Rows: 1
+
+use upper_case_table_name;
+
+++
+++
+
+create table system_Metric(ts timestamp time index);
+
+Affected Rows: 0
+
+insert into system_Metric values (0), (1);
+
+Affected Rows: 2
+
+select * from system_Metric;
+
+Error: 3000(PlanQuery), Error during planning: Table not found: greptime.upper_case_table_name.system_metric
+
+select * from "system_Metric";
+
++-------------------------+
+| ts                      |
++-------------------------+
+| 1970-01-01T00:00:00     |
+| 1970-01-01T00:00:00.001 |
++-------------------------+
+
+drop table system_Metric;
+
+Affected Rows: 1
+
+use public;
+
+++
+++
+

--- a/tests/cases/standalone/common/create/upper_case_table_name.sql
+++ b/tests/cases/standalone/common/create/upper_case_table_name.sql
@@ -1,0 +1,15 @@
+create database upper_case_table_name;
+
+use upper_case_table_name;
+
+create table system_Metric(ts timestamp time index);
+
+insert into system_Metric values (0), (1);
+
+select * from system_Metric;
+
+select * from "system_Metric";
+
+drop table system_Metric;
+
+use public;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Currently the planner will fill default catalog/schema when converting plan.

This case is originally for tables that don't have actual data like `information_schema.table` because they don't have route info. But when the catalog/schema change to other strings, filling the default catalog/schema will lead to wrong route info.

Elegant designs encountered:
- table in `information_schema` doesn't have table info. Workaround: only try to retrieve table info when table type is `Base`
- `DataFrame` will fill `?table?` as the table identifier when constructing it from an existing table source. Workaround: overwrite the fully resolved table name into the `TableScan` plan

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
