### PR TITLE
refactor(mito): port region manifest and column metadata structs to mito2 

### DIFF
--- a/src/datatypes/src/error.rs
+++ b/src/datatypes/src/error.rs
@@ -105,6 +105,21 @@ pub enum Error {
 
     #[snafu(display("Invalid timestamp precision: {}", precision))]
     InvalidTimestampPrecision { precision: u64, location: Location },
+
+    #[snafu(display(
+        "Failed to parse metadata to int, key_value: {}, source: {}",
+        key_value,
+        source
+    ))]
+    ParseMetaInt {
+        // Store key and value in one string to reduce the enum size.
+        key_value: String,
+        source: std::num::ParseIntError,
+        location: Location,
+    },
+
+    #[snafu(display("Metadata of {} not found", key))]
+    MetaNotFound { key: String, location: Location },
 }
 
 impl ErrorExt for Error {

--- a/src/datatypes/src/schema.rs
+++ b/src/datatypes/src/schema.rs
@@ -25,7 +25,9 @@ use snafu::{ensure, ResultExt};
 
 use crate::data_type::DataType;
 use crate::error::{self, Error, ProjectArrowSchemaSnafu, Result};
-pub use crate::schema::column_schema::{ColumnSchema, Metadata, COMMENT_KEY, TIME_INDEX_KEY};
+pub use crate::schema::column_schema::{
+    try_parse_int, ColumnSchema, Metadata, COMMENT_KEY, TIME_INDEX_KEY,
+};
 pub use crate::schema::constraint::ColumnDefaultConstraint;
 pub use crate::schema::raw::RawSchema;
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -18,6 +18,7 @@ use common_datasource::compression::CompressionType;
 use common_error::prelude::*;
 use snafu::Location;
 use store_api::manifest::ManifestVersion;
+use store_api::storage::{ColumnDescriptorBuilderError, ColumnId};
 
 use crate::manifest::action::RegionMetaAction;
 use crate::region::metadata::VersionNumber;
@@ -109,6 +110,54 @@ pub enum Error {
     InvalidAlterOperation {
         name: String,
         reason: String,
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Failed to convert to column schema, source: {}. Location {}",
+        source,
+        location
+    ))]
+    ToColumnSchema {
+        location: Location,
+        source: datatypes::error::Error,
+    },
+
+    #[snafu(display(
+        "Failed to build column descriptor, source: {}. Location {}",
+        source,
+        location
+    ))]
+    BuildColumnDescriptor {
+        source: ColumnDescriptorBuilderError,
+        location: Location,
+    },
+
+    #[snafu(display(
+        "Failed to access k-v metadata, source: {}. Location {}",
+        source,
+        location
+    ))]
+    AccessKvMetadata {
+        source: datatypes::Error,
+        location: Location,
+    },
+
+    #[snafu(display("Column name {} is reserved by the system", name))]
+    ReservedColumn { name: String, location: Location },
+
+    #[snafu(display("Column name {} already exists", name))]
+    ColNameExists { name: String, location: Location },
+
+    #[snafu(display("Column id {} already exists", id))]
+    ColIdExists { id: ColumnId, location: Location },
+
+    #[snafu(display("Missing timestamp key column"))]
+    MissingTimestamp { location: Location },
+
+    #[snafu(display("Error from storage metadata: {}. Location: {}", source, location))]
+    StorageMetadata {
+        source: storage::metadata::Error,
         location: Location,
     },
 }

--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -19,4 +19,5 @@ mod gc_task;
 mod helper;
 #[allow(unused_variables)]
 mod impl_;
+mod region;
 mod storage;

--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -21,3 +21,5 @@ mod helper;
 mod impl_;
 mod region;
 mod storage;
+#[cfg(test)]
+mod test_utils;

--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -14,7 +14,7 @@
 
 //! manifest storage
 
-mod action;
+pub(crate) mod action;
 mod gc_task;
 mod helper;
 #[allow(unused_variables)]

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -21,6 +21,7 @@ use store_api::manifest::action::{ProtocolAction, ProtocolVersion};
 use store_api::manifest::ManifestVersion;
 use store_api::storage::{RegionId, SequenceNumber};
 
+use crate::error::Result;
 use crate::manifest::helper;
 
 /// Minimal data that could be used to persist and recover [RegionMetadata](crate::metadata::RegionMetadata).
@@ -166,11 +167,11 @@ impl RegionCheckpoint {
         self.last_version
     }
 
