### PR TITLE
chore: upgrade toml version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "schemars",
  "serde",
  "serde_json",
@@ -426,7 +426,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half 2.2.1",
- "indexmap",
+ "indexmap 1.9.3",
  "lexical-core",
  "num",
  "serde",
@@ -1319,7 +1319,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf74ea341ae8905eac9a234b6a5a845e118c25bbbdecf85ec77431a8b3bfa0be"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "num-traits",
  "regex",
@@ -1450,7 +1450,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive 3.2.25",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
@@ -1620,7 +1620,7 @@ dependencies = [
  "temp-env",
  "tikv-jemallocator",
  "tokio",
- "toml",
+ "toml 0.7.6",
 ]
 
 [[package]]
@@ -1657,7 +1657,7 @@ dependencies = [
  "paste",
  "serde",
  "snafu",
- "toml",
+ "toml 0.7.6",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ dependencies = [
  "rust-ini 0.18.0",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -2451,7 +2451,7 @@ dependencies = [
  "futures",
  "glob",
  "hashbrown 0.13.2",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "lazy_static",
  "log",
@@ -2552,7 +2552,7 @@ dependencies = [
  "datafusion-row",
  "half 2.2.1",
  "hashbrown 0.13.2",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "lazy_static",
  "libc",
@@ -2669,7 +2669,7 @@ dependencies = [
  "table-procedure",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.7.6",
  "tonic",
  "tower",
  "tower-http",
@@ -2987,6 +2987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "erased-serde"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,7 +3292,7 @@ dependencies = [
  "substrait 0.3.2",
  "table",
  "tokio",
- "toml",
+ "toml 0.7.6",
  "tonic",
  "tower",
  "uuid",
@@ -4147,7 +4153,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -4187,6 +4193,12 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hashlink"
@@ -4473,6 +4485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,7 +4520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
  "ahash 0.8.3",
- "indexmap",
+ "indexmap 1.9.3",
  "is-terminal",
  "itoa",
  "log",
@@ -4961,7 +4983,7 @@ dependencies = [
  "cactus",
  "cfgrammar",
  "filetime",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "lrtable",
  "num-traits",
@@ -5239,7 +5261,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.7.6",
  "tonic",
  "tower",
  "tracing",
@@ -5283,7 +5305,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8603921e1f54ef386189335f288441af761e0fc61bcb552168d9cedfe63ebc70"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "metrics",
  "metrics-util",
  "parking_lot 0.12.1",
@@ -5328,7 +5350,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.3",
  "metrics",
  "num_cpus",
  "ordered-float 2.10.0",
@@ -6404,7 +6426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -6748,7 +6770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca9c6be70d989d21a136eb86c2d83e4b328447fac4a88dace2143c179c86267"
 dependencies = [
  "autocfg",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -6757,7 +6779,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -7885,7 +7907,7 @@ source = "git+https://github.com/discord9/RustPython?rev=9ed5137412#9ed51374125b
 dependencies = [
  "ahash 0.7.6",
  "bitflags 1.3.2",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "log",
  "num-complex",
@@ -7958,7 +7980,7 @@ name = "rustpython-derive-impl"
 version = "0.2.0"
 source = "git+https://github.com/discord9/RustPython?rev=9ed5137412#9ed51374125b5f1a9e5cee5dd7e27023b8591f1e"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "maplit",
  "once_cell",
@@ -8099,7 +8121,7 @@ dependencies = [
  "glob",
  "half 1.8.2",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "is-macro",
  "itertools",
  "libc",
@@ -8311,7 +8333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
 dependencies = [
  "dyn-clone",
- "indexmap",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -8543,6 +8565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_tokenstream"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8583,7 +8614,7 @@ version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -8996,7 +9027,7 @@ dependencies = [
  "prettydiff",
  "regex",
  "thiserror",
- "toml",
+ "toml 0.5.11",
  "walkdir",
 ]
 
@@ -9077,7 +9108,7 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "libc",
  "log",
@@ -10048,18 +10079,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.2"
+name = "toml"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -10130,7 +10178,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hdrhistogram",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ sqlparser = "0.34"
 tempfile = "3"
 tokio = { version = "1.28", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io-util", "compat"] }
+toml = "0.7"
 tonic = { version = "0.9", features = ["tls"] }
 uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
 metrics = "0.20"

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -51,7 +51,7 @@ common-test-util = { path = "../common/test-util" }
 rexpect = "0.5"
 temp-env = "0.3"
 serde.workspace = true
-toml = "0.5"
+toml.workspace = true
 
 [build-dependencies]
 build-data = "0.1.4"

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -14,4 +14,4 @@ serde = { version = "1.0", features = ["derive"] }
 snafu.workspace = true
 
 [dev-dependencies]
-toml = "0.5"
+toml.workspace = true

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -61,7 +61,7 @@ table = { path = "../table" }
 table-procedure = { path = "../table-procedure" }
 tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
-toml = "0.5"
+toml.workspace = true
 tonic.workspace = true
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -63,7 +63,7 @@ store-api = { path = "../store-api" }
 substrait = { path = "../common/substrait" }
 table = { path = "../table" }
 tokio.workspace = true
-toml = "0.5"
+toml.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -43,7 +43,7 @@ store-api = { path = "../store-api" }
 table = { path = "../table" }
 tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
-toml = "0.5"
+toml.workspace = true
 tonic.workspace = true
 tower = "0.4"
 typetag = "0.2"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

```rust
impl FrontendOptions {
    pub fn env_list_keys() -> Option<&'static [&'static str]> {
        Some(&["meta_client_options.metasrv_addrs"])
    }

    pub fn to_toml_string(&self) -> String {
        toml::to_string(&self).unwrap()
    }
}
```

`toml::to_string(&self).unwrap()` would cause `ValueAfterTable`, see [here](https://github.com/toml-rs/toml/issues/395)

This pr mainly upgrades `toml` version to fix this.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
