### PR TITLE
feat(mito): create region in mito2 engine

### DIFF
--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -14,6 +14,7 @@
 
 //! Configurations.
 
+use common_datasource::compression::CompressionType;
 use common_telemetry::logging;
 
 const DEFAULT_NUM_WORKERS: usize = 1;
@@ -21,12 +22,20 @@ const DEFAULT_NUM_WORKERS: usize = 1;
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
 #[derive(Debug)]
 pub struct MitoConfig {
+    // Worker configs:
     /// Number of region workers.
     pub num_workers: usize,
     /// Request channel size of each worker.
     pub worker_channel_size: usize,
     /// Max batch size for a worker to handle requests.
     pub worker_request_batch_size: usize,
+
+    // Manifest configs:
+    /// Number of meta action updated to trigger a new checkpoint
+    /// for the manifest. `None` to disable checkpoint.
+    pub manifest_checkpoint_interval: u64,
+    /// Manifest compression type.
+    pub manifest_compress_type: CompressionType,
 }
 
 impl Default for MitoConfig {
@@ -35,6 +44,8 @@ impl Default for MitoConfig {
             num_workers: DEFAULT_NUM_WORKERS,
             worker_channel_size: 128,
             worker_request_batch_size: 64,
+            manifest_checkpoint_interval: 10,
+            manifest_compress_type: CompressionType::Uncompressed,
         }
     }
 }

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -14,10 +14,14 @@
 
 //! Configurations.
 
+use common_base::readable_size::ReadableSize;
 use common_datasource::compression::CompressionType;
 use common_telemetry::logging;
 
+/// Default region worker num.
 const DEFAULT_NUM_WORKERS: usize = 1;
+/// Default region write buffer size.
+pub(crate) const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(32);
 
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
 #[derive(Debug)]

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -27,18 +27,18 @@ pub(crate) const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(32);
 #[derive(Debug)]
 pub struct MitoConfig {
     // Worker configs:
-    /// Number of region workers.
+    /// Number of region workers (default 1).
     pub num_workers: usize,
-    /// Request channel size of each worker.
+    /// Request channel size of each worker (default 128).
     pub worker_channel_size: usize,
-    /// Max batch size for a worker to handle requests.
+    /// Max batch size for a worker to handle requests (default 64).
     pub worker_request_batch_size: usize,
 
     // Manifest configs:
     /// Number of meta action updated to trigger a new checkpoint
-    /// for the manifest. `None` to disable checkpoint.
+    /// for the manifest (default 10).
     pub manifest_checkpoint_interval: u64,
-    /// Manifest compression type.
+    /// Manifest compression type (default uncompressed).
     pub manifest_compress_type: CompressionType,
 }
 

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Mito region engine.
+
+#[cfg(test)]
+mod tests;
+
 use std::sync::Arc;
 
 use object_store::ObjectStore;
@@ -84,19 +89,5 @@ impl EngineInner {
         self.workers.submit_to_worker(request).await?;
 
         receiver.await.context(RecvSnafu)?
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test_util::TestEnv;
-
-    #[tokio::test]
-    async fn test_engine_new_stop() {
-        let env = TestEnv::new("engine-stop");
-        let engine = env.create_engine(MitoConfig::default()).await;
-
-        engine.stop().await.unwrap();
     }
 }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use object_store::ObjectStore;
 use snafu::ResultExt;
 use store_api::logstore::LogStore;
+use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
 use crate::error::{RecvSnafu, Result};
@@ -57,6 +58,11 @@ impl MitoEngine {
     /// Creates a new region.
     pub async fn create_region(&self, request: CreateRequest) -> Result<()> {
         self.inner.create_region(request).await
+    }
+
+    /// Returns true if the specific region exists.
+    pub fn is_region_exists(&self, region_id: RegionId) -> bool {
+        self.inner.workers.is_region_exists(region_id)
     }
 }
 

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -69,7 +69,7 @@ impl EngineInner {
         object_store: ObjectStore,
     ) -> EngineInner {
         EngineInner {
-            workers: WorkerGroup::start(&config, log_store, object_store),
+            workers: WorkerGroup::start(config, log_store, object_store),
         }
     }
 

