### PR TITLE
refactor: use Batch::sort_and_dedup instead of Values::sort_in_place

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -366,12 +366,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to sort values source: {}, location: {}", source, location))]
-    SortValues {
-        source: ArrowError,
-        location: Location,
-    },
-
     #[snafu(display("Failed to compact values, source: {}, location: {}", source, location))]
     CompactValues {
         source: datatypes::error::Error,
@@ -446,7 +440,6 @@ impl ErrorExt for Error {
             ComputeArrow { .. } => StatusCode::Internal,
             ComputeVector { .. } => StatusCode::Internal,
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,
-            SortValues { .. } => StatusCode::Unexpected,
             CompactValues { source, .. } => source.status_code(),
             InvalidFlumeSender { .. } => StatusCode::InvalidArguments,
             InvalidSchedulerState { .. } => StatusCode::InvalidArguments,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use `Batch::sort_and_dedup` to sort the batches yielded by `TimeSeriesMemtable` instead of `Values::sort_in_place` and add some tests for this.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
