### PR TITLE
feat: necessary `Hash` derive for types

### DIFF
--- a/src/common/base/src/bytes.rs
+++ b/src/common/base/src/bytes.rs
@@ -17,7 +17,7 @@ use std::ops::Deref;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Bytes buffer.
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct Bytes(bytes::Bytes);
 
 impl From<Bytes> for bytes::Bytes {
@@ -80,7 +80,7 @@ impl PartialEq<Bytes> for [u8] {
 ///
 /// Now this buffer is restricted to only hold valid UTF-8 string (only allow constructing `StringBytes`
 /// from String or str). We may support other encoding in the future.
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StringBytes(bytes::Bytes);
 
 impl StringBytes {

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -35,7 +35,7 @@ use crate::types::{
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch(DataType)]
 pub enum ConcreteDataType {
     Null(NullType),

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -24,7 +24,7 @@ use crate::type_id::LogicalTypeId;
 use crate::value::Value;
 use crate::vectors::{BinaryVectorBuilder, MutableVector};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BinaryType;
 
 impl BinaryType {

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -23,7 +23,7 @@ use crate::type_id::LogicalTypeId;
 use crate::value::Value;
 use crate::vectors::{BooleanVectorBuilder, MutableVector};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BooleanType;
 
 impl BooleanType {

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -26,7 +26,7 @@ use crate::value::{Value, ValueRef};
 use crate::vectors::{DateVector, DateVectorBuilder, MutableVector, Vector};
 
 /// Data type for Date (YYYY-MM-DD).
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DateType;
 
 impl DataType for DateType {

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -24,7 +24,7 @@ use crate::types::LogicalPrimitiveType;
 use crate::vectors::{DateTimeVector, DateTimeVectorBuilder, PrimitiveVector};
 
 /// Data type for [`DateTime`].
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DateTimeType;
 
 impl DataType for DateTimeType {

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -21,7 +21,7 @@ use crate::value::Value;
 use crate::vectors::MutableVector;
 
 /// Used to represent the Dictionary datatype.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DictionaryType {
     // Use Box to avoid recursive dependency, as enum ConcreteDataType depends on DictionaryType.
     /// The type of Dictionary key.

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -40,7 +40,7 @@ use crate::vectors::{
 /// The "calendar" interval is a type of time interval that does not
 /// have a precise duration without taking into account a specific
 /// base timestamp.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[enum_dispatch(DataType)]
 pub enum IntervalType {
     YearMonth(IntervalYearMonthType),
@@ -62,7 +62,7 @@ impl IntervalType {
 macro_rules! impl_data_type_for_interval {
     ($unit: ident, $type: ty) => {
         paste! {
-            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
             pub struct [<Interval $unit Type>];
 
             impl DataType for [<Interval $unit Type>] {

--- a/src/datatypes/src/types/list_type.rs
+++ b/src/datatypes/src/types/list_type.rs
@@ -23,7 +23,7 @@ use crate::value::{ListValue, Value};
 use crate::vectors::{ListVectorBuilder, MutableVector};
 
 /// Used to represent the List datatype.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ListType {
     /// The type of List's item.
     // Use Box to avoid recursive dependency, as enum ConcreteDataType depends on ListType.

--- a/src/datatypes/src/types/null_type.rs
+++ b/src/datatypes/src/types/null_type.rs
@@ -22,7 +22,7 @@ use crate::type_id::LogicalTypeId;
 use crate::value::Value;
 use crate::vectors::{MutableVector, NullVectorBuilder};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct NullType;
 
 impl NullType {

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -194,7 +194,7 @@ macro_rules! define_logical_primitive_type {
         // We need to define it as an empty struct `struct DataType {}` instead of a struct-unit
         // `struct DataType;` to ensure the serialized JSON string is compatible with previous
         // implementation.
-        #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+        #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
         pub struct $DataType {}
 
         impl LogicalPrimitiveType for $DataType {

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -24,7 +24,7 @@ use crate::type_id::LogicalTypeId;
 use crate::value::Value;
 use crate::vectors::{MutableVector, StringVectorBuilder};
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StringType;
 
 impl StringType {

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -44,7 +44,7 @@ const MILLISECOND_VARIATION: u64 = 3;
 const MICROSECOND_VARIATION: u64 = 6;
 const NANOSECOND_VARIATION: u64 = 9;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[enum_dispatch(DataType)]
 pub enum TimeType {
     Second(TimeSecondType),
@@ -88,7 +88,7 @@ impl TimeType {
 macro_rules! impl_data_type_for_time {
     ($unit: ident,$arrow_type: ident, $type: ty) => {
         paste! {
-            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
             pub struct [<Time $unit Type>];
 
             impl DataType for [<Time $unit Type>] {

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -47,7 +47,7 @@ const MILLISECOND_VARIATION: u64 = 3;
 const MICROSECOND_VARIATION: u64 = 6;
 const NANOSECOND_VARIATION: u64 = 9;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[enum_dispatch(DataType)]
 pub enum TimestampType {
     Second(TimestampSecondType),
@@ -109,7 +109,7 @@ impl TimestampType {
 macro_rules! impl_data_type_for_timestamp {
     ($unit: ident) => {
         paste! {
-            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+            #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
             pub struct [<Timestamp $unit Type>];
 
             impl DataType for [<Timestamp $unit Type>] {

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -44,7 +44,7 @@ pub type OrderedF64 = OrderedFloat<f64>;
 /// Value holds a single arbitrary value of any [DataType](crate::data_type::DataType).
 ///
 /// Comparison between values with different types (expect Null) is not allowed.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Value {
     Null,
 
@@ -535,7 +535,7 @@ impl TryFrom<Value> for serde_json::Value {
 
 // TODO(yingwen): Consider removing the `datatype` field from `ListValue`.
 /// List value.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ListValue {
     /// List of nested Values (boxed to reduce size_of(Value))
     #[allow(clippy::box_collection)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add some derive I found useful when developing another project

- Summarize your change (**mandatory**)
add some `derive(Hash)` whene necessary

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

