### PR TITLE
feat: simplify the usage of channel_manage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "datatypes",
  "flatbuffers",
  "futures",
+ "lazy_static",
  "prost",
  "rand",
  "snafu",

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -22,7 +22,7 @@ datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
 flatbuffers = "23.1"
 futures = "0.3"
-lazy_static = "1.4"
+lazy_static.workspace = true
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tokio.workspace = true

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -22,6 +22,7 @@ datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
 flatbuffers = "23.1"
 futures = "0.3"
+lazy_static = "1.4"
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 tokio.workspace = true

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -483,7 +483,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_access_count() {
-        let mgr = Arc::new(ChannelManager::new());
+        let mgr = ChannelManager::new();
+        // Do not start recycle
+        mgr.channel_recycle_started.store(true, Ordering::Relaxed);
+        let mgr = Arc::new(mgr);
         let addr = "test_uri";
 
         let mut joins = Vec::with_capacity(10);

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -411,9 +411,7 @@ async fn new_metasrv_client(node_id: u64, meta_config: &MetaClientOptions) -> Re
         .timeout(Duration::from_millis(meta_config.timeout_millis))
         .connect_timeout(Duration::from_millis(meta_config.connect_timeout_millis))
         .tcp_nodelay(meta_config.tcp_nodelay);
-
     let channel_manager = ChannelManager::with_config(config);
-    channel_manager.start_channel_recycle();
 
     let mut meta_client = MetaClientBuilder::new(cluster_id, member_id, Role::Datanode)
         .enable_heartbeat()

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -129,7 +129,6 @@ impl FrontendCatalogManager {
 #[async_trait::async_trait]
 impl CatalogManager for FrontendCatalogManager {
     async fn start(&self) -> catalog::error::Result<()> {
-        self.datanode_clients.start();
         Ok(())
     }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -234,11 +234,10 @@ impl Instance {
                 meta_client_options.connect_timeout_millis,
             ))
             .tcp_nodelay(meta_client_options.tcp_nodelay);
-        let channel_manager = ChannelManager::with_config(channel_config);
-
         let ddl_channel_config = channel_config.clone().timeout(Duration::from_millis(
             meta_client_options.ddl_timeout_millis,
         ));
+        let channel_manager = ChannelManager::with_config(channel_config);
         let ddl_channel_manager = ChannelManager::with_config(ddl_channel_config);
 
         let mut meta_client = MetaClientBuilder::new(0, 0, Role::Frontend)

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -234,16 +234,12 @@ impl Instance {
                 meta_client_options.connect_timeout_millis,
             ))
             .tcp_nodelay(meta_client_options.tcp_nodelay);
+        let channel_manager = ChannelManager::with_config(channel_config);
 
         let ddl_channel_config = channel_config.clone().timeout(Duration::from_millis(
             meta_client_options.ddl_timeout_millis,
         ));
-
-        let channel_manager = ChannelManager::with_config(channel_config);
-        channel_manager.start_channel_recycle();
-
         let ddl_channel_manager = ChannelManager::with_config(ddl_channel_config);
-        ddl_channel_manager.start_channel_recycle();
 
         let mut meta_client = MetaClientBuilder::new(0, 0, Role::Frontend)
             .enable_router()


### PR DESCRIPTION


I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Simplify the usage of ﻿channel_manager by avoiding the external invocation of ﻿start.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
