### PR TITLE
feat: add table route manager and upgrade tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,6 +1601,7 @@ dependencies = [
  "metrics",
  "nu-ansi-term",
  "partition",
+ "prost",
  "query",
  "rand",
  "rexpect",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -42,6 +42,7 @@ meta-srv = { workspace = true }
 metrics.workspace = true
 nu-ansi-term = "0.46"
 partition = { workspace = true }
+prost.workspace = true
 query = { workspace = true }
 rand.workspace = true
 rustyline = "10.1"

--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -25,7 +25,7 @@ use common_meta::key::schema_name::{SchemaNameKey, SchemaNameValue};
 use common_meta::key::table_info::{TableInfoKey, TableInfoValue};
 use common_meta::key::table_name::{TableNameKey, TableNameValue};
 use common_meta::key::table_region::{RegionDistribution, TableRegionKey, TableRegionValue};
-use common_meta::key::table_route::NextTableRouteKey;
+use common_meta::key::table_route::{NextTableRouteKey, TableRouteValue as NextTableRouteValue};
 use common_meta::key::TableMetaKey;
 use common_meta::range_stream::PaginationStream;
 use common_meta::rpc::router::TableRoute;
@@ -150,6 +150,8 @@ impl MigrateTableMetadata {
         )
         .unwrap();
 
+        let new_table_value = NextTableRouteValue::new(table_route.region_routes);
+
         let new_key = NextTableRouteKey::new(table_route.table.id as u32);
         info!("Creating '{new_key}'");
 
@@ -160,7 +162,7 @@ impl MigrateTableMetadata {
                 .put(
                     PutRequest::new()
                         .with_key(new_key.as_raw_key())
-                        .with_value(table_route.try_as_raw_value().unwrap()),
+                        .with_value(new_table_value.try_as_raw_value().unwrap()),
                 )
                 .await
                 .unwrap();

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -24,6 +24,12 @@ use table::metadata::TableId;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub))]
 pub enum Error {
+    #[snafu(display("Failed to decode protobuf, source: {}", source))]
+    DecodeProto {
+        location: Location,
+        source: prost::DecodeError,
+    },
+
     #[snafu(display("Failed to encode object into json, source: {}", source))]
     EncodeJson {
         location: Location,
@@ -164,7 +170,8 @@ impl ErrorExt for Error {
             EncodeJson { .. }
             | DecodeJson { .. }
             | PayloadNotExist { .. }
-            | ConvertRawKey { .. } => StatusCode::Unexpected,
+            | ConvertRawKey { .. }
+            | DecodeProto { .. } => StatusCode::Unexpected,
 
             MetaSrv { source, .. } => source.status_code(),
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -53,7 +53,9 @@ pub mod schema_name;
 pub mod table_info;
 pub mod table_name;
 pub mod table_region;
-mod table_route;
+// TODO(weny): removes it.
+#[allow(unused)]
+pub mod table_route;
 
 use std::sync::Arc;
 
@@ -70,6 +72,7 @@ use self::schema_name::{SchemaManager, SchemaNameValue};
 use crate::error::{InvalidTableMetadataSnafu, Result, SerdeJsonSnafu};
 pub use crate::key::table_route::{TableRouteKey, TABLE_ROUTE_PREFIX};
 use crate::kv_backend::KvBackendRef;
+use crate::rpc::router::TableRoute;
 
 pub const REMOVED_PREFIX: &str = "__removed";
 
@@ -212,7 +215,8 @@ impl_table_meta_value! {
     TableNameValue,
     TableInfoValue,
     TableRegionValue,
-    DatanodeTableValue
+    DatanodeTableValue,
+    TableRoute
 }
 
 #[cfg(test)]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -69,10 +69,10 @@ use table_region::{TableRegionKey, TableRegionManager, TableRegionValue};
 
 use self::catalog_name::{CatalogManager, CatalogNameValue};
 use self::schema_name::{SchemaManager, SchemaNameValue};
+use self::table_route::TableRouteValue;
 use crate::error::{InvalidTableMetadataSnafu, Result, SerdeJsonSnafu};
 pub use crate::key::table_route::{TableRouteKey, TABLE_ROUTE_PREFIX};
 use crate::kv_backend::KvBackendRef;
-use crate::rpc::router::TableRoute;
 
 pub const REMOVED_PREFIX: &str = "__removed";
 
@@ -216,7 +216,7 @@ impl_table_meta_value! {
     TableInfoValue,
     TableRegionValue,
     DatanodeTableValue,
-    TableRoute
+    TableRouteValue
 }
 
 #[cfg(test)]

--- a/src/common/meta/src/rpc/router.rs
+++ b/src/common/meta/src/rpc/router.rs
@@ -76,13 +76,19 @@ impl TryFrom<PbRouteResponse> for RouteResponse {
 pub struct TableRoute {
     pub table: Table,
     pub region_routes: Vec<RegionRoute>,
+    region_leaders: HashMap<RegionNumber, Option<Peer>>,
 }
 
 impl TableRoute {
     pub fn new(table: Table, region_routes: Vec<RegionRoute>) -> Self {
+        let region_leaders = region_routes
+            .iter()
+            .map(|x| (x.region.id.region_number(), x.leader_peer.clone()))
+            .collect::<HashMap<_, _>>();
         Self {
             table,
             region_routes,
+            region_leaders,
         }
     }
 
@@ -208,10 +214,9 @@ impl TableRoute {
     }
 
     pub fn find_region_leader(&self, region_number: RegionNumber) -> Option<&Peer> {
-        self.region_routes
-            .iter()
-            .find(|x| x.region.id.region_number() == region_number)
-            .and_then(|x| x.leader_peer.as_ref())
+        self.region_leaders
+            .get(&region_number)
+            .and_then(|x| x.as_ref())
     }
 }
 
@@ -532,6 +537,10 @@ mod tests {
                     follower_peers: vec![Peer::new(2, "a2"), Peer::new(3, "a3")],
                 },
             ],
+            region_leaders: HashMap::from([
+                (2, Some(Peer::new(1, "a1"))),
+                (1, Some(Peer::new(2, "a2"))),
+            ]),
         };
 
         let from_raw = TableRoute::try_from_raw(&raw_peers, raw_table_route.clone()).unwrap();

--- a/src/common/meta/src/rpc/router.rs
+++ b/src/common/meta/src/rpc/router.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use api::v1::meta::{
     Partition as PbPartition, Peer as PbPeer, Region as PbRegion, RegionRoute as PbRegionRoute,
@@ -280,7 +280,7 @@ pub struct Region {
     pub id: RegionId,
     pub name: String,
     pub partition: Option<Partition>,
-    pub attrs: HashMap<String, String>,
+    pub attrs: BTreeMap<String, String>,
 }
 
 impl From<PbRegion> for Region {
@@ -289,7 +289,7 @@ impl From<PbRegion> for Region {
             id: r.id.into(),
             name: r.name,
             partition: r.partition.map(Into::into),
-            attrs: r.attrs,
+            attrs: r.attrs.into_iter().collect::<BTreeMap<_, _>>(),
         }
     }
 }
@@ -300,7 +300,7 @@ impl From<Region> for PbRegion {
             id: region.id.into(),
             name: region.name,
             partition: region.partition.map(Into::into),
-            attrs: region.attrs,
+            attrs: region.attrs.into_iter().collect::<HashMap<_, _>>(),
         }
     }
 }
