### PR TITLE
feat: invalidate table cache after altering

### DIFF
--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -515,6 +515,15 @@ impl DistInstance {
             .await
             .context(error::RequestMetaSnafu)?;
 
+        let table_info = table.table_info();
+        self.catalog_manager
+            .invalidate_table(
+                &table_info.catalog_name,
+                &table_info.schema_name,
+                &table_info.name,
+            )
+            .await;
+
         Ok(Output::AffectedRows(0))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Invalidate table cache after altering

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
