### PR TITLE
refactor: use table id instead of table ident

### DIFF
--- a/src/catalog/tests/remote_catalog_tests.rs
+++ b/src/catalog/tests/remote_catalog_tests.rs
@@ -396,7 +396,7 @@ mod tests {
         assert!(catalog_manager.register_table(request).await.unwrap());
 
         let keeper = region_alive_keepers
-            .find_keeper(&table_before)
+            .find_keeper(table_before.table_id)
             .await
             .unwrap();
         let deadline = keeper.deadline(0).await.unwrap();
@@ -435,7 +435,7 @@ mod tests {
         assert!(catalog_manager.register_table(request).await.unwrap());
 
         let keeper = region_alive_keepers
-            .find_keeper(&table_after)
+            .find_keeper(table_after.table_id)
             .await
             .unwrap();
         let deadline = keeper.deadline(0).await.unwrap();
@@ -443,7 +443,7 @@ mod tests {
         assert!(deadline <= Instant::now() + Duration::from_secs(20));
 
         let keeper = region_alive_keepers
-            .find_keeper(&table_before)
+            .find_keeper(table_before.table_id)
             .await
             .unwrap();
         let deadline = keeper.deadline(0).await.unwrap();

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -173,7 +173,10 @@ async fn test_open_region_handler() {
         InstructionReply::OpenRegion(SimpleReply { result: true, .. })
     );
 
-    let keeper = region_alive_keepers.find_keeper(table_ident).await.unwrap();
+    let keeper = region_alive_keepers
+        .find_keeper(table_ident.table_id)
+        .await
+        .unwrap();
     let deadline = keeper.deadline(0).await.unwrap();
     assert!(deadline <= Instant::now() + Duration::from_secs(20));
 
@@ -203,7 +206,7 @@ async fn test_open_region_handler() {
     );
 
     assert!(region_alive_keepers
-        .find_keeper(&non_exist_table_ident)
+        .find_keeper(non_exist_table_ident.table_id)
         .await
         .is_none());
 
@@ -222,7 +225,7 @@ async fn test_open_region_handler() {
     assert_test_table_not_found(instance.inner()).await;
 
     assert!(region_alive_keepers
-        .find_keeper(table_ident)
+        .find_keeper(table_ident.table_id)
         .await
         .is_none());
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

use table id instead of table ident

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
