### PR TITLE
build: update protobuf-build to support apple silicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "autotools"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8da1805e028a172334c3b680f93e71126f2327622faef2ec3d893c0a4ad77"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7074,13 +7083,14 @@ dependencies = [
 
 [[package]]
 name = "protobuf-build"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
+checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
 dependencies = [
  "bitflags 1.3.2",
  "protobuf",
  "protobuf-codegen",
+ "protobuf-src",
  "regex",
 ]
 
@@ -7091,6 +7101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
 dependencies = [
  "protobuf",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [build-dependencies]
-protobuf-build = { version = "0.15.1", default-features = false, features = [
+protobuf-build = { version = "0.15", default-features = false, features = [
     "protobuf-codec",
 ] }
 

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [build-dependencies]
-protobuf-build = { version = "0.14", default-features = false, features = [
+protobuf-build = { version = "0.15.1", default-features = false, features = [
     "protobuf-codec",
 ] }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

So, the story is that I want to build the greptimedb on my computer(Apple M1 & macOS 13.4.1 & libprotoc 23.4),
and I got an Error!

```
  --- stderr
  thread 'main' panicked at 'No suitable `protoc` (>= 3.1.0) found in PATH', 
  /Users/xiezheng/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/protobuf-build-0.14.1/src/protobuf_impl.rs:35:14
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I go checked the source code in protobuf-build(v0.14.1)

```rust
    // The bundled protoc should always match the version
    let protoc_bin_name = match (env::consts::OS, env::consts::ARCH) {
        ("linux", "x86") => "protoc-linux-x86_32",
        ("linux", "x86_64") => "protoc-linux-x86_64",
        ("linux", "aarch64") => "protoc-linux-aarch_64",
        ("linux", "powerpc64") => "protoc-linux-ppcle_64",
        ("macos", "x86_64") => "protoc-osx-x86_64",
        ("windows", _) => "protoc-win32.exe",
        
         // no considering for m1 mac!!!     
    
        /* ! ==> PANIC HERE <== */
        _ => panic!("No suitable `protoc` (>= 3.1.0) found in PATH"), 
    };
```

Indeed, the previous code (v0.14.0) appears to be broken. 
The TiKV team has already implemented updates, 
hence it would be beneficial to alter this crate's version to its most recent release, 
which is version 0.15.1.
This change will enable the successful building of the project on M1 Macs.


Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
   changed the version of protobuf-build in `src/log-store/Cargo.toml` to 0.15.1.
  

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
