### PR TITLE
feat(mito2): concat and projection

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -366,12 +366,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to compact values, source: {}, location: {}", source, location))]
-    CompactValues {
-        source: datatypes::error::Error,
-        location: Location,
-    },
-
     #[snafu(display("Invalid flume sender, location: {}", location,))]
     InvalidFlumeSender { location: Location },
 
@@ -440,7 +434,6 @@ impl ErrorExt for Error {
             ComputeArrow { .. } => StatusCode::Internal,
             ComputeVector { .. } => StatusCode::Internal,
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,
-            CompactValues { source, .. } => source.status_code(),
             InvalidFlumeSender { .. } => StatusCode::InvalidArguments,
             InvalidSchedulerState { .. } => StatusCode::InvalidArguments,
             StopScheduler { .. } => StatusCode::Internal,

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, Bound};
+use std::collections::{BTreeMap, Bound, HashMap};
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, RwLock};
 
@@ -28,7 +28,7 @@ use datatypes::vectors::{
 };
 use snafu::{ensure, ResultExt};
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::ScanRequest;
+use store_api::storage::{ColumnId, ScanRequest, SequenceNumber};
 
 use crate::error::{ComputeArrowSnafu, ConvertVectorSnafu, PrimaryKeyLengthMismatchSnafu, Result};
 use crate::memtable::{BoxedBatchIterator, KeyValues, Memtable, MemtableId};
