### PR TITLE
fix: print_anonymous_usage_data_disclaimer at wrong place

### DIFF
--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -50,10 +50,11 @@ impl GreptimeDBTelemetryTask {
     }
 
     pub fn start(&self, runtime: Runtime) -> Result<()> {
-        print_anonymous_usage_data_disclaimer();
-
         match self {
-            GreptimeDBTelemetryTask::Enable(task) => task.start(runtime),
+            GreptimeDBTelemetryTask::Enable(task) => {
+                print_anonymous_usage_data_disclaimer();
+                task.start(runtime)
+            }
             GreptimeDBTelemetryTask::Disable => Ok(()),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Print the disclaimer at the wrong place, it must be printed only when enabling telemetry.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
