### PR TITLE
fix: quote ident on rendered SQL

### DIFF
--- a/src/datanode/src/instance/sql.rs
+++ b/src/datanode/src/instance/sql.rs
@@ -141,7 +141,8 @@ impl Instance {
                 let table_ref = TableReference::full(&catalog, &schema, &table);
                 let table = self.sql_handler.get_table(&table_ref).await?;
 
-                query::sql::show_create_table(table, None).context(ExecuteStatementSnafu)
+                query::sql::show_create_table(table, None, query_ctx.clone())
+                    .context(ExecuteStatementSnafu)
             }
             Statement::TruncateTable(truncate_table) => {
                 let (catalog_name, schema_name, table_name) =

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -403,7 +403,8 @@ impl DistInstance {
                     .context(TableNotFoundSnafu { table_name: &table })?;
                 let table_name = TableName::new(catalog, schema, table);
 
-                self.show_create_table(table_name, table_ref).await
+                self.show_create_table(table_name, table_ref, query_ctx.clone())
+                    .await
             }
             Statement::TruncateTable(stmt) => {
                 let (catalog, schema, table) =
@@ -420,7 +421,12 @@ impl DistInstance {
         }
     }
 
-    async fn show_create_table(&self, table_name: TableName, table: TableRef) -> Result<Output> {
+    async fn show_create_table(
+        &self,
+        table_name: TableName,
+        table: TableRef,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
         let partitions = self
             .catalog_manager
             .partition_manager()
@@ -432,7 +438,8 @@ impl DistInstance {
 
         let partitions = create_partitions_stmt(partitions)?;
 
-        query::sql::show_create_table(table, partitions).context(error::ExecuteStatementSnafu)
+        query::sql::show_create_table(table, partitions, query_ctx)
+            .context(error::ExecuteStatementSnafu)
     }
 
     /// Handles distributed database creation

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -65,7 +65,12 @@ pub enum Error {
         source: std::io::Error,
     },
 
-    #[snafu(display("Failed to execute query: {}, source: {}", query, source))]
+    #[snafu(display(
+        "Failed to execute query, source: {}, query: {}, location: {}",
+        source,
+        query,
+        location
+    ))]
     ExecuteQuery {
         query: String,
         location: Location,

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -57,7 +57,7 @@ pub enum Error {
     UnsupportedDefaultValue { column_name: String, expr: Expr },
 
     // Syntax error from sql parser.
-    #[snafu(display("Syntax error, sql: {}, source: {}", sql, source))]
+    #[snafu(display("Syntax error, source: {}, sql: {}", source, sql))]
     Syntax { sql: String, source: ParserError },
 
     #[snafu(display("Missing time index constraint"))]

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -130,6 +130,15 @@ pub struct Partitions {
     pub entries: Vec<PartitionEntry>,
 }
 
+impl Partitions {
+    /// set quotes to all [Ident]s from column list
+    pub fn set_quote(&mut self, quote_style: char) {
+        self.column_list
+            .iter_mut()
+            .for_each(|c| c.quote_style = Some(quote_style));
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PartitionEntry {
     pub name: Ident,

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -109,18 +109,17 @@ PARTITION BY RANGE COLUMNS (ts) (
     let output = execute_sql(&frontend, "show create table demo").await;
 
     let expected = if instance.is_distributed_mode() {
-        "\
-+-------+----------------------------------------------------------+
+        r#"+-------+----------------------------------------------------------+
 | Table | Create Table                                             |
 +-------+----------------------------------------------------------+
-| demo  | CREATE TABLE IF NOT EXISTS demo (                        |
-|       |   host STRING NULL,                                      |
-|       |   cpu DOUBLE NULL,                                       |
-|       |   memory DOUBLE NULL,                                    |
-|       |   ts BIGINT NOT NULL,                                    |
-|       |   TIME INDEX (ts)                                        |
+| demo  | CREATE TABLE IF NOT EXISTS "demo" (                      |
+|       |   "host" STRING NULL,                                    |
+|       |   "cpu" DOUBLE NULL,                                     |
+|       |   "memory" DOUBLE NULL,                                  |
+|       |   "ts" BIGINT NOT NULL,                                  |
+|       |   TIME INDEX ("ts")                                      |
 |       | )                                                        |
-|       | PARTITION BY RANGE COLUMNS (ts) (                        |
+|       | PARTITION BY RANGE COLUMNS ("ts") (                      |
 |       |                       PARTITION r0 VALUES LESS THAN (1), |
 |       |   PARTITION r1 VALUES LESS THAN (10),                    |
 |       |   PARTITION r2 VALUES LESS THAN (100),                   |
@@ -130,24 +129,23 @@ PARTITION BY RANGE COLUMNS (ts) (
 |       | WITH(                                                    |
 |       |   regions = 4                                            |
 |       | )                                                        |
-+-------+----------------------------------------------------------+"
++-------+----------------------------------------------------------+"#
     } else {
-        "\
-+-------+-----------------------------------+
-| Table | Create Table                      |
-+-------+-----------------------------------+
-| demo  | CREATE TABLE IF NOT EXISTS demo ( |
-|       |   host STRING NULL,               |
-|       |   cpu DOUBLE NULL,                |
-|       |   memory DOUBLE NULL,             |
-|       |   ts BIGINT NOT NULL,             |
-|       |   TIME INDEX (ts)                 |
-|       | )                                 |
-|       | ENGINE=mito                       |
-|       | WITH(                             |
-|       |   regions = 1                     |
-|       | )                                 |
-+-------+-----------------------------------+"
+        r#"+-------+-------------------------------------+
+| Table | Create Table                        |
++-------+-------------------------------------+
+| demo  | CREATE TABLE IF NOT EXISTS "demo" ( |
+|       |   "host" STRING NULL,               |
+|       |   "cpu" DOUBLE NULL,                |
+|       |   "memory" DOUBLE NULL,             |
+|       |   "ts" BIGINT NOT NULL,             |
+|       |   TIME INDEX ("ts")                 |
+|       | )                                   |
+|       | ENGINE=mito                         |
+|       | WITH(                               |
+|       |   regions = 1                       |
+|       | )                                   |
++-------+-------------------------------------+"#
     };
 
     check_output_stream(output, expected).await;

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -22,15 +22,15 @@ SHOW CREATE TABLE system_metrics;
 +----------------+-----------------------------------------------------------+
 | Table          | Create Table                                              |
 +----------------+-----------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS `system_metrics` (             |
-|                |   `id` INT UNSIGNED NULL,                                 |
-|                |   `host` STRING NULL,                                     |
-|                |   `cpu` DOUBLE NULL,                                      |
-|                |   `disk` FLOAT NULL,                                      |
-|                |   `n` INT NULL,                                           |
-|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX (`ts`),                                      |
-|                |   PRIMARY KEY (`id`, `host`)                              |
+| system_metrics | CREATE TABLE IF NOT EXISTS "system_metrics" (             |
+|                |   "id" INT UNSIGNED NULL,                                 |
+|                |   "host" STRING NULL,                                     |
+|                |   "cpu" DOUBLE NULL,                                      |
+|                |   "disk" FLOAT NULL,                                      |
+|                |   "n" INT NULL,                                           |
+|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX ("ts"),                                      |
+|                |   PRIMARY KEY ("id", "host")                              |
 |                | )                                                         |
 |                | PARTITION BY RANGE COLUMNS (n) (                          |
 |                |                       PARTITION r0 VALUES LESS THAN (5),  |
@@ -58,9 +58,9 @@ show create table table_without_partition;
 +-------------------------+-----------------------------------------------------------+
 | Table                   | Create Table                                              |
 +-------------------------+-----------------------------------------------------------+
-| table_without_partition | CREATE TABLE IF NOT EXISTS `table_without_partition` (    |
-|                         |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                         |   TIME INDEX (`ts`)                                       |
+| table_without_partition | CREATE TABLE IF NOT EXISTS "table_without_partition" (    |
+|                         |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                         |   TIME INDEX ("ts")                                       |
 |                         | )                                                         |
 |                         |                                                           |
 |                         | ENGINE=mito                                               |

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -32,7 +32,7 @@ SHOW CREATE TABLE system_metrics;
 |                |   TIME INDEX ("ts"),                                      |
 |                |   PRIMARY KEY ("id", "host")                              |
 |                | )                                                         |
-|                | PARTITION BY RANGE COLUMNS (n) (                          |
+|                | PARTITION BY RANGE COLUMNS ("n") (                        |
 |                |                       PARTITION r0 VALUES LESS THAN (5),  |
 |                |   PARTITION r1 VALUES LESS THAN (9),                      |
 |                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)                |

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -19,29 +19,29 @@ Affected Rows: 0
 
 SHOW CREATE TABLE system_metrics;
 
-+----------------+----------------------------------------------------------+
-| Table          | Create Table                                             |
-+----------------+----------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS system_metrics (              |
-|                |   id INT UNSIGNED NULL,                                  |
-|                |   host STRING NULL,                                      |
-|                |   cpu DOUBLE NULL,                                       |
-|                |   disk FLOAT NULL,                                       |
-|                |   n INT NULL,                                            |
-|                |   ts TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(),  |
-|                |   TIME INDEX (ts),                                       |
-|                |   PRIMARY KEY (id, host)                                 |
-|                | )                                                        |
-|                | PARTITION BY RANGE COLUMNS (n) (                         |
-|                |                       PARTITION r0 VALUES LESS THAN (5), |
-|                |   PARTITION r1 VALUES LESS THAN (9),                     |
-|                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)               |
-|                |                 )                                        |
-|                | ENGINE=mito                                              |
-|                | WITH(                                                    |
-|                |   regions = 3                                            |
-|                | )                                                        |
-+----------------+----------------------------------------------------------+
++----------------+-----------------------------------------------------------+
+| Table          | Create Table                                              |
++----------------+-----------------------------------------------------------+
+| system_metrics | CREATE TABLE IF NOT EXISTS `system_metrics` (             |
+|                |   `id` INT UNSIGNED NULL,                                 |
+|                |   `host` STRING NULL,                                     |
+|                |   `cpu` DOUBLE NULL,                                      |
+|                |   `disk` FLOAT NULL,                                      |
+|                |   `n` INT NULL,                                           |
+|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (`ts`),                                      |
+|                |   PRIMARY KEY (`id`, `host`)                              |
+|                | )                                                         |
+|                | PARTITION BY RANGE COLUMNS (n) (                          |
+|                |                       PARTITION r0 VALUES LESS THAN (5),  |
+|                |   PARTITION r1 VALUES LESS THAN (9),                      |
+|                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)                |
+|                |                 )                                         |
+|                | ENGINE=mito                                               |
+|                | WITH(                                                     |
+|                |   regions = 3                                             |
+|                | )                                                         |
++----------------+-----------------------------------------------------------+
 
 DROP TABLE system_metrics;
 
@@ -55,19 +55,19 @@ Affected Rows: 0
 
 show create table table_without_partition;
 
-+-------------------------+---------------------------------------------------------+
-| Table                   | Create Table                                            |
-+-------------------------+---------------------------------------------------------+
-| table_without_partition | CREATE TABLE IF NOT EXISTS table_without_partition (    |
-|                         |   ts TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                         |   TIME INDEX (ts)                                       |
-|                         | )                                                       |
-|                         |                                                         |
-|                         | ENGINE=mito                                             |
-|                         | WITH(                                                   |
-|                         |   regions = 1                                           |
-|                         | )                                                       |
-+-------------------------+---------------------------------------------------------+
++-------------------------+-----------------------------------------------------------+
+| Table                   | Create Table                                              |
++-------------------------+-----------------------------------------------------------+
+| table_without_partition | CREATE TABLE IF NOT EXISTS `table_without_partition` (    |
+|                         |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                         |   TIME INDEX (`ts`)                                       |
+|                         | )                                                         |
+|                         |                                                           |
+|                         | ENGINE=mito                                               |
+|                         | WITH(                                                     |
+|                         |   regions = 1                                             |
+|                         | )                                                         |
++-------------------------+-----------------------------------------------------------+
 
 drop table table_without_partition;
 

--- a/tests/cases/standalone/show/show_create.result
+++ b/tests/cases/standalone/show/show_create.result
@@ -17,25 +17,25 @@ Affected Rows: 0
 
 SHOW CREATE TABLE system_metrics;
 
-+----------------+---------------------------------------------------------+
-| Table          | Create Table                                            |
-+----------------+---------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS system_metrics (             |
-|                |   id INT UNSIGNED NULL,                                 |
-|                |   host STRING NULL,                                     |
-|                |   cpu DOUBLE NULL COMMENT 'cpu',                        |
-|                |   disk FLOAT NULL,                                      |
-|                |   ts TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX (ts),                                      |
-|                |   PRIMARY KEY (id, host)                                |
-|                | )                                                       |
-|                | ENGINE=mito                                             |
-|                | WITH(                                                   |
-|                |   regions = 1,                                          |
-|                |   ttl = '7days',                                        |
-|                |   write_buffer_size = '1.0KiB'                          |
-|                | )                                                       |
-+----------------+---------------------------------------------------------+
++----------------+-----------------------------------------------------------+
+| Table          | Create Table                                              |
++----------------+-----------------------------------------------------------+
+| system_metrics | CREATE TABLE IF NOT EXISTS `system_metrics` (             |
+|                |   `id` INT UNSIGNED NULL,                                 |
+|                |   `host` STRING NULL,                                     |
+|                |   `cpu` DOUBLE NULL COMMENT 'cpu',                        |
+|                |   `disk` FLOAT NULL,                                      |
+|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX (`ts`),                                      |
+|                |   PRIMARY KEY (`id`, `host`)                              |
+|                | )                                                         |
+|                | ENGINE=mito                                               |
+|                | WITH(                                                     |
+|                |   regions = 1,                                            |
+|                |   ttl = '7days',                                          |
+|                |   write_buffer_size = '1.0KiB'                            |
+|                | )                                                         |
++----------------+-----------------------------------------------------------+
 
 DROP TABLE system_metrics;
 

--- a/tests/cases/standalone/show/show_create.result
+++ b/tests/cases/standalone/show/show_create.result
@@ -20,14 +20,14 @@ SHOW CREATE TABLE system_metrics;
 +----------------+-----------------------------------------------------------+
 | Table          | Create Table                                              |
 +----------------+-----------------------------------------------------------+
-| system_metrics | CREATE TABLE IF NOT EXISTS `system_metrics` (             |
-|                |   `id` INT UNSIGNED NULL,                                 |
-|                |   `host` STRING NULL,                                     |
-|                |   `cpu` DOUBLE NULL COMMENT 'cpu',                        |
-|                |   `disk` FLOAT NULL,                                      |
-|                |   `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
-|                |   TIME INDEX (`ts`),                                      |
-|                |   PRIMARY KEY (`id`, `host`)                              |
+| system_metrics | CREATE TABLE IF NOT EXISTS "system_metrics" (             |
+|                |   "id" INT UNSIGNED NULL,                                 |
+|                |   "host" STRING NULL,                                     |
+|                |   "cpu" DOUBLE NULL COMMENT 'cpu',                        |
+|                |   "disk" FLOAT NULL,                                      |
+|                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|                |   TIME INDEX ("ts"),                                      |
+|                |   PRIMARY KEY ("id", "host")                              |
 |                | )                                                         |
 |                | ENGINE=mito                                               |
 |                | WITH(                                                     |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When the table name or column name is a keyword, it should be quoted for escaping in `SHOW CREATE TABLE`. This patch adds quotes to every ident *unconditionally*. E.g.:

```sql
CREATE TABLE IF NOT EXISTS `xxx` (
  `ts` TIMESTAMP(3) NOT NULL,
  `mid` STRING NULL,
  `bvid` STRING NULL,
  `cid` DOUBLE NULL,
  `up` STRING NULL,
  `view` DOUBLE NULL,
  `danmaku` DOUBLE NULL,
  `favorite` DOUBLE NULL,
  `coin` DOUBLE NULL,
  `reply` DOUBLE NULL,
  `share` DOUBLE NULL,
  `like` DOUBLE NULL,
  `fans` DOUBLE NULL,
  `watchingcount` DOUBLE NULL,
  TIME INDEX (`ts`),
  PRIMARY KEY (`mid`, `bvid`)
)
ENGINE=mito
WITH(
  regions = 1
)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
