### PR TITLE
test: add conditional compilation flag for datanode mock module

### DIFF
--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -21,7 +21,7 @@ mod greptimedb_telemetry;
 pub mod heartbeat;
 pub mod instance;
 pub mod metrics;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 mod mock;
 pub mod server;
 pub mod sql;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix compilation flag for mock module

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
