### PR TITLE
feat: truncate region

### DIFF
--- a/src/catalog/src/remote/mock.rs
+++ b/src/catalog/src/remote/mock.rs
@@ -23,6 +23,7 @@ use table::engine::{CloseTableResult, EngineContext, TableEngine};
 use table::metadata::TableId;
 use table::requests::{
     AlterTableRequest, CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest,
+    TruncateTableRequest,
 };
 use table::test_util::MemTable;
 use table::TableRef;
@@ -115,5 +116,13 @@ impl TableEngine for MockTableEngine {
 
     async fn close(&self) -> table::Result<()> {
         Ok(())
+    }
+
+    async fn truncate_table(
+        &self,
+        _ctx: &EngineContext,
+        _request: TruncateTableRequest,
+    ) -> table::Result<bool> {
+        Ok(true)
     }
 }

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -117,7 +117,7 @@ impl TableEngine for ImmutableFileTableEngine {
     async fn truncate_table(
         &self,
         _ctx: &EngineContext,
-        _requets: TruncateTableRequest,
+        _request: TruncateTableRequest,
     ) -> TableResult<bool> {
         Ok(true)
     }

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -26,7 +26,9 @@ use snafu::ResultExt;
 use table::engine::{table_dir, EngineContext, TableEngine, TableEngineProcedure, TableReference};
 use table::error::TableOperationSnafu;
 use table::metadata::{TableId, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
-use table::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
+use table::requests::{
+    AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest, TruncateTableRequest,
+};
 use table::{error as table_error, Result as TableResult, Table, TableRef};
 use tokio::sync::Mutex;
 

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -111,6 +111,14 @@ impl TableEngine for ImmutableFileTableEngine {
     async fn close(&self) -> TableResult<()> {
         self.inner.close().await
     }
+
+    async fn truncate_table(
+        &self,
+        _ctx: &EngineContext,
+        _requets: TruncateTableRequest,
+    ) -> TableResult<bool> {
+        Ok(true)
+    }
 }
 
 #[async_trait]

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -719,19 +719,11 @@ impl<S: StorageEngine> MitoEngineInner<S> {
 
         let table_id = request.table_id;
         if let Some(table) = self.get_mito_table(table_id) {
-            let all_regions = table.region_ids();
-            let ctx = StorageEngineContext::default();
-
-            let opts = CloseOptions { flush: false };
-
-            for region_number in all_regions {
-                self.storage_engine
-                    .close_region(&ctx, &region_name(table_id, region_number), &opts)
-                    .await
-                    .map_err(BoxedError::new)
-                    .context(table_error::TableOperationSnafu)?;
-            }
-
+            table
+                .truncate()
+                .await
+                .map_err(BoxedError::new)
+                .context(table_error::TableOperationSnafu)?;
             Ok(true)
         } else {
             Ok(false)

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -43,6 +43,7 @@ use table::engine::{
 use table::metadata::{TableId, TableInfo, TableVersion};
 use table::requests::{
     AlterTableRequest, CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest,
+    TruncateTableRequest,
 };
 use table::{error as table_error, Result as TableResult, Table, TableRef};
 

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -960,7 +960,6 @@ async fn test_truncate_table() {
     let insert_req = new_insert_request("demo".to_string(), columns_values.clone());
     assert_eq!(4, table.insert(insert_req).await.unwrap());
 
-
     // truncate table.
     let truncate_req = new_truncate_request();
     let res = table_engine

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -38,7 +38,7 @@ use table::Table;
 
 use super::*;
 use crate::table::test_util::{
-    self, new_insert_request, setup_table, TestEngineComponents, TABLE_NAME,
+    self, new_insert_request, new_truncate_request, setup_table, TestEngineComponents, TABLE_NAME,
 };
 
 pub fn has_parquet_file(sst_dir: &str) -> bool {

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -960,21 +960,6 @@ async fn test_truncate_table() {
     let insert_req = new_insert_request("demo".to_string(), columns_values.clone());
     assert_eq!(4, table.insert(insert_req).await.unwrap());
 
-    let stream = table.scan_to_stream(ScanRequest::default()).await.unwrap();
-    let batches = util::collect_batches(stream).await.unwrap();
-
-    assert_eq!(
-        batches.pretty_print().unwrap(),
-        "\
-+-------+-----+--------+-------------------------+
-| host  | cpu | memory | ts                      |
-+-------+-----+--------+-------------------------+
-| host1 | 1.0 | 1.0    | 1970-01-01T00:00:00.001 |
-| host2 | 2.0 | 2.0    | 1970-01-01T00:00:00.002 |
-| host3 | 3.0 | 3.0    | 1970-01-01T00:00:00.002 |
-| host4 | 4.0 | 4.0    | 1970-01-01T00:00:00.001 |
-+-------+-----+--------+-------------------------+"
-    );
 
     // truncate table.
     let truncate_req = new_truncate_request();

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -933,3 +933,79 @@ async fn test_flush_table_with_region_id() {
 
     assert!(has_parquet_file(&region_dir));
 }
+
+#[tokio::test]
+async fn test_truncate_table() {
+    common_telemetry::init_default_ut_logging();
+    let ctx = EngineContext::default();
+    let TestEngineComponents {
+        table_engine,
+        table_ref: table,
+        dir: _dir,
+        ..
+    } = test_util::setup_test_engine_and_table().await;
+
+    let hosts: VectorRef = Arc::new(StringVector::from(vec!["host1", "host2", "host3", "host4"]));
+    let cpus: VectorRef = Arc::new(Float64Vector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
+    let memories: VectorRef = Arc::new(Float64Vector::from_vec(vec![1.0, 2.0, 3.0, 4.0]));
+    let tss: VectorRef = Arc::new(TimestampMillisecondVector::from_vec(vec![1, 2, 2, 1]));
+    let columns_values = HashMap::from([
+        ("host".to_string(), hosts.clone()),
+        ("cpu".to_string(), cpus.clone()),
+        ("memory".to_string(), memories.clone()),
+        ("ts".to_string(), tss.clone()),
+    ]);
+
+    // Insert data.
+    let insert_req = new_insert_request("demo".to_string(), columns_values.clone());
+    assert_eq!(4, table.insert(insert_req).await.unwrap());
+
+    let stream = table.scan_to_stream(ScanRequest::default()).await.unwrap();
+    let batches = util::collect_batches(stream).await.unwrap();
+
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+-----+--------+-------------------------+
+| host  | cpu | memory | ts                      |
++-------+-----+--------+-------------------------+
+| host1 | 1.0 | 1.0    | 1970-01-01T00:00:00.001 |
+| host2 | 2.0 | 2.0    | 1970-01-01T00:00:00.002 |
+| host3 | 3.0 | 3.0    | 1970-01-01T00:00:00.002 |
+| host4 | 4.0 | 4.0    | 1970-01-01T00:00:00.001 |
++-------+-----+--------+-------------------------+"
+    );
+
+    // truncate table.
+    let truncate_req = new_truncate_request();
+    let res = table_engine
+        .truncate_table(&ctx, truncate_req)
+        .await
+        .unwrap();
+    assert!(res);
+
+    // Verify table is empty.
+    let stream = table.scan_to_stream(ScanRequest::default()).await.unwrap();
+    let batches = util::collect(stream).await.unwrap();
+    assert!(batches.is_empty());
+
+    // Validate the data insertion again.
+    let insert_req = new_insert_request("demo".to_string(), columns_values);
+    assert_eq!(4, table.insert(insert_req).await.unwrap());
+
+    let stream = table.scan_to_stream(ScanRequest::default()).await.unwrap();
+    let batches = util::collect_batches(stream).await.unwrap();
+
+    assert_eq!(
+        batches.pretty_print().unwrap(),
+        "\
++-------+-----+--------+-------------------------+
+| host  | cpu | memory | ts                      |
++-------+-----+--------+-------------------------+
+| host1 | 1.0 | 1.0    | 1970-01-01T00:00:00.001 |
+| host2 | 2.0 | 2.0    | 1970-01-01T00:00:00.002 |
+| host3 | 3.0 | 3.0    | 1970-01-01T00:00:00.002 |
+| host4 | 4.0 | 4.0    | 1970-01-01T00:00:00.001 |
++-------+-----+--------+-------------------------+"
+    );
+}

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -360,6 +360,15 @@ impl<R: Region> Table for MitoTable<R> {
         Ok(())
     }
 
+    async fn truncate(&self) -> TableResult<()> {
+        let regions = self.regions.load();
+        let _ = futures::future::try_join_all(regions.values().map(|region| region.truncate()))
+            .await
+            .map_err(BoxedError::new)
+            .context(TableOperationSnafu)?;
+        Ok(())
+    }
+
     fn region_stats(&self) -> TableResult<Vec<RegionStat>> {
         let regions = self.regions.load();
 

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -30,7 +30,8 @@ use storage::EngineImpl;
 use table::engine::{EngineContext, TableEngine};
 use table::metadata::{TableId, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::requests::{
-    AlterKind, AlterTableRequest, CreateTableRequest, DropTableRequest, InsertRequest, TableOptions,
+    AlterKind, AlterTableRequest, CreateTableRequest, DropTableRequest, InsertRequest,
+    TableOptions, TruncateTableRequest,
 };
 use table::{Table, TableRef};
 
@@ -135,6 +136,15 @@ pub fn new_alter_request(alter_kind: AlterKind) -> AlterTableRequest {
 
 pub fn new_drop_request() -> DropTableRequest {
     DropTableRequest {
+        catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+        schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+        table_name: TABLE_NAME.to_string(),
+        table_id: TABLE_ID,
+    }
+}
+
+pub fn new_truncate_request() -> TruncateTableRequest {
+    TruncateTableRequest {
         catalog_name: DEFAULT_CATALOG_NAME.to_string(),
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: TABLE_NAME.to_string(),

--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -209,6 +209,10 @@ impl Region for MockRegion {
     async fn compact(&self, _ctx: &CompactContext) -> std::result::Result<(), Self::Error> {
         unimplemented!()
     }
+
+    async fn truncate(&self) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 impl MockRegionInner {
@@ -346,6 +350,10 @@ impl StorageEngine for MockEngine {
     }
 
     async fn close(&self, _ctx: &EngineContext) -> Result<()> {
+        Ok(())
+    }
+
+    async fn truncate_region(&self, _ctx: &EngineContext, _name: &str) -> Result<()> {
         Ok(())
     }
 }

--- a/src/mito/src/table/test_util/mock_engine.rs
+++ b/src/mito/src/table/test_util/mock_engine.rs
@@ -352,8 +352,4 @@ impl StorageEngine for MockEngine {
     async fn close(&self, _ctx: &EngineContext) -> Result<()> {
         Ok(())
     }
-
-    async fn truncate_region(&self, _ctx: &EngineContext, _name: &str) -> Result<()> {
-        Ok(())
-    }
 }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -730,7 +730,7 @@ mod tests {
         wb.put(put_data).unwrap();
 
         // Insert data.
-        let _ = region.write(&WriteContext::default(), wb).await.unwrap();
+        region.write(&WriteContext::default(), wb).await.unwrap();
         let ctx = EngineContext::default();
 
         // Truncate region.

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -734,7 +734,7 @@ mod tests {
         let ctx = EngineContext::default();
 
         // Truncate region.
-        assert!(region.truncate().await.unwrap());
+        assert!(region.truncate().await.is_ok());
         assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
 
         // Scan to verify the region is empty.

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -550,7 +550,10 @@ mod tests {
     use log_store::raft_engine::log_store::RaftEngineLogStore;
     use log_store::test_util::log_store_util;
     use object_store::services::Fs;
-    use store_api::storage::{FlushContext, Region, WriteContext, WriteRequest};
+    use store_api::storage::{
+        ChunkReader, FlushContext, ReadContext, Region, ScanRequest, Snapshot, WriteContext,
+        WriteRequest,
+    };
 
     use super::*;
     use crate::compaction::noop::NoopCompactionScheduler;
@@ -708,5 +711,55 @@ mod tests {
         // Wait for gc
         tokio::time::sleep(Duration::from_millis(60)).await;
         assert_eq!(0, parquet_file_num(&dir_path));
+    }
+
+    #[tokio::test]
+    async fn test_truncate_region() {
+        common_telemetry::init_default_ut_logging();
+        let dir = create_temp_dir("test_truncate_region");
+        let log_file_dir = create_temp_dir("test_engine_wal");
+
+        let region_name = "test_region";
+        let region_id = 123456;
+        let config = EngineConfig::default();
+
+        let (engine, region) =
+            create_engine_and_region(&dir, &log_file_dir, region_name, region_id, config).await;
+
+        assert_eq!(region_name, region.name());
+
+        let mut wb = region.write_request();
+        let k1 = Arc::new(Int32Vector::from_slice([1, 2, 3])) as VectorRef;
+        let v1 = Arc::new(Float32Vector::from_slice([0.1, 0.2, 0.3])) as VectorRef;
+        let tsv = Arc::new(TimestampMillisecondVector::from_slice([0, 0, 0])) as VectorRef;
+
+        let put_data = HashMap::from([
+            ("k1".to_string(), k1),
+            ("v1".to_string(), v1),
+            ("ts".to_string(), tsv),
+        ]);
+        wb.put(put_data).unwrap();
+
+        let _ = region.write(&WriteContext::default(), wb).await.unwrap();
+        let ctx = EngineContext::default();
+
+        let _ = engine.truncate_region(&ctx, region_name).await;
+        assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
+
+        let version = region.version_control().current();
+        for level in version.ssts().levels() {
+            for file in level.files() {
+                logging::info!("file name: {:?}", file.file_name());
+            }
+        }
+        // Scan
+        let read_ctx = ReadContext::default();
+        let snapshot = region.snapshot(&read_ctx).unwrap();
+        let resp = snapshot
+            .scan(&read_ctx, ScanRequest::default())
+            .await
+            .unwrap();
+        let mut reader = resp.reader;
+        assert!(reader.next_chunk().await.unwrap().is_none());
     }
 }

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -729,19 +729,15 @@ mod tests {
         ]);
         wb.put(put_data).unwrap();
 
+        // Insert data.
         let _ = region.write(&WriteContext::default(), wb).await.unwrap();
         let ctx = EngineContext::default();
 
+        // Truncate region.
         let _ = region.truncate().await;
         assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
 
-        let version = region.version_control().current();
-        for level in version.ssts().levels() {
-            for file in level.files() {
-                logging::info!("file name: {:?}", file.file_name());
-            }
-        }
-        // Scan
+        // Scan to verify the region is empty.
         let read_ctx = ReadContext::default();
         let snapshot = region.snapshot(&read_ctx).unwrap();
         let resp = snapshot

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -734,7 +734,7 @@ mod tests {
         let ctx = EngineContext::default();
 
         // Truncate region.
-        let _ = region.truncate().await;
+        assert!(region.truncate().await.unwrap());
         assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
 
         // Scan to verify the region is empty.

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -734,7 +734,7 @@ mod tests {
         let ctx = EngineContext::default();
 
         // Truncate region.
-        assert!(region.truncate().await.is_ok());
+        region.truncate().await.unwrap();
         assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
 
         // Scan to verify the region is empty.

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -106,6 +106,10 @@ impl<S: LogStore> StorageEngine for EngineImpl<S> {
 
         Ok(())
     }
+
+    async fn truncate_region(&self, _ctx: &EngineContext, name: &str) -> Result<()> {
+        self.inner.truncate_region(name).await
+    }
 }
 
 impl<S: LogStore> EngineImpl<S> {
@@ -525,6 +529,13 @@ impl<S: LogStore> EngineInner<S> {
         self.compaction_scheduler.stop(true).await?;
         self.flush_scheduler.stop().await?;
         self.file_purger.stop(true).await
+    }
+
+    async fn truncate_region(&self, name: &str) -> Result<()> {
+        if let Some(region) = self.get_region(name) {
+            region.truncate().await?;
+        }
+        Ok(())
     }
 }
 

--- a/src/storage/src/engine.rs
+++ b/src/storage/src/engine.rs
@@ -106,10 +106,6 @@ impl<S: LogStore> StorageEngine for EngineImpl<S> {
 
         Ok(())
     }
-
-    async fn truncate_region(&self, _ctx: &EngineContext, name: &str) -> Result<()> {
-        self.inner.truncate_region(name).await
-    }
 }
 
 impl<S: LogStore> EngineImpl<S> {
@@ -530,13 +526,6 @@ impl<S: LogStore> EngineInner<S> {
         self.flush_scheduler.stop().await?;
         self.file_purger.stop(true).await
     }
-
-    async fn truncate_region(&self, name: &str) -> Result<()> {
-        if let Some(region) = self.get_region(name) {
-            region.truncate().await?;
-        }
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -743,7 +732,7 @@ mod tests {
         let _ = region.write(&WriteContext::default(), wb).await.unwrap();
         let ctx = EngineContext::default();
 
-        let _ = engine.truncate_region(&ctx, region_name).await;
+        let _ = region.truncate().await;
         assert!(engine.get_region(&ctx, region.name()).unwrap().is_some());
 
         let version = region.version_control().current();

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -79,6 +79,12 @@ pub struct RegionEdit {
     pub compaction_time_window: Option<i64>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct RegionTruncate {
+    pub region_id: RegionId,
+    pub files_to_remove: Vec<FileMeta>,
+}
+
 /// The region version checkpoint
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct RegionVersion {
@@ -190,6 +196,7 @@ pub enum RegionMetaAction {
     Change(RegionChange),
     Remove(RegionRemove),
     Edit(RegionEdit),
+    Truncate(RegionTruncate),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -1,4 +1,4 @@
-// Copyright j023 Greptime Team
+// Copyright 2023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Greptime Team
+// Copyright j023 Greptime Team
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/storage/src/manifest/action.rs
+++ b/src/storage/src/manifest/action.rs
@@ -82,7 +82,7 @@ pub struct RegionEdit {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct RegionTruncate {
     pub region_id: RegionId,
-    pub files_to_remove: Vec<FileMeta>,
+    pub committed_sequence: SequenceNumber,
 }
 
 /// The region version checkpoint

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -336,7 +336,7 @@ mod tests {
 
         assert!(manifest
             .update(RegionMetaActionList::new(vec![RegionMetaAction::Truncate(
-                build_region_truncate(&[FileId::random(), FileId::random(), FileId::random()])
+                build_region_truncate(3)
             ),]))
             .await
             .is_ok());
@@ -376,7 +376,7 @@ mod tests {
 
         match action {
             RegionMetaAction::Truncate(t) => {
-                assert_eq!(3, t.files_to_remove.len())
+                assert_eq!(3, t.committed_sequence)
             }
             _ => unreachable!(),
         }

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -334,6 +334,13 @@ mod tests {
             .await
             .is_ok());
 
+        assert!(manifest
+            .update(RegionMetaActionList::new(vec![RegionMetaAction::Truncate(
+                build_region_truncate(&[FileId::random(), FileId::random(), FileId::random()])
+            ),]))
+            .await
+            .is_ok());
+
         let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
         let (v, action_list) = iter.next_action().await.unwrap().unwrap();
         assert_eq!(0, v);
@@ -362,6 +369,17 @@ mod tests {
         assert!(matches!(&action_list.actions[0], RegionMetaAction::Edit(_)));
         assert!(matches!(&action_list.actions[1], RegionMetaAction::Edit(_)));
 
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(2, v);
+        assert_eq!(1, action_list.actions.len());
+        let action = &action_list.actions[0];
+
+        match action {
+            RegionMetaAction::Truncate(t) => {
+                assert_eq!(3, t.files_to_remove.len())
+            }
+            _ => unreachable!(),
+        }
         // Reach end
         assert!(iter.next_action().await.unwrap().is_none());
 

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -617,7 +617,7 @@ mod tests {
         ];
 
         for action in actions {
-            assert!(manifest.update(action).await.is_ok());
+            manifest.update(action).await.unwrap();
         }
 
         // Scan manifest.

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -334,13 +334,6 @@ mod tests {
             .await
             .is_ok());
 
-        assert!(manifest
-            .update(RegionMetaActionList::new(vec![RegionMetaAction::Truncate(
-                build_region_truncate(3)
-            ),]))
-            .await
-            .is_ok());
-
         let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
         let (v, action_list) = iter.next_action().await.unwrap().unwrap();
         assert_eq!(0, v);
@@ -369,16 +362,6 @@ mod tests {
         assert!(matches!(&action_list.actions[0], RegionMetaAction::Edit(_)));
         assert!(matches!(&action_list.actions[1], RegionMetaAction::Edit(_)));
 
-        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
-        assert_eq!(2, v);
-        assert_eq!(1, action_list.actions.len());
-        let action = &action_list.actions[0];
-
-        if let RegionMetaAction::Truncate(t) = action {
-            assert_eq!(3, t.committed_sequence)
-        } else {
-            unreachable!()
-        }
         // Reach end
         assert!(iter.next_action().await.unwrap().is_none());
 
@@ -600,5 +583,96 @@ mod tests {
         }
 
         manifest.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_region_manifest_truncate() {
+        common_telemetry::init_default_ut_logging();
+
+        let manifest = new_fs_manifest(false, None).await;
+        let region_meta = Arc::new(build_region_meta());
+        let committed_sequence = 99;
+
+        let file = FileId::random();
+        let file_ids = vec![FileId::random(), FileId::random()];
+
+        // Save some actions.
+        let actions: Vec<RegionMetaActionList> = vec![
+            RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange {
+                metadata: region_meta.as_ref().into(),
+                committed_sequence: 1,
+            })),
+            RegionMetaActionList::new(vec![
+                RegionMetaAction::Edit(build_region_edit(2, &[file], &[])),
+                RegionMetaAction::Edit(build_region_edit(3, &file_ids, &[file])),
+            ]),
+            RegionMetaActionList::with_action(RegionMetaAction::Truncate(RegionTruncate {
+                region_id: 0.into(),
+                committed_sequence,
+            })),
+            RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange {
+                metadata: region_meta.as_ref().into(),
+                committed_sequence: 1,
+            })),
+        ];
+
+        for action in actions {
+            assert!(manifest.update(action).await.is_ok());
+        }
+
+        // Scan manifest.
+        let mut iter = manifest.scan(0, MAX_VERSION).await.unwrap();
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        info!("action_list = {:?}", action_list.actions);
+        assert_eq!(0, v);
+        assert_eq!(2, action_list.actions.len());
+        let protocol = &action_list.actions[0];
+        assert!(matches!(
+            protocol,
+            RegionMetaAction::Protocol(ProtocolAction { .. })
+        ));
+
+        let change = &action_list.actions[1];
+        assert!(matches!(
+            change,
+            RegionMetaAction::Change(RegionChange {
+                committed_sequence: 1,
+                ..
+            })
+        ));
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(1, v);
+        assert_eq!(2, action_list.actions.len());
+        assert!(matches!(&action_list.actions[0], RegionMetaAction::Edit(_)));
+        assert!(matches!(&action_list.actions[1], RegionMetaAction::Edit(_)));
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(2, v);
+        assert_eq!(1, action_list.actions.len());
+        let truncate = &action_list.actions[0];
+        assert!(matches!(
+            truncate,
+            RegionMetaAction::Truncate(RegionTruncate {
+                committed_sequence: 99,
+                ..
+            })
+        ));
+
+        let (v, action_list) = iter.next_action().await.unwrap().unwrap();
+        assert_eq!(3, v);
+        assert_eq!(1, action_list.actions.len());
+        let change = &action_list.actions[0];
+        assert!(matches!(
+            change,
+            RegionMetaAction::Change(RegionChange {
+                committed_sequence: 1,
+                ..
+            })
+        ));
+
+        // Reach end
+        assert!(iter.next_action().await.unwrap().is_none());
     }
 }

--- a/src/storage/src/manifest/region.rs
+++ b/src/storage/src/manifest/region.rs
@@ -374,11 +374,10 @@ mod tests {
         assert_eq!(1, action_list.actions.len());
         let action = &action_list.actions[0];
 
-        match action {
-            RegionMetaAction::Truncate(t) => {
-                assert_eq!(3, t.committed_sequence)
-            }
-            _ => unreachable!(),
+        if let RegionMetaAction::Truncate(t) = action {
+            assert_eq!(3, t.committed_sequence)
+        } else {
+            unreachable!()
         }
         // Reach end
         assert!(iter.next_action().await.unwrap().is_none());

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -74,3 +74,19 @@ pub fn build_region_edit(
         compaction_time_window: None,
     }
 }
+
+pub fn build_region_truncate(files_to_remove: &[FileId]) -> RegionTruncate {
+    RegionTruncate {
+        region_id: 0.into(),
+        files_to_remove: files_to_remove
+            .iter()
+            .map(|f| FileMeta {
+                region_id: 0.into(),
+                file_id: *f,
+                time_range: None,
+                level: 0,
+                file_size: DEFAULT_TEST_FILE_SIZE,
+            })
+            .collect(),
+    }
+}

--- a/src/storage/src/manifest/test_utils.rs
+++ b/src/storage/src/manifest/test_utils.rs
@@ -75,18 +75,9 @@ pub fn build_region_edit(
     }
 }
 
-pub fn build_region_truncate(files_to_remove: &[FileId]) -> RegionTruncate {
+pub fn build_region_truncate(committed_sequence: u64) -> RegionTruncate {
     RegionTruncate {
         region_id: 0.into(),
-        files_to_remove: files_to_remove
-            .iter()
-            .map(|f| FileMeta {
-                region_id: 0.into(),
-                file_id: *f,
-                time_range: None,
-                level: 0,
-                file_size: DEFAULT_TEST_FILE_SIZE,
-            })
-            .collect(),
+        committed_sequence,
     }
 }

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -555,22 +555,21 @@ impl<S: LogStore> RegionImpl<S> {
         action: RegionMetaAction,
         version: Option<Version>,
     ) -> Option<Version> {
-        match action {
-            RegionMetaAction::Edit(e) => {
-                let edit = VersionEdit {
-                    files_to_add: e.files_to_add,
-                    files_to_remove: e.files_to_remove,
-                    flushed_sequence: e.flushed_sequence,
-                    manifest_version,
-                    max_memtable_id: None,
-                    compaction_time_window: e.compaction_time_window,
-                };
-                version.map(|mut v| {
-                    v.apply_edit(edit);
-                    v
-                })
-            }
-            _ => version,
+        if let RegionMetaAction::Edit(e) = action {
+            let edit = VersionEdit {
+                files_to_add: e.files_to_add,
+                files_to_remove: e.files_to_remove,
+                flushed_sequence: e.flushed_sequence,
+                manifest_version,
+                max_memtable_id: None,
+                compaction_time_window: e.compaction_time_window,
+            };
+            version.map(|mut v| {
+                v.apply_edit(edit);
+                v
+            })
+        } else {
+            version
         }
     }
 

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -509,7 +509,7 @@ impl<S: LogStore> RegionImpl<S> {
                     (RegionMetaAction::Truncate(t), Some(mut v)) => {
                         let files = v.ssts().mark_all_files_deleted();
                         logging::info!(
-                            "Try to remove all SSTs, region: {}, files: {:?}",
+                            "Try to remove all SSTs on truncate, region: {}, files: {:?}",
                             t.region_id,
                             files
                         );

--- a/src/storage/src/region.rs
+++ b/src/storage/src/region.rs
@@ -56,7 +56,7 @@ pub use crate::region::writer::{
 use crate::region::writer::{DropContext, TruncateContext};
 use crate::schema::compat::CompatWrite;
 use crate::snapshot::SnapshotImpl;
-use crate::sst::{AccessLayerRef, FileId};
+use crate::sst::AccessLayerRef;
 use crate::version::{
     Version, VersionControl, VersionControlRef, VersionEdit, INIT_COMMITTED_SEQUENCE,
 };
@@ -493,16 +493,11 @@ impl<S: LogStore> RegionImpl<S> {
                     (RegionMetaAction::Remove(r), Some(v)) => {
                         manifest.stop().await?;
 
-                        let files = v
-                            .ssts()
-                            .mark_all_files_deleted()
-                            .iter()
-                            .map(|f| f.file_id)
-                            .collect::<Vec<FileId>>();
+                        let files = v.ssts().mark_all_files_deleted();
                         logging::info!(
                             "Try to remove all SSTs, region: {}, files: {:?}",
                             r.region_id,
-                            files,
+                            files
                         );
 
                         manifest
@@ -818,9 +813,6 @@ impl<S: LogStore> RegionInner<S> {
             shared: &self.shared,
             wal: &self.wal,
             manifest: &self.manifest,
-            flush_scheduler: &self.flush_scheduler,
-            compaction_scheduler: &self.compaction_scheduler,
-            sst_layer: &self.sst_layer,
         };
 
         self.writer.truncate(&ctx, writer_ctx).await?;

--- a/src/storage/src/region/tests.rs
+++ b/src/storage/src/region/tests.rs
@@ -63,6 +63,7 @@ mod compact;
 mod drop;
 mod flush;
 mod projection;
+mod truncate;
 
 /// Create metadata of a region with schema: (timestamp, v0).
 pub fn new_metadata(region_name: &str) -> RegionMetadata {

--- a/src/storage/src/region/tests/truncate.rs
+++ b/src/storage/src/region/tests/truncate.rs
@@ -146,7 +146,8 @@ async fn test_put_data_after_truncate() {
         (1002, None),
         (1003, Some("1003".to_string())),
     ];
-    let _ = tester.base().put(&data).await;
+
+    tester.base().put(&data).await;
 
     // Manually trigger flush.
     tester.flush().await;
@@ -157,7 +158,7 @@ async fn test_put_data_after_truncate() {
         (1004, Some("1004".to_string())),
         (1005, Some("1005".to_string())),
     ];
-    let _ = tester.base().put(&data).await;
+    tester.base().put(&data).await;
 
     // Truncate region.
     tester.truncate().await;
@@ -170,7 +171,8 @@ async fn test_put_data_after_truncate() {
         (1012, Some("2".to_string())),
         (1013, Some("3".to_string())),
     ];
-    let _ = tester.base().put(&new_data).await;
+    tester.base().put(&new_data).await;
+
     let res = tester.base().full_scan().await;
     assert_eq!(new_data, res.as_slice());
 }
@@ -201,7 +203,7 @@ async fn test_truncate_reopen() {
         (1004, Some("1004".to_string())),
         (1005, Some("1005".to_string())),
     ];
-    let _ = tester.base().put(&data).await;
+    tester.base().put(&data).await;
 
     let manifest = &tester.base().region.inner.manifest;
     let manifest_version = tester
@@ -220,7 +222,7 @@ async fn test_truncate_reopen() {
     // Persist the meta action.
     let prev_version = manifest_version;
     action_list.set_prev_version(prev_version);
-    let _ = manifest.update(action_list).await.unwrap();
+    assert!(manifest.update(action_list).await.is_ok());
 
     // Reopen and put data.
     tester.reopen().await;
@@ -234,7 +236,7 @@ async fn test_truncate_reopen() {
         (3, Some("3".to_string())),
     ];
 
-    let _ = tester.base().put(&new_data).await;
+    tester.base().put(&new_data).await;
     let res = tester.base().full_scan().await;
     assert_eq!(new_data, res.as_slice());
 }

--- a/src/storage/src/region/tests/truncate.rs
+++ b/src/storage/src/region/tests/truncate.rs
@@ -1,0 +1,239 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region truncate tests.
+
+use std::sync::Arc;
+
+use common_test_util::temp_dir::create_temp_dir;
+use log_store::raft_engine::log_store::RaftEngineLogStore;
+use store_api::manifest::{Manifest, MetaAction};
+use store_api::storage::{FlushContext, OpenOptions, Region};
+
+use crate::config::EngineConfig;
+use crate::engine;
+use crate::flush::FlushStrategyRef;
+use crate::manifest::action::{RegionMetaAction, RegionMetaActionList, RegionTruncate};
+use crate::region::tests::{self, FileTesterBase};
+use crate::region::RegionImpl;
+use crate::sst::FileMeta;
+use crate::test_util::config_util;
+use crate::test_util::flush_switch::{has_parquet_file, FlushSwitch};
+
+const REGION_NAME: &str = "region-truncate-0";
+
+/// Create a new region for truncate tests.
+async fn create_region_for_truncate(
+    store_dir: &str,
+    flush_strategy: FlushStrategyRef,
+) -> RegionImpl<RaftEngineLogStore> {
+    let metadata = tests::new_metadata(REGION_NAME);
+
+    let mut store_config =
+        config_util::new_store_config(REGION_NAME, store_dir, EngineConfig::default()).await;
+    store_config.flush_strategy = flush_strategy;
+
+    RegionImpl::create(metadata, store_config).await.unwrap()
+}
+
+/// Tester for truncate tests.
+struct TruncateTester {
+    store_dir: String,
+    base: Option<FileTesterBase>,
+}
+
+impl TruncateTester {
+    async fn new(store_dir: &str, flush_strategy: FlushStrategyRef) -> TruncateTester {
+        let region = create_region_for_truncate(store_dir, flush_strategy).await;
+        TruncateTester {
+            store_dir: store_dir.to_string(),
+            base: Some(FileTesterBase::with_region(region)),
+        }
+    }
+
+    #[inline]
+    fn base(&self) -> &FileTesterBase {
+        self.base.as_ref().unwrap()
+    }
+
+    async fn flush(&self) {
+        let ctx = FlushContext::default();
+        self.base().region.flush(&ctx).await.unwrap();
+    }
+
+    async fn truncate(&self) {
+        self.base().region.truncate().await.unwrap();
+    }
+
+    async fn reopen(&mut self) {
+        let store_config = config_util::new_store_config(
+            REGION_NAME,
+            &self.store_dir,
+            EngineConfig {
+                max_files_in_l0: usize::MAX,
+                ..Default::default()
+            },
+        )
+        .await;
+
+        let opts = OpenOptions::default();
+        let region = RegionImpl::open(REGION_NAME.to_string(), store_config, &opts)
+            .await
+            .unwrap()
+            .unwrap();
+
+        self.base = Some(FileTesterBase::with_region(region));
+    }
+
+    async fn close(&mut self) {
+        if let Some(base) = self.base.take() {
+            base.close().await;
+        }
+    }
+
+    fn collect_file_metas(&self) -> Vec<FileMeta> {
+        let version = self.base().region.version_control().current();
+        version
+            .ssts()
+            .levels()
+            .iter()
+            .fold(vec![], |mut files, level| {
+                files.extend(level.files().map(|f| f.meta()));
+                files
+            })
+    }
+}
+
+#[tokio::test]
+async fn test_truncate_basic() {
+    let dir = create_temp_dir("truncate-basic");
+    common_telemetry::init_default_ut_logging();
+    let store_dir = dir.path().to_str().unwrap();
+
+    // let sst_dir = format!("{}/{}", store_dir, engine::region_sst_dir("", REGION_NAME));
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let tester = TruncateTester::new(store_dir, flush_switch.clone()).await;
+
+    let data = [
+        (1000, Some("1000".to_string())),
+        (1001, Some("1001".to_string())),
+        (1002, Some("1002".to_string())),
+        (1003, Some("1003".to_string())),
+    ];
+
+    let _ = tester.base().put(&data).await;
+    let res = tester.base().full_scan().await;
+    assert_eq!(4, res.len());
+
+    // Truncate region.
+    tester.truncate().await;
+
+    let res = tester.base().full_scan().await;
+    assert_eq!(0, res.len());
+}
+
+#[tokio::test]
+async fn test_put_data_after_truncate() {
+    let dir = create_temp_dir("put_data_after_truncate");
+    common_telemetry::init_default_ut_logging();
+    let store_dir = dir.path().to_str().unwrap();
+
+    // let sst_dir = format!("{}/{}", store_dir, engine::region_sst_dir("", REGION_NAME));
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let tester = TruncateTester::new(store_dir, flush_switch.clone()).await;
+
+    let data = [
+        (1000, Some("1000".to_string())),
+        (1001, Some("1001".to_string())),
+        (1002, None),
+        (1003, Some("1003".to_string())),
+    ];
+
+    let _ = tester.base().put(&data).await;
+    // Truncate region.
+    tester.truncate().await;
+    let res = tester.base().full_scan().await;
+    assert_eq!(0, res.len());
+
+    let new_data = [
+        (1000, Some("0".to_string())),
+        (1001, Some("1".to_string())),
+        (1002, Some("2".to_string())),
+        (1003, Some("3".to_string())),
+    ];
+
+    let _ = tester.base().put(&new_data).await;
+    let res = tester.base().full_scan().await;
+    assert_eq!(new_data, res.as_slice());
+}
+
+#[tokio::test]
+async fn test_truncate_reopen() {
+    let dir = create_temp_dir("put_data_after_truncate");
+    common_telemetry::init_default_ut_logging();
+    let store_dir = dir.path().to_str().unwrap();
+
+    let sst_dir = format!("{}/{}", store_dir, engine::region_sst_dir("", REGION_NAME));
+    let flush_switch = Arc::new(FlushSwitch::default());
+    let mut tester = TruncateTester::new(store_dir, flush_switch.clone()).await;
+
+    let data = [
+        (1000, Some("1000".to_string())),
+        (1001, Some("1001".to_string())),
+        (1002, None),
+        (1003, Some("1003".to_string())),
+    ];
+
+    tester.base().put(&data).await;
+
+    // Manually trigger flush.
+    tester.flush().await;
+    assert!(has_parquet_file(&sst_dir));
+
+    let files = tester.collect_file_metas();
+    let manifest = &tester.base().region.inner.manifest;
+    let manifest_version = tester
+        .base()
+        .region
+        .version_control()
+        .current_manifest_version();
+
+    let mut action_list =
+        RegionMetaActionList::with_action(RegionMetaAction::Truncate(RegionTruncate {
+            region_id: 0.into(),
+            files_to_remove: files.clone(),
+        }));
+
+    // Persist the meta action.
+    let prev_version = manifest_version;
+    action_list.set_prev_version(prev_version);
+    let _ = manifest.update(action_list).await.unwrap();
+    tester.close().await;
+
+    // Reopen and put data.
+    tester.reopen().await;
+    let res = tester.base().full_scan().await;
+    assert_eq!(0, res.len());
+
+    let new_data = [
+        (0, Some("0".to_string())),
+        (1, Some("1".to_string())),
+        (2, Some("2".to_string())),
+        (3, Some("3".to_string())),
+    ];
+
+    let _ = tester.base().put(&new_data).await;
+    let res = tester.base().full_scan().await;
+    assert_eq!(new_data, res.as_slice());
+}

--- a/src/storage/src/region/tests/truncate.rs
+++ b/src/storage/src/region/tests/truncate.rs
@@ -165,10 +165,10 @@ async fn test_put_data_after_truncate() {
     assert_eq!(0, res.len());
 
     let new_data = [
-        (1000, Some("0".to_string())),
-        (1001, Some("1".to_string())),
-        (1002, Some("2".to_string())),
-        (1003, Some("3".to_string())),
+        (1010, Some("0".to_string())),
+        (1011, Some("1".to_string())),
+        (1012, Some("2".to_string())),
+        (1013, Some("3".to_string())),
     ];
     let _ = tester.base().put(&new_data).await;
     let res = tester.base().full_scan().await;

--- a/src/storage/src/region/tests/truncate.rs
+++ b/src/storage/src/region/tests/truncate.rs
@@ -119,7 +119,7 @@ async fn test_truncate_basic() {
     ];
 
     // Data in Memtable
-    let _ = tester.base().put(&data).await;
+    tester.base().put(&data).await;
     let res = tester.base().full_scan().await;
     assert_eq!(4, res.len());
 

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -336,12 +336,7 @@ where
         );
 
         // Mark all SSTs deleted
-        let files = current_version
-            .ssts()
-            .mark_all_files_deleted()
-            .iter()
-            .map(|f| f.file_id)
-            .collect::<Vec<FileId>>();
+        let files = current_version.ssts().mark_all_files_deleted();
         logging::info!(
             "Try to remove all SSTs, region: {}, files: {:?}",
             drop_ctx.shared.id(),
@@ -428,9 +423,9 @@ where
         let committed_sequence = version_control.committed_sequence();
         ctx.wal.obsolete(committed_sequence).await?;
 
-        // Mark all SSTs deleted
+        // Collect the `FileMeta` of all SST.
         let current_version = version_control.current();
-        let files = current_version.ssts().mark_all_files_deleted();
+        let files = current_version.ssts().collect_all_files();
         let manifest_version = version_control.current_manifest_version();
 
         logging::info!(
@@ -539,9 +534,6 @@ pub struct TruncateContext<'a, S: LogStore> {
     pub shared: &'a SharedDataRef,
     pub wal: &'a Wal<S>,
     pub manifest: &'a RegionManifest,
-    pub flush_scheduler: &'a FlushSchedulerRef<S>,
-    pub compaction_scheduler: &'a CompactionSchedulerRef<S>,
-    pub sst_layer: &'a AccessLayerRef,
 }
 
 impl<'a, S: LogStore> TruncateContext<'a, S> {

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -423,7 +423,7 @@ where
         let manifest_version = version_control.current_manifest_version();
         let prev_version = manifest_version;
         action_list.set_prev_version(prev_version);
-        let _ = ctx.manifest.update(action_list).await?;
+        ctx.manifest.update(action_list).await?;
 
         // Mark all data obsolete
         ctx.wal.obsolete(committed_sequence).await?;

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -157,6 +157,10 @@ impl LevelMetas {
     pub fn levels(&self) -> &[LevelMeta] {
         &self.levels
     }
+
+    pub fn file_purger(&self) -> FilePurgerRef {
+        self.file_purger.clone()
+    }
 }
 
 /// Metadata of files in same SST level.

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -137,12 +137,19 @@ impl LevelMetas {
         merged
     }
 
-    pub fn mark_all_files_deleted(&self) -> Vec<FileMeta> {
+    pub fn mark_all_files_deleted(&self) -> Vec<FileId> {
         self.levels().iter().fold(vec![], |mut files, level| {
             files.extend(level.files().map(|f| {
                 f.mark_deleted();
-                f.meta()
+                f.file_id()
             }));
+            files
+        })
+    }
+
+    pub fn collect_all_files(&self) -> Vec<FileMeta> {
+        self.levels().iter().fold(vec![], |mut files, level| {
+            files.extend(level.files().map(|f| f.meta()));
             files
         })
     }

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -147,13 +147,6 @@ impl LevelMetas {
         })
     }
 
-    pub fn collect_all_files(&self) -> Vec<FileMeta> {
-        self.levels().iter().fold(vec![], |mut files, level| {
-            files.extend(level.files().map(|f| f.meta()));
-            files
-        })
-    }
-
     pub fn levels(&self) -> &[LevelMeta] {
         &self.levels
     }

--- a/src/storage/src/sst.rs
+++ b/src/storage/src/sst.rs
@@ -137,11 +137,11 @@ impl LevelMetas {
         merged
     }
 
-    pub fn mark_all_files_deleted(&self) -> Vec<FileId> {
+    pub fn mark_all_files_deleted(&self) -> Vec<FileMeta> {
         self.levels().iter().fold(vec![], |mut files, level| {
             files.extend(level.files().map(|f| {
                 f.mark_deleted();
-                f.file_id()
+                f.meta()
             }));
             files
         })

--- a/src/storage/src/version.rs
+++ b/src/storage/src/version.rs
@@ -125,6 +125,17 @@ impl VersionControl {
         version_to_update.apply_metadata(metadata, manifest_version);
         version_to_update.commit();
     }
+
+    pub fn reset_version(
+        &self,
+        manifest_version: ManifestVersion,
+        memtables: MemtableVersionRef,
+        ssts: LevelMetasRef,
+    ) {
+        let mut version_to_update = self.version.lock();
+        version_to_update.reset(manifest_version, memtables, ssts, 0);
+        version_to_update.commit();
+    }
 }
 
 #[derive(Debug)]
@@ -306,6 +317,19 @@ impl Version {
     #[inline]
     pub fn manifest_version(&self) -> ManifestVersion {
         self.manifest_version
+    }
+
+    pub fn reset(
+        &mut self,
+        manifest_version: ManifestVersion,
+        memtables: MemtableVersionRef,
+        ssts: LevelMetasRef,
+        flushed_sequence: SequenceNumber,
+    ) {
+        self.memtables = memtables;
+        self.ssts = ssts;
+        self.manifest_version = manifest_version;
+        self.flushed_sequence = flushed_sequence;
     }
 }
 

--- a/src/store-api/src/storage/engine.rs
+++ b/src/store-api/src/storage/engine.rs
@@ -85,6 +85,9 @@ pub trait StorageEngine: Send + Sync + Clone + 'static {
 
     /// Close the engine.
     async fn close(&self, ctx: &EngineContext) -> Result<(), Self::Error>;
+
+    /// Truncate region by region name.
+    async fn truncate_region(&self, ctx: &EngineContext, name: &str) -> Result<(), Self::Error>;
 }
 
 /// Storage engine context.

--- a/src/store-api/src/storage/engine.rs
+++ b/src/store-api/src/storage/engine.rs
@@ -85,9 +85,6 @@ pub trait StorageEngine: Send + Sync + Clone + 'static {
 
     /// Close the engine.
     async fn close(&self, ctx: &EngineContext) -> Result<(), Self::Error>;
-
-    /// Truncate region by region name.
-    async fn truncate_region(&self, ctx: &EngineContext, name: &str) -> Result<(), Self::Error>;
 }
 
 /// Storage engine context.

--- a/src/store-api/src/storage/region.rs
+++ b/src/store-api/src/storage/region.rs
@@ -88,6 +88,8 @@ pub trait Region: Send + Sync + Clone + std::fmt::Debug + 'static {
     async fn flush(&self, ctx: &FlushContext) -> Result<(), Self::Error>;
 
     async fn compact(&self, ctx: &CompactContext) -> Result<(), Self::Error>;
+
+    async fn truncate(&self) -> Result<(), Self::Error>;
 }
 
 #[derive(Default, Debug)]

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -23,6 +23,7 @@ use crate::error::{self, Result};
 use crate::metadata::TableId;
 use crate::requests::{
     AlterTableRequest, CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest,
+    TruncateTableRequest,
 };
 use crate::TableRef;
 pub mod manager;

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -132,6 +132,12 @@ pub trait TableEngine: Send + Sync {
 
     /// Close the engine.
     async fn close(&self) -> Result<()>;
+
+    async fn truncate_table(
+        &self,
+        _ctx: &EngineContext,
+        _request: TruncateTableRequest,
+    ) -> Result<bool>;
 }
 
 pub type TableEngineRef = Arc<dyn TableEngine>;

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -130,6 +130,13 @@ pub trait Table: Send + Sync {
         }
         .fail()?
     }
+
+    async fn truncate(&self) -> Result<()> {
+        UnsupportedSnafu {
+            operation: "TRUNCATE",
+        }
+        .fail()?
+    }
 }
 
 pub type TableRef = Arc<dyn Table>;

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -103,6 +103,14 @@ impl TableEngine for MockTableEngine {
     async fn close(&self) -> Result<()> {
         Ok(())
     }
+
+    async fn truncate_table(
+        &self,
+        _ctx: &EngineContext,
+        _request: TruncateTableRequest,
+    ) -> Result<bool> {
+        Ok(true)
+    }
 }
 
 impl TableEngineProcedure for MockTableEngine {

--- a/src/table/src/test_util/mock_engine.rs
+++ b/src/table/src/test_util/mock_engine.rs
@@ -21,7 +21,9 @@ use tokio::sync::Mutex;
 
 use crate::engine::{EngineContext, TableEngine, TableEngineProcedure};
 use crate::metadata::TableId;
-use crate::requests::{AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest};
+use crate::requests::{
+    AlterTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest, TruncateTableRequest,
+};
 use crate::test_util::EmptyTable;
 use crate::{Result, TableRef};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1.  Implement reset version. 
2.  Implement truncate region.
    1.  Acquires the `RegionWriter` lock.
    2.  Create `RegionMetaAction::Truncate` to store `committed_sequence` and persist it for recovery from the manifest.
    3.  Mark all data in the WAL as `obsolete`.
    4.  Mark all SSTs as deleted.
    5.  Reset Version. 
3.  Recover from `RegionMetaAction::Truncate`.
    1.  Mark all SSTs as deleted.
    2.  Reset the Version and set the `committed_sequence` from `RegionMetaAction::Truncate` as the Version's `flushed_sequence`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
