### PR TITLE
feat: return metasrv leader addr

### DIFF
--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -210,7 +210,7 @@ impl MetaClient {
 
     /// Ask the leader address of `metasrv`, and the heartbeat component
     /// needs to create a bidirectional streaming to the leader.
-    pub async fn ask_leader(&self) -> Result<()> {
+    pub async fn ask_leader(&self) -> Result<String> {
         self.heartbeat_client()?.ask_leader().await
     }
 

--- a/src/meta-client/src/client/heartbeat.rs
+++ b/src/meta-client/src/client/heartbeat.rs
@@ -107,7 +107,7 @@ impl Client {
         inner.start(urls).await
     }
 
-    pub async fn ask_leader(&mut self) -> Result<()> {
+    pub async fn ask_leader(&mut self) -> Result<String> {
         let inner = self.inner.read().await;
         inner.ask_leader().await
     }
@@ -169,7 +169,7 @@ impl Inner {
         Ok(())
     }
 
-    async fn ask_leader(&self) -> Result<()> {
+    async fn ask_leader(&self) -> Result<String> {
         ensure!(
             self.is_started(),
             error::IllegalGrpcClientStateSnafu {
@@ -177,8 +177,7 @@ impl Inner {
             }
         );
 
-        let _ = self.ask_leader.as_ref().unwrap().ask_leader().await;
-        Ok(())
+        self.ask_leader.as_ref().unwrap().ask_leader().await
     }
 
     async fn heartbeat(&self) -> Result<(HeartbeatSender, HeartbeatStream)> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Return metasrv leader address. 

It's used for test purposes, e.g., killing the leader's service after figuring out the leader's address.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
