### PR TITLE
feat(mito): Write wal and memtable

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -91,8 +91,6 @@ impl MitoEngine {
 
     /// Write to a region.
     pub async fn write_region(&self, mut write_request: WriteRequest) -> Result<()> {
-        write_request.validate()?;
-
         let region = self
             .inner
             .workers

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::sync::Arc;
 
 use common_datasource::compression::CompressionType;
 use common_error::ext::{BoxedError, ErrorExt};
@@ -260,6 +261,10 @@ pub enum Error {
         location: Location,
         source: BoxedError,
     },
+
+    // Shared error for each writer in the write group.
+    #[snafu(display("Failed to write region, source: {}", source))]
+    WriteGroup { source: Arc<Error> },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -296,6 +301,7 @@ impl ErrorExt for Error {
             | EncodeWal { .. }
             | DecodeWal { .. } => StatusCode::Internal,
             WriteBuffer { source, .. } => source.status_code(),
+            WriteGroup { source, .. } => source.status_code(),
         }
     }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -186,15 +186,10 @@ pub enum Error {
 
     /// An error type to indicate that schema is changed and we need
     /// to fill default values again.
-    #[snafu(display(
-        "Need to fill default value to column {} of region {}",
-        column,
-        region_id
-    ))]
+    #[snafu(display("Need to fill default value for region {}", region_id))]
     FillDefault {
         region_id: RegionId,
-        column: String,
-        // The error is for retry purpose so we don't need a location.
+        // The error is for internal use so we don't need a location.
     },
 
     #[snafu(display(
@@ -268,6 +263,13 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// Returns true if we need to fill default value for a region.
+    pub(crate) fn is_fill_default(&self) -> bool {
+        matches!(self, Error::FillDefault { .. })
+    }
+}
 
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -22,7 +22,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use crate::error::Result;
-use crate::memtable::key_values::KeyValues;
+pub use crate::memtable::key_values::KeyValues;
 use crate::metadata::RegionMetadataRef;
 
 /// Id for memtables.

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -190,11 +190,12 @@ mod tests {
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use greptime_proto::v1;
-    use greptime_proto::v1::{value, ColumnDataType, Value};
+    use greptime_proto::v1::ColumnDataType;
     use store_api::storage::RegionId;
 
     use super::*;
     use crate::metadata::{ColumnMetadata, RegionMetadataBuilder};
+    use crate::proto_util::i64_value;
 
     const TS_NAME: &str = "ts";
     const START_SEQ: SequenceNumber = 100;
@@ -287,12 +288,6 @@ mod tests {
             op_type: OpType::Put as i32,
             sequence: START_SEQ,
             rows: Some(rows),
-        }
-    }
-
-    fn i64_value(data: i64) -> Value {
-        Value {
-            value: Some(value::Value::I64Value(data)),
         }
     }
 

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -37,4 +37,9 @@ impl MemtableVersion {
             immutables: vec![],
         }
     }
+
+    /// Returns the mutable memtable.
+    pub(crate) fn mutable(&self) -> &MemtableRef {
+        &self.mutable
+    }
 }

--- a/src/mito2/src/proto_util.rs
+++ b/src/mito2/src/proto_util.rs
@@ -153,6 +153,23 @@ pub(crate) fn proto_value_type(value: &v1::Value) -> Option<ColumnDataType> {
     Some(value_type)
 }
 