--- a/src/mito2/src/engine/tests.rs
+++ b/src/mito2/src/engine/tests.rs
@@ -1,0 +1,26 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for mito engine.
+
+use super::*;
+use crate::test_util::TestEnv;
+
+#[tokio::test]
+async fn test_engine_new_stop() {
+    let env = TestEnv::new("engine-stop");
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    engine.stop().await.unwrap();
+}

--- a/src/mito2/src/engine/tests.rs
+++ b/src/mito2/src/engine/tests.rs
@@ -14,8 +14,10 @@
 
 //! Tests for mito engine.
 
+use store_api::storage::RegionId;
+
 use super::*;
-use crate::test_util::TestEnv;
+use crate::test_util::{CreateRequestMocker, TestEnv};
 
 #[tokio::test]
 async fn test_engine_new_stop() {
@@ -23,4 +25,13 @@ async fn test_engine_new_stop() {
     let engine = env.create_engine(MitoConfig::default()).await;
 
     engine.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_engine_create_new_region() {
+    let env = TestEnv::new("engine-stop");
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let request = CreateRequestMocker::new(RegionId::new(1, 1)).build();
+    engine.create_region(request).await.unwrap();
 }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -19,6 +19,7 @@ use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use snafu::{Location, Snafu};
 use store_api::manifest::ManifestVersion;
+use store_api::storage::RegionId;
 
 use crate::worker::WorkerId;
 
@@ -110,6 +111,12 @@ pub enum Error {
         source: datatypes::error::Error,
         location: Location,
     },
+
+    #[snafu(display("Region {} already exists, location: {}", region_id, location))]
+    RegionExists {
+        region_id: RegionId,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -120,9 +127,11 @@ impl ErrorExt for Error {
 
         match self {
             OpenDal { .. } => StatusCode::StorageUnavailable,
-            CompressObject { .. } | DecompressObject { .. } | SerdeJson { .. } | Utf8 { .. } => {
-                StatusCode::Unexpected
-            }
+            CompressObject { .. }
+            | DecompressObject { .. }
+            | SerdeJson { .. }
+            | Utf8 { .. }
+            | RegionExists { .. } => StatusCode::Unexpected,
             InvalidScanIndex { .. }
             | InitialMetadata { .. }
             | InvalidMeta { .. }

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -292,7 +292,7 @@ mod test {
     async fn create_region_without_initial_metadata() {
         let env = TestEnv::new("");
         let result = env
-            .create_manifest_manager(CompressionType::Uncompressed, None, None)
+            .create_manifest_manager(CompressionType::Uncompressed, 10, None)
             .await;
         assert!(matches!(
             result.err().unwrap(),
@@ -305,7 +305,7 @@ mod test {
         let metadata = basic_region_metadata();
         let env = TestEnv::new("");
         let manager = env
-            .create_manifest_manager(CompressionType::Uncompressed, None, Some(metadata.clone()))
+            .create_manifest_manager(CompressionType::Uncompressed, 10, Some(metadata.clone()))
             .await
             .unwrap();
 
@@ -318,7 +318,7 @@ mod test {
         let metadata = basic_region_metadata();
         let env = TestEnv::new("");
         let manager = env
-            .create_manifest_manager(CompressionType::Uncompressed, None, Some(metadata.clone()))
+            .create_manifest_manager(CompressionType::Uncompressed, 10, Some(metadata.clone()))
             .await
             .unwrap();
 

--- a/src/mito2/src/manifest/options.rs
+++ b/src/mito2/src/manifest/options.rs
@@ -26,8 +26,10 @@ pub struct RegionManifestOptions {
     pub compress_type: CompressionType,
     /// Interval of version ([ManifestVersion](store_api::manifest::ManifestVersion)) between two checkpoints
     /// `None` means disable checkpoint.
+    // TODO(yingwen): Remove Option.
     pub checkpoint_interval: Option<u64>,
     /// Initial [RegionMetadata](crate::metadata::RegionMetadata) of this region.
     /// Only need to set when create a new region, otherwise it will be ignored.
+    // TODO(yingwen): Could we pass RegionMetadataRef?
     pub initial_metadata: Option<RegionMetadata>,
 }

--- a/src/mito2/src/manifest/options.rs
+++ b/src/mito2/src/manifest/options.rs
@@ -26,8 +26,7 @@ pub struct RegionManifestOptions {
     pub compress_type: CompressionType,
     /// Interval of version ([ManifestVersion](store_api::manifest::ManifestVersion)) between two checkpoints
     /// `None` means disable checkpoint.
-    // TODO(yingwen): Remove Option.
-    pub checkpoint_interval: Option<u64>,
+    pub checkpoint_interval: u64,
     /// Initial [RegionMetadata](crate::metadata::RegionMetadata) of this region.
     /// Only need to set when create a new region, otherwise it will be ignored.
     // TODO(yingwen): Could we pass RegionMetadataRef?

--- a/src/mito2/src/manifest/options.rs
+++ b/src/mito2/src/manifest/options.rs
@@ -24,8 +24,7 @@ pub struct RegionManifestOptions {
     pub manifest_dir: String,
     pub object_store: ObjectStore,
     pub compress_type: CompressionType,
-    /// Interval of version ([ManifestVersion](store_api::manifest::ManifestVersion)) between two checkpoints
-    /// `None` means disable checkpoint.
+    /// Interval of version ([ManifestVersion](store_api::manifest::ManifestVersion)) between two checkpoints.
     pub checkpoint_interval: u64,
     /// Initial [RegionMetadata](crate::metadata::RegionMetadata) of this region.
     /// Only need to set when create a new region, otherwise it will be ignored.

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -27,6 +27,9 @@ use store_api::storage::{ColumnId, RegionId};
 use crate::error::{InvalidMetaSnafu, InvalidSchemaSnafu, Result};
 use crate::region::VersionNumber;
 
+/// Initial version number of a new region.
+pub(crate) const INIT_REGION_VERSION: VersionNumber = 0;
+
 #[cfg_attr(doc, aquamarine::aquamarine)]
 /// Static metadata of a region.
 ///

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -60,6 +60,9 @@ pub struct RegionMetadata {
     /// Latest schema constructed from [column_metadatas](RegionMetadata::column_metadatas).
     #[serde(skip)]
     pub schema: SchemaRef,
+
+    // We don't pub `time_index` and `id_to_index` and always construct them via [SkippedFields]
+    // so we can assumes they are valid.
     /// Id of the time index column.
     #[serde(skip)]
     time_index: ColumnId,
@@ -156,6 +159,22 @@ impl SkippedFields {
 }
 
 impl RegionMetadata {
+    /// Find column by id.
+    pub(crate) fn column_by_id(&self, column_id: ColumnId) -> Option<&ColumnMetadata> {
+        self.id_to_index
+            .get(&column_id)
+            .map(|index| &self.column_metadatas[*index])
+    }
+
+    /// Returns the time index column
+    ///
+    /// # Panics
+    /// Panics if the time index column id is invalid.
+    pub(crate) fn time_index_column(&self) -> &ColumnMetadata {
+        let index = self.id_to_index[&self.time_index];
+        &self.column_metadatas[index]
+    }
+
     /// Checks whether the metadata is valid.
     fn validate(&self) -> Result<()> {
         // Id to name.
@@ -188,6 +207,17 @@ impl RegionMetadata {
             num_time_index == 1,
             InvalidMetaSnafu {
                 reason: format!("expect only one time index, found {}", num_time_index),
+            }
+        );
+
+        // Checks the time index column is not nullable.
+        ensure!(
+            !self.time_index_column().column_schema.is_nullable(),
+            InvalidMetaSnafu {
+                reason: format!(
+                    "time index column {} must be NOT NULL",
+                    self.time_index_column().column_schema.name
+                ),
             }
         );
 
@@ -366,6 +396,17 @@ mod test {
     }
 
     #[test]
+    fn test_region_metadata() {
+        let region_metadata = build_test_region_metadata();
+        assert_eq!("c", region_metadata.time_index_column().column_schema.name);
+        assert_eq!(
+            "a",
+            region_metadata.column_by_id(1).unwrap().column_schema.name
+        );
+        assert_eq!(None, region_metadata.column_by_id(10));
+    }
+
+    #[test]
     fn test_region_metadata_serde() {
         let region_metadata = build_test_region_metadata();
         let serialized = serde_json::to_string(&region_metadata).unwrap();
@@ -534,6 +575,27 @@ mod test {
         assert!(
             err.to_string()
                 .contains("column ts is already a time index column"),
+            "unexpected err: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_nullable_time_index() {
+        let mut builder = create_builder();
+        builder.push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                true,
+            ),
+            semantic_type: SemanticType::Timestamp,
+            column_id: 1,
+        });
+        let err = builder.build().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("time index column ts must be NOT NULL"),
             "unexpected err: {}",
             err
         );

--- a/src/mito2/src/metadata.rs
+++ b/src/mito2/src/metadata.rs
@@ -428,8 +428,7 @@ mod test {
         let err = builder.build().unwrap_err();
         assert!(
             err.to_string().contains("ts is not timestamp compatible"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -440,8 +439,7 @@ mod test {
         // A region must have a time index.
         assert!(
             err.to_string().contains("time index not found"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -467,8 +465,7 @@ mod test {
         assert!(
             err.to_string()
                 .contains("column a and b have the same column id"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -497,8 +494,7 @@ mod test {
         let err = builder.build().unwrap_err();
         assert!(
             err.to_string().contains("expect only one time index"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -524,8 +520,7 @@ mod test {
         let err = builder.build().unwrap_err();
         assert!(
             err.to_string().contains("unknown column id 3"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -552,8 +547,7 @@ mod test {
         assert!(
             err.to_string()
                 .contains("duplicate column a in primary key"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -575,8 +569,7 @@ mod test {
         assert!(
             err.to_string()
                 .contains("column ts is already a time index column"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 
@@ -596,8 +589,7 @@ mod test {
         assert!(
             err.to_string()
                 .contains("time index column ts must be NOT NULL"),
-            "unexpected err: {}",
-            err
+            "unexpected err: {err}",
         );
     }
 }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -42,6 +42,14 @@ pub(crate) struct RegionMap {
     regions: RwLock<HashMap<RegionId, MitoRegionRef>>,
 }
 
+impl RegionMap {
+    /// Returns true if the region exists.
+    pub(crate) fn is_region_exists(&self, region_id: RegionId) -> bool {
+        let regions = self.regions.read().unwrap();
+        regions.contains_key(&region_id)
+    }
+}
+
 pub(crate) type RegionMapRef = Arc<RegionMap>;
 
 /// [MitoRegion] builder.

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -32,8 +32,9 @@ pub type VersionNumber = u32;
 #[derive(Debug)]
 pub(crate) struct MitoRegion {
     /// Id of this region.
-    // Accessing region id from the version control is inconvenient so
-    // we also store it here.
+    ///
+    /// Accessing region id from the version control is inconvenient so
+    /// we also store it here.
     pub(crate) region_id: RegionId,
 
     /// Version controller for this region.

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -34,7 +34,7 @@ pub(crate) struct MitoRegion {
     /// Id of this region.
     // Accessing region id from the version control is inconvenient so
     // we also store it here.
-    region_id: RegionId,
+    pub(crate) region_id: RegionId,
 
     /// Version controller for this region.
     version_control: VersionControlRef,
@@ -55,6 +55,12 @@ impl RegionMap {
     pub(crate) fn is_region_exists(&self, region_id: RegionId) -> bool {
         let regions = self.regions.read().unwrap();
         regions.contains_key(&region_id)
+    }
+
+    /// Inserts a new region into the map.
+    pub(crate) fn insert_region(&self, region: MitoRegionRef) {
+        let mut regions = self.regions.write().unwrap();
+        regions.insert(region.region_id, region);
     }
 }
 

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -16,7 +16,6 @@
 
 use std::sync::Arc;
 
-use common_telemetry::logging;
 use object_store::util::join_dir;
 use object_store::ObjectStore;
 
@@ -58,7 +57,7 @@ impl RegionOpener {
         self
     }
 
-    /// Creates a new region.
+    /// Writes region manifest and creates a new region.
     pub(crate) async fn create(self, config: &MitoConfig) -> Result<MitoRegion> {
         let region_id = self.metadata.region_id;
         // Create a manifest manager for this region.
@@ -70,6 +69,7 @@ impl RegionOpener {
             // We are creating a new region, so we need to set this field.
             initial_metadata: Some(self.metadata.clone()),
         };
+        // Writes regions to the manifest file.
         let manifest_manager = RegionManifestManager::new(options).await?;
 
         let metadata = Arc::new(self.metadata);
@@ -77,9 +77,6 @@ impl RegionOpener {
 
         let version = VersionBuilder::new(metadata, mutable).build();
         let version_control = Arc::new(VersionControl::new(version));
-
-        // TODO(yingwen): Custom the Debug format for the metadata and also print it.
-        logging::info!("A new region created, region_id: {}", region_id);
 
         Ok(MitoRegion {
             region_id,

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -1,0 +1,95 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region opener.
+
+use std::sync::Arc;
+
+use common_telemetry::logging;
+use object_store::util::join_dir;
+use object_store::ObjectStore;
+
+use crate::config::MitoConfig;
+use crate::error::Result;
+use crate::manifest::manager::RegionManifestManager;
+use crate::manifest::options::RegionManifestOptions;
+use crate::memtable::MemtableBuilderRef;
+use crate::metadata::RegionMetadata;
+use crate::region::version::{VersionBuilder, VersionControl};
+use crate::region::MitoRegion;
+
+/// Builder to create a new [MitoRegion] or open an existing one.
+pub(crate) struct RegionOpener {
+    metadata: RegionMetadata,
+    memtable_builder: MemtableBuilderRef,
+    object_store: ObjectStore,
+    region_dir: String,
+}
+
+impl RegionOpener {
+    /// Returns a new opener.
+    pub(crate) fn new(
+        metadata: RegionMetadata,
+        memtable_builder: MemtableBuilderRef,
+        object_store: ObjectStore,
+    ) -> RegionOpener {
+        RegionOpener {
+            metadata,
+            memtable_builder,
+            object_store,
+            region_dir: String::new(),
+        }
+    }
+
+    /// Sets the region dir.
+    pub(crate) fn region_dir(mut self, value: &str) -> Self {
+        self.region_dir = value.to_string();
+        self
+    }
+
+    /// Creates a new region.
+    pub(crate) async fn create(self, config: &MitoConfig) -> Result<MitoRegion> {
+        let region_id = self.metadata.region_id;
+        // Create a manifest manager for this region.
+        let options = RegionManifestOptions {
+            manifest_dir: new_manifest_dir(&self.region_dir),
+            object_store: self.object_store,
+            compress_type: config.manifest_compress_type,
+            checkpoint_interval: Some(config.manifest_checkpoint_interval),
+            // We are creating a new region, so we need to set this field.
+            initial_metadata: Some(self.metadata.clone()),
+        };
+        let manifest_manager = RegionManifestManager::new(options).await?;
+
+        let metadata = Arc::new(self.metadata);
+        let mutable = self.memtable_builder.build(&metadata);
+
+        let version = VersionBuilder::new(metadata, mutable).build();
+        let version_control = Arc::new(VersionControl::new(version));
+
+        // TODO(yingwen): Custom the Debug format for the metadata and also print it.
+        logging::info!("A new region created, region_id: {}", region_id);
+
+        Ok(MitoRegion {
+            region_id,
+            version_control,
+            manifest_manager,
+        })
+    }
+}
+
+/// Returns the directory to the manifest files.
+fn new_manifest_dir(region_dir: &str) -> String {
+    join_dir(region_dir, "manifest")
+}

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -65,7 +65,7 @@ impl RegionOpener {
             manifest_dir: new_manifest_dir(&self.region_dir),
             object_store: self.object_store,
             compress_type: config.manifest_compress_type,
-            checkpoint_interval: Some(config.manifest_checkpoint_interval),
+            checkpoint_interval: config.manifest_checkpoint_interval,
             // We are creating a new region, so we need to set this field.
             initial_metadata: Some(self.metadata.clone()),
         };

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -68,8 +68,10 @@ pub(crate) struct Version {
     ssts: SstVersionRef,
     /// Inclusive max sequence of flushed data.
     flushed_sequence: SequenceNumber,
+    // TODO(yingwen): Remove this.
     /// Current version of region manifest.
     manifest_version: ManifestVersion,
+    // TODO(yingwen): RegionOptions.
 }
 
 /// Version builder.

--- a/src/mito2/src/sst/version.rs
+++ b/src/mito2/src/sst/version.rs
@@ -23,7 +23,7 @@ use crate::sst::file::{FileHandle, FileId, Level, MAX_LEVEL};
 #[derive(Debug)]
 pub(crate) struct SstVersion {
     /// SST metadata organized by levels.
-    levels: LevelMetaVec,
+    levels: LevelMetaArray,
 }
 
 pub(crate) type SstVersionRef = Arc<SstVersion>;
@@ -38,8 +38,8 @@ impl SstVersion {
 }
 
 // We only has fixed number of level, so we use array to hold elements. This implementation
-// detail of LevelMetaVec should not be exposed to the user of [LevelMetas].
-type LevelMetaVec = [LevelMeta; MAX_LEVEL as usize];
+// detail of LevelMetaArray should not be exposed to users of [LevelMetas].
+type LevelMetaArray = [LevelMeta; MAX_LEVEL as usize];
 
 /// Metadata of files in the same SST level.
 pub struct LevelMeta {
@@ -68,10 +68,10 @@ impl fmt::Debug for LevelMeta {
     }
 }
 
-fn new_level_meta_vec() -> LevelMetaVec {
+fn new_level_meta_vec() -> LevelMetaArray {
     (0u8..MAX_LEVEL)
         .map(LevelMeta::new)
         .collect::<Vec<_>>()
         .try_into()
-        .unwrap() // safety: LevelMetaVec is a fixed length array with length MAX_LEVEL
+        .unwrap() // safety: LevelMetaArray is a fixed length array with length MAX_LEVEL
 }

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -56,7 +56,7 @@ impl TestEnv {
     }
 
     /// Creates a new [WorkerGroup] with specific config under this env.
-    pub(crate) async fn create_worker_group(&self, config: &MitoConfig) -> WorkerGroup {
+    pub(crate) async fn create_worker_group(&self, config: MitoConfig) -> WorkerGroup {
         let (log_store, object_store) = self.create_log_and_object_store().await;
 
         WorkerGroup::start(config, Arc::new(log_store), object_store)

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -103,7 +103,7 @@ impl TestEnv {
 }
 
 /// Builder to mock a [CreateRequest].
-pub struct CreateRequestMocker {
+pub struct CreateRequestBuilder {
     region_id: RegionId,
     region_dir: String,
     tag_num: usize,
@@ -111,9 +111,9 @@ pub struct CreateRequestMocker {
     create_if_not_exists: bool,
 }
 
-impl Default for CreateRequestMocker {
+impl Default for CreateRequestBuilder {
     fn default() -> Self {
-        CreateRequestMocker {
+        CreateRequestBuilder {
             region_id: RegionId::default(),
             region_dir: "test".to_string(),
             tag_num: 1,
@@ -123,9 +123,9 @@ impl Default for CreateRequestMocker {
     }
 }
 
-impl CreateRequestMocker {
-    pub fn new(region_id: RegionId) -> CreateRequestMocker {
-        CreateRequestMocker {
+impl CreateRequestBuilder {
+    pub fn new(region_id: RegionId) -> CreateRequestBuilder {
+        CreateRequestBuilder {
             region_id,
             ..Default::default()
         }
@@ -151,7 +151,7 @@ impl CreateRequestMocker {
         self
     }
 
-    pub fn build(self) -> CreateRequest {
+    pub fn build(&self) -> CreateRequest {
         let mut column_id = 0;
         let mut column_metadatas = Vec::with_capacity(self.tag_num + self.field_num + 1);
         let mut primary_key = Vec::with_capacity(self.tag_num);
@@ -192,7 +192,7 @@ impl CreateRequestMocker {
 
         CreateRequest {
             region_id: self.region_id,
-            region_dir: self.region_dir,
+            region_dir: self.region_dir.clone(),
             column_metadatas,
             primary_key,
             create_if_not_exists: self.create_if_not_exists,

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -163,7 +163,7 @@ impl CreateRequestBuilder {
                     true,
                 ),
                 semantic_type: SemanticType::Tag,
-                column_id: column_id,
+                column_id,
             });
             primary_key.push(column_id);
             column_id += 1;
@@ -176,7 +176,7 @@ impl CreateRequestBuilder {
                     true,
                 ),
                 semantic_type: SemanticType::Field,
-                column_id: column_id,
+                column_id,
             });
             column_id += 1;
         }
@@ -187,7 +187,7 @@ impl CreateRequestBuilder {
                 false,
             ),
             semantic_type: SemanticType::Timestamp,
-            column_id: column_id,
+            column_id,
         });
 
         CreateRequest {

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -80,7 +80,7 @@ impl TestEnv {
     pub async fn create_manifest_manager(
         &self,
         compress_type: CompressionType,
-        checkpoint_interval: Option<u64>,
+        checkpoint_interval: u64,
         initial_metadata: Option<RegionMetadata>,
     ) -> Result<RegionManifestManager> {
         let data_home = self.data_home.path().to_str().unwrap();

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -125,6 +125,11 @@ impl WorkerGroup {
             .await
     }
 
+    /// Returns true if the specific region exists.
+    pub(crate) fn is_region_exists(&self, region_id: RegionId) -> bool {
+        self.worker(region_id).is_region_exists(region_id)
+    }
+
     /// Get worker for specific `region_id`.
     fn worker(&self, region_id: RegionId) -> &RegionWorker {
         let mut hasher = DefaultHasher::new();
@@ -238,6 +243,11 @@ impl RegionWorker {
     /// Sets whether the worker is still running.
     fn set_running(&self, value: bool) {
         self.running.store(value, Ordering::Relaxed)
+    }
+
+    /// Returns true if the worker contains specific region.
+    fn is_region_exists(&self, region_id: RegionId) -> bool {
+        self.regions.is_region_exists(region_id)
     }
 }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -35,6 +35,7 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::config::MitoConfig;
 use crate::error::{JoinSnafu, Result, WorkerStoppedSnafu};
+use crate::memtable::{DefaultMemtableBuilder, MemtableBuilderRef};
 use crate::region::{RegionMap, RegionMapRef};
 use crate::worker::request::{RegionRequest, RequestBody, WorkerRequest};
 
@@ -186,6 +187,7 @@ impl RegionWorker {
             object_store,
             running: running.clone(),
             request_batch_size: config.request_batch_size,
+            memtable_builder: Arc::new(DefaultMemtableBuilder::default()),
         };
         let handle = common_runtime::spawn_bg(async move {
             worker_thread.run().await;
@@ -278,6 +280,8 @@ struct RegionWorkerLoop<S> {
     running: Arc<AtomicBool>,
     /// Batch size to fetch requests from channel.
     request_batch_size: usize,
+    /// Memtable builder for each region.
+    memtable_builder: MemtableBuilderRef,
 }
 
 impl<S> RegionWorkerLoop<S> {

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -36,7 +36,7 @@ impl<S> RegionWorkerLoop<S> {
                 }
             );
 
-            // Table already exists.
+            // Region already exists.
             return Ok(());
         }
 

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -14,6 +14,9 @@
 
 //! Handling create request.
 
+use std::sync::Arc;
+
+use common_telemetry::logging;
 use snafu::ensure;
 
 use crate::error::{RegionExistsSnafu, Result};
@@ -51,11 +54,16 @@ impl<S> RegionWorkerLoop<S> {
             self.memtable_builder.clone(),
             self.object_store.clone(),
         )
-        .region_dir(&request.region_dir);
+        .region_dir(&request.region_dir)
+        .create(&self.config)
+        .await?;
 
-        // Write manifest
+        // TODO(yingwen): Custom the Debug format for the metadata and also print it.
+        logging::info!("A new region created, region_id: {}", region.region_id);
 
         // Insert the MitoRegion into the RegionMap.
-        unimplemented!()
+        self.regions.insert_region(Arc::new(region));
+
+        Ok(())
     }
 }

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -14,17 +14,34 @@
 
 //! Handling create request.
 
-use crate::error::Result;
+use snafu::ensure;
+
+use crate::error::{RegionExistsSnafu, Result};
 use crate::worker::request::CreateRequest;
 use crate::worker::RegionWorkerLoop;
 
 impl<S> RegionWorkerLoop<S> {
-    pub(crate) async fn handle_create_request(&mut self, _request: CreateRequest) -> Result<()> {
-        // 1. Checks whether the table exists.
+    pub(crate) async fn handle_create_request(&mut self, request: CreateRequest) -> Result<()> {
+        // Checks whether the table exists.
+        if self.regions.is_region_exists(request.region_id) {
+            ensure!(
+                request.create_if_not_exists,
+                RegionExistsSnafu {
+                    region_id: request.region_id,
+                }
+            );
 
-        // 2. Convert the request into RegionMetadata
+            // Table already exists.
+            return Ok(());
+        }
 
-        // 3. Write manifest
+        // Convert the request into a RegionMetadata and validate it.
+
+        // Create a MitoRegion from the RegionMetadata.
+
+        // Write manifest
+
+        // Insert the MitoRegion into the RegionMap.
         unimplemented!()
     }
 }

--- a/src/mito2/src/worker/request.rs
+++ b/src/mito2/src/worker/request.rs
@@ -51,13 +51,6 @@ pub struct CreateRequest {
     pub options: RegionOptions,
 }
 
-impl CreateRequest {
-    /// Validate the request.
-    fn validate(&self) -> Result<()> {
-        unimplemented!()
-    }
-}
-
 /// Open region request.
 #[derive(Debug)]
 pub struct OpenRequest {

--- a/src/mito2/src/worker/request.rs
+++ b/src/mito2/src/worker/request.rs
@@ -20,6 +20,7 @@ use common_base::readable_size::ReadableSize;
 use store_api::storage::{ColumnId, CompactionStrategy, RegionId};
 use tokio::sync::oneshot::{self, Receiver, Sender};
 
+use crate::config::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::error::Result;
 use crate::metadata::ColumnMetadata;
 
@@ -34,6 +35,16 @@ pub struct RegionOptions {
     pub ttl: Option<Duration>,
     /// Compaction strategy.
     pub compaction_strategy: CompactionStrategy,
+}
+
+impl Default for RegionOptions {
+    fn default() -> Self {
+        RegionOptions {
+            write_buffer_size: Some(DEFAULT_WRITE_BUFFER_SIZE),
+            ttl: None,
+            compaction_strategy: CompactionStrategy::LeveledTimeWindow,
+        }
+    }
 }
 
 /// Create region request.

--- a/src/mito2/src/worker/request.rs
+++ b/src/mito2/src/worker/request.rs
@@ -41,6 +41,8 @@ pub struct RegionOptions {
 pub struct CreateRequest {
     /// Region to create.
     pub region_id: RegionId,
+    /// Data directory of the region.
+    pub region_dir: String,
     /// Columns in this region.
     pub column_metadatas: Vec<ColumnMetadata>,
     /// Columns in the primary key.

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -39,8 +39,7 @@ pub fn normalize_dir(dir: &str) -> String {
 pub fn join_dir(parent: &str, child: &str) -> String {
     // Always adds a `/` to the output path.
     let output = format!("{parent}/{child}/");
-    // We call opendal's normalize_dir which doesn't push `/` to
-    // the end of path.
+    // We call opendal's normalize_root which keep the last `/`.
     opendal::raw::normalize_root(&output)
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements `create_region()` for the mito2 engine.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869
