### PR TITLE
fix: cargo lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7225,6 +7225,7 @@ dependencies = [
  "ahash 0.8.3",
  "approx_eq",
  "arc-swap",
+ "arrow",
  "arrow-schema",
  "async-stream",
  "async-trait",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly updates `Cargo.lock` file by running `cargo check`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