-    fn encode(&self) -> Result<Vec<u8>, ()> {
+    fn encode(&self) -> Result<Vec<u8>> {
         todo!()
     }
 
-    fn decode(bs: &[u8], reader_version: ProtocolVersion) -> Result<Self, ()> {
+    fn decode(bs: &[u8], reader_version: ProtocolVersion) -> Result<Self> {
         helper::decode_checkpoint(bs, reader_version)
     }
 }
@@ -216,14 +217,14 @@ impl RegionMetaActionList {
     }
 
     /// Encode self into json in the form of string lines, starts with prev_version and then action json list.
-    fn encode(&self) -> Result<Vec<u8>, ()> {
+    fn encode(&self) -> Result<Vec<u8>> {
         helper::encode_actions(self.prev_version, &self.actions)
     }
 
     fn decode(
         _bs: &[u8],
         _reader_version: ProtocolVersion,
-    ) -> Result<(Self, Option<ProtocolAction>), ()> {
+    ) -> Result<(Self, Option<ProtocolAction>)> {
         todo!()
     }
 }
@@ -239,7 +240,7 @@ impl MetaActionIteratorImpl {
         self.last_protocol.clone()
     }
 
-    async fn next_action(&mut self) -> Result<Option<(ManifestVersion, RegionMetaActionList)>, ()> {
+    pub async fn next_action(&mut self) -> Result<Option<(ManifestVersion, RegionMetaActionList)>> {
         todo!()
     }
 }

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use storage::metadata::{ColumnMetadata, VersionNumber};
+use storage::metadata::VersionNumber;
 use storage::sst::{FileId, FileMeta};
 use store_api::manifest::action::{ProtocolAction, ProtocolVersion};
 use store_api::manifest::ManifestVersion;
@@ -23,6 +23,7 @@ use store_api::storage::{RegionId, SequenceNumber};
 
 use crate::error::Result;
 use crate::manifest::helper;
+use crate::region::columns::ColumnMetadata;
 
 /// Minimal data that could be used to persist and recover [RegionMetadata](crate::metadata::RegionMetadata).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use storage::metadata::{ColumnFamilyMetadata, ColumnMetadata, VersionNumber};
+use storage::metadata::{ColumnMetadata, VersionNumber};
 use storage::sst::{FileId, FileMeta};
 use store_api::manifest::action::{ProtocolAction, ProtocolVersion};
 use store_api::manifest::ManifestVersion;
@@ -30,7 +30,6 @@ pub struct RawRegionMetadata {
     pub id: RegionId,
     pub name: String,
     pub columns: RawColumnsMetadata,
-    pub column_families: RawColumnFamiliesMetadata,
     pub version: VersionNumber,
 }
 
@@ -41,12 +40,6 @@ pub struct RawColumnsMetadata {
     pub row_key_end: usize,
     pub timestamp_key_index: usize,
     pub user_column_end: usize,
-}
-
-/// Minimal data that could be used to persist and recover [ColumnFamiliesMetadata](crate::metadata::ColumnFamiliesMetadata).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct RawColumnFamiliesMetadata {
-    pub column_families: Vec<ColumnFamilyMetadata>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/mito2/src/manifest/helper.rs
+++ b/src/mito2/src/manifest/helper.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use store_api::manifest::action::ProtocolVersion;
 use store_api::manifest::ManifestVersion;
 
+use crate::error::Result;
 use crate::manifest::action::RegionCheckpoint;
 
 pub const NEWLINE: &[u8] = b"\n";
@@ -23,17 +24,14 @@ pub const NEWLINE: &[u8] = b"\n";
 pub fn encode_actions<T: Serialize>(
     prev_version: ManifestVersion,
     actions: &[T],
-) -> Result<Vec<u8>, ()> {
+) -> Result<Vec<u8>> {
     todo!()
 }
 
-pub fn encode_checkpoint(snasphot: &RegionCheckpoint) -> Result<Vec<u8>, ()> {
+pub fn encode_checkpoint(snasphot: &RegionCheckpoint) -> Result<Vec<u8>> {
     todo!()
 }
 
-pub fn decode_checkpoint(
-    bs: &[u8],
-    reader_version: ProtocolVersion,
-) -> Result<RegionCheckpoint, ()> {
+pub fn decode_checkpoint(bs: &[u8], reader_version: ProtocolVersion) -> Result<RegionCheckpoint> {
     todo!()
 }

--- a/src/mito2/src/manifest/impl_.rs
+++ b/src/mito2/src/manifest/impl_.rs
@@ -33,6 +33,32 @@ use crate::manifest::storage::ManifestObjectStore;
 pub struct RegionManifest {}
 
 impl RegionManifest {
+    // pub fn with_checkpointer(
+    //     manifest_dir: &str,
+    //     object_store: ObjectStore,
+    //     compress_type: CompressionType,
+    //     checkpoint_actions_margin: Option<u16>,
+    //     gc_duration: Option<Duration>,
+    // ) -> Self {
+    //     Self::new(
+    //         manifest_dir,
+    //         object_store,
+    //         compress_type,
+    //         checkpoint_actions_margin,
+    //         gc_duration,
+    //         Some(Arc::new(RegionManifestCheckpointer {
+    //             flushed_manifest_version: AtomicU64::new(0),
+    //         })),
+    //     )
+    // }
+
+    // Update flushed manifest version in checkpointer
+    pub fn set_flushed_manifest_version(&self, manifest_version: ManifestVersion) {
+        if let Some(checkpointer) = self.checkpointer() {
+            checkpointer.set_flushed_manifest_version(manifest_version);
+        }
+    }
+
     // from impl ManifestImpl
 
     pub fn new() -> Self {

--- a/src/mito2/src/manifest/impl_.rs
+++ b/src/mito2/src/manifest/impl_.rs
@@ -12,23 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_datasource::compression::CompressionType;
 use object_store::ObjectStore;
 use store_api::manifest::action::{ProtocolAction, ProtocolVersion};
 use store_api::manifest::ManifestVersion;
 
+use crate::error::Result;
 use crate::manifest::action::{MetaActionIteratorImpl, RegionCheckpoint, RegionMetaActionList};
-
-type Result<T> = std::result::Result<T, ()>;
+use crate::manifest::region::RegionManifestCheckpointer;
+use crate::manifest::storage::ManifestObjectStore;
 
 // rewrite note:
 // trait Checkpoint -> struct RegionCheckpoint
 // trait MetaAction -> struct RegionMetaActionList
 // trait MetaActionIterator -> struct MetaActionIteratorImpl
+// struct ManifestImpl -> RegionManifest
 #[derive(Clone, Debug)]
-pub struct Regionmanifest {}
+pub struct RegionManifest {}
 
-impl Regionmanifest {
+impl RegionManifest {
     // from impl ManifestImpl
 
     pub fn new() -> Self {
@@ -43,9 +47,9 @@ impl Regionmanifest {
         todo!()
     }
 
-    // pub (crate) fn checkpointer(&self) -> Checkpointer {
-    //     todo!()
-    // }
+    pub(crate) fn checkpointer(&self) -> Option<RegionManifestCheckpointer> {
+        todo!()
+    }
 
     pub(crate) fn set_last_checkpoint_version(&self, _version: ManifestVersion) {
         todo!()
@@ -64,17 +68,17 @@ impl Regionmanifest {
         todo!()
     }
 
-    // pub(crate) fn manifest_store(&self) -> &Arc<ManifestObjectStore> {
-    //     todo!()
-    // }
-
-    // from Manifest
-
-    async fn update(&self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
+    pub(crate) fn manifest_store(&self) -> &Arc<ManifestObjectStore> {
         todo!()
     }
 
-    async fn scan(
+    // from Manifest
+
+    pub async fn update(&self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
+        todo!()
+    }
+
+    pub async fn scan(
         &self,
         start: ManifestVersion,
         end: ManifestVersion,
@@ -82,19 +86,19 @@ impl Regionmanifest {
         todo!()
     }
 
-    async fn do_checkpoint(&self) -> Result<Option<RegionCheckpoint>> {
+    pub async fn do_checkpoint(&self) -> Result<Option<RegionCheckpoint>> {
         todo!()
     }
 
-    async fn last_checkpoint(&self) -> Result<Option<RegionCheckpoint>> {
+    pub async fn last_checkpoint(&self) -> Result<Option<RegionCheckpoint>> {
         todo!()
     }
 
-    async fn start(&self) -> Result<()> {
+    pub async fn start(&self) -> Result<()> {
         todo!()
     }
 
-    async fn stop(&self) -> Result<()> {
+    pub async fn stop(&self) -> Result<()> {
         todo!()
     }
 

--- a/src/mito2/src/manifest/region.rs
+++ b/src/mito2/src/manifest/region.rs
@@ -1,0 +1,586 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region manifest impl
+
+// rewrite note:
+// - trait `Checkpointer` -> struct `RegionManifestCheckpointer`
+
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_datasource::compression::CompressionType;
+use common_telemetry::{info, warn};
+use object_store::ObjectStore;
+use store_api::manifest::action::ProtocolAction;
+use store_api::manifest::{ManifestVersion, MIN_VERSION};
+
+use crate::error::Result;
+use crate::manifest::action::{RegionCheckpoint, RegionManifestDataBuilder, RegionMetaAction};
+use crate::manifest::impl_::RegionManifest;
+
+// pub type RegionManifest = ManifestImpl<RegionCheckpoint, RegionMetaActionList>;
+
+#[derive(Debug)]
+pub struct RegionManifestCheckpointer {
+    // The latest manifest version when flushing memtables.
+    // Checkpoint can't exceed over flushed manifest version because we have to keep
+    // the region metadata for replaying WAL to ensure correct data schema.
+    flushed_manifest_version: AtomicU64,
+}
+
+impl RegionManifestCheckpointer {
+    pub(crate) fn set_flushed_manifest_version(&self, manifest_version: ManifestVersion) {
+        self.flushed_manifest_version
+            .store(manifest_version, Ordering::Relaxed);
+    }
+}
+
+impl RegionManifestCheckpointer {
+    // type Checkpoint = RegionCheckpoint;
+    // type MetaAction = RegionMetaActionList;
+
+    async fn do_checkpoint(&self, manifest: &RegionManifest) -> Result<Option<RegionCheckpoint>> {
+        let last_checkpoint = manifest.last_checkpoint().await?;
+
+        let current_version = manifest.last_version();
+        let (start_version, mut protocol, mut manifest_builder) =
+            if let Some(checkpoint) = last_checkpoint {
+                (
+                    checkpoint.last_version + 1,
+                    checkpoint.protocol,
+                    RegionManifestDataBuilder::with_checkpoint(checkpoint.checkpoint),
+                )
+            } else {
+                (
+                    MIN_VERSION,
+                    ProtocolAction::default(),
+                    RegionManifestDataBuilder::default(),
+                )
+            };
+
+        let end_version =
+            current_version.min(self.flushed_manifest_version.load(Ordering::Relaxed)) + 1;
+        if start_version >= end_version {
+            return Ok(None);
+        }
+
+        let mut iter = manifest.scan(start_version, end_version).await?;
+
+        let mut last_version = start_version;
+        let mut compacted_actions = 0;
+        while let Some((version, action_list)) = iter.next_action().await? {
+            for action in action_list.actions {
+                match action {
+                    RegionMetaAction::Change(c) => manifest_builder.apply_change(c),
+                    RegionMetaAction::Edit(e) => manifest_builder.apply_edit(version, e),
+                    RegionMetaAction::Protocol(p) => protocol = p,
+                    action => {
+                        return ManifestCheckpointSnafu {
+                            msg: format!("can't apply region action: {:?}", action),
+                        }
+                        .fail();
+                    }
+                }
+            }
+            last_version = version;
+            compacted_actions += 1;
+        }
+
+        if compacted_actions == 0 {
+            return Ok(None);
+        }
+
+        let region_manifest = manifest_builder.build();
+        let checkpoint = RegionCheckpoint {
+            protocol,
+            last_version,
+            compacted_actions,
+            checkpoint: Some(region_manifest),
+        };
+
+        manifest.save_checkpoint(&checkpoint).await?;
+        if let Err(e) = manifest
+            .manifest_store()
+            .delete(start_version, last_version + 1)
+            .await
+        {
+            // We only log when the error kind isn't `NotFound`
+            if !e.is_object_to_delete_not_found() {
+                // It doesn't matter when deletion fails, they will be purged by gc task.
+                warn!(
+                    "Failed to delete manifest logs [{},{}] in path: {}. err: {}",
+                    start_version,
+                    last_version,
+                    manifest.manifest_store().path(),
+                    e
+                );
+            }
+        }
+
+        info!("Region manifest checkpoint, start_version: {}, last_version: {}, compacted actions: {}", start_version, last_version, compacted_actions);
+
+        Ok(Some(checkpoint))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl RegionManifest {
+    pub fn with_checkpointer(
+        manifest_dir: &str,
+        object_store: ObjectStore,
+        compress_type: CompressionType,
+        checkpoint_actions_margin: Option<u16>,
+        gc_duration: Option<Duration>,
+    ) -> Self {
+        Self::new(
+            manifest_dir,
+            object_store,
+            compress_type,
+            checkpoint_actions_margin,
+            gc_duration,
+            Some(Arc::new(RegionManifestCheckpointer {
+                flushed_manifest_version: AtomicU64::new(0),
+            })),
+        )
+    }
+
+    // Update flushed manifest version in checkpointer
+    pub fn set_flushed_manifest_version(&self, manifest_version: ManifestVersion) {
+        if let Some(checkpointer) = self.checkpointer() {
+            if let Some(checkpointer) = checkpointer
+                .as_any()
+                .downcast_ref::<RegionManifestCheckpointer>()
+            {
+                checkpointer.set_flushed_manifest_version(manifest_version);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_test_util::temp_dir::create_temp_dir;
+    use object_store::services::{Fs, S3};
+    use object_store::test_util::{s3_test_config, TempFolder};
+    use object_store::ObjectStore;
+    use storage::metadata::RegionMetadata;
+    use storage::sst::FileId;
+    use store_api::manifest::action::ProtocolAction;
+    use store_api::manifest::{Manifest, MetaActionIterator, MAX_VERSION};
+
+    use super::*;
+    use crate::manifest::action::{
+        RawRegionMetadata, RegionChange, RegionManifestData, RegionMetaActionList, RegionVersion,
+    };
+    use crate::manifest::storage::manifest_compress_type;
+    use crate::manifest::test_utils::*;
+
+    #[tokio::test]
+    async fn test_fs_region_manifest_compress() {
+        let manifest = new_fs_manifest(true, None).await;
+        test_region_manifest(&manifest).await
+    }
+
+    #[tokio::test]
+    async fn test_fs_region_manifest_uncompress() {
+        let manifest = new_fs_manifest(false, None).await;
+        test_region_manifest(&manifest).await
+    }
+
+    #[tokio::test]
+    async fn test_s3_region_manifest_compress() {
+        if s3_test_config().is_some() {
+            let (manifest, temp_dir) = new_s3_manifest(true, None).await;
+            test_region_manifest(&manifest).await;
+            temp_dir.remove_all().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_s3_region_manifest_uncompress() {
+        if s3_test_config().is_some() {
+            let (manifest, temp_dir) = new_s3_manifest(false, None).await;
+            test_region_manifest(&manifest).await;
+            temp_dir.remove_all().await.unwrap();
+        }
+    }
+
+    async fn new_fs_manifest(compress: bool, gc_duration: Option<Duration>) -> RegionManifest {
+        let tmp_dir = create_temp_dir("test_region_manifest");
+        let mut builder = Fs::default();
+        let _ = builder.root(&tmp_dir.path().to_string_lossy());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
+
+        let manifest = RegionManifest::with_checkpointer(
+            "/manifest/",
+            object_store,
+            manifest_compress_type(compress),
+            None,
+            gc_duration,
+        );
+        manifest.start().await.unwrap();
+        manifest
+    }
+
+    async fn new_s3_manifest(
+        compress: bool,
+        gc_duration: Option<Duration>,
+    ) -> (RegionManifest, TempFolder) {
+        let s3_config = s3_test_config().unwrap();
+        let mut builder = S3::default();
+        let _ = builder
+            .root(&s3_config.root)
+            .access_key_id(&s3_config.access_key_id)
+            .secret_access_key(&s3_config.secret_access_key)
+            .bucket(&s3_config.bucket);
+
+        if s3_config.region.is_some() {
+            let _ = builder.region(s3_config.region.as_ref().unwrap());
+        }
+        let store = ObjectStore::new(builder).unwrap().finish();
+        let temp_folder = TempFolder::new(&store, "/");
+        let manifest = RegionManifest::with_checkpointer(
+            "/manifest/",
+            store,
+            manifest_compress_type(compress),
+            None,
+            gc_duration,
+        );
+        manifest.start().await.unwrap();
+
+        (manifest, temp_folder)
+    }
+
+    async fn test_region_manifest(manifest: &RegionManifest) {
+        common_telemetry::init_default_ut_logging();
+
+        let region_meta = Arc::new(build_region_meta());
+
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
+
+        assert!(manifest
+            .update(RegionMetaActionList::with_action(RegionMetaAction::Change(
+                RegionChange {
+                    metadata: region_meta.as_ref().into(),
+                    committed_sequence: 99,
+                },
+            )))
+            .await
+            .is_ok());
+
+        let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(0, v);
+        assert_eq!(2, action_list.actions.len());
+        let protocol = &action_list.actions[0];
+        assert!(matches!(
+            protocol,
+            RegionMetaAction::Protocol(ProtocolAction { .. })
+        ));
+
+        let action = &action_list.actions[1];
+
+        match action {
+            RegionMetaAction::Change(c) => {
+                assert_eq!(
+                    RegionMetadata::try_from(c.metadata.clone()).unwrap(),
+                    *region_meta
+                );
+                assert_eq!(c.committed_sequence, 99);
+            }
+            _ => unreachable!(),
+        }
+
+        // Save some actions
+        assert!(manifest
+            .update(RegionMetaActionList::new(vec![
+                RegionMetaAction::Edit(build_region_edit(1, &[FileId::random()], &[])),
+                RegionMetaAction::Edit(build_region_edit(
+                    2,
+                    &[FileId::random(), FileId::random()],
+                    &[],
+                )),
+            ]))
+            .await
+            .is_ok());
+
+        let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(0, v);
+        assert_eq!(2, action_list.actions.len());
+        let protocol = &action_list.actions[0];
+        assert!(matches!(
+            protocol,
+            RegionMetaAction::Protocol(ProtocolAction { .. })
+        ));
+
+        let action = &action_list.actions[1];
+        match action {
+            RegionMetaAction::Change(c) => {
+                assert_eq!(
+                    RegionMetadata::try_from(c.metadata.clone()).unwrap(),
+                    *region_meta
+                );
+                assert_eq!(c.committed_sequence, 99);
+            }
+            _ => unreachable!(),
+        }
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(1, v);
+        assert_eq!(2, action_list.actions.len());
+        assert!(matches!(&action_list.actions[0], RegionMetaAction::Edit(_)));
+        assert!(matches!(&action_list.actions[1], RegionMetaAction::Edit(_)));
+
+        // Reach end
+        assert!(iter.next_action().await.unwrap().is_none());
+
+        manifest.stop().await.unwrap();
+    }
+
+    async fn assert_scan(manifest: &RegionManifest, start_version: ManifestVersion, expected: u64) {
+        let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
+        let mut actions = 0;
+        while let Some((v, _)) = iter.next_action().await.unwrap() {
+            assert_eq!(v, start_version + actions);
+            actions += 1;
+        }
+        assert_eq!(expected, actions);
+    }
+
+    #[tokio::test]
+    async fn test_fs_region_manifest_checkpoint_compress() {
+        let duration = Duration::from_millis(50);
+        let manifest = new_fs_manifest(true, Some(duration)).await;
+
+        test_region_manifest_checkpoint(&manifest, duration).await
+    }
+
+    #[tokio::test]
+    async fn test_fs_region_manifest_checkpoint_uncompress() {
+        let duration = Duration::from_millis(50);
+        let manifest = new_fs_manifest(false, Some(duration)).await;
+
+        test_region_manifest_checkpoint(&manifest, duration).await
+    }
+
+    #[tokio::test]
+    async fn test_s3_region_manifest_checkpoint_compress() {
+        if s3_test_config().is_some() {
+            let duration = Duration::from_millis(50);
+            let (manifest, temp_dir) = new_s3_manifest(true, Some(duration)).await;
+
+            test_region_manifest_checkpoint(&manifest, duration).await;
+            temp_dir.remove_all().await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_s3_region_manifest_checkpoint_uncompress() {
+        if s3_test_config().is_some() {
+            let duration = Duration::from_millis(50);
+            let (manifest, temp_dir) = new_s3_manifest(false, Some(duration)).await;
+
+            test_region_manifest_checkpoint(&manifest, duration).await;
+            temp_dir.remove_all().await.unwrap();
+        }
+    }
+
+    async fn test_region_manifest_checkpoint(
+        manifest: &RegionManifest,
+        test_gc_duration: Duration,
+    ) {
+        common_telemetry::init_default_ut_logging();
+
+        let region_meta = Arc::new(build_region_meta());
+        let new_region_meta = Arc::new(build_altered_region_meta());
+
+        let file = FileId::random();
+        let file_ids = vec![FileId::random(), FileId::random()];
+
+        let actions: Vec<RegionMetaActionList> = vec![
+            RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange {
+                metadata: region_meta.as_ref().into(),
+                committed_sequence: 1,
+            })),
+            RegionMetaActionList::new(vec![
+                RegionMetaAction::Edit(build_region_edit(2, &[file], &[])),
+                RegionMetaAction::Edit(build_region_edit(3, &file_ids, &[file])),
+            ]),
+            RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange {
+                metadata: new_region_meta.as_ref().into(),
+                committed_sequence: 99,
+            })),
+        ];
+
+        for action in actions {
+            let _ = manifest.update(action).await.unwrap();
+        }
+        assert!(manifest.last_checkpoint().await.unwrap().is_none());
+        assert_scan(manifest, 0, 3).await;
+        // update flushed manifest version for doing checkpoint
+        manifest.set_flushed_manifest_version(2);
+
+        let mut checkpoint_versions = vec![];
+
+        // do a checkpoint
+        let checkpoint = manifest.do_checkpoint().await.unwrap().unwrap();
+        let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
+        assert_eq!(checkpoint, last_checkpoint);
+        assert_eq!(checkpoint.compacted_actions, 3);
+        assert_eq!(checkpoint.last_version, 2);
+        checkpoint_versions.push(2);
+        let alterd_raw_meta = RawRegionMetadata::from(new_region_meta.as_ref());
+        assert!(matches!(&checkpoint.checkpoint, Some(RegionManifestData {
+            committed_sequence: 99,
+            metadata,
+            version: Some(RegionVersion {
+                manifest_version: 1,
+                flushed_sequence: Some(3),
+                files,
+            }),
+        }) if files.len() == 2 &&
+                         files.contains_key(&file_ids[0]) &&
+                         files.contains_key(&file_ids[1]) &&
+                         *metadata == alterd_raw_meta));
+        // all actions were compacted
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
+
+        assert!(manifest.do_checkpoint().await.unwrap().is_none());
+        let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
+        assert_eq!(checkpoint, last_checkpoint);
+
+        // add new actions
+        let new_file = FileId::random();
+        let actions: Vec<RegionMetaActionList> = vec![
+            RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange {
+                metadata: region_meta.as_ref().into(),
+                committed_sequence: 200,
+            })),
+            RegionMetaActionList::new(vec![RegionMetaAction::Edit(build_region_edit(
+                201,
+                &[new_file],
+                &file_ids,
+            ))]),
+        ];
+        for action in actions {
+            let _ = manifest.update(action).await.unwrap();
+        }
+
+        assert_scan(manifest, 3, 2).await;
+
+        // do another checkpoints
+        // compacted RegionChange
+        manifest.set_flushed_manifest_version(3);
+        let checkpoint = manifest.do_checkpoint().await.unwrap().unwrap();
+        let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
+        assert_eq!(checkpoint, last_checkpoint);
+        assert_eq!(checkpoint.compacted_actions, 1);
+        assert_eq!(checkpoint.last_version, 3);
+        checkpoint_versions.push(3);
+        assert!(matches!(&checkpoint.checkpoint, Some(RegionManifestData {
+            committed_sequence: 200,
+            metadata,
+            version: Some(RegionVersion {
+                manifest_version: 1,
+                flushed_sequence: Some(3),
+                files,
+            }),
+        }) if files.len() == 2 &&
+                         files.contains_key(&file_ids[0]) &&
+                         files.contains_key(&file_ids[1]) &&
+                         *metadata == RawRegionMetadata::from(region_meta.as_ref())));
+
+        assert_scan(manifest, 4, 1).await;
+        // compacted RegionEdit
+        manifest.set_flushed_manifest_version(4);
+        let checkpoint = manifest.do_checkpoint().await.unwrap().unwrap();
+        let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
+        assert_eq!(checkpoint, last_checkpoint);
+        assert_eq!(checkpoint.compacted_actions, 1);
+        assert_eq!(checkpoint.last_version, 4);
+        checkpoint_versions.push(4);
+        assert!(matches!(&checkpoint.checkpoint, Some(RegionManifestData {
+            committed_sequence: 200,
+            metadata,
+            version: Some(RegionVersion {
+                manifest_version: 4,
+                flushed_sequence: Some(201),
+                files,
+            }),
+        }) if files.len() == 1 &&
+                         files.contains_key(&new_file) &&
+                         *metadata == RawRegionMetadata::from(region_meta.as_ref())));
+
+        // all actions were compacted
+        assert_eq!(
+            None,
+            manifest
+                .scan(0, MAX_VERSION)
+                .await
+                .unwrap()
+                .next_action()
+                .await
+                .unwrap()
+        );
+
+        // wait for gc
+        tokio::time::sleep(test_gc_duration * 3).await;
+
+        for v in checkpoint_versions {
+            if v < 4 {
+                // ensure old checkpoints were purged.
+                assert!(manifest
+                    .manifest_store()
+                    .load_checkpoint(v)
+                    .await
+                    .unwrap()
+                    .is_none());
+            } else {
+                // the last checkpoints is still exists.
+                let last_checkpoint = manifest.last_checkpoint().await.unwrap().unwrap();
+                assert_eq!(checkpoint, last_checkpoint);
+            }
+        }
+
+        manifest.stop().await.unwrap();
+    }
+}

--- a/src/mito2/src/manifest/region.rs
+++ b/src/mito2/src/manifest/region.rs
@@ -134,10 +134,7 @@ mod tests {
     use core::time::Duration;
     use std::sync::Arc;
 
-    use common_test_util::temp_dir::create_temp_dir;
-    use object_store::services::{Fs, S3};
     use object_store::test_util::{s3_test_config, TempFolder};
-    use object_store::ObjectStore;
     use storage::sst::FileId;
     use store_api::manifest::action::ProtocolAction;
     use store_api::manifest::MAX_VERSION;
@@ -146,23 +143,25 @@ mod tests {
     use crate::manifest::action::{
         RawRegionMetadata, RegionChange, RegionManifestData, RegionMetaActionList, RegionVersion,
     };
-    use crate::manifest::storage::manifest_compress_type;
     use crate::manifest::test_utils::*;
     use crate::region::metadata::RegionMetadata;
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_fs_region_manifest_compress() {
         let manifest = new_fs_manifest(true, None).await;
         test_region_manifest(&manifest).await
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_fs_region_manifest_uncompress() {
         let manifest = new_fs_manifest(false, None).await;
         test_region_manifest(&manifest).await
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_s3_region_manifest_compress() {
         if s3_test_config().is_some() {
             let (manifest, temp_dir) = new_s3_manifest(true, None).await;
@@ -172,6 +171,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_s3_region_manifest_uncompress() {
         if s3_test_config().is_some() {
             let (manifest, temp_dir) = new_s3_manifest(false, None).await;
@@ -181,49 +181,51 @@ mod tests {
     }
 
     async fn new_fs_manifest(compress: bool, gc_duration: Option<Duration>) -> RegionManifest {
-        let tmp_dir = create_temp_dir("test_region_manifest");
-        let mut builder = Fs::default();
-        let _ = builder.root(&tmp_dir.path().to_string_lossy());
-        let object_store = ObjectStore::new(builder).unwrap().finish();
+        // let tmp_dir = create_temp_dir("test_region_manifest");
+        // let mut builder = Fs::default();
+        // let _ = builder.root(&tmp_dir.path().to_string_lossy());
+        // let object_store = ObjectStore::new(builder).unwrap().finish();
 
-        let manifest = RegionManifest::with_checkpointer(
-            "/manifest/",
-            object_store,
-            manifest_compress_type(compress),
-            None,
-            gc_duration,
-        );
-        manifest.start().await.unwrap();
-        manifest
+        // let manifest = RegionManifest::with_checkpointer(
+        //     "/manifest/",
+        //     object_store,
+        //     manifest_compress_type(compress),
+        //     None,
+        //     gc_duration,
+        // );
+        // manifest.start().await.unwrap();
+        // manifest
+        todo!()
     }
 
     async fn new_s3_manifest(
         compress: bool,
         gc_duration: Option<Duration>,
     ) -> (RegionManifest, TempFolder) {
-        let s3_config = s3_test_config().unwrap();
-        let mut builder = S3::default();
-        let _ = builder
-            .root(&s3_config.root)
-            .access_key_id(&s3_config.access_key_id)
-            .secret_access_key(&s3_config.secret_access_key)
-            .bucket(&s3_config.bucket);
+        // let s3_config = s3_test_config().unwrap();
+        // let mut builder = S3::default();
+        // let _ = builder
+        //     .root(&s3_config.root)
+        //     .access_key_id(&s3_config.access_key_id)
+        //     .secret_access_key(&s3_config.secret_access_key)
+        //     .bucket(&s3_config.bucket);
 
-        if s3_config.region.is_some() {
-            let _ = builder.region(s3_config.region.as_ref().unwrap());
-        }
-        let store = ObjectStore::new(builder).unwrap().finish();
-        let temp_folder = TempFolder::new(&store, "/");
-        let manifest = RegionManifest::with_checkpointer(
-            "/manifest/",
-            store,
-            manifest_compress_type(compress),
-            None,
-            gc_duration,
-        );
-        manifest.start().await.unwrap();
+        // if s3_config.region.is_some() {
+        //     let _ = builder.region(s3_config.region.as_ref().unwrap());
+        // }
+        // let store = ObjectStore::new(builder).unwrap().finish();
+        // let temp_folder = TempFolder::new(&store, "/");
+        // let manifest = RegionManifest::with_checkpointer(
+        //     "/manifest/",
+        //     store,
+        //     manifest_compress_type(compress),
+        //     None,
+        //     gc_duration,
+        // );
+        // manifest.start().await.unwrap();
 
-        (manifest, temp_folder)
+        // (manifest, temp_folder)
+        todo!()
     }
 
     async fn test_region_manifest(manifest: &RegionManifest) {
@@ -334,6 +336,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_fs_region_manifest_checkpoint_compress() {
         let duration = Duration::from_millis(50);
         let manifest = new_fs_manifest(true, Some(duration)).await;
@@ -342,6 +345,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_fs_region_manifest_checkpoint_uncompress() {
         let duration = Duration::from_millis(50);
         let manifest = new_fs_manifest(false, Some(duration)).await;
@@ -350,6 +354,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_s3_region_manifest_checkpoint_compress() {
         if s3_test_config().is_some() {
             let duration = Duration::from_millis(50);
@@ -361,6 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "wait for RegionManifest::with_checkpointer()"]
     async fn test_s3_region_manifest_checkpoint_uncompress() {
         if s3_test_config().is_some() {
             let duration = Duration::from_millis(50);

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -363,7 +363,7 @@ impl ManifestObjectStore {
             .context(OpenDalSnafu)
     }
 
-    async fn delete(&self, start: ManifestVersion, end: ManifestVersion) -> Result<()> {
+    pub async fn delete(&self, start: ManifestVersion, end: ManifestVersion) -> Result<()> {
         ensure!(start <= end, InvalidScanIndexSnafu { start, end });
 
         // Due to backward compatibility, it is possible that the user's log between start and end has not been compressed,
@@ -434,7 +434,7 @@ impl ManifestObjectStore {
         Ok(())
     }
 
-    async fn load_checkpoint(
+    pub async fn load_checkpoint(
         &self,
         version: ManifestVersion,
     ) -> Result<Option<(ManifestVersion, Vec<u8>)>> {

--- a/src/mito2/src/manifest/test_utils.rs
+++ b/src/mito2/src/manifest/test_utils.rs
@@ -1,0 +1,192 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use datatypes::prelude::ConcreteDataType;
+use datatypes::type_id::LogicalTypeId;
+use storage::sst::{FileId, FileMeta};
+use store_api::storage::{
+    ColumnDescriptor, ColumnDescriptorBuilder, ColumnFamilyDescriptorBuilder, ColumnId,
+    RegionDescriptor, RegionId, RowKeyDescriptorBuilder, SequenceNumber,
+};
+
+use crate::manifest::action::*;
+use crate::region::metadata::RegionMetadata;
+
+pub const DEFAULT_TEST_FILE_SIZE: u64 = 1024;
+
+/// Column definition: (name, datatype, is_nullable)
+pub type ColumnDef<'a> = (&'a str, LogicalTypeId, bool);
+
+pub const TIMESTAMP_NAME: &str = "timestamp";
+
+pub fn build_region_meta() -> RegionMetadata {
+    let region_name = "region-0";
+    let desc = RegionDescBuilder::new(region_name)
+        .id(0)
+        .push_key_column(("k1", LogicalTypeId::Int32, false))
+        .push_field_column(("v1", LogicalTypeId::Float32, true))
+        .build();
+    desc.try_into().unwrap()
+}
+
+pub fn build_altered_region_meta() -> RegionMetadata {
+    let region_name = "region-0";
+    let desc = RegionDescBuilder::new(region_name)
+        .id(0)
+        .push_key_column(("k1", LogicalTypeId::Int32, false))
+        .push_field_column(("v1", LogicalTypeId::Float32, true))
+        .push_field_column(("v2", LogicalTypeId::Float32, true))
+        .build();
+    desc.try_into().unwrap()
+}
+
+pub fn build_region_edit(
+    sequence: SequenceNumber,
+    files_to_add: &[FileId],
+    files_to_remove: &[FileId],
+) -> RegionEdit {
+    RegionEdit {
+        region_version: 0,
+        flushed_sequence: Some(sequence),
+        files_to_add: files_to_add
+            .iter()
+            .map(|f| FileMeta {
+                region_id: 0.into(),
+                file_id: *f,
+                time_range: None,
+                level: 0,
+                file_size: DEFAULT_TEST_FILE_SIZE,
+            })
+            .collect(),
+        files_to_remove: files_to_remove
+            .iter()
+            .map(|f| FileMeta {
+                region_id: 0.into(),
+                file_id: *f,
+                time_range: None,
+                level: 0,
+                file_size: DEFAULT_TEST_FILE_SIZE,
+            })
+            .collect(),
+        compaction_time_window: None,
+    }
+}
+
+/// A RegionDescriptor builder for test.
+pub struct RegionDescBuilder {
+    id: RegionId,
+    name: String,
+    last_column_id: ColumnId,
+    key_builder: RowKeyDescriptorBuilder,
+    default_cf_builder: ColumnFamilyDescriptorBuilder,
+}
+
+impl RegionDescBuilder {
+    pub fn new<T: Into<String>>(name: T) -> Self {
+        let key_builder = RowKeyDescriptorBuilder::new(
+            ColumnDescriptorBuilder::new(
+                1,
+                TIMESTAMP_NAME,
+                ConcreteDataType::timestamp_millisecond_datatype(),
+            )
+            .is_nullable(false)
+            .is_time_index(true)
+            .build()
+            .unwrap(),
+        );
+
+        Self {
+            id: 0.into(),
+            name: name.into(),
+            last_column_id: 1,
+            key_builder,
+            default_cf_builder: ColumnFamilyDescriptorBuilder::default(),
+        }
+    }
+
+    pub fn id(mut self, id: impl Into<RegionId>) -> Self {
+        self.id = id.into();
+        self
+    }
+
+    pub fn timestamp(mut self, column_def: ColumnDef) -> Self {
+        let column = self.new_ts_column(column_def);
+        self.key_builder = self.key_builder.timestamp(column);
+        self
+    }
+
+    pub fn push_key_column(mut self, column_def: ColumnDef) -> Self {
+        let column = self.new_column(column_def);
+        self.key_builder = self.key_builder.push_column(column);
+        self
+    }
+
+    pub fn push_field_column(mut self, column_def: ColumnDef) -> Self {
+        let column = self.new_column(column_def);
+        self.default_cf_builder = self.default_cf_builder.push_column(column);
+        self
+    }
+
+    pub fn set_last_column_id(mut self, column_id: ColumnId) -> Self {
+        self.last_column_id = column_id;
+        self
+    }
+
+    pub fn build(self) -> RegionDescriptor {
+        RegionDescriptor {
+            id: self.id,
+            name: self.name,
+            row_key: self.key_builder.build().unwrap(),
+            default_cf: self.default_cf_builder.build().unwrap(),
+            extra_cfs: Vec::new(),
+        }
+    }
+
+    pub fn last_column_id(&self) -> ColumnId {
+        self.last_column_id
+    }
+
+    fn alloc_column_id(&mut self) -> ColumnId {
+        self.last_column_id += 1;
+        self.last_column_id
+    }
+
+    fn new_ts_column(&mut self, column_def: ColumnDef) -> ColumnDescriptor {
+        let datatype = column_def.1.data_type();
+        ColumnDescriptorBuilder::new(self.alloc_column_id(), column_def.0, datatype)
+            .is_nullable(column_def.2)
+            .is_time_index(true)
+            .build()
+            .unwrap()
+    }
+
+    fn new_column(&mut self, column_def: ColumnDef) -> ColumnDescriptor {
+        let datatype = column_def.1.data_type();
+        ColumnDescriptorBuilder::new(self.alloc_column_id(), column_def.0, datatype)
+            .is_nullable(column_def.2)
+            .build()
+            .unwrap()
+    }
+}
+
+/// Create desc with schema (k0, timestamp, v0, ... vn-1)
+pub fn desc_with_field_columns(region_name: &str, num_field_columns: usize) -> RegionDescriptor {
+    let mut builder =
+        RegionDescBuilder::new(region_name).push_key_column(("k0", LogicalTypeId::Int64, false));
+    for i in 0..num_field_columns {
+        let name = format!("v{i}");
+        builder = builder.push_field_column((&name, LogicalTypeId::Int64, true));
+    }
+    builder.build()
+}

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -14,6 +14,7 @@
 
 //! Mito region.
 
+pub(crate) mod columns;
 pub(crate) mod metadata;
 mod version;
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -14,7 +14,7 @@
 
 //! Mito region.
 
-mod metadata;
+pub(crate) mod metadata;
 mod version;
 
 use std::collections::HashMap;

--- a/src/mito2/src/region/columns.rs
+++ b/src/mito2/src/region/columns.rs
@@ -1,0 +1,298 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Metadata of mito columns.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use datatypes::schema::{try_parse_int, Metadata, COMMENT_KEY};
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, OptionExt, ResultExt};
+use storage::metadata::{internal_column_descs, is_internal_field_column};
+use store_api::storage::{
+    ColumnDescriptor, ColumnDescriptorBuilder, ColumnId, ColumnSchema, RowKeyDescriptor,
+    RowKeyDescriptorBuilder,
+};
+
+use crate::error::{
+    AccessKvMetadataSnafu, BuildColumnDescriptorSnafu, ColIdExistsSnafu, ColNameExistsSnafu,
+    MissingTimestampSnafu, ReservedColumnSnafu, Result, ToColumnSchemaSnafu,
+};
+use crate::manifest::action::RawColumnsMetadata;
+
+const METADATA_COLUMN_ID_KEY: &str = "greptime:storage:column_id";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnMetadata {
+    pub desc: ColumnDescriptor,
+}
+
+impl ColumnMetadata {
+    #[inline]
+    pub fn id(&self) -> ColumnId {
+        self.desc.id
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.desc.name
+    }
+
+    /// Convert `self` to [`ColumnSchema`] for building a [`StoreSchema`](crate::schema::StoreSchema). This
+    /// would store additional metadatas to the ColumnSchema.
+    pub fn to_column_schema(&self) -> Result<ColumnSchema> {
+        let desc = &self.desc;
+
+        ColumnSchema::new(&desc.name, desc.data_type.clone(), desc.is_nullable())
+            .with_metadata(self.to_metadata())
+            .with_time_index(self.desc.is_time_index())
+            .with_default_constraint(desc.default_constraint().cloned())
+            .context(ToColumnSchemaSnafu)
+    }
+
+    /// Convert [`ColumnSchema`] in [`StoreSchema`](crate::schema::StoreSchema) to [`ColumnMetadata`].
+    pub fn from_column_schema(column_schema: &ColumnSchema) -> Result<ColumnMetadata> {
+        let metadata = column_schema.metadata();
+        let column_id =
+            try_parse_int(metadata, METADATA_COLUMN_ID_KEY, None).context(AccessKvMetadataSnafu)?;
+        let comment = metadata.get(COMMENT_KEY).cloned().unwrap_or_default();
+
+        let desc = ColumnDescriptorBuilder::new(
+            column_id,
+            &column_schema.name,
+            column_schema.data_type.clone(),
+        )
+        .is_nullable(column_schema.is_nullable())
+        .is_time_index(column_schema.is_time_index())
+        .default_constraint(column_schema.default_constraint().cloned())
+        .comment(comment)
+        .build()
+        .context(BuildColumnDescriptorSnafu)?;
+
+        Ok(ColumnMetadata { desc })
+    }
+
+    fn to_metadata(&self) -> Metadata {
+        let mut metadata = Metadata::new();
+        let _ = metadata.insert(METADATA_COLUMN_ID_KEY.to_string(), self.desc.id.to_string());
+        if !self.desc.comment.is_empty() {
+            let _ = metadata.insert(COMMENT_KEY.to_string(), self.desc.comment.clone());
+        }
+
+        metadata
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ColumnsMetadata {
+    /// All columns.
+    ///
+    /// Columns are organized in the following order:
+    /// ```text
+    /// key columns, timestamp, [version,] value columns, internal columns
+    /// ```
+    ///
+    /// The key columns, timestamp and version forms the row key.
+    pub columns: Vec<ColumnMetadata>,
+    /// Maps column name to index of columns, used to fast lookup column by name.
+    pub name_to_col_index: HashMap<String, usize>,
+    /// Exclusive end index of row key columns.
+    pub row_key_end: usize,
+    /// Index of timestamp key column.
+    pub timestamp_key_index: usize,
+    /// Exclusive end index of user columns.
+    ///
+    /// Columns in `[user_column_end..)` are internal columns.
+    pub user_column_end: usize,
+}
+
+impl ColumnsMetadata {
+    /// Returns an iterator to all row key columns.
+    ///
+    /// Row key columns includes all key columns, the timestamp column and the
+    /// optional version column.
+    pub fn iter_row_key_columns(&self) -> impl Iterator<Item = &ColumnMetadata> {
+        self.columns.iter().take(self.row_key_end)
+    }
+
+    /// Returns an iterator to all value columns (internal columns are excluded).
+    pub fn iter_field_columns(&self) -> impl Iterator<Item = &ColumnMetadata> {
+        self.columns[self.row_key_end..self.user_column_end].iter()
+    }
+
+    pub fn iter_user_columns(&self) -> impl Iterator<Item = &ColumnMetadata> {
+        self.columns.iter().take(self.user_column_end)
+    }
+
+    #[inline]
+    pub fn columns(&self) -> &[ColumnMetadata] {
+        &self.columns
+    }
+
+    #[inline]
+    pub fn num_row_key_columns(&self) -> usize {
+        self.row_key_end
+    }
+
+    #[inline]
+    pub fn num_field_columns(&self) -> usize {
+        self.user_column_end - self.row_key_end
+    }
+
+    #[inline]
+    pub fn timestamp_key_index(&self) -> usize {
+        self.timestamp_key_index
+    }
+
+    #[inline]
+    pub fn row_key_end(&self) -> usize {
+        self.row_key_end
+    }
+
+    #[inline]
+    pub fn user_column_end(&self) -> usize {
+        self.user_column_end
+    }
+
+    #[inline]
+    pub fn column_metadata(&self, idx: usize) -> &ColumnMetadata {
+        &self.columns[idx]
+    }
+
+    pub fn to_row_key_descriptor(&self) -> RowKeyDescriptor {
+        let mut builder = RowKeyDescriptorBuilder::default();
+        for (idx, column) in self.iter_row_key_columns().enumerate() {
+            // Not a timestamp column.
+            if idx != self.timestamp_key_index {
+                builder = builder.push_column(column.desc.clone());
+            }
+        }
+        builder = builder.timestamp(self.column_metadata(self.timestamp_key_index).desc.clone());
+        // Since the metadata is built from descriptor, so it should always be able to build the descriptor back.
+        builder.build().unwrap()
+    }
+}
+
+pub type ColumnsMetadataRef = Arc<ColumnsMetadata>;
+
+impl From<&ColumnsMetadata> for RawColumnsMetadata {
+    fn from(data: &ColumnsMetadata) -> RawColumnsMetadata {
+        RawColumnsMetadata {
+            columns: data.columns.clone(),
+            row_key_end: data.row_key_end,
+            timestamp_key_index: data.timestamp_key_index,
+            user_column_end: data.user_column_end,
+        }
+    }
+}
+
+impl From<RawColumnsMetadata> for ColumnsMetadata {
+    fn from(raw: RawColumnsMetadata) -> ColumnsMetadata {
+        let name_to_col_index = raw
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(i, col)| (col.desc.name.clone(), i))
+            .collect();
+
+        ColumnsMetadata {
+            columns: raw.columns,
+            name_to_col_index,
+            row_key_end: raw.row_key_end,
+            timestamp_key_index: raw.timestamp_key_index,
+            user_column_end: raw.user_column_end,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ColumnsMetadataBuilder {
+    pub columns: Vec<ColumnMetadata>,
+    name_to_col_index: HashMap<String, usize>,
+    /// Column id set, used to validate column id uniqueness.
+    column_ids: HashSet<ColumnId>,
+
+    // Row key metadata:
+    row_key_end: usize,
+    timestamp_key_index: Option<usize>,
+}
+
+impl ColumnsMetadataBuilder {
+    pub fn row_key(&mut self, key: RowKeyDescriptor) -> Result<&mut Self> {
+        for col in key.columns {
+            let _ = self.push_row_key_column(col)?;
+        }
+
+        // TODO(yingwen): Validate this is a timestamp column.
+        self.timestamp_key_index = Some(self.columns.len());
+        let _ = self.push_row_key_column(key.timestamp)?;
+        self.row_key_end = self.columns.len();
+
+        Ok(self)
+    }
+
+    fn push_row_key_column(&mut self, desc: ColumnDescriptor) -> Result<&mut Self> {
+        self.push_field_column(desc)
+    }
+
+    pub fn push_field_column(&mut self, desc: ColumnDescriptor) -> Result<&mut Self> {
+        ensure!(
+            !is_internal_field_column(&desc.name),
+            ReservedColumnSnafu { name: &desc.name }
+        );
+
+        self.push_new_column(desc)
+    }
+
+    fn push_new_column(&mut self, desc: ColumnDescriptor) -> Result<&mut Self> {
+        ensure!(
+            !self.name_to_col_index.contains_key(&desc.name),
+            ColNameExistsSnafu { name: &desc.name }
+        );
+        ensure!(
+            !self.column_ids.contains(&desc.id),
+            ColIdExistsSnafu { id: desc.id }
+        );
+
+        let column_name = desc.name.clone();
+        let column_id = desc.id;
+        let meta = ColumnMetadata { desc };
+
+        let column_index = self.columns.len();
+        self.columns.push(meta);
+        let _ = self.name_to_col_index.insert(column_name, column_index);
+        let _ = self.column_ids.insert(column_id);
+
+        Ok(self)
+    }
+
+    pub fn build(mut self) -> Result<ColumnsMetadata> {
+        let timestamp_key_index = self.timestamp_key_index.context(MissingTimestampSnafu)?;
+
+        let user_column_end = self.columns.len();
+        // Setup internal columns.
+        for internal_desc in internal_column_descs() {
+            let _ = self.push_new_column(internal_desc)?;
+        }
+
+        Ok(ColumnsMetadata {
+            columns: self.columns,
+            name_to_col_index: self.name_to_col_index,
+            row_key_end: self.row_key_end,
+            timestamp_key_index,
+            user_column_end,
+        })
+    }
+}

--- a/src/mito2/src/region/metadata.rs
+++ b/src/mito2/src/region/metadata.rs
@@ -16,19 +16,21 @@
 
 // rewrite note:
 // Structs related to column (ColumnsMetadata etc.) still reference to storage/metadata
-// Other structs are ported to this file
+//   other structs are ported to this file
+// Those builder/descriptor can be simplified
 
 use std::sync::Arc;
 
 use snafu::ensure;
 use storage::metadata::{
-    ColumnFamiliesMetadata, ColumnFamiliesMetadataBuilder, ColumnsMetadata, ColumnsMetadataBuilder,
-    ColumnsMetadataRef,
+    ColumnFamiliesMetadata, ColumnFamiliesMetadataBuilder, ColumnFamilyMetadata, ColumnsMetadata,
+    ColumnsMetadataBuilder, ColumnsMetadataRef,
 };
 use storage::schema::{RegionSchema, RegionSchemaRef};
 use store_api::storage::{
-    AddColumn, AlterOperation, AlterRequest, ColumnFamilyDescriptorBuilder, RegionDescriptor,
-    RegionId, SchemaRef,
+    consts, AddColumn, AlterOperation, AlterRequest, ColumnFamilyDescriptor,
+    ColumnFamilyDescriptorBuilder, RegionDescriptor, RegionDescriptorBuilder, RegionId,
+    RowKeyDescriptor, Schema, SchemaRef,
 };
 
 use crate::error::{Error, InvalidAlterOperationSnafu, InvalidAlterVersionSnafu, Result};

--- a/src/mito2/src/region/metadata.rs
+++ b/src/mito2/src/region/metadata.rs
@@ -222,6 +222,18 @@ impl TryFrom<RawRegionMetadata> for RegionMetadata {
     }
 }
 
+impl TryFrom<RegionDescriptor> for RegionMetadata {
+    type Error = Error;
+
+    fn try_from(desc: RegionDescriptor) -> Result<RegionMetadata> {
+        // Doesn't set version explicitly here, because this is a new region meta
+        // created from descriptor, using initial version is reasonable.
+        let builder = RegionMetadataBuilder::try_from(desc)?;
+
+        builder.build()
+    }
+}
+
 struct RegionMetadataBuilder {
     id: RegionId,
     name: String,

--- a/src/mito2/src/region/metadata.rs
+++ b/src/mito2/src/region/metadata.rs
@@ -14,10 +14,302 @@
 
 //! Metadata of mito regions.
 
+// rewrite note:
+// Structs related to column (ColumnsMetadata etc.) still reference to storage/metadata
+// Other structs are ported to this file
+
 use std::sync::Arc;
 
-/// Static metadata of a region.
-#[derive(Debug)]
-pub(crate) struct RegionMetadata {}
+use snafu::ensure;
+use storage::metadata::{
+    ColumnFamiliesMetadata, ColumnFamiliesMetadataBuilder, ColumnsMetadata, ColumnsMetadataBuilder,
+    ColumnsMetadataRef,
+};
+use storage::schema::{RegionSchema, RegionSchemaRef};
+use store_api::storage::{
+    AddColumn, AlterOperation, AlterRequest, ColumnFamilyDescriptorBuilder, RegionDescriptor,
+    RegionId, SchemaRef,
+};
 
-pub(crate) type RegionMetadataRef = Arc<RegionMetadata>;
+use crate::error::{Error, InvalidAlterOperationSnafu, InvalidAlterVersionSnafu, Result};
+use crate::manifest::action::{RawColumnFamiliesMetadata, RawColumnsMetadata, RawRegionMetadata};
+
+pub type VersionNumber = u32;
+
+/// Static metadata of region.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegionMetadata {
+    // The following fields are immutable.
+    id: RegionId,
+    name: String,
+
+    // The following fields are mutable.
+    /// Latest schema of the region.
+    schema: RegionSchemaRef,
+    pub columns: ColumnsMetadataRef,
+    column_families: ColumnFamiliesMetadata,
+    version: VersionNumber,
+}
+
+impl RegionMetadata {
+    #[inline]
+    pub fn id(&self) -> RegionId {
+        self.id
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[inline]
+    pub fn schema(&self) -> &RegionSchemaRef {
+        &self.schema
+    }
+
+    #[inline]
+    pub fn user_schema(&self) -> &SchemaRef {
+        self.schema.user_schema()
+    }
+
+    #[inline]
+    pub fn version(&self) -> u32 {
+        self.schema.version()
+    }
+
+    /// Checks whether the `req` is valid, returns `Err` if it is invalid.
+    pub fn validate_alter(&self, req: &AlterRequest) -> Result<()> {
+        ensure!(
+            req.version == self.version,
+            InvalidAlterVersionSnafu {
+                expect: req.version,
+                given: self.version,
+            }
+        );
+
+        match &req.operation {
+            AlterOperation::AddColumns { columns } => {
+                for col in columns {
+                    self.validate_add_column(col)?;
+                }
+            }
+            AlterOperation::DropColumns { names } => {
+                for name in names {
+                    self.validate_drop_column(name)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns a new [RegionMetadata] after alteration, leave `self` unchanged.
+    ///
+    /// Caller should use [RegionMetadata::validate_alter] to validate the `req` and
+    /// ensure the version of the `req` is equal to the version of the metadata.
+    ///
+    /// # Panics
+    /// Panics if `req.version != self.version`.
+    pub fn alter(&self, req: &AlterRequest) -> Result<RegionMetadata> {
+        // The req should have been validated before.
+        assert_eq!(req.version, self.version);
+
+        let mut desc = self.to_descriptor();
+        // Apply the alter operation to the descriptor.
+        req.operation.apply(&mut desc);
+
+        RegionMetadataBuilder::try_from(desc)?
+            .version(self.version + 1) // Bump the metadata version.
+            .build()
+    }
+
+    fn validate_add_column(&self, add_column: &AddColumn) -> Result<()> {
+        // We don't check the case that the column is not nullable but default constraint is null. The
+        // caller should guarantee this.
+        ensure!(
+            add_column.desc.is_nullable() || add_column.desc.default_constraint().is_some(),
+            InvalidAlterOperationSnafu {
+                name: &add_column.desc.name,
+                reason: "add a non null column without default value"
+            }
+        );
+
+        // Use the store schema to check the column as it contains all internal columns.
+        let store_schema = self.schema.store_schema();
+        ensure!(
+            !store_schema.contains_column(&add_column.desc.name),
+            InvalidAlterOperationSnafu {
+                name: &add_column.desc.name,
+                reason: "duplicate column name"
+            }
+        );
+
+        Ok(())
+    }
+
+    fn validate_drop_column(&self, name: &str) -> Result<()> {
+        let store_schema = self.schema.store_schema();
+        ensure!(
+            store_schema.contains_column(name),
+            InvalidAlterOperationSnafu {
+                name,
+                reason: "no such column"
+            }
+        );
+        ensure!(
+            !store_schema.is_key_column(name),
+            InvalidAlterOperationSnafu {
+                name,
+                reason: "it's part of the key columns"
+            }
+        );
+        ensure!(
+            store_schema.is_user_column(name),
+            InvalidAlterOperationSnafu {
+                name,
+                reason: "it's an internal column"
+            }
+        );
+
+        Ok(())
+    }
+
+    fn to_descriptor(&self) -> RegionDescriptor {
+        let row_key = self.columns.to_row_key_descriptor();
+        let mut builder = RegionDescriptorBuilder::default()
+            .id(self.id)
+            .name(&self.name)
+            .row_key(row_key);
+
+        for (cf_id, cf) in &self.column_families.id_to_cfs {
+            let mut cf_builder = ColumnFamilyDescriptorBuilder::default()
+                .cf_id(*cf_id)
+                .name(&cf.name);
+            for column in &self.columns.columns[cf.column_index_start..cf.column_index_end] {
+                cf_builder = cf_builder.push_column(column.desc.clone());
+            }
+            // It should always be able to build the descriptor back.
+            let desc = cf_builder.build().unwrap();
+            if *cf_id == consts::DEFAULT_CF_ID {
+                builder = builder.default_cf(desc);
+            } else {
+                builder = builder.push_extra_column_family(desc);
+            }
+        }
+
+        // We could ensure all fields are set here.
+        builder.build().unwrap()
+    }
+}
+
+pub type RegionMetadataRef = Arc<RegionMetadata>;
+
+impl From<&RegionMetadata> for RawRegionMetadata {
+    fn from(data: &RegionMetadata) -> RawRegionMetadata {
+        RawRegionMetadata {
+            id: data.id,
+            name: data.name.clone(),
+            columns: RawColumnsMetadata::from(&*data.columns),
+            column_families: RawColumnFamiliesMetadata::from(&data.column_families),
+            version: data.version,
+        }
+    }
+}
+
+impl TryFrom<RawRegionMetadata> for RegionMetadata {
+    type Error = Error;
+
+    fn try_from(raw: RawRegionMetadata) -> Result<RegionMetadata> {
+        let columns = Arc::new(ColumnsMetadata::from(raw.columns));
+        let schema = Arc::new(RegionSchema::new(columns.clone(), raw.version)?);
+
+        Ok(RegionMetadata {
+            id: raw.id,
+            name: raw.name,
+            schema,
+            columns,
+            column_families: raw.column_families.into(),
+            version: raw.version,
+        })
+    }
+}
+
+struct RegionMetadataBuilder {
+    id: RegionId,
+    name: String,
+    columns_meta_builder: ColumnsMetadataBuilder,
+    cfs_meta_builder: ColumnFamiliesMetadataBuilder,
+    version: VersionNumber,
+}
+
+impl Default for RegionMetadataBuilder {
+    fn default() -> RegionMetadataBuilder {
+        RegionMetadataBuilder::new()
+    }
+}
+
+impl RegionMetadataBuilder {
+    fn new() -> RegionMetadataBuilder {
+        RegionMetadataBuilder {
+            id: 0.into(),
+            name: String::new(),
+            columns_meta_builder: ColumnsMetadataBuilder::default(),
+            cfs_meta_builder: ColumnFamiliesMetadataBuilder::default(),
+            version: Schema::INITIAL_VERSION,
+        }
+    }
+
+    fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    fn id(mut self, id: RegionId) -> Self {
+        self.id = id;
+        self
+    }
+
+    fn version(mut self, version: VersionNumber) -> Self {
+        self.version = version;
+        self
+    }
+
+    fn row_key(mut self, key: RowKeyDescriptor) -> Result<Self> {
+        let _ = self.columns_meta_builder.row_key(key)?;
+
+        Ok(self)
+    }
+
+    fn add_column_family(mut self, cf: ColumnFamilyDescriptor) -> Result<Self> {
+        let column_index_start = self.columns_meta_builder.columns.len();
+        let column_index_end = column_index_start + cf.columns.len();
+        let cf_meta = ColumnFamilyMetadata {
+            name: cf.name.clone(),
+            cf_id: cf.cf_id,
+            column_index_start,
+            column_index_end,
+        };
+
+        let _ = self.cfs_meta_builder.add_column_family(cf_meta)?;
+
+        for col in cf.columns {
+            let _ = self.columns_meta_builder.push_field_column(cf.cf_id, col)?;
+        }
+
+        Ok(self)
+    }
+
+    fn build(self) -> Result<RegionMetadata> {
+        let columns = Arc::new(self.columns_meta_builder.build()?);
+        let schema = Arc::new(RegionSchema::new(columns.clone(), self.version)?);
+
+        Ok(RegionMetadata {
+            id: self.id,
+            name: self.name,
+            schema,
+            columns,
+            column_families: self.cfs_meta_builder.build(),
+            version: self.version,
+        })
+    }
+}

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use common_error::prelude::*;
 use datatypes::data_type::ConcreteDataType;
-use datatypes::schema::{ColumnSchema, Metadata, COMMENT_KEY};
+use datatypes::schema::{ColumnSchema, Metadata, Schema, COMMENT_KEY};
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, Location, OptionExt};
 use store_api::storage::consts::{self, ReservedColumnId};
@@ -27,7 +27,7 @@ use store_api::storage::{
     AddColumn, AlterOperation, AlterRequest, ColumnDescriptor, ColumnDescriptorBuilder,
     ColumnDescriptorBuilderError, ColumnFamilyDescriptor, ColumnFamilyDescriptorBuilder,
     ColumnFamilyId, ColumnId, RegionDescriptor, RegionDescriptorBuilder, RegionId, RegionMeta,
-    RowKeyDescriptor, RowKeyDescriptorBuilder, Schema, SchemaRef,
+    RowKeyDescriptor, RowKeyDescriptorBuilder, SchemaRef,
 };
 
 use crate::manifest::action::{RawColumnFamiliesMetadata, RawColumnsMetadata, RawRegionMetadata};
@@ -645,7 +645,7 @@ impl TryFrom<RegionDescriptor> for RegionMetadata {
 
 #[derive(Default)]
 pub struct ColumnsMetadataBuilder {
-    columns: Vec<ColumnMetadata>,
+    pub columns: Vec<ColumnMetadata>,
     name_to_col_index: HashMap<String, usize>,
     /// Column id set, used to validate column id uniqueness.
     column_ids: HashSet<ColumnId>,
@@ -656,7 +656,7 @@ pub struct ColumnsMetadataBuilder {
 }
 
 impl ColumnsMetadataBuilder {
-    fn row_key(&mut self, key: RowKeyDescriptor) -> Result<&mut Self> {
+    pub fn row_key(&mut self, key: RowKeyDescriptor) -> Result<&mut Self> {
         for col in key.columns {
             let _ = self.push_row_key_column(col)?;
         }
@@ -673,7 +673,7 @@ impl ColumnsMetadataBuilder {
         self.push_field_column(consts::KEY_CF_ID, desc)
     }
 
-    fn push_field_column(
+    pub fn push_field_column(
         &mut self,
         cf_id: ColumnFamilyId,
         desc: ColumnDescriptor,

--- a/src/storage/src/metadata.rs
+++ b/src/storage/src/metadata.rs
@@ -462,15 +462,15 @@ pub struct ColumnsMetadata {
     /// The key columns, timestamp and version forms the row key.
     pub columns: Vec<ColumnMetadata>,
     /// Maps column name to index of columns, used to fast lookup column by name.
-    name_to_col_index: HashMap<String, usize>,
+    pub name_to_col_index: HashMap<String, usize>,
     /// Exclusive end index of row key columns.
-    row_key_end: usize,
+    pub row_key_end: usize,
     /// Index of timestamp key column.
-    timestamp_key_index: usize,
+    pub timestamp_key_index: usize,
     /// Exclusive end index of user columns.
     ///
     /// Columns in `[user_column_end..)` are internal columns.
-    user_column_end: usize,
+    pub user_column_end: usize,
 }
 
 impl ColumnsMetadata {
@@ -842,7 +842,7 @@ impl RegionMetadataBuilder {
     }
 }
 
-fn internal_column_descs() -> [ColumnDescriptor; 2] {
+pub fn internal_column_descs() -> [ColumnDescriptor; 2] {
     [
         ColumnDescriptorBuilder::new(
             ReservedColumnId::sequence(),
@@ -865,7 +865,7 @@ fn internal_column_descs() -> [ColumnDescriptor; 2] {
 
 /// Returns true if this is an internal column for value column.
 #[inline]
-fn is_internal_field_column(column_name: &str) -> bool {
+pub fn is_internal_field_column(column_name: &str) -> bool {
     matches!(
         column_name,
         consts::SEQUENCE_COLUMN_NAME | consts::OP_TYPE_COLUMN_NAME

--- a/src/storage/src/schema/store.rs
+++ b/src/storage/src/schema/store.rs
@@ -86,18 +86,18 @@ impl StoreSchema {
         self.row_key_end - 1
     }
 
-    pub(crate) fn contains_column(&self, name: &str) -> bool {
+    pub fn contains_column(&self, name: &str) -> bool {
         self.schema.column_schema_by_name(name).is_some()
     }
 
-    pub(crate) fn is_key_column(&self, name: &str) -> bool {
+    pub fn is_key_column(&self, name: &str) -> bool {
         self.schema
             .column_index_by_name(name)
             .map(|idx| idx < self.row_key_end)
             .unwrap_or(false)
     }
 
-    pub(crate) fn is_user_column(&self, name: &str) -> bool {
+    pub fn is_user_column(&self, name: &str) -> bool {
         self.schema
             .column_index_by_name(name)
             .map(|idx| idx < self.user_column_end)

--- a/src/store-api/src/storage/descriptors.rs
+++ b/src/store-api/src/storage/descriptors.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
+use crate::storage::consts::ReservedColumnId;
 use crate::storage::{consts, ColumnDefaultConstraint, ColumnSchema, ConcreteDataType};
 
 /// Id of column, unique in each region.

--- a/src/store-api/src/storage/descriptors.rs
+++ b/src/store-api/src/storage/descriptors.rs
@@ -17,7 +17,6 @@ use std::fmt;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::storage::consts::ReservedColumnId;
 use crate::storage::{consts, ColumnDefaultConstraint, ColumnSchema, ConcreteDataType};
 
 /// Id of column, unique in each region.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


- trait `Checkpointer` -> struct `RegionManifestCheckpointer`
- remove column family related structs
- some test utils
- column metadata and region metadata

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
