### PR TITLE
feat(mito): Implement mito2 Wal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,7 +4114,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ec4b84931378004db60d168e2604bc3fb9735e9c#ec4b84931378004db60d168e2604bc3fb9735e9c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=10c349c033dded29097d0dc933fbc2f89f658032#10c349c033dded29097d0dc933fbc2f89f658032"
 dependencies = [
  "prost",
  "serde",
@@ -5510,12 +5510,13 @@ dependencies = [
  "datafusion-common",
  "datatypes",
  "futures",
- "greptime-proto 0.1.0 (git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ec4b84931378004db60d168e2604bc3fb9735e9c)",
+ "greptime-proto 0.1.0 (git+https://github.com/GreptimeTeam/greptime-proto.git?rev=10c349c033dded29097d0dc933fbc2f89f658032)",
  "lazy_static",
  "log-store",
  "metrics",
  "object-store",
  "parquet",
+ "prost",
  "regex",
  "serde",
  "serde_json",

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -33,12 +33,13 @@ datafusion.workspace = true
 datatypes = { path = "../datatypes" }
 futures.workspace = true
 # TODO(yingwen): Update and use api crate once https://github.com/GreptimeTeam/greptime-proto/pull/75 is merged.
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ec4b84931378004db60d168e2604bc3fb9735e9c" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "10c349c033dded29097d0dc933fbc2f89f658032" }
 lazy_static = "1.4"
 log-store = { path = "../log-store" }
 metrics.workspace = true
 object-store = { path = "../object-store" }
 parquet = { workspace = true, features = ["async"] }
+prost.workspace = true
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -52,6 +52,9 @@ impl MitoEngine {
     }
 
     /// Stop the engine.
+    ///
+    /// Stopping the engine doesn't stop the underlying log store as other components might
+    /// still use it.
     pub async fn stop(&self) -> Result<()> {
         self.inner.stop().await
     }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -248,6 +248,18 @@ pub enum Error {
         location: Location,
         source: DecodeError,
     },
+
+    #[snafu(display(
+        "Failed to delete WAL, region_id: {}, location: {}, source: {}",
+        region_id,
+        location,
+        source
+    ))]
+    DeleteWal {
+        region_id: RegionId,
+        location: Location,
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -261,7 +273,8 @@ impl ErrorExt for Error {
             | WriteParquet { .. }
             | ReadParquet { .. }
             | WriteWal { .. }
-            | ReadWal { .. } => StatusCode::StorageUnavailable,
+            | ReadWal { .. }
+            | DeleteWal { .. } => StatusCode::StorageUnavailable,
             CompressObject { .. }
             | DecompressObject { .. }
             | SerdeJson { .. }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -15,9 +15,10 @@
 use std::any::Any;
 
 use common_datasource::compression::CompressionType;
-use common_error::ext::ErrorExt;
+use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use datatypes::arrow::error::ArrowError;
+use prost::{DecodeError, EncodeError};
 use snafu::{Location, Snafu};
 use store_api::manifest::ManifestVersion;
 use store_api::storage::RegionId;
@@ -205,6 +206,48 @@ pub enum Error {
         column: String,
         source: datatypes::Error,
     },
+
+    #[snafu(display(
+        "Failed to encode WAL entry, region_id: {}, location: {}, source: {}",
+        region_id,
+        location,
+        source
+    ))]
+    EncodeWal {
+        region_id: RegionId,
+        location: Location,
+        source: EncodeError,
+    },
+
+    #[snafu(display("Failed to write WAL, location: {}, source: {}", location, source))]
+    WriteWal {
+        location: Location,
+        source: BoxedError,
+    },
+
+    #[snafu(display(
+        "Failed to read WAL, region_id: {}, location: {}, source: {}",
+        region_id,
+        location,
+        source
+    ))]
+    ReadWal {
+        region_id: RegionId,
+        location: Location,
+        source: BoxedError,
+    },
+
+    #[snafu(display(
+        "Failed to decode WAL entry, region_id: {}, location: {}, source: {}",
+        region_id,
+        location,
+        source
+    ))]
+    DecodeWal {
+        region_id: RegionId,
+        location: Location,
+        source: DecodeError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -214,9 +257,11 @@ impl ErrorExt for Error {
         use Error::*;
 
         match self {
-            OpenDal { .. } | WriteParquet { .. } | ReadParquet { .. } => {
-                StatusCode::StorageUnavailable
-            }
+            OpenDal { .. }
+            | WriteParquet { .. }
+            | ReadParquet { .. }
+            | WriteWal { .. }
+            | ReadWal { .. } => StatusCode::StorageUnavailable,
             CompressObject { .. }
             | DecompressObject { .. }
             | SerdeJson { .. }
@@ -231,9 +276,12 @@ impl ErrorExt for Error {
             | InvalidSchema { .. }
             | InvalidRequest { .. }
             | FillDefault { .. } => StatusCode::InvalidArguments,
-            RegionMetadataNotFound { .. } | Join { .. } | WorkerStopped { .. } | Recv { .. } => {
-                StatusCode::Internal
-            }
+            RegionMetadataNotFound { .. }
+            | Join { .. }
+            | WorkerStopped { .. }
+            | Recv { .. }
+            | EncodeWal { .. }
+            | DecodeWal { .. } => StatusCode::Internal,
             WriteBuffer { source, .. } => source.status_code(),
         }
     }

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -39,6 +39,7 @@ mod region;
 pub mod request;
 #[allow(dead_code)]
 pub mod sst;
+pub mod wal;
 #[allow(dead_code)]
 mod worker;
 

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -40,6 +40,7 @@ use crate::worker::WorkerGroup;
 pub struct TestEnv {
     /// Path to store data.
     data_home: TempDir,
+    // TODO(yingwen): Maybe provide a way to close the log store.
 }
 
 impl Default for TestEnv {

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -1,0 +1,33 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Write ahead log of the engine.
+
+use std::sync::Arc;
+
+/// Write ahead log.
+///
+/// All regions in the engine shares the same WAL instance.
+#[derive(Debug)]
+pub struct Wal<S> {
+    /// The underlying log store.
+    store: Arc<S>,
+}
+
+impl<S> Wal<S> {
+    /// Creates a new [Wal] from the log store.
+    pub fn new(store: Arc<S>) -> Self {
+        Self { store }
+    }
+}

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -14,7 +14,25 @@
 
 //! Write ahead log of the engine.
 
+use std::mem;
 use std::sync::Arc;
+
+use common_error::ext::BoxedError;
+use futures::stream::BoxStream;
+use futures::{stream, StreamExt, TryStreamExt};
+use greptime_proto::v1::mito::WalEntry;
+use prost::Message;
+use snafu::ResultExt;
+use store_api::logstore::entry::Entry;
+use store_api::logstore::LogStore;
+use store_api::storage::RegionId;
+
+use crate::error::{DecodeWalSnafu, EncodeWalSnafu, ReadWalSnafu, Result, WriteWalSnafu};
+
+/// WAL entry id.
+pub type EntryId = store_api::logstore::entry::Id;
+/// A stream that yields tuple of WAL entry id and corresponding entry.
+pub type WalEntryStream<'a> = BoxStream<'a, Result<(EntryId, WalEntry)>>;
 
 /// Write ahead log.
 ///
@@ -31,3 +49,105 @@ impl<S> Wal<S> {
         Self { store }
     }
 }
+
+impl<S: LogStore> Wal<S> {
+    /// Returns a writer to write to the WAL.
+    pub fn writer(&self) -> WalWriter<S> {
+        WalWriter {
+            store: self.store.clone(),
+            entries: Vec::new(),
+            entry_encode_buf: Vec::new(),
+        }
+    }
+
+    /// Scan entries of specific region starting from `start_id` (inclusive).
+    pub async fn scan_region(
+        &self,
+        region_id: RegionId,
+        start_id: EntryId,
+    ) -> Result<WalEntryStream> {
+        let namespace = self.store.namespace(region_id.into());
+        let stream = self
+            .store
+            .read(&namespace, start_id)
+            .await
+            .map_err(BoxedError::new)
+            .context(ReadWalSnafu { region_id })?;
+
+        let stream = stream
+            .map(move |entries_ret| {
+                // Maps results from the WAL stream to our results.
+                entries_ret
+                    .map_err(BoxedError::new)
+                    .context(ReadWalSnafu { region_id })
+            })
+            .and_then(move |entries| async move {
+                let iter = entries
+                    .into_iter()
+                    .map(move |entry| decode_entry(region_id, entry));
+
+                Ok(stream::iter(iter))
+            })
+            .try_flatten();
+
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Decode Wal entry from log store.
+fn decode_entry<E: Entry>(region_id: RegionId, entry: E) -> Result<(EntryId, WalEntry)> {
+    let entry_id = entry.id();
+    let data = entry.data();
+
+    let wal_entry = WalEntry::decode(data).context(DecodeWalSnafu { region_id })?;
+
+    Ok((entry_id, wal_entry))
+}
+
+/// WAL batch writer.
+pub struct WalWriter<S: LogStore> {
+    /// Log store of the WAL.
+    store: Arc<S>,
+    /// Entries to write.
+    entries: Vec<S::Entry>,
+    /// Buffer to encode WAL entry.
+    entry_encode_buf: Vec<u8>,
+}
+
+impl<S: LogStore> WalWriter<S> {
+    /// Add an wal entry for specific region to the writer's buffer.
+    pub fn add_entry(
+        &mut self,
+        region_id: RegionId,
+        entry_id: EntryId,
+        wal_entry: &WalEntry,
+    ) -> Result<()> {
+        let namespace = self.store.namespace(region_id.into());
+        // Encode wal entry to log store entry.
+        self.entry_encode_buf.clear();
+        wal_entry
+            .encode(&mut self.entry_encode_buf)
+            .context(EncodeWalSnafu { region_id })?;
+        let entry = self
+            .store
+            .entry(&self.entry_encode_buf, entry_id, namespace);
+
+        self.entries.push(entry);
+
+        Ok(())
+    }
+
+    /// Write all buffered entries to the WAL.
+    pub async fn write_to_wal(&mut self) -> Result<()> {
+        // TODO(yingwen): metrics.
+
+        let entries = mem::take(&mut self.entries);
+        self.store
+            .append_batch(entries)
+            .await
+            .map_err(BoxedError::new)
+            .context(WriteWalSnafu)
+    }
+}
+
+// TODO(yingwen): Tests.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -39,6 +39,7 @@ use crate::error::{JoinSnafu, Result, WorkerStoppedSnafu};
 use crate::memtable::{DefaultMemtableBuilder, MemtableBuilderRef};
 use crate::region::{RegionMap, RegionMapRef};
 use crate::request::{RegionRequest, RequestBody, SenderWriteRequest, WorkerRequest};
+use crate::wal::Wal;
 
 /// Identifier for a worker.
 pub(crate) type WorkerId = u32;
@@ -179,7 +180,7 @@ impl RegionWorker {
             config,
             regions: regions.clone(),
             receiver,
-            log_store,
+            wal: Wal::new(log_store),
             object_store,
             running: running.clone(),
             memtable_builder: Arc::new(DefaultMemtableBuilder::default()),
@@ -274,8 +275,8 @@ struct RegionWorkerLoop<S> {
     regions: RegionMapRef,
     /// Request receiver.
     receiver: Receiver<WorkerRequest>,
-    // TODO(yingwen): Replaced by Wal.
-    log_store: Arc<S>,
+    /// WAL of the engine.
+    wal: Wal<S>,
     /// Object store for manifest and SSTs.
     object_store: ObjectStore,
     /// Whether the worker thread is still running.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements Wal for mito2 engine.
- It uses the new row based `WalEntry` in https://github.com/GreptimeTeam/greptime-proto/pull/75
- It supports batching wal entries of multiple regions and send it to the log store

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 
- https://github.com/GreptimeTeam/greptime-proto/pull/75