@@ -94,13 +94,13 @@ impl Memtable for TimeSeriesMemtable {
     }
 
     fn iter(&self, req: ScanRequest) -> BoxedBatchIterator {
-        let _projection = req.projection.map(|p| {
+        let projection = req.projection.map(|p| {
             p.iter()
                 .map(|idx| self.region_metadata.column_metadatas[*idx].column_id)
                 .collect::<Vec<_>>()
         });
 
-        Box::new(self.series_set.iter_series())
+        Box::new(self.series_set.iter_series(projection, req.sequence))
     }
 }
 
@@ -139,10 +139,16 @@ impl SeriesSet {
     }
 
     /// Iterates all series in [SeriesSet].
-    fn iter_series(&self) -> Iter {
+    fn iter_series(
+        &self,
+        projection: Option<Vec<ColumnId>>,
+        sequence: Option<SequenceNumber>,
+    ) -> Iter {
         Iter {
             metadata: self.region_metadata.clone(),
             series: self.series.clone(),
+            projection,
+            sequence,
             last_key: None,
         }
     }
@@ -151,6 +157,8 @@ impl SeriesSet {
 struct Iter {
     metadata: RegionMetadataRef,
     series: Arc<SeriesRwLockMap>,
+    projection: Option<Vec<ColumnId>>,
+    sequence: Option<SequenceNumber>,
     last_key: Option<Vec<u8>>,
 }
 
@@ -169,7 +177,11 @@ impl Iterator for Iter {
         if let Some((primary_key, series)) = range.next() {
             self.last_key = Some(primary_key.clone());
             let values = series.write().unwrap().compact(&self.metadata);
-            Some(values.and_then(|v| v.to_batch(primary_key, &self.metadata)))
+            Some(
+                values.and_then(|v| {
+                    v.to_batch(primary_key, &self.metadata, self.projection.as_deref())
+                }),
+            )
         } else {
             None
         }
@@ -338,7 +350,7 @@ impl ValueBuilder {
     }
 }
 
-/// [Values] holds an immutable vectors of field columns, including `sequence` and `op_typee`.
+/// [Values] holds an immutable vectors of field columns, including `sequence` and `op_type`.
 #[derive(Clone)]
 struct Values {
     timestamp: VectorRef,
@@ -377,7 +389,12 @@ impl Values {
 
     /// Converts [Values] to `Batch`, sorts the batch according to `timestamp, sequence` desc and
     /// keeps only the latest row for the same timestamp.
-    pub fn to_batch(&self, primary_key: &[u8], metadata: &RegionMetadataRef) -> Result<Batch> {
+    pub fn to_batch(
+        &self,
+        primary_key: &[u8],
+        metadata: &RegionMetadataRef,
+        projection: Option<&[ColumnId]>,
+    ) -> Result<Batch> {
         let builder = BatchBuilder::with_required_columns(
             primary_key.to_vec(),
             self.timestamp.clone(),
@@ -385,14 +402,36 @@ impl Values {
             self.op_type.clone(),
         );
 
-        let fields = metadata
-            .field_columns()
-            .zip(self.fields.iter())
-            .map(|(c, f)| BatchColumn {
-                column_id: c.column_id,
-                data: f.clone(),
-            })
-            .collect();
+        let fields = if let Some(projection) = projection {
+            let fields = metadata
+                .field_columns()
+                .zip(self.fields.iter())
+                .map(|(c, f)| {
+                    (
+                        c.column_id,
+                        BatchColumn {
+                            column_id: c.column_id,
+                            data: f.clone(),
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+
+            // simply ignore those columns which are not field.
+            projection
+                .iter()
+                .filter_map(|column_id| fields.get(column_id).cloned())
+                .collect()
+        } else {
+            metadata
+                .field_columns()
+                .zip(self.fields.iter())
+                .map(|(c, f)| BatchColumn {
+                    column_id: c.column_id,
+                    data: f.clone(),
+                })
+                .collect::<Vec<_>>()
+        };
 
         let mut batch = builder.with_fields(fields).build()?;
         batch.sort_and_dedup()?;
@@ -610,7 +649,7 @@ mod tests {
             fields,
         };
 
-        let batch = values.to_batch(b"test", &schema).unwrap();
+        let batch = values.to_batch(b"test", &schema, None).unwrap();
         check_value(
             &batch,
             vec![
@@ -646,7 +685,7 @@ mod tests {
         )
     }
 
-    fn build_key_values(schema: &RegionMetadataRef, len: usize) -> KeyValues {
+    fn build_key_values(schema: &RegionMetadataRef, k0: String, k1: i64, len: usize) -> KeyValues {
         let column_schema = schema
             .column_metadatas
             .iter()
@@ -663,10 +702,10 @@ mod tests {
             .map(|i| Row {
                 values: vec![
                     api::v1::Value {
-                        value_data: Some(ValueData::StringValue(i.to_string())),
+                        value_data: Some(ValueData::StringValue(k0.clone())),
                     },
                     api::v1::Value {
-                        value_data: Some(ValueData::I64Value(i as i64)),
+                        value_data: Some(ValueData::I64Value(k1)),
                     },
                     api::v1::Value {
                         value_data: Some(ValueData::TsMillisecondValue(i as i64)),
@@ -767,7 +806,7 @@ mod tests {
     fn test_memtable() {
         common_telemetry::init_default_ut_logging();
         let schema = schema_for_test();
-        let kvs = build_key_values(&schema, 100);
+        let kvs = build_key_values(&schema, "hello".to_string(), 42, 100);
         let memtable = TimeSeriesMemtable::new(schema, 42).unwrap();
         memtable.write(&kvs).unwrap();
 
@@ -792,5 +831,36 @@ mod tests {
             .map(|v| v.unwrap().0.value())
             .collect::<HashSet<_>>();
         assert_eq!(expected_ts, read);
+    }
+
+    #[test]
+    fn test_memtable_projection() {
+        common_telemetry::init_default_ut_logging();
+        let schema = schema_for_test();
+        let kvs = build_key_values(&schema, "hello".to_string(), 42, 100);
+        let memtable = TimeSeriesMemtable::new(schema, 42).unwrap();
+        memtable.write(&kvs).unwrap();
+
+        let iter = memtable.iter(ScanRequest {
+            projection: Some(vec![3]), // k0, k1, ts, v0, v1, only take v0
+            ..Default::default()
+        });
+
+        let mut v0_all = vec![];
+
+        for res in iter {
+            let batch = res.unwrap();
+            assert_eq!(1, batch.fields().len());
+            let v0 = batch
+                .fields()
+                .get(0)
+                .unwrap()
+                .data
+                .as_any()
+                .downcast_ref::<Int64Vector>()
+                .unwrap();
+            v0_all.extend(v0.iter_data().map(|v| v.unwrap()));
+        }
+        assert_eq!((0..100i64).collect::<Vec<_>>(), v0_all);
     }
 }

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -28,7 +28,7 @@ use datatypes::vectors::{
 };
 use snafu::{ensure, ResultExt};
 use store_api::metadata::RegionMetadataRef;
-use store_api::storage::{ColumnId, ScanRequest, SequenceNumber};
+use store_api::storage::{ColumnId, ScanRequest};
 
 use crate::error::{ComputeArrowSnafu, ConvertVectorSnafu, PrimaryKeyLengthMismatchSnafu, Result};
 use crate::memtable::{BoxedBatchIterator, KeyValues, Memtable, MemtableId};
@@ -100,7 +100,7 @@ impl Memtable for TimeSeriesMemtable {
                 .collect::<Vec<_>>()
         });
 
-        Box::new(self.series_set.iter_series(projection, req.sequence))
+        Box::new(self.series_set.iter_series(projection))
     }
 }
 
@@ -139,16 +139,11 @@ impl SeriesSet {
     }
 
     /// Iterates all series in [SeriesSet].
-    fn iter_series(
-        &self,
-        projection: Option<Vec<ColumnId>>,
-        sequence: Option<SequenceNumber>,
-    ) -> Iter {
+    fn iter_series(&self, projection: Option<Vec<ColumnId>>) -> Iter {
         Iter {
             metadata: self.region_metadata.clone(),
             series: self.series.clone(),
             projection,
-            sequence,
             last_key: None,
         }
     }
@@ -158,7 +153,6 @@ struct Iter {
     metadata: RegionMetadataRef,
     series: Arc<SeriesRwLockMap>,
     projection: Option<Vec<ColumnId>>,
-    sequence: Option<SequenceNumber>,
     last_key: Option<Vec<u8>>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
- Use `arrow::compute::concat` to concat vectors in memtable
- Respect projection


## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
