### PR TITLE
refactor: move DatanodeAlterTable after InvalidateTableCache

### DIFF
--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use catalog::helper::TableGlobalValue;
 use clap::Parser;
+use common_meta::helper::TableGlobalValue;
 use common_meta::key::datanode_table::{DatanodeTableKey, DatanodeTableValue};
 use common_meta::key::table_info::{TableInfoKey, TableInfoValue};
 use common_meta::key::table_name::{TableNameKey, TableNameValue};

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -514,16 +514,6 @@ impl DistInstance {
             .await
             .context(error::RequestMetaSnafu)?;
 
-        let table_info = table.table_info();
-        self.catalog_manager
-            .invalidate_table(
-                &table_info.catalog_name,
-                &table_info.schema_name,
-                &table_info.name,
-                table_info.table_id(),
-            )
-            .await;
-
         Ok(Output::AffectedRows(0))
     }
 

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -357,16 +357,13 @@ impl Procedure for RegionFailoverProcedure {
 
     fn lock_key(&self) -> LockKey {
         let region_ident = &self.node.failed_region;
-        let key = format!(
-            "{}/region-{}",
-            common_catalog::format_full_table_name(
-                &region_ident.table_ident.catalog,
-                &region_ident.table_ident.schema,
-                &region_ident.table_ident.table
-            ),
-            region_ident.region_number
+        let table_key = common_catalog::format_full_table_name(
+            &region_ident.table_ident.catalog,
+            &region_ident.table_ident.schema,
+            &region_ident.table_ident.table,
         );
-        LockKey::single(key)
+        let region_key = format!("{}/region-{}", table_key, region_ident.region_number);
+        LockKey::new(vec![table_key, region_key])
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Move AlterProcedure `DatanodeAlterTable` step after `InvalidateTableCache`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
