### PR TITLE
feat: accept influxdb request without timestamp even if table doesn't exist

### DIFF
--- a/src/common/grpc/src/writer.rs
+++ b/src/common/grpc/src/writer.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt::Display;
 
 use api::helper::values_with_capacity;
 use api::v1::column::SemanticType;
@@ -244,6 +245,19 @@ pub enum Precision {
     Second,
     Minute,
     Hour,
+}
+
+impl Display for Precision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Precision::Nanosecond => write!(f, "Precision::Nanosecond"),
+            Precision::Microsecond => write!(f, "Precision::Microsecond"),
+            Precision::Millisecond => write!(f, "Precision::Millisecond"),
+            Precision::Second => write!(f, "Precision::Second"),
+            Precision::Minute => write!(f, "Precision::Minute"),
+            Precision::Hour => write!(f, "Precision::Hour"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests-integration/src/influxdb.rs
+++ b/tests-integration/src/influxdb.rs
@@ -75,7 +75,12 @@ monitor1,host=host2 memory=1027";
         let output = output.remove(0).unwrap();
         let Output::Stream(stream) = output else { unreachable!() };
 
-        assert!(RecordBatches::try_collect(stream).await.is_ok());
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        let recordbatches: Vec<_> = recordbatches.iter().collect();
+        let total = recordbatches
+            .into_iter()
+            .fold(0, |total, recordbatch| total + recordbatch.num_rows());
+        assert_eq!(total, 2);
     }
 
     async fn test_put_influxdb_lines(instance: &Arc<Instance>) {

--- a/tests-integration/src/influxdb.rs
+++ b/tests-integration/src/influxdb.rs
@@ -42,6 +42,42 @@ mod test {
         test_put_influxdb_lines(&instance.frontend()).await;
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_standalone_put_influxdb_lines_without_time_column() {
+        let standalone =
+            tests::create_standalone_instance("test_standalone_put_influxdb_lines").await;
+        test_put_influxdb_lines_without_time_column(&standalone.instance).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_distributed_put_influxdb_lines_without_time_column() {
+        let instance =
+            tests::create_distributed_instance("test_distributed_put_influxdb_lines").await;
+        test_put_influxdb_lines_without_time_column(&instance.frontend()).await;
+    }
+
+    async fn test_put_influxdb_lines_without_time_column(instance: &Arc<Instance>) {
+        let lines = r"
+monitor1,host=host1 cpu=66.6,memory=1024
+monitor1,host=host2 memory=1027";
+        let request = InfluxdbRequest {
+            precision: None,
+            lines: lines.to_string(),
+        };
+        assert!(instance.exec(&request, QueryContext::arc()).await.is_ok());
+
+        let mut output = instance
+            .do_query(
+                "SELECT ts, host, cpu, memory FROM monitor1 ORDER BY ts",
+                QueryContext::arc(),
+            )
+            .await;
+        let output = output.remove(0).unwrap();
+        let Output::Stream(stream) = output else { unreachable!() };
+
+        assert!(RecordBatches::try_collect(stream).await.is_ok());
+    }
+
     async fn test_put_influxdb_lines(instance: &Arc<Instance>) {
         let lines = r"
 monitor1,host=host1 cpu=66.6,memory=1024 1663840496100023100


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR allows `greptimedb` to accept influxdb request without timestamp even if a corresponding table doesn't exist.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

close #1997
