### PR TITLE
feat: support append entries from multiple regions at a time

### DIFF
--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -82,7 +82,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Malformed append batch,expect namespace: {}, actual namespace: {}, location: {}",
+        "Malformed append batch, expect namespace: {}, actual namespace: {}, location: {}",
         expect_ns,
         actual_ns,
         location

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -80,18 +80,6 @@ pub enum Error {
         attempt_index: u64,
         location: Location,
     },
-
-    #[snafu(display(
-        "Malformed append batch, expect namespace: {}, actual namespace: {}, location: {}",
-        expect_ns,
-        actual_ns,
-        location
-    ))]
-    MalformedBatch {
-        expect_ns: u64,
-        actual_ns: u64,
-        location: Location,
-    },
 }
 
 impl ErrorExt for Error {

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -80,6 +80,18 @@ pub enum Error {
         attempt_index: u64,
         location: Location,
     },
+
+    #[snafu(display(
+        "Malformed append batch,expect namespace: {}, actual namespace: {}, location: {}",
+        expect_ns,
+        actual_ns,
+        location
+    ))]
+    MalformedBatch {
+        expect_ns: u64,
+        actual_ns: u64,
+        location: Location,
+    },
 }
 
 impl ErrorExt for Error {

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use store_api::logstore::entry::{Entry, Id};
 use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
 use store_api::logstore::{AppendResponse, LogStore};
@@ -67,7 +65,7 @@ impl LogStore for NoopLogStore {
         Ok(AppendResponse { entry_id: 0 })
     }
 
-    async fn append_batch(&self, _e: HashMap<Self::Namespace, Vec<Self::Entry>>) -> Result<()> {
+    async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<()> {
         Ok(())
     }
 
@@ -133,10 +131,7 @@ mod tests {
         let store = NoopLogStore::default();
         let e = store.entry("".as_bytes(), 1, NamespaceImpl::default());
         let _ = store.append(e.clone()).await.unwrap();
-        assert!(store
-            .append_batch([(NamespaceImpl::default(), vec![e])].into_iter().collect())
-            .await
-            .is_ok());
+        assert!(store.append_batch(vec![e]).await.is_ok());
         store
             .create_namespace(&NamespaceImpl::default())
             .await

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
 use store_api::logstore::entry::{Entry, Id};
 use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
 use store_api::logstore::{AppendResponse, LogStore};
@@ -25,7 +27,7 @@ pub struct NoopLogStore;
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct EntryImpl;
 
-#[derive(Debug, Clone, Default, Hash, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, Hash)]
 pub struct NamespaceImpl;
 
 impl Namespace for NamespaceImpl {
@@ -65,8 +67,8 @@ impl LogStore for NoopLogStore {
         Ok(AppendResponse { entry_id: 0 })
     }
 
-    async fn append_batch(&self, _ns: &Self::Namespace, _e: Vec<Self::Entry>) -> Result<Vec<Id>> {
-        Ok(vec![])
+    async fn append_batch(&self, _e: HashMap<Self::Namespace, Vec<Self::Entry>>) -> Result<()> {
+        Ok(())
     }
 
     async fn read(
@@ -132,7 +134,7 @@ mod tests {
         let e = store.entry("".as_bytes(), 1, NamespaceImpl::default());
         let _ = store.append(e.clone()).await.unwrap();
         assert!(store
-            .append_batch(&NamespaceImpl::default(), vec![e])
+            .append_batch([(NamespaceImpl::default(), vec![e])].into_iter().collect())
             .await
             .is_ok());
         store

--- a/src/log-store/src/raft_engine.rs
+++ b/src/log-store/src/raft_engine.rs
@@ -36,6 +36,7 @@ impl EntryImpl {
         }
     }
 }
+
 impl NamespaceImpl {
     pub fn with_id(id: Id) -> Self {
         Self {

--- a/src/log-store/src/raft_engine.rs
+++ b/src/log-store/src/raft_engine.rs
@@ -52,6 +52,8 @@ impl Hash for NamespaceImpl {
     }
 }
 
+impl Eq for NamespaceImpl {}
+
 impl Namespace for NamespaceImpl {
     fn id(&self) -> store_api::logstore::namespace::Id {
         self.id

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -202,6 +202,7 @@ impl LogStore for RaftEngineLogStore {
 
     /// Append a batch of entries to logstore. `RaftEngineLogStore` assures the atomicity of
     /// batch append.
+    #[allow(clippy::mutable_key_type)] // this is a false positive because NamespaceImpl contains protobuf generated fields.
     async fn append_batch(
         &self,
         entries: HashMap<Self::Namespace, Vec<Self::Entry>>,
@@ -598,6 +599,7 @@ mod tests {
         assert_eq!(101, vec.first().unwrap().id);
     }
 
+    #[allow(clippy::mutable_key_type)]
     #[tokio::test]
     async fn test_append_batch() {
         common_telemetry::init_default_ut_logging();
@@ -621,7 +623,6 @@ mod tests {
             entries.insert(
                 namespace.clone(),
                 (0..16)
-                    .into_iter()
                     .map(|idx| Entry::create(idx, namespace.id(), data.clone()))
                     .collect(),
             );

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -38,9 +38,10 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
 
     /// Append an `Entry` to WAL with given namespace and return append response containing
     /// the entry id.
-    async fn append(&self, mut e: Self::Entry) -> Result<AppendResponse, Self::Error>;
+    async fn append(&self, e: Self::Entry) -> Result<AppendResponse, Self::Error>;
 
     /// Append a batch of entries atomically and return the offset of first entry.
+    #[allow(clippy::mutable_key_type)]
     async fn append_batch(
         &self,
         e: HashMap<Self::Namespace, Vec<Self::Entry>>,

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -14,6 +14,8 @@
 
 //! LogStore APIs.
 
+use std::collections::HashMap;
+
 use common_error::ext::ErrorExt;
 
 use crate::logstore::entry::{Entry, Id};
@@ -41,9 +43,8 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     /// Append a batch of entries atomically and return the offset of first entry.
     async fn append_batch(
         &self,
-        ns: &Self::Namespace,
-        e: Vec<Self::Entry>,
-    ) -> Result<Vec<Id>, Self::Error>;
+        e: HashMap<Self::Namespace, Vec<Self::Entry>>,
+    ) -> Result<(), Self::Error>;
 
     /// Create a new `EntryStream` to asynchronously generates `Entry` with ids
     /// starting from `id`.

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -14,8 +14,6 @@
 
 //! LogStore APIs.
 
-use std::collections::HashMap;
-
 use common_error::ext::ErrorExt;
 
 use crate::logstore::entry::{Entry, Id};
@@ -41,11 +39,7 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     async fn append(&self, e: Self::Entry) -> Result<AppendResponse, Self::Error>;
 
     /// Append a batch of entries atomically and return the offset of first entry.
-    #[allow(clippy::mutable_key_type)]
-    async fn append_batch(
-        &self,
-        e: HashMap<Self::Namespace, Vec<Self::Entry>>,
-    ) -> Result<(), Self::Error>;
+    async fn append_batch(&self, e: Vec<Self::Entry>) -> Result<(), Self::Error>;
 
     /// Create a new `EntryStream` to asynchronously generates `Entry` with ids
     /// starting from `id`.

--- a/src/store-api/src/logstore/namespace.rs
+++ b/src/store-api/src/logstore/namespace.rs
@@ -16,6 +16,6 @@ use std::hash::Hash;
 
 pub type Id = u64;
 
-pub trait Namespace: Send + Sync + Clone + std::fmt::Debug + Hash + PartialEq {
+pub trait Namespace: Send + Sync + Clone + std::fmt::Debug + Hash + PartialEq + Eq {
     fn id(&self) -> Id;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR: 
- adds support for appending entries from multiple regions at a time
- removes the return value of `append_batch` in that underlying impl should guarantee the atomicity of `append_batch`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #1958 