@@ -521,7 +521,7 @@ mod tests {
                         id: 1.into(),
                         name: "r1".to_string(),
                         partition: None,
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: Some(Peer::new(2, "a2")),
                     follower_peers: vec![Peer::new(1, "a1"), Peer::new(3, "a3")],
@@ -531,7 +531,7 @@ mod tests {
                         id: 2.into(),
                         name: "r2".to_string(),
                         partition: None,
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: Some(Peer::new(1, "a1")),
                     follower_peers: vec![Peer::new(2, "a2"), Peer::new(3, "a3")],

--- a/src/common/meta/src/rpc/store.rs
+++ b/src/common/meta/src/rpc/store.rs
@@ -612,9 +612,9 @@ impl TryFrom<PbCompareAndPutResponse> for CompareAndPutResponse {
 }
 
 impl CompareAndPutResponse {
-    pub fn handle<R, E, F>(&self, f: F) -> std::result::Result<R, E>
+    pub fn handle<R, E, F>(self, f: F) -> std::result::Result<R, E>
     where
-        F: FnOnce(&Self) -> std::result::Result<R, E>,
+        F: FnOnce(Self) -> std::result::Result<R, E>,
     {
         f(self)
     }

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -377,7 +377,7 @@ impl PartitionExec {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
@@ -445,7 +445,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: Some(Peer::new(3, "")),
                     follower_peers: vec![],
@@ -462,7 +462,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: Some(Peer::new(2, "")),
                     follower_peers: vec![],
@@ -479,7 +479,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: Some(Peer::new(1, "")),
                     follower_peers: vec![],
@@ -517,7 +517,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: None,
                     follower_peers: vec![],
@@ -537,7 +537,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: None,
                     follower_peers: vec![],
@@ -554,7 +554,7 @@ pub(crate) mod test {
                             .try_into()
                             .unwrap(),
                         ),
-                        attrs: HashMap::new(),
+                        attrs: BTreeMap::new(),
                     },
                     leader_peer: None,
                     follower_peers: vec![],


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Add table route manager (for the new implementation, i.e., `__table_route/{TableId}`)
2. Add table route  upgrade tool

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1986