### PR TITLE
refactor: let metasrv returns ref always

### DIFF
--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -238,57 +238,46 @@ impl MetaSrv {
         &self.options
     }
 
-    #[inline]
-    pub fn in_memory(&self) -> ResettableKvStoreRef {
-        self.in_memory.clone()
+    pub fn in_memory(&self) -> &ResettableKvStoreRef {
+        &self.in_memory
     }
 
-    #[inline]
-    pub fn kv_store(&self) -> KvStoreRef {
-        self.kv_store.clone()
+    pub fn kv_store(&self) -> &KvStoreRef {
+        &self.kv_store
     }
 
-    #[inline]
-    pub fn leader_cached_kv_store(&self) -> ResettableKvStoreRef {
-        self.leader_cached_kv_store.clone()
+    pub fn leader_cached_kv_store(&self) -> &ResettableKvStoreRef {
+        &self.leader_cached_kv_store
     }
 
-    #[inline]
-    pub fn meta_peer_client(&self) -> MetaPeerClientRef {
-        self.meta_peer_client.clone()
+    pub fn meta_peer_client(&self) -> &MetaPeerClientRef {
+        &self.meta_peer_client
     }
 
-    #[inline]
-    pub fn table_id_sequence(&self) -> SequenceRef {
-        self.table_id_sequence.clone()
+    pub fn table_id_sequence(&self) -> &SequenceRef {
+        &self.table_id_sequence
     }
 
-    #[inline]
-    pub fn selector(&self) -> SelectorRef {
-        self.selector.clone()
+    pub fn selector(&self) -> &SelectorRef {
+        &self.selector
     }
 
-    #[inline]
-    pub fn handler_group(&self) -> HeartbeatHandlerGroup {
-        self.handler_group.clone()
+    pub fn handler_group(&self) -> &HeartbeatHandlerGroup {
+        &self.handler_group
     }
 
-    #[inline]
-    pub fn election(&self) -> Option<ElectionRef> {
-        self.election.clone()
+    pub fn election(&self) -> Option<&ElectionRef> {
+        self.election.as_ref()
     }
 
-    #[inline]
     pub fn lock(&self) -> &DistLockRef {
         &self.lock
     }
 
-    #[inline]
-    pub fn mailbox(&self) -> MailboxRef {
-        self.mailbox.clone()
+    pub fn mailbox(&self) -> &MailboxRef {
+        &self.mailbox
     }
 
-    #[inline]
     pub fn ddl_manager(&self) -> &DdlManagerRef {
         &self.ddl_manager
     }
@@ -304,12 +293,12 @@ impl MetaSrv {
     #[inline]
     pub fn new_ctx(&self) -> Context {
         let server_addr = self.options().server_addr.clone();
-        let in_memory = self.in_memory();
-        let kv_store = self.kv_store();
-        let leader_cached_kv_store = self.leader_cached_kv_store();
-        let meta_peer_client = self.meta_peer_client();
-        let mailbox = self.mailbox();
-        let election = self.election();
+        let in_memory = self.in_memory.clone();
+        let kv_store = self.kv_store.clone();
+        let leader_cached_kv_store = self.leader_cached_kv_store.clone();
+        let meta_peer_client = self.meta_peer_client.clone();
+        let mailbox = self.mailbox.clone();
+        let election = self.election.clone();
         let skip_all = Arc::new(AtomicBool::new(false));
         Context {
             server_addr,

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -36,35 +36,35 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     let router = router.route(
         "/node-lease",
         node_lease::NodeLeaseHandler {
-            meta_peer_client: meta_srv.meta_peer_client(),
+            meta_peer_client: meta_srv.meta_peer_client().clone(),
         },
     );
 
     let router = router.route(
         "/heartbeat",
         heartbeat::HeartBeatHandler {
-            meta_peer_client: meta_srv.meta_peer_client(),
+            meta_peer_client: meta_srv.meta_peer_client().clone(),
         },
     );
 
     let router = router.route(
         "/catalogs",
         meta::CatalogsHandler {
-            kv_store: meta_srv.kv_store(),
+            kv_store: meta_srv.kv_store().clone(),
         },
     );
 
     let router = router.route(
         "/schemas",
         meta::SchemasHandler {
-            kv_store: meta_srv.kv_store(),
+            kv_store: meta_srv.kv_store().clone(),
         },
     );
 
     let router = router.route(
         "/tables",
         meta::TablesHandler {
-            kv_store: meta_srv.kv_store(),
+            kv_store: meta_srv.kv_store().clone(),
             table_metadata_manager: meta_srv.table_metadata_manager().clone(),
         },
     );
@@ -72,7 +72,7 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     let router = router.route(
         "/table",
         meta::TableHandler {
-            kv_store: meta_srv.kv_store(),
+            kv_store: meta_srv.kv_store().clone(),
             table_metadata_manager: meta_srv.table_metadata_manager().clone(),
         },
     );
@@ -80,14 +80,14 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     let router = router.route(
         "/leader",
         leader::LeaderHandler {
-            election: meta_srv.election(),
+            election: meta_srv.election().cloned(),
         },
     );
 
     let router = router.route(
         "/route",
         route::RouteHandler {
-            kv_store: meta_srv.kv_store(),
+            kv_store: meta_srv.kv_store().clone(),
         },
     );
 

--- a/src/meta-srv/src/service/ddl.rs
+++ b/src/meta-srv/src/service/ddl.rs
@@ -53,8 +53,8 @@ impl ddl_task_server::DdlTask for MetaSrv {
         let ctx = SelectorContext {
             datanode_lease_secs: self.options().datanode_lease_secs,
             server_addr: self.options().server_addr.clone(),
-            kv_store: self.kv_store(),
-            meta_peer_client: self.meta_peer_client(),
+            kv_store: self.kv_store().clone(),
+            meta_peer_client: self.meta_peer_client().clone(),
             catalog: None,
             schema: None,
             table: None,

--- a/src/meta-srv/src/service/heartbeat.rs
+++ b/src/meta-srv/src/service/heartbeat.rs
@@ -43,7 +43,7 @@ impl heartbeat_server::Heartbeat for MetaSrv {
     ) -> GrpcResult<Self::HeartbeatStream> {
         let mut in_stream = req.into_inner();
         let (tx, rx) = mpsc::channel(128);
-        let handler_group = self.handler_group();
+        let handler_group = self.handler_group().clone();
         let ctx = self.new_ctx();
         let _handle = common_runtime::spawn_bg(async move {
             let mut pusher_key = None;

--- a/src/meta-srv/src/service/router.rs
+++ b/src/meta-srv/src/service/router.rs
@@ -85,8 +85,8 @@ impl router_server::Router for MetaSrv {
         let ctx = SelectorContext {
             datanode_lease_secs: self.options().datanode_lease_secs,
             server_addr: self.options().server_addr.clone(),
-            kv_store: self.kv_store(),
-            meta_peer_client: self.meta_peer_client(),
+            kv_store: self.kv_store().clone(),
+            meta_peer_client: self.meta_peer_client().clone(),
             catalog: Some(table_name.catalog_name.clone()),
             schema: Some(table_name.schema_name.clone()),
             table: Some(table_name.table_name.clone()),
@@ -140,8 +140,8 @@ impl router_server::Router for MetaSrv {
 async fn handle_create(
     req: CreateRequest,
     ctx: SelectorContext,
-    selector: SelectorRef,
-    table_id_sequence: SequenceRef,
+    selector: &SelectorRef,
+    table_id_sequence: &SequenceRef,
 ) -> Result<RouteResponse> {
     let CreateRequest {
         header,

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -97,7 +97,7 @@ impl GreptimeDbClusterBuilder {
 
         build_datanode_clients(datanode_clients.clone(), &datanode_instances, datanodes).await;
 
-        self.wait_datanodes_alive(&meta_srv.meta_srv.meta_peer_client(), datanodes)
+        self.wait_datanodes_alive(meta_srv.meta_srv.meta_peer_client(), datanodes)
             .await;
 
         let frontend = self
@@ -131,7 +131,7 @@ impl GreptimeDbClusterBuilder {
         let mock =
             meta_srv::mocks::mock(opt, self.kv_store.clone(), None, Some(datanode_clients)).await;
 
-        let metadata_service = DefaultMetadataService::new(mock.meta_srv.kv_store());
+        let metadata_service = DefaultMetadataService::new(mock.meta_srv.kv_store().clone());
         metadata_service
             .create_schema("another_catalog", "another_schema", true)
             .await

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -332,13 +332,13 @@ async fn run_region_failover_procedure(
     let procedure = RegionFailoverProcedure::new(
         failed_region.clone(),
         RegionFailoverContext {
-            mailbox: meta_srv.mailbox(),
+            mailbox: meta_srv.mailbox().clone(),
             selector,
             selector_ctx: SelectorContext {
                 datanode_lease_secs: meta_srv.options().datanode_lease_secs,
                 server_addr: meta_srv.options().server_addr.clone(),
-                kv_store: meta_srv.kv_store(),
-                meta_peer_client: meta_srv.meta_peer_client(),
+                kv_store: meta_srv.kv_store().clone(),
+                meta_peer_client: meta_srv.meta_peer_client().clone(),
                 catalog: None,
                 schema: None,
                 table: None,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Metasrv has many fields, we defined some getters, some return a clone internally, some return a reference, we should unify the behavior.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
