### PR TITLE
docs: fix playground section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,9 @@ for years. Based on their best-practices, GreptimeDB is born to give you:
 
 ## Quick Start
 
-### GreptimePlay
+### [GreptimePlay](https://greptime.com/playground)
 
 Try out the features of GreptimeDB right from your browser.
-
-<a href="https://greptime.com/playground" target="_blank"><img
-src="https://www.greptime.com/assets/greptime_play_button_colorful.1bbe2746.png"
-alt="GreptimePlay" width="200px" /></a>
 
 ### Build
 


### PR DESCRIPTION


I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

The image link keeps changing after website build, here we remove the broken image and use link temporarily

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
