### PR TITLE
chore: bump proto to 917ead6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,7 +4109,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/WenyXu/greptime-proto.git?rev=1eda4691a5d2c8ffc463d48ca2317905ba7e4b2d#1eda4691a5d2c8ffc463d48ca2317905ba7e4b2d"
+source = "git+https://github.com/WenyXu/greptime-proto.git?rev=24ba50e636917bc1e2c72bd0c3b5186c3117e4ef#24ba50e636917bc1e2c72bd0c3b5186c3117e4ef"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,7 +4109,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/WenyXu/greptime-proto.git?rev=24ba50e636917bc1e2c72bd0c3b5186c3117e4ef#24ba50e636917bc1e2c72bd0c3b5186c3117e4ef"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=917ead6274b4dccbaf33c59a7360646ba2f285a9#917ead6274b4dccbaf33c59a7360646ba2f285a9"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ datafusion-sql = { git = "https://github.com/waynexia/arrow-datafusion.git", rev
 datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/WenyXu/greptime-proto.git", rev = "1eda4691a5d2c8ffc463d48ca2317905ba7e4b2d" }
+greptime-proto = { git = "https://github.com/WenyXu/greptime-proto.git", rev = "24ba50e636917bc1e2c72bd0c3b5186c3117e4ef" }
 itertools = "0.10"
 parquet = "40.0"
 paste = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ datafusion-sql = { git = "https://github.com/waynexia/arrow-datafusion.git", rev
 datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/WenyXu/greptime-proto.git", rev = "24ba50e636917bc1e2c72bd0c3b5186c3117e4ef" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "917ead6274b4dccbaf33c59a7360646ba2f285a9" }
 itertools = "0.10"
 parquet = "40.0"
 paste = "1.0"

--- a/src/common/grpc-expr/src/alter.rs
+++ b/src/common/grpc-expr/src/alter.rs
@@ -240,6 +240,7 @@ mod tests {
                     location: None,
                 }],
             })),
+            ..Default::default()
         };
 
         let alter_request = alter_expr_to_request(1, expr).unwrap();
@@ -297,6 +298,7 @@ mod tests {
                     },
                 ],
             })),
+            ..Default::default()
         };
 
         let alter_request = alter_expr_to_request(1, expr).unwrap();
@@ -345,6 +347,7 @@ mod tests {
                     name: "mem_usage".to_string(),
                 }],
             })),
+            ..Default::default()
         };
 
         let alter_request = alter_expr_to_request(1, expr).unwrap();

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -52,6 +52,7 @@ impl TryFrom<Task> for DdlTask {
             Task::CreateTableTask(create_table) => {
                 Ok(DdlTask::CreateTable(create_table.try_into()?))
             }
+            _ => todo!(),
         }
     }
 }

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -408,6 +408,7 @@ mod test {
                         },
                     ],
                 })),
+                ..Default::default()
             })),
         });
         let output = instance.do_query(query, QueryContext::arc()).await.unwrap();

--- a/src/frontend/src/expr_factory.rs
+++ b/src/frontend/src/expr_factory.rs
@@ -320,6 +320,7 @@ pub(crate) fn to_alter_expr(
         schema_name,
         table_name,
         kind: Some(kind),
+        ..Default::default()
     })
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -401,6 +401,7 @@ impl Instance {
             schema_name: ctx.current_schema(),
             table_name: table_name.to_string(),
             kind: Some(Kind::AddColumns(add_columns)),
+            ..Default::default()
         };
 
         self.grpc_query_handler

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -270,6 +270,7 @@ impl DistInstance {
             catalog_name: table_name.catalog_name.clone(),
             schema_name: table_name.schema_name.clone(),
             table_name: table_name.table_name.clone(),
+            ..Default::default()
         };
         for table_route in route_response.table_routes.iter() {
             for datanode in table_route.find_leaders() {
@@ -330,6 +331,7 @@ impl DistInstance {
             schema_name: table_name.schema_name.clone(),
             table_name: table_name.table_name.clone(),
             region_number,
+            ..Default::default()
         };
 
         for table_route in &route_response.table_routes {

--- a/src/servers/src/http/admin.rs
+++ b/src/servers/src/http/admin.rs
@@ -59,6 +59,7 @@ pub async fn flush(
             schema_name: schema_name.clone(),
             table_name: table_name.clone(),
             region_number,
+            ..Default::default()
         })),
     });
 

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -119,6 +119,7 @@ mod test {
                         location: None,
                     }],
                 })),
+                ..Default::default()
             })),
         });
         let output = query(instance, request).await;
@@ -152,6 +153,7 @@ mod test {
                 catalog_name: "greptime".to_string(),
                 schema_name: "database_created_through_grpc".to_string(),
                 table_name: "table_created_through_grpc".to_string(),
+                ..Default::default()
             })),
         });
         let output = query(instance, request).await;
@@ -416,6 +418,7 @@ CREATE TABLE {table_name} (
                 schema_name: schema_name.to_string(),
                 table_name: table_name.to_string(),
                 region_number,
+                ..Default::default()
             })),
         });
 

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -209,6 +209,7 @@ pub async fn test_insert_and_select(store_type: StorageType) {
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: "demo".to_string(),
         kind: Some(kind),
+        ..Default::default()
     };
     let result = db.alter(expr).await.unwrap();
     assert!(matches!(result, Output::AffectedRows(0)));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

bump proto to 917ead6

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
