### PR TITLE
refactor: region lease

### DIFF
--- a/src/common/meta/src/ident.rs
+++ b/src/common/meta/src/ident.rs
@@ -20,7 +20,7 @@ use snafu::OptionExt;
 
 use crate::error::{Error, InvalidProtoMsgSnafu};
 
-#[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
+#[derive(Eq, Hash, PartialEq, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TableIdent {
     pub catalog: String,
     pub schema: String,

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -89,9 +89,9 @@ impl HeartbeatHandler for RegionFailureHandler {
                     cluster_id: stat.cluster_id,
                     datanode_id: stat.id,
                     table_ident: TableIdent {
-                        catalog: x.catalog.clone(),
-                        schema: x.schema.clone(),
-                        table: x.table.clone(),
+                        catalog: x.table_ident.catalog.clone(),
+                        schema: x.table_ident.schema.clone(),
+                        table: x.table_ident.table.clone(),
                         table_id: RegionId::from(x.id).table_id(),
                         // TODO(#1583): Use the actual table engine.
                         engine: MITO_ENGINE.to_string(),
@@ -132,9 +132,13 @@ mod tests {
         fn new_region_stat(region_id: u64) -> RegionStat {
             RegionStat {
                 id: region_id,
-                catalog: "a".to_string(),
-                schema: "b".to_string(),
-                table: "c".to_string(),
+                table_ident: TableIdent {
+                    catalog: "a".to_string(),
+                    schema: "b".to_string(),
+                    table: "c".to_string(),
+                    table_id: 0,
+                    engine: "d".to_string(),
+                },
                 rcus: 0,
                 wcus: 0,
                 approximate_bytes: 0,

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -36,7 +36,6 @@ pub(crate) struct DatanodeHeartbeat {
 
 pub struct RegionFailureHandler {
     failure_detect_runner: FailureDetectRunner,
-    region_failover_manager: Arc<RegionFailoverManager>,
 }
 
 impl RegionFailureHandler {
@@ -52,12 +51,7 @@ impl RegionFailureHandler {
 
         Ok(Self {
             failure_detect_runner,
-            region_failover_manager,
         })
-    }
-
-    pub(crate) fn region_failover_manager(&self) -> &Arc<RegionFailoverManager> {
-        &self.region_failover_manager
     }
 }
 

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -13,70 +13,22 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use api::v1::meta::{HeartbeatRequest, RegionLease, Role};
 use async_trait::async_trait;
-use catalog::helper::TableGlobalKey;
-use common_meta::ident::TableIdent;
-use common_meta::ClusterId;
-use store_api::storage::{RegionId, RegionNumber};
+use store_api::storage::RegionId;
 
 use crate::error::Result;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
-use crate::procedure::region_failover::{RegionFailoverKey, RegionFailoverManager};
-use crate::service::store::kv::KvStoreRef;
-use crate::table_routes;
 
 /// The lease seconds of a region. It's set by two default heartbeat intervals (5 second × 2) plus
 /// two roundtrip time (2 second × 2 × 2), plus some extra buffer (2 second).
 // TODO(LFC): Make region lease seconds calculated from Datanode heartbeat configuration.
 pub(crate) const REGION_LEASE_SECONDS: u64 = 20;
 
-pub(crate) struct RegionLeaseHandler {
-    kv_store: KvStoreRef,
-    region_failover_manager: Option<Arc<RegionFailoverManager>>,
-}
-
-impl RegionLeaseHandler {
-    pub(crate) fn new(
-        kv_store: KvStoreRef,
-        region_failover_manager: Option<Arc<RegionFailoverManager>>,
-    ) -> Self {
-        Self {
-            kv_store,
-            region_failover_manager,
-        }
-    }
-
-    /// Filter out the regions that are currently in failover.
-    /// It's meaningless to extend the lease of a region if it is in failover.
-    fn filter_failover_regions(
-        &self,
-        cluster_id: ClusterId,
-        table_ident: &TableIdent,
-        regions: Vec<RegionNumber>,
-    ) -> Vec<RegionNumber> {
-        if let Some(region_failover_manager) = &self.region_failover_manager {
-            let mut region_failover_key = RegionFailoverKey {
-                cluster_id,
-                table_ident: table_ident.clone(),
-                region_number: 0,
-            };
-
-            regions
-                .into_iter()
-                .filter(|region| {
-                    region_failover_key.region_number = *region;
-                    !region_failover_manager.is_region_failover_running(&region_failover_key)
-                })
-                .collect()
-        } else {
-            regions
-        }
-    }
-}
+#[derive(Default)]
+pub(crate) struct RegionLeaseHandler;
 
 #[async_trait]
 impl HeartbeatHandler for RegionLeaseHandler {
@@ -92,56 +44,25 @@ impl HeartbeatHandler for RegionLeaseHandler {
     ) -> Result<()> {
         let Some(stat) = acc.stat.as_ref() else { return Ok(()) };
 
-        let mut datanode_regions = HashMap::new();
-        stat.region_stats.iter().for_each(|x| {
-            let key = TableGlobalKey {
-                catalog_name: x.table_ident.catalog.to_string(),
-                schema_name: x.table_ident.schema.to_string(),
-                table_name: x.table_ident.table.to_string(),
-            };
-            datanode_regions
-                .entry(key)
+        let mut table_region_leases = HashMap::new();
+        stat.region_stats.iter().for_each(|region_stat| {
+            let table_ident = region_stat.table_ident.clone();
+            table_region_leases
+                .entry(table_ident)
                 .or_insert_with(Vec::new)
-                .push(RegionId::from(x.id).region_number());
+                .push(RegionId::from(region_stat.id).region_number());
         });
 
-        // TODO(LFC): Retrieve table global values from some cache here.
-        let table_global_values = table_routes::batch_get_table_global_value(
-            &self.kv_store,
-            datanode_regions.keys().collect::<Vec<_>>(),
-        )
-        .await?;
-
-        let mut region_leases = Vec::with_capacity(datanode_regions.len());
-        for (table_global_key, local_regions) in datanode_regions {
-            let Some(Some(table_global_value)) = table_global_values.get(&table_global_key) else { continue };
-
-            let Some(global_regions) = table_global_value.regions_id_map.get(&stat.id) else { continue };
-
-            // Filter out the designated regions from table global metadata for the given table on the given Datanode.
-            let designated_regions = local_regions
-                .into_iter()
-                .filter(|x| global_regions.contains(x))
-                .collect::<Vec<_>>();
-
-            let table_ident = TableIdent {
-                catalog: table_global_key.catalog_name.to_string(),
-                schema: table_global_key.schema_name.to_string(),
-                table: table_global_key.table_name.to_string(),
-                table_id: table_global_value.table_id(),
-                engine: table_global_value.engine().to_string(),
-            };
-            let designated_regions =
-                self.filter_failover_regions(stat.cluster_id, &table_ident, designated_regions);
-
-            region_leases.push(RegionLease {
+        acc.region_leases = table_region_leases
+            .into_iter()
+            .map(|(table_ident, regions)| RegionLease {
                 table_ident: Some(table_ident.into()),
-                regions: designated_regions,
+                regions,
                 duration_since_epoch: req.duration_since_epoch,
                 lease_seconds: REGION_LEASE_SECONDS,
-            });
-        }
-        acc.region_leases = region_leases;
+            })
+            .collect();
+
         Ok(())
     }
 }
@@ -149,24 +70,15 @@ impl HeartbeatHandler for RegionLeaseHandler {
 #[cfg(test)]
 mod test {
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_meta::ident::TableIdent;
 
     use super::*;
     use crate::handler::node_stat::{RegionStat, Stat};
     use crate::metasrv::builder::MetaSrvBuilder;
-    use crate::test_util;
 
     #[tokio::test]
     async fn test_handle_region_lease() {
-        let region_failover_manager = test_util::create_region_failover_manager();
-        let kv_store = region_failover_manager
-            .create_context()
-            .selector_ctx
-            .kv_store
-            .clone();
-
         let table_name = "my_table";
-        let _ = table_routes::tests::prepare_table_global_value(&kv_store, table_name).await;
-
         let table_ident = TableIdent {
             catalog: DEFAULT_CATALOG_NAME.to_string(),
             schema: DEFAULT_SCHEMA_NAME.to_string(),
@@ -174,17 +86,8 @@ mod test {
             table_id: 1,
             engine: "mito".to_string(),
         };
-        let _ = region_failover_manager
-            .running_procedures()
-            .write()
-            .unwrap()
-            .insert(RegionFailoverKey {
-                cluster_id: 1,
-                table_ident: table_ident.clone(),
-                region_number: 1,
-            });
 
-        let handler = RegionLeaseHandler::new(kv_store, Some(region_failover_manager));
+        let handler = RegionLeaseHandler::default();
 
         let req = HeartbeatRequest {
             duration_since_epoch: 1234,
@@ -203,7 +106,8 @@ mod test {
                     catalog: DEFAULT_CATALOG_NAME.to_string(),
                     schema: DEFAULT_SCHEMA_NAME.to_string(),
                     table: table_name.to_string(),
-                    ..Default::default()
+                    table_id: 1,
+                    engine: "mito".to_string(),
                 },
                 ..Default::default()
             }
@@ -217,12 +121,10 @@ mod test {
 
         handler.handle(&req, ctx, acc).await.unwrap();
 
-        // region 1 is during failover and region 3 is not in table global value,
-        // so only region 2's lease is extended.
         assert_eq!(acc.region_leases.len(), 1);
         let lease = acc.region_leases.remove(0);
         assert_eq!(lease.table_ident.unwrap(), table_ident.into());
-        assert_eq!(lease.regions, vec![2]);
+        assert_eq!(lease.regions, vec![1, 2, 3]);
         assert_eq!(lease.duration_since_epoch, 1234);
         assert_eq!(lease.lease_seconds, REGION_LEASE_SECONDS);
     }

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -95,9 +95,9 @@ impl HeartbeatHandler for RegionLeaseHandler {
         let mut datanode_regions = HashMap::new();
         stat.region_stats.iter().for_each(|x| {
             let key = TableGlobalKey {
-                catalog_name: x.catalog.to_string(),
-                schema_name: x.schema.to_string(),
-                table_name: x.table.to_string(),
+                catalog_name: x.table_ident.catalog.to_string(),
+                schema_name: x.table_ident.schema.to_string(),
+                table_name: x.table_ident.table.to_string(),
             };
             datanode_regions
                 .entry(key)
@@ -199,9 +199,12 @@ mod test {
         let new_region_stat = |region_id: u64| -> RegionStat {
             RegionStat {
                 id: region_id,
-                catalog: DEFAULT_CATALOG_NAME.to_string(),
-                schema: DEFAULT_SCHEMA_NAME.to_string(),
-                table: table_name.to_string(),
+                table_ident: TableIdent {
+                    catalog: DEFAULT_CATALOG_NAME.to_string(),
+                    schema: DEFAULT_SCHEMA_NAME.to_string(),
+                    table: table_name.to_string(),
+                    ..Default::default()
+                },
                 ..Default::default()
             }
         };

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -205,13 +205,6 @@ impl MetaSrvBuilder {
                     )
                 };
 
-                let region_lease_handler = RegionLeaseHandler::new(
-                    kv_store.clone(),
-                    region_failover_handler
-                        .as_ref()
-                        .map(|x| x.region_failover_manager().clone()),
-                );
-
                 let group = HeartbeatHandlerGroup::new(pushers);
                 group.add_handler(ResponseHeaderHandler::default()).await;
                 // `KeepLeaseHandler` should preferably be in front of `CheckLeaderHandler`,
@@ -225,7 +218,7 @@ impl MetaSrvBuilder {
                 if let Some(region_failover_handler) = region_failover_handler {
                     group.add_handler(region_failover_handler).await;
                 }
-                group.add_handler(region_lease_handler).await;
+                group.add_handler(RegionLeaseHandler::default()).await;
                 group.add_handler(PersistStatsHandler::default()).await;
                 group
             }

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -129,10 +129,6 @@ impl RegionFailoverManager {
             })
     }
 
-    pub(crate) fn is_region_failover_running(&self, key: &RegionFailoverKey) -> bool {
-        self.running_procedures.read().unwrap().contains(key)
-    }
-
     fn insert_running_procedures(
         &self,
         failed_region: &RegionIdent,
@@ -147,11 +143,6 @@ impl RegionFailoverManager {
         } else {
             None
         }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn running_procedures(&self) -> Arc<RwLock<HashSet<RegionFailoverKey>>> {
-        self.running_procedures.clone()
     }
 
     pub(crate) async fn do_region_failover(&self, failed_region: &RegionIdent) -> Result<()> {

--- a/src/meta-srv/src/selector/load_based.rs
+++ b/src/meta-srv/src/selector/load_based.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use api::v1::meta::Peer;
+use common_meta::ident::TableIdent;
 use common_telemetry::warn;
 
 use crate::error::Result;
@@ -102,9 +103,13 @@ fn contains_table(
 
     if let Some(latest) = may_latest {
         for RegionStat {
-            catalog,
-            schema,
-            table,
+            table_ident:
+                TableIdent {
+                    catalog,
+                    schema,
+                    table,
+                    ..
+                },
             ..
         } in latest.region_stats.iter()
         {
@@ -121,6 +126,8 @@ fn contains_table(
 
 #[cfg(test)]
 mod tests {
+    use common_meta::ident::TableIdent;
+
     use crate::handler::node_stat::{RegionStat, Stat};
     use crate::keys::StatValue;
     use crate::selector::load_based::contains_table;
@@ -135,44 +142,30 @@ mod tests {
                 Stat {
                     region_stats: vec![
                         RegionStat {
-                            catalog: "greptime_1".to_string(),
-                            schema: "public_1".to_string(),
-                            table: "demo_1".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_1".to_string(),
+                                schema: "public_1".to_string(),
+                                table: "demo_1".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         RegionStat {
-                            catalog: "greptime_2".to_string(),
-                            schema: "public_2".to_string(),
-                            table: "demo_2".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_2".to_string(),
+                                schema: "public_2".to_string(),
+                                table: "demo_2".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         RegionStat {
-                            catalog: "greptime_3".to_string(),
-                            schema: "public_3".to_string(),
-                            table: "demo_3".to_string(),
-                            ..Default::default()
-                        },
-                    ],
-                    ..Default::default()
-                },
-                Stat {
-                    region_stats: vec![
-                        RegionStat {
-                            catalog: "greptime_1".to_string(),
-                            schema: "public_1".to_string(),
-                            table: "demo_1".to_string(),
-                            ..Default::default()
-                        },
-                        RegionStat {
-                            catalog: "greptime_2".to_string(),
-                            schema: "public_2".to_string(),
-                            table: "demo_2".to_string(),
-                            ..Default::default()
-                        },
-                        RegionStat {
-                            catalog: "greptime_3".to_string(),
-                            schema: "public_3".to_string(),
-                            table: "demo_3".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_3".to_string(),
+                                schema: "public_3".to_string(),
+                                table: "demo_3".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                     ],
@@ -181,21 +174,62 @@ mod tests {
                 Stat {
                     region_stats: vec![
                         RegionStat {
-                            catalog: "greptime_1".to_string(),
-                            schema: "public_1".to_string(),
-                            table: "demo_1".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_1".to_string(),
+                                schema: "public_1".to_string(),
+                                table: "demo_1".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         RegionStat {
-                            catalog: "greptime_2".to_string(),
-                            schema: "public_2".to_string(),
-                            table: "demo_2".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_2".to_string(),
+                                schema: "public_2".to_string(),
+                                table: "demo_2".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         RegionStat {
-                            catalog: "greptime_4".to_string(),
-                            schema: "public_4".to_string(),
-                            table: "demo_4".to_string(),
+                            table_ident: TableIdent {
+                                catalog: "greptime_3".to_string(),
+                                schema: "public_3".to_string(),
+                                table: "demo_3".to_string(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+                Stat {
+                    region_stats: vec![
+                        RegionStat {
+                            table_ident: TableIdent {
+                                catalog: "greptime_1".to_string(),
+                                schema: "public_1".to_string(),
+                                table: "demo_1".to_string(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        RegionStat {
+                            table_ident: TableIdent {
+                                catalog: "greptime_2".to_string(),
+                                schema: "public_2".to_string(),
+                                table: "demo_2".to_string(),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        RegionStat {
+                            table_ident: TableIdent {
+                                catalog: "greptime_4".to_string(),
+                                schema: "public_4".to_string(),
+                                table: "demo_4".to_string(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                     ],

--- a/src/meta-srv/src/table_routes.rs
+++ b/src/meta-srv/src/table_routes.rs
@@ -37,7 +37,7 @@ pub async fn get_table_global_value(
         .transpose()
 }
 
-pub(crate) async fn batch_get_table_global_value(
+pub async fn batch_get_table_global_value(
     kv_store: &KvStoreRef,
     keys: Vec<&TableGlobalKey>,
 ) -> Result<HashMap<TableGlobalKey, Option<TableGlobalValue>>> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Currently we need to query remote metadata when handling datanode heartbeats and renewing leases, which will become the bottleneck of metasrv.

The current design can be optimized, no metadata query is required, just renew the lease according to the information in the heartbeat, except for those nodes that are performing failover.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
