### PR TITLE
refactor: use workspace dependencies for internal modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "src/common/error",
     "src/common/function",
     "src/common/function-macro",
+    "src/common/greptimedb-telemetry",
     "src/common/grpc",
     "src/common/grpc-expr",
     "src/common/mem-prof",
@@ -25,6 +26,7 @@ members = [
     "src/common/telemetry",
     "src/common/test-util",
     "src/common/time",
+    "src/common/version",
     "src/datanode",
     "src/datatypes",
     "src/file-table-engine",
@@ -97,6 +99,54 @@ tonic = { version = "0.9", features = ["tls"] }
 uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
 metrics = "0.20"
 meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "abbd357c1e193cd270ea65ee7652334a150b628f" }
+## workspaces members
+api = { path = "src/api" }
+catalog = { path = "src/catalog" }
+client = { path = "src/client" }
+cmd = { path = "src/cmd" }
+common-base = { path = "src/common/base" }
+common-catalog = { path = "src/common/catalog" }
+common-datasource = { path = "src/common/datasource" }
+common-error = { path = "src/common/error" }
+common-function = { path = "src/common/function" }
+common-function-macro = { path = "src/common/function-macro" }
+common-greptimedb-telemetry = { path = "src/common/greptimedb-telemetry" }
+common-grpc = { path = "src/common/grpc" }
+common-grpc-expr = { path = "src/common/grpc-expr" }
+common-mem-prof = { path = "src/common/mem-prof" }
+common-meta = { path = "src/common/meta" }
+common-procedure = { path = "src/common/procedure" }
+common-procedure-test = { path = "src/common/procedure-test" }
+common-pprof = { path = "src/common/pprof" }
+common-query = { path = "src/common/query" }
+common-recordbatch = { path = "src/common/recordbatch" }
+common-runtime = { path = "src/common/runtime" }
+substrait = { path = "src/common/substrait" }
+common-telemetry = { path = "src/common/telemetry" }
+common-test-util = { path = "src/common/test-util" }
+common-time = { path = "src/common/time" }
+common-version = { path = "src/common/version" }
+datanode = { path = "src/datanode" }
+datatypes = { path = "src/datatypes" }
+file-table-engine = { path = "src/file-table-engine" }
+frontend = { path = "src/frontend" }
+log-store = { path = "src/log-store" }
+meta-client = { path = "src/meta-client" }
+meta-srv = { path = "src/meta-srv" }
+mito = { path = "src/mito" }
+mito2 = { path = "src/mito2" }
+object-store = { path = "src/object-store" }
+partition = { path = "src/partition" }
+promql = { path = "src/promql" }
+query = { path = "src/query" }
+script = { path = "src/script" }
+servers = { path = "src/servers" }
+session = { path = "src/session" }
+sql = { path = "src/sql" }
+storage = { path = "src/storage" }
+store-api = { path = "src/store-api" }
+table = { path = "src/table" }
+table-procedure = { path = "src/table-procedure" }
 
 [workspace.dependencies.meter-macros]
 git = "https://github.com/GreptimeTeam/greptime-meter.git"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 arrow.workspace = true
 clap = { version = "4.0", features = ["derive"] }
-client = { path = "../src/client" }
+client = { workspace = true }
 indicatif = "0.17.1"
 itertools.workspace = true
 parquet.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-base = { path = "../common/base" }
