### PR TITLE
refactor(table): eliminate calls to DistTable.insert

### DIFF
--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -57,6 +57,7 @@ use sql::statements::create::{PartitionEntry, Partitions};
 use sql::statements::statement::Statement;
 use sql::statements::{self, sql_value_to_value};
 use store_api::storage::RegionNumber;
+use table::error::TableOperationSnafu;
 use table::metadata::{RawTableInfo, RawTableMeta, TableId, TableIdent, TableInfo, TableType};
 use table::requests::{AlterTableRequest, TableOptions};
 use table::TableRef;
@@ -372,26 +373,24 @@ impl DistInstance {
                 self.drop_table(table_name).await
             }
             Statement::Insert(insert) => {
-                let (catalog, schema, table) =
+                let (catalog, schema, _) =
                     table_idents_to_full_name(insert.table_name(), query_ctx.clone())
                         .map_err(BoxedError::new)
                         .context(error::ExternalSnafu)?;
-
-                let table = self
-                    .catalog_manager
-                    .table(&catalog, &schema, &table)
-                    .await
-                    .context(CatalogSnafu)?
-                    .context(TableNotFoundSnafu { table_name: table })?;
 
                 let insert_request =
                     SqlHandler::insert_to_request(self.catalog_manager.clone(), &insert, query_ctx)
                         .await
                         .context(InvokeDatanodeSnafu)?;
 
-                Ok(Output::AffectedRows(
-                    table.insert(insert_request).await.context(TableSnafu)?,
-                ))
+                let inserter = DistInserter::new(catalog, schema, self.catalog_manager.clone());
+                let affected_rows = inserter
+                    .insert(vec![insert_request])
+                    .await
+                    .map_err(BoxedError::new)
+                    .context(TableOperationSnafu)
+                    .context(TableSnafu)?;
+                Ok(Output::AffectedRows(affected_rows as usize))
             }
             Statement::ShowCreateTable(show) => {
                 let (catalog, schema, table) =

--- a/src/frontend/src/statement/copy_table_from.rs
+++ b/src/frontend/src/statement/copy_table_from.rs
@@ -310,7 +310,7 @@ impl StatementExecutor {
             let mut pending = vec![];
 
             while let Some(r) = stream.next().await {
-                let record_batch = r.context(error::ReadRecordBatchSnafu)?;
+                let record_batch = r.context(error::ReadDfRecordBatchSnafu)?;
                 let vectors =
                     Helper::try_into_vectors(record_batch.columns()).context(IntoVectorsSnafu)?;
 
@@ -322,7 +322,7 @@ impl StatementExecutor {
                     .zip(vectors)
                     .collect::<HashMap<_, _>>();
 
-                pending.push(table.insert(InsertRequest {
+                pending.push(self.send_insert_request(InsertRequest {
                     catalog_name: req.catalog_name.to_string(),
                     schema_name: req.schema_name.to_string(),
                     table_name: req.table_name.to_string(),
@@ -332,14 +332,12 @@ impl StatementExecutor {
                 }));
 
                 if pending_mem_size as u64 >= pending_mem_threshold {
-                    rows_inserted +=
-                        batch_insert(&mut pending, &mut pending_mem_size, &req.table_name).await?;
+                    rows_inserted += batch_insert(&mut pending, &mut pending_mem_size).await?;
                 }
             }
 
             if !pending.is_empty() {
-                rows_inserted +=
-                    batch_insert(&mut pending, &mut pending_mem_size, &req.table_name).await?;
+                rows_inserted += batch_insert(&mut pending, &mut pending_mem_size).await?;
             }
         }
 
@@ -349,16 +347,11 @@ impl StatementExecutor {
 
 /// Executes all pending inserts all at once, drain pending requests and reset pending bytes.
 async fn batch_insert(
-    pending: &mut Vec<impl Future<Output = table::error::Result<usize>>>,
+    pending: &mut Vec<impl Future<Output = Result<usize>>>,
     pending_bytes: &mut usize,
-    table_name: &str,
 ) -> Result<usize> {
     let batch = pending.drain(..);
-    let res: usize = futures::future::try_join_all(batch)
-        .await
-        .context(error::InsertSnafu { table_name })?
-        .iter()
-        .sum();
+    let res: usize = futures::future::try_join_all(batch).await?.iter().sum();
     *pending_bytes = 0;
     Ok(res)
 }

--- a/src/frontend/src/statement/insert.rs
+++ b/src/frontend/src/statement/insert.rs
@@ -1,0 +1,116 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_error::ext::BoxedError;
+use common_query::Output;
+use datafusion_expr::{DmlStatement, LogicalPlan as DfLogicalPlan, WriteOp};
+use datanode::instance::sql::table_idents_to_full_name;
+use futures_util::StreamExt;
+use query::parser::QueryStatement;
+use query::plan::LogicalPlan;
+use session::context::QueryContextRef;
+use snafu::ResultExt;
+use sql::statements::insert::Insert;
+use sql::statements::statement::Statement;
+use table::engine::TableReference;
+use table::requests::InsertRequest;
+
+use super::StatementExecutor;
+use crate::error::{
+    BuildColumnVectorsSnafu, ExecLogicalPlanSnafu, ExecuteStatementSnafu, ExternalSnafu,
+    PlanStatementSnafu, ReadRecordBatchSnafu, Result, UnexpectedSnafu,
+};
+
+impl StatementExecutor {
+    pub async fn insert(&self, insert: Box<Insert>, query_ctx: QueryContextRef) -> Result<Output> {
+        if insert.can_extract_values() {
+            // Fast path: plain insert ("insert with literal values") is executed directly
+            self.sql_stmt_executor
+                .execute_sql(Statement::Insert(insert), query_ctx)
+                .await
+                .context(ExecuteStatementSnafu)
+        } else {
+            // Slow path: insert with subquery. Execute the subquery first, via query engine. Then
+            // insert the results by sending insert requests.
+
+            let (catalog_name, schema_name, table_name) =
+                table_idents_to_full_name(insert.table_name(), query_ctx.clone())
+                    .map_err(BoxedError::new)
+                    .context(ExternalSnafu)?;
+
+            // 1. Plan the whole insert statement into a logical plan, then a wrong insert statement
+            //    will be caught and a plan error will be returned.
+            let logical_plan = self
+                .query_engine
+                .planner()
+                .plan(
+                    QueryStatement::Sql(Statement::Insert(insert)),
+                    query_ctx.clone(),
+                )
+                .await
+                .context(PlanStatementSnafu)?;
+
+            // 2. Execute the subquery, get the results as a record batch stream.
+            let subquery_plan = extract_subquery_plan_from_dml(logical_plan)?;
+            let output = self
+                .query_engine
+                .execute(subquery_plan, query_ctx)
+                .await
+                .context(ExecLogicalPlanSnafu)?;
+            let Output::Stream(mut stream) = output else {
+                return UnexpectedSnafu {
+                    violated: "expected a stream",
+                }
+                .fail();
+            };
+
+            // 3. Send insert requests.
+            let mut affected_rows = 0;
+            let table_ref = TableReference::full(&catalog_name, &schema_name, &table_name);
+            let table = self.get_table(&table_ref).await?;
+            while let Some(batch) = stream.next().await {
+                let record_batch = batch.context(ReadRecordBatchSnafu)?;
+                let columns_values = record_batch
+                    .column_vectors(&table_name, table.schema())
+                    .context(BuildColumnVectorsSnafu)?;
+
+                let insert_request = InsertRequest {
+                    catalog_name: catalog_name.clone(),
+                    schema_name: schema_name.clone(),
+                    table_name: table_name.clone(),
+                    columns_values,
+                    region_number: 0,
+                };
+                affected_rows += self.send_insert_request(insert_request).await?;
+            }
+
+            Ok(Output::AffectedRows(affected_rows))
+        }
+    }
+}
+
+fn extract_subquery_plan_from_dml(logical_plan: LogicalPlan) -> Result<LogicalPlan> {
+    let LogicalPlan::DfPlan(df_plan) = logical_plan;
+    match df_plan {
+        DfLogicalPlan::Dml(DmlStatement {
+            op: WriteOp::Insert,
+            input,
+            ..
+        }) => Ok(LogicalPlan::from(input.as_ref().clone())),
+        _ => UnexpectedSnafu {
+            violated: "expected a plan of insert dml",
+        }
+        .fail(),
+    }
+}

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -41,14 +41,13 @@ use snafu::prelude::*;
 use store_api::storage::ScanRequest;
 use table::error::TableOperationSnafu;
 use table::metadata::{FilterPushDownType, TableInfoRef, TableType};
-use table::requests::{DeleteRequest, InsertRequest};
+use table::requests::DeleteRequest;
 use table::Table;
 use tokio::sync::RwLock;
 
 use crate::catalog::FrontendCatalogManager;
 use crate::error::Result;
 use crate::instance::distributed::deleter::DistDeleter;
-use crate::instance::distributed::inserter::DistInserter;
 use crate::table::scan::{DatanodeInstance, TableScanPlan};
 
 pub mod delete;
@@ -78,20 +77,6 @@ impl Table for DistTable {
 
     fn table_type(&self) -> TableType {
         self.table_info.table_type
-    }
-
-    async fn insert(&self, request: InsertRequest) -> table::Result<usize> {
-        let inserter = DistInserter::new(
-            request.catalog_name.clone(),
-            request.schema_name.clone(),
-            self.catalog_manager.clone(),
-        );
-        let affected_rows = inserter
-            .insert(vec![request])
-            .await
-            .map_err(BoxedError::new)
-            .context(TableOperationSnafu)?;
-        Ok(affected_rows as usize)
     }
 
     // TODO(ruihang): DistTable should not call this method directly
@@ -321,6 +306,7 @@ pub(crate) mod test {
     use partition::PartitionRuleRef;
     use store_api::storage::RegionNumber;
     use table::meter_insert_request;
+    use table::requests::InsertRequest;
 
     use super::*;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

In the frontend, for all `table.insert` operations, either directly use DistInserter if the table is a DistTable, or wrap the call with `send_insert_request` to await further refactoring in the future.

For the frontend statement executor, manual handling of subqueries is needed for insert operations to avoid direct invocation of the query engine, eliminating the need for a call to table.insert.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
