### PR TITLE
feat: initial implementation for OpenTelemetry otlp/http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -4224,6 +4225,31 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -8753,6 +8779,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "digest",
  "futures",
+ "headers",
  "hex",
  "http-body",
  "humantime-serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
  "greptime-proto",
  "prost",
  "snafu",
- "tonic",
+ "tonic 0.9.2",
  "tonic-build",
 ]
 
@@ -396,7 +396,7 @@ dependencies = [
  "paste",
  "prost",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ dependencies = [
  "substrait 0.7.5",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1778,7 +1778,7 @@ dependencies = [
  "rand",
  "snafu",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower",
 ]
 
@@ -1946,7 +1946,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-util",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.17.0",
  "opentelemetry-jaeger",
  "parking_lot 0.12.1",
  "serde",
@@ -2031,7 +2031,7 @@ checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
- "tonic",
+ "tonic 0.9.2",
  "tracing-core",
 ]
 
@@ -2053,7 +2053,7 @@ dependencies = [
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -2673,7 +2673,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.6",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tower-http",
  "url",
@@ -3065,7 +3065,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tonic-build",
  "tower",
  "tower-service",
@@ -3278,6 +3278,7 @@ dependencies = [
  "moka 0.9.7",
  "object-store",
  "openmetrics-parser",
+ "opentelemetry-proto",
  "partition",
  "prost",
  "query",
@@ -3296,7 +3297,7 @@ dependencies = [
  "table",
  "tokio",
  "toml 0.7.6",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "uuid",
 ]
@@ -4140,7 +4141,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "tonic",
+ "tonic 0.9.2",
  "tonic-build",
 ]
 
@@ -5215,7 +5216,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -5266,7 +5267,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.6",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -6071,6 +6072,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
 name = "opentelemetry-jaeger"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6078,11 +6089,24 @@ checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
 dependencies = [
  "async-trait",
  "lazy_static",
- "opentelemetry",
+ "opentelemetry 0.17.0",
  "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift 0.15.0",
  "tokio",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry 0.19.0",
+ "prost",
+ "tonic 0.8.3",
 ]
 
 [[package]]
@@ -6091,7 +6115,43 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.17.0",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap 1.9.3",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "dashmap",
+ "fnv",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "percent-encoding",
+ "rand",
+ "thiserror",
 ]
 
 [[package]]
@@ -8707,6 +8767,7 @@ dependencies = [
  "once_cell",
  "openmetrics-parser",
  "opensrv-mysql",
+ "opentelemetry-proto",
  "parking_lot 0.12.1",
  "pgwire",
  "pin-project",
@@ -8738,7 +8799,7 @@ dependencies = [
  "tokio-rustls 0.24.0",
  "tokio-stream",
  "tokio-test",
- "tonic",
+ "tonic 0.9.2",
  "tonic-reflection",
  "tower",
  "tower-http",
@@ -9296,7 +9357,7 @@ dependencies = [
  "table",
  "tokio",
  "tokio-util",
- "tonic",
+ "tonic 0.9.2",
  "tonic-build",
  "uuid",
 ]
@@ -9755,7 +9816,7 @@ dependencies = [
  "table",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.9.2",
  "tower",
  "uuid",
 ]
@@ -10149,6 +10210,38 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
@@ -10201,7 +10294,7 @@ dependencies = [
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -10360,7 +10453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.17.0",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -10783,6 +10876,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ futures-util = "0.3"
 greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9b26cca2132df83916692cc6fc092a26a1a76f0b" }
 itertools = "0.10"
 lazy_static = "1.4"
+opentelemetry-proto = { version = "0.2", features = ["gen-tonic", "metrics"] }
 parquet = "40.0"
 paste = "1.0"
 prost = "0.11"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -47,6 +47,7 @@ mito = { path = "../mito", features = ["test"] }
 moka = { version = "0.9", features = ["future"] }
 object-store = { path = "../object-store" }
 openmetrics-parser = "0.4"
+opentelemetry-proto.workspace = true
 partition = { path = "../partition" }
 prost.workspace = true
 query = { path = "../query" }

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -19,8 +19,8 @@ use servers::http::HttpOptions;
 use servers::Mode;
 
 use crate::service_config::{
-    GrpcOptions, InfluxdbOptions, MysqlOptions, OpentsdbOptions, PostgresOptions, PromStoreOptions,
-    PrometheusOptions,
+    GrpcOptions, InfluxdbOptions, MysqlOptions, OpentsdbOptions, OtlpOptions, PostgresOptions,
+    PromStoreOptions, PrometheusOptions,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -37,6 +37,7 @@ pub struct FrontendOptions {
     pub influxdb_options: Option<InfluxdbOptions>,
     pub prom_store_options: Option<PromStoreOptions>,
     pub prometheus_options: Option<PrometheusOptions>,
+    pub otlp_options: Option<OtlpOptions>,
     pub meta_client_options: Option<MetaClientOptions>,
     pub logging: LoggingOptions,
 }
@@ -55,6 +56,7 @@ impl Default for FrontendOptions {
             influxdb_options: Some(InfluxdbOptions::default()),
             prom_store_options: Some(PromStoreOptions::default()),
             prometheus_options: Some(PrometheusOptions::default()),
+            otlp_options: Some(OtlpOptions::default()),
             meta_client_options: None,
             logging: LoggingOptions::default(),
         }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -16,6 +16,7 @@ pub mod distributed;
 mod grpc;
 mod influxdb;
 mod opentsdb;
+mod otlp;
 mod prom_store;
 mod script;
 mod standalone;
@@ -65,7 +66,8 @@ use servers::prometheus::PrometheusHandler;
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::{
-    InfluxdbLineProtocolHandler, OpentsdbProtocolHandler, PromStoreProtocolHandler, ScriptHandler,
+    InfluxdbLineProtocolHandler, OpenTelemetryProtocolHandler, OpentsdbProtocolHandler,
+    PromStoreProtocolHandler, ScriptHandler,
 };
 use session::context::QueryContextRef;
 use snafu::prelude::*;
@@ -97,6 +99,7 @@ pub trait FrontendInstance:
     + OpentsdbProtocolHandler
     + InfluxdbLineProtocolHandler
     + PromStoreProtocolHandler
+    + OpenTelemetryProtocolHandler
     + ScriptHandler
     + PrometheusHandler
     + Send

--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -1,0 +1,49 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use common_error::ext::BoxedError;
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
+use servers::error::{self, Result as ServerResult};
+use servers::otlp;
+use servers::query_handler::OpenTelemetryProtocolHandler;
+use session::context::QueryContextRef;
+use snafu::ResultExt;
+
+use crate::instance::Instance;
+
+#[async_trait]
+impl OpenTelemetryProtocolHandler for Instance {
+    async fn metrics(
+        &self,
+        request: ExportMetricsServiceRequest,
+        ctx: QueryContextRef,
+    ) -> ServerResult<ExportMetricsServiceResponse> {
+        let requests = otlp::to_grpc_insert_requests(request)?;
+        let _ = self
+            .handle_inserts(requests, ctx)
+            .await
+            .map_err(BoxedError::new)
+            .context(error::ExecuteGrpcQuerySnafu)?;
+
+        // TODO(sunng97): metrics
+        // counter!(OTLP_REMOTE_WRITE_SAMPLES, samples as u64);
+        let resp = ExportMetricsServiceResponse {
+            partial_success: None,
+        };
+        Ok(resp)
+    }
+}

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -24,3 +24,5 @@ pub const DIST_INGEST_ROW_COUNT: &str = "frontend.dist.ingest_rows";
 
 /// The samples count of Prometheus remote write.
 pub const PROM_STORE_REMOTE_WRITE_SAMPLES: &str = "frontend.prometheus.remote_write.samples";
+
+pub const OTLP_METRICS_ROWS: &str = "frontend.otlp.metrics.rows";

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -38,7 +38,7 @@ use crate::error::Error::StartServer;
 use crate::error::{self, Result};
 use crate::frontend::FrontendOptions;
 use crate::instance::FrontendInstance;
-use crate::service_config::{InfluxdbOptions, PromStoreOptions};
+use crate::service_config::{InfluxdbOptions, OtlpOptions, PromStoreOptions};
 
 pub(crate) struct Services;
 
@@ -176,6 +176,10 @@ impl Services {
                 Some(PromStoreOptions { enable: true })
             ) {
                 let _ = http_server_builder.with_prom_handler(instance.clone());
+            }
+
+            if matches!(opts.otlp_options, Some(OtlpOptions { enable: true })) {
+                let _ = http_server_builder.with_otlp_handler(instance.clone());
             }
 
             let http_server = http_server_builder

--- a/src/frontend/src/service_config/otlp.rs
+++ b/src/frontend/src/service_config/otlp.rs
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod grpc;
-pub mod influxdb;
-pub mod mysql;
-pub mod opentsdb;
-pub mod otlp;
-pub mod postgres;
-pub mod prom_store;
-pub mod prometheus;
+use serde::{Deserialize, Serialize};
 
-pub use grpc::GrpcOptions;
-pub use influxdb::InfluxdbOptions;
-pub use mysql::MysqlOptions;
-pub use opentsdb::OpentsdbOptions;
-pub use otlp::OtlpOptions;
-pub use postgres::PostgresOptions;
-pub use prom_store::PromStoreOptions;
-pub use prometheus::PrometheusOptions;
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OtlpOptions {
+    pub enable: bool,
+}
+
+impl Default for OtlpOptions {
+    fn default() -> Self {
+        Self { enable: true }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_otlp_options() {
+        let default = OtlpOptions::default();
+        assert!(default.enable);
+    }
+}

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -54,6 +54,7 @@ num_cpus = "1.13"
 once_cell = "1.16"
 openmetrics-parser = "0.4"
 opensrv-mysql = "0.4"
+opentelemetry-proto.workspace = true
 parking_lot = "0.12"
 pgwire = "0.15"
 pin-project = "1.0"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -14,7 +14,7 @@ aide = { version = "0.9", features = ["axum"] }
 api = { path = "../api" }
 arrow-flight.workspace = true
 async-trait = "0.1"
-axum = "0.6"
+axum = { version = "0.6", features = ["headers"] }
 axum-macros = "0.3"
 base64 = "0.13"
 bytes = "1.2"
@@ -40,6 +40,7 @@ datatypes = { path = "../datatypes" }
 derive_builder = "0.12"
 digest = "0.10"
 futures = "0.3"
+headers = "0.3"
 hex = { version = "0.4" }
 http-body = "0.4"
 humantime-serde = "1.1"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -91,6 +91,7 @@ tower-http = { version = "0.3", features = ["full"] }
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
+catalog = { path = "../catalog", features = ["testing"] }
 client = { path = "../client" }
 common-base = { path = "../common/base" }
 common-test-util = { path = "../common/test-util" }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -136,7 +136,7 @@ pub enum Error {
         source: common_grpc::error::Error,
     },
 
-    #[snafu(display("Failed to write OPTL metrics, source: {}", source))]
+    #[snafu(display("Failed to write OTLP metrics, source: {}", source))]
     OtlpMetricsWrite {
         location: Location,
         source: common_grpc::error::Error,

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -137,7 +137,7 @@ pub enum Error {
     },
 
     #[snafu(display("Failed to write OPTL metrics, source: {}", source))]
-    OptlMetricsWrite {
+    OtlpMetricsWrite {
         location: Location,
         source: common_grpc::error::Error,
     },
@@ -379,7 +379,7 @@ impl ErrorExt for Error {
 
             InfluxdbLinesWrite { source, .. }
             | PromSeriesWrite { source, .. }
-            | OptlMetricsWrite { source, .. } => source.status_code(),
+            | OtlpMetricsWrite { source, .. } => source.status_code(),
 
             Hyper { .. } => StatusCode::Unknown,
             TlsRequired { .. } => StatusCode::Unknown,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -15,6 +15,7 @@
 mod admin;
 pub mod authorize;
 pub mod handler;
+pub mod header;
 pub mod influxdb;
 pub mod mem_prof;
 pub mod opentsdb;

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use headers::{Header, HeaderName, HeaderValue};
+
+pub static GREPTIME_DB_NAME_HEADER_NAME: HeaderName = HeaderName::from_static("x-greptime-db-name");
+
+pub struct GreptimeDbName(Option<String>);
+
+impl Header for GreptimeDbName {
+    fn name() -> &'static HeaderName {
+        &GREPTIME_DB_NAME_HEADER_NAME
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>
+    where
+        Self: Sized,
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        if let Some(value) = values.next() {
+            let str_value = value.to_str().map_err(|_| headers::Error::invalid())?;
+            Ok(Self(Some(str_value.to_owned())))
+        } else {
+            Ok(Self(None))
+        }
+    }
+
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        if let Some(name) = &self.0 {
+            if let Ok(value) = HeaderValue::from_str(name) {
+                values.extend(std::iter::once(value));
+            }
+        }
+    }
+}
+
+impl GreptimeDbName {
+    pub fn value(&self) -> Option<&String> {
+        self.0.as_ref()
+    }
+}

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -14,59 +14,41 @@
 
 use std::sync::Arc;
 
-use axum::extract::{Query, RawBody, State};
+use axum::extract::{RawBody, State};
 use axum::http::header;
 use axum::response::IntoResponse;
-use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use axum::TypedHeader;
 use common_telemetry::timer;
 use hyper::Body;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     ExportMetricsServiceRequest, ExportMetricsServiceResponse,
 };
 use prost::Message;
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use session::context::QueryContext;
 use snafu::prelude::*;
 
 use crate::error::{self, Result};
+use crate::http::header::GreptimeDbName;
 use crate::parse_catalog_and_schema_from_client_database_name;
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-pub struct DatabaseQuery {
-    pub db: Option<String>,
-}
-
-impl Default for DatabaseQuery {
-    fn default() -> DatabaseQuery {
-        Self {
-            db: Some(DEFAULT_SCHEMA_NAME.to_string()),
-        }
-    }
-}
 
 #[axum_macros::debug_handler]
 pub async fn metrics(
     State(handler): State<OpenTelemetryProtocolHandlerRef>,
-    Query(params): Query<DatabaseQuery>,
+    TypedHeader(db): TypedHeader<GreptimeDbName>,
     RawBody(body): RawBody,
 ) -> Result<OtlpResponse> {
-    let request = parse_body(body).await?;
-    let _timer = timer!(
-        crate::metrics::METRIC_HTTP_OPENTELEMETRY_ELAPSED,
-        &[(
-            crate::metrics::METRIC_DB_LABEL,
-            params.db.clone().unwrap_or_default()
-        )]
-    );
-    let ctx = if let Some(db) = params.db {
-        let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
+    let ctx = if let Some(db) = db.value() {
+        let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(db);
         Arc::new(QueryContext::with(catalog, schema))
     } else {
         QueryContext::arc()
     };
-
+    let _timer = timer!(
+        crate::metrics::METRIC_HTTP_OPENTELEMETRY_ELAPSED,
+        &[(crate::metrics::METRIC_DB_LABEL, ctx.get_db_string())]
+    );
+    let request = parse_body(body).await?;
     handler.metrics(request, ctx).await.map(OtlpResponse)
 }
 

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use axum::extract::{Query, RawBody, State};
+use axum::http::header;
+use axum::response::IntoResponse;
+use common_catalog::consts::DEFAULT_SCHEMA_NAME;
+use common_telemetry::timer;
+use hyper::Body;
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
+use prost::Message;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use session::context::QueryContext;
+use snafu::prelude::*;
+
+use crate::error::{self, Result};
+use crate::parse_catalog_and_schema_from_client_database_name;
+use crate::query_handler::OpenTelemetryProtocolHandlerRef;
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DatabaseQuery {
+    pub db: Option<String>,
+}
+
+impl Default for DatabaseQuery {
+    fn default() -> DatabaseQuery {
+        Self {
+            db: Some(DEFAULT_SCHEMA_NAME.to_string()),
+        }
+    }
+}
+
+#[axum_macros::debug_handler]
+pub async fn metrics(
+    State(handler): State<OpenTelemetryProtocolHandlerRef>,
+    Query(params): Query<DatabaseQuery>,
+    RawBody(body): RawBody,
+) -> Result<OtlpResponse> {
+    let request = parse_body(body).await?;
+    let _timer = timer!(
+        crate::metrics::METRIC_HTTP_OPENTELEMETRY_ELAPSED,
+        &[(
+            crate::metrics::METRIC_DB_LABEL,
+            params.db.clone().unwrap_or_default()
+        )]
+    );
+    let ctx = if let Some(db) = params.db {
+        let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
+        Arc::new(QueryContext::with(catalog, schema))
+    } else {
+        QueryContext::arc()
+    };
+
+    handler.metrics(request, ctx).await.map(OtlpResponse)
+}
+
+async fn parse_body(body: Body) -> Result<ExportMetricsServiceRequest> {
+    hyper::body::to_bytes(body)
+        .await
+        .context(error::HyperSnafu)
+        .and_then(|buf| {
+            ExportMetricsServiceRequest::decode(&buf[..]).context(error::DecodeOtlpRequestSnafu)
+        })
+}
+
+pub struct OtlpResponse(ExportMetricsServiceResponse);
+
+impl IntoResponse for OtlpResponse {
+    fn into_response(self) -> axum::response::Response {
+        (
+            [(header::CONTENT_TYPE, "application/x-protobuf")],
+            self.0.encode_to_vec(),
+        )
+            .into_response()
+    }
+}

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -32,6 +32,7 @@ mod metrics;
 pub mod metrics_handler;
 pub mod mysql;
 pub mod opentsdb;
+pub mod otlp;
 pub mod postgres;
 pub mod prom_store;
 pub mod prometheus;

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -43,6 +43,7 @@ pub(crate) const METRIC_HTTP_INFLUXDB_WRITE_ELAPSED: &str = "servers.http_influx
 pub(crate) const METRIC_HTTP_PROM_STORE_WRITE_ELAPSED: &str =
     "servers.http_prometheus_write_elapsed";
 pub(crate) const METRIC_HTTP_PROM_STORE_READ_ELAPSED: &str = "servers.http_prometheus_read_elapsed";
+pub(crate) const METRIC_HTTP_OPENTELEMETRY_ELAPSED: &str = "servers.http_otlp_elapsed";
 pub(crate) const METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED: &str =
     "servers.opentsdb_line_write_elapsed";
 

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -88,14 +88,14 @@ fn write_attribute(lines: &mut LinesWriter, attr: &KeyValue) -> Result<()> {
         match val {
             any_value::Value::StringValue(s) => lines
                 .write_tag(&attr.key, s)
-                .context(error::OptlMetricsWriteSnafu)?,
+                .context(error::OtlpMetricsWriteSnafu)?,
 
             any_value::Value::IntValue(v) => lines
                 .write_tag(&normalize_otlp_name(&attr.key), &v.to_string())
-                .context(error::OptlMetricsWriteSnafu)?,
+                .context(error::OtlpMetricsWriteSnafu)?,
             any_value::Value::DoubleValue(v) => lines
                 .write_tag(&normalize_otlp_name(&attr.key), &v.to_string())
-                .context(error::OptlMetricsWriteSnafu)?,
+                .context(error::OtlpMetricsWriteSnafu)?,
             // TODO(sunng87): allow different type of values
             _ => {}
         }
@@ -107,7 +107,7 @@ fn write_attribute(lines: &mut LinesWriter, attr: &KeyValue) -> Result<()> {
 fn write_timestamp(lines: &mut LinesWriter, time_nano: i64) -> Result<()> {
     lines
         .write_ts(GREPTIME_TIMESTAMP, (time_nano, Precision::Nanosecond))
-        .context(error::OptlMetricsWriteSnafu)?;
+        .context(error::OtlpMetricsWriteSnafu)?;
     Ok(())
 }
 
@@ -130,12 +130,12 @@ fn encode_gauge(name: &str, gauge: &Gauge) -> Result<InsertRequest> {
                 // we coerce all values to f64
                 lines
                     .write_f64(GREPTIME_VALUE, val as f64)
-                    .context(error::OptlMetricsWriteSnafu)?
+                    .context(error::OtlpMetricsWriteSnafu)?
             }
             Some(number_data_point::Value::AsDouble(val)) => {
                 lines
                     .write_f64(GREPTIME_VALUE, val)
-                    .context(error::OptlMetricsWriteSnafu)?
+                    .context(error::OtlpMetricsWriteSnafu)?
             }
             _ => {}
         }
@@ -170,12 +170,12 @@ fn encode_sum(name: &str, sum: &Sum) -> Result<InsertRequest> {
                 // we coerce all values to f64
                 lines
                     .write_f64(GREPTIME_VALUE, val as f64)
-                    .context(error::OptlMetricsWriteSnafu)?
+                    .context(error::OtlpMetricsWriteSnafu)?
             }
             Some(number_data_point::Value::AsDouble(val)) => {
                 lines
                     .write_f64(GREPTIME_VALUE, val)
-                    .context(error::OptlMetricsWriteSnafu)?
+                    .context(error::OtlpMetricsWriteSnafu)?
             }
             _ => {}
         }
@@ -208,19 +208,19 @@ fn encode_histogram(name: &str, hist: &Histogram) -> Result<InsertRequest> {
             // here we don't store bucket boundary
             lines
                 .write_u64(&format!("bucket_{}", idx), *count)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         if let Some(min) = data_point.min {
             lines
                 .write_f64("min", min)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         if let Some(max) = data_point.max {
             lines
                 .write_f64("max", max)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         lines.commit();
@@ -255,7 +255,7 @@ fn encode_exponential_histogram(name: &str, hist: &ExponentialHistogram) -> Resu
                         &format!("bucket_{}", idx + positive_buckets.offset as usize),
                         *count,
                     )
-                    .context(error::OptlMetricsWriteSnafu)?;
+                    .context(error::OtlpMetricsWriteSnafu)?;
             }
         }
 
@@ -266,20 +266,20 @@ fn encode_exponential_histogram(name: &str, hist: &ExponentialHistogram) -> Resu
                         &format!("bucket_{}", idx + negative_buckets.offset as usize),
                         *count,
                     )
-                    .context(error::OptlMetricsWriteSnafu)?;
+                    .context(error::OtlpMetricsWriteSnafu)?;
             }
         }
 
         if let Some(min) = data_point.min {
             lines
                 .write_f64("min", min)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         if let Some(max) = data_point.max {
             lines
                 .write_f64("max", max)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         lines.commit();
@@ -308,12 +308,12 @@ fn encode_summary(name: &str, summary: &Summary) -> Result<InsertRequest> {
             // here we don't store bucket boundary
             lines
                 .write_f64(&format!("p{:02}", quantile.quantile), quantile.value)
-                .context(error::OptlMetricsWriteSnafu)?;
+                .context(error::OtlpMetricsWriteSnafu)?;
         }
 
         lines
             .write_u64("count", data_point.count)
-            .context(error::OptlMetricsWriteSnafu)?;
+            .context(error::OtlpMetricsWriteSnafu)?;
 
         lines.commit();
     }

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -70,14 +70,14 @@ fn encode_metrics(metric: &Metric) -> Result<Option<InsertRequest>> {
     // note that we don't store description or unit, we might want to deal with
     // these fields in the future.
     if let Some(data) = &metric.data {
-        let inserts = match data {
-            metric::Data::Gauge(gauge) => encode_gauge(name, gauge)?,
-            metric::Data::Sum(sum) => encode_sum(name, sum)?,
-            metric::Data::Histogram(hist) => encode_histogram(name, hist)?,
-            metric::Data::ExponentialHistogram(hist) => encode_exponential_histogram(name, hist)?,
-            metric::Data::Summary(summary) => encode_summary(name, summary)?,
-        };
-        Ok(Some(inserts))
+        match data {
+            metric::Data::Gauge(gauge) => encode_gauge(name, gauge).map(Some),
+            metric::Data::Sum(sum) => encode_sum(name, sum).map(Some),
+            metric::Data::Summary(summary) => encode_summary(name, summary).map(Some),
+            // TODO(sunng87) leave histogram for next release
+            metric::Data::Histogram(_hist) => Ok(None),
+            metric::Data::ExponentialHistogram(_hist) => Ok(None),
+        }
     } else {
         Ok(None)
     }
@@ -192,6 +192,8 @@ fn encode_sum(name: &str, sum: &Sum) -> Result<InsertRequest> {
     })
 }
 
+// TODO(sunng87): we may need better implementation for histogram
+#[allow(dead_code)]
 fn encode_histogram(name: &str, hist: &Histogram) -> Result<InsertRequest> {
     let mut lines = LinesWriter::with_lines(hist.data_points.len());
 
@@ -233,6 +235,7 @@ fn encode_histogram(name: &str, hist: &Histogram) -> Result<InsertRequest> {
     })
 }
 
+#[allow(dead_code)]
 fn encode_exponential_histogram(name: &str, hist: &ExponentialHistogram) -> Result<InsertRequest> {
     let mut lines = LinesWriter::with_lines(hist.data_points.len());
 

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -1,0 +1,169 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::{InsertRequest, InsertRequests};
+use common_grpc::writer::{LinesWriter, Precision};
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::common::v1::{any_value, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1::{metric, number_data_point, *};
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+
+const GREPTIME_TIMESTAMP: &str = "greptime_timestamp";
+const GREPTIME_VALUE: &str = "greptime_value";
+
+/// Normalize otlp instrumentation, metric and attribute names
+///
+/// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax
+/// - since the name are case-insensitive, we transform them to lowercase for
+/// better sql usability
+/// - replace `.` and `-` with `_`
+fn normalize_otlp_name(name: &str) -> String {
+    name.to_lowercase().replace(|c| c == '.' || c == '-', "_")
+}
+
+/// Convert OpenTelemetry metrics to GreptimeDB insert requests
+///
+/// See
+/// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/metrics/v1/metrics.proto#L162
+/// for data structure of OTLP metrics.
+pub fn to_grpc_insert_requests(request: ExportMetricsServiceRequest) -> Result<InsertRequests> {
+    let metrics = request
+        .resource_metrics
+        .iter()
+        .flat_map(|resource_metrics| &resource_metrics.scope_metrics)
+        .flat_map(|scope_metrics| &scope_metrics.metrics);
+
+    let mut insert_batch = Vec::with_capacity(metrics.size_hint().0);
+    for metric in metrics {
+        if let Some(insert) = encode_metrics(metric)? {
+            insert_batch.push(insert);
+        }
+    }
+
+    let inserts = InsertRequests {
+        inserts: insert_batch,
+    };
+
+    Ok(inserts)
+}
+
+fn encode_metrics(metric: &Metric) -> Result<Option<InsertRequest>> {
+    let name = &metric.name;
+    // note that we don't store description or unit, we might want to deal with
+    // these fields in the future.
+    if let Some(data) = &metric.data {
+        let inserts = match data {
+            metric::Data::Gauge(gauge) => encode_gauge(name, gauge)?,
+            metric::Data::Sum(sum) => encode_sum(name, sum)?,
+            _ => {
+                todo!()
+            }
+        };
+        Ok(Some(inserts))
+    } else {
+        Ok(None)
+    }
+}
+
+fn write_attribute(lines: &mut LinesWriter, attr: &KeyValue) -> Result<()> {
+    if let Some(val) = attr.value.as_ref().and_then(|v| v.value.as_ref()) {
+        match val {
+            any_value::Value::StringValue(s) => lines
+                .write_tag(&attr.key, s)
+                .context(error::OptlMetricsWriteSnafu)?,
+
+            any_value::Value::IntValue(v) => lines
+                .write_tag(&normalize_otlp_name(&attr.key), &v.to_string())
+                .context(error::OptlMetricsWriteSnafu)?,
+            any_value::Value::DoubleValue(v) => lines
+                .write_tag(&normalize_otlp_name(&attr.key), &v.to_string())
+                .context(error::OptlMetricsWriteSnafu)?,
+            // TODO(sunng87): allow different type of values
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn write_timestamp(lines: &mut LinesWriter, time_nano: i64) -> Result<()> {
+    lines
+        .write_ts(GREPTIME_TIMESTAMP, (time_nano, Precision::Nanosecond))
+        .context(error::OptlMetricsWriteSnafu)?;
+    Ok(())
+}
+
+/// encode this gauge metric
+///
+/// note that there can be multiple data points in the request, it's going to be
+/// stored as multiple rows
+fn encode_gauge(name: &str, gauge: &Gauge) -> Result<InsertRequest> {
+    let mut lines = LinesWriter::with_lines(gauge.data_points.len());
+
+    for data_point in &gauge.data_points {
+        // TODO(sunng87): pull up this
+        for attr in &data_point.attributes {
+            write_attribute(&mut lines, attr)?;
+        }
+
+        write_timestamp(&mut lines, data_point.time_unix_nano as i64)?;
+
+        match data_point.value {
+            Some(number_data_point::Value::AsInt(val)) => {
+                // we coerce all values to f64
+                lines
+                    .write_f64(GREPTIME_VALUE, val as f64)
+                    .context(error::OptlMetricsWriteSnafu)?
+            }
+            Some(number_data_point::Value::AsDouble(val)) => {
+                lines
+                    .write_f64(GREPTIME_VALUE, val)
+                    .context(error::OptlMetricsWriteSnafu)?
+            }
+            _ => {}
+        }
+
+        lines.commit();
+    }
+
+    let (columns, row_count) = lines.finish();
+    Ok(InsertRequest {
+        table_name: normalize_otlp_name(name),
+        region_number: 0,
+        columns,
+        row_count,
+    })
+}
+
+/// encode this sum metric
+fn encode_sum(_name: &str, _sum: &Sum) -> Result<InsertRequest> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_normalize_otlp_name() {
+        assert_eq!(normalize_otlp_name("jvm.memory.free"), "jvm_memory_free");
+        assert_eq!(normalize_otlp_name("jvm-memory-free"), "jvm_memory_free");
+        assert_eq!(normalize_otlp_name("jvm_memory_free"), "jvm_memory_free");
+        assert_eq!(normalize_otlp_name("JVM_MEMORY_FREE"), "jvm_memory_free");
+        assert_eq!(normalize_otlp_name("JVM_memory_FREE"), "jvm_memory_free");
+    }
+}

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -31,6 +31,9 @@ use std::sync::Arc;
 use api::prom_store::remote::{ReadRequest, WriteRequest};
 use async_trait::async_trait;
 use common_query::Output;
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
 use session::context::QueryContextRef;
 
 use crate::error::Result;
@@ -41,6 +44,7 @@ use crate::prom_store::Metrics;
 pub type OpentsdbProtocolHandlerRef = Arc<dyn OpentsdbProtocolHandler + Send + Sync>;
 pub type InfluxdbLineProtocolHandlerRef = Arc<dyn InfluxdbLineProtocolHandler + Send + Sync>;
 pub type PromStoreProtocolHandlerRef = Arc<dyn PromStoreProtocolHandler + Send + Sync>;
+pub type OpenTelemetryProtocolHandlerRef = Arc<dyn OpenTelemetryProtocolHandler + Send + Sync>;
 pub type ScriptHandlerRef = Arc<dyn ScriptHandler + Send + Sync>;
 
 #[async_trait]
@@ -82,4 +86,14 @@ pub trait PromStoreProtocolHandler {
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse>;
     /// Handling push gateway requests
     async fn ingest_metrics(&self, metrics: Metrics) -> Result<()>;
+}
+
+#[async_trait]
+pub trait OpenTelemetryProtocolHandler {
+    /// Handling opentelemetry metrics request
+    async fn metrics(
+        &self,
+        request: ExportMetricsServiceRequest,
+        ctx: QueryContextRef,
+    ) -> Result<ExportMetricsServiceResponse>;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

After some investigation we found OTLP might be the most promising push-based protocol for metrics. We are going to add OTLP based examples on our cloud onboarding process. This patch is going to add otlp/http support on greptimedb.

Reference:
- OTLP: https://opentelemetry.io/docs/specs/otlp/#otlphttp
- Java Demo: https://github.com/sunng87/opentelemetry-java-examples/blob/metric-otlp-example/metrics/src/main/java/io/opentelemetry/example/metrics/GaugeExample.java

### Tasks

- [x] http api and handlers
- [x] interceptor
- [x] support for metrics types
  - [x] gauge
  - [x] sum
  - [x] ~~histogram~~ defer to next patch due undecided data modeling for histogram
  - [x] ~~exponential histogram~~ defer to next patch
  - [x] summary
- [x] metrics
- [x] database header
- [x] ~~integration tests~~ defer to next patch

### What we stored in this patch:

- Gauge
  - Every attribute are stored as tag
  - value is stored as field `greptime_value` following the convention of prometheus interface
  - timestamp is stored as `greptime_timestamp` too
- Sum
  - Same as gauge. 
- Summary 
  - Every attribute are stored as tag
  - count is stored as field `count`
  - Every quantile value is stored as `pxx` column
- Histogram: histogram is implemented but I want further discussion with community about its data modelling, so disabled for now

### DB Name and authentication

Some otlp clients doesn't support url query string (javascript client for example), so here we add http header `x-greptime-db-name` for providing database name.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
