### PR TITLE
test: add unit test for distributed limit pushdown

### DIFF
--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -52,6 +52,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 approx_eq = "0.1"
+catalog = { path = "../catalog", features = ["testing"] }
 common-function-macro = { path = "../common/function-macro" }
 format_num = "0.1"
 num = "0.4"

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -314,4 +314,29 @@ mod test {
         );
         assert_eq!(expected, format!("{:?}", result));
     }
+
+    #[test]
+    fn transform_single_limit() {
+        let numbers_table = Arc::new(NumbersTable::new(0)) as _;
+        let table_source = Arc::new(DefaultTableSource::new(Arc::new(
+            DfTableProviderAdapter::new(numbers_table),
+        )));
+
+        let plan = LogicalPlanBuilder::scan_with_filters("t", table_source, None, vec![])
+            .unwrap()
+            .limit(0, Some(1))
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let config = ConfigOptions::default();
+        let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
+        let expected = String::from(
+            "Limit: skip=0, fetch=1\
+            \n  MergeScan [is_placeholder=false]\
+            \n    Limit: skip=0, fetch=1\
+            \n      TableScan: t",
+        );
+        assert_eq!(expected, format!("{:?}", result));
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add test case to cover `LogicalPlan::Limit` for distributed planner

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
