### PR TITLE
feat(information_schema): implement `table_factory` method

### DIFF
--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -73,24 +73,22 @@ impl InformationSchemaProvider {
     }
 
     pub fn table_factory(&self, name: &str) -> Result<Option<TableFactory>> {
-        let stream_builder: Arc<dyn InformationStreamBuilder> =
-            match name.to_ascii_lowercase().as_ref() {
-                TABLES => Arc::new(InformationSchemaTables::new(
-                    self.catalog_name.clone(),
-                    self.catalog_manager.clone(),
-                )) as _,
-                COLUMNS => Arc::new(InformationSchemaColumns::new(
-                    self.catalog_name.clone(),
-                    self.catalog_manager.clone(),
-                )) as _,
-                _ => {
-                    return Ok(None);
-                }
-            };
+        let stream_builder = match name.to_ascii_lowercase().as_ref() {
+            TABLES => Arc::new(InformationSchemaTables::new(
+                self.catalog_name.clone(),
+                self.catalog_manager.clone(),
+            )) as _,
+            COLUMNS => Arc::new(InformationSchemaColumns::new(
+                self.catalog_name.clone(),
+                self.catalog_manager.clone(),
+            )) as _,
+            _ => {
+                return Ok(None);
+            }
+        };
+        let data_source = Arc::new(InformationTable::new(stream_builder));
 
-        Ok(Some(Arc::new(move || {
-            Arc::new(InformationTable::new(stream_builder.clone()))
-        })))
+        Ok(Some(Arc::new(move || data_source.clone())))
     }
 }
 

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -37,6 +37,7 @@ pub mod local;
 mod metrics;
 pub mod remote;
 pub mod system;
+pub mod table_factory;
 pub mod table_source;
 pub mod tables;
 

--- a/src/catalog/src/table_factory.rs
+++ b/src/catalog/src/table_factory.rs
@@ -11,20 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(assert_matches)]
 
-pub mod data_source;
-pub mod engine;
-pub mod error;
-pub mod metadata;
-pub mod predicate;
-pub mod requests;
-pub mod stats;
-pub mod table;
-pub mod test_util;
+use std::sync::Arc;
 
-pub use store_api::storage::RegionStat;
+use table::data_source::DataSourceRef;
 
-pub use crate::error::{Error, Result};
-pub use crate::stats::{ColumnStatistics, TableStatistics};
-pub use crate::table::{Table, TableRef};
+pub type TableFactory = Arc<dyn Fn() -> DataSourceRef>;

--- a/src/table/src/data_source.rs
+++ b/src/table/src/data_source.rs
@@ -19,10 +19,10 @@ use store_api::storage::ScanRequest;
 
 use crate::error::Result;
 
-// This trait represents a common data source abstraction which provides an interface
-// for retrieving data in the form of a stream of record batches.
+/// This trait represents a common data source abstraction which provides an interface
+/// for retrieving data in the form of a stream of record batches.
 pub trait DataSource {
-    // Retrieves a stream of record batches based on the provided scan request.
+    /// Retrieves a stream of record batches based on the provided scan request.
     fn get_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream>;
 }
 

--- a/src/table/src/data_source.rs
+++ b/src/table/src/data_source.rs
@@ -11,20 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(assert_matches)]
 
-pub mod data_source;
-pub mod engine;
-pub mod error;
-pub mod metadata;
-pub mod predicate;
-pub mod requests;
-pub mod stats;
-pub mod table;
-pub mod test_util;
+use std::sync::Arc;
 
-pub use store_api::storage::RegionStat;
+use common_recordbatch::SendableRecordBatchStream;
+use store_api::storage::ScanRequest;
 
-pub use crate::error::{Error, Result};
-pub use crate::stats::{ColumnStatistics, TableStatistics};
-pub use crate::table::{Table, TableRef};
+use crate::error::Result;
+
+// This trait represents a common data source abstraction which provides an interface
+// for retrieving data in the form of a stream of record batches.
+pub trait DataSource {
+    // Retrieves a stream of record batches based on the provided scan request.
+    fn get_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream>;
+}
+
+pub type DataSourceRef = Arc<dyn DataSource>;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* Add `DataSource` trait
* impl `DataSource` for `InformationTable`
* impl `table_factory` method for `InformationTable`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/2065