### PR TITLE
refactor: create_current_timestamp_vector by using VectorOp::cast 

### DIFF
--- a/src/datatypes/src/schema/constraint.rs
+++ b/src/datatypes/src/schema/constraint.rs
@@ -162,8 +162,6 @@ fn create_current_timestamp_vector(
     data_type: &ConcreteDataType,
     num_rows: usize,
 ) -> Result<VectorRef> {
-    // FIXME(yingwen): We should implements cast in VectorOp so we could cast the millisecond vector
-    // to other data type and avoid this match.
     let current_timestamp_vector = TimestampMillisecondVector::from_values(
         std::iter::repeat(util::current_time_millis()).take(num_rows),
     );
@@ -263,6 +261,39 @@ mod tests {
         let constraint = ColumnDefaultConstraint::Function(CURRENT_TIMESTAMP.to_string());
         // Timestamp type.
         let data_type = ConcreteDataType::timestamp_millisecond_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        assert_eq!(4, v.len());
+        assert!(
+            matches!(v.get(0), Value::Timestamp(_)),
+            "v {:?} is not timestamp",
+            v.get(0)
+        );
+
+        let data_type = ConcreteDataType::timestamp_second_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        assert_eq!(4, v.len());
+        assert!(
+            matches!(v.get(0), Value::Timestamp(_)),
+            "v {:?} is not timestamp",
+            v.get(0)
+        );
+
+        let data_type = ConcreteDataType::timestamp_microsecond_datatype();
+        let v = constraint
+            .create_default_vector(&data_type, false, 4)
+            .unwrap();
+        assert_eq!(4, v.len());
+        assert!(
+            matches!(v.get(0), Value::Timestamp(_)),
+            "v {:?} is not timestamp",
+            v.get(0)
+        );
+
+        let data_type = ConcreteDataType::timestamp_nanosecond_datatype();
         let v = constraint
             .create_default_vector(&data_type, false, 4)
             .unwrap();

--- a/src/datatypes/src/vectors.rs
+++ b/src/datatypes/src/vectors.rs
@@ -34,7 +34,7 @@ mod eq;
 mod helper;
 mod list;
 mod null;
-mod operations;
+pub(crate) mod operations;
 mod primitive;
 mod string;
 mod time;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

using `VectorOp::cast` refactor `create_current_timestamp_vector` function.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2030 
