### PR TITLE
fix: fix ddl client can not update leader addr

### DIFF
--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -45,6 +45,9 @@ use crate::error::{ConvertMetaResponseSnafu, Result};
 
 pub type Id = (u64, u64);
 
+const DEFAULT_ASK_LEADER_MAX_RETRY: usize = 3;
+const DEFAULT_SUBMIT_DDL_MAX_RETRY: usize = 3;
+
 #[derive(Clone, Debug, Default)]
 pub struct MetaClientBuilder {
     id: Id,
@@ -130,7 +133,12 @@ impl MetaClientBuilder {
         let mgr = client.channel_manager.clone();
 
         if self.enable_heartbeat {
-            client.heartbeat = Some(HeartbeatClient::new(self.id, self.role, mgr.clone()));
+            client.heartbeat = Some(HeartbeatClient::new(
+                self.id,
+                self.role,
+                mgr.clone(),
+                DEFAULT_ASK_LEADER_MAX_RETRY,
+            ));
         }
         if self.enable_router {
             client.router = Some(RouterClient::new(self.id, self.role, mgr.clone()));
@@ -143,7 +151,12 @@ impl MetaClientBuilder {
         }
         if self.enable_ddl {
             let mgr = self.ddl_channel_manager.unwrap_or(mgr);
-            client.ddl = Some(DdlClient::new(self.id, self.role, mgr));
+            client.ddl = Some(DdlClient::new(
+                self.id,
+                self.role,
+                mgr,
+                DEFAULT_SUBMIT_DDL_MAX_RETRY,
+            ));
         }
 
         client

--- a/src/meta-client/src/client/ask_leader.rs
+++ b/src/meta-client/src/client/ask_leader.rs
@@ -117,7 +117,10 @@ impl AskLeader {
             }
         }
 
-        error::RetryTimesExceededSnafu {}.fail()
+        error::RetryTimesExceededSnafu {
+            msg: "Failed to ask leader",
+        }
+        .fail()
     }
 
     fn create_asker(&self, addr: impl AsRef<str>) -> Result<HeartbeatClient<Channel>> {

--- a/src/meta-client/src/client/ask_leader.rs
+++ b/src/meta-client/src/client/ask_leader.rs
@@ -38,6 +38,7 @@ pub struct AskLeader {
     role: Role,
     leadership_group: Arc<RwLock<LeadershipGroup>>,
     channel_manager: ChannelManager,
+    max_retry: usize,
 }
 
 impl AskLeader {
@@ -46,6 +47,7 @@ impl AskLeader {
         role: Role,
         peers: impl Into<Vec<String>>,
         channel_manager: ChannelManager,
+        max_retry: usize,
     ) -> Self {
         let leadership_group = Arc::new(RwLock::new(LeadershipGroup {
             leader: None,
@@ -56,6 +58,7 @@ impl AskLeader {
             role,
             leadership_group,
             channel_manager,
+            max_retry,
         }
     }
 
@@ -63,7 +66,7 @@ impl AskLeader {
         self.leadership_group.read().unwrap().leader.clone()
     }
 
-    pub async fn ask_leader(&self) -> Result<String> {
+    async fn ask_leader_inner(&self) -> Result<String> {
         let mut peers = {
             let leadership_group = self.leadership_group.read().unwrap();
             leadership_group.peers.clone()
@@ -97,6 +100,24 @@ impl AskLeader {
         leadership_group.leader = Some(leader.clone());
 
         Ok(leader)
+    }
+
+    pub async fn ask_leader(&self) -> Result<String> {
+        let mut times = 0;
+        while times < self.max_retry {
+            match self.ask_leader_inner().await {
+                Ok(res) => {
+                    return Ok(res);
+                }
+                Err(err) => {
+                    warn!("Failed to ask leader, source: {err}, retry {times} times");
+                    times += 1;
+                    continue;
+                }
+            }
+        }
+
+        error::RetryTimesExceededSnafu {}.fail()
     }
 
     fn create_asker(&self, addr: impl AsRef<str>) -> Result<HeartbeatClient<Channel>> {

--- a/src/meta-client/src/client/ask_leader.rs
+++ b/src/meta-client/src/client/ask_leader.rs
@@ -119,6 +119,7 @@ impl AskLeader {
 
         error::RetryTimesExceededSnafu {
             msg: "Failed to ask leader",
+            times: self.max_retry,
         }
         .fail()
     }

--- a/src/meta-client/src/client/ddl.rs
+++ b/src/meta-client/src/client/ddl.rs
@@ -174,6 +174,9 @@ impl Inner {
             }
         }
 
-        error::RetryTimesExceededSnafu.fail()
+        error::RetryTimesExceededSnafu {
+            msg: "Failed to submit DDL client",
+        }
+        .fail()
     }
 }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -65,6 +65,9 @@ pub enum Error {
         location: Location,
         source: common_meta::error::Error,
     },
+
+    #[snafu(display("Retry exceeded max times"))]
+    RetryTimesExceeded {},
 }
 
 #[allow(dead_code)]
@@ -83,7 +86,8 @@ impl ErrorExt for Error {
             | Error::NotStarted { .. }
             | Error::SendHeartbeat { .. }
             | Error::CreateHeartbeatStream { .. }
-            | Error::CreateChannel { .. } => StatusCode::Internal,
+            | Error::CreateChannel { .. }
+            | Error::RetryTimesExceeded { .. } => StatusCode::Internal,
 
             Error::MetaServer { code, .. } => *code,
 

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -66,8 +66,8 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
-    #[snafu(display("Retry exceeded max times, message: {}", msg))]
-    RetryTimesExceeded { msg: String },
+    #[snafu(display("Retry exceeded max times({}), message: {}", times, msg))]
+    RetryTimesExceeded { times: usize, msg: String },
 }
 
 #[allow(dead_code)]

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -66,8 +66,8 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
-    #[snafu(display("Retry exceeded max times"))]
-    RetryTimesExceeded {},
+    #[snafu(display("Retry exceeded max times, message: {}", msg))]
+    RetryTimesExceeded { msg: String },
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix DDL client can not update leader address

<img width="1102" alt="Screenshot 2023-08-18 at 16 51 38" src="https://github.com/GreptimeTeam/greptimedb/assets/32535939/735c0cae-5f54-4e2d-8d02-50bec1fb9009">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
