### PR TITLE
chore(ci): run clippy, coverage and sqlness in parallel

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -117,7 +117,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
-    needs: [clippy]
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1
@@ -191,7 +190,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
-    needs: [clippy]
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/setup-protoc@v1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Pipeline before this change:
![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/6c9687e7-bdd3-4e23-96cc-f38aefbc198e)

Where the sqlness and coverage will wait clippy to start. But they can be run in parallel.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Those requires were added in https://github.com/GreptimeTeam/greptimedb/pull/1093