### PR TITLE
ci: add retry for uploading artifacts to s3

### DIFF
--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -76,20 +76,23 @@ runs:
 
     - name: Upload artifacts to S3
       if: ${{ inputs.upload-to-s3 == 'true' }}
-      working-directory: ${{ inputs.working-dir }}
-      shell: bash
-      # The bucket layout will be:
-      # releases/greptimedb
-      # ├── v0.1.0
-      # │   ├── greptime-darwin-amd64-pyo3-v0.1.0.sha256sum
-      # │   └── greptime-darwin-amd64-pyo3-v0.1.0.tar.gz
-      # └── v0.2.0
-      #    ├── greptime-darwin-amd64-pyo3-v0.2.0.sha256sum
-      #    └── greptime-darwin-amd64-pyo3-v0.2.0.tar.gz
-      run: |
-        aws s3 cp \
-          ${{ inputs.artifacts-dir }}.tar.gz \
-          s3://${{ inputs.release-to-s3-bucket }}/releases/greptimedb/${{ inputs.version }}/${{ inputs.artifacts-dir }}.tar.gz && \
-        aws s3 cp \
-          ${{ inputs.artifacts-dir }}.sha256sum \
-          s3://${{ inputs.release-to-s3-bucket }}/releases/greptimedb/${{ inputs.version }}/${{ inputs.artifacts-dir }}.sha256sum
+      uses: nick-invision/retry@v2
+      with:
+        max_attempts: 20
+        timeout_minutes: 5
+        # The bucket layout will be:
+        # releases/greptimedb
+        # ├── v0.1.0
+        # │   ├── greptime-darwin-amd64-pyo3-v0.1.0.sha256sum
+        # │   └── greptime-darwin-amd64-pyo3-v0.1.0.tar.gz
+        # └── v0.2.0
+        #    ├── greptime-darwin-amd64-pyo3-v0.2.0.sha256sum
+        #    └── greptime-darwin-amd64-pyo3-v0.2.0.tar.gz
+        command: |
+          cd ${{ inputs.working-dir }} && \
+          aws s3 cp \
+            ${{ inputs.artifacts-dir }}.tar.gz \
+            s3://${{ inputs.release-to-s3-bucket }}/releases/greptimedb/${{ inputs.version }}/${{ inputs.artifacts-dir }}.tar.gz && \
+          aws s3 cp \
+            ${{ inputs.artifacts-dir }}.sha256sum \
+            s3://${{ inputs.release-to-s3-bucket }}/releases/greptimedb/${{ inputs.version }}/${{ inputs.artifacts-dir }}.sha256sum


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

ci: add retry for uploading artifacts to s3.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
