### PR TITLE
fix: add the missing 'NIGHTLY_RELEASE_PREFIX' and fail fast in 'allocate-runners' job

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,7 +1,7 @@
 # Nightly build only do the following things:
 # 1. Run integration tests;
 # 2. Build binaries and images for linux-amd64 and linux-arm64 platform;
-name: GreptimeDB Nightly build
+name: GreptimeDB Nightly Build
 
 on:
   schedule:
@@ -64,6 +64,8 @@ env:
   # Always use 'dev' to indicate it's the nightly build.
   NEXT_RELEASE_VERSION: dev
 
+  NIGHTLY_RELEASE_PREFIX: nightly
+
 jobs:
   allocate-runners:
     name: Allocate runners
@@ -90,7 +92,7 @@ jobs:
       - name: Create version
         id: create-version
         run: |
-          echo "version=$(./.github/scripts/create-version.sh)" >> $GITHUB_OUTPUT
+          version=$(./.github/scripts/create-version.sh) && echo "version=$version" >> $GITHUB_ENV
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add the missing 'NIGHTLY_RELEASE_PREFIX' and fail fast in 'allocate-runners' job.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
