### PR TITLE
fix(deps): update greptime-proto rev to the one after merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "3d8ac534a0c8fd1c6ec66d129345b44c95665ebc" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "eeae2d0dfa8ee320a7b9e987b4631a6c1c732ebd" }
 itertools = "0.10"
 lazy_static = "1.4"
 once_cell = "1.18"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This error casually occurs:

```
cargo build --locked --profile nightly --features servers/dashboard
    Updating crates.io index
    Updating git repository `https://github.com/waynexia/arrow-datafusion.git`
    Updating git submodule `https://github.com/apache/parquet-testing.git`
    Updating git submodule `https://github.com/apache/arrow-testing`
    Updating git repository `https://github.com/GreptimeTeam/greptime-proto.git`
error: failed to get `greptime-proto` as a dependency of package `api v0.3.2 (/Users/runner/work/greptimedb/greptimedb/src/api)`

Caused by:
  failed to load source for dependency `greptime-proto`

Caused by:
  Unable to update https://github.com/GreptimeTeam/greptime-proto.git?rev=3d8ac534a0c8fd1c6ec66d129345b44c95665ebc#3d8ac534

Caused by:
  object not found - no match for id (3d8ac534a0c8fd1c6ec66d129345b44c95665ebc); class=Odb (9); code=NotFound (-3)
make: *** [build] Error 101
Error: Process completed with exit code 2.
```

It's caused by the `greptime-proto` dep is referring to a commit that belongs to a deleted branch
![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/101ee7da-083c-41ec-9bf6-a60efbc0c726)

This patch change it to the one after merged

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
