### PR TITLE
feat: redact secrets in sql when logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9220,6 +9220,7 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "once_cell",
+ "regex",
  "snafu",
  "sqlparser 0.34.0",
 ]

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -44,7 +44,7 @@ use common_meta::heartbeat::handler::HandlerGroupExecutor;
 use common_meta::key::TableMetadataManager;
 use common_query::Output;
 use common_telemetry::logging::{debug, info};
-use common_telemetry::timer;
+use common_telemetry::{error, timer};
 use datanode::instance::sql::table_idents_to_full_name;
 use datanode::instance::InstanceRef as DnInstanceRef;
 use datatypes::schema::Schema;
@@ -524,6 +524,9 @@ impl SqlQueryHandler for Instance {
                             results.push(output_result);
                         }
                         Err(e) => {
+                            let redacted = sql::util::redact_sql_secrets(query.as_ref());
+                            error!(e; "Failed to execute query: {redacted}");
+
                             results.push(Err(e));
                             break;
                         }

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -16,7 +16,6 @@ use std::ops::Deref;
 
 use common_query::Output;
 use common_recordbatch::{util, RecordBatch};
-use common_telemetry::warn;
 use datatypes::prelude::{ConcreteDataType, Value};
 use datatypes::schema::SchemaRef;
 use metrics::increment_counter;
@@ -31,9 +30,8 @@ use crate::error::{self, Error, Result};
 use crate::metrics::*;
 
 /// Try to write multiple output to the writer if possible.
-pub async fn write_output<'a, W: AsyncWrite + Send + Sync + Unpin>(
-    w: QueryResultWriter<'a, W>,
-    query: &str,
+pub async fn write_output<W: AsyncWrite + Send + Sync + Unpin>(
+    w: QueryResultWriter<'_, W>,
     query_context: QueryContextRef,
     outputs: Vec<Result<Output>>,
 ) -> Result<()> {
@@ -42,7 +40,7 @@ pub async fn write_output<'a, W: AsyncWrite + Send + Sync + Unpin>(
         let result_writer = writer.take().context(error::InternalSnafu {
             err_msg: "Sending multiple result set is unsupported",
         })?;
-        writer = result_writer.try_write_one(query, output).await?;
+        writer = result_writer.try_write_one(output).await?;
     }
 
     if let Some(result_writer) = writer {
@@ -75,7 +73,6 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
     /// Try to write one result set. If there are more than one result set, return `Some`.
     pub async fn try_write_one(
         self,
-        query: &str,
         output: Result<Output>,
     ) -> Result<Option<MysqlResultWriter<'a, W>>> {
         // We don't support sending multiple query result because the RowWriter's lifetime is bound to
@@ -91,16 +88,14 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                         recordbatches,
                         schema,
                     };
-                    Self::write_query_result(query, query_result, self.writer, self.query_context)
-                        .await?;
+                    Self::write_query_result(query_result, self.writer, self.query_context).await?;
                 }
                 Output::RecordBatches(recordbatches) => {
                     let query_result = QueryResult {
                         schema: recordbatches.schema(),
                         recordbatches: recordbatches.take(),
                     };
-                    Self::write_query_result(query, query_result, self.writer, self.query_context)
-                        .await?;
+                    Self::write_query_result(query_result, self.writer, self.query_context).await?;
                 }
                 Output::AffectedRows(rows) => {
                     let next_writer = Self::write_affected_rows(self.writer, rows).await?;
@@ -110,7 +105,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                     )));
                 }
             },
-            Err(error) => Self::write_query_error(query, error, self.writer).await?,
+            Err(error) => Self::write_query_error(error, self.writer).await?,
         }
         Ok(None)
     }
@@ -135,7 +130,6 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
     }
 
     async fn write_query_result(
-        query: &str,
         query_result: QueryResult,
         writer: QueryResultWriter<'a, W>,
         query_context: QueryContextRef,
@@ -152,7 +146,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
                 row_writer.finish().await?;
                 Ok(())
             }
-            Err(error) => Self::write_query_error(query, error, writer).await,
+            Err(error) => Self::write_query_error(error, writer).await,
         }
     }
 
@@ -200,12 +194,7 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
         Ok(())
     }
 
-    async fn write_query_error(
-        query: &str,
-        error: Error,
-        w: QueryResultWriter<'a, W>,
-    ) -> Result<()> {
-        warn!(error; "Failed to execute query '{}'", query);
+    async fn write_query_error(error: Error, w: QueryResultWriter<'a, W>) -> Result<()> {
         increment_counter!(
             METRIC_ERROR_COUNTER,
             &[(METRIC_PROTOCOL_LABEL, METRIC_ERROR_COUNTER_LABEL_MYSQL)]

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -16,6 +16,7 @@ datatypes = { workspace = true }
 hex = "0.4"
 itertools.workspace = true
 once_cell.workspace = true
+regex.workspace = true
 snafu = { version = "0.7", features = ["backtraces"] }
 sqlparser.workspace = true
 

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -14,6 +14,7 @@
 #![feature(box_patterns)]
 #![feature(assert_matches)]
 #![feature(let_chains)]
+#![feature(lazy_cell)]
 
 pub mod ast;
 pub mod dialect;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The SQL will be printed in logs as is when it executes with an error, this could leak sensetive secrets. For example, the following SQL contains access key to S3:

```sql
COPY 'my_table' FROM '/test.orc' WITH (FORMAT = 'orc') CONNECTION(ENDPOINT = 's3.storage.site', REGION = 'hz', ACCESS_KEY_ID='my_key_id', SECRET_ACCESS_KEY="my_access_key");
```

This PR redacted the secrets in sql when logging. After redacted, the above sql is seen as

```sql
COPY 'my_table' FROM '/test.orc' WITH (FORMAT = 'orc') CONNECTION(ENDPOINT = 's3.storage.site', REGION = 'hz', ACCESS_KEY_ID='******', SECRET_ACCESS_KEY="******");
```

in logs.

Redaction is simply done by regex pattern matching on common seen secrets values.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
