### PR TITLE
chore: add meter-core dependency

### DIFF
--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -41,6 +41,8 @@ futures-util.workspace = true
 humantime-serde = "1.1"
 itertools.workspace = true
 meta-client = { path = "../meta-client" }
+# Although it is not used, please do not delete it.
+meter-core.workspace = true
 meter-macros.workspace = true
 metrics.workspace = true
 mito = { path = "../mito", features = ["test"] }
@@ -72,7 +74,6 @@ catalog = { path = "../catalog", features = ["testing"] }
 common-test-util = { path = "../common/test-util" }
 datanode = { path = "../datanode" }
 futures = "0.3"
-meter-core.workspace = true
 meta-srv = { path = "../meta-srv", features = ["mock"] }
 strfmt = "0.2"
 tower = "0.4"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly add `meter-core` dependency in frontend crate.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
