### PR TITLE
refactor: move heartbeat configuration into an independent section

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -10,8 +10,10 @@ rpc_addr = "127.0.0.1:3001"
 rpc_hostname = "127.0.0.1"
 # The number of gRPC server worker threads, 8 by default.
 rpc_runtime_size = 8
+
+[heartbeat]
 # Interval for sending heartbeat messages to the Metasrv in milliseconds, 5000 by default.
-heartbeat_interval_millis = 5000
+interval_millis = 5000
 
 # Metasrv client options.
 [meta_client_options]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -1,7 +1,9 @@
 # Node running mode, see `standalone.example.toml`.
 mode = "distributed"
+
+[heartbeat]
 # Interval for sending heartbeat task to the Metasrv in milliseconds, 5000 by default.
-heartbeat_interval_millis = 5000
+interval_millis = 5000
 # Interval for retry sending heartbeat task in milliseconds, 5000 by default.
 retry_interval_millis = 5000
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -26,6 +26,7 @@ use common_telemetry::logging::LoggingOptions;
 use meta_client::MetaClientOptions;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
+use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
 use servers::Mode;
 use snafu::ResultExt;
@@ -354,7 +355,7 @@ pub struct DatanodeOptions {
     pub rpc_addr: String,
     pub rpc_hostname: Option<String>,
     pub rpc_runtime_size: usize,
-    pub heartbeat_interval_millis: u64,
+    pub heartbeat: HeartbeatOptions,
     pub http_opts: HttpOptions,
     pub meta_client_options: Option<MetaClientOptions>,
     pub wal: WalConfig,
@@ -378,7 +379,7 @@ impl Default for DatanodeOptions {
             storage: StorageConfig::default(),
             procedure: ProcedureConfig::default(),
             logging: LoggingOptions::default(),
-            heartbeat_interval_millis: 5000,
+            heartbeat: HeartbeatOptions::default(),
         }
     }
 }

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -148,7 +148,7 @@ impl Instance {
                     meta_client,
                     catalog_manager,
                     Arc::new(handlers_executor),
-                    opts.heartbeat_interval_millis,
+                    opts.heartbeat.interval_millis,
                     region_alive_keepers,
                 ))
             }
@@ -248,7 +248,7 @@ impl Instance {
 
                 let region_alive_keepers = Arc::new(RegionAliveKeepers::new(
                     engine_manager.clone(),
-                    opts.heartbeat_interval_millis,
+                    opts.heartbeat.interval_millis,
                 ));
 
                 let catalog_manager = Arc::new(RemoteCatalogManager::new(

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -15,6 +15,7 @@
 use common_telemetry::logging::LoggingOptions;
 use meta_client::MetaClientOptions;
 use serde::{Deserialize, Serialize};
+use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
 use servers::Mode;
 
@@ -27,8 +28,7 @@ use crate::service_config::{
 #[serde(default)]
 pub struct FrontendOptions {
     pub mode: Mode,
-    pub heartbeat_interval_millis: u64,
-    pub retry_interval_millis: u64,
+    pub heartbeat: HeartbeatOptions,
     pub http_options: Option<HttpOptions>,
     pub grpc_options: Option<GrpcOptions>,
     pub mysql_options: Option<MysqlOptions>,
@@ -45,8 +45,7 @@ impl Default for FrontendOptions {
     fn default() -> Self {
         Self {
             mode: Mode::Standalone,
-            heartbeat_interval_millis: 5000,
-            retry_interval_millis: 5000,
+            heartbeat: HeartbeatOptions::default(),
             http_options: Some(HttpOptions::default()),
             grpc_options: Some(GrpcOptions::default()),
             mysql_options: Some(MysqlOptions::default()),

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -22,6 +22,7 @@ use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MailboxRef, OutgoingMess
 use common_meta::heartbeat::utils::outgoing_message_to_mailbox_message;
 use common_telemetry::{debug, error, info};
 use meta_client::client::{HeartbeatSender, HeartbeatStream, MetaClient};
+use servers::heartbeat_options::HeartbeatOptions;
 use snafu::ResultExt;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
@@ -43,14 +44,13 @@ pub struct HeartbeatTask {
 impl HeartbeatTask {
     pub fn new(
         meta_client: Arc<MetaClient>,
-        heartbeat_interval_millis: u64,
-        retry_interval_millis: u64,
+        heartbeat: HeartbeatOptions,
         resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
     ) -> Self {
         HeartbeatTask {
             meta_client,
-            report_interval: heartbeat_interval_millis,
-            retry_interval: retry_interval_millis,
+            report_interval: heartbeat.interval_millis,
+            retry_interval: heartbeat.retry_interval_millis,
             resp_handler_executor,
         }
     }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -200,8 +200,7 @@ impl Instance {
 
         let heartbeat_task = Some(HeartbeatTask::new(
             meta_client,
-            opts.heartbeat_interval_millis,
-            opts.retry_interval_millis,
+            opts.heartbeat.clone(),
             Arc::new(handlers_executor),
         ));
 

--- a/src/servers/src/heartbeat_options.rs
+++ b/src/servers/src/heartbeat_options.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct HeartbeatOptions {
+    pub interval_millis: u64,
+    pub retry_interval_millis: u64,
+}
+
+impl Default for HeartbeatOptions {
+    fn default() -> Self {
+        Self {
+            interval_millis: 5000,
+            retry_interval_millis: 5000,
+        }
+    }
+}

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -24,6 +24,7 @@ pub mod auth;
 pub mod configurator;
 pub mod error;
 pub mod grpc;
+pub mod heartbeat_options;
 pub mod http;
 pub mod influxdb;
 pub mod interceptor;

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -511,7 +511,10 @@ pub async fn test_config_api(store_type: StorageType) {
     enable_memory_catalog = false
     rpc_addr = "127.0.0.1:3001"
     rpc_runtime_size = 8
-    heartbeat_interval_millis = 5000
+
+    [heartbeat]
+    interval_millis = 5000
+    retry_interval_millis = 5000
 
     [http_opts]
     addr = "127.0.0.1:4000"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

move heartbeat configuration into an independent section in config file, add a new HeartbeatOptions struct, use it instead heartbeat_interval_millis and retry_interval_millis, change HeartbeatTask::new() to take it as argument, and change corresponding test cases and example files.

* refactor: move heartbeat configuration into an independent section in config file
* feat: add HeartbeatOptions struct
* test: modify corresponding test case
* chore: modify corresponding example file

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1936