### PR TITLE
refactor(mito): define region metadata

### DIFF
--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -25,6 +25,8 @@ pub mod error;
 #[allow(unused_variables)]
 pub mod manifest;
 #[allow(dead_code)]
+pub mod metadata;
+#[allow(dead_code)]
 mod region;
 #[allow(dead_code)]
 mod worker;
@@ -138,7 +140,6 @@ mod worker;
 ///     +Level level
 ///     +u64 file_size
 /// }
-///
 /// VersionControl o-- Version
 /// Version o-- RegionMetadata
 /// Version o-- MemtableVersion
@@ -146,47 +147,22 @@ mod worker;
 /// LevelMetas o-- LevelMeta
 /// LevelMeta o-- FileHandle
 /// FileHandle o-- FileMeta
-///
 /// class RegionMetadata {
 ///     +RegionId region_id
 ///     +VersionNumber version
-///     +SchemaRef table_schema
-///     +Vec~usize~ primary_key_indices
-///     +Vec~usize~ value_indices
-///     +ColumnId next_column_id
+///     +SchemaRef schema
 ///     +TableOptions region_options
-///     +DateTime~Utc~ created_on
-///     +RegionSchemaRef region_schema
-/// }
-/// class RegionSchema {
-///     -SchemaRef user_schema
-///     -StoreSchemaRef store_schema
-///     -ColumnsMetadataRef columns
+///     +Vec&lt;ColumnMetadata&gt; column_metadatas
 /// }
 /// class Schema
-/// class StoreSchema {
-///     -Vec~ColumnMetadata~ columns
-///     -SchemaRef schema
-///     -usize row_key_end
-///     -usize user_column_end
+/// class ColumnMetadata {
+///     +ColumnSchema column_schema
+///     +SemanticTyle semantic_type
+///     +ColumnId column_id
 /// }
-/// class ColumnsMetadata {
-///     -Vec~ColumnMetadata~ columns
-///     -HashMap&lt;String, usize&gt; name_to_col_index
-///     -usize row_key_end
-///     -usize timestamp_key_index
-///     -usize user_column_end
-/// }
-/// class ColumnMetadata
-///
-/// RegionMetadata o-- RegionSchema
+/// class SemanticType
 /// RegionMetadata o-- Schema
-/// RegionSchema o-- StoreSchema
-/// RegionSchema o-- Schema
-/// RegionSchema o-- ColumnsMetadata
-/// StoreSchema o-- ColumnsMetadata
-/// StoreSchema o-- Schema
-/// StoreSchema o-- ColumnMetadata
-/// ColumnsMetadata o-- ColumnMetadata
+/// RegionMetadata o-- ColumnMetadata
+/// ColumnMetadata o-- SemanticType
 /// ```
 mod docs {}

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -147,21 +147,6 @@ mod worker;
 /// LevelMetas o-- LevelMeta
 /// LevelMeta o-- FileHandle
 /// FileHandle o-- FileMeta
-/// class RegionMetadata {
-///     +RegionId region_id
-///     +VersionNumber version
-///     +SchemaRef schema
-///     +Vec&lt;ColumnMetadata&gt; column_metadatas
-/// }
-/// class Schema
-/// class ColumnMetadata {
-///     +ColumnSchema column_schema
-///     +SemanticTyle semantic_type
-///     +ColumnId column_id
-/// }
-/// class SemanticType
-/// RegionMetadata o-- Schema
-/// RegionMetadata o-- ColumnMetadata
-/// ColumnMetadata o-- SemanticType
+/// class RegionMetadata
 /// ```
 mod docs {}

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -151,7 +151,6 @@ mod worker;
 ///     +RegionId region_id
 ///     +VersionNumber version
 ///     +SchemaRef schema
-///     +TableOptions region_options
 ///     +Vec&lt;ColumnMetadata&gt; column_metadatas
 /// }
 /// class Schema

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -22,6 +22,26 @@ use store_api::storage::{ColumnId, RegionId};
 use crate::region::VersionNumber;
 
 /// Static metadata of a region.
