### PR TITLE
fix: remove useless mirror subsitution and RUN command 

### DIFF
--- a/docker/Dockerfile-centos7-builder
+++ b/docker/Dockerfile-centos7-builder
@@ -3,13 +3,8 @@ FROM centos:7
 ENV LANG en_US.utf8
 WORKDIR /greptimedb
 
-RUN sed -e 's|^mirrorlist=|#mirrorlist=|g' \
-             -e 's|^#baseurl=http://mirror.centos.org/centos|baseurl=http://mirrors.tuna.tsinghua.edu.cn/centos|g' \
-             -i.bak \
-             /etc/yum.repos.d/CentOS-*.repo
-
 # Install dependencies
-RUN RUN ulimit -n 1024000 && yum groupinstall -y 'Development Tools'
+RUN ulimit -n 1024000 && yum groupinstall -y 'Development Tools'
 RUN yum install -y epel-release  \
     openssl \
     openssl-devel  \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove useless mirror subsitution and RUN command from CentOS-7 builder docker file.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