+// TODO(yingwen): Support conversion in greptime-proto.
+/// Creates value for i64.
+#[cfg(test)]
+pub(crate) fn i64_value(data: i64) -> v1::Value {
+    v1::Value {
+        value: Some(v1::value::Value::I64Value(data)),
+    }
+}
+
+/// Creates value for timestamp millis.
+#[cfg(test)]
+pub(crate) fn ts_ms_value(data: i64) -> v1::Value {
+    v1::Value {
+        value: Some(v1::value::Value::TsMillisecondValue(data)),
+    }
+}
+
 /// Convert [ConcreteDataType] to [ColumnDataType].
 pub(crate) fn to_column_data_type(data_type: &ConcreteDataType) -> Option<ColumnDataType> {
     let column_data_type = match data_type {

--- a/src/mito2/src/proto_util.rs
+++ b/src/mito2/src/proto_util.rs
@@ -120,6 +120,39 @@ pub(crate) fn to_proto_value(value: Value) -> Option<v1::Value> {
     Some(proto_value)
 }
 
+/// Returns the [ColumnDataType] of the value.
+///
+/// If value is null, returns `None`.
+pub(crate) fn proto_value_type(value: &v1::Value) -> Option<ColumnDataType> {
+    let value_data = value.value.as_ref()?;
+    let value_type = match value_data {
+        v1::value::Value::I8Value(_) => ColumnDataType::Int8,
+        v1::value::Value::I16Value(_) => ColumnDataType::Int16,
+        v1::value::Value::I32Value(_) => ColumnDataType::Int32,
+        v1::value::Value::I64Value(_) => ColumnDataType::Int64,
+        v1::value::Value::U8Value(_) => ColumnDataType::Uint8,
+        v1::value::Value::U16Value(_) => ColumnDataType::Uint16,
+        v1::value::Value::U32Value(_) => ColumnDataType::Uint32,
+        v1::value::Value::U64Value(_) => ColumnDataType::Uint64,
+        v1::value::Value::F32Value(_) => ColumnDataType::Float32,
+        v1::value::Value::F64Value(_) => ColumnDataType::Float64,
+        v1::value::Value::BoolValue(_) => ColumnDataType::Boolean,
+        v1::value::Value::BinaryValue(_) => ColumnDataType::Binary,
+        v1::value::Value::StringValue(_) => ColumnDataType::String,
+        v1::value::Value::DateValue(_) => ColumnDataType::Date,
+        v1::value::Value::DatetimeValue(_) => ColumnDataType::Datetime,
+        v1::value::Value::TsSecondValue(_) => ColumnDataType::TimestampSecond,
+        v1::value::Value::TsMillisecondValue(_) => ColumnDataType::TimestampMillisecond,
+        v1::value::Value::TsMicrosecondValue(_) => ColumnDataType::TimestampMicrosecond,
+        v1::value::Value::TsNanosecondValue(_) => ColumnDataType::TimestampNanosecond,
+        v1::value::Value::TimeSecondValue(_) => ColumnDataType::TimeSecond,
+        v1::value::Value::TimeMillisecondValue(_) => ColumnDataType::TimeMillisecond,
+        v1::value::Value::TimeMicrosecondValue(_) => ColumnDataType::TimeMicrosecond,
+        v1::value::Value::TimeNanosecondValue(_) => ColumnDataType::TimeNanosecond,
+    };
+    Some(value_type)
+}
+
 /// Convert [ConcreteDataType] to [ColumnDataType].
 pub(crate) fn to_column_data_type(data_type: &ConcreteDataType) -> Option<ColumnDataType> {
     let column_data_type = match data_type {
@@ -186,3 +219,5 @@ fn is_column_type_eq(column_type: ColumnDataType, expect_type: &ConcreteDataType
         false
     }
 }
+
+// TODO(yingwen): Tests.

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -25,7 +25,7 @@ use store_api::storage::RegionId;
 
 use crate::error::Result;
 use crate::manifest::manager::RegionManifestManager;
-use crate::region::version::{VersionControlRef, VersionRef};
+use crate::region::version::VersionControlRef;
 
 /// Type to store region version.
 pub type VersionNumber = u32;
@@ -40,7 +40,7 @@ pub(crate) struct MitoRegion {
     pub(crate) region_id: RegionId,
 
     /// Version controller for this region.
-    version_control: VersionControlRef,
+    pub(crate) version_control: VersionControlRef,
     /// Manager to maintain manifest for this region.
     manifest_manager: RegionManifestManager,
 }
@@ -55,11 +55,6 @@ impl MitoRegion {
         info!("Stopped region, region_id: {}", self.region_id);
 
         Ok(())
-    }
-
-    /// Returns current version of the region.
-    pub(crate) fn version(&self) -> VersionRef {
-        self.version_control.current()
     }
 }
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -25,6 +25,7 @@ use store_api::storage::RegionId;
 
 use crate::error::Result;
 use crate::manifest::manager::RegionManifestManager;
+use crate::metadata::RegionMetadataRef;
 use crate::region::version::VersionControlRef;
 
 /// Type to store region version.
@@ -55,6 +56,12 @@ impl MitoRegion {
         info!("Stopped region, region_id: {}", self.region_id);
 
         Ok(())
+    }
+
+    /// Returns current metadata of the region.
+    pub(crate) fn metadata(&self) -> RegionMetadataRef {
+        let version_data = self.version_control.current();
+        version_data.version.metadata.clone()
     }
 }
 

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -39,41 +39,39 @@ use crate::wal::EntryId;
 /// will generate a new [Version].
 #[derive(Debug)]
 pub(crate) struct VersionControl {
-    /// Latest version.
-    version: VersionRef,
-    /// Sequence number of last committed data.
-    committed_sequence: SequenceNumber,
-    /// Last WAL entry Id.
-    last_entry_id: EntryId,
+    data: RwLock<VersionControlData>,
 }
 
 impl VersionControl {
     /// Returns a new [VersionControl] with specific `version`.
     pub(crate) fn new(version: Version) -> VersionControl {
         VersionControl {
-            version: Arc::new(version),
-            committed_sequence: 0,
-            last_entry_id: 0,
+            data: RwLock::new(VersionControlData {
+                version: Arc::new(version),
+                committed_sequence: 0,
+                last_entry_id: 0,
+            }),
         }
     }
 
-    /// Returns current [Version].
-    pub(crate) fn version(&self) -> VersionRef {
-        self.version.clone()
-    }
-
-    /// Returns last committed sequence.
-    pub(crate) fn committed_sequence(&self) -> SequenceNumber {
-        self.committed_sequence
-    }
-
-    /// Returns last entry id.
-    pub(crate) fn last_entry_id(&self) -> EntryId {
-        self.last_entry_id
+    /// Returns current copy of data.
+    pub(crate) fn current(&self) -> VersionControlData {
+        self.data.read().unwrap().clone()
     }
 }
 
-pub(crate) type VersionControlRef = Arc<RwLock<VersionControl>>;
+pub(crate) type VersionControlRef = Arc<VersionControl>;
+
+/// Data of [VersionControl].
+#[derive(Debug, Clone)]
+pub(crate) struct VersionControlData {
+    /// Latest version.
+    pub(crate) version: VersionRef,
+    /// Sequence number of last committed data.
+    pub(crate) committed_sequence: SequenceNumber,
+    /// Last WAL entry Id.
+    pub(crate) last_entry_id: EntryId,
+}
 
 /// Static metadata of a region.
 #[derive(Clone, Debug)]

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -127,7 +127,7 @@ impl WriteRequest {
             ensure!(
                 row.values.len() == rows.schema.len(),
                 InvalidRequestSnafu {
-                    region_id: region_id,
+                    region_id,
                     reason: format!(
                         "row has {} columns but schema has {}",
                         row.values.len(),

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -133,7 +133,7 @@ impl WriteRequest {
         Ok(request)
     }
 
-    /// Initailizes and validates the request.
+    /// Initializes and validates the request.
     ///
     /// Ensures rows match the schema.
     fn init(&mut self) -> Result<()> {

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -190,11 +190,7 @@ impl WriteRequest {
                     }
                 );
 
-                return FillDefaultSnafu {
-                    region_id,
-                    column: &column.column_schema.name,
-                }
-                .fail();
+                return FillDefaultSnafu { region_id }.fail();
             }
         }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -37,7 +37,7 @@ use tokio::sync::{mpsc, Mutex};
 use crate::config::MitoConfig;
 use crate::error::{JoinSnafu, Result, WorkerStoppedSnafu};
 use crate::memtable::{DefaultMemtableBuilder, MemtableBuilderRef};
-use crate::region::{RegionMap, RegionMapRef};
+use crate::region::{MitoRegionRef, RegionMap, RegionMapRef};
 use crate::request::{RegionRequest, RequestBody, SenderWriteRequest, WorkerRequest};
 use crate::wal::Wal;
 
@@ -131,6 +131,13 @@ impl WorkerGroup {
     /// Returns true if the specific region exists.
     pub(crate) fn is_region_exists(&self, region_id: RegionId) -> bool {
         self.worker(region_id).is_region_exists(region_id)
+    }
+
+    /// Returns region of specific `region_id`.
+    ///
+    /// This method should not be public.
+    pub(crate) fn get_region(&self, region_id: RegionId) -> Option<MitoRegionRef> {
+        self.worker(region_id).get_region(region_id)
     }
 
     /// Get worker for specific `region_id`.
@@ -251,6 +258,11 @@ impl RegionWorker {
     /// Returns true if the worker contains specific region.
     fn is_region_exists(&self, region_id: RegionId) -> bool {
         self.regions.is_region_exists(region_id)
+    }
+
+    /// Returns region of specific `region_id`.
+    fn get_region(&self, region_id: RegionId) -> Option<MitoRegionRef> {
+        self.regions.get_region(region_id)
     }
 }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -285,7 +285,7 @@ struct RegionWorkerLoop<S> {
     memtable_builder: MemtableBuilderRef,
 }
 
-impl<S> RegionWorkerLoop<S> {
+impl<S: LogStore> RegionWorkerLoop<S> {
     /// Starts the worker loop.
     async fn run(&mut self) {
         info!("Start region worker thread {}", self.id);
@@ -353,7 +353,9 @@ impl<S> RegionWorkerLoop<S> {
 
         self.handle_ddl_requests(ddl_requests).await;
     }
+}
 
+impl<S> RegionWorkerLoop<S> {
     /// Takes and handles all ddl requests.
     async fn handle_ddl_requests(&mut self, ddl_requests: Vec<RegionRequest>) {
         if ddl_requests.is_empty() {

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -15,30 +15,52 @@
 //! Handling write requests.
 
 use std::collections::{hash_map, HashMap};
+use std::mem;
+use std::sync::Arc;
 
 use greptime_proto::v1::mito::{Mutation, WalEntry};
-use store_api::storage::RegionId;
+use snafu::ResultExt;
+use store_api::logstore::LogStore;
+use store_api::storage::{RegionId, SequenceNumber};
 use tokio::sync::oneshot::Sender;
 
-use crate::error::{RegionNotFoundSnafu, Result};
+use crate::error::{Error, RegionNotFoundSnafu, Result, WriteGroupSnafu};
 use crate::proto_util::to_proto_op_type;
-use crate::region::version::VersionRef;
+use crate::region::version::{VersionControlData, VersionRef};
 use crate::region::MitoRegionRef;
 use crate::request::SenderWriteRequest;
+use crate::wal::{EntryId, WalWriter};
 use crate::worker::RegionWorkerLoop;
 
-impl<S> RegionWorkerLoop<S> {
+impl<S: LogStore> RegionWorkerLoop<S> {
     /// Takes and handles all write requests.
     pub(crate) async fn handle_write_requests(&mut self, write_requests: Vec<SenderWriteRequest>) {
         if write_requests.is_empty() {
             return;
         }
 
-        let region_ctxs = self.prepare_region_write_ctx(write_requests);
+        let mut region_ctxs = self.prepare_region_write_ctx(write_requests);
+
+        // Write WAL.
+        let mut wal_writer = self.wal.writer();
+        for region_ctx in region_ctxs.values_mut() {
+            if let Err(e) = region_ctx.add_wal_entry(&mut wal_writer).map_err(Arc::new) {
+                region_ctx.set_error(e);
+            }
+        }
+        if let Err(e) = wal_writer.write_to_wal().await.map_err(Arc::new) {
+            // Failed to write wal.
+            for mut region_ctx in region_ctxs.into_values() {
+                region_ctx.set_error(e.clone());
+            }
+            return;
+        }
 
         todo!()
     }
+}
 
+impl<S> RegionWorkerLoop<S> {
     /// Validates and groups requests by region.
     fn prepare_region_write_ctx(
         &self,
@@ -95,33 +117,87 @@ struct RegionWriteCtx {
     region: MitoRegionRef,
     /// Version of the region while creating the context.
     version: VersionRef,
+    /// Next sequence number to write.
+    ///
+    /// The context assigns a unique sequence number for each row.
+    next_sequence: SequenceNumber,
+    /// Next entry id of WAL to write.
+    next_entry_id: EntryId,
     /// Valid WAL entry to write.
     wal_entry: WalEntry,
+    /// Error during writing this region.
+    err: Option<Arc<Error>>,
     /// Result senders.
     ///
-    /// The sender is 1:1 map to the mutation in `mutations`.
-    senders: Vec<Option<Sender<Result<()>>>>,
+    /// All senders will receive the same result.
+    senders: Vec<Sender<Result<()>>>,
 }
 
 impl RegionWriteCtx {
     /// Returns an empty context.
     fn new(region: MitoRegionRef) -> RegionWriteCtx {
-        let version = region.version();
+        let VersionControlData {
+            version,
+            committed_sequence,
+            last_entry_id,
+        } = region.version_control.current();
         RegionWriteCtx {
             region,
             version,
+            next_sequence: committed_sequence + 1,
+            next_entry_id: last_entry_id + 1,
             wal_entry: WalEntry::default(),
+            err: None,
             senders: Vec::new(),
         }
     }
 
     /// Push [SenderWriteRequest] to the context.
     fn push_sender_request(&mut self, sender_req: SenderWriteRequest) {
+        let num_rows = sender_req.request.rows.rows.len() as u64;
+
         self.wal_entry.mutations.push(Mutation {
             op_type: to_proto_op_type(sender_req.request.op_type) as i32,
-            sequence: 0, // TODO(yingwen): Set sequence.
+            sequence: self.next_sequence,
             rows: Some(sender_req.request.rows),
         });
-        self.senders.push(sender_req.sender);
+        if let Some(sender) = sender_req.sender {
+            self.senders.push(sender);
+        }
+
+        // Increase sequence number.
+        self.next_sequence += num_rows;
+    }
+
+    /// Encode and add WAL entry to the writer.
+    fn add_wal_entry<S: LogStore>(&self, wal_writer: &mut WalWriter<S>) -> Result<()> {
+        wal_writer.add_entry(self.region.region_id, self.next_entry_id, &self.wal_entry)
+    }
+
+    /// Sets error and marks the write operation is failed.
+    ///
+    /// The context will send the error to waiters on drop.
+    fn set_error(&mut self, err: Arc<Error>) {
+        self.err = Some(err);
+    }
+
+    /// Sends result to waiters.
+    fn notify_result(&mut self) {
+        let senders = mem::take(&mut self.senders);
+        for sender in senders {
+            if let Some(err) = &self.err {
+                // Try to send the error to waiters.
+                let _ = sender.send(Err(err.clone()).context(WriteGroupSnafu));
+            } else {
+                // Send success result.
+                let _ = sender.send(Ok(()));
+            }
+        }
+    }
+}
+
+impl Drop for RegionWriteCtx {
+    fn drop(&mut self) {
+        self.notify_result();
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR writes data into WAL and memtables. It validates write requests before writing them.

The worker collects requests from different regions and writes them to the WAL in one batch.

To handle schema change, it fills default values before sending the request to the writer. Inside the writer, if the request still misses some columns, the writer pads default values again. This is possible if the write request comes during altering schema.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 
