### PR TITLE
fix: table options can't be found in distributed mode

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -218,10 +218,10 @@ impl TableMetadataManager {
         mut table_info: RawTableInfo,
         region_routes: Vec<RegionRoute>,
     ) -> Result<()> {
-        let mut region_numbers = vec![];
-        for region in region_routes.iter() {
-            region_numbers.push(region.region.id.region_number());
-        }
+        let region_numbers = region_routes
+            .iter()
+            .map(|region| region.region.id.region_number())
+            .collect::<Vec<_>>();
         table_info.meta.region_numbers = region_numbers;
         let table_id = table_info.ident.table_id;
 

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -122,9 +122,6 @@ impl DistInstance {
 
         table_info.ident.table_id = table_id;
 
-        // TODO: Fetch a latest region_numbers from MetaSrv so that FrontCatalogManager can use a latest one.
-        // Though the table_info has a region_numbers, it is created before DistInstance sends a create-table request to MetaSrv.
-        // So, the region_numbers is empty.
         let table_info = Arc::new(table_info.try_into().context(error::CreateTableInfoSnafu)?);
 
         create_table.table_id = Some(api::v1::TableId { id: table_id });

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -121,6 +121,10 @@ impl DistInstance {
         info!("Successfully created distributed table '{table_name}' with table id {table_id}");
 
         table_info.ident.table_id = table_id;
+
+        // TODO: Fetch a latest region_numbers from MetaSrv so that FrontCatalogManager can use a latest one.
+        // Though the table_info has a region_numbers, it is created before DistInstance sends a create-table request to MetaSrv.
+        // So, the region_numbers is empty.
         let table_info = Arc::new(table_info.try_into().context(error::CreateTableInfoSnafu)?);
 
         create_table.table_id = Some(api::v1::TableId { id: table_id });

--- a/src/meta-srv/src/procedure/create_table.rs
+++ b/src/meta-srv/src/procedure/create_table.rs
@@ -110,12 +110,10 @@ impl CreateTableProcedure {
         );
 
         let table_id = self.table_info().ident.table_id as TableId;
-
         let manager = &self.context.table_metadata_manager;
 
         let raw_table_info = self.table_info().clone();
         let region_routes = self.region_routes().clone();
-
         manager
             .create_table_metadata(raw_table_info, region_routes)
             .await

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -38,7 +38,9 @@ SHOW CREATE TABLE system_metrics;
 |                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)               |
 |                |                 )                                        |
 |                | ENGINE=mito                                              |
-|                |                                                          |
+|                | WITH(                                                    |
+|                |   regions = 3                                            |
+|                | )                                                        |
 +----------------+----------------------------------------------------------+
 
 DROP TABLE system_metrics;
@@ -62,7 +64,9 @@ show create table table_without_partition;
 |                         | )                                                       |
 |                         |                                                         |
 |                         | ENGINE=mito                                             |
-|                         |                                                         |
+|                         | WITH(                                                   |
+|                         |   regions = 1                                           |
+|                         | )                                                       |
 +-------------------------+---------------------------------------------------------+
 
 drop table table_without_partition;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR fixes that table options can't be found in distributed mode.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

close #1433