### PR TITLE
fix: disable region failover in sqlness test

### DIFF
--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -15,9 +15,7 @@
 use std::fmt::Display;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
-// use tokio::process::{Child, Command};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -177,6 +175,7 @@ impl Env {
                     "start".to_string(),
                     "--use-memory-store".to_string(),
                     "--http-addr=0.0.0.0:5001".to_string(),
+                    "--disable-region-failover".to_string(),
                 ];
                 (args, METASRV_ADDR.to_string())
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Region failover makes the sqlness result unstable. It should be covered in chaos test instead of sqlness. I've verified this flag works:
```
  24   │ 2023-08-04T08:15:47.597656Z  INFO cmd::metasrv: MetaSrv options: MetaSrvOptions {
  25   │     bind_addr: "127.0.0.1:3002",
  26   │     server_addr: "127.0.0.1:3002",
  27   │     store_addr: "127.0.0.1:2379",
  28   │     datanode_lease_secs: 15,
  29   │     selector: LoadBased,
  30   │     use_memory_store: true,
  31   │     disable_region_failover: true,
  32   │     http_opts: HttpOptions {
  33   │         addr: "0.0.0.0:5001",
  34   │         timeout: 30s,
  35   │         disable_dashboard: true,
  36   │         body_limit: ReadableSize(
  37   │             67108864,
  38   │         ),
  39   │     },
  40   │     logging: LoggingOptions {
  41   │         dir: "/tmp/greptimedb/logs",
  42   │         level: Some(
  43   │             "debug,hyper=warn,tower=warn,datafusion=warn,reqwest=warn,sqlparser=warn,h2=info,opendal=info",
  44   │         ),
  45   │         enable_jaeger_tracing: false,
  46   │     },
  47   │     procedure: ProcedureConfig {
  48   │         max_retry_times: 3,
  49   │         retry_delay: 500ms,
  50   │     },
  51   │     datanode: DatanodeOptions {
  52   │         client_options: DatanodeClientOptions {
  53   │             timeout_millis: 10000,
  54   │             connect_timeout_millis: 10000,
  55   │             tcp_nodelay: true,
  56   │         },
  57   │     },
  58   │ }
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
