### PR TITLE
fix: panic on truncate table in distributed mode

### DIFF
--- a/src/meta-srv/src/ddl.rs
+++ b/src/meta-srv/src/ddl.rs
@@ -19,11 +19,15 @@ use common_meta::key::TableMetadataManagerRef;
 use common_meta::rpc::ddl::{AlterTableTask, CreateTableTask, DropTableTask, TruncateTableTask};
 use common_meta::rpc::router::TableRoute;
 use common_procedure::{watcher, ProcedureId, ProcedureManagerRef, ProcedureWithId};
+use common_telemetry::error;
 use snafu::ResultExt;
 use table::metadata::RawTableInfo;
 use table::requests::AlterTableRequest;
 
-use crate::error::{self, Result};
+use crate::error::{
+    RegisterProcedureLoaderSnafu, Result, SubmitProcedureSnafu, UnsupportedSnafu,
+    WaitProcedureSnafu,
+};
 use crate::procedure::alter_table::AlterTableProcedure;
 use crate::procedure::create_table::CreateTableProcedure;
 use crate::procedure::drop_table::DropTableProcedure;
@@ -91,7 +95,7 @@ impl DdlManager {
                     CreateTableProcedure::from_json(json, context).map(|p| Box::new(p) as _)
                 }),
             )
-            .context(error::RegisterProcedureLoaderSnafu {
+            .context(RegisterProcedureLoaderSnafu {
                 type_name: CreateTableProcedure::TYPE_NAME,
             })?;
 
@@ -105,7 +109,7 @@ impl DdlManager {
                     DropTableProcedure::from_json(json, context).map(|p| Box::new(p) as _)
                 }),
             )
-            .context(error::RegisterProcedureLoaderSnafu {
+            .context(RegisterProcedureLoaderSnafu {
                 type_name: DropTableProcedure::TYPE_NAME,
             })?;
 
@@ -119,7 +123,7 @@ impl DdlManager {
                     AlterTableProcedure::from_json(json, context).map(|p| Box::new(p) as _)
                 }),
             )
-            .context(error::RegisterProcedureLoaderSnafu {
+            .context(RegisterProcedureLoaderSnafu {
                 type_name: AlterTableProcedure::TYPE_NAME,
             })
     }
@@ -183,8 +187,13 @@ impl DdlManager {
         truncate_table_task: TruncateTableTask,
         table_route: TableRoute,
     ) -> Result<ProcedureId> {
-        todo!("implement truncate table procedure, cluster_id = {}, truncate_table_task = {:?}, table_route = {:?}",
+        error!("truncate table procedure is not supported, cluster_id = {}, truncate_table_task = {:?}, table_route = {:?}",
             cluster_id, truncate_table_task, table_route);
+
+        UnsupportedSnafu {
+            operation: "TRUNCATE TABLE",
+        }
+        .fail()
     }
 
     async fn submit_procedure(&self, procedure_with_id: ProcedureWithId) -> Result<ProcedureId> {
@@ -194,11 +203,11 @@ impl DdlManager {
             .procedure_manager
             .submit(procedure_with_id)
             .await
-            .context(error::SubmitProcedureSnafu)?;
+            .context(SubmitProcedureSnafu)?;
 
         watcher::wait(&mut watcher)
             .await
-            .context(error::WaitProcedureSnafu)?;
+            .context(WaitProcedureSnafu)?;
 
         Ok(procedure_id)
     }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -489,6 +489,12 @@ pub enum Error {
 
     #[snafu(display("Too many partitions, location: {}", location))]
     TooManyPartitions { location: Location },
+
+    #[snafu(display("Unsupported operation {}, location: {}", operation, location))]
+    Unsupported {
+        operation: String,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -535,7 +541,8 @@ impl ErrorExt for Error {
             | Error::NoEnoughAvailableDatanode { .. }
             | Error::ConvertGrpcExpr { .. }
             | Error::PublishMessage { .. }
-            | Error::Join { .. } => StatusCode::Internal,
+            | Error::Join { .. }
+            | Error::Unsupported { .. } => StatusCode::Internal,
             Error::EmptyKey { .. }
             | Error::MissingRequiredParameter { .. }
             | Error::MissingRequestHeader { .. }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Fix panic
```
[2mcommon_telemetry::panic_hook[0m[2m:[0m panicked at greptimedb/src/meta-srv/src/ddl.rs:186:9:
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
