### PR TITLE
refactor: add snafu::Location to error prelude

### DIFF
--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 use std::str::FromStr;
 
 use common_error::prelude::*;
-use snafu::Location;
 use tonic::{Code, Status};
 
 #[derive(Debug, Snafu)]

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::prelude::*;
 use config::ConfigError;
 use rustyline::error::ReadlineError;
-use snafu::Location;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/src/common/datasource/src/error.rs
+++ b/src/common/datasource/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use arrow_schema::ArrowError;
 use common_error::prelude::*;
 use datafusion::parquet::errors::ParquetError;
-use snafu::Location;
 use url::ParseError;
 
 #[derive(Debug, Snafu)]

--- a/src/common/error/src/lib.rs
+++ b/src/common/error/src/lib.rs
@@ -19,7 +19,7 @@ pub mod status_code;
 
 pub mod prelude {
     pub use snafu::prelude::*;
-    pub use snafu::{Backtrace, ErrorCompat};
+    pub use snafu::{ErrorCompat, Location};
 
     pub use crate::ext::{BoxedError, ErrorExt};
     pub use crate::format::DebugFormat;

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -14,7 +14,6 @@
 
 use common_error::prelude::*;
 use serde_json::error::Error as JsonError;
-use snafu::Location;
 use store_api::storage::RegionNumber;
 use table::metadata::TableId;
 

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -17,7 +17,6 @@ use std::string::FromUtf8Error;
 use std::sync::Arc;
 
 use common_error::prelude::*;
-use snafu::Location;
 
 use crate::procedure::ProcedureId;
 

--- a/src/common/query/src/error.rs
+++ b/src/common/query/src/error.rs
@@ -22,7 +22,6 @@ use datatypes::arrow;
 use datatypes::arrow::datatypes::DataType as ArrowDatatype;
 use datatypes::error::Error as DataTypeError;
 use datatypes::prelude::ConcreteDataType;
-use snafu::Location;
 use statrs::StatsError;
 
 #[derive(Debug, Snafu)]

--- a/src/common/recordbatch/src/error.rs
+++ b/src/common/recordbatch/src/error.rs
@@ -18,7 +18,6 @@ use std::any::Any;
 use common_error::ext::BoxedError;
 use common_error::prelude::*;
 use datatypes::prelude::ConcreteDataType;
-use snafu::Location;
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/common/runtime/src/error.rs
+++ b/src/common/runtime/src/error.rs
@@ -15,7 +15,6 @@
 use std::any::Any;
 
 use common_error::prelude::*;
-use snafu::Location;
 use tokio::task::JoinError;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::prelude::*;
 use common_procedure::ProcedureId;
 use serde_json::error::Error as JsonError;
-use snafu::Location;
 use store_api::storage::RegionNumber;
 use table::error::Error as TableError;
 

--- a/src/file-table-engine/src/error.rs
+++ b/src/file-table-engine/src/error.rs
@@ -19,7 +19,6 @@ use common_error::prelude::*;
 use datafusion::arrow::error::ArrowError;
 use datafusion::error::DataFusionError;
 use serde_json::error::Error as JsonError;
-use snafu::Location;
 use table::metadata::{TableInfoBuilderError, TableMetaBuilderError};
 
 #[derive(Debug, Snafu)]

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -19,7 +19,6 @@ use common_error::prelude::*;
 use datafusion::parquet;
 use datatypes::arrow::error::ArrowError;
 use datatypes::value::Value;
-use snafu::Location;
 use store_api::storage::RegionNumber;
 
 #[derive(Debug, Snafu)]

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use common_error::prelude::*;
-use snafu::Location;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -15,7 +15,6 @@
 use common_error::prelude::*;
 use common_meta::peer::Peer;
 use common_runtime::JoinError;
-use snafu::Location;
 use tokio::sync::mpsc::error::SendError;
 use tonic::codegen::http;
 use tonic::Code;

--- a/src/mito/src/error.rs
+++ b/src/mito/src/error.rs
@@ -15,7 +15,6 @@
 use std::any::Any;
 
 use common_error::prelude::*;
-use snafu::Location;
 use store_api::storage::RegionNumber;
 use table::metadata::{TableInfoBuilderError, TableMetaBuilderError, TableVersion};
 

--- a/src/partition/src/error.rs
+++ b/src/partition/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::prelude::*;
 use common_query::prelude::Expr;
 use datafusion_common::ScalarValue;
-use snafu::{Location, Snafu};
 use store_api::storage::{RegionId, RegionNumber};
 
 #[derive(Debug, Snafu)]

--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::prelude::*;
 use datafusion::error::DataFusionError;
 use promql_parser::parser::{Expr as PromExpr, TokenType};
-use snafu::Location;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/src/query/src/datafusion/error.rs
+++ b/src/query/src/datafusion/error.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 
 use common_error::prelude::*;
 use datafusion::error::DataFusionError;
-use snafu::Location;
 
 /// Inner error of datafusion based query engine.
 #[derive(Debug, Snafu)]

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -19,7 +19,6 @@ use common_meta::table_name::TableName;
 use datafusion::error::DataFusionError;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::Value;
-use snafu::{Location, Snafu};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -25,7 +25,6 @@ use common_telemetry::logging;
 use datatypes::prelude::ConcreteDataType;
 use query::parser::PromQuery;
 use serde_json::json;
-use snafu::Location;
 use tonic::codegen::http::{HeaderMap, HeaderValue};
 use tonic::metadata::MetadataMap;
 use tonic::Code;

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -18,7 +18,6 @@ use common_error::prelude::*;
 use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
 use datatypes::prelude::{ConcreteDataType, Value};
-use snafu::Location;
 use sqlparser::parser::ParserError;
 
 use crate::ast::{Expr, Value as SqlValue};

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -23,7 +23,6 @@ use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
 use object_store::ErrorKind;
 use serde_json::error::Error as JsonError;
-use snafu::Location;
 use store_api::manifest::action::ProtocolVersion;
 use store_api::manifest::ManifestVersion;
 use store_api::storage::{RegionId, SequenceNumber};

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -21,7 +21,7 @@ use common_error::prelude::*;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Metadata, COMMENT_KEY};
 use serde::{Deserialize, Serialize};
-use snafu::{ensure, Location, OptionExt};
+use snafu::{ensure, OptionExt};
 use store_api::storage::consts::{self, ReservedColumnId};
 use store_api::storage::{
     AddColumn, AlterOperation, AlterRequest, ColumnDescriptor, ColumnDescriptorBuilder,

--- a/src/table-procedure/src/error.rs
+++ b/src/table-procedure/src/error.rs
@@ -15,7 +15,6 @@
 use std::any::Any;
 
 use common_error::prelude::*;
-use snafu::Location;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]

--- a/src/table/src/error.rs
+++ b/src/table/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::prelude::*;
 use datafusion::error::DataFusionError;
 use datatypes::arrow::error::ArrowError;
-use snafu::Location;
 
 use crate::metadata::TableId;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Add snafu::Location to `common_error::prelude` so we don't need to import them again. It removes `Backtrace` from the prelude mod.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
