### PR TITLE
ci: fix sqlness action in docs.yml doesn't have same name as develop.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,6 +55,7 @@ jobs:
       - run: 'echo "No action required"'
 
   sqlness:
+    name: Sqlness Test
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
#1900 didn't set `sqlness` job's name 😅 so we couldn't pass the sqlness test.

<img width="896" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/7058520/a1b03575-017d-4922-ab76-0be90c1801a0">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
