### PR TITLE
fix(metasrv)!: do not overwrite boolean options unconditionally

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -91,9 +91,9 @@ struct StartCommand {
     #[clap(short, long)]
     selector: Option<String>,
     #[clap(long)]
-    use_memory_store: bool,
+    use_memory_store: Option<bool>,
     #[clap(long)]
-    disable_region_failover: bool,
+    disable_region_failover: Option<bool>,
     #[clap(long)]
     http_addr: Option<String>,
     #[clap(long)]
@@ -136,9 +136,13 @@ impl StartCommand {
                 .context(error::UnsupportedSelectorTypeSnafu { selector_type })?;
         }
 
-        opts.use_memory_store = self.use_memory_store;
+        if let Some(use_memory_store) = self.use_memory_store {
+            opts.use_memory_store = use_memory_store;
+        }
 
-        opts.disable_region_failover = self.disable_region_failover;
+        if let Some(disable_region_failover) = self.disable_region_failover {
+            opts.disable_region_failover = disable_region_failover;
+        }
 
         if let Some(http_addr) = &self.http_addr {
             opts.http_opts.addr = http_addr.clone();

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -106,7 +106,11 @@ pub enum Error {
     #[snafu(display("Empty key is not allowed"))]
     EmptyKey { location: Location },
 
-    #[snafu(display("Failed to execute via Etcd, source: {}", source))]
+    #[snafu(display(
+        "Failed to execute via Etcd, source: {}, location: {}",
+        source,
+        location
+    ))]
     EtcdFailed {
         source: etcd_client::Error,
         location: Location,

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -177,8 +177,10 @@ impl Env {
                     subcommand.to_string(),
                     "start".to_string(),
                     "--use-memory-store".to_string(),
+                    "true".to_string(),
                     "--http-addr=127.0.0.1:5001".to_string(),
                     "--disable-region-failover".to_string(),
+                    "true".to_string(),
                 ];
                 (args, METASRV_ADDR.to_string())
             }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Before this patch, `use_memory_store` and `disable_region_failover` cannot be set via config file or env because they will always be overwritten by cli options, even if it's not provided in cli args.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
