### PR TITLE
fix: correct grpc metric labels

### DIFF
--- a/src/servers/src/grpc/handler.rs
+++ b/src/servers/src/grpc/handler.rs
@@ -36,8 +36,8 @@ use crate::error::{
 };
 use crate::grpc::TonicResult;
 use crate::metrics::{
-    METRIC_AUTH_FAILURE, METRIC_CODE_LABEL, METRIC_SERVER_GRPC_DB_REQUEST_TIMER,
-    METRIC_STATUS_LABEL, METRIC_TYPE_LABEL,
+    METRIC_AUTH_FAILURE, METRIC_CODE_LABEL, METRIC_DB_LABEL, METRIC_SERVER_GRPC_DB_REQUEST_TIMER,
+    METRIC_TYPE_LABEL,
 };
 use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 
@@ -214,9 +214,9 @@ impl Drop for RequestTimer {
             METRIC_SERVER_GRPC_DB_REQUEST_TIMER,
             self.start.elapsed(),
             &[
-                (METRIC_CODE_LABEL, std::mem::take(&mut self.db)),
+                (METRIC_DB_LABEL, std::mem::take(&mut self.db)),
                 (METRIC_TYPE_LABEL, self.request_type.to_string()),
-                (METRIC_STATUS_LABEL, self.status_code.to_string())
+                (METRIC_CODE_LABEL, self.status_code.to_string())
             ]
         );
     }

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -70,8 +70,8 @@ use crate::configurator::ConfiguratorRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
 use crate::http::admin::{compact, flush};
 use crate::metrics::{
-    METRIC_HTTP_REQUESTS_ELAPSED, METRIC_HTTP_REQUESTS_TOTAL, METRIC_METHOD_LABEL,
-    METRIC_PATH_LABEL, METRIC_STATUS_LABEL,
+    METRIC_CODE_LABEL, METRIC_HTTP_REQUESTS_ELAPSED, METRIC_HTTP_REQUESTS_TOTAL,
+    METRIC_METHOD_LABEL, METRIC_PATH_LABEL,
 };
 use crate::metrics_handler::MetricsHandler;
 use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
@@ -710,7 +710,7 @@ pub(crate) async fn track_metrics<B>(req: Request<B>, next: Next<B>) -> impl Int
     let labels = [
         (METRIC_METHOD_LABEL, method.to_string()),
         (METRIC_PATH_LABEL, path),
-        (METRIC_STATUS_LABEL, status),
+        (METRIC_CODE_LABEL, status),
     ];
 
     metrics::increment_counter!(METRIC_HTTP_REQUESTS_TOTAL, &labels);

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -80,7 +80,6 @@ pub(crate) const METRIC_GRPC_REQUESTS_TOTAL: &str = "servers.grpc_requests_total
 pub(crate) const METRIC_GRPC_REQUESTS_ELAPSED: &str = "servers.grpc_requests_elapsed";
 pub(crate) const METRIC_METHOD_LABEL: &str = "method";
 pub(crate) const METRIC_PATH_LABEL: &str = "path";
-pub(crate) const METRIC_STATUS_LABEL: &str = "status";
 pub(crate) const METRIC_JEMALLOC_RESIDENT: &str = "sys.jemalloc.resident";
 pub(crate) const METRIC_JEMALLOC_ALLOCATED: &str = "sys.jemalloc.allocated";
 
@@ -185,7 +184,7 @@ where
             let latency = start.elapsed().as_secs_f64();
             let status = response.status().as_u16().to_string();
 
-            let labels = [(METRIC_PATH_LABEL, path), (METRIC_STATUS_LABEL, status)];
+            let labels = [(METRIC_PATH_LABEL, path), (METRIC_CODE_LABEL, status)];
             metrics::increment_counter!(METRIC_GRPC_REQUESTS_TOTAL, &labels);
             metrics::histogram!(METRIC_GRPC_REQUESTS_ELAPSED, latency, &labels);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch fixes metric label regression:

- fix db label for grpc database requests (misconfigured on `code` now)
- unified `status` and `code` labels, which have same semantic

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
