### PR TITLE
ci: disable ci on develop

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,6 @@ on:
       - '.gitignore'
   push:
     branches:
-      - develop
       - main
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

We now uses merge queue to serialize pull requests ci for develop branch so there is no need for ci to run on develop branch again.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
