### PR TITLE
fix: fix test_scheduler_continuous_stop in scheduler

### DIFF
--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -235,7 +235,7 @@ mod tests {
         let local_stop = local.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(5)).await;
-            local_stop.stop(false).await.unwrap();
+            local_stop.stop(true).await.unwrap();
             barrier_clone.wait().await;
         });
 

--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -125,6 +125,7 @@ impl Scheduler for LocalScheduler {
             .map_err(|_| InvalidFlumeSenderSnafu {}.build())
     }
 
+    /// if await_termination is true, scheduler will wait all tasks finished before stopping
     async fn stop(&self, await_termination: bool) -> Result<()> {
         ensure!(
             self.state.load(Ordering::Relaxed) == STATE_RUNNING,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
if  parameter await_termination of fn stop in LocalScheduler is true, scheduler will wait all tasks finished before stopping.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
