### PR TITLE
chore: grpc-timeput = 10s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,6 +5239,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic",
  "tower",
  "tracing",

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -28,7 +28,8 @@ use tower::make::MakeConnection;
 use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
-const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 2;
+const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Clone, Debug)]
 pub struct ChannelManager {
@@ -238,7 +239,7 @@ impl Default for ChannelConfig {
     fn default() -> Self {
         Self {
             timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
-            connect_timeout: Some(Duration::from_secs(4)),
+            connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
             concurrency_limit: None,
             rate_limit: None,
             initial_stream_window_size: None,

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -500,7 +500,7 @@ mod tests {
         assert_eq!(
             ChannelConfig {
                 timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
-                connect_timeout: Some(Duration::from_secs(4)),
+                connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
                 concurrency_limit: None,
                 rate_limit: None,
                 initial_stream_window_size: None,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change grpc request-timeout and connect-timeout to 10s

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
