### PR TITLE
feat: support desc [table] <table_name>

### DIFF
--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -261,10 +261,8 @@ impl<'a> ParserContext<'a> {
     fn parse_describe(&mut self) -> Result<Statement> {
         if self.matches_keyword(Keyword::TABLE) {
             let _ = self.parser.next_token();
-            self.parse_describe_table()
-        } else {
-            self.parse_describe_table()
         }
+        self.parse_describe_table()
     }
 
     fn parse_describe_table(&mut self) -> Result<Statement> {

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -263,7 +263,7 @@ impl<'a> ParserContext<'a> {
             let _ = self.parser.next_token();
             self.parse_describe_table()
         } else {
-            self.unsupported(self.peek_token_as_string())
+            self.parse_describe_table()
         }
     }
 
@@ -676,5 +676,21 @@ mod tests {
         let expr =
             ParserContext::parse_function("current_timestamp()", &GreptimeDbDialect {}).unwrap();
         assert!(matches!(expr, Expr::Function(_)));
+    }
+
+    fn assert_describe_table(sql: &str) {
+        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
+            .unwrap()
+            .pop()
+            .unwrap();
+        assert!(matches!(stmt, Statement::DescribeTable(_)))
+    }
+
+    #[test]
+    fn test_parse_describe_table() {
+        assert_describe_table("desc table t;");
+        assert_describe_table("describe table t;");
+        assert_describe_table("desc t;");
+        assert_describe_table("describe t;");
     }
 }

--- a/tests/cases/standalone/common/describe/describe_table.result
+++ b/tests/cases/standalone/common/describe/describe_table.result
@@ -1,0 +1,58 @@
+create table host_load1(
+    ts timestamp time index,
+    collector string,
+    host string,
+    val double,
+    primary key (collector, host)
+);
+
+Affected Rows: 0
+
+describe table host_load1;
+
++-----------+----------------------+------+---------+---------------+
+| Field     | Type                 | Null | Default | Semantic Type |
++-----------+----------------------+------+---------+---------------+
+| ts        | TimestampMillisecond | NO   |         | TIME INDEX    |
+| collector | String               | YES  |         | PRIMARY KEY   |
+| host      | String               | YES  |         | PRIMARY KEY   |
+| val       | Float64              | YES  |         | FIELD         |
++-----------+----------------------+------+---------+---------------+
+
+describe host_load1;
+
++-----------+----------------------+------+---------+---------------+
+| Field     | Type                 | Null | Default | Semantic Type |
++-----------+----------------------+------+---------+---------------+
+| ts        | TimestampMillisecond | NO   |         | TIME INDEX    |
+| collector | String               | YES  |         | PRIMARY KEY   |
+| host      | String               | YES  |         | PRIMARY KEY   |
+| val       | Float64              | YES  |         | FIELD         |
++-----------+----------------------+------+---------+---------------+
+
+desc table host_load1;
+
++-----------+----------------------+------+---------+---------------+
+| Field     | Type                 | Null | Default | Semantic Type |
++-----------+----------------------+------+---------+---------------+
+| ts        | TimestampMillisecond | NO   |         | TIME INDEX    |
+| collector | String               | YES  |         | PRIMARY KEY   |
+| host      | String               | YES  |         | PRIMARY KEY   |
+| val       | Float64              | YES  |         | FIELD         |
++-----------+----------------------+------+---------+---------------+
+
+desc host_load1;
+
++-----------+----------------------+------+---------+---------------+
+| Field     | Type                 | Null | Default | Semantic Type |
++-----------+----------------------+------+---------+---------------+
+| ts        | TimestampMillisecond | NO   |         | TIME INDEX    |
+| collector | String               | YES  |         | PRIMARY KEY   |
+| host      | String               | YES  |         | PRIMARY KEY   |
+| val       | Float64              | YES  |         | FIELD         |
++-----------+----------------------+------+---------+---------------+
+
+drop table host_load1;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/describe/describe_table.sql
+++ b/tests/cases/standalone/common/describe/describe_table.sql
@@ -1,0 +1,17 @@
+create table host_load1(
+    ts timestamp time index,
+    collector string,
+    host string,
+    val double,
+    primary key (collector, host)
+);
+
+describe table host_load1;
+
+describe host_load1;
+
+desc table host_load1;
+
+desc host_load1;
+
+drop table host_load1;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Make the keyword `TABLE` in `DESCRIBE` clause optional. SQL like `desc <table_name>` is supported after this patch

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

fixes https://github.com/GreptimeTeam/greptimedb/issues/1941