### PR TITLE
fix: introduce `taplo.toml` and sort `Cargo.toml`

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install taplo
         run: cargo install taplo-cli --version ^0.8 --locked
       - name: Run taplo
-        run: taplo format --check --option "indent_string=    "
+        run: taplo format --check
 
   # Use coverage to run test.
   # test:

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,11 @@ fmt: ## Format all the Rust code.
 
 .PHONY: fmt-toml
 fmt-toml: ## Format all TOML files.
-	taplo format --option "indent_string=    "
+	taplo format
 
 .PHONY: check-toml
 check-toml: ## Check all TOML files.
-	taplo format --check --option "indent_string=    "
+	taplo format --check
 
 .PHONY: docker-image
 docker-image: multi-platform-buildx ## Build docker image.

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -43,8 +43,8 @@ tokio.workspace = true
 
 [dev-dependencies]
 catalog = { path = ".", features = ["testing"] }
-common-test-util = { path = "../common/test-util" }
 chrono.workspace = true
+common-test-util = { path = "../common/test-util" }
 log-store = { path = "../log-store" }
 mito = { path = "../mito", features = ["test"] }
 object-store = { path = "../object-store" }

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -15,11 +15,11 @@ common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
+common-meta = { path = "../common/meta" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-common-time = { path = "../common/time" }
-common-meta = { path = "../common/meta" }
 common-telemetry = { path = "../common/telemetry" }
+common-time = { path = "../common/time" }
 datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 enum_dispatch = "0.3"
@@ -37,10 +37,10 @@ tonic.workspace = true
 common-grpc-expr = { path = "../common/grpc-expr" }
 datanode = { path = "../datanode" }
 derive-new = "0.5"
+prost.workspace = true
 substrait = { path = "../common/substrait" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-prost.workspace = true
 
 [dev-dependencies.substrait_proto]
 package = "substrait"

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -27,8 +27,8 @@ clap = { version = "3.1", features = ["derive"] }
 client = { path = "../client" }
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
-common-query = { path = "../common/query" }
 common-meta = { path = "../common/meta" }
+common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry", features = [
     "deadlock_detection",
@@ -60,8 +60,8 @@ tokio.workspace = true
 [dev-dependencies]
 common-test-util = { path = "../common/test-util" }
 rexpect = "0.5"
-temp-env = "0.3"
 serde.workspace = true
+temp-env = "0.3"
 toml.workspace = true
 
 [build-dependencies]

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-arrow.workspace = true
 arrow-schema.workspace = true
+arrow.workspace = true
 async-compression = { version = "0.3", features = [
     "bzip2",
     "gzip",
@@ -24,12 +24,12 @@ derive_builder.workspace = true
 futures.workspace = true
 object-store = { path = "../../object-store" }
 orc-rust = "0.2"
+paste = "1.0"
 regex = "1.7"
 snafu.workspace = true
-tokio.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 url = "2.3"
-paste = "1.0"
 
 [dev-dependencies]
 common-test-util = { path = "../test-util" }

--- a/src/common/function-macro/Cargo.toml
+++ b/src/common/function-macro/Cargo.toml
@@ -8,11 +8,11 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-common-telemetry = { path = "../telemetry" }
 backtrace = "0.3"
+common-telemetry = { path = "../telemetry" }
+proc-macro2 = "1.0"
 quote = "1.0"
 syn = "1.0"
-proc-macro2 = "1.0"
 
 [dev-dependencies]
 arc-swap = "1.0"

--- a/src/common/greptimedb-telemetry/Cargo.toml
+++ b/src/common/greptimedb-telemetry/Cargo.toml
@@ -9,6 +9,7 @@ async-trait.workspace = true
 common-error = { path = "../error" }
 common-runtime = { path = "../runtime" }
 common-telemetry = { path = "../telemetry" }
+once_cell = "1.17.0"
 reqwest = { version = "0.11", features = [
     "json",
     "rustls-tls",
@@ -17,11 +18,10 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-once_cell = "1.17.0"
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["full"] }
 common-test-util = { path = "../test-util" }
+hyper = { version = "0.14", features = ["full"] }
 
 [build-dependencies]
 common-version = { path = "../version" }

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -12,5 +12,5 @@ tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tokio.workspace = true
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+version = "0.5"

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-async-trait.workspace = true
 async-stream.workspace = true
+async-trait.workspace = true
 backon = "0.4"
 common-error = { path = "../error" }
 common-runtime = { path = "../runtime" }

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -10,9 +10,9 @@ async-trait.workspace = true
 common-error = { path = "../error" }
 common-recordbatch = { path = "../recordbatch" }
 common-time = { path = "../time" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
 serde.workspace = true
 snafu.workspace = true

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 common-error = { path = "../error" }
-datafusion.workspace = true
 datafusion-common.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
 futures.workspace = true
 paste = "1.0"

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -12,8 +12,8 @@ metrics.workspace = true
 once_cell.workspace = true
 paste.workspace = true
 snafu.workspace = true
-tokio.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/common/substrait/Cargo.toml
+++ b/src/common/substrait/Cargo.toml
@@ -12,10 +12,10 @@ catalog = { path = "../../catalog" }
 common-catalog = { path = "../catalog" }
 common-error = { path = "../error" }
 common-telemetry = { path = "../telemetry" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-substrait.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../../datatypes" }
 futures = "0.3"
 promql = { path = "../../promql" }

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 arrow.workspace = true
-chrono.workspace = true
 chrono-tz = "0.8"
+chrono.workspace = true
 common-error = { path = "../error" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -8,18 +8,19 @@ license.workspace = true
 greptimedb-telemetry = []
 
 [dependencies]
+api = { path = "../api" }
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait.workspace = true
-api = { path = "../api" }
 axum = "0.6"
 axum-macros = "0.3"
 catalog = { path = "../catalog" }
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
 common-datasource = { path = "../common/datasource" }
+common-error = { path = "../common/error" }
 common-function = { path = "../common/function" }
+common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
 common-grpc = { path = "../common/grpc" }
 common-grpc-expr = { path = "../common/grpc-expr" }
 common-meta = { path = "../common/meta" }
@@ -29,17 +30,16 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 file-table-engine = { path = "../file-table-engine" }
 futures = "0.3"
 futures-util.workspace = true
-key-lock = "0.1"
-hyper = { version = "0.14", features = ["full"] }
 humantime-serde = "1.1"
+hyper = { version = "0.14", features = ["full"] }
+key-lock = "0.1"
 log-store = { path = "../log-store" }
 meta-client = { path = "../meta-client" }
 meta-srv = { path = "../meta-srv", features = ["mock"] }
@@ -61,8 +61,8 @@ store-api = { path = "../store-api" }
 substrait = { path = "../common/substrait" }
 table = { path = "../table" }
 table-procedure = { path = "../table-procedure" }
-tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
+tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 tower = { version = "0.4", features = ["full"] }
@@ -73,7 +73,7 @@ uuid.workspace = true
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
 client = { path = "../client" }
-common-test-util = { path = "../common/test-util" }
 common-query = { path = "../common/query" }
+common-test-util = { path = "../common/test-util" }
 datafusion-common.workspace = true
 session = { path = "../session", features = ["testing"] }

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -9,13 +9,13 @@ default = []
 test = []
 
 [dependencies]
-arrow.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
+arrow.workspace = true
 common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
-common-time = { path = "../common/time" }
 common-telemetry = { path = "../common/telemetry" }
+common-time = { path = "../common/time" }
 datafusion-common.workspace = true
 enum_dispatch = "0.3"
 num = "0.4"

--- a/src/file-table-engine/Cargo.toml
+++ b/src/file-table-engine/Cargo.toml
@@ -17,6 +17,7 @@ common-procedure = { path = "../common/procedure" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry" }
+common-test-util = { path = "../common/test-util", optional = true }
 common-time = { path = "../common/time" }
 datafusion.workspace = true
 datatypes = { path = "../datatypes" }
@@ -27,7 +28,6 @@ serde_json = "1.0"
 snafu.workspace = true
 store-api = { path = "../store-api" }
 table = { path = "../table" }
-common-test-util = { path = "../common/test-util", optional = true }
 tokio.workspace = true
 
 [dev-dependencies]

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -24,15 +24,15 @@ common-error = { path = "../common/error" }
 common-function = { path = "../common/function" }
 common-grpc = { path = "../common/grpc" }
 common-grpc-expr = { path = "../common/grpc-expr" }
-common-query = { path = "../common/query" }
 common-meta = { path = "../common/meta" }
+common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion.workspace = true
 datanode = { path = "../datanode" }
 datatypes = { path = "../datatypes" }
 file-table-engine = { path = "../file-table-engine" }

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -19,14 +19,14 @@ common-base = { path = "../common/base" }
 common-error = { path = "../common/error" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
-futures.workspace = true
 futures-util.workspace = true
+futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }
 raft-engine = "0.3"
 snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
-tokio.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 common-test-util = { path = "../common/test-util" }

--- a/src/meta-client/Cargo.toml
+++ b/src/meta-client/Cargo.toml
@@ -10,16 +10,16 @@ async-trait = "0.1"
 chrono.workspace = true
 common-error = { path = "../common/error" }
 common-grpc = { path = "../common/grpc" }
-common-telemetry = { path = "../common/telemetry" }
 common-meta = { path = "../common/meta" }
+common-telemetry = { path = "../common/telemetry" }
 etcd-client.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 table = { path = "../table" }
-tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
+tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -18,6 +18,7 @@ client = { path = "../client" }
 common-base = { path = "../common/base" }
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
+common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
 common-grpc = { path = "../common/grpc" }
 common-grpc-expr = { path = "../common/grpc-expr" }
 common-meta = { path = "../common/meta" }
@@ -25,7 +26,6 @@ common-procedure = { path = "../common/procedure" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
 dashmap = "5.4"
 datatypes = { path = "../datatypes" }
 derive_builder.workspace = true
@@ -42,17 +42,17 @@ rand.workspace = true
 regex.workspace = true
 serde = "1.0"
 serde_json = "1.0"
+servers = { path = "../servers" }
 snafu.workspace = true
 store-api = { path = "../store-api" }
 table = { path = "../table" }
-tokio.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
+tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 tower = "0.4"
 typetag = "0.2"
 url = "2.3"
-servers = { path = "../servers" }
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -15,17 +15,17 @@ async-stream.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
 common-catalog = { path = "../common/catalog" }
+common-datasource = { path = "../common/datasource" }
 common-error = { path = "../common/error" }
 common-procedure = { path = "../common/procedure" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
-common-datasource = { path = "../common/datasource" }
 common-telemetry = { path = "../common/telemetry" }
 common-test-util = { path = "../common/test-util", optional = true }
 common-time = { path = "../common/time" }
 dashmap = "5.4"
-datafusion.workspace = true
 datafusion-common.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures.workspace = true
 key-lock = "0.1"
@@ -41,5 +41,5 @@ table = { path = "../table" }
 tokio.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../common/test-util" }
 common-procedure-test = { path = "../common/procedure-test" }
+common-test-util = { path = "../common/test-util" }

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -9,27 +9,27 @@ default = []
 test = ["common-test-util"]
 
 [dependencies]
-aquamarine = "0.3"
 anymap = "1.0.0-beta.2"
+aquamarine = "0.3"
 arc-swap = "1.0"
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
-common-catalog = { path = "../common/catalog" }
 common-base = { path = "../common/base" }
+common-catalog = { path = "../common/catalog" }
+common-datasource = { path = "../common/datasource" }
 common-error = { path = "../common/error" }
 common-procedure = { path = "../common/procedure" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
-common-datasource = { path = "../common/datasource" }
 common-telemetry = { path = "../common/telemetry" }
 common-test-util = { path = "../common/test-util", optional = true }
 common-time = { path = "../common/time" }
 dashmap = "5.4"
-datafusion.workspace = true
 datafusion-common.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures.workspace = true
 # TODO(yingwen): Update and use api crate once https://github.com/GreptimeTeam/greptime-proto/pull/75 is merged.
@@ -50,5 +50,5 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../common/test-util" }
 common-procedure-test = { path = "../common/procedure-test" }
+common-test-util = { path = "../common/test-util" }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-lru = "0.9"
 async-trait = "0.1"
 bytes = "1.4"
 futures = { version = "0.3" }
+lru = "0.9"
 md5 = "0.7"
 metrics.workspace = true
 opendal = { version = "0.36", features = ["layers-tracing", "layers-metrics"] }

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -11,8 +11,8 @@ api = { path = "../api" }
 async-trait = "0.1"
 common-catalog = { path = "../common/catalog" }
 common-error = { path = "../common/error" }
-common-query = { path = "../common/query" }
 common-meta = { path = "../common/meta" }
+common-query = { path = "../common/query" }
 common-telemetry = { path = "../common/telemetry" }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -9,9 +9,10 @@ async-recursion = "1.0"
 async-trait.workspace = true
 bytemuck = "1.12"
 catalog = { path = "../catalog" }
-common-error = { path = "../common/error" }
 common-catalog = { path = "../common/catalog" }
+common-error = { path = "../common/error" }
 common-function-macro = { path = "../common/function-macro" }
+common-telemetry = { path = "../common/telemetry" }
 datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures = "0.3"
@@ -21,9 +22,8 @@ prost.workspace = true
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 table = { path = "../table" }
-common-telemetry = { path = "../common/telemetry" }
 
 [dev-dependencies]
-tokio.workspace = true
 query = { path = "../query" }
 session = { path = "../session", features = ["testing"] }
+tokio.workspace = true

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -23,12 +23,12 @@ common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-optimizer.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion-sql.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures = "0.3"
 futures-util.workspace = true
@@ -44,15 +44,15 @@ regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 session = { path = "../session" }
-substrait = { path = "../common/substrait" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
+substrait = { path = "../common/substrait" }
 table = { path = "../table" }
 tokio.workspace = true
 
 [dev-dependencies]
-arrow.workspace = true
 approx_eq = "0.1"
+arrow.workspace = true
 catalog = { path = "../catalog", features = ["testing"] }
 common-function-macro = { path = "../common/function-macro" }
 format_num = "0.1"

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -32,9 +32,9 @@ common-error = { path = "../common/error" }
 common-function = { path = "../common/function" }
 common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
+common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-common-runtime = { path = "../common/runtime" }
 console = "0.15"
 crossbeam-utils = "0.8.14"
 datafusion = { workspace = true, optional = true }
@@ -42,12 +42,13 @@ datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
 datatypes = { path = "../datatypes" }
-futures.workspace = true
 futures-util.workspace = true
+futures.workspace = true
 once_cell.workspace = true
 paste = { workspace = true, optional = true }
 query = { path = "../query" }
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After RustPython support GC
+pyo3 = { version = "0.19", optional = true, features = ["abi3", "abi3-py37"] }
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "9ed5137412" }
 rustpython-codegen = { git = "https://github.com/discord9/RustPython", optional = true, rev = "9ed5137412" }
 rustpython-compiler = { git = "https://github.com/discord9/RustPython", optional = true, rev = "9ed5137412" }
@@ -61,7 +62,6 @@ rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = tru
     "default",
     "codegen",
 ] }
-pyo3 = { version = "0.19", optional = true, features = ["abi3", "abi3-py37"] }
 session = { path = "../session" }
 snafu = { version = "0.7", features = ["backtraces"] }
 sql = { path = "../sql" }
@@ -72,15 +72,15 @@ tokio.workspace = true
 [dev-dependencies]
 catalog = { path = "../catalog", features = ["testing"] }
 common-test-util = { path = "../common/test-util" }
+criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
 log-store = { path = "../log-store" }
 mito = { path = "../mito", features = ["test"] }
+rayon = "1.0"
 ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 session = { path = "../session", features = ["testing"] }
 storage = { path = "../storage" }
 tokio-test = "0.4"
-criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
-rayon = "1.0"
 
 [[bench]]
 name = "py_benchmark"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -32,9 +32,9 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion.workspace = true
 
 datatypes = { path = "../datatypes" }
 derive_builder.workspace = true
@@ -66,9 +66,9 @@ prost.workspace = true
 query = { path = "../query" }
 rand.workspace = true
 regex.workspace = true
+rust-embed = { version = "6.6", features = ["debug-embed"] }
 rustls = "0.21"
 rustls-pemfile = "1.0"
-rust-embed = { version = "6.6", features = ["debug-embed"] }
 schemars = "0.8"
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde.workspace = true
@@ -84,11 +84,10 @@ tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
-tonic.workspace = true
 tonic-reflection = "0.9"
+tonic.workspace = true
 tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.3", features = ["full"] }
-
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -6,11 +6,11 @@ license.workspace = true
 
 [dependencies]
 arc-swap = "1.0"
+arrow-array.workspace = true
+arrow.workspace = true
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
-arrow.workspace = true
-arrow-array.workspace = true
 bytes = "1.1"
 common-base = { path = "../common/base" }
 common-datasource = { path = "../common/datasource" }
@@ -20,13 +20,13 @@ common-recordbatch = { path = "../common/recordbatch" }
 common-runtime = { path = "../common/runtime" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-datatypes = { path = "../datatypes" }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion.workspace = true
-futures.workspace = true
+datatypes = { path = "../datatypes" }
 futures-util.workspace = true
+futures.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 metrics.workspace = true
@@ -40,15 +40,15 @@ serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 store-api = { path = "../store-api" }
 table = { path = "../table" }
-tokio.workspace = true
 tokio-util.workspace = true
+tokio.workspace = true
 tonic.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
 atomic_float = "0.1"
-criterion = "0.3"
 common-test-util = { path = "../common/test-util" }
+criterion = "0.3"
 datatypes = { path = "../datatypes", features = ["test"] }
 log-store = { path = "../log-store" }
 rand.workspace = true

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -19,10 +19,10 @@ common-query = { path = "../common/query" }
 common-recordbatch = { path = "../common/recordbatch" }
 common-telemetry = { path = "../common/telemetry" }
 common-time = { path = "../common/time" }
-datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
+datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 derive_builder.workspace = true
 futures.workspace = true
@@ -37,5 +37,5 @@ tokio.workspace = true
 [dev-dependencies]
 common-test-util = { path = "../common/test-util" }
 parquet = { workspace = true, features = ["async"] }
-tokio-util = { version = "0.7", features = ["compat"] }
 serde_json.workspace = true
+tokio-util = { version = "0.7", features = ["compat"] }

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,36 @@
+## https://taplo.tamasfe.dev/configuration/file.html
+
+include = ["**/Cargo.toml"]
+
+[formatting]
+# Align consecutive entries vertically.
+align_entries = false
+# Append trailing commas for multi-line arrays.
+array_trailing_comma = true
+# Expand arrays to multiple lines that exceed the maximum column width.
+array_auto_expand = true
+# Collapse arrays that don't exceed the maximum column width and don't contain comments.
+array_auto_collapse = false
+# Omit white space padding from single-line arrays
+compact_arrays = true
+# Omit white space padding from the start and end of inline tables.
+compact_inline_tables = false
+# Maximum column width in characters, affects array expansion and collapse, this doesn't take whitespace into account.
+# Note that this is not set in stone, and works on a best-effort basis.
+column_width = 120
+# Indent based on tables and arrays of tables and their subtables, subtables out of order are not indented.
+indent_tables = false
+# The substring that is used for indentation, should be tabs or spaces (but technically can be anything).
+indent_string = '    '
+# Add trailing newline at the end of the file if not present.
+trailing_newline = true
+# Alphabetically reorder keys that are not separated by empty lines.
+reorder_keys = false
+# Maximum amount of allowed consecutive blank lines. This does not affect the whitespace at the end of the document, as it is always stripped.
+allowed_blank_lines = 1
+# Use CRLF for line endings.
+crlf = false
+
+[[rule]]
+keys = ["dependencies", "dev-dependencies", "build-dependencies"]
+formatting = { reorder_keys = true }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -9,9 +9,9 @@ dashboard = []
 
 [dependencies]
 api = { path = "../src/api" }
+async-trait = "0.1"
 axum = "0.6"
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-async-trait = "0.1"
 catalog = { path = "../src/catalog" }
 chrono.workspace = true
 client = { path = "../src/client", features = ["testing"] }
@@ -61,13 +61,13 @@ uuid.workspace = true
 
 [dev-dependencies]
 common-procedure = { path = "../src/common/procedure" }
-datafusion.workspace = true
 datafusion-expr.workspace = true
+datafusion.workspace = true
 itertools.workspace = true
+opentelemetry-proto.workspace = true
 partition = { path = "../src/partition" }
 paste.workspace = true
 prost.workspace = true
 script = { path = "../src/script" }
 session = { path = "../src/session", features = ["testing"] }
 store-api = { path = "../src/store-api" }
-opentelemetry-proto.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly does
1. introduce `taplo.toml` file
2. modify `Makefile` and ci file to utilize new config
3. run `make fmt-toml` to sort toml keys

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
