### PR TITLE
refactor(script): not to call `scan_to_stream` on table

### DIFF
--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -83,15 +83,9 @@ pub enum Error {
     #[snafu(display("Failed to cast type, msg: {}", msg))]
     CastType { msg: String, location: Location },
 
-    #[snafu(display("Failed to parse internal SQL, source: {}", source))]
-    ParseInternalSQL {
-        source: query::error::Error,
-        location: Location,
-    },
-
-    #[snafu(display("Failed to plan internal statement, source: {}", source))]
-    PlanInternalStatement {
-        source: query::error::Error,
+    #[snafu(display("Failed to build DataFusion logical plan, source: {}", source))]
+    BuildDfLogicalPlan {
+        source: datafusion_common::DataFusionError,
         location: Location,
     },
 
@@ -118,9 +112,8 @@ impl ErrorExt for Error {
             FindScript { source, .. } => source.status_code(),
             CollectRecords { source, .. } => source.status_code(),
             ScriptNotFound { .. } => StatusCode::InvalidArguments,
-            ParseInternalSQL { source, .. }
-            | PlanInternalStatement { source, .. }
-            | ExecuteInternalStatement { source, .. } => source.status_code(),
+            BuildDfLogicalPlan { .. } => StatusCode::Internal,
+            ExecuteInternalStatement { source, .. } => source.status_code(),
         }
     }
 

--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -82,6 +82,24 @@ pub enum Error {
 
     #[snafu(display("Failed to cast type, msg: {}", msg))]
     CastType { msg: String, location: Location },
+
+    #[snafu(display("Failed to parse internal SQL, source: {}", source))]
+    ParseInternalSQL {
+        source: query::error::Error,
+        location: Location,
+    },
+
+    #[snafu(display("Failed to plan internal statement, source: {}", source))]
+    PlanInternalStatement {
+        source: query::error::Error,
+        location: Location,
+    },
+
+    #[snafu(display("Failed to execute internal statement, source: {}", source))]
+    ExecuteInternalStatement {
+        source: query::error::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -100,6 +118,9 @@ impl ErrorExt for Error {
             FindScript { source, .. } => source.status_code(),
             CollectRecords { source, .. } => source.status_code(),
             ScriptNotFound { .. } => StatusCode::InvalidArguments,
+            ParseInternalSQL { source, .. }
+            | PlanInternalStatement { source, .. }
+            | ExecuteInternalStatement { source, .. } => source.status_code(),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
parse-plan-execute instead of directly calling the removing `scan_to_stream`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2065