### PR TITLE
refactor: query context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8871,6 +8871,7 @@ dependencies = [
  "common-catalog",
  "common-telemetry",
  "common-time",
+ "derive_builder 0.12.0",
  "sql",
 ]
 
@@ -9433,7 +9434,7 @@ dependencies = [
  "common-recordbatch",
  "common-time",
  "datatypes",
- "derive_builder 0.11.2",
+ "derive_builder 0.12.0",
  "futures",
  "serde",
  "serde_json",
@@ -9711,7 +9712,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "datatypes",
- "derive_builder 0.11.2",
+ "derive_builder 0.12.0",
  "futures",
  "humantime",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ datafusion-optimizer = { git = "https://github.com/waynexia/arrow-datafusion.git
 datafusion-physical-expr = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
 datafusion-sql = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
 datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git", rev = "63e52dde9e44cac4b1f6c6e6b6bf6368ba3bd323" }
+derive_builder = "0.12"
 etcd-client = "0.11"
 futures = "0.3"
 futures-util = "0.3"

--- a/src/cmd/src/cli/repl.rs
+++ b/src/cmd/src/cli/repl.rs
@@ -165,10 +165,7 @@ impl Repl {
             let stmt = QueryLanguageParser::parse_sql(&sql)
                 .with_context(|_| ParseSqlSnafu { sql: sql.clone() })?;
 
-            let query_ctx = Arc::new(QueryContext::with(
-                self.database.catalog(),
-                self.database.schema(),
-            ));
+            let query_ctx = QueryContext::with(self.database.catalog(), self.database.schema());
 
             let plan = query_engine
                 .planner()

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -21,7 +21,7 @@ common-base = { path = "../base" }
 common-error = { path = "../error" }
 common-runtime = { path = "../runtime" }
 datafusion.workspace = true
-derive_builder = "0.12"
+derive_builder.workspace = true
 futures.workspace = true
 object-store = { path = "../../object-store" }
 orc-rust = "0.2"

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -287,7 +287,6 @@ impl SqlStatementExecutor for Instance {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
 
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use session::context::QueryContext;
@@ -305,7 +304,7 @@ mod test {
         let bare = ObjectName(vec![my_table.into()]);
 
         let using_schema = "foo";
-        let query_ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, using_schema));
+        let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, using_schema);
         let empty_ctx = QueryContext::arc();
 
         assert_eq!(

--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -306,7 +306,7 @@ mod test {
 
         let using_schema = "foo";
         let query_ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, using_schema));
-        let empty_ctx = Arc::new(QueryContext::new());
+        let empty_ctx = QueryContext::arc();
 
         assert_eq!(
             table_idents_to_full_name(&full, query_ctx.clone()).unwrap(),

--- a/src/frontend/src/expr_factory.rs
+++ b/src/frontend/src/expr_factory.rs
@@ -342,7 +342,7 @@ mod tests {
             .unwrap();
 
         let Statement::CreateTable(create_table) = stmt else { unreachable!() };
-        let expr = create_to_expr(&create_table, Arc::new(QueryContext::default())).unwrap();
+        let expr = create_to_expr(&create_table, QueryContext::arc()).unwrap();
         assert_eq!("3days", expr.table_options.get("ttl").unwrap());
         assert_eq!(
             "1.0MiB",

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -777,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_exec_validation() {
-        let query_ctx = Arc::new(QueryContext::new());
+        let query_ctx = QueryContext::arc();
         let plugins = Plugins::new();
         plugins.insert(QueryOptions {
             disallow_cross_schema_query: true,

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -623,7 +623,7 @@ pub fn check_permission(
         // These are executed by query engine, and will be checked there.
         Statement::Query(_) | Statement::Explain(_) | Statement::Tql(_) | Statement::Delete(_) => {}
         // database ops won't be checked
-        Statement::CreateDatabase(_) | Statement::ShowDatabases(_) | Statement::Use(_) => {}
+        Statement::CreateDatabase(_) | Statement::ShowDatabases(_) => {}
         // show create table and alter are not supported yet
         Statement::ShowCreateTable(_) | Statement::CreateExternalTable(_) | Statement::Alter(_) => {
         }
@@ -807,11 +807,6 @@ mod tests {
             let re = check_permission(plugins.clone(), &stmt, &query_ctx);
             re.unwrap();
         }
-
-        let sql = "USE randomschema";
-        let stmts = parse_stmt(sql, &GreptimeDbDialect {}).unwrap();
-        let re = check_permission(plugins.clone(), &stmts[0], &query_ctx);
-        re.unwrap();
 
         fn replace_test(template_sql: &str, plugins: Arc<Plugins>, query_ctx: &QueryContextRef) {
             // test right

--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -101,8 +101,6 @@ impl StatementExecutor {
 
             Statement::DescribeTable(stmt) => self.describe_table(stmt, query_ctx).await,
 
-            Statement::Use(db) => self.handle_use(db, query_ctx).await,
-
             Statement::ShowDatabases(stmt) => self.show_databases(stmt, query_ctx).await,
 
             Statement::ShowTables(stmt) => self.show_tables(stmt, query_ctx).await,
@@ -148,15 +146,6 @@ impl StatementExecutor {
             .execute(plan, query_ctx)
             .await
             .context(ExecLogicalPlanSnafu)
-    }
-
-    async fn handle_use(&self, _db: String, _query_ctx: QueryContextRef) -> Result<Output> {
-        // use in mysql actually goes into `on_init` in mysql shim
-        // pg doesn't have this behavior
-        // stateless api schema is set on connection
-
-        // so this method is actually unreachable
-        unreachable!()
     }
 
     async fn get_table(&self, table_ref: &TableReference<'_>) -> Result<TableRef> {

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -26,7 +26,7 @@ common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
 dashmap = "5.4"
 datatypes = { path = "../datatypes" }
-derive_builder = "0.12"
+derive_builder.workspace = true
 etcd-client.workspace = true
 futures.workspace = true
 h2 = "0.3"

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -1374,7 +1374,7 @@ mod test {
             })
             .await
             .is_ok());
-        DfTableSourceProvider::new(catalog_list, false, &QueryContext::new())
+        DfTableSourceProvider::new(catalog_list, false, QueryContext::arc().as_ref())
     }
 
     // {

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -59,6 +59,7 @@ num = "0.4"
 num-traits = "0.2"
 paste = "1.0"
 rand.workspace = true
+session = { path = "../session", features = ["testing"] }
 statrs = "0.16"
 stats-cli = "3.0"
 store-api = { path = "../store-api" }

--- a/src/query/src/query_engine/options.rs
+++ b/src/query/src/query_engine/options.rs
@@ -47,7 +47,6 @@ pub fn validate_catalog_and_schema(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use session::context::QueryContext;
 
@@ -55,7 +54,7 @@ mod tests {
 
     #[test]
     fn test_validate_catalog_and_schema() {
-        let context = Arc::new(QueryContext::with("greptime", "public"));
+        let context = QueryContext::with("greptime", "public");
 
         validate_catalog_and_schema("greptime", "public", &context).unwrap();
         let re = validate_catalog_and_schema("greptime", "wrong_schema", &context);

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -381,7 +381,7 @@ impl PyQueryEngine {
                 let res = handle.block_on(async {
                     let plan = engine
                         .planner()
-                        .plan(stmt, QueryContextBuilder::default().build_to_arc())
+                        .plan(stmt, QueryContextBuilder::default().build())
                         .await
                         .map_err(|e| e.to_string())?;
                     let res = engine

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -34,7 +34,7 @@ use rustpython_compiler_core::CodeObject;
 use rustpython_vm as vm;
 #[cfg(test)]
 use serde::Deserialize;
-use session::context::QueryContext;
+use session::context::{QueryContext, QueryContextBuilder};
 use snafu::{OptionExt, ResultExt};
 use vm::convert::ToPyObject;
 use vm::{pyclass as rspyclass, PyObjectRef, PyPayload, PyResult, VirtualMachine};
@@ -381,7 +381,7 @@ impl PyQueryEngine {
                 let res = handle.block_on(async {
                     let plan = engine
                         .planner()
-                        .plan(stmt, Default::default())
+                        .plan(stmt, QueryContextBuilder::default().build_to_arc())
                         .await
                         .map_err(|e| e.to_string())?;
                     let res = engine

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -37,7 +37,7 @@ datafusion-common.workspace = true
 datafusion-expr.workspace = true
 
 datatypes = { path = "../datatypes" }
-derive_builder = "0.12"
+derive_builder.workspace = true
 digest = "0.10"
 futures = "0.3"
 headers = "0.3"
@@ -103,6 +103,7 @@ rand.workspace = true
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
 script = { path = "../script", features = ["python"] }
 serde_json = "1.0"
+session = { path = "../session", features = ["testing"] }
 table = { path = "../table" }
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.10"

--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -172,7 +172,7 @@ pub(crate) fn create_query_context(header: Option<&RequestHeader>) -> QueryConte
         .current_catalog(catalog.to_string())
         .current_schema(schema.to_string())
         .try_trace_id(header.and_then(|h: &RequestHeader| h.trace_id))
-        .build_to_arc()
+        .build()
 }
 
 /// Histogram timer for handling gRPC request.

--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -168,12 +168,11 @@ pub(crate) fn create_query_context(header: Option<&RequestHeader>) -> QueryConte
         })
         .unwrap_or((DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME));
 
-    QueryContextBuilder::new()
-        .catalog(catalog.to_string())
-        .schema(schema.to_string())
+    QueryContextBuilder::default()
+        .current_catalog(catalog.to_string())
+        .current_schema(schema.to_string())
         .try_trace_id(header.and_then(|h: &RequestHeader| h.trace_id))
-        .build()
-        .to_arc()
+        .build_to_arc()
 }
 
 /// Histogram timer for handling gRPC request.

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -90,7 +90,7 @@ pub(crate) async fn query_context_from_db(
         let (catalog, schema) = super::parse_catalog_and_schema_from_client_database_name(db);
 
         match query_handler.is_valid_schema(catalog, schema).await {
-            Ok(true) => Ok(Arc::new(QueryContext::with(catalog, schema))),
+            Ok(true) => Ok(QueryContext::with(catalog, schema)),
             Ok(false) => Err(JsonResponse::with_error(
                 format!("Database not found: {db}"),
                 StatusCode::DatabaseNotFound,

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -88,7 +87,7 @@ pub async fn influxdb_write(
     );
 
     let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(db);
-    let ctx = Arc::new(QueryContext::with(catalog, schema));
+    let ctx = QueryContext::with(catalog, schema);
 
     let request = InfluxdbRequest { precision, lines };
 

--- a/src/servers/src/http/opentsdb.rs
+++ b/src/servers/src/http/opentsdb.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use axum::extract::{Query, RawBody, State};
 use axum::http::StatusCode as HttpStatusCode;
@@ -91,7 +90,7 @@ pub async fn put(
         .unwrap_or(DEFAULT_SCHEMA_NAME);
 
     let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(db);
-    let ctx = Arc::new(QueryContext::with(catalog, schema));
+    let ctx = QueryContext::with(catalog, schema);
 
     let data_points = parse_data_points(body).await?;
 

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use axum::extract::{RawBody, State};
 use axum::http::header;
 use axum::response::IntoResponse;
@@ -40,7 +38,7 @@ pub async fn metrics(
 ) -> Result<OtlpResponse> {
     let ctx = if let Some(db) = db.value() {
         let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(db);
-        Arc::new(QueryContext::with(catalog, schema))
+        QueryContext::with(catalog, schema)
     } else {
         QueryContext::arc()
     };

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use api::prom_store::remote::{ReadRequest, WriteRequest};
 use axum::extract::{Query, RawBody, State};
 use axum::http::{header, StatusCode};
@@ -62,7 +60,7 @@ pub async fn remote_write(
     );
     let ctx = if let Some(db) = params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
-        Arc::new(QueryContext::with(catalog, schema))
+        QueryContext::with(catalog, schema)
     } else {
         QueryContext::arc()
     };
@@ -102,7 +100,7 @@ pub async fn remote_read(
     );
     let ctx = if let Some(db) = params.db {
         let (catalog, schema) = parse_catalog_and_schema_from_client_database_name(&db);
-        Arc::new(QueryContext::with(catalog, schema))
+        QueryContext::with(catalog, schema)
     } else {
         QueryContext::arc()
     };

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -333,15 +333,15 @@ mod test {
     #[test]
     fn test_check() {
         let query = "select 1";
-        let result = check(query, Arc::new(QueryContext::new()));
+        let result = check(query, QueryContext::arc());
         assert!(result.is_none());
 
         let query = "select versiona";
-        let output = check(query, Arc::new(QueryContext::new()));
+        let output = check(query, QueryContext::arc());
         assert!(output.is_none());
 
         fn test(query: &str, expected: &str) {
-            let output = check(query, Arc::new(QueryContext::new()));
+            let output = check(query, QueryContext::arc());
             match output.unwrap() {
                 Output::RecordBatches(r) => {
                     assert_eq!(&r.pretty_print().unwrap(), expected)
@@ -428,7 +428,7 @@ mod test {
 
     #[test]
     fn test_set_time_zone() {
-        let query_context = Arc::new(QueryContext::new());
+        let query_context = QueryContext::arc();
         let output = check("set time_zone = 'UTC'", query_context.clone());
         match output.unwrap() {
             Output::AffectedRows(rows) => {

--- a/src/servers/src/opentsdb/handler.rs
+++ b/src/servers/src/opentsdb/handler.rs
@@ -62,7 +62,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin> Handler<S> {
 
     pub(crate) async fn run(&mut self) -> Result<()> {
         // TODO(shuiyisong): figure out how to auth in tcp connection.
-        let ctx = QueryContextBuilder::default().build_to_arc();
+        let ctx = QueryContextBuilder::default().build();
         while !self.shutdown.is_shutdown() {
             // While reading a request, also listen for the shutdown signal.
             let maybe_line = tokio::select! {

--- a/src/servers/src/opentsdb/handler.rs
+++ b/src/servers/src/opentsdb/handler.rs
@@ -15,7 +15,7 @@
 //! Modified from Tokio's mini-redis example.
 
 use common_telemetry::timer;
-use session::context::QueryContext;
+use session::context::QueryContextBuilder;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::error::Result;
@@ -62,7 +62,7 @@ impl<S: AsyncWrite + AsyncRead + Unpin> Handler<S> {
 
     pub(crate) async fn run(&mut self) -> Result<()> {
         // TODO(shuiyisong): figure out how to auth in tcp connection.
-        let ctx = QueryContext::arc();
+        let ctx = QueryContextBuilder::default().build_to_arc();
         while !self.shutdown.is_shutdown() {
             // While reading a request, also listen for the shutdown signal.
             let maybe_line = tokio::select! {

--- a/src/servers/src/prometheus.rs
+++ b/src/servers/src/prometheus.rs
@@ -446,7 +446,7 @@ pub async fn instant_query(
 
     let query_ctx = QueryContext::with(catalog, schema);
 
-    let result = handler.do_query(&prom_query, Arc::new(query_ctx)).await;
+    let result = handler.do_query(&prom_query, query_ctx).await;
     let (metric_name, result_type) = match retrieve_metric_name_and_result_type(&prom_query.query) {
         Ok((metric_name, result_type)) => (metric_name.unwrap_or_default(), result_type),
         Err(err) => {
@@ -485,7 +485,7 @@ pub async fn range_query(
 
     let query_ctx = QueryContext::with(catalog, schema);
 
-    let result = handler.do_query(&prom_query, Arc::new(query_ctx)).await;
+    let result = handler.do_query(&prom_query, query_ctx).await;
     let metric_name = match retrieve_metric_name_and_result_type(&prom_query.query) {
         Err(err) => {
             return PrometheusJsonResponse::error(err.status_code().to_string(), err.to_string())
@@ -565,7 +565,7 @@ pub async fn labels_query(
 
     let db = &params.db.unwrap_or(DEFAULT_SCHEMA_NAME.to_string());
     let (catalog, schema) = crate::parse_catalog_and_schema_from_client_database_name(db);
-    let query_ctx = Arc::new(QueryContext::with(catalog, schema));
+    let query_ctx = QueryContext::with(catalog, schema);
 
     let mut labels = HashSet::new();
     let _ = labels.insert(METRIC_NAME.to_string());
@@ -792,7 +792,7 @@ pub async fn label_values_query(
     let end = params.end.unwrap_or_else(current_time_rfc3339);
     let db = &params.db.unwrap_or(DEFAULT_SCHEMA_NAME.to_string());
     let (catalog, schema) = crate::parse_catalog_and_schema_from_client_database_name(db);
-    let query_ctx = Arc::new(QueryContext::with(catalog, schema));
+    let query_ctx = QueryContext::with(catalog, schema);
 
     let mut label_values = HashSet::new();
 
@@ -914,7 +914,7 @@ pub async fn series_query(
 
     let db = &params.db.unwrap_or(DEFAULT_SCHEMA_NAME.to_string());
     let (catalog, schema) = super::parse_catalog_and_schema_from_client_database_name(db);
-    let query_ctx = Arc::new(QueryContext::with(catalog, schema));
+    let query_ctx = QueryContext::with(catalog, schema);
 
     let mut series = Vec::new();
     for query in queries {

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::sync::Arc;
 
 use api::v1::greptime_request::Request;
 use api::v1::{InsertRequest, InsertRequests};
@@ -38,7 +37,7 @@ impl SqlQueryInterceptor for NoopInterceptor {
 #[test]
 fn test_default_interceptor_behaviour() {
     let di = NoopInterceptor;
-    let ctx = Arc::new(QueryContext::new());
+    let ctx = QueryContext::arc();
 
     let query = "SELECT 1";
     assert_eq!("SELECT 1;", di.pre_parsing(query, ctx).unwrap());
@@ -72,7 +71,7 @@ impl GrpcQueryInterceptor for NoopInterceptor {
 #[test]
 fn test_grpc_interceptor() {
     let di = NoopInterceptor;
-    let ctx = Arc::new(QueryContext::new());
+    let ctx = QueryContext::arc();
 
     let req = Request::Inserts(InsertRequests {
         inserts: vec![InsertRequest {
@@ -117,7 +116,7 @@ impl PromQueryInterceptor for NoopInterceptor {
 #[test]
 fn test_prom_interceptor() {
     let di = NoopInterceptor;
-    let ctx = Arc::new(QueryContext::new());
+    let ctx = QueryContext::arc();
 
     let query = PromQuery {
         query: "up".to_string(),

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use servers::error::Result;
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::ScriptHandler;
@@ -24,7 +22,7 @@ use crate::create_testing_instance;
 
 #[tokio::test]
 async fn test_insert_py_udf_and_query() -> Result<()> {
-    let query_ctx = Arc::new(QueryContext::new());
+    let query_ctx = QueryContext::arc();
     let table = MemTable::default_numbers_table();
 
     let instance = create_testing_instance(table);

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -4,9 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+testing = []
+
 [dependencies]
 arc-swap = "1.5"
 common-catalog = { path = "../common/catalog" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
+derive_builder.workspace = true
 sql = { path = "../sql" }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -103,10 +103,10 @@ impl QueryContextBuilder {
         Arc::new(QueryContext {
             current_catalog: self
                 .current_catalog
-                .unwrap_or(DEFAULT_CATALOG_NAME.to_string()),
+                .unwrap_or_else(|| DEFAULT_CATALOG_NAME.to_string()),
             current_schema: self
                 .current_schema
-                .unwrap_or(DEFAULT_SCHEMA_NAME.to_string()),
+                .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string()),
             time_zone: self.time_zone.unwrap_or(ArcSwap::new(Arc::new(None))),
             sql_dialect: self.sql_dialect.unwrap_or(Box::new(GreptimeDbDialect {})),
             trace_id: self.trace_id.unwrap_or(common_telemetry::gen_trace_id()),

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -51,10 +51,10 @@ impl Display for QueryContext {
 impl QueryContext {
     #[cfg(any(test, feature = "testing"))]
     pub fn arc() -> QueryContextRef {
-        QueryContextBuilder::default().build_to_arc()
+        QueryContextBuilder::default().build()
     }
 
-    pub fn with(catalog: &str, schema: &str) -> Self {
+    pub fn with(catalog: &str, schema: &str) -> QueryContextRef {
         QueryContextBuilder::default()
             .current_catalog(catalog.to_string())
             .current_schema(schema.to_string())
@@ -99,8 +99,8 @@ impl QueryContext {
 }
 
 impl QueryContextBuilder {
-    pub fn build(self) -> QueryContext {
-        QueryContext {
+    pub fn build(self) -> QueryContextRef {
+        Arc::new(QueryContext {
             current_catalog: self
                 .current_catalog
                 .unwrap_or(DEFAULT_CATALOG_NAME.to_string()),
@@ -110,11 +110,7 @@ impl QueryContextBuilder {
             time_zone: self.time_zone.unwrap_or(ArcSwap::new(Arc::new(None))),
             sql_dialect: self.sql_dialect.unwrap_or(Box::new(GreptimeDbDialect {})),
             trace_id: self.trace_id.unwrap_or(common_telemetry::gen_trace_id()),
-        }
-    }
-
-    pub fn build_to_arc(self) -> QueryContextRef {
-        Arc::new(self.build())
+        })
     }
 
     pub fn try_trace_id(mut self, trace_id: Option<u64>) -> Self {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -107,9 +107,13 @@ impl QueryContextBuilder {
             current_schema: self
                 .current_schema
                 .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string()),
-            time_zone: self.time_zone.unwrap_or(ArcSwap::new(Arc::new(None))),
-            sql_dialect: self.sql_dialect.unwrap_or(Box::new(GreptimeDbDialect {})),
-            trace_id: self.trace_id.unwrap_or(common_telemetry::gen_trace_id()),
+            time_zone: self
+                .time_zone
+                .unwrap_or_else(|| ArcSwap::new(Arc::new(None))),
+            sql_dialect: self
+                .sql_dialect
+                .unwrap_or_else(|| Box::new(GreptimeDbDialect {})),
+            trace_id: self.trace_id.unwrap_or_else(common_telemetry::gen_trace_id),
         })
     }
 

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -51,7 +51,7 @@ impl Session {
             .current_catalog(self.catalog.load().to_string())
             .current_schema(self.schema.load().to_string())
             .sql_dialect(self.conn_info.channel.dialect())
-            .build_to_arc()
+            .build()
     }
 
     #[inline]

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -47,12 +47,11 @@ impl Session {
 
     #[inline]
     pub fn new_query_context(&self) -> QueryContextRef {
-        QueryContextBuilder::new()
-            .catalog(self.catalog.load().to_string())
-            .schema(self.schema.load().to_string())
+        QueryContextBuilder::default()
+            .current_catalog(self.catalog.load().to_string())
+            .current_schema(self.schema.load().to_string())
             .sql_dialect(self.conn_info.channel.dialect())
-            .build()
-            .to_arc()
+            .build_to_arc()
     }
 
     #[inline]

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -107,20 +107,6 @@ impl<'a> ParserContext<'a> {
 
                     Keyword::DROP => self.parse_drop(),
 
-                    Keyword::USE => {
-                        let _ = self.parser.next_token();
-
-                        let database_name =
-                            self.parser
-                                .parse_identifier()
-                                .context(error::UnexpectedSnafu {
-                                    sql: self.sql,
-                                    expected: "a database name",
-                                    actual: self.peek_token_as_string(),
-                                })?;
-                        Ok(Statement::Use(database_name.value))
-                    }
-
                     Keyword::COPY => self.parse_copy(),
 
                     Keyword::TRUNCATE => self.parse_truncate(),

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -58,7 +58,6 @@ pub enum Statement {
     DescribeTable(DescribeTable),
     // EXPLAIN QUERY
     Explain(Explain),
-    Use(String),
     // COPY
     Copy(crate::statements::copy::Copy),
     Tql(Tql),

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -13,7 +13,7 @@ common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-time = { path = "../common/time" }
 datatypes = { path = "../datatypes" }
-derive_builder = "0.11"
+derive_builder.workspace = true
 futures.workspace = true
 serde.workspace = true
 snafu.workspace = true

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -24,7 +24,7 @@ datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datatypes = { path = "../datatypes" }
-derive_builder = "0.11"
+derive_builder.workspace = true
 futures.workspace = true
 humantime = "2.1"
 humantime-serde = "1.1"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -68,5 +68,6 @@ partition = { path = "../src/partition" }
 paste.workspace = true
 prost.workspace = true
 script = { path = "../src/script" }
+session = { path = "../src/session", features = ["testing"] }
 store-api = { path = "../src/store-api" }
 opentelemetry-proto.workspace = true

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -356,7 +356,7 @@ mod tests {
             }
         }
 
-        let query_ctx = Arc::new(QueryContext::new());
+        let query_ctx = QueryContext::arc();
 
         let standalone = tests::create_standalone_instance("test_db_hook").await;
         let mut instance = standalone.instance;

--- a/tests-integration/src/opentsdb.rs
+++ b/tests-integration/src/opentsdb.rs
@@ -75,7 +75,7 @@ mod tests {
         let output = instance
             .do_query(
                 "select * from my_metric_1 order by greptime_timestamp",
-                Arc::new(QueryContext::new()),
+                QueryContext::arc(),
             )
             .await
             .remove(0)

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -50,7 +50,7 @@ mod test {
     async fn test_otlp(instance: &Arc<Instance>) {
         let req = build_request();
         let db = "otlp";
-        let ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, db));
+        let ctx = QueryContext::with(DEFAULT_CATALOG_NAME, db);
 
         assert!(SqlQueryHandler::do_query(
             instance.as_ref(),

--- a/tests-integration/src/prom_store.rs
+++ b/tests-integration/src/prom_store.rs
@@ -53,7 +53,7 @@ mod tests {
         };
 
         let db = "prometheus";
-        let ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, db));
+        let ctx = QueryContext::with(DEFAULT_CATALOG_NAME, db);
 
         assert!(SqlQueryHandler::do_query(
             instance.as_ref(),

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -844,7 +844,7 @@ async fn test_rename_table(instance: Arc<dyn MockInstance>) {
     let output = execute_sql(&instance, "create database db").await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let query_ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, "db"));
+    let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, "db");
     let output = execute_sql_with(
         &instance,
         "create table demo(host string, cpu double, memory double, ts timestamp, time index(ts))",
@@ -912,7 +912,7 @@ async fn test_create_table_after_rename_table(instance: Arc<dyn MockInstance>) {
 
     // create test table
     let table_name = "demo";
-    let query_ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, "db"));
+    let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, "db");
     let output = execute_sql_with(
         &instance,
         &format!("create table {table_name}(host string, cpu double, memory double, ts timestamp, time index(ts))"),
@@ -1096,7 +1096,7 @@ async fn test_use_database(instance: Arc<dyn MockInstance>) {
     let output = execute_sql(&instance, "create database db1").await;
     assert!(matches!(output, Output::AffectedRows(1)));
 
-    let query_ctx = Arc::new(QueryContext::with(DEFAULT_CATALOG_NAME, "db1"));
+    let query_ctx = QueryContext::with(DEFAULT_CATALOG_NAME, "db1");
     let output = execute_sql_with(
         &instance,
         "create table tb1(col_i32 int, ts bigint, TIME INDEX(ts))",
@@ -1410,7 +1410,7 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
     let instance = instance.frontend();
 
     let sql = "create table another_table(i bigint time index)";
-    let query_ctx = Arc::new(QueryContext::with("another_catalog", "another_schema"));
+    let query_ctx = QueryContext::with("another_catalog", "another_schema");
     let output = execute_sql_with(&instance, sql, query_ctx.clone()).await;
     assert!(matches!(output, Output::AffectedRows(0)));
 
@@ -1469,7 +1469,7 @@ async fn test_information_schema_dot_columns(instance: Arc<dyn MockInstance>) {
     let instance = instance.frontend();
 
     let sql = "create table another_table(i bigint time index)";
-    let query_ctx = Arc::new(QueryContext::with("another_catalog", "another_schema"));
+    let query_ctx = QueryContext::with("another_catalog", "another_schema");
     let output = execute_sql_with(&instance, sql, query_ctx.clone()).await;
     assert!(matches!(output, Output::AffectedRows(0)));
 

--- a/tests/cases/standalone/common/catalog/schema.result
+++ b/tests/cases/standalone/common/catalog/schema.result
@@ -29,8 +29,7 @@ SHOW DATABASES WHERE Schemas='test_public_schema';
 
 USE test_public_schema;
 
-++
-++
+Affected Rows: 0
 
 CREATE TABLE hello(i BIGINT TIME INDEX);
 
@@ -125,6 +124,5 @@ Error: 3000(PlanQuery), Error during planning: Table not found: greptime.test_pu
 
 USE public;
 
-++
-++
+Affected Rows: 0
 

--- a/tests/cases/standalone/common/create/upper_case_table_name.result
+++ b/tests/cases/standalone/common/create/upper_case_table_name.result
@@ -4,8 +4,7 @@ Affected Rows: 1
 
 use upper_case_table_name;
 
-++
-++
+Affected Rows: 0
 
 create table system_Metric(ts timestamp time index);
 
@@ -34,6 +33,5 @@ Affected Rows: 1
 
 use public;
 
-++
-++
+Affected Rows: 0
 

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -5,8 +5,7 @@ Affected Rows: 1
 
 use my_db;
 
-++
-++
+Affected Rows: 0
 
 create table foo
 (
@@ -52,6 +51,5 @@ order by table_schema, table_name;
 
 use public;
 
-++
-++
+Affected Rows: 0
 

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -331,10 +331,13 @@ impl Database for GreptimeDB {
                 .expect("Illegal `USE` statement: expecting a database.")
                 .trim_end_matches(';');
             client.set_schema(database);
+            Box::new(ResultDisplayer {
+                result: Ok(Output::AffectedRows(0)),
+            }) as _
+        } else {
+            let result = client.sql(&query).await;
+            Box::new(ResultDisplayer { result }) as _
         }
-
-        let result = client.sql(&query).await;
-        Box::new(ResultDisplayer { result }) as _
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly refactors `QueryContext`
1. change builder to use `derive_builder`
2. make `catalog` and `schema` within query context immutable
  - stateless clients like grpc and http should be able to change it on demand before sending request
  - stateful clients like mysql and pg should use `Session` to hold `catalog` and `schema`, and construct immutable query context on receiving next query
3. mark `arc()` as test only. Query context should be constructed with catalog and schema explicitly to avoid potential bug

Discussion
1. now that we actually use session to hold mutable `catalog` and `schema`, should we remove `Statement::Use` since its basically unreachable?
  - on mysql it calls `on_init` rather than treat `use` statement as a normal query
  - we require schema parameter on connecting with pg protocol. it would be strange to allow `use` statement within pg session; or we can process it before it goes into `SqlHandler` like mysql does

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
