### PR TITLE
feat: don't enable telemetry for debug building

### DIFF
--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -57,7 +57,7 @@ pub async fn get_greptimedb_telemetry_task(
     mode: &Mode,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
-    if !enable || cfg!(test) {
+    if !enable || cfg!(test) || cfg!(debug_assertions) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
 

--- a/src/meta-srv/src/greptimedb_telemetry.rs
+++ b/src/meta-srv/src/greptimedb_telemetry.rs
@@ -60,7 +60,7 @@ pub async fn get_greptimedb_telemetry_task(
     meta_peer_client: MetaPeerClientRef,
     enable: bool,
 ) -> Arc<GreptimeDBTelemetryTask> {
-    if !enable || cfg!(test) {
+    if !enable || cfg!(test) || cfg!(debug_assertions) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Don't enable telemetry for debug builds.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
