### PR TITLE
refactor: arrange lease kvs randomly in lease_based selector

### DIFF
--- a/src/meta-srv/src/selector/lease_based.rs
+++ b/src/meta-srv/src/selector/lease_based.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use api::v1::meta::Peer;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 
 use crate::error::Result;
 use crate::lease;
@@ -34,9 +36,9 @@ impl Selector for LeaseBasedSelector {
                 .into_iter()
                 .collect();
 
-        // TODO(jiachun): At the moment we are just pushing the latest to the forefront,
-        // and it is better to use load-based strategies in the future.
-        lease_kvs.sort_by(|a, b| b.1.timestamp_millis.cmp(&a.1.timestamp_millis));
+        // TODO(jiachun): At the moment we are just arrange them randomly, and it is better
+        // to use load-based strategies in the future.
+        lease_kvs.shuffle(&mut thread_rng());
 
         let peers = lease_kvs
             .into_iter()

--- a/src/meta-srv/src/selector/lease_based.rs
+++ b/src/meta-srv/src/selector/lease_based.rs
@@ -36,8 +36,6 @@ impl Selector for LeaseBasedSelector {
                 .into_iter()
                 .collect();
 
-        // TODO(jiachun): At the moment we are just arrange them randomly, and it is better
-        // to use load-based strategies in the future.
         lease_kvs.shuffle(&mut thread_rng());
 
         let peers = lease_kvs


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This pr mainly change: arrange lease kvs randomly in lease_based selector, instead of pushing the latest lease kv to the forefront.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
