### PR TITLE
chore: bump latest greptime-proto version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,7 +4112,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=917ead6274b4dccbaf33c59a7360646ba2f285a9#917ead6274b4dccbaf33c59a7360646ba2f285a9"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=0f30b7fcbf950f0596f1159373947a21ff737216#0f30b7fcbf950f0596f1159373947a21ff737216"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 etcd-client = "0.11"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "917ead6274b4dccbaf33c59a7360646ba2f285a9" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "0f30b7fcbf950f0596f1159373947a21ff737216" }
 itertools = "0.10"
 lazy_static = "1.4"
 parquet = "40.0"

--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -257,6 +257,7 @@ fn ddl_request_type(request: &DdlRequest) -> &'static str {
         Some(Expr::DropTable(_)) => "ddl.drop_table",
         Some(Expr::FlushTable(_)) => "ddl.flush_table",
         None => "ddl.empty",
+        _ => unreachable!("https://github.com/GreptimeTeam/greptimedb/pull/1912"),
     }
 }
 

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use api::v1::ddl_request::Expr as DdlExpr;
+use api::v1::ddl_request::{Expr as DdlExpr, Expr};
 use api::v1::greptime_request::Request as GrpcRequest;
 use api::v1::query_request::Query;
 use api::v1::{CreateDatabaseExpr, DdlRequest, DeleteRequest, InsertRequests};
@@ -198,6 +198,9 @@ impl Instance {
             DdlExpr::CreateDatabase(expr) => self.handle_create_database(expr, query_ctx).await,
             DdlExpr::DropTable(expr) => self.handle_drop_table(expr).await,
             DdlExpr::FlushTable(expr) => self.handle_flush_table(expr).await,
+            Expr::CompactTable(_) => {
+                unreachable!("https://github.com/GreptimeTeam/greptimedb/pull/1912")
+            }
         }
     }
 }

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api::helper::ColumnDataTypeWrapper;
-use api::v1::ddl_request::Expr as DdlExpr;
+use api::v1::ddl_request::{Expr as DdlExpr, Expr};
 use api::v1::greptime_request::Request;
 use api::v1::{
     column_def, AlterExpr, CreateDatabaseExpr, CreateTableExpr, DeleteRequest, DropTableExpr,
@@ -596,6 +596,9 @@ impl GrpcQueryHandler for DistInstance {
                         let table_name =
                             TableName::new(&expr.catalog_name, &expr.schema_name, &expr.table_name);
                         self.flush_table(table_name, expr.region_number).await
+                    }
+                    Expr::CompactTable(_) => {
+                        unreachable!("https://github.com/GreptimeTeam/greptimedb/pull/1912")
                     }
                 }
             }

--- a/src/meta-srv/src/cluster.rs
+++ b/src/meta-srv/src/cluster.rs
@@ -260,7 +260,6 @@ mod tests {
             cluster_id: 0,
             id: 100,
             addr: "127.0.0.1:3001".to_string(),
-            is_leader: true,
             ..Default::default()
         };
         let stat_val = StatValue { stats: vec![stat] }.try_into().unwrap();
@@ -280,7 +279,6 @@ mod tests {
         assert_eq!(0, stat.cluster_id);
         assert_eq!(100, stat.id);
         assert_eq!("127.0.0.1:3001", stat.addr);
-        assert!(stat.is_leader);
     }
 
     #[test]

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -278,7 +278,6 @@ mod tests {
         let stat = Stat {
             cluster_id: 0,
             id: 101,
-            is_leader: false,
             region_num: Some(100),
             ..Default::default()
         };
@@ -294,7 +293,6 @@ mod tests {
         let stat = stats.get(0).unwrap();
         assert_eq!(0, stat.cluster_id);
         assert_eq!(101, stat.id);
-        assert!(!stat.is_leader);
         assert_eq!(Some(100), stat.region_num);
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump greptime-proto version

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
