### PR TITLE
fix(table): return correct table types

### DIFF
--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -124,8 +124,8 @@ impl Table for InformationTable {
         unreachable!("Should not call table_info() of InformationTable directly")
     }
 
-    fn table_type(&self) -> table::metadata::TableType {
-        TableType::View
+    fn table_type(&self) -> TableType {
+        TableType::Temporary
     }
 
     async fn scan_to_stream(&self, request: ScanRequest) -> TableResult<SendableRecordBatchStream> {

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::storage::ScanRequest;
 use table::engine::{EngineContext, TableEngineRef};
-use table::metadata::{TableId, TableInfoRef};
+use table::metadata::{TableId, TableInfoRef, TableType};
 use table::requests::{
     CreateTableRequest, DeleteRequest, InsertRequest, OpenTableRequest, TableOptions,
 };
@@ -69,6 +69,10 @@ impl Table for SystemCatalogTable {
 
     fn table_info(&self) -> TableInfoRef {
         self.0.table_info()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.0.table_type()
     }
 
     async fn delete(&self, request: DeleteRequest) -> TableResult<usize> {

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -43,7 +43,7 @@ use partition::splitter::WriteSplitter;
 use snafu::prelude::*;
 use store_api::storage::{RegionNumber, ScanRequest};
 use table::error::TableOperationSnafu;
-use table::metadata::{FilterPushDownType, TableInfoRef};
+use table::metadata::{FilterPushDownType, TableInfoRef, TableType};
 use table::requests::{DeleteRequest, InsertRequest};
 use table::Table;
 use tokio::sync::RwLock;
@@ -77,6 +77,10 @@ impl Table for DistTable {
 
     fn table_info(&self) -> TableInfoRef {
         self.table_info.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.table_info.table_type
     }
 
     async fn insert(&self, request: InsertRequest) -> table::Result<usize> {

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -297,14 +297,15 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = String::from(
-            "Distinct:\
-            \n  MergeScan [is_placeholder=false]\
-            \n    Distinct:\
-            \n      Projection: t.number\
-            \n        Filter: t.number < Int32(10)\
-            \n          TableScan: t",
-        );
+        let expected = vec![
+            "Distinct:",
+            "  MergeScan [is_placeholder=false]",
+            "    Distinct:",
+            "      Projection: t.number",
+            "        Filter: t.number < Int32(10)",
+            "          TableScan: t",
+        ]
+        .join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 
@@ -324,11 +325,11 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = String::from(
-            "Aggregate: groupBy=[[]], aggr=[[AVG(t.number)]]\
-            \n  MergeScan [is_placeholder=false]\
-            \n    TableScan: t",
-        );
+        let expected = vec![
+            "Aggregate: groupBy=[[]], aggr=[[AVG(t.number)]]",
+            "  TableScan: t",
+        ]
+        .join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 
@@ -350,13 +351,12 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = String::from(
-            "Sort: t.number ASC NULLS LAST\
-            \n  Distinct:\
-            \n    MergeScan [is_placeholder=false]\
-            \n      Distinct:\
-            \n        TableScan: t",
-        );
+        let expected = vec![
+            "Sort: t.number ASC NULLS LAST",
+            "  Distinct:",
+            "    TableScan: t",
+        ]
+        .join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 
@@ -376,12 +376,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = String::from(
-            "Limit: skip=0, fetch=1\
-            \n  MergeScan [is_placeholder=false]\
-            \n    Limit: skip=0, fetch=1\
-            \n      TableScan: t",
-        );
+        let expected = vec!["Limit: skip=0, fetch=1", "  TableScan: t"].join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 }

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -295,7 +295,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = vec![
+        let expected = [
             "Distinct:",
             "  MergeScan [is_placeholder=false]",
             "    Distinct:",
@@ -323,7 +323,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = vec![
+        let expected = [
             "Aggregate: groupBy=[[]], aggr=[[AVG(t.number)]]",
             "  TableScan: t",
         ]
@@ -349,7 +349,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = vec![
+        let expected = [
             "Sort: t.number ASC NULLS LAST",
             "  Distinct:",
             "    TableScan: t",
@@ -374,7 +374,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = vec!["Limit: skip=0, fetch=1", "  TableScan: t"].join("\n");
+        let expected = ["Limit: skip=0, fetch=1", "  TableScan: t"].join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 }

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -374,10 +374,7 @@ mod test {
 
         let config = ConfigOptions::default();
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
-        let expected = vec![
-            "Limit: skip=0, fetch=1",
-            "  TableScan: t",
-        ].join("\n");
+        let expected = vec!["Limit: skip=0, fetch=1", "  TableScan: t"].join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }
 }

--- a/src/query/src/dist_plan/analyzer.rs
+++ b/src/query/src/dist_plan/analyzer.rs
@@ -325,7 +325,7 @@ mod test {
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
         let expected = vec![
             "Aggregate: groupBy=[[]], aggr=[[AVG(t.number)]]",
-            "  MergeScan [is_placeholder=false]",
+            "  TableScan: t",
         ]
         .join("\n");
         assert_eq!(expected, format!("{:?}", result));
@@ -352,7 +352,7 @@ mod test {
         let expected = vec![
             "Sort: t.number ASC NULLS LAST",
             "  Distinct:",
-            "    MergeScan [is_placeholder=false]",
+            "    TableScan: t",
         ]
         .join("\n");
         assert_eq!(expected, format!("{:?}", result));
@@ -376,7 +376,7 @@ mod test {
         let result = DistPlannerAnalyzer {}.analyze(plan, &config).unwrap();
         let expected = vec![
             "Limit: skip=0, fetch=1",
-            "  MergeScan [is_placeholder=false]",
+            "  TableScan: t",
         ].join("\n");
         assert_eq!(expected, format!("{:?}", result));
     }

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -27,7 +27,7 @@ use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{Int64Vector, TimestampMillisecondVector};
 use store_api::storage::ScanRequest;
-use table::metadata::{FilterPushDownType, TableInfoRef};
+use table::metadata::{FilterPushDownType, TableInfoRef, TableType};
 use table::predicate::TimeRangePredicateBuilder;
 use table::test_util::MemTable;
 use table::Table;
@@ -59,6 +59,10 @@ impl Table for MemTableWrapper {
 
     fn table_info(&self) -> TableInfoRef {
         self.inner.table_info()
+    }
+
+    fn table_type(&self) -> TableType {
+        self.inner.table_type()
     }
 
     async fn scan_to_stream(

--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -47,9 +47,7 @@ pub trait Table: Send + Sync {
     fn table_info(&self) -> TableInfoRef;
 
     /// Get the type of this table for metadata/catalog purposes.
-    fn table_type(&self) -> TableType {
-        TableType::Base
-    }
+    fn table_type(&self) -> TableType;
 
     /// Insert values into table.
     ///

--- a/src/table/src/table/numbers.rs
+++ b/src/table/src/table/numbers.rs
@@ -109,6 +109,10 @@ impl Table for NumbersTable {
         )
     }
 
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
     async fn scan_to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream> {
         Ok(Box::pin(NumbersStream {
             limit: request.limit.unwrap_or(100) as u32,

--- a/src/table/src/table/numbers.rs
+++ b/src/table/src/table/numbers.rs
@@ -93,7 +93,7 @@ impl Table for NumbersTable {
                 .catalog_name(DEFAULT_CATALOG_NAME)
                 .schema_name(DEFAULT_SCHEMA_NAME)
                 .table_version(0)
-                .table_type(TableType::Base)
+                .table_type(TableType::Temporary)
                 .meta(
                     TableMetaBuilder::default()
                         .schema(self.schema.clone())
@@ -110,7 +110,7 @@ impl Table for NumbersTable {
     }
 
     fn table_type(&self) -> TableType {
-        TableType::Base
+        TableType::Temporary
     }
 
     async fn scan_to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream> {

--- a/src/table/src/test_util/empty_table.rs
+++ b/src/table/src/test_util/empty_table.rs
@@ -74,6 +74,10 @@ impl Table for EmptyTable {
         self.info.clone()
     }
 
+    fn table_type(&self) -> TableType {
+        self.info.table_type
+    }
+
     async fn insert(&self, _request: InsertRequest) -> Result<usize> {
         Ok(0)
     }

--- a/src/table/src/test_util/memtable.rs
+++ b/src/table/src/test_util/memtable.rs
@@ -135,6 +135,10 @@ impl Table for MemTable {
         self.info.clone()
     }
 
+    fn table_type(&self) -> TableType {
+        self.info.table_type
+    }
+
     async fn scan_to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let df_recordbatch = if let Some(indices) = request.projection {
             self.recordbatch

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -1422,21 +1422,21 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
     let expected = match is_distributed_mode {
         true => {
             "\
-+---------------+--------------+------------+------------+----------+-------------+
-| table_catalog | table_schema | table_name | table_type | table_id | engine      |
-+---------------+--------------+------------+------------+----------+-------------+
-| greptime      | public       | numbers    | BASE TABLE | 2        | test_engine |
-| greptime      | public       | scripts    | BASE TABLE | 1024     | mito        |
-+---------------+--------------+------------+------------+----------+-------------+"
++---------------+--------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
++---------------+--------------+------------+-----------------+----------+-------------+
+| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
+| greptime      | public       | scripts    | BASE TABLE      | 1024     | mito        |
++---------------+--------------+------------+-----------------+----------+-------------+"
         }
         false => {
             "\
-+---------------+--------------+------------+------------+----------+-------------+
-| table_catalog | table_schema | table_name | table_type | table_id | engine      |
-+---------------+--------------+------------+------------+----------+-------------+
-| greptime      | public       | numbers    | BASE TABLE | 2        | test_engine |
-| greptime      | public       | scripts    | BASE TABLE | 1        | mito        |
-+---------------+--------------+------------+------------+----------+-------------+"
++---------------+--------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
++---------------+--------------+------------+-----------------+----------+-------------+
+| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
+| greptime      | public       | scripts    | BASE TABLE      | 1        | mito        |
++---------------+--------------+------------+-----------------+----------+-------------+"
         }
     };
 

--- a/tests/cases/distributed/optimizer/order_by.result
+++ b/tests/cases/distributed/optimizer/order_by.result
@@ -3,7 +3,7 @@ explain select * from numbers;
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                  |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                                                                                                                                      |
+| logical_plan  | TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                       |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -14,7 +14,7 @@ explain select * from numbers order by number desc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number DESC NULLS FIRST                                                                                                                                                   |
-|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
+|               |   TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | SortExec: expr=[number@0 DESC]                                                                                                                                                          |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -26,7 +26,7 @@ explain select * from numbers order by number asc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number ASC NULLS LAST                                                                                                                                                     |
-|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
+|               |   TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                                                                                                                                                |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -39,7 +39,7 @@ explain select * from numbers order by number desc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number DESC NULLS FIRST, fetch=10                                                                                                                                         |
-|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
+|               |     TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 DESC]                                                                                                                                                |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
@@ -53,7 +53,7 @@ explain select * from numbers order by number asc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number ASC NULLS LAST, fetch=10                                                                                                                                           |
-|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
+|               |     TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 ASC NULLS LAST]                                                                                                                                      |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |

--- a/tests/cases/distributed/optimizer/order_by.result
+++ b/tests/cases/distributed/optimizer/order_by.result
@@ -3,8 +3,7 @@ explain select * from numbers;
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                  |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                                                                                                                                      |
-|               |   TableScan: numbers projection=[number]                                                                                                                                              |
+| logical_plan  | TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                       |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -15,8 +14,7 @@ explain select * from numbers order by number desc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number DESC NULLS FIRST                                                                                                                                                   |
-|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
-|               |     TableScan: numbers projection=[number]                                                                                                                                              |
+|               |   TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | SortExec: expr=[number@0 DESC]                                                                                                                                                          |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -28,8 +26,7 @@ explain select * from numbers order by number asc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number ASC NULLS LAST                                                                                                                                                     |
-|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
-|               |     TableScan: numbers projection=[number]                                                                                                                                              |
+|               |   TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                                                                                                                                                |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -42,8 +39,7 @@ explain select * from numbers order by number desc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number DESC NULLS FIRST, fetch=10                                                                                                                                         |
-|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
-|               |       TableScan: numbers projection=[number]                                                                                                                                              |
+|               |     TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 DESC]                                                                                                                                                |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
@@ -57,8 +53,7 @@ explain select * from numbers order by number asc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number ASC NULLS LAST, fetch=10                                                                                                                                           |
-|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
-|               |       TableScan: numbers projection=[number]                                                                                                                                              |
+|               |     TableScan: numbers projection=[number]                                                                                                                                                |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 ASC NULLS LAST]                                                                                                                                      |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* remove default impl of `table_type` method
* check and reimplement `table_type` for `Table`s
  - `numbers` as temporary table
  - `schema_information` as temporary table

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
