### PR TITLE
fix: fix wait procedure watcher bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,6 +4301,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5107,6 +5118,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -8697,6 +8714,7 @@ dependencies = [
  "digest",
  "futures",
  "hex",
+ "hostname",
  "http-body",
  "humantime-serde",
  "hyper",

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -545,7 +545,7 @@ impl TaskFunction<Error> for RemoveOutdatedMetaFunction {
 
 /// Create a new [ProcedureMeta] for test purpose.
 #[cfg(test)]
-mod test_util {
+pub(crate) mod test_util {
     use common_test_util::temp_dir::TempDir;
     use object_store::services::Fs as Builder;
     use object_store::ObjectStore;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix waiting for the watcher bug. It should wait for the retrying instead of throwing an error. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
