### PR TITLE
chore!: change logstore namespace prefix

### DIFF
--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -33,7 +33,7 @@ use crate::error::{
 };
 use crate::raft_engine::protos::logstore::{EntryImpl, NamespaceImpl as Namespace};
 
-const NAMESPACE_PREFIX: &str = "__sys_namespace_";
+const NAMESPACE_PREFIX: &str = "$sys_namespace$";
 const SYSTEM_NAMESPACE: u64 = 0;
 
 pub struct RaftEngineLogStore {

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -33,7 +33,7 @@ use crate::error::{
 };
 use crate::raft_engine::protos::logstore::{EntryImpl, NamespaceImpl as Namespace};
 
-const NAMESPACE_PREFIX: &str = "$sys_namespace$";
+const NAMESPACE_PREFIX: &str = "$sys/";
 const SYSTEM_NAMESPACE: u64 = 0;
 
 pub struct RaftEngineLogStore {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR changes the prefix of reserved keys of logstore implementation based on raft-engine, in that later raft-engine releases use `__sys_` as their reserved prefix.

This is a breaking change that may corrupt existing data.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
