### PR TITLE
fix: normalize otlp string keys

### DIFF
--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -108,7 +108,7 @@ fn write_attribute(lines: &mut LinesWriter, attr: &KeyValue) -> Result<()> {
     if let Some(val) = attr.value.as_ref().and_then(|v| v.value.as_ref()) {
         match val {
             any_value::Value::StringValue(s) => lines
-                .write_tag(&attr.key, s)
+                .write_tag(&normalize_otlp_name(&attr.key), s)
                 .context(error::OtlpMetricsWriteSnafu)?,
 
             any_value::Value::IntValue(v) => lines

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -79,12 +79,12 @@ mod test {
         assert_eq!(
             recordbatches.pretty_print().unwrap(),
             "\
-+------------+-------+------------+---------------------+----------------+
-| resource   | scope | host       | greptime_timestamp  | greptime_value |
-+------------+-------+------------+---------------------+----------------+
-| greptimedb | otel  | testserver | 1970-01-01T00:00:00 | 105.0          |
-| greptimedb | otel  | testsevrer | 1970-01-01T00:00:00 | 100.0          |
-+------------+-------+------------+---------------------+----------------+",
++------------+-------+--------------------+------------+---------------------+----------------+
+| resource   | scope | telemetry_sdk_name | host       | greptime_timestamp  | greptime_value |
++------------+-------+--------------------+------------+---------------------+----------------+
+| greptimedb | otel  | java               | testserver | 1970-01-01T00:00:00 | 105.0          |
+| greptimedb | otel  | java               | testsevrer | 1970-01-01T00:00:00 | 100.0          |
++------------+-------+--------------------+------------+---------------------+----------------+",
         );
     }
 
@@ -115,7 +115,10 @@ mod test {
                         data: Some(metric::Data::Gauge(gauge)),
                     }],
                     scope: Some(InstrumentationScope {
-                        attributes: vec![keyvalue("scope", "otel")],
+                        attributes: vec![
+                            keyvalue("scope", "otel"),
+                            keyvalue("telemetry.sdk.name", "java"),
+                        ],
                         ..Default::default()
                     }),
                     ..Default::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixes a bug that some column name didn't get normalized. Test cases added.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
