### PR TITLE
chore: make `tables()` return kv instead of key only

### DIFF
--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -248,16 +248,30 @@ impl TableNameManager {
             .transpose()
     }
 
-    pub async fn tables(&self, catalog: &str, schema: &str) -> Result<Vec<String>> {
+    pub async fn tables(
+        &self,
+        catalog: &str,
+        schema: &str,
+    ) -> Result<Vec<(String, TableNameValue)>> {
         let key = TableNameKey::prefix_to_table(catalog, schema).into_bytes();
         let req = RangeRequest::new().with_prefix(key);
         let resp = self.kv_backend.range(req).await?;
-        let table_names = resp
-            .kvs
-            .into_iter()
-            .map(|kv| TableNameKey::strip_table_name(kv.key()))
-            .collect::<Result<Vec<_>>>()?;
-        Ok(table_names)
+
+        let mut res = Vec::with_capacity(resp.kvs.len());
+        for kv in resp.kvs {
+            res.push((
+                TableNameKey::strip_table_name(kv.key())?,
+                TableNameValue::try_from_raw_value(kv.value)?,
+            ))
+        }
+        Ok(res)
+
+        // let table_names = resp
+        //     .kvs
+        //     .into_iter()
+        //     .map(|kv| TableNameKey::strip_table_name(kv.key()))
+        //     .collect::<Result<Vec<_>>>()?;
+        // Ok(table_names)
     }
 
     pub async fn remove(&self, key: TableNameKey<'_>) -> Result<()> {
@@ -334,7 +348,14 @@ mod tests {
 
         let tables = manager.tables("my_catalog", "my_schema").await.unwrap();
         assert_eq!(tables.len(), 3);
-        assert_eq!(tables, vec!["table_1_new", "table_2", "table_3"]);
+        assert_eq!(
+            tables,
+            vec![
+                ("table_1_new".to_string(), TableNameValue::new(1)),
+                ("table_2".to_string(), TableNameValue::new(2)),
+                ("table_3".to_string(), TableNameValue::new(3))
+            ]
+        )
     }
 
     #[test]

--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -265,13 +265,6 @@ impl TableNameManager {
             ))
         }
         Ok(res)
-
-        // let table_names = resp
-        //     .kvs
-        //     .into_iter()
-        //     .map(|kv| TableNameKey::strip_table_name(kv.key()))
-        //     .collect::<Result<Vec<_>>>()?;
-        // Ok(table_names)
     }
 
     pub async fn remove(&self, key: TableNameKey<'_>) -> Result<()> {

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -332,7 +332,10 @@ impl CatalogManager for FrontendCatalogManager {
             .table_name_manager()
             .tables(catalog, schema)
             .await
-            .context(TableMetadataManagerSnafu)?;
+            .context(TableMetadataManagerSnafu)?
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect::<Vec<String>>();
         if catalog == DEFAULT_CATALOG_NAME && schema == DEFAULT_SCHEMA_NAME {
             tables.push("numbers".to_string());
         }

--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -90,7 +90,10 @@ impl HttpHandler for TablesHandler {
             .table_name_manager()
             .tables(catalog, schema)
             .await
-            .context(TableMetadataManagerSnafu)?;
+            .context(TableMetadataManagerSnafu)?
+            .into_iter()
+            .map(|(k, _)| k)
+            .collect();
 
         to_http_response(tables)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly makes `tables()` method in `TableNameManager` return table name and table id at the same time.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
