### PR TITLE
ci: require cargo.lock up to date

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Run cargo check
-        run: cargo check --workspace --all-targets
+        run: cargo check --locked --workspace --all-targets
 
   toml:
     name: Toml Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7225,6 +7225,7 @@ dependencies = [
  "ahash 0.8.3",
  "approx_eq",
  "arc-swap",
+ "arrow",
  "arrow-schema",
  "async-stream",
  "async-trait",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Require cargo.lock up to date on `cargo check`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