-common-error = { path = "../common/error" }
-common-time = { path = "../common/time" }
-datatypes = { path = "../datatypes" }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-time = { workspace = true }
+datatypes = { workspace = true }
 greptime-proto.workspace = true
 prost.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -8,45 +8,45 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 arc-swap = "1.0"
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-grpc = { path = "../common/grpc" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 dashmap = "5.4"
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures = "0.3"
 futures-util.workspace = true
 lazy_static.workspace = true
-meta-client = { path = "../meta-client" }
+meta-client = { workspace = true }
 metrics.workspace = true
 moka = { version = "0.11", features = ["future"] }
 parking_lot = "0.12"
 regex.workspace = true
 serde = "1.0"
 serde_json = "1.0"
-session = { path = "../session" }
+session = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
-catalog = { path = ".", features = ["testing"] }
+catalog = { workspace = true, features = ["testing"] }
 chrono.workspace = true
-common-test-util = { path = "../common/test-util" }
-log-store = { path = "../log-store" }
-mito = { path = "../mito", features = ["test"] }
-object-store = { path = "../object-store" }
-storage = { path = "../storage" }
+common-test-util = { workspace = true }
+log-store = { workspace = true }
+mito = { workspace = true, features = ["test"] }
+object-store = { workspace = true }
+storage = { workspace = true }
 tokio.workspace = true

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -8,20 +8,20 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 arrow-flight.workspace = true
 async-stream.workspace = true
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-grpc = { path = "../common/grpc" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 enum_dispatch = "0.3"
 futures-util.workspace = true
 moka = { version = "0.9", features = ["future"] }
@@ -34,11 +34,11 @@ tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-common-grpc-expr = { path = "../common/grpc-expr" }
-datanode = { path = "../datanode" }
+common-grpc-expr = { workspace = true }
+datanode = { workspace = true }
 derive-new = "0.5"
 prost.workspace = true
-substrait = { path = "../common/substrait" }
+substrait = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -21,48 +21,48 @@ greptimedb-telemetry = [
 [dependencies]
 anymap = "1.0.0-beta.2"
 async-trait.workspace = true
-catalog = { path = "../catalog" }
+catalog = { workspace = true }
 chrono.workspace = true
 clap = { version = "3.1", features = ["derive"] }
-client = { path = "../client" }
-common-base = { path = "../common/base" }
-common-error = { path = "../common/error" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry", features = [
+client = { workspace = true }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true, features = [
     "deadlock_detection",
 ] }
 config = "0.13"
-datanode = { path = "../datanode" }
-datatypes = { path = "../datatypes" }
+datanode = { workspace = true }
+datatypes = { workspace = true }
 either = "1.8"
 etcd-client.workspace = true
-frontend = { path = "../frontend" }
+frontend = { workspace = true }
 futures.workspace = true
-meta-client = { path = "../meta-client" }
-meta-srv = { path = "../meta-srv" }
+meta-client = { workspace = true }
+meta-srv = { workspace = true }
 metrics.workspace = true
 nu-ansi-term = "0.46"
-partition = { path = "../partition" }
-query = { path = "../query" }
+partition = { workspace = true }
+query = { workspace = true }
 rand.workspace = true
 rustyline = "10.1"
 serde.workspace = true
-servers = { path = "../servers" }
-session = { path = "../session" }
+servers = { workspace = true }
+session = { workspace = true }
 snafu.workspace = true
-substrait = { path = "../common/substrait" }
-table = { path = "../table" }
+substrait = { workspace = true }
+table = { workspace = true }
 tikv-jemallocator = "0.5"
 tokio.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../common/test-util" }
+common-test-util = { workspace = true }
 rexpect = "0.5"
 serde.workspace = true
 temp-env = "0.3"
 toml.workspace = true
 
 [build-dependencies]
-common-version = { path = "../common/version" }
+common-version = { workspace = true }

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 anymap = "1.0.0-beta.2"
 bitvec = "1.0"
 bytes = { version = "1.1", features = ["serde"] }
-common-error = { path = "../error" }
+common-error = { workspace = true }
 paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 snafu.workspace = true

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { path = "../error" }
+common-error = { workspace = true }
 serde.workspace = true
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -17,12 +17,12 @@ async-compression = { version = "0.3", features = [
 ] }
 async-trait.workspace = true
 bytes = "1.1"
-common-error = { path = "../error" }
-common-runtime = { path = "../runtime" }
+common-error = { workspace = true }
+common-runtime = { workspace = true }
 datafusion.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
-object-store = { path = "../../object-store" }
+object-store = { workspace = true }
 orc-rust = "0.2"
 paste = "1.0"
 regex = "1.7"
@@ -32,4 +32,4 @@ tokio.workspace = true
 url = "2.3"
 
 [dev-dependencies]
-common-test-util = { path = "../test-util" }
+common-test-util = { workspace = true }

--- a/src/common/function-macro/Cargo.toml
+++ b/src/common/function-macro/Cargo.toml
@@ -9,14 +9,14 @@ proc-macro = true
 
 [dependencies]
 backtrace = "0.3"
-common-telemetry = { path = "../telemetry" }
+common-telemetry = { workspace = true }
 proc-macro2 = "1.0.66"
 quote = "1.0"
 syn = "1.0"
 
 [dev-dependencies]
 arc-swap = "1.0"
-common-query = { path = "../query" }
-datatypes = { path = "../../datatypes" }
+common-query = { workspace = true }
+datatypes = { workspace = true }
 snafu.workspace = true
 static_assertions = "1.1.0"

--- a/src/common/function/Cargo.toml
+++ b/src/common/function/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 [dependencies]
 arc-swap = "1.0"
 chrono-tz = "0.6"
-common-error = { path = "../error" }
-common-function-macro = { path = "../function-macro" }
-common-query = { path = "../query" }
-common-time = { path = "../time" }
+common-error = { workspace = true }
+common-function-macro = { workspace = true }
+common-query = { workspace = true }
+common-time = { workspace = true }
 datafusion.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 libc = "0.2"
 num = "0.4"
 num-traits = "0.2"

--- a/src/common/greptimedb-telemetry/Cargo.toml
+++ b/src/common/greptimedb-telemetry/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-error = { path = "../error" }
-common-runtime = { path = "../runtime" }
-common-telemetry = { path = "../telemetry" }
+common-error = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
 once_cell = "1.17.0"
 reqwest = { version = "0.11", features = [
     "json",
@@ -20,8 +20,8 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../test-util" }
+common-test-util = { workspace = true }
 hyper = { version = "0.14", features = ["full"] }
 
 [build-dependencies]
-common-version = { path = "../version" }
+common-version = { workspace = true }

--- a/src/common/grpc-expr/Cargo.toml
+++ b/src/common/grpc-expr/Cargo.toml
@@ -5,17 +5,17 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../../api" }
+api = { workspace = true }
 async-trait.workspace = true
-common-base = { path = "../base" }
-common-catalog = { path = "../catalog" }
-common-error = { path = "../error" }
-common-query = { path = "../query" }
-common-telemetry = { path = "../telemetry" }
-common-time = { path = "../time" }
-datatypes = { path = "../../datatypes" }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-query = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
+datatypes = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-table = { path = "../../table" }
+table = { workspace = true }
 
 [dev-dependencies]
 paste = "1.0"

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -5,18 +5,18 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../../api" }
+api = { workspace = true }
 arrow-flight.workspace = true
 async-trait = "0.1"
 backtrace = "0.3"
-common-base = { path = "../base" }
-common-error = { path = "../error" }
-common-recordbatch = { path = "../recordbatch" }
-common-runtime = { path = "../runtime" }
-common-telemetry = { path = "../telemetry" }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
 dashmap = "5.4"
 datafusion.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 flatbuffers = "23.1"
 futures = "0.3"
 lazy_static.workspace = true

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { path = "../error" }
+common-error = { workspace = true }
 snafu.workspace = true
 tempfile = "3.4"
 tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../../api" }
+api = { workspace = true }
 async-stream.workspace = true
 async-trait.workspace = true
-common-catalog = { path = "../catalog" }
-common-error = { path = "../error" }
-common-runtime = { path = "../runtime" }
-common-telemetry = { path = "../telemetry" }
-common-time = { path = "../time" }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 etcd-client.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
@@ -21,11 +21,11 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-store-api = { path = "../../store-api" }
-table = { path = "../../table" }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 hyper = { version = "0.14", features = ["full"] }

--- a/src/common/pprof/Cargo.toml
+++ b/src/common/pprof/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { path = "../error" }
+common-error = { workspace = true }
 pprof = { version = "0.11", features = [
     "flamegraph",
     "prost-codec",

--- a/src/common/procedure-test/Cargo.toml
+++ b/src/common/procedure-test/Cargo.toml
@@ -6,4 +6,4 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-procedure = { path = "../procedure" }
+common-procedure = { workspace = true }

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -8,12 +8,12 @@ license.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 backon = "0.4"
-common-error = { path = "../error" }
-common-runtime = { path = "../runtime" }
-common-telemetry = { path = "../telemetry" }
+common-error = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
 futures.workspace = true
 humantime-serde = "1.1"
-object-store = { path = "../../object-store" }
+object-store = { workspace = true }
 serde.workspace = true
 serde_json = "1.0"
 smallvec = "1"
@@ -22,5 +22,5 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../test-util" }
+common-test-util = { workspace = true }
 futures-util.workspace = true

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -5,19 +5,19 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../../api" }
+api = { workspace = true }
 async-trait.workspace = true
-common-error = { path = "../error" }
-common-recordbatch = { path = "../recordbatch" }
-common-time = { path = "../time" }
+common-error = { workspace = true }
+common-recordbatch = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 serde.workspace = true
 snafu.workspace = true
 statrs = "0.16"
 
 [dev-dependencies]
-common-base = { path = "../base" }
+common-base = { workspace = true }
 tokio.workspace = true

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { path = "../error" }
+common-error = { workspace = true }
 datafusion-common.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 futures.workspace = true
 paste = "1.0"
 serde = "1.0"

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-error = { path = "../error" }
-common-telemetry = { path = "../telemetry" }
+common-error = { workspace = true }
+common-telemetry = { workspace = true }
 metrics.workspace = true
 once_cell.workspace = true
 paste.workspace = true

--- a/src/common/substrait/Cargo.toml
+++ b/src/common/substrait/Cargo.toml
@@ -8,27 +8,27 @@ license.workspace = true
 async-recursion = "1.0"
 async-trait.workspace = true
 bytes = "1.1"
-catalog = { path = "../../catalog" }
-common-catalog = { path = "../catalog" }
-common-error = { path = "../error" }
-common-telemetry = { path = "../telemetry" }
+catalog = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-telemetry = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-substrait.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../../datatypes" }
+datatypes = { workspace = true }
 futures = "0.3"
-promql = { path = "../../promql" }
+promql = { workspace = true }
 prost.workspace = true
-session = { path = "../../session" }
+session = { workspace = true }
 snafu.workspace = true
-table = { path = "../../table" }
+table = { workspace = true }
 
 [dependencies.substrait_proto]
 package = "substrait"
 version = "0.12"
 
 [dev-dependencies]
-datatypes = { path = "../../datatypes" }
-table = { path = "../../table" }
+datatypes = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -10,7 +10,7 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 
 [dependencies]
 backtrace = "0.3"
-common-error = { path = "../error" }
+common-error = { workspace = true }
 console-subscriber = { version = "0.1", optional = true }
 metrics-exporter-prometheus = { version = "0.11", default-features = false }
 metrics-util = "0.14"

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 arrow.workspace = true
 chrono-tz = "0.8"
 chrono.workspace = true
-common-error = { path = "../error" }
+common-error = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [features]
 greptimedb-telemetry = []
+testing = ["meta-srv/mock"]
 
 [dependencies]
 api = { workspace = true }
@@ -76,6 +77,5 @@ client = { workspace = true }
 common-query = { workspace = true }
 common-test-util = { workspace = true }
 datafusion-common.workspace = true
-meta-srv = { workspace = true, features = ["mock"] }
 mito = { workspace = true, features = ["test"] }
 session = { workspace = true }

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -8,59 +8,59 @@ license.workspace = true
 greptimedb-telemetry = []
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait.workspace = true
 axum = "0.6"
 axum-macros = "0.3"
-catalog = { path = "../catalog" }
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-function = { path = "../common/function" }
-common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
-common-grpc = { path = "../common/grpc" }
-common-grpc-expr = { path = "../common/grpc-expr" }
-common-meta = { path = "../common/meta" }
-common-procedure = { path = "../common/procedure" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+catalog = { workspace = true }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-function = { workspace = true }
+common-greptimedb-telemetry = { workspace = true }
+common-grpc = { workspace = true }
+common-grpc-expr = { workspace = true }
+common-meta = { workspace = true }
+common-procedure = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
-file-table-engine = { path = "../file-table-engine" }
+datatypes = { workspace = true }
+file-table-engine = { workspace = true }
 futures = "0.3"
 futures-util.workspace = true
 humantime-serde = "1.1"
 hyper = { version = "0.14", features = ["full"] }
 key-lock = "0.1"
-log-store = { path = "../log-store" }
-meta-client = { path = "../meta-client" }
-meta-srv = { path = "../meta-srv", features = ["mock"] }
+log-store = { workspace = true }
+meta-client = { workspace = true }
+meta-srv = { workspace = true }
 metrics.workspace = true
-mito = { path = "../mito", features = ["test"] }
-object-store = { path = "../object-store" }
+mito = { workspace = true }
+object-store = { workspace = true }
 pin-project = "1.0"
 prost.workspace = true
-query = { path = "../query" }
+query = { workspace = true }
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde = "1.0"
 serde_json = "1.0"
-servers = { path = "../servers" }
-session = { path = "../session" }
+servers = { workspace = true }
+session = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-sql = { path = "../sql" }
-storage = { path = "../storage" }
-store-api = { path = "../store-api" }
-substrait = { path = "../common/substrait" }
-table = { path = "../table" }
-table-procedure = { path = "../table-procedure" }
+sql = { workspace = true }
+storage = { workspace = true }
+store-api = { workspace = true }
+substrait = { workspace = true }
+table = { workspace = true }
+table-procedure = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 toml.workspace = true
@@ -72,8 +72,10 @@ uuid.workspace = true
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-client = { path = "../client" }
-common-query = { path = "../common/query" }
-common-test-util = { path = "../common/test-util" }
+client = { workspace = true }
+common-query = { workspace = true }
+common-test-util = { workspace = true }
 datafusion-common.workspace = true
-session = { path = "../session", features = ["testing"] }
+meta-srv = { workspace = true, features = ["mock"] }
+mito = { workspace = true, features = ["test"] }
+session = { workspace = true }

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -21,6 +21,7 @@ mod greptimedb_telemetry;
 pub mod heartbeat;
 pub mod instance;
 pub mod metrics;
+#[cfg(feature = "testing")]
 mod mock;
 pub mod server;
 pub mod sql;

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -12,10 +12,10 @@ test = []
 arrow-array.workspace = true
 arrow-schema.workspace = true
 arrow.workspace = true
-common-base = { path = "../common/base" }
-common-error = { path = "../common/error" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 enum_dispatch = "0.3"
 num = "0.4"

--- a/src/file-table-engine/Cargo.toml
+++ b/src/file-table-engine/Cargo.toml
@@ -10,26 +10,26 @@ test = ["common-test-util"]
 
 [dependencies]
 async-trait = "0.1"
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-procedure = { path = "../common/procedure" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry" }
-common-test-util = { path = "../common/test-util", optional = true }
-common-time = { path = "../common/time" }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-procedure = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true }
+common-test-util = { workspace = true, optional = true }
+common-time = { workspace = true }
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures.workspace = true
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu.workspace = true
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
-common-procedure-test = { path = "../common/procedure-test" }
-common-test-util = { path = "../common/test-util" }
+common-procedure-test = { workspace = true }
+common-test-util = { workspace = true }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -10,71 +10,72 @@ python = ["dep:script"]
 testing = []
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
-catalog = { path = "../catalog" }
+catalog = { workspace = true }
 chrono.workspace = true
-client = { path = "../client" }
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-function = { path = "../common/function" }
-common-grpc = { path = "../common/grpc" }
-common-grpc-expr = { path = "../common/grpc-expr" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+client = { workspace = true }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-function = { workspace = true }
+common-grpc = { workspace = true }
+common-grpc-expr = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datanode = { path = "../datanode" }
-datatypes = { path = "../datatypes" }
-file-table-engine = { path = "../file-table-engine" }
+datanode = { workspace = true }
+datatypes = { workspace = true }
+file-table-engine = { workspace = true }
 futures = "0.3"
 futures-util.workspace = true
 humantime-serde = "1.1"
 itertools.workspace = true
-meta-client = { path = "../meta-client" }
+meta-client = { workspace = true }
 # Although it is not used, please do not delete it.
 meter-core.workspace = true
 meter-macros.workspace = true
 metrics.workspace = true
-mito = { path = "../mito", features = ["test"] }
+mito = { workspace = true }
 moka = { version = "0.9", features = ["future"] }
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 openmetrics-parser = "0.4"
 opentelemetry-proto.workspace = true
-partition = { path = "../partition" }
+partition = { workspace = true }
 prost.workspace = true
-query = { path = "../query" }
+query = { workspace = true }
 regex.workspace = true
-script = { path = "../script", features = ["python"], optional = true }
+script = { workspace = true, features = ["python"], optional = true }
 serde = "1.0"
 serde_json = "1.0"
-servers = { path = "../servers" }
-session = { path = "../session" }
+servers = { workspace = true }
+session = { workspace = true }
 snafu.workspace = true
-sql = { path = "../sql" }
-storage = { path = "../storage" }
-store-api = { path = "../store-api" }
-substrait = { path = "../common/substrait" }
-table = { path = "../table" }
+sql = { workspace = true }
+storage = { workspace = true }
+store-api = { workspace = true }
+substrait = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-catalog = { path = "../catalog", features = ["testing"] }
-common-test-util = { path = "../common/test-util" }
-datanode = { path = "../datanode" }
+catalog = { workspace = true }
+common-test-util = { workspace = true }
+datanode = { workspace = true }
 futures = "0.3"
-meta-srv = { path = "../meta-srv", features = ["mock"] }
+meta-srv = { workspace = true, features = ["mock"] }
+mito = { workspace = true, features = ["test"] }
 strfmt = "0.2"
 tower = "0.4"
 uuid.workspace = true

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -15,19 +15,19 @@ async-trait.workspace = true
 base64 = "0.13"
 byteorder = "1.4"
 bytes = "1.1"
-common-base = { path = "../common/base" }
-common-error = { path = "../common/error" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
 futures-util.workspace = true
 futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }
 raft-engine = "0.3"
 snafu = { version = "0.7", features = ["backtraces"] }
-store-api = { path = "../store-api" }
+store-api = { workspace = true }
 tokio-util.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../common/test-util" }
+common-test-util = { workspace = true }
 rand.workspace = true

--- a/src/meta-client/Cargo.toml
+++ b/src/meta-client/Cargo.toml
@@ -5,27 +5,27 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 async-trait = "0.1"
 chrono.workspace = true
-common-error = { path = "../common/error" }
-common-grpc = { path = "../common/grpc" }
-common-meta = { path = "../common/meta" }
-common-telemetry = { path = "../common/telemetry" }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-meta = { workspace = true }
+common-telemetry = { workspace = true }
 etcd-client.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-table = { path = "../table" }
+table = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures = "0.3"
-meta-srv = { path = "../meta-srv", features = ["mock"] }
+meta-srv = { workspace = true, features = ["mock"] }
 tower = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -10,24 +10,24 @@ greptimedb-telemetry = []
 
 [dependencies]
 anymap = "1.0.0-beta.2"
-api = { path = "../api" }
+api = { workspace = true }
 async-stream.workspace = true
 async-trait = "0.1"
-catalog = { path = "../catalog" }
-client = { path = "../client" }
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-greptimedb-telemetry = { path = "../common/greptimedb-telemetry" }
-common-grpc = { path = "../common/grpc" }
-common-grpc-expr = { path = "../common/grpc-expr" }
-common-meta = { path = "../common/meta" }
-common-procedure = { path = "../common/procedure" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+catalog = { workspace = true }
+client = { workspace = true }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-greptimedb-telemetry = { workspace = true }
+common-grpc = { workspace = true }
+common-grpc-expr = { workspace = true }
+common-meta = { workspace = true }
+common-procedure = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 dashmap = "5.4"
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 derive_builder.workspace = true
 etcd-client.workspace = true
 futures.workspace = true
@@ -42,10 +42,10 @@ rand.workspace = true
 regex.workspace = true
 serde = "1.0"
 serde_json = "1.0"
-servers = { path = "../servers" }
+servers = { workspace = true }
 snafu.workspace = true
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 toml.workspace = true
@@ -57,7 +57,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-common-procedure-test = { path = "../common/procedure-test" }
-session = { path = "../session", features = ["testing"] }
+common-procedure-test = { workspace = true }
+session = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/mito/Cargo.toml
+++ b/src/mito/Cargo.toml
@@ -14,32 +14,32 @@ arc-swap = "1.0"
 async-stream.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-procedure = { path = "../common/procedure" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry" }
-common-test-util = { path = "../common/test-util", optional = true }
-common-time = { path = "../common/time" }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-procedure = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true }
+common-test-util = { workspace = true, optional = true }
+common-time = { workspace = true }
 dashmap = "5.4"
 datafusion-common.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures.workspace = true
 key-lock = "0.1"
-log-store = { path = "../log-store" }
+log-store = { workspace = true }
 metrics.workspace = true
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu.workspace = true
-storage = { path = "../storage" }
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+storage = { workspace = true }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
-common-procedure-test = { path = "../common/procedure-test" }
-common-test-util = { path = "../common/test-util" }
+common-procedure-test = { workspace = true }
+common-test-util = { workspace = true }

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -16,40 +16,40 @@ async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-procedure = { path = "../common/procedure" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-test-util = { path = "../common/test-util", optional = true }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-procedure = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-test-util = { workspace = true, optional = true }
+common-time = { workspace = true }
 dashmap = "5.4"
 datafusion-common.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures.workspace = true
 # TODO(yingwen): Update and use api crate once https://github.com/GreptimeTeam/greptime-proto/pull/75 is merged.
 greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "10c349c033dded29097d0dc933fbc2f89f658032" }
 lazy_static = "1.4"
-log-store = { path = "../log-store" }
+log-store = { workspace = true }
 metrics.workspace = true
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 prost.workspace = true
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu.workspace = true
-storage = { path = "../storage" }
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+storage = { workspace = true }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-procedure-test = { path = "../common/procedure-test" }
-common-test-util = { path = "../common/test-util" }
+common-procedure-test = { workspace = true }
+common-test-util = { workspace = true }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -18,5 +18,5 @@ uuid.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0"
-common-telemetry = { path = "../common/telemetry" }
-common-test-util = { path = "../common/test-util" }
+common-telemetry = { workspace = true }
+common-test-util = { workspace = true }

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -7,21 +7,21 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-api = { path = "../api" }
+api = { workspace = true }
 async-trait = "0.1"
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-telemetry = { path = "../common/telemetry" }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-telemetry = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
-meta-client = { path = "../meta-client" }
+datatypes = { workspace = true }
+meta-client = { workspace = true }
 moka = { version = "0.9", features = ["future"] }
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+store-api = { workspace = true }
+table = { workspace = true }

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 async-recursion = "1.0"
 async-trait.workspace = true
 bytemuck = "1.12"
-catalog = { path = "../catalog" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-function-macro = { path = "../common/function-macro" }
-common-telemetry = { path = "../common/telemetry" }
+catalog = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-function-macro = { workspace = true }
+common-telemetry = { workspace = true }
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures = "0.3"
 greptime-proto.workspace = true
 promql-parser = "0.1.1"
 prost.workspace = true
-session = { path = "../session" }
+session = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-table = { path = "../table" }
+table = { workspace = true }
 
 [dev-dependencies]
-query = { path = "../query" }
-session = { path = "../session", features = ["testing"] }
+query = { workspace = true }
+session = { workspace = true, features = ["testing"] }
 tokio.workspace = true

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -10,60 +10,60 @@ arc-swap = "1.0"
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
-catalog = { path = "../catalog" }
+catalog = { workspace = true }
 chrono.workspace = true
-client = { path = "../client" }
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-function = { path = "../common/function" }
-common-meta = { path = "../common/meta" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+client = { workspace = true }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-function = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-optimizer.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion-sql.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures = "0.3"
 futures-util.workspace = true
 greptime-proto.workspace = true
 humantime = "2.1"
 metrics.workspace = true
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 once_cell.workspace = true
-partition = { path = "../partition" }
-promql = { path = "../promql" }
+partition = { workspace = true }
+promql = { workspace = true }
 promql-parser = "0.1.1"
 regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
-session = { path = "../session" }
+session = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-sql = { path = "../sql" }
-substrait = { path = "../common/substrait" }
-table = { path = "../table" }
+sql = { workspace = true }
+substrait = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
 approx_eq = "0.1"
 arrow.workspace = true
-catalog = { path = "../catalog", features = ["testing"] }
-common-function-macro = { path = "../common/function-macro" }
+catalog = { workspace = true }
+common-function-macro = { workspace = true }
 format_num = "0.1"
 num = "0.4"
 num-traits = "0.2"
 paste = "1.0"
 rand.workspace = true
-session = { path = "../session", features = ["testing"] }
+session = { workspace = true, features = ["testing"] }
 statrs = "0.16"
 stats-cli = "3.0"
-store-api = { path = "../store-api" }
+store-api = { workspace = true }
 streaming-stats = "0.2"
-table = { path = "../table", features = ["testing"] }
+table = { workspace = true, features = ["testing"] }
 tokio-stream = "0.1"

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -26,27 +26,27 @@ python = [
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true
-catalog = { path = "../catalog" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-function = { path = "../common/function" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+catalog = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-function = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 console = "0.15"
 crossbeam-utils = "0.8.14"
 datafusion = { workspace = true, optional = true }
 datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures-util.workspace = true
 futures.workspace = true
 once_cell.workspace = true
 paste = { workspace = true, optional = true }
-query = { path = "../query" }
+query = { workspace = true }
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After RustPython support GC
 pyo3 = { version = "0.19", optional = true, features = ["abi3", "abi3-py37"] }
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "9ed5137412" }
@@ -62,24 +62,24 @@ rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = tru
     "default",
     "codegen",
 ] }
-session = { path = "../session" }
+session = { workspace = true }
 snafu = { version = "0.7", features = ["backtraces"] }
-sql = { path = "../sql" }
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+sql = { workspace = true }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
-catalog = { path = "../catalog", features = ["testing"] }
-common-test-util = { path = "../common/test-util" }
+catalog = { workspace = true, features = ["testing"] }
+common-test-util = { workspace = true }
 criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
-log-store = { path = "../log-store" }
-mito = { path = "../mito", features = ["test"] }
+log-store = { workspace = true }
+mito = { workspace = true }
 rayon = "1.0"
 ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
-session = { path = "../session", features = ["testing"] }
-storage = { path = "../storage" }
+session = { workspace = true, features = ["testing"] }
+storage = { workspace = true }
 tokio-test = "0.4"
 
 [[bench]]

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -11,32 +11,32 @@ pprof = ["dep:common-pprof"]
 
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
-api = { path = "../api" }
+api = { workspace = true }
 arrow-flight.workspace = true
 async-trait = "0.1"
 axum = { version = "0.6", features = ["headers"] }
 axum-macros = "0.3.8"
 base64 = "0.13"
 bytes = "1.2"
-catalog = { path = "../catalog" }
+catalog = { workspace = true }
 chrono.workspace = true
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-grpc = { path = "../common/grpc" }
-common-grpc-expr = { path = "../common/grpc-expr" }
-common-mem-prof = { path = "../common/mem-prof", optional = true }
-common-pprof = { path = "../common/pprof", optional = true }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-grpc-expr = { workspace = true }
+common-mem-prof = { workspace = true, optional = true }
+common-pprof = { workspace = true, optional = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
 
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 derive_builder.workspace = true
 digest = "0.10"
 futures = "0.3"
@@ -63,7 +63,7 @@ pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }
 promql-parser = "0.1.1"
 prost.workspace = true
-query = { path = "../query" }
+query = { workspace = true }
 rand.workspace = true
 regex.workspace = true
 rust-embed = { version = "6.6", features = ["debug-embed"] }
@@ -73,13 +73,13 @@ schemars = "0.8"
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde.workspace = true
 serde_json = "1.0"
-session = { path = "../session" }
+session = { workspace = true }
 sha1 = "0.10"
 snafu = { version = "0.7", features = ["backtraces"] }
 snap = "1"
-sql = { path = "../sql" }
+sql = { workspace = true }
 strum = { version = "0.24", features = ["derive"] }
-table = { path = "../table" }
+table = { workspace = true }
 tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
@@ -91,18 +91,19 @@ tower-http = { version = "0.3", features = ["full"] }
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-catalog = { path = "../catalog", features = ["testing"] }
-client = { path = "../client" }
-common-base = { path = "../common/base" }
-common-test-util = { path = "../common/test-util" }
+catalog = { workspace = true, features = ["testing"] }
+client = { workspace = true }
+common-base = { workspace = true }
+common-test-util = { workspace = true }
 mysql_async = { git = "https://github.com/blackbeam/mysql_async.git", rev = "32c6f2a986789f97108502c2d0c755a089411b66", default-features = false, features = [
     "default-rustls",
 ] }
 rand.workspace = true
 rustls = { version = "0.21", features = ["dangerous_configuration"] }
-script = { path = "../script", features = ["python"] }
+script = { workspace = true, features = ["python"] }
 serde_json = "1.0"
-table = { path = "../table" }
+session = { workspace = true, features = ["testing"] }
+table = { workspace = true }
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.10"
 tokio-test = "0.4"

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -9,8 +9,8 @@ testing = []
 
 [dependencies]
 arc-swap = "1.5"
-common-catalog = { path = "../common/catalog" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-catalog = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 derive_builder.workspace = true
-sql = { path = "../sql" }
+sql = { workspace = true }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -5,14 +5,14 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { path = "../api" }
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-query = { path = "../common/query" }
-common-time = { path = "../common/time" }
+api = { workspace = true }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-query = { workspace = true }
+common-time = { workspace = true }
 datafusion-sql.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 hex = "0.4"
 itertools.workspace = true
 once_cell.workspace = true
@@ -20,4 +20,4 @@ snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser.workspace = true
 
 [dev-dependencies]
-common-datasource = { path = "../common/datasource" }
+common-datasource = { workspace = true }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -12,25 +12,25 @@ async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
 bytes = "1.1"
-common-base = { path = "../common/base" }
-common-datasource = { path = "../common/datasource" }
-common-error = { path = "../common/error" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-runtime = { path = "../common/runtime" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-datasource = { workspace = true }
+common-error = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 futures-util.workspace = true
 futures.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 metrics.workspace = true
-object-store = { path = "../object-store" }
+object-store = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 paste.workspace = true
 prost.workspace = true
@@ -38,8 +38,8 @@ regex = "1.5"
 serde.workspace = true
 serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
-store-api = { path = "../store-api" }
-table = { path = "../table" }
+store-api = { workspace = true }
+table = { workspace = true }
 tokio-util.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -47,10 +47,10 @@ uuid.workspace = true
 
 [dev-dependencies]
 atomic_float = "0.1"
-common-test-util = { path = "../common/test-util" }
+common-test-util = { workspace = true }
 criterion = "0.3"
-datatypes = { path = "../datatypes", features = ["test"] }
-log-store = { path = "../log-store" }
+datatypes = { workspace = true, features = ["test"] }
+log-store = { workspace = true }
 rand.workspace = true
 
 [build-dependencies]

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 [dependencies]
 async-trait.workspace = true
 bytes = "1.1"
-common-base = { path = "../common/base" }
-common-error = { path = "../common/error" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-time = { path = "../common/time" }
-datatypes = { path = "../datatypes" }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-time = { workspace = true }
+datatypes = { workspace = true }
 derive_builder.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/src/table-procedure/Cargo.toml
+++ b/src/table-procedure/Cargo.toml
@@ -6,22 +6,22 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-catalog = { path = "../catalog" }
-common-error = { path = "../common/error" }
-common-procedure = { path = "../common/procedure" }
-common-telemetry = { path = "../common/telemetry" }
-datatypes = { path = "../datatypes" }
+catalog = { workspace = true }
+common-error = { workspace = true }
+common-procedure = { workspace = true }
+common-telemetry = { workspace = true }
+datatypes = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-table = { path = "../table" }
+table = { workspace = true }
 
 [dev-dependencies]
-common-catalog = { path = "../common/catalog" }
-common-procedure-test = { path = "../common/procedure-test" }
-common-test-util = { path = "../common/test-util" }
-log-store = { path = "../log-store" }
-mito = { path = "../mito" }
-object-store = { path = "../object-store" }
-storage = { path = "../storage" }
+common-catalog = { workspace = true }
+common-procedure-test = { workspace = true }
+common-test-util = { workspace = true }
+log-store = { workspace = true }
+mito = { workspace = true }
+object-store = { workspace = true }
+storage = { workspace = true }
 tokio.workspace = true

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -11,19 +11,19 @@ testing = []
 anymap = "1.0.0-beta.2"
 async-trait = "0.1"
 chrono.workspace = true
-common-base = { path = "../common/base" }
-common-catalog = { path = "../common/catalog" }
-common-error = { path = "../common/error" }
-common-procedure = { path = "../common/procedure" }
-common-query = { path = "../common/query" }
-common-recordbatch = { path = "../common/recordbatch" }
-common-telemetry = { path = "../common/telemetry" }
-common-time = { path = "../common/time" }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-procedure = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-telemetry = { workspace = true }
+common-time = { workspace = true }
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion.workspace = true
-datatypes = { path = "../datatypes" }
+datatypes = { workspace = true }
 derive_builder.workspace = true
 futures.workspace = true
 humantime = "2.1"
@@ -31,11 +31,11 @@ humantime-serde = "1.1"
 paste = "1.0"
 serde = "1.0.136"
 snafu = { version = "0.7", features = ["backtraces"] }
-store-api = { path = "../store-api" }
+store-api = { workspace = true }
 tokio.workspace = true
 
 [dev-dependencies]
-common-test-util = { path = "../common/test-util" }
+common-test-util = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 serde_json.workspace = true
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -8,51 +8,51 @@ license.workspace = true
 dashboard = []
 
 [dependencies]
-api = { path = "../src/api" }
+api = { workspace = true }
 async-trait = "0.1"
 axum = "0.6"
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-catalog = { path = "../src/catalog" }
+catalog = { workspace = true }
 chrono.workspace = true
-client = { path = "../src/client", features = ["testing"] }
-common-base = { path = "../src/common/base" }
-common-catalog = { path = "../src/common/catalog" }
-common-error = { path = "../src/common/error" }
-common-grpc = { path = "../src/common/grpc" }
-common-meta = { path = "../src/common/meta" }
-common-query = { path = "../src/common/query" }
-common-recordbatch = { path = "../src/common/recordbatch" }
-common-runtime = { path = "../src/common/runtime" }
-common-telemetry = { path = "../src/common/telemetry" }
-common-test-util = { path = "../src/common/test-util" }
-datanode = { path = "../src/datanode", features = ["testing"] }
-datatypes = { path = "../src/datatypes" }
+client = { workspace = true, features = ["testing"] }
+common-base = { workspace = true }
+common-catalog = { workspace = true }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-meta = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+common-runtime = { workspace = true }
+common-telemetry = { workspace = true }
+common-test-util = { workspace = true }
+datanode = { workspace = true, features = ["testing"] }
+datatypes = { workspace = true }
 dotenv = "0.15"
-frontend = { path = "../src/frontend", features = ["testing"] }
+frontend = { workspace = true, features = ["testing"] }
 futures.workspace = true
-meta-client = { path = "../src/meta-client" }
-meta-srv = { path = "../src/meta-srv" }
-mito = { path = "../src/mito", features = ["test"] }
-object-store = { path = "../src/object-store" }
+meta-client = { workspace = true }
+meta-srv = { workspace = true }
+mito = { workspace = true, features = ["test"] }
+object-store = { workspace = true }
 once_cell.workspace = true
-query = { path = "../src/query" }
+query = { workspace = true }
 rand.workspace = true
 rstest = "0.17"
 rstest_reuse = "0.5"
 secrecy = "0.8"
 serde.workspace = true
 serde_json = "1.0"
-servers = { path = "../src/servers" }
-session = { path = "../src/session" }
+servers = { workspace = true }
+session = { workspace = true }
 snafu.workspace = true
-sql = { path = "../src/sql" }
+sql = { workspace = true }
 sqlx = { version = "0.6", features = [
     "runtime-tokio-rustls",
     "mysql",
     "postgres",
     "chrono",
 ] }
-table = { path = "../src/table" }
+table = { workspace = true }
 tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -60,14 +60,14 @@ tower = "0.4"
 uuid.workspace = true
 
 [dev-dependencies]
-common-procedure = { path = "../src/common/procedure" }
+common-procedure = { workspace = true }
 datafusion-expr.workspace = true
 datafusion.workspace = true
 itertools.workspace = true
 opentelemetry-proto.workspace = true
-partition = { path = "../src/partition" }
+partition = { workspace = true }
 paste.workspace = true
 prost.workspace = true
-script = { path = "../src/script" }
-session = { path = "../src/session", features = ["testing"] }
-store-api = { path = "../src/store-api" }
+script = { workspace = true }
+session = { workspace = true, features = ["testing"] }
+store-api = { workspace = true }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -25,7 +25,7 @@ common-recordbatch = { path = "../src/common/recordbatch" }
 common-runtime = { path = "../src/common/runtime" }
 common-telemetry = { path = "../src/common/telemetry" }
 common-test-util = { path = "../src/common/test-util" }
-datanode = { path = "../src/datanode" }
+datanode = { path = "../src/datanode", features = ["testing"] }
 datatypes = { path = "../src/datatypes" }
 dotenv = "0.15"
 frontend = { path = "../src/frontend", features = ["testing"] }

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -6,12 +6,12 @@ license.workspace = true
 
 [dependencies]
 async-trait = "0.1"
-client = { path = "../../src/client" }
-common-base = { path = "../../src/common/base" }
-common-error = { path = "../../src/common/error" }
-common-grpc = { path = "../../src/common/grpc" }
-common-query = { path = "../../src/common/query" }
-common-time = { path = "../../src/common/time" }
+client = { workspace = true }
+common-base = { workspace = true }
+common-error = { workspace = true }
+common-grpc = { workspace = true }
+common-query = { workspace = true }
+common-time = { workspace = true }
 serde.workspace = true
 sqlness = { version = "0.5" }
 tinytemplate = "1.2"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch updates our cargo TOMLs to manage internal dependencies in workspace. In this manner, we built an abstraction between module name and actually implementation, by which we can replace implementation by configuring workspace toml.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
