### PR TITLE
feat(mito): Defines the read Batch struct for mito2

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -294,7 +294,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to deserialize field, source: {} location: {}",
+        "Failed to deserialize field, source: {}, location: {}",
         source,
         location
     ))]
@@ -302,6 +302,9 @@ pub enum Error {
         source: memcomparable::Error,
         location: Location,
     },
+
+    #[snafu(display("Invalid batch, {}, location: {}", reason, location))]
+    InvalidBatch { reason: String, location: Location },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -351,6 +354,7 @@ impl ErrorExt for Error {
             SerializeField { .. } => StatusCode::Internal,
             NotSupportedField { .. } => StatusCode::Unsupported,
             DeserializeField { .. } => StatusCode::Unexpected,
+            InvalidBatch { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -56,7 +56,7 @@ impl Batch {
         fields: Vec<BatchColumn>,
     ) -> Result<Batch> {
         BatchBuilder::new(primary_key, timestamps, sequences, op_types)
-            .fields(fields)
+            .with_fields(fields)
             .build()
     }
 
@@ -124,7 +124,7 @@ impl BatchBuilder {
     }
 
     /// Set all field columns.
-    pub fn fields(&mut self, fields: Vec<BatchColumn>) -> &mut Self {
+    pub fn with_fields(mut self, fields: Vec<BatchColumn>) -> Self {
         self.fields = fields;
         self
     }

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -61,9 +61,19 @@ impl Batch {
             .build()
     }
 
+    /// Returns primary key of the batch.
+    pub fn primary_key(&self) -> &[u8] {
+        &self.primary_key
+    }
+
     /// Returns fields in the batch.
     pub fn fields(&self) -> &[BatchColumn] {
         &self.fields
+    }
+
+    /// Returns timestamps of the batch.
+    pub fn timestamps(&self) -> &VectorRef {
+        &self.timestamps
     }
 
     /// Returns sequences of the batch.

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -15,12 +15,14 @@
 //! Parquet writer.
 
 use common_telemetry::debug;
+use datatypes::arrow::record_batch::RecordBatch;
 use object_store::ObjectStore;
 use parquet::basic::{Compression, Encoding, ZstdLevel};
 use parquet::file::metadata::KeyValue;
 use parquet::file::properties::WriterProperties;
+use snafu::ResultExt;
 
-use crate::error::Result;
+use crate::error::{NewRecordBatchSnafu, Result};
 use crate::read::Source;
 use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
 use crate::sst::stream_writer::BufferedWriter;
@@ -64,17 +66,28 @@ impl<'a> ParquetWriter<'a> {
 
         let writer_props = props_builder.build();
 
+        let arrow_schema = metadata.schema.arrow_schema();
         let mut buffered_writer = BufferedWriter::try_new(
             self.file_path.to_string(),
             self.object_store.clone(),
-            &metadata.schema,
+            arrow_schema.clone(),
             Some(writer_props),
             opts.write_buffer_size.as_bytes() as usize,
         )
         .await?;
 
         while let Some(batch) = self.source.next_batch().await? {
-            buffered_writer.write(&batch).await?;
+            let arrow_batch = RecordBatch::try_new(
+                arrow_schema.clone(),
+                batch
+                    .columns
+                    .iter()
+                    .map(|v| v.to_arrow_array())
+                    .collect::<Vec<_>>(),
+            )
+            .context(NewRecordBatchSnafu)?;
+
+            buffered_writer.write(&arrow_batch).await?;
         }
         // Get stats from the source.
         let stats = self.source.stats();

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -80,9 +80,9 @@ impl<'a> ParquetWriter<'a> {
             let arrow_batch = RecordBatch::try_new(
                 arrow_schema.clone(),
                 batch
-                    .columns
+                    .fields()
                     .iter()
-                    .map(|v| v.to_arrow_array())
+                    .map(|v| v.data.to_arrow_array())
                     .collect::<Vec<_>>(),
             )
             .context(NewRecordBatchSnafu)?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Defines the new read Batch struct. This struct can hold rows for the same time series.

It also replaces `SchemaRef` and `Batch` in `BufferedWriter` with arrow's `SchemaRef` and `RecordBatch`. I plan to implement the conversion between `Batch` and `RecordBatch` outside of the `BufferedWriter`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 
