### PR TITLE
feat: expose metasrv `datanode_client_options`

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -25,3 +25,9 @@ use_memory_store = false
 max_retry_times = 3
 # Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
+
+# Datanode client options.
+# [datanode_client_options]
+# timeout_millis = 10000
+# connect_timeout_millis = 10000
+# tcp_nodelay = true

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -26,8 +26,10 @@ max_retry_times = 3
 # Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
 
-# Datanode client options.
-# [datanode_client_options]
+# # Datanode options.
+# [datanode]
+# # Datanode client options.
+# [datanode.client_options]
 # timeout_millis = 10000
 # connect_timeout_millis = 10000
 # tcp_nodelay = true

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -29,8 +29,8 @@ use tower::make::MakeConnection;
 use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
-const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 10;
-const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 10;
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 
 lazy_static! {
     static ref ID: AtomicU64 = AtomicU64::new(0);

--- a/src/common/grpc/src/channel_manager.rs
+++ b/src/common/grpc/src/channel_manager.rs
@@ -29,8 +29,8 @@ use tower::make::MakeConnection;
 use crate::error::{CreateChannelSnafu, InvalidConfigFilePathSnafu, InvalidTlsConfigSnafu, Result};
 
 const RECYCLE_CHANNEL_INTERVAL_SECS: u64 = 60;
-pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 10;
-pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+pub const DEFAULT_GRPC_REQUEST_TIMEOUT_SECS: u64 = 10;
+pub const DEFAULT_GRPC_CONNECT_TIMEOUT_SECS: u64 = 10;
 
 lazy_static! {
     static ref ID: AtomicU64 = AtomicU64::new(0);
@@ -252,8 +252,8 @@ pub struct ChannelConfig {
 impl Default for ChannelConfig {
     fn default() -> Self {
         Self {
-            timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
-            connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
+            timeout: Some(Duration::from_secs(DEFAULT_GRPC_REQUEST_TIMEOUT_SECS)),
+            connect_timeout: Some(Duration::from_secs(DEFAULT_GRPC_CONNECT_TIMEOUT_SECS)),
             concurrency_limit: None,
             rate_limit: None,
             initial_stream_window_size: None,
@@ -516,8 +516,8 @@ mod tests {
         let default_cfg = ChannelConfig::new();
         assert_eq!(
             ChannelConfig {
-                timeout: Some(Duration::from_secs(DEFAULT_REQUEST_TIMEOUT_SECS)),
-                connect_timeout: Some(Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS)),
+                timeout: Some(Duration::from_secs(DEFAULT_GRPC_REQUEST_TIMEOUT_SECS)),
+                connect_timeout: Some(Duration::from_secs(DEFAULT_GRPC_CONNECT_TIMEOUT_SECS)),
                 concurrency_limit: None,
                 rate_limit: None,
                 initial_stream_window_size: None,

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use api::v1::meta::Peer;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_grpc::channel_manager;
 use common_meta::key::TableMetadataManagerRef;
 use common_procedure::options::ProcedureConfig;
 use common_procedure::ProcedureManagerRef;
@@ -55,7 +56,7 @@ pub struct MetaSrvOptions {
     pub http_opts: HttpOptions,
     pub logging: LoggingOptions,
     pub procedure: ProcedureConfig,
-    pub datanode_client_options: DatanodeClientOptions,
+    pub datanode: DatanodeOptions,
 }
 
 impl Default for MetaSrvOptions {
@@ -71,7 +72,7 @@ impl Default for MetaSrvOptions {
             http_opts: HttpOptions::default(),
             logging: LoggingOptions::default(),
             procedure: ProcedureConfig::default(),
-            datanode_client_options: DatanodeClientOptions::default(),
+            datanode: DatanodeOptions::default(),
         }
     }
 }
@@ -82,7 +83,13 @@ impl MetaSrvOptions {
     }
 }
 
-// Options for database client
+// Options for datanode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DatanodeOptions {
+    client_options: DatanodeClientOptions,
+}
+
+// Options for datanode client.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DatanodeClientOptions {
     pub timeout_millis: u64,
@@ -93,8 +100,8 @@ pub struct DatanodeClientOptions {
 impl Default for DatanodeClientOptions {
     fn default() -> Self {
         Self {
-            timeout_millis: common_grpc::channel_manager::DEFAULT_REQUEST_TIMEOUT_SECS,
-            connect_timeout_millis: common_grpc::channel_manager::DEFAULT_CONNECT_TIMEOUT_SECS,
+            timeout_millis: channel_manager::DEFAULT_GRPC_REQUEST_TIMEOUT_SECS * 1000,
+            connect_timeout_millis: channel_manager::DEFAULT_GRPC_CONNECT_TIMEOUT_SECS * 1000,
             tcp_nodelay: true,
         }
     }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -55,6 +55,7 @@ pub struct MetaSrvOptions {
     pub http_opts: HttpOptions,
     pub logging: LoggingOptions,
     pub procedure: ProcedureConfig,
+    pub datanode_client_options: DatanodeClientOptions,
 }
 
 impl Default for MetaSrvOptions {
@@ -70,6 +71,7 @@ impl Default for MetaSrvOptions {
             http_opts: HttpOptions::default(),
             logging: LoggingOptions::default(),
             procedure: ProcedureConfig::default(),
+            datanode_client_options: DatanodeClientOptions::default(),
         }
     }
 }
@@ -77,6 +79,24 @@ impl Default for MetaSrvOptions {
 impl MetaSrvOptions {
     pub fn to_toml_string(&self) -> String {
         toml::to_string(&self).unwrap()
+    }
+}
+
+// Options for database client
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatanodeClientOptions {
+    pub timeout_millis: u64,
+    pub connect_timeout_millis: u64,
+    pub tcp_nodelay: bool,
+}
+
+impl Default for DatanodeClientOptions {
+    fn default() -> Self {
+        Self {
+            timeout_millis: common_grpc::channel_manager::DEFAULT_REQUEST_TIMEOUT_SECS,
+            connect_timeout_millis: common_grpc::channel_manager::DEFAULT_CONNECT_TIMEOUT_SECS,
+            tcp_nodelay: true,
+        }
     }
 }
 

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -180,17 +180,17 @@ impl MetaSrvBuilder {
             kv_store.clone(),
         )));
 
-        let datanode_client_channel_config = ChannelConfig::new()
-            .timeout(Duration::from_millis(
-                options.datanode_client_options.timeout_millis,
-            ))
-            .connect_timeout(Duration::from_millis(
-                options.datanode_client_options.connect_timeout_millis,
-            ))
-            .tcp_nodelay(options.datanode_client_options.tcp_nodelay);
-
-        let datanode_clients = datanode_clients
-            .unwrap_or_else(|| Arc::new(DatanodeClients::new(datanode_client_channel_config)));
+        let datanode_clients = datanode_clients.unwrap_or_else(|| {
+            let datanode_client_channel_config = ChannelConfig::new()
+                .timeout(Duration::from_millis(
+                    options.datanode.client_options.timeout_millis,
+                ))
+                .connect_timeout(Duration::from_millis(
+                    options.datanode.client_options.connect_timeout_millis,
+                ))
+                .tcp_nodelay(options.datanode.client_options.tcp_nodelay);
+            Arc::new(DatanodeClients::new(datanode_client_channel_config))
+        });
 
         // TODO(weny): considers to modify the default config of procedure manager
         let ddl_manager = Arc::new(DdlManager::new(

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -14,8 +14,10 @@
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::Duration;
 
 use client::client_manager::DatanodeClients;
+use common_grpc::channel_manager::ChannelConfig;
 use common_meta::key::TableMetadataManager;
 use common_procedure::local::{LocalManager, ManagerConfig};
 
@@ -178,11 +180,23 @@ impl MetaSrvBuilder {
             kv_store.clone(),
         )));
 
+        let datanode_client_channel_config = ChannelConfig::new()
+            .timeout(Duration::from_millis(
+                options.datanode_client_options.timeout_millis,
+            ))
+            .connect_timeout(Duration::from_millis(
+                options.datanode_client_options.connect_timeout_millis,
+            ))
+            .tcp_nodelay(options.datanode_client_options.tcp_nodelay);
+
+        let datanode_clients = datanode_clients
+            .unwrap_or_else(|| Arc::new(DatanodeClients::new(datanode_client_channel_config)));
+
         // TODO(weny): considers to modify the default config of procedure manager
         let ddl_manager = Arc::new(DdlManager::new(
             procedure_manager.clone(),
             kv_store.clone(),
-            datanode_clients.unwrap_or_else(|| Arc::new(DatanodeClients::default())),
+            datanode_clients,
             mailbox.clone(),
             options.server_addr.clone(),
             table_metadata_manager.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Expose metasrv `datanode_client_options`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
