### PR TITLE
feat!: enable telemetry by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,10 +1722,10 @@ dependencies = [
  "common-test-util",
  "common-version",
  "hyper",
- "once_cell",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "uuid",
 ]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -10,7 +10,7 @@ rpc_addr = "127.0.0.1:3001"
 rpc_hostname = "127.0.0.1"
 # The number of gRPC server worker threads, 8 by default.
 rpc_runtime_size = 8
-# Wheter to enable greptimedb telemetry, true by default.
+# Whether to enable greptimedb telemetry, true by default.
 enable_telemetry = true
 
 [heartbeat]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -10,8 +10,6 @@ rpc_addr = "127.0.0.1:3001"
 rpc_hostname = "127.0.0.1"
 # The number of gRPC server worker threads, 8 by default.
 rpc_runtime_size = 8
-# Whether to enable greptimedb telemetry, true by default.
-enable_telemetry = true
 
 [heartbeat]
 # Interval for sending heartbeat messages to the Metasrv in milliseconds, 5000 by default.

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -10,6 +10,8 @@ rpc_addr = "127.0.0.1:3001"
 rpc_hostname = "127.0.0.1"
 # The number of gRPC server worker threads, 8 by default.
 rpc_runtime_size = 8
+# Wheter to enable greptimedb telemetry, true by default.
+enable_telemetry = true
 
 [heartbeat]
 # Interval for sending heartbeat messages to the Metasrv in milliseconds, 5000 by default.

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -40,8 +40,9 @@ sync_write = false
 
 # Storage options, see `standalone.example.toml`.
 [storage]
-type = "File"
+# The working home directory.
 data_home = "/tmp/greptimedb/"
+type = "File"
 # TTL for all tables. Disabled by default.
 # global_ttl = "7d"
 

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -13,6 +13,8 @@ datanode_lease_secs = 15
 selector = "LeaseBased"
 # Store data in memory, false by default.
 use_memory_store = false
+# Wheter to enable greptimedb telemetry, true by default.
+enable_telemetry = true
 
 # Log options, see `standalone.example.toml`
 # [logging]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -1,3 +1,5 @@
+# The working home directory.
+data_home = "/tmp/metasrv/"
 # The bind address of metasrv, "127.0.0.1:3002" by default.
 bind_addr = "127.0.0.1:3002"
 # The communication server address for frontend and datanode to connect to metasrv,  "127.0.0.1:3002" by default for localhost.

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -13,7 +13,7 @@ datanode_lease_secs = 15
 selector = "LeaseBased"
 # Store data in memory, false by default.
 use_memory_store = false
-# Wheter to enable greptimedb telemetry, true by default.
+# Whether to enable greptimedb telemetry, true by default.
 enable_telemetry = true
 
 # Log options, see `standalone.example.toml`

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -2,6 +2,8 @@
 mode = "standalone"
 # Whether to use in-memory catalog, `false` by default.
 enable_memory_catalog = false
+# Wheter to enable greptimedb telemetry, true by default.
+enable_telemetry = true
 
 # HTTP server options.
 [http_options]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -2,7 +2,7 @@
 mode = "standalone"
 # Whether to use in-memory catalog, `false` by default.
 enable_memory_catalog = false
-# Wheter to enable greptimedb telemetry, true by default.
+# Whether to enable greptimedb telemetry, true by default.
 enable_telemetry = true
 
 # HTTP server options.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -98,10 +98,10 @@ sync_write = false
 
 # Storage options.
 [storage]
+# The working home directory.
+data_home = "/tmp/greptimedb/"
 # Storage type.
 type = "File"
-# Data directory, "/tmp/greptimedb/data" by default.
-data_home = "/tmp/greptimedb/"
 # TTL for all tables. Disabled by default.
 # global_ttl = "7d"
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -13,10 +13,6 @@ path = "src/bin/greptime.rs"
 default = ["metrics-process"]
 tokio-console = ["common-telemetry/tokio-console"]
 metrics-process = ["servers/metrics-process"]
