### PR TITLE
refactor(frontend): TableScan instead of `scan_to_stream` for `COPY TO`

### DIFF
--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -106,9 +106,10 @@ impl StatementExecutor {
             Statement::Copy(sql::statements::copy::Copy::CopyTable(stmt)) => {
                 let req = to_copy_table_request(stmt, query_ctx.clone())?;
                 match req.direction {
-                    CopyDirection::Export => {
-                        self.copy_table_to(req, query_ctx).await.map(Output::AffectedRows)
-                    }
+                    CopyDirection::Export => self
+                        .copy_table_to(req, query_ctx)
+                        .await
+                        .map(Output::AffectedRows),
                     CopyDirection::Import => {
                         self.copy_table_from(req).await.map(Output::AffectedRows)
                     }

--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -104,10 +104,10 @@ impl StatementExecutor {
             Statement::ShowTables(stmt) => self.show_tables(stmt, query_ctx).await,
 
             Statement::Copy(sql::statements::copy::Copy::CopyTable(stmt)) => {
-                let req = to_copy_table_request(stmt, query_ctx)?;
+                let req = to_copy_table_request(stmt, query_ctx.clone())?;
                 match req.direction {
                     CopyDirection::Export => {
-                        self.copy_table_to(req).await.map(Output::AffectedRows)
+                        self.copy_table_to(req, query_ctx).await.map(Output::AffectedRows)
                     }
                     CopyDirection::Import => {
                         self.copy_table_from(req).await.map(Output::AffectedRows)

--- a/src/frontend/src/statement/backup.rs
+++ b/src/frontend/src/statement/backup.rs
@@ -66,19 +66,20 @@ impl StatementExecutor {
             );
 
             let exported = self
-                .copy_table_to(CopyTableRequest {
-                    catalog_name: req.catalog_name.clone(),
-                    schema_name: req.schema_name.clone(),
-                    table_name,
-                    location: table_file,
-                    with: req.with.clone(),
-                    connection: req.connection.clone(),
-                    pattern: None,
-                    direction: CopyDirection::Export,
-                    timestamp_range: req.time_range,
-                },
-                QueryContextBuilder::default().build(),
-            )
+                .copy_table_to(
+                    CopyTableRequest {
+                        catalog_name: req.catalog_name.clone(),
+                        schema_name: req.schema_name.clone(),
+                        table_name,
+                        location: table_file,
+                        with: req.with.clone(),
+                        connection: req.connection.clone(),
+                        pattern: None,
+                        direction: CopyDirection::Export,
+                        timestamp_range: req.time_range,
+                    },
+                    QueryContextBuilder::default().build(),
+                )
                 .await?;
             exported_rows += exported;
         }

--- a/src/frontend/src/statement/backup.rs
+++ b/src/frontend/src/statement/backup.rs
@@ -15,6 +15,7 @@
 use common_datasource::file_format::Format;
 use common_query::Output;
 use common_telemetry::info;
+use session::context::QueryContextBuilder;
 use snafu::{ensure, ResultExt};
 use table::requests::{CopyDatabaseRequest, CopyDirection, CopyTableRequest};
 
@@ -75,7 +76,9 @@ impl StatementExecutor {
                     pattern: None,
                     direction: CopyDirection::Export,
                     timestamp_range: req.time_range,
-                })
+                },
+                QueryContextBuilder::default().build(),
+            )
                 .await?;
             exported_rows += exported;
         }

--- a/src/table/src/engine.rs
+++ b/src/table/src/engine.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use common_base::paths::DATA_DIR;
 use common_procedure::BoxedProcedure;
+use datafusion_common::TableReference as DfTableReference;
 use store_api::storage::RegionNumber;
 
 use crate::error::{self, Result};
@@ -60,6 +61,12 @@ impl<'a> TableReference<'a> {
 impl<'a> Display for TableReference<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{}.{}", self.catalog, self.schema, self.table)
+    }
+}
+
+impl<'a> From<TableReference<'a>> for DfTableReference<'a> {
+    fn from(val: TableReference<'a>) -> Self {
+        DfTableReference::full(val.catalog, val.schema, val.table)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Similar to #2241, replace the invocation of `scan_to_stream` with constructing a TableScan LogicalPlan, and then execute it using the query engine.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2065