### PR TITLE
refactor: remove misdirectional alias "Request as GreptimeRequest"

### DIFF
--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use api::v1::greptime_request::Request as GreptimeRequest;
+use api::v1::greptime_request::Request;
 use async_trait::async_trait;
 use common_query::Output;
 use datanode::error::Error as DatanodeError;
@@ -36,7 +36,7 @@ impl StandaloneGrpcQueryHandler {
 impl GrpcQueryHandler for StandaloneGrpcQueryHandler {
     type Error = error::Error;
 
-    async fn do_query(&self, query: GreptimeRequest, ctx: QueryContextRef) -> Result<Output> {
+    async fn do_query(&self, query: Request, ctx: QueryContextRef) -> Result<Output> {
         self.0
             .do_query(query, ctx)
             .await

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -37,7 +37,7 @@ mod sequence;
 pub mod service;
 pub mod table_routes;
 
+pub use crate::error::Result;
+
 #[cfg(test)]
 mod test_util;
-
-pub use crate::error::Result;

--- a/src/servers/src/query_handler/grpc.rs
+++ b/src/servers/src/query_handler/grpc.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use api::v1::greptime_request::Request as GreptimeRequest;
+use api::v1::greptime_request::Request;
 use async_trait::async_trait;
 use common_error::prelude::*;
 use common_query::Output;
@@ -31,7 +31,7 @@ pub trait GrpcQueryHandler {
 
     async fn do_query(
         &self,
-        query: GreptimeRequest,
+        query: Request,
         ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error>;
 }
@@ -51,7 +51,7 @@ where
 {
     type Error = error::Error;
 
-    async fn do_query(&self, query: GreptimeRequest, ctx: QueryContextRef) -> Result<Output> {
+    async fn do_query(&self, query: Request, ctx: QueryContextRef) -> Result<Output> {
         self.0
             .do_query(query, ctx)
             .await

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use api::v1::greptime_request::{Request as GreptimeRequest, Request};
+use api::v1::greptime_request::Request;
 use api::v1::query_request::Query;
 use async_trait::async_trait;
 use catalog::local::MemoryCatalogManager;
@@ -156,7 +156,7 @@ impl GrpcQueryHandler for DummyInstance {
 
     async fn do_query(
         &self,
-        request: GreptimeRequest,
+        request: Request,
         ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error> {
         let output = match request {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

 There is an actual struct named `GreptimeRequest`. And their relationship is
```rust
struct GreptimeRequest {
  Request request
}
```

![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/4f0cbd3a-13be-429c-a811-80e0298bbccc)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
