### PR TITLE
chore: fix collect region stat on non-base table

### DIFF
--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -25,7 +25,7 @@ use api::v1::meta::{RegionStat, TableIdent, TableName};
 use common_telemetry::{info, warn};
 use snafu::ResultExt;
 use table::engine::{EngineContext, TableEngineRef};
-use table::metadata::TableId;
+use table::metadata::{TableId, TableType};
 use table::requests::CreateTableRequest;
 use table::TableRef;
 
@@ -239,6 +239,10 @@ pub async fn datanode_stat(catalog_manager: &CatalogManagerRef) -> (u64, Vec<Reg
                 else {
                     continue;
                 };
+
+                if table.table_type() != TableType::Base {
+                    continue;
+                }
 
                 let table_info = table.table_info();
                 let region_numbers = &table_info.meta.region_numbers;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

This pr mainly fixes invoking `region_stat()` on information schema

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
