### PR TITLE
chore: add interceptor for prometheus query

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -573,10 +573,9 @@ impl PromHandler for Instance {
         query: &PromQuery,
         query_ctx: QueryContextRef,
     ) -> server_error::Result<Output> {
-        let interceptor_ref = self
+        let interceptor = self
             .plugins
             .get::<PromQueryInterceptorRef<server_error::Error>>();
-        let interceptor = interceptor_ref.as_ref();
         interceptor.pre_execute(query, query_ctx.clone())?;
 
         let stmt = QueryLanguageParser::parse_promql(query).with_context(|_| ParsePromQLSnafu {

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -216,7 +216,7 @@ pub trait PromQueryInterceptor {
 pub type PromQueryInterceptorRef<E> =
     Arc<dyn PromQueryInterceptor<Error = E> + Send + Sync + 'static>;
 
-impl<E> PromQueryInterceptor for Option<&PromQueryInterceptorRef<E>>
+impl<E> PromQueryInterceptor for Option<PromQueryInterceptorRef<E>>
 where
     E: ErrorExt,
 {

--- a/src/servers/src/interceptor.rs
+++ b/src/servers/src/interceptor.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use api::v1::greptime_request::Request;
 use common_error::prelude::ErrorExt;
 use common_query::Output;
+use query::parser::PromQuery;
 use query::plan::LogicalPlan;
 use session::context::QueryContextRef;
 use sql::statements::statement::Statement;
@@ -181,6 +182,65 @@ where
     ) -> Result<Output, Self::Error> {
         if let Some(this) = self {
             this.post_execute(output, _query_ctx)
+        } else {
+            Ok(output)
+        }
+    }
+}
+
+/// PromQueryInterceptor can track life cycle of a prometheus request and customize or
+/// abort its execution at given point.
+pub trait PromQueryInterceptor {
+    type Error: ErrorExt;
+
+    /// Called before request is actually executed.
+    fn pre_execute(
+        &self,
+        _query: &PromQuery,
+        _query_ctx: QueryContextRef,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Called after execution finished. The implementation can modify the
+    /// output if needed.
+    fn post_execute(
+        &self,
+        output: Output,
+        _query_ctx: QueryContextRef,
+    ) -> Result<Output, Self::Error> {
+        Ok(output)
+    }
+}
+
+pub type PromQueryInterceptorRef<E> =
+    Arc<dyn PromQueryInterceptor<Error = E> + Send + Sync + 'static>;
+
+impl<E> PromQueryInterceptor for Option<&PromQueryInterceptorRef<E>>
+where
+    E: ErrorExt,
+{
+    type Error = E;
+
+    fn pre_execute(
+        &self,
+        query: &PromQuery,
+        query_ctx: QueryContextRef,
+    ) -> Result<(), Self::Error> {
+        if let Some(this) = self {
+            this.pre_execute(query, query_ctx)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn post_execute(
+        &self,
+        output: Output,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output, Self::Error> {
+        if let Some(this) = self {
+            this.post_execute(output, query_ctx)
         } else {
             Ok(output)
         }

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -128,7 +128,7 @@ fn test_prom_interceptor() {
     assert!(fail.is_err());
 
     let output = Output::AffectedRows(1);
-    let two = PromQueryInterceptor::post_execute(&di, output, ctx.clone());
+    let two = PromQueryInterceptor::post_execute(&di, output, ctx);
     assert!(two.is_ok());
     matches!(two.unwrap(), Output::AffectedRows(2));
 }

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -17,8 +17,10 @@ use std::sync::Arc;
 
 use api::v1::greptime_request::Request;
 use api::v1::{InsertRequest, InsertRequests};
-use servers::error::{self, NotSupportedSnafu, Result};
-use servers::interceptor::{GrpcQueryInterceptor, SqlQueryInterceptor};
+use common_query::Output;
+use query::parser::PromQuery;
+use servers::error::{self, InternalSnafu, NotSupportedSnafu, Result};
+use servers::interceptor::{GrpcQueryInterceptor, PromQueryInterceptor, SqlQueryInterceptor};
 use session::context::{QueryContext, QueryContextRef};
 use snafu::ensure;
 
@@ -84,4 +86,49 @@ fn test_grpc_interceptor() {
 
     let req = Request::Inserts(InsertRequests::default());
     GrpcQueryInterceptor::pre_execute(&di, &req, ctx).unwrap();
+}
+
+impl PromQueryInterceptor for NoopInterceptor {
+    type Error = error::Error;
+
+    fn pre_execute(
+        &self,
+        query: &PromQuery,
+        _query_ctx: QueryContextRef,
+    ) -> std::result::Result<(), Self::Error> {
+        match query.query.as_str() {
+            "up" => InternalSnafu { err_msg: "test" }.fail(),
+            _ => Ok(()),
+        }
+    }
+
+    fn post_execute(
+        &self,
+        output: Output,
+        _query_ctx: QueryContextRef,
+    ) -> std::result::Result<Output, Self::Error> {
+        match output {
+            Output::AffectedRows(1) => Ok(Output::AffectedRows(2)),
+            _ => Ok(output),
+        }
+    }
+}
+
+#[test]
+fn test_prom_interceptor() {
+    let di = NoopInterceptor;
+    let ctx = Arc::new(QueryContext::new());
+
+    let query = PromQuery {
+        query: "up".to_string(),
+        ..Default::default()
+    };
+
+    let fail = PromQueryInterceptor::pre_execute(&di, &query, ctx.clone());
+    assert!(fail.is_err());
+
+    let output = Output::AffectedRows(1);
+    let two = PromQueryInterceptor::post_execute(&di, output, ctx.clone());
+    assert!(two.is_ok());
+    matches!(two.unwrap(), Output::AffectedRows(2));
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly adds `PromQueryInterceptor` to `PromHandler` while processing prometheus query requests. `PromHandler` covers requests from grpc server(prom query) and prom http server.

todo:
- check requests from `remote_read` too

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