-greptimedb-telemetry = [
-    "datanode/greptimedb-telemetry",
-    "meta-srv/greptimedb-telemetry",
-]
 
 [dependencies]
 anymap = "1.0.0-beta.2"

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -83,6 +83,7 @@ impl SubCommand {
 pub struct StandaloneOptions {
     pub mode: Mode,
     pub enable_memory_catalog: bool,
+    pub enable_telemetry: bool,
     pub http_options: Option<HttpOptions>,
     pub grpc_options: Option<GrpcOptions>,
     pub mysql_options: Option<MysqlOptions>,
@@ -102,6 +103,7 @@ impl Default for StandaloneOptions {
         Self {
             mode: Mode::Standalone,
             enable_memory_catalog: false,
+            enable_telemetry: true,
             http_options: Some(HttpOptions::default()),
             grpc_options: Some(GrpcOptions::default()),
             mysql_options: Some(MysqlOptions::default()),
@@ -139,6 +141,7 @@ impl StandaloneOptions {
     fn datanode_options(self) -> DatanodeOptions {
         DatanodeOptions {
             enable_memory_catalog: self.enable_memory_catalog,
+            enable_telemetry: self.enable_telemetry,
             wal: self.wal,
             storage: self.storage,
             procedure: self.procedure,

--- a/src/common/greptimedb-telemetry/Cargo.toml
+++ b/src/common/greptimedb-telemetry/Cargo.toml
@@ -9,7 +9,6 @@ async-trait.workspace = true
 common-error = { workspace = true }
 common-runtime = { workspace = true }
 common-telemetry = { workspace = true }
-once_cell = "1.17.0"
 reqwest = { version = "0.11", features = [
     "json",
     "rustls-tls",
@@ -21,6 +20,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 common-test-util = { workspace = true }
+tempfile.workspace = true
 hyper = { version = "0.14", features = ["full"] }
 
 [build-dependencies]

--- a/src/common/greptimedb-telemetry/Cargo.toml
+++ b/src/common/greptimedb-telemetry/Cargo.toml
@@ -20,8 +20,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 common-test-util = { workspace = true }
-tempfile.workspace = true
 hyper = { version = "0.14", features = ["full"] }
+tempfile.workspace = true
 
 [build-dependencies]
 common-version = { workspace = true }

--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -148,9 +148,8 @@ pub trait Collector {
 fn print_warning_log() {
     info!("Attention: GreptimeDB now collects anonymous usage data to help improve its roadmap and prioritize features.");
     info!(
-        "To learn more about this program and how to disable it, please visit the following URL: "
-    );
-    info!("https://docs.greptime.com/user-guide/operations/configuration#greptimedb-telemetry");
+        "To learn more about this anonymous program and how to deactivate it if you don't want to participate, please visit the following URL: ");
+    info!("https://docs.greptime.com/reference/telemetry");
 }
 
 pub fn default_get_uuid(working_home: &Option<String>) -> Option<String> {

--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -50,6 +50,8 @@ impl GreptimeDBTelemetryTask {
     }
 
     pub fn start(&self, runtime: Runtime) -> Result<()> {
+        print_warning_log();
+
         match self {
             GreptimeDBTelemetryTask::Enable(task) => task.start(runtime),
             GreptimeDBTelemetryTask::Disable => Ok(()),
@@ -140,6 +142,15 @@ pub trait Collector {
             }
         }
     }
+}
+
+/// Print warning log about telemetry
+fn print_warning_log() {
+    info!("Attention: GreptimeDB now collects anonymous usage data to help improve its roadmap and prioritize features.");
+    info!(
+        "To learn more about this program and how to disable it, please visit the following URL: "
+    );
+    info!("https://docs.greptime.com/user-guide/operations/configuration#greptimedb-telemetry");
 }
 
 pub fn default_get_uuid(working_home: &Option<String>) -> Option<String> {

--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -50,7 +50,7 @@ impl GreptimeDBTelemetryTask {
     }
 
     pub fn start(&self, runtime: Runtime) -> Result<()> {
-        print_warning_log();
+        print_anonymous_usage_data_disclaimer();
 
         match self {
             GreptimeDBTelemetryTask::Enable(task) => task.start(runtime),
@@ -144,8 +144,7 @@ pub trait Collector {
     }
 }
 
-/// Print warning log about telemetry
-fn print_warning_log() {
+fn print_anonymous_usage_data_disclaimer() {
     info!("Attention: GreptimeDB now collects anonymous usage data to help improve its roadmap and prioritize features.");
     info!(
         "To learn more about this anonymous program and how to deactivate it if you don't want to participate, please visit the following URL: ");

--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -33,7 +33,7 @@ pub static TELEMETRY_INTERVAL: Duration = Duration::from_secs(60 * 30);
 /// The default connect timeout to greptime cloud.
 const GREPTIMEDB_TELEMETRY_CLIENT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// The default request timeout to greptime cloud.
-const GREPTIMEDB_TELEMETRY_CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+const GREPTIMEDB_TELEMETRY_CLIENT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub enum GreptimeDBTelemetryTask {
     Enable(RepeatedTask<Error>),
@@ -209,7 +209,7 @@ impl GreptimeDBTelemetry {
     pub fn new(working_home: Option<String>, statistics: Box<dyn Collector + Send + Sync>) -> Self {
         let client = Client::builder()
             .connect_timeout(GREPTIMEDB_TELEMETRY_CLIENT_CONNECT_TIMEOUT)
-            .timeout(GREPTIMEDB_TELEMETRY_CLIENT_TIMEOUT)
+            .timeout(GREPTIMEDB_TELEMETRY_CLIENT_REQUEST_TIMEOUT)
             .build();
         Self {
             working_home,

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [features]
-greptimedb-telemetry = []
 testing = ["meta-srv/mock"]
 
 [dependencies]

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -58,7 +58,7 @@ pub enum ObjectStoreConfig {
 }
 
 /// Storage engine config
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct StorageConfig {
     /// Retention period for all tables.
@@ -68,6 +68,8 @@ pub struct StorageConfig {
     /// The precedence order is: ttl in table options > global ttl.
     #[serde(with = "humantime_serde")]
     pub global_ttl: Option<Duration>,
+    /// The working directory of database
+    pub data_home: String,
     #[serde(flatten)]
     pub store: ObjectStoreConfig,
     pub compaction: CompactionConfig,
@@ -75,11 +77,22 @@ pub struct StorageConfig {
     pub flush: FlushConfig,
 }
 
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            global_ttl: None,
+            data_home: DEFAULT_DATA_HOME.to_string(),
+            store: ObjectStoreConfig::default(),
+            compaction: CompactionConfig::default(),
+            manifest: RegionManifestConfig::default(),
+            flush: FlushConfig::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Default, Deserialize)]
 #[serde(default)]
-pub struct FileConfig {
-    pub data_home: String,
-}
+pub struct FileConfig {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -198,9 +211,7 @@ impl Default for GcsConfig {
 
 impl Default for ObjectStoreConfig {
     fn default() -> Self {
-        ObjectStoreConfig::File(FileConfig {
-            data_home: DEFAULT_DATA_HOME.to_string(),
-        })
+        ObjectStoreConfig::File(FileConfig {})
     }
 }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -362,6 +362,7 @@ pub struct DatanodeOptions {
     pub storage: StorageConfig,
     pub procedure: ProcedureConfig,
     pub logging: LoggingOptions,
+    pub enable_telemetry: bool,
 }
 
 impl Default for DatanodeOptions {
@@ -380,6 +381,7 @@ impl Default for DatanodeOptions {
             procedure: ProcedureConfig::default(),
             logging: LoggingOptions::default(),
             heartbeat: HeartbeatOptions::default(),
+            enable_telemetry: true,
         }
     }
 }

--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -57,7 +57,7 @@ pub async fn get_greptimedb_telemetry_task(
     mode: &Mode,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
-    if !enable {
+    if !enable || cfg!(test) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
     match mode {

--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -53,6 +53,7 @@ impl Collector for StandaloneGreptimeDBTelemetryCollector {
 }
 
 pub async fn get_greptimedb_telemetry_task(
+    working_home: Option<String>,
     mode: &Mode,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
@@ -62,12 +63,13 @@ pub async fn get_greptimedb_telemetry_task(
     match mode {
         Mode::Standalone => Arc::new(GreptimeDBTelemetryTask::enable(
             TELEMETRY_INTERVAL,
-            Box::new(GreptimeDBTelemetry::new(Box::new(
-                StandaloneGreptimeDBTelemetryCollector {
-                    uuid: default_get_uuid(),
+            Box::new(GreptimeDBTelemetry::new(
+                working_home.clone(),
+                Box::new(StandaloneGreptimeDBTelemetryCollector {
+                    uuid: default_get_uuid(&working_home),
                     retry: 0,
-                },
-            ))),
+                }),
+            )),
         )),
         Mode::Distributed => Arc::new(GreptimeDBTelemetryTask::disable()),
     }

--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -12,72 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "greptimedb-telemetry")]
-pub mod telemetry {
-    use std::sync::Arc;
+use std::sync::Arc;
 
-    use async_trait::async_trait;
-    use common_greptimedb_telemetry::{
-        default_get_uuid, Collector, GreptimeDBTelemetry, GreptimeDBTelemetryTask,
-        Mode as VersionReporterMode, TELEMETRY_INTERVAL,
-    };
-    use servers::Mode;
+use async_trait::async_trait;
+use common_greptimedb_telemetry::{
+    default_get_uuid, Collector, GreptimeDBTelemetry, GreptimeDBTelemetryTask,
+    Mode as VersionReporterMode, TELEMETRY_INTERVAL,
+};
+use servers::Mode;
 
-    struct StandaloneGreptimeDBTelemetryCollector {
-        uuid: Option<String>,
-        retry: i32,
-    }
-    #[async_trait]
-    impl Collector for StandaloneGreptimeDBTelemetryCollector {
-        fn get_mode(&self) -> VersionReporterMode {
-            VersionReporterMode::Standalone
-        }
-
-        async fn get_nodes(&self) -> Option<i32> {
-            Some(1)
-        }
-
-        fn get_retry(&self) -> i32 {
-            self.retry
-        }
-
-        fn inc_retry(&mut self) {
-            self.retry += 1;
-        }
-
-        fn set_uuid_cache(&mut self, uuid: String) {
-            self.uuid = Some(uuid);
-        }
-
-        fn get_uuid_cache(&self) -> Option<String> {
-            self.uuid.clone()
-        }
+struct StandaloneGreptimeDBTelemetryCollector {
+    uuid: Option<String>,
+    retry: i32,
+}
+#[async_trait]
+impl Collector for StandaloneGreptimeDBTelemetryCollector {
+    fn get_mode(&self) -> VersionReporterMode {
+        VersionReporterMode::Standalone
     }
 
-    pub async fn get_greptimedb_telemetry_task(mode: &Mode) -> Arc<GreptimeDBTelemetryTask> {
-        match mode {
-            Mode::Standalone => Arc::new(GreptimeDBTelemetryTask::enable(
-                TELEMETRY_INTERVAL,
-                Box::new(GreptimeDBTelemetry::new(Box::new(
-                    StandaloneGreptimeDBTelemetryCollector {
-                        uuid: default_get_uuid(),
-                        retry: 0,
-                    },
-                ))),
-            )),
-            Mode::Distributed => Arc::new(GreptimeDBTelemetryTask::disable()),
-        }
+    async fn get_nodes(&self) -> Option<i32> {
+        Some(1)
+    }
+
+    fn get_retry(&self) -> i32 {
+        self.retry
+    }
+
+    fn inc_retry(&mut self) {
+        self.retry += 1;
+    }
+
+    fn set_uuid_cache(&mut self, uuid: String) {
+        self.uuid = Some(uuid);
+    }
+
+    fn get_uuid_cache(&self) -> Option<String> {
+        self.uuid.clone()
     }
 }
 
-#[cfg(not(feature = "greptimedb-telemetry"))]
-pub mod telemetry {
-    use std::sync::Arc;
-
-    use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
-    use servers::Mode;
-
-    pub async fn get_greptimedb_telemetry_task(_: &Mode) -> Arc<GreptimeDBTelemetryTask> {
-        Arc::new(GreptimeDBTelemetryTask::disable())
+pub async fn get_greptimedb_telemetry_task(
+    mode: &Mode,
+    enable: bool,
+) -> Arc<GreptimeDBTelemetryTask> {
+    if !enable {
+        return Arc::new(GreptimeDBTelemetryTask::disable());
+    }
+    match mode {
+        Mode::Standalone => Arc::new(GreptimeDBTelemetryTask::enable(
+            TELEMETRY_INTERVAL,
+            Box::new(GreptimeDBTelemetry::new(Box::new(
+                StandaloneGreptimeDBTelemetryCollector {
+                    uuid: default_get_uuid(),
+                    retry: 0,
+                },
+            ))),
+        )),
+        Mode::Distributed => Arc::new(GreptimeDBTelemetryTask::disable()),
     }
 }

--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -60,6 +60,7 @@ pub async fn get_greptimedb_telemetry_task(
     if !enable || cfg!(test) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
+
     match mode {
         Mode::Standalone => Arc::new(GreptimeDBTelemetryTask::enable(
             TELEMETRY_INTERVAL,

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -64,12 +64,12 @@ use crate::error::{
     MissingNodeIdSnafu, NewCatalogSnafu, OpenLogStoreSnafu, RecoverProcedureSnafu, Result,
     ShutdownInstanceSnafu, StartProcedureManagerSnafu, StopProcedureManagerSnafu,
 };
+use crate::greptimedb_telemetry::get_greptimedb_telemetry_task;
 use crate::heartbeat::handler::close_region::CloseRegionHandler;
 use crate::heartbeat::handler::open_region::OpenRegionHandler;
 use crate::heartbeat::HeartbeatTask;
 use crate::sql::{SqlHandler, SqlRequest};
 use crate::store;
-use crate::telemetry::get_greptimedb_telemetry_task;
 
 mod grpc;
 pub mod sql;
@@ -305,7 +305,7 @@ impl Instance {
             catalog_manager: catalog_manager.clone(),
             table_id_provider,
             procedure_manager,
-            greptimedb_telemetry_task: get_greptimedb_telemetry_task(&opts.mode).await,
+            greptimedb_telemetry_task: get_greptimedb_telemetry_task(&opts.mode, true).await,
         });
 
         let heartbeat_task = Instance::build_heartbeat_task(

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -305,7 +305,11 @@ impl Instance {
             catalog_manager: catalog_manager.clone(),
             table_id_provider,
             procedure_manager,
-            greptimedb_telemetry_task: get_greptimedb_telemetry_task(&opts.mode, true).await,
+            greptimedb_telemetry_task: get_greptimedb_telemetry_task(
+                &opts.mode,
+                opts.enable_telemetry,
+            )
+            .await,
         });
 
         let heartbeat_task = Instance::build_heartbeat_task(

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -309,6 +309,7 @@ impl Instance {
             table_id_provider,
             procedure_manager,
             greptimedb_telemetry_task: get_greptimedb_telemetry_task(
+                Some(opts.storage.data_home.clone()),
                 &opts.mode,
                 opts.enable_telemetry,
             )

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -27,7 +27,5 @@ pub mod server;
 pub mod sql;
 mod store;
 
-use greptimedb_telemetry::telemetry;
-
 #[cfg(test)]
 mod tests;

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -33,9 +33,14 @@ use snafu::prelude::*;
 use crate::datanode::{ObjectStoreConfig, DEFAULT_OBJECT_STORE_CACHE_SIZE};
 use crate::error::{self, Result};
 
-pub(crate) async fn new_object_store(store_config: &ObjectStoreConfig) -> Result<ObjectStore> {
+pub(crate) async fn new_object_store(
+    data_home: &str,
+    store_config: &ObjectStoreConfig,
+) -> Result<ObjectStore> {
     let object_store = match store_config {
-        ObjectStoreConfig::File(file_config) => fs::new_fs_object_store(file_config).await,
+        ObjectStoreConfig::File(file_config) => {
+            fs::new_fs_object_store(data_home, file_config).await
+        }
         ObjectStoreConfig::S3(s3_config) => s3::new_s3_object_store(s3_config).await,
         ObjectStoreConfig::Oss(oss_config) => oss::new_oss_object_store(oss_config).await,
         ObjectStoreConfig::Azblob(azblob_config) => {

--- a/src/datanode/src/tests/test_util.rs
+++ b/src/datanode/src/tests/test_util.rs
@@ -74,9 +74,8 @@ fn create_tmp_dir_and_datanode_opts(name: &str) -> (DatanodeOptions, TestGuard) 
             ..Default::default()
         },
         storage: StorageConfig {
-            store: ObjectStoreConfig::File(FileConfig {
-                data_home: data_tmp_dir.path().to_str().unwrap().to_string(),
-            }),
+            data_home: data_tmp_dir.path().to_str().unwrap().to_string(),
+            store: ObjectStoreConfig::File(FileConfig {}),
             ..Default::default()
         },
         mode: Mode::Standalone,

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [features]
 mock = []
-greptimedb-telemetry = []
 
 [dependencies]
 anymap = "1.0.0-beta.2"

--- a/src/meta-srv/src/greptimedb_telemetry.rs
+++ b/src/meta-srv/src/greptimedb_telemetry.rs
@@ -60,7 +60,7 @@ pub async fn get_greptimedb_telemetry_task(
     meta_peer_client: MetaPeerClientRef,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
-    if !enable {
+    if !enable || cfg!(test) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
 

--- a/src/meta-srv/src/greptimedb_telemetry.rs
+++ b/src/meta-srv/src/greptimedb_telemetry.rs
@@ -56,6 +56,7 @@ impl Collector for DistributedGreptimeDBTelemetryCollector {
 }
 
 pub async fn get_greptimedb_telemetry_task(
+    working_home: Option<String>,
     meta_peer_client: MetaPeerClientRef,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
@@ -65,12 +66,13 @@ pub async fn get_greptimedb_telemetry_task(
 
     Arc::new(GreptimeDBTelemetryTask::enable(
         TELEMETRY_INTERVAL,
-        Box::new(GreptimeDBTelemetry::new(Box::new(
-            DistributedGreptimeDBTelemetryCollector {
+        Box::new(GreptimeDBTelemetry::new(
+            working_home.clone(),
+            Box::new(DistributedGreptimeDBTelemetryCollector {
                 meta_peer_client,
-                uuid: default_get_uuid(),
+                uuid: default_get_uuid(&working_home),
                 retry: 0,
-            },
-        ))),
+            }),
+        )),
     ))
 }

--- a/src/meta-srv/src/greptimedb_telemetry.rs
+++ b/src/meta-srv/src/greptimedb_telemetry.rs
@@ -12,77 +12,65 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "greptimedb-telemetry")]
-pub mod telemetry {
-    use std::sync::Arc;
+use std::sync::Arc;
 
-    use async_trait::async_trait;
-    use common_greptimedb_telemetry::{
-        default_get_uuid, Collector, GreptimeDBTelemetry, GreptimeDBTelemetryTask,
-        Mode as VersionReporterMode, TELEMETRY_INTERVAL,
-    };
+use async_trait::async_trait;
+use common_greptimedb_telemetry::{
+    default_get_uuid, Collector, GreptimeDBTelemetry, GreptimeDBTelemetryTask,
+    Mode as VersionReporterMode, TELEMETRY_INTERVAL,
+};
 
-    use crate::cluster::MetaPeerClientRef;
+use crate::cluster::MetaPeerClientRef;
 
-    struct DistributedGreptimeDBTelemetryCollector {
-        meta_peer_client: MetaPeerClientRef,
-        uuid: Option<String>,
-        retry: i32,
+struct DistributedGreptimeDBTelemetryCollector {
+    meta_peer_client: MetaPeerClientRef,
+    uuid: Option<String>,
+    retry: i32,
+}
+
+#[async_trait]
+impl Collector for DistributedGreptimeDBTelemetryCollector {
+    fn get_mode(&self) -> VersionReporterMode {
+        VersionReporterMode::Distributed
     }
 
-    #[async_trait]
-    impl Collector for DistributedGreptimeDBTelemetryCollector {
-        fn get_mode(&self) -> VersionReporterMode {
-            VersionReporterMode::Distributed
-        }
-
-        async fn get_nodes(&self) -> Option<i32> {
-            self.meta_peer_client.get_node_cnt().await.ok()
-        }
-
-        fn get_retry(&self) -> i32 {
-            self.retry
-        }
-
-        fn inc_retry(&mut self) {
-            self.retry += 1;
-        }
-
-        fn set_uuid_cache(&mut self, uuid: String) {
-            self.uuid = Some(uuid);
-        }
-
-        fn get_uuid_cache(&self) -> Option<String> {
-            self.uuid.clone()
-        }
+    async fn get_nodes(&self) -> Option<i32> {
+        self.meta_peer_client.get_node_cnt().await.ok()
     }
 
-    pub async fn get_greptimedb_telemetry_task(
-        meta_peer_client: MetaPeerClientRef,
-    ) -> Arc<GreptimeDBTelemetryTask> {
-        Arc::new(GreptimeDBTelemetryTask::enable(
-            TELEMETRY_INTERVAL,
-            Box::new(GreptimeDBTelemetry::new(Box::new(
-                DistributedGreptimeDBTelemetryCollector {
-                    meta_peer_client,
-                    uuid: default_get_uuid(),
-                    retry: 0,
-                },
-            ))),
-        ))
+    fn get_retry(&self) -> i32 {
+        self.retry
+    }
+
+    fn inc_retry(&mut self) {
+        self.retry += 1;
+    }
+
+    fn set_uuid_cache(&mut self, uuid: String) {
+        self.uuid = Some(uuid);
+    }
+
+    fn get_uuid_cache(&self) -> Option<String> {
+        self.uuid.clone()
     }
 }
 
-#[cfg(not(feature = "greptimedb-telemetry"))]
-pub mod telemetry {
-    use std::sync::Arc;
-
-    use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
-
-    use crate::cluster::MetaPeerClientRef;
-    pub async fn get_greptimedb_telemetry_task(
-        _: MetaPeerClientRef,
-    ) -> Arc<GreptimeDBTelemetryTask> {
-        Arc::new(GreptimeDBTelemetryTask::disable())
+pub async fn get_greptimedb_telemetry_task(
+    meta_peer_client: MetaPeerClientRef,
+    enable: bool,
+) -> Arc<GreptimeDBTelemetryTask> {
+    if !enable {
+        return Arc::new(GreptimeDBTelemetryTask::disable());
     }
+
+    Arc::new(GreptimeDBTelemetryTask::enable(
+        TELEMETRY_INTERVAL,
+        Box::new(GreptimeDBTelemetry::new(Box::new(
+            DistributedGreptimeDBTelemetryCollector {
+                meta_peer_client,
+                uuid: default_get_uuid(),
+                retry: 0,
+            },
+        ))),
+    ))
 }

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -42,7 +42,6 @@ pub use crate::error::Result;
 mod inactive_node_manager;
 
 mod greptimedb_telemetry;
-use greptimedb_telemetry::telemetry;
 
 #[cfg(test)]
 mod test_util;

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -44,6 +44,7 @@ use crate::sequence::SequenceRef;
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::kv::{KvStoreRef, ResettableKvStoreRef};
 pub const TABLE_ID_SEQ: &str = "table_id";
+const METASRV_HOME: &str = "/tmp/metasrv";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
@@ -60,6 +61,7 @@ pub struct MetaSrvOptions {
     pub procedure: ProcedureConfig,
     pub datanode: DatanodeOptions,
     pub enable_telemetry: bool,
+    pub data_home: String,
 }
 
 impl Default for MetaSrvOptions {
@@ -73,10 +75,14 @@ impl Default for MetaSrvOptions {
             use_memory_store: false,
             disable_region_failover: false,
             http_opts: HttpOptions::default(),
-            logging: LoggingOptions::default(),
+            logging: LoggingOptions {
+                dir: format!("{METASRV_HOME}/logs"),
+                ..Default::default()
+            },
             procedure: ProcedureConfig::default(),
             datanode: DatanodeOptions::default(),
             enable_telemetry: true,
+            data_home: METASRV_HOME.to_string(),
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -59,6 +59,7 @@ pub struct MetaSrvOptions {
     pub logging: LoggingOptions,
     pub procedure: ProcedureConfig,
     pub datanode: DatanodeOptions,
+    pub enable_telemetry: bool,
 }
 
 impl Default for MetaSrvOptions {
@@ -75,6 +76,7 @@ impl Default for MetaSrvOptions {
             logging: LoggingOptions::default(),
             procedure: ProcedureConfig::default(),
             datanode: DatanodeOptions::default(),
+            enable_telemetry: true,
         }
     }
 }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -234,6 +234,8 @@ impl MetaSrvBuilder {
             }
         };
 
+        let enable_telemetry = options.enable_telemetry;
+
         Ok(MetaSrv {
             started,
             options,
@@ -251,7 +253,11 @@ impl MetaSrvBuilder {
             mailbox,
             ddl_manager,
             table_metadata_manager,
-            greptimedb_telemetry_task: get_greptimedb_telemetry_task(meta_peer_client, true).await,
+            greptimedb_telemetry_task: get_greptimedb_telemetry_task(
+                meta_peer_client,
+                enable_telemetry,
+            )
+            .await,
             pubsub,
         })
     }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -235,6 +235,7 @@ impl MetaSrvBuilder {
         };
 
         let enable_telemetry = options.enable_telemetry;
+        let metasrv_home = options.data_home.to_string();
 
         Ok(MetaSrv {
             started,
@@ -254,6 +255,7 @@ impl MetaSrvBuilder {
             ddl_manager,
             table_metadata_manager,
             greptimedb_telemetry_task: get_greptimedb_telemetry_task(
+                Some(metasrv_home),
                 meta_peer_client,
                 enable_telemetry,
             )

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -25,6 +25,7 @@ use common_procedure::ProcedureManagerRef;
 use crate::cluster::{MetaPeerClientBuilder, MetaPeerClientRef};
 use crate::ddl::{DdlManager, DdlManagerRef};
 use crate::error::Result;
+use crate::greptimedb_telemetry::get_greptimedb_telemetry_task;
 use crate::handler::mailbox_handler::MailboxHandler;
 use crate::handler::publish_heartbeat_handler::PublishHeartbeatHandler;
 use crate::handler::region_lease_handler::RegionLeaseHandler;
@@ -48,7 +49,6 @@ use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::{CheckLeader, LeaderCachedKvStore};
 use crate::service::store::kv::{KvBackendAdapter, KvStoreRef, ResettableKvStoreRef};
 use crate::service::store::memory::MemStore;
-use crate::telemetry::get_greptimedb_telemetry_task;
 
 // TODO(fys): try use derive_builder macro
 pub struct MetaSrvBuilder {
@@ -251,7 +251,7 @@ impl MetaSrvBuilder {
             mailbox,
             ddl_manager,
             table_metadata_manager,
-            greptimedb_telemetry_task: get_greptimedb_telemetry_task(meta_peer_client).await,
+            greptimedb_telemetry_task: get_greptimedb_telemetry_task(meta_peer_client, true).await,
             pubsub,
         })
     }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -289,8 +289,8 @@ pub fn create_tmp_dir_and_datanode_opts(
 ) -> (DatanodeOptions, TestGuard) {
     let home_tmp_dir = create_temp_dir(&format!("gt_data_{name}"));
     let wal_tmp_dir = create_temp_dir(&format!("gt_wal_{name}"));
-    let wal_dir = wal_tmp_dir.path().to_str().unwrap().to_string();
     let home_dir = home_tmp_dir.path().to_str().unwrap().to_string();
+    let wal_dir = wal_tmp_dir.path().to_str().unwrap().to_string();
 
     let (store, data_tmp_dir) = get_test_store_config(&store_type);
     let opts = create_datanode_opts(store, home_dir, wal_dir);

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -597,6 +597,7 @@ pub async fn test_config_api(store_type: StorageType) {
     enable_memory_catalog = false
     rpc_addr = "127.0.0.1:3001"
     rpc_runtime_size = 8
+    enable_telemetry = true
 
     [heartbeat]
     interval_millis = 5000

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -85,7 +85,7 @@ pub async fn test_region_failover(store_type: StorageType) {
 
     let cluster_name = "test_region_failover";
 
-    let (store_config, _guard) = get_test_store_config(&store_type, cluster_name);
+    let (store_config, _guard) = get_test_store_config(&store_type);
 
     let datanodes = 5u64;
     let cluster = GreptimeDbClusterBuilder::new(cluster_name)

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -79,7 +79,12 @@ macro_rules! region_failover_tests {
 }
 
 pub async fn test_region_failover(store_type: StorageType) {
+    if store_type == StorageType::File {
+        // Region failover doesn't make sense when using local file storage.
+        return;
+    }
     common_telemetry::init_default_ut_logging();
+    info!("Running region failover test for {}", store_type);
 
     let mut logical_timer = 1685508715000;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Main changes:

* Remove the `greptimedb-telemetry` feature in metasrv and datanode.
* Adds new option `enable_telemetry` to datanode and metasrv configurations, `true` by default.
* Move `data_home` from `FileConfig` to `StorageConfig` in datanode.
* Adds `data_home` to metasrv options.
* Store the installation uuid into `data_home` directory in datanode and metasrv.
* Print warning log when enabling telemetry.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
