### PR TITLE
fix: set the correct working dir before building the artifacts

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -71,6 +71,9 @@ env:
   # Use the different image name to avoid conflict with the release images.
   IMAGE_NAME: greptimedb-dev
 
+  # The source code will check out in the following path: '${WORKING_DIR}/dev/greptime'.
+  CHECKOUT_GREPTIMEDB_PATH: dev/greptimedb
+
 jobs:
   allocate-runners:
     name: Allocate runners
@@ -153,13 +156,10 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.commit }}
-          path: dev/greptimedb
-
-      - name: Enter greptimedb
-        run: |
-          cd dev/greptimedb
+          path: ${{ env.CHECKOUT_GREPTIMEDB_PATH }}
 
       - uses: ./.github/actions/build-linux-artifacts
+        working-directory: ${{ env.CHECKOUT_GREPTIMEDB_PATH }}
         with:
           arch: amd64
           cargo-profile: ${{ env.CARGO_PROFILE }}
@@ -190,13 +190,10 @@ jobs:
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.commit }}
-          path: dev/greptimedb
-
-      - name: Enter greptimedb
-        run: |
-          cd dev/greptimedb
+          path: ${{ env.CHECKOUT_GREPTIMEDB_PATH }}
 
       - uses: ./.github/actions/build-linux-artifacts
+        working-directory: ${{ env.CHECKOUT_GREPTIMEDB_PATH }}
         with:
           arch: arm64
           cargo-profile: ${{ env.CARGO_PROFILE }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix: set the correct working dir before building the artifacts

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
