### PR TITLE
refactor: set default metasrv procedure retry times to 12

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -26,7 +26,7 @@ enable_telemetry = true
 # Procedure storage options.
 [procedure]
 # Procedure max retry time.
-max_retry_times = 3
+max_retry_times = 12
 # Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -16,6 +16,7 @@ pub mod builder;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use api::v1::meta::Peer;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
@@ -79,7 +80,10 @@ impl Default for MetaSrvOptions {
                 dir: format!("{METASRV_HOME}/logs"),
                 ..Default::default()
             },
-            procedure: ProcedureConfig::default(),
+            procedure: ProcedureConfig {
+                max_retry_times: 12,
+                retry_delay: Duration::from_millis(500),
+            },
             datanode: DatanodeOptions::default(),
             enable_telemetry: true,
             data_home: METASRV_HOME.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Set default metasrv procedure retry times to 12

| Delay(s) | Time | Retry Delay(s) | Acc Delay(s) | Procedure(s) | Start(s) | End(s) | Start(m) | End(m) |
| -------- | ---- | -------------- | ------------ | ------------ | -------- | ------ | -------- | ------ |
| 0.5      | 1    | 0.5            | 1            | 30           | 1        | 31     | 0.0      | 0.5    |
|          | 2    | 1              | 1.5          | 60           | 1.5      | 61.5   | 0.0      | 1.0    |
|          | 3    | 2              | 3.5          | 90           | 3.5      | 93.5   | 0.1      | 1.6    |
|          | 4    | 4              | 7.5          | 120          | 7.5      | 127.5  | 0.1      | 2.1    |
|          | 5    | 8              | 15.5         | 150          | 15.5     | 165.5  | 0.3      | 2.8    |
|          | 6    | 16             | 31.5         | 180          | 31.5     | 211.5  | 0.5      | 3.5    |
|          | 7    | 32             | 63.5         | 210          | 63.5     | 273.5  | 1.1      | 4.6    |
|          | 8    | 64             | 127.5        | 240          | 127.5    | 367.5  | 2.1      | 6.1    |
|          | 9    | 128            | 255.5        | 270          | 255.5    | 525.5  | 4.3      | 8.8    |
|          | 10   | 256            | 511.5        | 300          | 511.5    | 811.5  | 8.5      | 13.5   |
|          | 11   | 512            | 1023.5       | 330          | 1023.5   | 1353.5 | 17.1     | 22.6   |
|          | 12   | 1024           | 2047.5       | 360          | 2047.5   | 2407.5 | 34.1     | 40.1   |

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
