### PR TITLE
fix: let information_schema know itself

### DIFF
--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -41,8 +41,8 @@ use crate::information_schema::tables::InformationSchemaTables;
 use crate::table_factory::TableFactory;
 use crate::CatalogManager;
 
-const TABLES: &str = "tables";
-const COLUMNS: &str = "columns";
+pub const TABLES: &str = "tables";
+pub const COLUMNS: &str = "columns";
 
 pub struct InformationSchemaProvider {
     catalog_name: String,

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -58,7 +58,7 @@ impl InformationSchemaProvider {
     }
 
     /// Build a map of [TableRef] in information schema.
-    /// Includeing `tables` and `columns`.
+    /// Including `tables` and `columns`.
     pub fn build(
         catalog_name: String,
         catalog_manager: Weak<dyn CatalogManager>,

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -20,15 +20,19 @@ use std::collections::HashMap;
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
+use common_catalog::consts::{
+    INFORMATION_SCHEMA_COLUMNS_TABLE_ID, INFORMATION_SCHEMA_NAME,
+    INFORMATION_SCHEMA_TABLES_TABLE_ID,
+};
 use common_error::ext::BoxedError;
 use common_recordbatch::{RecordBatchStreamAdaptor, SendableRecordBatchStream};
 use datatypes::schema::SchemaRef;
 use futures_util::StreamExt;
 use snafu::ResultExt;
-use store_api::storage::ScanRequest;
+use store_api::storage::{ScanRequest, TableId};
 use table::data_source::DataSource;
 use table::error::{SchemaConversionSnafu, TablesRecordBatchSnafu};
-use table::metadata::TableType;
+use table::metadata::{TableIdent, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::{Result as TableResult, Table, TableRef};
 
 use self::columns::InformationSchemaColumns;
@@ -61,53 +65,84 @@ impl InformationSchemaProvider {
 
         schema.insert(
             TABLES.to_string(),
-            Arc::new(InformationTable::new(Arc::new(
-                InformationSchemaTables::new(catalog_name.clone(), catalog_manager.clone()),
-            ))) as _,
+            Arc::new(InformationTable::new(
+                catalog_name.clone(),
+                INFORMATION_SCHEMA_TABLES_TABLE_ID,
+                TABLES.to_string(),
+                Arc::new(InformationSchemaTables::new(
+                    catalog_name.clone(),
+                    catalog_manager.clone(),
+                )),
+            )) as _,
         );
         schema.insert(
             COLUMNS.to_string(),
-            Arc::new(InformationTable::new(Arc::new(
-                InformationSchemaColumns::new(catalog_name, catalog_manager),
-            ))) as _,
+            Arc::new(InformationTable::new(
+                catalog_name.clone(),
+                INFORMATION_SCHEMA_COLUMNS_TABLE_ID,
+                COLUMNS.to_string(),
+                Arc::new(InformationSchemaColumns::new(catalog_name, catalog_manager)),
+            )) as _,
         );
 
         schema
     }
 
     pub fn table(&self, name: &str) -> Result<Option<TableRef>> {
-        let stream_builder = match name.to_ascii_lowercase().as_ref() {
-            TABLES => Arc::new(InformationSchemaTables::new(
-                self.catalog_name.clone(),
-                self.catalog_manager.clone(),
-            )) as _,
-            COLUMNS => Arc::new(InformationSchemaColumns::new(
-                self.catalog_name.clone(),
-                self.catalog_manager.clone(),
-            )) as _,
+        let (stream_builder, table_id) = match name.to_ascii_lowercase().as_ref() {
+            TABLES => (
+                Arc::new(InformationSchemaTables::new(
+                    self.catalog_name.clone(),
+                    self.catalog_manager.clone(),
+                )) as _,
+                INFORMATION_SCHEMA_TABLES_TABLE_ID,
+            ),
+            COLUMNS => (
+                Arc::new(InformationSchemaColumns::new(
+                    self.catalog_name.clone(),
+                    self.catalog_manager.clone(),
+                )) as _,
+                INFORMATION_SCHEMA_COLUMNS_TABLE_ID,
+            ),
             _ => {
                 return Ok(None);
             }
         };
 
-        Ok(Some(Arc::new(InformationTable::new(stream_builder))))
+        Ok(Some(Arc::new(InformationTable::new(
+            self.catalog_name.clone(),
+            table_id,
+            name.to_string(),
+            stream_builder,
+        ))))
     }
 
     pub fn table_factory(&self, name: &str) -> Result<Option<TableFactory>> {
-        let stream_builder = match name.to_ascii_lowercase().as_ref() {
-            TABLES => Arc::new(InformationSchemaTables::new(
-                self.catalog_name.clone(),
-                self.catalog_manager.clone(),
-            )) as _,
-            COLUMNS => Arc::new(InformationSchemaColumns::new(
-                self.catalog_name.clone(),
-                self.catalog_manager.clone(),
-            )) as _,
+        let (stream_builder, table_id) = match name.to_ascii_lowercase().as_ref() {
+            TABLES => (
+                Arc::new(InformationSchemaTables::new(
+                    self.catalog_name.clone(),
+                    self.catalog_manager.clone(),
+                )) as _,
+                INFORMATION_SCHEMA_TABLES_TABLE_ID,
+            ),
+            COLUMNS => (
+                Arc::new(InformationSchemaColumns::new(
+                    self.catalog_name.clone(),
+                    self.catalog_manager.clone(),
+                )) as _,
+                INFORMATION_SCHEMA_COLUMNS_TABLE_ID,
+            ),
             _ => {
                 return Ok(None);
             }
         };
-        let data_source = Arc::new(InformationTable::new(stream_builder));
+        let data_source = Arc::new(InformationTable::new(
+            self.catalog_name.clone(),
+            table_id,
+            name.to_string(),
+            stream_builder,
+        ));
 
         Ok(Some(Arc::new(move || data_source.clone())))
     }
@@ -122,12 +157,25 @@ pub trait InformationStreamBuilder: Send + Sync {
 }
 
 pub struct InformationTable {
+    catalog_name: String,
+    table_id: TableId,
+    name: String,
     stream_builder: Arc<dyn InformationStreamBuilder>,
 }
 
 impl InformationTable {
-    pub fn new(stream_builder: Arc<dyn InformationStreamBuilder>) -> Self {
-        Self { stream_builder }
+    pub fn new(
+        catalog_name: String,
+        table_id: TableId,
+        name: String,
+        stream_builder: Arc<dyn InformationStreamBuilder>,
+    ) -> Self {
+        Self {
+            catalog_name,
+            table_id,
+            name,
+            stream_builder,
+        }
     }
 }
 
@@ -142,7 +190,26 @@ impl Table for InformationTable {
     }
 
     fn table_info(&self) -> table::metadata::TableInfoRef {
-        unreachable!("Should not call table_info() of InformationTable directly")
+        let table_meta = TableMetaBuilder::default()
+            .schema(self.stream_builder.schema())
+            .primary_key_indices(vec![])
+            .next_column_id(0)
+            .build()
+            .unwrap();
+        Arc::new(
+            TableInfoBuilder::default()
+                .ident(TableIdent {
+                    table_id: self.table_id,
+                    version: 0,
+                })
+                .name(self.name.clone())
+                .catalog_name(self.catalog_name.clone())
+                .schema_name(INFORMATION_SCHEMA_NAME.to_string())
+                .meta(table_meta)
+                .table_type(TableType::Temporary)
+                .build()
+                .unwrap(),
+        )
     }
 
     fn table_type(&self) -> TableType {

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -57,7 +57,9 @@ impl InformationSchemaProvider {
         }
     }
 
-    pub fn build_information_schema(
+    /// Build a map of [TableRef] in information schema.
+    /// Includeing `tables` and `columns`.
+    pub fn build(
         catalog_name: String,
         catalog_manager: Weak<dyn CatalogManager>,
     ) -> HashMap<String, TableRef> {

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -15,6 +15,10 @@
 use std::sync::{Arc, Weak};
 
 use arrow_schema::SchemaRef as ArrowSchemaRef;
+use common_catalog::consts::{
+    INFORMATION_SCHEMA_COLUMNS_TABLE_ID, INFORMATION_SCHEMA_NAME,
+    INFORMATION_SCHEMA_TABLES_TABLE_ID,
+};
 use common_error::ext::BoxedError;
 use common_query::physical_plan::TaskContext;
 use common_recordbatch::adapter::RecordBatchStreamAdapter;
@@ -28,6 +32,7 @@ use datatypes::vectors::{StringVectorBuilder, UInt32VectorBuilder};
 use snafu::{OptionExt, ResultExt};
 use table::metadata::TableType;
 
+use super::{COLUMNS, TABLES};
 use crate::error::{
     CreateRecordBatchSnafu, InternalSnafu, Result, UpgradeWeakCatalogManagerRefSnafu,
 };
@@ -42,19 +47,22 @@ pub(super) struct InformationSchemaTables {
 
 impl InformationSchemaTables {
     pub(super) fn new(catalog_name: String, catalog_manager: Weak<dyn CatalogManager>) -> Self {
-        let schema = Arc::new(Schema::new(vec![
+        Self {
+            schema: Self::schema(),
+            catalog_name,
+            catalog_manager,
+        }
+    }
+
+    pub(crate) fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
             ColumnSchema::new("table_catalog", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_schema", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_name", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_type", ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_id", ConcreteDataType::uint32_datatype(), true),
             ColumnSchema::new("engine", ConcreteDataType::string_datatype(), true),
-        ]));
-        Self {
-            schema,
-            catalog_name,
-            catalog_manager,
-        }
+        ]))
     }
 
     fn builder(&self) -> InformationSchemaTablesBuilder {
@@ -147,21 +155,43 @@ impl InformationSchemaTablesBuilder {
                 .table_names(&catalog_name, &schema_name)
                 .await?
             {
-                let Some(table) = catalog_manager
+                if let Some(table) = catalog_manager
                     .table(&catalog_name, &schema_name, &table_name)
                     .await?
-                else {
-                    continue;
+                {
+                    let table_info = table.table_info();
+                    self.add_table(
+                        &catalog_name,
+                        &schema_name,
+                        &table_name,
+                        table.table_type(),
+                        Some(table_info.ident.table_id),
+                        Some(&table_info.meta.engine),
+                    );
+                } else {
+                    // TODO: this specific branch is only a workaround for FrontendCatalogManager.
+                    if schema_name == INFORMATION_SCHEMA_NAME {
+                        if table_name == COLUMNS {
+                            self.add_table(
+                                &catalog_name,
+                                &schema_name,
+                                &table_name,
+                                TableType::Temporary,
+                                Some(INFORMATION_SCHEMA_COLUMNS_TABLE_ID),
+                                None,
+                            );
+                        } else if table_name == TABLES {
+                            self.add_table(
+                                &catalog_name,
+                                &schema_name,
+                                &table_name,
+                                TableType::Temporary,
+                                Some(INFORMATION_SCHEMA_TABLES_TABLE_ID),
+                                None,
+                            );
+                        }
+                    }
                 };
-                let table_info = table.table_info();
-                self.add_table(
-                    &catalog_name,
-                    &schema_name,
-                    &table_name,
-                    table.table_type(),
-                    Some(table_info.ident.table_id),
-                    Some(&table_info.meta.engine),
-                );
             }
         }
 

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -15,7 +15,6 @@
 use std::sync::{Arc, Weak};
 
 use arrow_schema::SchemaRef as ArrowSchemaRef;
-use common_catalog::consts::INFORMATION_SCHEMA_NAME;
 use common_error::ext::BoxedError;
 use common_query::physical_plan::TaskContext;
 use common_recordbatch::adapter::RecordBatchStreamAdapter;
@@ -137,9 +136,6 @@ impl InformationSchemaTablesBuilder {
             .context(UpgradeWeakCatalogManagerRefSnafu)?;
 
         for schema_name in catalog_manager.schema_names(&catalog_name).await? {
-            if schema_name == INFORMATION_SCHEMA_NAME {
-                continue;
-            }
             if !catalog_manager
                 .schema_exist(&catalog_name, &schema_name)
                 .await?

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -49,7 +49,7 @@ pub trait CatalogManager: Send + Sync {
     async fn start(&self) -> Result<()>;
 
     /// Registers a catalog to catalog manager, returns whether the catalog exist before.
-    async fn register_catalog(&self, name: String) -> Result<bool>;
+    async fn register_catalog(self: Arc<Self>, name: String) -> Result<bool>;
 
     /// Register a schema with catalog name and schema name. Retuens whether the
     /// schema registered.

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -43,7 +43,6 @@ use crate::error::{
     SystemCatalogTypeMismatchSnafu, TableEngineNotFoundSnafu, TableExistsSnafu, TableNotExistSnafu,
     TableNotFoundSnafu, UnimplementedSnafu,
 };
-use crate::information_schema::InformationSchemaProvider;
 use crate::local::memory::MemoryCatalogManager;
 use crate::system::{
     decode_system_catalog, Entry, SystemCatalogTable, TableEntry, ENTRY_TYPE_INDEX, KEY_INDEX,
@@ -51,9 +50,8 @@ use crate::system::{
 };
 use crate::tables::SystemCatalog;
 use crate::{
-    handle_system_table_request, CatalogManager, CatalogManagerRef, DeregisterSchemaRequest,
-    DeregisterTableRequest, RegisterSchemaRequest, RegisterSystemTableRequest,
-    RegisterTableRequest, RenameTableRequest,
+    handle_system_table_request, CatalogManager, DeregisterSchemaRequest, DeregisterTableRequest,
+    RegisterSchemaRequest, RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
 };
 
 /// A `CatalogManager` consists of a system catalog and a bunch of user catalogs.
@@ -547,13 +545,6 @@ impl CatalogManager for LocalCatalogManager {
         schema_name: &str,
         table_name: &str,
     ) -> Result<Option<TableRef>> {
-        if schema_name == INFORMATION_SCHEMA_NAME {
-            let manager: CatalogManagerRef = self.catalogs.clone() as _;
-            let provider =
-                InformationSchemaProvider::new(catalog_name.to_string(), Arc::downgrade(&manager));
-            return provider.table(table_name);
-        }
-
         self.catalogs
             .table(catalog_name, schema_name, table_name)
             .await

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -230,9 +230,8 @@ impl LocalCatalogManager {
         for entry in entries {
             match entry {
                 Entry::Catalog(c) => {
-                    let _ = self
-                        .catalogs
-                        .register_catalog_if_absent(c.catalog_name.clone());
+                    self.catalogs
+                        .register_catalog_sync(c.catalog_name.clone())?;
                     info!("Register catalog: {}", c.catalog_name);
                 }
                 Entry::Schema(s) => {

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -118,7 +118,6 @@ impl LocalCatalogManager {
     async fn init_system_catalog(&self) -> Result<()> {
         // register default catalog and default schema
         self.catalogs
-            .clone()
             .register_catalog_sync(DEFAULT_CATALOG_NAME.to_string())?;
         self.catalogs.register_schema_sync(RegisterSchemaRequest {
             catalog: DEFAULT_CATALOG_NAME.to_string(),
@@ -127,7 +126,6 @@ impl LocalCatalogManager {
 
         // register SystemCatalogTable
         self.catalogs
-            .clone()
             .register_catalog_sync(SYSTEM_CATALOG_NAME.to_string())?;
         self.catalogs.register_schema_sync(RegisterSchemaRequest {
             catalog: SYSTEM_CATALOG_NAME.to_string(),
@@ -228,7 +226,6 @@ impl LocalCatalogManager {
             match entry {
                 Entry::Catalog(c) => {
                     self.catalogs
-                        .clone()
                         .register_catalog_sync(c.catalog_name.clone())?;
                     info!("Register catalog: {}", c.catalog_name);
                 }

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -16,9 +16,11 @@ use std::any::Any;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, Weak};
 
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MIN_USER_TABLE_ID};
+use common_catalog::consts::{
+    DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME, MIN_USER_TABLE_ID,
+};
 use metrics::{decrement_gauge, increment_gauge};
 use snafu::OptionExt;
 use table::metadata::TableId;
@@ -28,6 +30,7 @@ use table::TableRef;
 use crate::error::{
     CatalogNotFoundSnafu, Result, SchemaNotFoundSnafu, TableExistsSnafu, TableNotFoundSnafu,
 };
+use crate::information_schema::InformationSchemaProvider;
 use crate::{
     CatalogManager, DeregisterSchemaRequest, DeregisterTableRequest, RegisterSchemaRequest,
     RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
@@ -40,24 +43,6 @@ pub struct MemoryCatalogManager {
     /// Collection of catalogs containing schemas and ultimately Tables
     pub catalogs: RwLock<HashMap<String, SchemaEntries>>,
     pub table_id: AtomicU32,
-}
-
-impl Default for MemoryCatalogManager {
-    fn default() -> Self {
-        let manager = Self {
-            table_id: AtomicU32::new(MIN_USER_TABLE_ID),
-            catalogs: Default::default(),
-        };
-
-        let catalog = HashMap::from([(DEFAULT_SCHEMA_NAME.to_string(), HashMap::new())]);
-        let _ = manager
-            .catalogs
-            .write()
-            .unwrap()
-            .insert(DEFAULT_CATALOG_NAME.to_string(), catalog);
-
-        manager
-    }
 }
 
 #[async_trait::async_trait]
@@ -250,7 +235,7 @@ impl CatalogManager for MemoryCatalogManager {
             .collect())
     }
 
-    async fn register_catalog(&self, name: String) -> Result<bool> {
+    async fn register_catalog(self: Arc<Self>, name: String) -> Result<bool> {
         self.register_catalog_sync(name)
     }
 
@@ -260,6 +245,27 @@ impl CatalogManager for MemoryCatalogManager {
 }
 
 impl MemoryCatalogManager {
+    pub fn default() -> Arc<Self> {
+        let manager = Arc::new(Self {
+            table_id: AtomicU32::new(MIN_USER_TABLE_ID),
+            catalogs: Default::default(),
+        });
+
+        // Safety: default catalog/schema is registerd in order so no CatalogNotFound error will occur
+        manager
+            .clone()
+            .register_catalog_sync(DEFAULT_CATALOG_NAME.to_string())
+            .unwrap();
+        manager
+            .register_schema_sync(RegisterSchemaRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_SCHEMA_NAME.to_string(),
+            })
+            .unwrap();
+
+        manager
+    }
+
     /// Registers a catalog and return the catalog already exist
     pub fn register_catalog_if_absent(&self, name: String) -> bool {
         let mut catalogs = self.catalogs.write().unwrap();
@@ -273,12 +279,13 @@ impl MemoryCatalogManager {
         }
     }
 
-    pub fn register_catalog_sync(&self, name: String) -> Result<bool> {
+    pub fn register_catalog_sync(self: Arc<Self>, name: String) -> Result<bool> {
         let mut catalogs = self.catalogs.write().unwrap();
 
-        match catalogs.entry(name) {
+        match catalogs.entry(name.clone()) {
             Entry::Vacant(e) => {
-                e.insert(HashMap::new());
+                let catalog = self.clone().create_catalog_entry(name.clone());
+                e.insert(catalog);
                 increment_gauge!(crate::metrics::METRIC_CATALOG_MANAGER_CATALOG_COUNT, 1.0);
                 Ok(true)
             }
@@ -332,8 +339,18 @@ impl MemoryCatalogManager {
         Ok(true)
     }
 
+    fn create_catalog_entry(self: Arc<Self>, catalog: String) -> SchemaEntries {
+        let information_schema = InformationSchemaProvider::build_information_schema(
+            catalog.clone(),
+            Arc::downgrade(&self) as Weak<dyn CatalogManager>,
+        );
+        let mut catalog = HashMap::new();
+        catalog.insert(INFORMATION_SCHEMA_NAME.to_string(), information_schema);
+        catalog
+    }
+
     #[cfg(any(test, feature = "testing"))]
-    pub fn new_with_table(table: TableRef) -> Self {
+    pub fn new_with_table(table: TableRef) -> Arc<Self> {
         let manager = Self::default();
         let request = RegisterTableRequest {
             catalog: DEFAULT_CATALOG_NAME.to_string(),
@@ -349,7 +366,7 @@ impl MemoryCatalogManager {
 
 /// Create a memory catalog list contains a numbers table for test
 pub fn new_memory_catalog_manager() -> Result<Arc<MemoryCatalogManager>> {
-    Ok(Arc::new(MemoryCatalogManager::default()))
+    Ok(MemoryCatalogManager::default())
 }
 
 #[cfg(test)]
@@ -567,6 +584,7 @@ mod tests {
             table: Arc::new(NumbersTable::default()),
         };
         catalog
+            .clone()
             .register_catalog(catalog_name.clone())
             .await
             .unwrap();

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -245,6 +245,8 @@ impl CatalogManager for MemoryCatalogManager {
 }
 
 impl MemoryCatalogManager {
+    /// Yes this is the `default()` constructor
+    #[allow(clippy::should_implement_trait)]
     pub fn default() -> Arc<Self> {
         let manager = Arc::new(Self {
             table_id: AtomicU32::new(MIN_USER_TABLE_ID),

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -245,9 +245,9 @@ impl CatalogManager for MemoryCatalogManager {
 }
 
 impl MemoryCatalogManager {
-    /// Yes this is the `default()` constructor
-    #[allow(clippy::should_implement_trait)]
-    pub fn default() -> Arc<Self> {
+    /// Create a manager with some default setups
+    /// (e.g. default catalog/schema and information schema)
+    pub fn with_default_setup() -> Arc<Self> {
         let manager = Arc::new(Self {
             table_id: AtomicU32::new(MIN_USER_TABLE_ID),
             catalogs: Default::default(),
@@ -353,7 +353,7 @@ impl MemoryCatalogManager {
 
     #[cfg(any(test, feature = "testing"))]
     pub fn new_with_table(table: TableRef) -> Arc<Self> {
-        let manager = Self::default();
+        let manager = Self::with_default_setup();
         let request = RegisterTableRequest {
             catalog: DEFAULT_CATALOG_NAME.to_string(),
             schema: DEFAULT_SCHEMA_NAME.to_string(),
@@ -368,7 +368,7 @@ impl MemoryCatalogManager {
 
 /// Create a memory catalog list contains a numbers table for test
 pub fn new_memory_catalog_manager() -> Result<Arc<MemoryCatalogManager>> {
-    Ok(MemoryCatalogManager::default())
+    Ok(MemoryCatalogManager::with_default_setup())
 }
 
 #[cfg(test)]
@@ -411,7 +411,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mem_manager_rename_table() {
-        let catalog = MemoryCatalogManager::default();
+        let catalog = MemoryCatalogManager::with_default_setup();
         let table_name = "test_table";
         assert!(!catalog
             .table_exist(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, table_name)
@@ -475,7 +475,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog_rename_table() {
-        let catalog = MemoryCatalogManager::default();
+        let catalog = MemoryCatalogManager::with_default_setup();
         let table_name = "num";
         let table_id = 2333;
         let table: TableRef = Arc::new(NumbersTable::new(table_id));
@@ -526,14 +526,14 @@ mod tests {
 
     #[test]
     pub fn test_register_if_absent() {
-        let list = MemoryCatalogManager::default();
+        let list = MemoryCatalogManager::with_default_setup();
         assert!(!list.register_catalog_if_absent("test_catalog".to_string(),));
         assert!(list.register_catalog_if_absent("test_catalog".to_string()));
     }
 
     #[tokio::test]
     pub async fn test_catalog_deregister_table() {
-        let catalog = MemoryCatalogManager::default();
+        let catalog = MemoryCatalogManager::with_default_setup();
         let table_name = "foo_table";
 
         let register_table_req = RegisterTableRequest {
@@ -568,7 +568,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog_deregister_schema() {
-        let catalog = MemoryCatalogManager::default();
+        let catalog = MemoryCatalogManager::with_default_setup();
 
         // Registers a catalog, a schema, and a table.
         let catalog_name = "foo_catalog".to_string();

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -342,7 +342,7 @@ impl MemoryCatalogManager {
     }
 
     fn create_catalog_entry(self: Arc<Self>, catalog: String) -> SchemaEntries {
-        let information_schema = InformationSchemaProvider::build_information_schema(
+        let information_schema = InformationSchemaProvider::build(
             catalog.clone(),
             Arc::downgrade(&self) as Weak<dyn CatalogManager>,
         );

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -253,7 +253,7 @@ impl MemoryCatalogManager {
             catalogs: Default::default(),
         });
 
-        // Safety: default catalog/schema is registerd in order so no CatalogNotFound error will occur
+        // Safety: default catalog/schema is registered in order so no CatalogNotFound error will occur
         manager
             .clone()
             .register_catalog_sync(DEFAULT_CATALOG_NAME.to_string())

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -180,9 +180,7 @@ async fn open_and_register_table(
         .catalog_exist(&table_ident.catalog)
         .await?
     {
-        memory_catalog_manager
-            .clone()
-            .register_catalog_sync(table_ident.catalog.clone())?;
+        memory_catalog_manager.register_catalog_sync(table_ident.catalog.clone())?;
     }
 
     if !memory_catalog_manager
@@ -427,9 +425,7 @@ impl CatalogManager for RemoteCatalogManager {
     }
 
     async fn register_catalog(self: Arc<Self>, name: String) -> Result<bool> {
-        self.memory_catalog_manager
-            .clone()
-            .register_catalog_sync(name)
+        self.memory_catalog_manager.register_catalog_sync(name)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -67,7 +67,7 @@ impl RemoteCatalogManager {
             backend,
             system_table_requests: Default::default(),
             region_alive_keepers,
-            memory_catalog_manager: MemoryCatalogManager::default(),
+            memory_catalog_manager: MemoryCatalogManager::with_default_setup(),
             table_metadata_manager,
         }
     }

--- a/src/catalog/src/table_source.rs
+++ b/src/catalog/src/table_source.rs
@@ -130,7 +130,7 @@ mod tests {
         let query_ctx = &QueryContext::with("greptime", "public");
 
         let table_provider =
-            DfTableSourceProvider::new(MemoryCatalogManager::default(), true, query_ctx);
+            DfTableSourceProvider::new(MemoryCatalogManager::with_default_setup(), true, query_ctx);
 
         let table_ref = TableReference::Bare {
             table: Cow::Borrowed("table_name"),

--- a/src/catalog/src/table_source.rs
+++ b/src/catalog/src/table_source.rs
@@ -130,7 +130,7 @@ mod tests {
         let query_ctx = &QueryContext::with("greptime", "public");
 
         let table_provider =
-            DfTableSourceProvider::new(Arc::new(MemoryCatalogManager::default()), true, query_ctx);
+            DfTableSourceProvider::new(MemoryCatalogManager::default(), true, query_ctx);
 
         let table_ref = TableReference::Bare {
             table: Cow::Borrowed("table_name"),

--- a/src/catalog/tests/remote_catalog_tests.rs
+++ b/src/catalog/tests/remote_catalog_tests.rs
@@ -309,6 +309,7 @@ mod tests {
         // register catalog to catalog manager
         assert!(components
             .catalog_manager
+            .clone()
             .register_catalog(catalog_name.clone())
             .await
             .is_ok());

--- a/src/catalog/tests/remote_catalog_tests.rs
+++ b/src/catalog/tests/remote_catalog_tests.rs
@@ -26,7 +26,9 @@ mod tests {
     use catalog::remote::region_alive_keeper::RegionAliveKeepers;
     use catalog::remote::{CachedMetaKvBackend, RemoteCatalogManager};
     use catalog::{CatalogManager, RegisterSchemaRequest, RegisterTableRequest};
-    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MITO_ENGINE};
+    use common_catalog::consts::{
+        DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME, MITO_ENGINE,
+    };
     use common_meta::helper::{CatalogKey, CatalogValue, SchemaKey, SchemaValue};
     use common_meta::ident::TableIdent;
     use common_meta::key::TableMetadataManager;
@@ -179,12 +181,17 @@ mod tests {
             catalog_manager.catalog_names().await.unwrap()
         );
 
+        let mut schema_names = catalog_manager
+            .schema_names(DEFAULT_CATALOG_NAME)
+            .await
+            .unwrap();
+        schema_names.sort_unstable();
         assert_eq!(
-            vec![DEFAULT_SCHEMA_NAME.to_string()],
-            catalog_manager
-                .schema_names(DEFAULT_CATALOG_NAME)
-                .await
-                .unwrap()
+            vec![
+                INFORMATION_SCHEMA_NAME.to_string(),
+                DEFAULT_SCHEMA_NAME.to_string()
+            ],
+            schema_names
         );
     }
 
@@ -240,13 +247,18 @@ mod tests {
     async fn test_register_table() {
         let node_id = 42;
         let components = prepare_components(node_id).await;
+        let mut schema_names = components
+            .catalog_manager
+            .schema_names(DEFAULT_CATALOG_NAME)
+            .await
+            .unwrap();
+        schema_names.sort_unstable();
         assert_eq!(
-            vec![DEFAULT_SCHEMA_NAME.to_string()],
-            components
-                .catalog_manager
-                .schema_names(DEFAULT_CATALOG_NAME)
-                .await
-                .unwrap()
+            vec![
+                INFORMATION_SCHEMA_NAME.to_string(),
+                DEFAULT_SCHEMA_NAME.to_string(),
+            ],
+            schema_names
         );
 
         // register a new table with an nonexistent catalog
@@ -375,7 +387,7 @@ mod tests {
             .unwrap());
 
         assert_eq!(
-            HashSet::from([schema_name.clone()]),
+            HashSet::from([schema_name.clone(), INFORMATION_SCHEMA_NAME.to_string()]),
             components
                 .catalog_manager
                 .schema_names(&catalog_name)

--- a/src/common/catalog/src/consts.rs
+++ b/src/common/catalog/src/consts.rs
@@ -29,6 +29,10 @@ pub const SYSTEM_CATALOG_TABLE_ID: u32 = 0;
 pub const SCRIPTS_TABLE_ID: u32 = 1;
 /// numbers table id
 pub const NUMBERS_TABLE_ID: u32 = 2;
+/// id for information_schema.tables
+pub const INFORMATION_SCHEMA_TABLES_TABLE_ID: u32 = 3;
+/// id for information_schema.columns
+pub const INFORMATION_SCHEMA_COLUMNS_TABLE_ID: u32 = 4;
 
 pub const MITO_ENGINE: &str = "mito";
 pub const IMMUTABLE_FILE_ENGINE: &str = "file";

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -208,7 +208,7 @@ impl Instance {
         let (catalog_manager, table_id_provider, region_alive_keepers) = match opts.mode {
             Mode::Standalone => {
                 if opts.enable_memory_catalog {
-                    let catalog = catalog::local::MemoryCatalogManager::default();
+                    let catalog = catalog::local::MemoryCatalogManager::with_default_setup();
                     let table = NumbersTable::new(MIN_USER_TABLE_ID);
 
                     let _ = catalog

--- a/src/datanode/src/instance.rs
+++ b/src/datanode/src/instance.rs
@@ -208,7 +208,7 @@ impl Instance {
         let (catalog_manager, table_id_provider, region_alive_keepers) = match opts.mode {
             Mode::Standalone => {
                 if opts.enable_memory_catalog {
-                    let catalog = Arc::new(catalog::local::MemoryCatalogManager::default());
+                    let catalog = catalog::local::MemoryCatalogManager::default();
                     let table = NumbersTable::new(MIN_USER_TABLE_ID);
 
                     let _ = catalog

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -379,10 +379,8 @@ impl CatalogManager for FrontendCatalogManager {
     }
 
     async fn table_exist(&self, catalog: &str, schema: &str, table: &str) -> CatalogResult<bool> {
-        if schema == INFORMATION_SCHEMA_NAME {
-            if table == TABLES || table == COLUMNS {
-                return Ok(true);
-            }
+        if schema == INFORMATION_SCHEMA_NAME && (table == TABLES || table == COLUMNS) {
+            return Ok(true);
         }
 
         let key = TableNameKey::new(catalog, schema, table);

--- a/src/frontend/src/catalog.rs
+++ b/src/frontend/src/catalog.rs
@@ -160,7 +160,7 @@ impl CatalogManager for FrontendCatalogManager {
         Ok(())
     }
 
-    async fn register_catalog(&self, _name: String) -> CatalogResult<bool> {
+    async fn register_catalog(self: Arc<Self>, _name: String) -> CatalogResult<bool> {
         unimplemented!("FrontendCatalogManager does not support registering catalog")
     }
 

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -79,7 +79,7 @@ const MAX_VALUE: &str = "MAXVALUE";
 #[derive(Clone)]
 pub struct DistInstance {
     meta_client: Arc<MetaClient>,
-    catalog_manager: Arc<FrontendCatalogManager>,
+    pub(crate) catalog_manager: Arc<FrontendCatalogManager>,
     datanode_clients: Arc<DatanodeClients>,
 }
 

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -1389,7 +1389,7 @@ mod test {
             .build()
             .unwrap();
         let table = Arc::new(EmptyTable::from_table_info(&table_info));
-        let catalog_list = MemoryCatalogManager::default();
+        let catalog_list = MemoryCatalogManager::with_default_setup();
         assert!(catalog_list
             .register_table(RegisterTableRequest {
                 catalog: DEFAULT_CATALOG_NAME.to_string(),

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -1389,7 +1389,7 @@ mod test {
             .build()
             .unwrap();
         let table = Arc::new(EmptyTable::from_table_info(&table_info));
-        let catalog_list = Arc::new(MemoryCatalogManager::default());
+        let catalog_list = MemoryCatalogManager::default();
         assert!(catalog_list
             .register_table(RegisterTableRequest {
                 catalog: DEFAULT_CATALOG_NAME.to_string(),

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use catalog::CatalogManagerRef;
 use client::client_manager::DatanodeClients;
 use common_base::bytes::Bytes;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME};
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_meta::peer::Peer;
 use common_meta::table_name::TableName;
 use datafusion::common::Result;
@@ -92,13 +92,6 @@ impl ExtensionPlanner for DistExtensionPlanner {
                     // no relation found in input plan, going to execute them locally
                     return Ok(Some(input_physical_plan));
                 };
-
-                if table_name.schema_name == INFORMATION_SCHEMA_NAME {
-                    return planner
-                        .create_physical_plan(input_plan, session_state)
-                        .await
-                        .map(Some);
-                }
 
                 let input_schema = input_physical_plan.schema().clone();
                 let input_plan = self.set_table_name(&table_name, input_plan.clone())?;

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -379,7 +379,7 @@ mod test {
             .build()
             .unwrap();
         let table = Arc::new(EmptyTable::from_table_info(&table_info));
-        let catalog_list = MemoryCatalogManager::default();
+        let catalog_list = MemoryCatalogManager::with_default_setup();
         assert!(catalog_list
             .register_table(RegisterTableRequest {
                 catalog: DEFAULT_CATALOG_NAME.to_string(),

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -379,7 +379,7 @@ mod test {
             .build()
             .unwrap();
         let table = Arc::new(EmptyTable::from_table_info(&table_info));
-        let catalog_list = Arc::new(MemoryCatalogManager::default());
+        let catalog_list = MemoryCatalogManager::default();
         assert!(catalog_list
             .register_table(RegisterTableRequest {
                 catalog: DEFAULT_CATALOG_NAME.to_string(),

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod show;
+mod show_create_table;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -185,7 +185,7 @@ pub async fn show_tables(
 pub fn show_create_table(table: TableRef, partitions: Option<Partitions>) -> Result<Output> {
     let table_info = table.table_info();
     let table_name = &table_info.name;
-    let mut stmt = show::create_table_stmt(&table_info)?;
+    let mut stmt = show_create_table::create_table_stmt(&table_info)?;
     stmt.partitions = partitions;
     let sql = format!("{}", stmt);
     let columns = vec![

--- a/src/query/src/sql/show_create_table.rs
+++ b/src/query/src/sql/show_create_table.rs
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+//! Implementation of `SHOW CREATE TABLE` statement.
+
 use std::fmt::Display;
 
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, SchemaRef, COMMENT_KEY};

--- a/src/query/src/tests.rs
+++ b/src/query/src/tests.rs
@@ -52,7 +52,7 @@ async fn exec_selection(engine: QueryEngineRef, sql: &str) -> Vec<RecordBatch> {
 
 pub fn new_query_engine_with_table(table: MemTable) -> QueryEngineRef {
     let table = Arc::new(table);
-    let catalog_manager = Arc::new(MemoryCatalogManager::new_with_table(table));
+    let catalog_manager = MemoryCatalogManager::new_with_table(table);
 
     QueryEngineFactory::new(catalog_manager, false).query_engine()
 }

--- a/src/script/benches/py_benchmark.rs
+++ b/src/script/benches/py_benchmark.rs
@@ -49,9 +49,7 @@ where
 }
 
 pub(crate) fn sample_script_engine() -> PyEngine {
-    let catalog_manager = Arc::new(MemoryCatalogManager::new_with_table(Arc::new(
-        NumbersTable::default(),
-    )));
+    let catalog_manager = MemoryCatalogManager::new_with_table(Arc::new(NumbersTable::default()));
     let query_engine = QueryEngineFactory::new(catalog_manager, false).query_engine();
 
     PyEngine::new(query_engine.clone())

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -369,9 +369,8 @@ mod tests {
     use super::*;
 
     pub(crate) fn sample_script_engine() -> PyEngine {
-        let catalog_manager = Arc::new(MemoryCatalogManager::new_with_table(Arc::new(
-            NumbersTable::default(),
-        )));
+        let catalog_manager =
+            MemoryCatalogManager::new_with_table(Arc::new(NumbersTable::default()));
         let query_engine = QueryEngineFactory::new(catalog_manager, false).query_engine();
 
         PyEngine::new(query_engine.clone())

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -202,7 +202,7 @@ impl GrpcQueryHandler for DummyInstance {
 
 fn create_testing_instance(table: MemTable) -> DummyInstance {
     let table = Arc::new(table);
-    let catalog_manager = Arc::new(MemoryCatalogManager::new_with_table(table));
+    let catalog_manager = MemoryCatalogManager::new_with_table(table);
     let query_engine = QueryEngineFactory::new(catalog_manager, false).query_engine();
     DummyInstance::new(query_engine)
 }

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -83,7 +83,7 @@ impl TestEnv {
         let state_store = Arc::new(ObjectStateStore::new(object_store));
         let procedure_manager = Arc::new(LocalManager::new(config, state_store));
 
-        let catalog_manager = MemoryCatalogManager::default();
+        let catalog_manager = MemoryCatalogManager::with_default_setup();
 
         TestEnv {
             dir,

--- a/src/table-procedure/src/test_util.rs
+++ b/src/table-procedure/src/test_util.rs
@@ -83,7 +83,7 @@ impl TestEnv {
         let state_store = Arc::new(ObjectStateStore::new(object_store));
         let procedure_manager = Arc::new(LocalManager::new(config, state_store));
 
-        let catalog_manager = Arc::new(MemoryCatalogManager::default());
+        let catalog_manager = MemoryCatalogManager::default();
 
         TestEnv {
             dir,

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -86,6 +86,7 @@ pub(crate) async fn create_standalone_instance(test_name: &str) -> MockStandalon
 
     assert!(dn_instance
         .catalog_manager()
+        .clone()
         .register_catalog("another_catalog".to_string())
         .await
         .is_ok());

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -1402,12 +1402,14 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
         }
         false => {
             "\
-+---------------+--------------+------------+-----------------+----------+-------------+
-| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
-+---------------+--------------+------------+-----------------+----------+-------------+
-| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
-| greptime      | public       | scripts    | BASE TABLE      | 1        | mito        |
-+---------------+--------------+------------+-----------------+----------+-------------+"
++---------------+--------------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema       | table_name | table_type      | table_id | engine      |
++---------------+--------------------+------------+-----------------+----------+-------------+
+| greptime      | information_schema | columns    | LOCAL TEMPORARY | 4        |             |
+| greptime      | public             | numbers    | LOCAL TEMPORARY | 2        | test_engine |
+| greptime      | public             | scripts    | BASE TABLE      | 1        | mito        |
+| greptime      | information_schema | tables     | LOCAL TEMPORARY | 3        |             |
++---------------+--------------------+------------+-----------------+----------+-------------+"
         }
     };
 
@@ -1425,11 +1427,13 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
         }
         false => {
             "\
-+-----------------+----------------+---------------+------------+----------+--------+
-| table_catalog   | table_schema   | table_name    | table_type | table_id | engine |
-+-----------------+----------------+---------------+------------+----------+--------+
-| another_catalog | another_schema | another_table | BASE TABLE | 1024     | mito   |
-+-----------------+----------------+---------------+------------+----------+--------+"
++-----------------+--------------------+---------------+-----------------+----------+--------+
+| table_catalog   | table_schema       | table_name    | table_type      | table_id | engine |
++-----------------+--------------------+---------------+-----------------+----------+--------+
+| another_catalog | another_schema     | another_table | BASE TABLE      | 1024     | mito   |
+| another_catalog | information_schema | columns       | LOCAL TEMPORARY | 4        |        |
+| another_catalog | information_schema | tables        | LOCAL TEMPORARY | 3        |        |
++-----------------+--------------------+---------------+-----------------+----------+--------+"
         }
     };
     check_output_stream(output, expected).await;
@@ -1450,28 +1454,52 @@ async fn test_information_schema_dot_columns(instance: Arc<dyn MockInstance>) {
 
     let output = execute_sql(&instance, sql).await;
     let expected = "\
-+---------------+--------------+------------+--------------+----------------------+---------------+
-| table_catalog | table_schema | table_name | column_name  | data_type            | semantic_type |
-+---------------+--------------+------------+--------------+----------------------+---------------+
-| greptime      | public       | numbers    | number       | UInt32               | PRIMARY KEY   |
-| greptime      | public       | scripts    | schema       | String               | PRIMARY KEY   |
-| greptime      | public       | scripts    | name         | String               | PRIMARY KEY   |
-| greptime      | public       | scripts    | script       | String               | FIELD         |
-| greptime      | public       | scripts    | engine       | String               | FIELD         |
-| greptime      | public       | scripts    | timestamp    | TimestampMillisecond | TIME INDEX    |
-| greptime      | public       | scripts    | gmt_created  | TimestampMillisecond | FIELD         |
-| greptime      | public       | scripts    | gmt_modified | TimestampMillisecond | FIELD         |
-+---------------+--------------+------------+--------------+----------------------+---------------+";
++---------------+--------------------+------------+---------------+----------------------+---------------+
+| table_catalog | table_schema       | table_name | column_name   | data_type            | semantic_type |
++---------------+--------------------+------------+---------------+----------------------+---------------+
+| greptime      | information_schema | columns    | table_catalog | String               | FIELD         |
+| greptime      | information_schema | columns    | table_schema  | String               | FIELD         |
+| greptime      | information_schema | columns    | table_name    | String               | FIELD         |
+| greptime      | information_schema | columns    | column_name   | String               | FIELD         |
+| greptime      | information_schema | columns    | data_type     | String               | FIELD         |
+| greptime      | information_schema | columns    | semantic_type | String               | FIELD         |
+| greptime      | public             | numbers    | number        | UInt32               | PRIMARY KEY   |
+| greptime      | public             | scripts    | schema        | String               | PRIMARY KEY   |
+| greptime      | public             | scripts    | name          | String               | PRIMARY KEY   |
+| greptime      | public             | scripts    | script        | String               | FIELD         |
+| greptime      | public             | scripts    | engine        | String               | FIELD         |
+| greptime      | public             | scripts    | timestamp     | TimestampMillisecond | TIME INDEX    |
+| greptime      | public             | scripts    | gmt_created   | TimestampMillisecond | FIELD         |
+| greptime      | public             | scripts    | gmt_modified  | TimestampMillisecond | FIELD         |
+| greptime      | information_schema | tables     | table_catalog | String               | FIELD         |
+| greptime      | information_schema | tables     | table_schema  | String               | FIELD         |
+| greptime      | information_schema | tables     | table_name    | String               | FIELD         |
+| greptime      | information_schema | tables     | table_type    | String               | FIELD         |
+| greptime      | information_schema | tables     | table_id      | UInt32               | FIELD         |
+| greptime      | information_schema | tables     | engine        | String               | FIELD         |
++---------------+--------------------+------------+---------------+----------------------+---------------+";
 
     check_output_stream(output, expected).await;
 
     let output = execute_sql_with(&instance, sql, query_ctx).await;
     let expected = "\
-+-----------------+----------------+---------------+-------------+-----------+---------------+
-| table_catalog   | table_schema   | table_name    | column_name | data_type | semantic_type |
-+-----------------+----------------+---------------+-------------+-----------+---------------+
-| another_catalog | another_schema | another_table | i           | Int64     | TIME INDEX    |
-+-----------------+----------------+---------------+-------------+-----------+---------------+";
++-----------------+--------------------+---------------+---------------+-----------+---------------+
+| table_catalog   | table_schema       | table_name    | column_name   | data_type | semantic_type |
++-----------------+--------------------+---------------+---------------+-----------+---------------+
+| another_catalog | another_schema     | another_table | i             | Int64     | TIME INDEX    |
+| another_catalog | information_schema | columns       | table_catalog | String    | FIELD         |
+| another_catalog | information_schema | columns       | table_schema  | String    | FIELD         |
+| another_catalog | information_schema | columns       | table_name    | String    | FIELD         |
+| another_catalog | information_schema | columns       | column_name   | String    | FIELD         |
+| another_catalog | information_schema | columns       | data_type     | String    | FIELD         |
+| another_catalog | information_schema | columns       | semantic_type | String    | FIELD         |
+| another_catalog | information_schema | tables        | table_catalog | String    | FIELD         |
+| another_catalog | information_schema | tables        | table_schema  | String    | FIELD         |
+| another_catalog | information_schema | tables        | table_name    | String    | FIELD         |
+| another_catalog | information_schema | tables        | table_type    | String    | FIELD         |
+| another_catalog | information_schema | tables        | table_id      | UInt32    | FIELD         |
+| another_catalog | information_schema | tables        | engine        | String    | FIELD         |
++-----------------+--------------------+---------------+---------------+-----------+---------------+";
 
     check_output_stream(output, expected).await;
 }

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -1393,12 +1393,14 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
     let expected = match is_distributed_mode {
         true => {
             "\
-+---------------+--------------+------------+-----------------+----------+-------------+
-| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
-+---------------+--------------+------------+-----------------+----------+-------------+
-| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
-| greptime      | public       | scripts    | BASE TABLE      | 1024     | mito        |
-+---------------+--------------+------------+-----------------+----------+-------------+"
++---------------+--------------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema       | table_name | table_type      | table_id | engine      |
++---------------+--------------------+------------+-----------------+----------+-------------+
+| greptime      | information_schema | columns    | LOCAL TEMPORARY | 4        |             |
+| greptime      | public             | numbers    | LOCAL TEMPORARY | 2        | test_engine |
+| greptime      | public             | scripts    | BASE TABLE      | 1024     | mito        |
+| greptime      | information_schema | tables     | LOCAL TEMPORARY | 3        |             |
++---------------+--------------------+------------+-----------------+----------+-------------+"
         }
         false => {
             "\
@@ -1419,11 +1421,13 @@ async fn test_information_schema_dot_tables(instance: Arc<dyn MockInstance>) {
     let expected = match is_distributed_mode {
         true => {
             "\
-+-----------------+----------------+---------------+------------+----------+--------+
-| table_catalog   | table_schema   | table_name    | table_type | table_id | engine |
-+-----------------+----------------+---------------+------------+----------+--------+
-| another_catalog | another_schema | another_table | BASE TABLE | 1025     | mito   |
-+-----------------+----------------+---------------+------------+----------+--------+"
++-----------------+--------------------+---------------+-----------------+----------+--------+
+| table_catalog   | table_schema       | table_name    | table_type      | table_id | engine |
++-----------------+--------------------+---------------+-----------------+----------+--------+
+| another_catalog | another_schema     | another_table | BASE TABLE      | 1025     | mito   |
+| another_catalog | information_schema | columns       | LOCAL TEMPORARY | 4        |        |
+| another_catalog | information_schema | tables        | LOCAL TEMPORARY | 3        |        |
++-----------------+--------------------+---------------+-----------------+----------+--------+"
         }
         false => {
             "\

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -392,11 +392,14 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
             assert_eq!(1, databases[0].num_columns());
-            assert_eq!(databases[0].column(0).len(), 1);
+            assert_eq!(databases[0].column(0).len(), 2);
 
             assert_eq!(
                 *databases[0].column(0),
-                Arc::new(StringVector::from(vec![Some("public")])) as VectorRef
+                Arc::new(StringVector::from(vec![
+                    Some("information_schema"),
+                    Some("public")
+                ])) as VectorRef
             );
         }
         _ => unreachable!(),

--- a/tests/cases/standalone/common/show/show_databases_tables.result
+++ b/tests/cases/standalone/common/show/show_databases_tables.result
@@ -1,0 +1,24 @@
+show databases;
+
++-----------------------+
+| Schemas               |
++-----------------------+
+| information_schema    |
+| public                |
+| test_public_schema    |
+| upper_case_table_name |
++-----------------------+
+
+use information_schema;
+
+Affected Rows: 0
+
+show tables;
+
++---------+
+| Tables  |
++---------+
+| columns |
+| tables  |
++---------+
+

--- a/tests/cases/standalone/common/show/show_databases_tables.sql
+++ b/tests/cases/standalone/common/show/show_databases_tables.sql
@@ -1,0 +1,5 @@
+show databases;
+
+use information_schema;
+
+show tables;

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -31,11 +31,13 @@ where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-+---------------+--------------+------------+------------+--------+
-| table_catalog | table_schema | table_name | table_type | engine |
-+---------------+--------------+------------+------------+--------+
-| greptime      | my_db        | foo        | BASE TABLE | mito   |
-+---------------+--------------+------------+------------+--------+
++---------------+--------------------+------------+-----------------+--------+
+| table_catalog | table_schema       | table_name | table_type      | engine |
++---------------+--------------------+------------+-----------------+--------+
+| greptime      | information_schema | columns    | LOCAL TEMPORARY |        |
+| greptime      | information_schema | tables     | LOCAL TEMPORARY |        |
+| greptime      | my_db              | foo        | BASE TABLE      | mito   |
++---------------+--------------------+------------+-----------------+--------+
 
 select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
 from information_schema.columns
@@ -43,13 +45,29 @@ where table_catalog = 'greptime'
   and table_schema != 'public'
 order by table_schema, table_name;
 
-+---------------+--------------+------------+-------------+-----------+---------------+
-| table_catalog | table_schema | table_name | column_name | data_type | semantic_type |
-+---------------+--------------+------------+-------------+-----------+---------------+
-| greptime      | my_db        | foo        | ts          | Int64     | TIME INDEX    |
-+---------------+--------------+------------+-------------+-----------+---------------+
++---------------+--------------------+------------+---------------+-----------+---------------+
+| table_catalog | table_schema       | table_name | column_name   | data_type | semantic_type |
++---------------+--------------------+------------+---------------+-----------+---------------+
+| greptime      | information_schema | columns    | table_catalog | String    | FIELD         |
+| greptime      | information_schema | columns    | table_schema  | String    | FIELD         |
+| greptime      | information_schema | columns    | table_name    | String    | FIELD         |
+| greptime      | information_schema | columns    | column_name   | String    | FIELD         |
+| greptime      | information_schema | columns    | data_type     | String    | FIELD         |
+| greptime      | information_schema | columns    | semantic_type | String    | FIELD         |
+| greptime      | information_schema | tables     | table_catalog | String    | FIELD         |
+| greptime      | information_schema | tables     | table_schema  | String    | FIELD         |
+| greptime      | information_schema | tables     | table_name    | String    | FIELD         |
+| greptime      | information_schema | tables     | table_type    | String    | FIELD         |
+| greptime      | information_schema | tables     | table_id      | UInt32    | FIELD         |
+| greptime      | information_schema | tables     | engine        | String    | FIELD         |
+| greptime      | my_db              | foo        | ts            | Int64     | TIME INDEX    |
++---------------+--------------------+------------+---------------+-----------+---------------+
 
 use public;
 
 Affected Rows: 0
+
+drop schema my_db;
+
+Error: 1001(Unsupported), SQL statement is not supported: drop schema my_db;, keyword: schema
 

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -1,3 +1,44 @@
+-- scripts table has different table ids in different modes
+select *
+from information_schema.tables
+where table_name != 'scripts'
+order by table_schema, table_name;
+
++---------------+--------------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema       | table_name | table_type      | table_id | engine      |
++---------------+--------------------+------------+-----------------+----------+-------------+
+| greptime      | information_schema | columns    | LOCAL TEMPORARY | 4        |             |
+| greptime      | information_schema | tables     | LOCAL TEMPORARY | 3        |             |
+| greptime      | public             | numbers    | LOCAL TEMPORARY | 2        | test_engine |
++---------------+--------------------+------------+-----------------+----------+-------------+
+
+select * from information_schema.columns order by table_schema, table_name;
+
++---------------+--------------------+------------+---------------+----------------------+---------------+
+| table_catalog | table_schema       | table_name | column_name   | data_type            | semantic_type |
++---------------+--------------------+------------+---------------+----------------------+---------------+
+| greptime      | information_schema | columns    | table_catalog | String               | FIELD         |
+| greptime      | information_schema | columns    | table_schema  | String               | FIELD         |
+| greptime      | information_schema | columns    | table_name    | String               | FIELD         |
+| greptime      | information_schema | columns    | column_name   | String               | FIELD         |
+| greptime      | information_schema | columns    | data_type     | String               | FIELD         |
+| greptime      | information_schema | columns    | semantic_type | String               | FIELD         |
+| greptime      | information_schema | tables     | table_catalog | String               | FIELD         |
+| greptime      | information_schema | tables     | table_schema  | String               | FIELD         |
+| greptime      | information_schema | tables     | table_name    | String               | FIELD         |
+| greptime      | information_schema | tables     | table_type    | String               | FIELD         |
+| greptime      | information_schema | tables     | table_id      | UInt32               | FIELD         |
+| greptime      | information_schema | tables     | engine        | String               | FIELD         |
+| greptime      | public             | numbers    | number        | UInt32               | PRIMARY KEY   |
+| greptime      | public             | scripts    | schema        | String               | PRIMARY KEY   |
+| greptime      | public             | scripts    | name          | String               | PRIMARY KEY   |
+| greptime      | public             | scripts    | script        | String               | FIELD         |
+| greptime      | public             | scripts    | engine        | String               | FIELD         |
+| greptime      | public             | scripts    | timestamp     | TimestampMillisecond | TIME INDEX    |
+| greptime      | public             | scripts    | gmt_created   | TimestampMillisecond | FIELD         |
+| greptime      | public             | scripts    | gmt_modified  | TimestampMillisecond | FIELD         |
++---------------+--------------------+------------+---------------+----------------------+---------------+
+
 create
 database my_db;
 
@@ -29,39 +70,27 @@ select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'
+  and table_schema != 'information_schema'
 order by table_schema, table_name;
 
-+---------------+--------------------+------------+-----------------+--------+
-| table_catalog | table_schema       | table_name | table_type      | engine |
-+---------------+--------------------+------------+-----------------+--------+
-| greptime      | information_schema | columns    | LOCAL TEMPORARY |        |
-| greptime      | information_schema | tables     | LOCAL TEMPORARY |        |
-| greptime      | my_db              | foo        | BASE TABLE      | mito   |
-+---------------+--------------------+------------+-----------------+--------+
++---------------+--------------+------------+------------+--------+
+| table_catalog | table_schema | table_name | table_type | engine |
++---------------+--------------+------------+------------+--------+
+| greptime      | my_db        | foo        | BASE TABLE | mito   |
++---------------+--------------+------------+------------+--------+
 
 select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
 from information_schema.columns
 where table_catalog = 'greptime'
   and table_schema != 'public'
+  and table_schema != 'information_schema'
 order by table_schema, table_name;
 
-+---------------+--------------------+------------+---------------+-----------+---------------+
-| table_catalog | table_schema       | table_name | column_name   | data_type | semantic_type |
-+---------------+--------------------+------------+---------------+-----------+---------------+
-| greptime      | information_schema | columns    | table_catalog | String    | FIELD         |
-| greptime      | information_schema | columns    | table_schema  | String    | FIELD         |
-| greptime      | information_schema | columns    | table_name    | String    | FIELD         |
-| greptime      | information_schema | columns    | column_name   | String    | FIELD         |
-| greptime      | information_schema | columns    | data_type     | String    | FIELD         |
-| greptime      | information_schema | columns    | semantic_type | String    | FIELD         |
-| greptime      | information_schema | tables     | table_catalog | String    | FIELD         |
-| greptime      | information_schema | tables     | table_schema  | String    | FIELD         |
-| greptime      | information_schema | tables     | table_name    | String    | FIELD         |
-| greptime      | information_schema | tables     | table_type    | String    | FIELD         |
-| greptime      | information_schema | tables     | table_id      | UInt32    | FIELD         |
-| greptime      | information_schema | tables     | engine        | String    | FIELD         |
-| greptime      | my_db              | foo        | ts            | Int64     | TIME INDEX    |
-+---------------+--------------------+------------+---------------+-----------+---------------+
++---------------+--------------+------------+-------------+-----------+---------------+
+| table_catalog | table_schema | table_name | column_name | data_type | semantic_type |
++---------------+--------------+------------+-------------+-----------+---------------+
+| greptime      | my_db        | foo        | ts          | Int64     | TIME INDEX    |
++---------------+--------------+------------+-------------+-----------+---------------+
 
 use public;
 

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -1,3 +1,11 @@
+-- scripts table has different table ids in different modes
+select *
+from information_schema.tables
+where table_name != 'scripts'
+order by table_schema, table_name;
+
+select * from information_schema.columns order by table_schema, table_name;
+
 create
 database my_db;
 
@@ -17,12 +25,14 @@ select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
   and table_schema != 'public'
+  and table_schema != 'information_schema'
 order by table_schema, table_name;
 
 select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
 from information_schema.columns
 where table_catalog = 'greptime'
   and table_schema != 'public'
+  and table_schema != 'information_schema'
 order by table_schema, table_name;
 
 use public;

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -26,3 +26,5 @@ where table_catalog = 'greptime'
 order by table_schema, table_name;
 
 use public;
+
+drop schema my_db;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

makes `SHOW DATABASES`/`information_schema.tables`/`information_schema.columns` know themselves.

There are some dumb if-else branches for `FrontendCatalogManager`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