+///
+/// ```mermaid
+/// class RegionMetadata {
+///     +RegionId region_id
+///     +VersionNumber version
+///     +SchemaRef schema
+///     +Vec&lt;ColumnMetadata&gt; column_metadatas
+///     +Vec&lt;ColumnId&gt; primary_keys
+/// }
+/// class Schema
+/// class ColumnMetadata {
+///     +ColumnSchema column_schema
+///     +SemanticTyle semantic_type
+///     +ColumnId column_id
+/// }
+/// class SemanticType
+/// RegionMetadata o-- Schema
+/// RegionMetadata o-- ColumnMetadata
+/// ColumnMetadata o-- SemanticType
+/// ```
 #[derive(Debug)]
 pub(crate) struct RegionMetadata {
     /// Latest schema of this region

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -29,7 +29,7 @@ pub(crate) struct RegionMetadata {
     column_metadatas: Vec<ColumnMetadata>,
     version: VersionNumber,
 
-    // Immutable and unique id
+    /// Immutable and unique id
     id: RegionId,
 }
 

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -16,8 +16,39 @@
 
 use std::sync::Arc;
 
+use datatypes::schema::{ColumnSchema, SchemaRef};
+use store_api::storage::{ColumnId, RegionId};
+
+use crate::region::VersionNumber;
+
 /// Static metadata of a region.
 #[derive(Debug)]
-pub(crate) struct RegionMetadata {}
+pub(crate) struct RegionMetadata {
+    /// Latest schema of this region
+    schema: SchemaRef,
+    column_metadatas: Vec<ColumnMetadata>,
+    version: VersionNumber,
+
+    // Immutable properties
+    id: RegionId,
+    name: String,
+}
 
 pub(crate) type RegionMetadataRef = Arc<RegionMetadata>;
+
+/// Metadata of a column.
+#[derive(Debug)]
+pub(crate) struct ColumnMetadata {
+    /// Schema of this column. Is the same as `column_schema` in [SchemaRef].
+    column_schema: ColumnSchema,
+    semantic_type: SemanticType,
+    column_id: ColumnId,
+}
+
+/// The semantic type of one column
+#[derive(Debug)]
+pub(crate) enum SemanticType {
+    Tag,
+    Field,
+    Timestamp,
+}

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -27,7 +27,10 @@ pub(crate) struct RegionMetadata {
     /// Latest schema of this region
     schema: SchemaRef,
     column_metadatas: Vec<ColumnMetadata>,
+    /// Version of metadata.
     version: VersionNumber,
+    /// Maintains an ordered list of primary keys
+    primary_keys: Vec<ColumnId>,
 
     /// Immutable and unique id
     id: RegionId,

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -29,9 +29,8 @@ pub(crate) struct RegionMetadata {
     column_metadatas: Vec<ColumnMetadata>,
     version: VersionNumber,
 
-    // Immutable properties
+    // Immutable and unique id
     id: RegionId,
-    name: String,
 }
 
 pub(crate) type RegionMetadataRef = Arc<RegionMetadata>;

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -14,7 +14,6 @@
 
 //! Mito region.
 
-mod metadata;
 mod version;
 
 use std::collections::HashMap;
@@ -23,6 +22,7 @@ use std::sync::{Arc, RwLock};
 use store_api::storage::RegionId;
 
 use crate::region::version::VersionControlRef;
+pub type VersionNumber = u32;
 
 /// Metadata and runtime status of a region.
 #[derive(Debug)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Simplify the region metadata. In this version `StoreSchema` and `RegionSchema` are deprecated

Before 
```mermaid
classDiagram

class RegionMetadata {
    +RegionId region_id
    +VersionNumber version
    +SchemaRef table_schema
    +Vec~usize~ primary_key_indices
    +Vec~usize~ value_indices
    +ColumnId next_column_id
    +TableOptions region_options
    +DateTime~Utc~ created_on
    +RegionSchemaRef region_schema
}
class RegionSchema {
    -SchemaRef user_schema
    -StoreSchemaRef store_schema
    -ColumnsMetadataRef columns
}
class Schema
class StoreSchema {
    -Vec~ColumnMetadata~ columns
    -SchemaRef schema
    -usize row_key_end
    -usize user_column_end
}
class ColumnsMetadata {
    -Vec~ColumnMetadata~ columns
    -HashMap&lt;String, usize&gt; name_to_col_index
    -usize row_key_end
    -usize timestamp_key_index
    -usize user_column_end
}
class ColumnMetadata

RegionMetadata o-- RegionSchema
RegionMetadata o-- Schema
RegionSchema o-- StoreSchema
RegionSchema o-- Schema
RegionSchema o-- ColumnsMetadata
StoreSchema o-- ColumnsMetadata
StoreSchema o-- Schema
StoreSchema o-- ColumnMetadata
ColumnsMetadata o-- ColumnMetadata
```

After
```mermaid
classDiagram

class RegionMetadata {
    +RegionId region_id
    +VersionNumber version
    +SchemaRef schema
    +Vec&lt;ColumnMetadata&gt; column_metadatas
}
class Schema
class ColumnMetadata {
    +ColumnSchema column_schema
    +SemanticType semantic_type
    +ColumnId column_id
}
class SemanticType
RegionMetadata o-- Schema
RegionMetadata o-- ColumnMetadata
ColumnMetadata o-- SemanticType
```


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
