### PR TITLE
refactor: change logging level for mysql error log

### DIFF
--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 parking_lot = { version = "0.12", features = [
     "deadlock_detection",
 ], optional = true }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 tokio.workspace = true
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -24,7 +24,7 @@ opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 parking_lot = { version = "0.12", features = [
     "deadlock_detection",
 ], optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde.workspace = true
 tokio.workspace = true
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src/common/telemetry/src/macros.rs
+++ b/src/common/telemetry/src/macros.rs
@@ -140,6 +140,50 @@ macro_rules! warn {
         $crate::log!(target: $target, $crate::logging::Level::WARN, $($arg)+)
     };
 
+    // warn!(e; "a {} event", "log")
+    ($e:expr; $($arg:tt)+) => ({
+        use std::error::Error;
+        use $crate::common_error::ext::ErrorExt;
+        match ($e.source(), $e.location_opt()) {
+            (Some(source), Some(location)) => {
+                $crate::log!(
+                    $crate::logging::Level::WARN,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    err.location = %location,
+                    $($arg)+
+                )
+            },
+            (Some(source), None) => {
+                $crate::log!(
+                    $crate::logging::Level::WARN,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.source = source,
+                    $($arg)+
+                )
+            },
+            (None, Some(location)) => {
+                $crate::log!(
+                    $crate::logging::Level::WARN,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    err.location = %location,
+                    $($arg)+
+                )
+            },
+            (None, None) => {
+                $crate::log!(
+                    $crate::logging::Level::WARN,
+                    err.msg = %$e,
+                    err.code = %$e.status_code(),
+                    $($arg)+
+                )
+            }
+        }
+    });
+
     // warn!("a {} event", "log")
     ($($arg:tt)+) => {
         $crate::log!($crate::logging::Level::WARN, $($arg)+)

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -31,6 +31,10 @@ use crate::error::UpdateJemallocMetricsSnafu;
 pub(crate) const METRIC_DB_LABEL: &str = "db";
 pub(crate) const METRIC_CODE_LABEL: &str = "code";
 pub(crate) const METRIC_TYPE_LABEL: &str = "type";
+pub(crate) const METRIC_PROTOCOL_LABEL: &str = "protocol";
+
+pub(crate) const METRIC_ERROR_COUNTER: &str = "servers.error";
+pub(crate) const METRIC_ERROR_COUNTER_LABEL_MYSQL: &str = "mysql";
 
 pub(crate) const METRIC_HTTP_SQL_ELAPSED: &str = "servers.http_sql_elapsed";
 pub(crate) const METRIC_HTTP_PROMQL_ELAPSED: &str = "servers.http_promql_elapsed";


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch changed error logging of mysql protocol to level `WARN`. 

It also includes a metrics to track error count so that we can count error rate later.
More error count for other protocols to come in next patches.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
