### PR TITLE
feat: add `deregister_schema` to `CatalogManager`

### DIFF
--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -59,6 +59,9 @@ pub trait CatalogManager: Send + Sync {
     /// This method will/should fail if catalog not exist
     async fn register_schema(&self, request: RegisterSchemaRequest) -> Result<bool>;
 
+    /// Deregisters a database within given catalog/schema to catalog manager
+    async fn deregister_schema(&self, request: DeregisterSchemaRequest) -> Result<bool>;
+
     /// Registers a table within given catalog/schema to catalog manager,
     /// returns whether the table registered.
     ///
@@ -147,6 +150,12 @@ pub struct DeregisterTableRequest {
     pub catalog: String,
     pub schema: String,
     pub table_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeregisterSchemaRequest {
+    pub catalog: String,
+    pub schema: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -41,7 +41,7 @@ use crate::error::{
     self, CatalogNotFoundSnafu, IllegalManagerStateSnafu, OpenTableSnafu, ReadSystemCatalogSnafu,
     Result, SchemaExistsSnafu, SchemaNotFoundSnafu, SystemCatalogSnafu,
     SystemCatalogTypeMismatchSnafu, TableEngineNotFoundSnafu, TableExistsSnafu, TableNotExistSnafu,
-    TableNotFoundSnafu,
+    TableNotFoundSnafu, UnimplementedSnafu,
 };
 use crate::information_schema::InformationSchemaProvider;
 use crate::local::memory::MemoryCatalogManager;
@@ -51,8 +51,9 @@ use crate::system::{
 };
 use crate::tables::SystemCatalog;
 use crate::{
-    handle_system_table_request, CatalogManager, CatalogManagerRef, DeregisterTableRequest,
-    RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
+    handle_system_table_request, CatalogManager, CatalogManagerRef, DeregisterSchemaRequest,
+    DeregisterTableRequest, RegisterSchemaRequest, RegisterSystemTableRequest,
+    RegisterTableRequest, RenameTableRequest,
 };
 
 /// A `CatalogManager` consists of a system catalog and a bunch of user catalogs.
@@ -514,6 +515,13 @@ impl CatalogManager for LocalCatalogManager {
                 .await?;
             self.catalogs.register_schema_sync(request)
         }
+    }
+
+    async fn deregister_schema(&self, _request: DeregisterSchemaRequest) -> Result<bool> {
+        UnimplementedSnafu {
+            operation: "deregister schema",
+        }
+        .fail()
     }
 
     async fn register_system_table(&self, request: RegisterSystemTableRequest) -> Result<()> {

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -158,7 +158,7 @@ impl CatalogManager for MemoryCatalogManager {
                 catalog_name: &request.catalog,
             })?;
         let table_count = schemas
-            .get(&request.schema)
+            .remove(&request.schema)
             .with_context(|| SchemaNotFoundSnafu {
                 catalog: &request.catalog,
                 schema: &request.schema,
@@ -170,8 +170,6 @@ impl CatalogManager for MemoryCatalogManager {
             &[crate::metrics::db_label(&request.catalog, &request.schema)],
         );
 
-        // Safety: We've already checked whether the schema exists.
-        schemas.remove(&request.schema).unwrap();
         decrement_gauge!(
             crate::metrics::METRIC_CATALOG_MANAGER_SCHEMA_COUNT,
             1.0,

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -34,7 +34,7 @@ use tokio::sync::Mutex;
 use crate::error::{
     CatalogNotFoundSnafu, CreateTableSnafu, InvalidCatalogValueSnafu, OpenTableSnafu,
     ParallelOpenTableSnafu, Result, SchemaNotFoundSnafu, TableEngineNotFoundSnafu,
-    TableMetadataManagerSnafu,
+    TableMetadataManagerSnafu, UnimplementedSnafu,
 };
 use crate::helper::{
     build_catalog_prefix, build_schema_prefix, build_table_global_prefix,
@@ -43,8 +43,8 @@ use crate::helper::{
 };
 use crate::remote::region_alive_keeper::RegionAliveKeepers;
 use crate::{
-    handle_system_table_request, CatalogManager, DeregisterTableRequest, RegisterSchemaRequest,
-    RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
+    handle_system_table_request, CatalogManager, DeregisterSchemaRequest, DeregisterTableRequest,
+    RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
 };
 
 /// Catalog manager based on metasrv.
@@ -724,6 +724,13 @@ impl CatalogManager for RemoteCatalogManager {
 
         increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_SCHEMA_COUNT, 1.0);
         Ok(true)
+    }
+
+    async fn deregister_schema(&self, _request: DeregisterSchemaRequest) -> Result<bool> {
+        UnimplementedSnafu {
+            operation: "deregister schema",
+        }
+        .fail()
     }
 
     async fn rename_table(&self, request: RenameTableRequest) -> Result<bool> {

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -130,7 +130,7 @@ impl CatalogManager for FrontendCatalogManager {
     }
 
     async fn register_catalog(&self, _name: String) -> CatalogResult<bool> {
-        unimplemented!("FrontendCatalogManager does not support register catalog")
+        unimplemented!("FrontendCatalogManager does not support registering catalog")
     }
 
     // TODO(LFC): Handle the table caching in (de)register_table.
@@ -151,7 +151,7 @@ impl CatalogManager for FrontendCatalogManager {
         &self,
         _request: RegisterSchemaRequest,
     ) -> catalog::error::Result<bool> {
-        unimplemented!("FrontendCatalogManager does not support register schema")
+        unimplemented!("FrontendCatalogManager does not support registering schema")
     }
 
     async fn deregister_schema(

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -158,7 +158,7 @@ impl CatalogManager for FrontendCatalogManager {
         &self,
         _request: DeregisterSchemaRequest,
     ) -> catalog_err::Result<bool> {
-        unimplemented!("FrontendCatalogManager does not support deregister schema")
+        unimplemented!("FrontendCatalogManager does not support deregistering schema")
     }
 
     async fn rename_table(&self, _request: RenameTableRequest) -> catalog_err::Result<bool> {

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -28,8 +28,8 @@ use catalog::helper::{
 use catalog::information_schema::InformationSchemaProvider;
 use catalog::remote::KvCacheInvalidatorRef;
 use catalog::{
-    CatalogManager, DeregisterTableRequest, RegisterSchemaRequest, RegisterSystemTableRequest,
-    RegisterTableRequest, RenameTableRequest,
+    CatalogManager, DeregisterSchemaRequest, DeregisterTableRequest, RegisterSchemaRequest,
+    RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
 };
 use client::client_manager::DatanodeClients;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME};
@@ -152,6 +152,13 @@ impl CatalogManager for FrontendCatalogManager {
         _request: RegisterSchemaRequest,
     ) -> catalog::error::Result<bool> {
         unimplemented!("FrontendCatalogManager does not support register schema")
+    }
+
+    async fn deregister_schema(
+        &self,
+        _request: DeregisterSchemaRequest,
+    ) -> catalog_err::Result<bool> {
+        unimplemented!("FrontendCatalogManager does not support deregister schema")
     }
 
     async fn rename_table(&self, _request: RenameTableRequest) -> catalog_err::Result<bool> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds `deregister_schema` method to `CatalogManager`, and implements it for `MemoryCatalogManager`.
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Part of #825