### PR TITLE
feat: add maintenance mode (#1586)

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -78,6 +78,7 @@ use crate::rpc::router::{region_distribution, RegionRoute};
 use crate::DatanodeId;
 
 pub const REMOVED_PREFIX: &str = "__removed";
+pub const MAINTENANCE_KEY: &[u8] = "maintenance_key".as_bytes();
 
 const NAME_PATTERN: &str = "[a-zA-Z_:-][a-zA-Z0-9_:-]*";
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -78,7 +78,7 @@ use crate::rpc::router::{region_distribution, RegionRoute};
 use crate::DatanodeId;
 
 pub const REMOVED_PREFIX: &str = "__removed";
-pub const MAINTENANCE_KEY: &[u8] = "maintenance_key".as_bytes();
+pub const MAINTENANCE_KEY: &[u8] = "maintenance".as_bytes();
 
 const NAME_PATTERN: &str = "[a-zA-Z_:-][a-zA-Z0-9_:-]*";
 

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -222,6 +222,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to parse bool: {}, source: {}", err_msg, source))]
+    ParseBool {
+        err_msg: String,
+        source: std::str::ParseBoolError,
+        location: Location,
+    },
+
     #[snafu(display("Invalid arguments: {}", err_msg))]
     InvalidArguments { err_msg: String, location: Location },
 
@@ -570,6 +577,7 @@ impl ErrorExt for Error {
             | Error::InvalidStatKey { .. }
             | Error::InvalidInactiveRegionKey { .. }
             | Error::ParseNum { .. }
+            | Error::ParseBool { .. }
             | Error::UnsupportedSelectorType { .. }
             | Error::InvalidArguments { .. }
             | Error::InvalidHeartbeatRequest { .. }

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -158,7 +158,8 @@ mod tests {
         let dump = handler.failure_detect_runner.dump().await;
         assert_eq!(dump.iter().collect::<Vec<_>>().len(), 0);
     }
-    #[tokio::test(flavor = "multi_thread")]
+
+        #[tokio::test(flavor = "multi_thread")]
     async fn test_maintenance_mode() {
         let region_failover_manager = create_region_failover_manager();
         let in_memory = region_failover_manager.create_context().in_memory.clone();

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -16,6 +16,7 @@ mod health;
 mod heartbeat;
 mod inactive_regions;
 mod leader;
+mod maintenance;
 mod meta;
 mod node_lease;
 mod route;
@@ -102,6 +103,14 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         "/inactive-regions/clear",
         inactive_regions::ClearInactiveRegionsHandler {
             store: meta_srv.in_memory().clone(),
+        },
+    );
+
+    let router = router.route(
+        "/set-maintenance",
+        maintenance::MaintenanceHandler {
+            kv_store: meta_srv.kv_store().clone(),
+            in_memory: meta_srv.in_memory().clone(),
         },
     );
 

--- a/src/meta-srv/src/service/admin/maintenance.rs
+++ b/src/meta-srv/src/service/admin/maintenance.rs
@@ -1,0 +1,64 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use common_meta::key::MAINTENANCE_KEY;
+use common_meta::rpc::store::PutRequest;
+use snafu::{OptionExt, ResultExt};
+use tonic::codegen::http;
+
+use crate::error::{self, Result};
+use crate::service::admin::HttpHandler;
+use crate::service::store::kv::{KvStoreRef, ResettableKvStoreRef};
+pub struct MaintenanceHandler {
+    pub kv_store: KvStoreRef,
+    pub in_memory: ResettableKvStoreRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for MaintenanceHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let switch_on = params
+            .get("switch_on")
+            .map(|on| on.parse::<bool>())
+            .context(error::MissingRequiredParameterSnafu { param: "switch-on" })?
+            .context(error::ParseBoolSnafu {
+                err_msg: "`switch_on` is not a valid bool",
+            })?;
+
+        let req = PutRequest {
+            key: Vec::from(MAINTENANCE_KEY),
+            value: vec![],
+            prev_kv: false,
+        };
+
+        if switch_on {
+            self.kv_store.put(req.clone()).await?;
+            self.in_memory.put(req).await?;
+        } else {
+            self.kv_store.delete(MAINTENANCE_KEY, false).await?;
+            self.in_memory.delete(MAINTENANCE_KEY, false).await?;
+        }
+
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body("metasvc is succeed to be set maintenance mode".to_string())
+            .context(error::InvalidHttpBodySnafu)
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add maintenance mode in  admin http interface so that Metasrv could suspend region failover for datanodes  planned to be unavailable for a short period of time

Please explain IN DETAIL what the changes are in this PR and why they are needed:

-
- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close https://github.com/GreptimeTeam/greptimedb/issues/1586