### PR TITLE
refactor: query_ctx from http middleware

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -64,7 +64,7 @@ use servers::error::{AuthSnafu, ExecuteQuerySnafu, ParsePromQLSnafu};
 use servers::interceptor::{
     PromQueryInterceptor, PromQueryInterceptorRef, SqlQueryInterceptor, SqlQueryInterceptorRef,
 };
-use servers::prometheus::PrometheusHandler;
+use servers::prometheus_handler::PrometheusHandler;
 use servers::query_handler::grpc::{GrpcQueryHandler, GrpcQueryHandlerRef};
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::{

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -51,7 +51,7 @@ use self::region_server::{RegionServerHandlerRef, RegionServerRequestHandler};
 use crate::error::{AlreadyStartedSnafu, InternalSnafu, Result, StartGrpcSnafu, TcpBindSnafu};
 use crate::grpc::database::DatabaseService;
 use crate::grpc::greptime_handler::GreptimeRequestHandler;
-use crate::prometheus::PrometheusHandlerRef;
+use crate::prometheus_handler::PrometheusHandlerRef;
 use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 use crate::server::Server;
 

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -35,9 +35,8 @@ use tonic::{Request, Response};
 use crate::error::InvalidQuerySnafu;
 use crate::grpc::greptime_handler::{auth, create_query_context};
 use crate::grpc::TonicResult;
-use crate::prometheus::{
-    retrieve_metric_name_and_result_type, PrometheusHandlerRef, PrometheusJsonResponse,
-};
+use crate::http::prometheus::{retrieve_metric_name_and_result_type, PrometheusJsonResponse};
+use crate::prometheus_handler::PrometheusHandlerRef;
 
 pub struct PrometheusGatewayService {
     handler: PrometheusHandlerRef,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -28,7 +28,6 @@ pub mod script;
 mod dashboard;
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aide::axum::{routing as apirouting, ApiRouter, IntoApiResponse};
@@ -43,8 +42,6 @@ use axum::middleware::{self, Next};
 use axum::response::{Html, IntoResponse, Json};
 use axum::{routing, BoxError, Extension, Router};
 use common_base::readable_size::ReadableSize;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
-use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use common_query::Output;
@@ -55,7 +52,6 @@ use futures::FutureExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use session::context::QueryContext;
 use snafu::{ensure, ResultExt};
 use tokio::sync::oneshot::{self, Sender};
 use tokio::sync::Mutex;
@@ -85,36 +81,6 @@ use crate::query_handler::{
     PromStoreProtocolHandlerRef, ScriptHandlerRef,
 };
 use crate::server::Server;
-
-/// create query context from database name information, catalog and schema are
-/// resolved from the name
-pub(crate) async fn query_context_from_db(
-    query_handler: ServerSqlQueryHandlerRef,
-    db: Option<String>,
-) -> std::result::Result<Arc<QueryContext>, JsonResponse> {
-    let (catalog, schema) = if let Some(db) = &db {
-        let (catalog, schema) = parse_catalog_and_schema_from_db_string(db);
-
-        match query_handler.is_valid_schema(catalog, schema).await {
-            Ok(true) => (catalog, schema),
-            Ok(false) => {
-                return Err(JsonResponse::with_error(
-                    format!("Database not found: {db}"),
-                    StatusCode::DatabaseNotFound,
-                ))
-            }
-            Err(e) => {
-                return Err(JsonResponse::with_error(
-                    format!("Error checking database: {db}, {e}"),
-                    StatusCode::Internal,
-                ))
-            }
-        }
-    } else {
-        (DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME)
-    };
-    Ok(QueryContext::with(catalog, schema))
-}
 
 pub const HTTP_API_VERSION: &str = "v1";
 pub const HTTP_API_PREFIX: &str = "/v1/";

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -22,6 +22,7 @@ pub mod opentsdb;
 pub mod otlp;
 mod pprof;
 pub mod prom_store;
+pub mod prometheus;
 pub mod script;
 
 #[cfg(feature = "dashboard")]
@@ -65,15 +66,15 @@ use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb
 use crate::configurator::ConfiguratorRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
 use crate::http::admin::{compact, flush};
+use crate::http::prometheus::{
+    instant_query, label_values_query, labels_query, range_query, series_query,
+};
 use crate::metrics::{
     METRIC_CODE_LABEL, METRIC_HTTP_REQUESTS_ELAPSED, METRIC_HTTP_REQUESTS_TOTAL,
     METRIC_METHOD_LABEL, METRIC_PATH_LABEL,
 };
 use crate::metrics_handler::MetricsHandler;
-use crate::prometheus::{
-    instant_query, label_values_query, labels_query, range_query, series_query,
-    PrometheusHandlerRef,
-};
+use crate::prometheus_handler::PrometheusHandlerRef;
 use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 use crate::query_handler::{

--- a/src/servers/src/http/admin.rs
+++ b/src/servers/src/http/admin.rs
@@ -19,8 +19,9 @@ use api::v1::greptime_request::Request;
 use api::v1::{CompactTableExpr, DdlRequest, FlushTableExpr};
 use axum::extract::{Query, RawBody, State};
 use axum::http::StatusCode;
+use axum::Extension;
 use common_catalog::consts::DEFAULT_CATALOG_NAME;
-use session::context::QueryContext;
+use session::context::QueryContextRef;
 use snafu::OptionExt;
 
 use crate::error;
@@ -31,6 +32,7 @@ use crate::query_handler::grpc::ServerGrpcQueryHandlerRef;
 pub async fn flush(
     State(grpc_handler): State<ServerGrpcQueryHandlerRef>,
     Query(params): Query<HashMap<String, String>>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     RawBody(_): RawBody,
 ) -> Result<(StatusCode, ())> {
     let catalog_name = params
@@ -64,9 +66,7 @@ pub async fn flush(
         })),
     });
 
-    grpc_handler
-        .do_query(request, QueryContext::with(&catalog_name, &schema_name))
-        .await?;
+    grpc_handler.do_query(request, query_ctx).await?;
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -74,6 +74,7 @@ pub async fn flush(
 pub async fn compact(
     State(grpc_handler): State<ServerGrpcQueryHandlerRef>,
     Query(params): Query<HashMap<String, String>>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     RawBody(_): RawBody,
 ) -> Result<(StatusCode, ())> {
     let catalog_name = params
@@ -106,8 +107,6 @@ pub async fn compact(
         })),
     });
 
-    grpc_handler
-        .do_query(request, QueryContext::with(&catalog_name, &schema_name))
-        .await?;
+    grpc_handler.do_query(request, query_ctx).await?;
     Ok((StatusCode::NO_CONTENT, ()))
 }

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -17,7 +17,6 @@ use std::env;
 use std::time::Instant;
 
 use aide::transform::TransformOperation;
-use auth::UserInfoRef;
 use axum::extract::{Json, Query, State};
 use axum::response::{IntoResponse, Response};
 use axum::{Extension, Form};
@@ -26,6 +25,7 @@ use common_telemetry::timer;
 use query::parser::PromQuery;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use session::context::QueryContextRef;
 
 use crate::http::{ApiState, GreptimeOptionsConfigState, JsonResponse};
 use crate::metrics_handler::MetricsHandler;
@@ -41,8 +41,7 @@ pub struct SqlQuery {
 pub async fn sql(
     State(state): State<ApiState>,
     Query(query_params): Query<SqlQuery>,
-    // TODO(fys): pass _user_info into query context
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
     Form(form_params): Form<SqlQuery>,
 ) -> Json<JsonResponse> {
     let sql_handler = &state.sql_handler;
@@ -59,13 +58,7 @@ pub async fn sql(
     );
 
     let resp = if let Some(sql) = &sql {
-        match crate::http::query_context_from_db(sql_handler.clone(), db).await {
-            Ok(query_ctx) => {
-                query_ctx.set_current_user(Some(user_info.0));
-                JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
-            }
-            Err(resp) => resp,
-        }
+        JsonResponse::from_output(sql_handler.do_query(sql, query_ctx.0).await).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),
@@ -101,8 +94,7 @@ impl From<PromqlQuery> for PromQuery {
 pub async fn promql(
     State(state): State<ApiState>,
     Query(params): Query<PromqlQuery>,
-    // TODO(fys): pass _user_info into query context
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
 ) -> Json<JsonResponse> {
     let sql_handler = &state.sql_handler;
     let exec_start = Instant::now();
@@ -116,14 +108,9 @@ pub async fn promql(
     );
 
     let prom_query = params.into();
-    let resp = match super::query_context_from_db(sql_handler.clone(), db).await {
-        Ok(query_ctx) => {
-            query_ctx.set_current_user(Some(user_info.0));
-            JsonResponse::from_output(sql_handler.do_promql_query(&prom_query, query_ctx).await)
-                .await
-        }
-        Err(resp) => resp,
-    };
+    let resp =
+        JsonResponse::from_output(sql_handler.do_promql_query(&prom_query, query_ctx.0).await)
+            .await;
 
     Json(resp.with_execution_time(exec_start.elapsed().as_millis()))
 }

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -52,7 +52,7 @@ pub async fn sql(
     let db = query_ctx.get_db_string();
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_SQL_ELAPSED,
-        &[(crate::metrics::METRIC_DB_LABEL, db.clone())]
+        &[(crate::metrics::METRIC_DB_LABEL, db)]
     );
 
     let resp = if let Some(sql) = &sql {
@@ -103,7 +103,7 @@ pub async fn promql(
     let db = query_ctx.get_db_string();
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_PROMQL_ELAPSED,
-        &[(crate::metrics::METRIC_DB_LABEL, db.clone())]
+        &[(crate::metrics::METRIC_DB_LABEL, db)]
     );
 
     if let Some(resp) = validate_schema(sql_handler.clone(), query_ctx.clone()).await {

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -41,7 +41,7 @@ pub struct SqlQuery {
 pub async fn sql(
     State(state): State<ApiState>,
     Query(query_params): Query<SqlQuery>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     Form(form_params): Form<SqlQuery>,
 ) -> Json<JsonResponse> {
     let sql_handler = &state.sql_handler;
@@ -58,7 +58,7 @@ pub async fn sql(
     );
 
     let resp = if let Some(sql) = &sql {
-        JsonResponse::from_output(sql_handler.do_query(sql, query_ctx.0).await).await
+        JsonResponse::from_output(sql_handler.do_query(sql, query_ctx).await).await
     } else {
         JsonResponse::with_error(
             "sql parameter is required.".to_string(),
@@ -94,7 +94,7 @@ impl From<PromqlQuery> for PromQuery {
 pub async fn promql(
     State(state): State<ApiState>,
     Query(params): Query<PromqlQuery>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
 ) -> Json<JsonResponse> {
     let sql_handler = &state.sql_handler;
     let exec_start = Instant::now();
@@ -109,8 +109,7 @@ pub async fn promql(
 
     let prom_query = params.into();
     let resp =
-        JsonResponse::from_output(sql_handler.do_promql_query(&prom_query, query_ctx.0).await)
-            .await;
+        JsonResponse::from_output(sql_handler.do_promql_query(&prom_query, query_ctx).await).await;
 
     Json(resp.with_execution_time(exec_start.elapsed().as_millis()))
 }

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -14,16 +14,14 @@
 
 use std::collections::HashMap;
 
-use auth::UserInfoRef;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
-use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_grpc::writer::Precision;
 use common_telemetry::timer;
-use session::context::QueryContext;
+use session::context::QueryContextRef;
 
 use crate::error::{Result, TimePrecisionSnafu};
 use crate::influxdb::InfluxdbRequest;
@@ -45,7 +43,7 @@ pub async fn influxdb_health() -> Result<impl IntoResponse> {
 pub async fn influxdb_write_v1(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = params
@@ -57,14 +55,14 @@ pub async fn influxdb_write_v1(
         .map(|val| parse_time_precision(val))
         .transpose()?;
 
-    influxdb_write(&db, precision, lines, handler, user_info.0).await
+    influxdb_write(&db, precision, lines, handler, query_ctx.0).await
 }
 
 #[axum_macros::debug_handler]
 pub async fn influxdb_write_v2(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = params
@@ -76,7 +74,7 @@ pub async fn influxdb_write_v2(
         .map(|val| parse_time_precision(val))
         .transpose()?;
 
-    influxdb_write(&db, precision, lines, handler, user_info.0).await
+    influxdb_write(&db, precision, lines, handler, query_ctx.0).await
 }
 
 pub async fn influxdb_write(
@@ -84,19 +82,14 @@ pub async fn influxdb_write(
     precision: Option<Precision>,
     lines: String,
     handler: InfluxdbLineProtocolHandlerRef,
-    user_info: UserInfoRef,
+    ctx: QueryContextRef,
 ) -> Result<impl IntoResponse> {
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_INFLUXDB_WRITE_ELAPSED,
         &[(crate::metrics::METRIC_DB_LABEL, db.to_string())]
     );
 
-    let (catalog, schema) = parse_catalog_and_schema_from_db_string(db);
-    let ctx = QueryContext::with(catalog, schema);
-    ctx.set_current_user(Some(user_info));
-
     let request = InfluxdbRequest { precision, lines };
-
     handler.exec(request, ctx).await?;
 
     Ok((StatusCode::NO_CONTENT, ()))

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -43,7 +43,7 @@ pub async fn influxdb_health() -> Result<impl IntoResponse> {
 pub async fn influxdb_write_v1(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = params
@@ -55,14 +55,14 @@ pub async fn influxdb_write_v1(
         .map(|val| parse_time_precision(val))
         .transpose()?;
 
-    influxdb_write(&db, precision, lines, handler, query_ctx.0).await
+    influxdb_write(&db, precision, lines, handler, query_ctx).await
 }
 
 #[axum_macros::debug_handler]
 pub async fn influxdb_write_v2(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = params
@@ -74,7 +74,7 @@ pub async fn influxdb_write_v2(
         .map(|val| parse_time_precision(val))
         .transpose()?;
 
-    influxdb_write(&db, precision, lines, handler, query_ctx.0).await
+    influxdb_write(&db, precision, lines, handler, query_ctx).await
 }
 
 pub async fn influxdb_write(

--- a/src/servers/src/http/opentsdb.rs
+++ b/src/servers/src/http/opentsdb.rs
@@ -14,13 +14,12 @@
 
 use std::collections::HashMap;
 
-use auth::UserInfoRef;
 use axum::extract::{Query, RawBody, State};
 use axum::http::StatusCode as HttpStatusCode;
 use axum::{Extension, Json};
 use hyper::Body;
 use serde::{Deserialize, Serialize};
-use session::context::QueryContext;
+use session::context::QueryContextRef;
 use snafu::ResultExt;
 
 use crate::error::{self, Error, Result};
@@ -78,16 +77,14 @@ pub enum OpentsdbPutResponse {
 pub async fn put(
     State(opentsdb_handler): State<OpentsdbProtocolHandlerRef>,
     Query(params): Query<HashMap<String, String>>,
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<(HttpStatusCode, Json<OpentsdbPutResponse>)> {
     let summary = params.contains_key("summary");
     let details = params.contains_key("details");
 
-    let ctx = QueryContext::with_db_name(params.get("db"));
-    ctx.set_current_user(Some(user_info.0));
-
     let data_points = parse_data_points(body).await?;
+    let ctx = query_ctx.0;
 
     let response = if !summary && !details {
         for data_point in data_points.into_iter() {

--- a/src/servers/src/http/opentsdb.rs
+++ b/src/servers/src/http/opentsdb.rs
@@ -77,14 +77,13 @@ pub enum OpentsdbPutResponse {
 pub async fn put(
     State(opentsdb_handler): State<OpentsdbProtocolHandlerRef>,
     Query(params): Query<HashMap<String, String>>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(ctx): Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<(HttpStatusCode, Json<OpentsdbPutResponse>)> {
     let summary = params.contains_key("summary");
     let details = params.contains_key("details");
 
     let data_points = parse_data_points(body).await?;
-    let ctx = query_ctx.0;
 
     let response = if !summary && !details {
         for data_point in data_points.into_iter() {

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -12,39 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use auth::UserInfoRef;
 use axum::extract::{RawBody, State};
 use axum::http::header;
 use axum::response::IntoResponse;
-use axum::{Extension, TypedHeader};
+use axum::Extension;
 use common_telemetry::timer;
 use hyper::Body;
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     ExportMetricsServiceRequest, ExportMetricsServiceResponse,
 };
 use prost::Message;
-use session::context::QueryContext;
+use session::context::QueryContextRef;
 use snafu::prelude::*;
 
 use crate::error::{self, Result};
-use crate::http::header::GreptimeDbName;
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 
 #[axum_macros::debug_handler]
 pub async fn metrics(
     State(handler): State<OpenTelemetryProtocolHandlerRef>,
-    TypedHeader(db): TypedHeader<GreptimeDbName>,
-    user_info: Extension<UserInfoRef>,
+    query_ctx: Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<OtlpResponse> {
-    let ctx = QueryContext::with_db_name(db.value());
-    ctx.set_current_user(Some(user_info.0));
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_OPENTELEMETRY_ELAPSED,
-        &[(crate::metrics::METRIC_DB_LABEL, ctx.get_db_string())]
+        &[(crate::metrics::METRIC_DB_LABEL, query_ctx.0.get_db_string())]
     );
     let request = parse_body(body).await?;
-    handler.metrics(request, ctx).await.map(OtlpResponse)
+    handler
+        .metrics(request, query_ctx.0)
+        .await
+        .map(OtlpResponse)
 }
 
 async fn parse_body(body: Body) -> Result<ExportMetricsServiceRequest> {

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -31,18 +31,15 @@ use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 #[axum_macros::debug_handler]
 pub async fn metrics(
     State(handler): State<OpenTelemetryProtocolHandlerRef>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<OtlpResponse> {
     let _timer = timer!(
         crate::metrics::METRIC_HTTP_OPENTELEMETRY_ELAPSED,
-        &[(crate::metrics::METRIC_DB_LABEL, query_ctx.0.get_db_string())]
+        &[(crate::metrics::METRIC_DB_LABEL, query_ctx.get_db_string())]
     );
     let request = parse_body(body).await?;
-    handler
-        .metrics(request, query_ctx.0)
-        .await
-        .map(OtlpResponse)
+    handler.metrics(request, query_ctx).await.map(OtlpResponse)
 }
 
 async fn parse_body(body: Body) -> Result<ExportMetricsServiceRequest> {

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -47,7 +47,7 @@ impl Default for DatabaseQuery {
 pub async fn remote_write(
     State(handler): State<PromStoreProtocolHandlerRef>,
     Query(params): Query<DatabaseQuery>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<(StatusCode, ())> {
     let request = decode_remote_write_request(body).await?;
@@ -60,7 +60,7 @@ pub async fn remote_write(
         )]
     );
 
-    handler.write(request, query_ctx.0).await?;
+    handler.write(request, query_ctx).await?;
     Ok((StatusCode::NO_CONTENT, ()))
 }
 
@@ -81,7 +81,7 @@ impl IntoResponse for PromStoreResponse {
 pub async fn remote_read(
     State(handler): State<PromStoreProtocolHandlerRef>,
     Query(params): Query<DatabaseQuery>,
-    query_ctx: Extension<QueryContextRef>,
+    Extension(query_ctx): Extension<QueryContextRef>,
     RawBody(body): RawBody,
 ) -> Result<PromStoreResponse> {
     let request = decode_remote_read_request(body).await?;
@@ -93,7 +93,7 @@ pub async fn remote_read(
             params.db.clone().unwrap_or_default()
         )]
     );
-    handler.read(request, query_ctx.0).await
+    handler.read(request, query_ctx).await
 }
 
 async fn decode_remote_write_request(body: Body) -> Result<WriteRequest> {

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -14,9 +14,7 @@
 
 //! prom supply the prometheus HTTP API Server compliance
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::Arc;
 
-use async_trait::async_trait;
 use axum::extract::{Path, Query, State};
 use axum::{Extension, Form, Json};
 use catalog::CatalogManagerRef;
@@ -47,17 +45,7 @@ use crate::error::{
     CollectRecordbatchSnafu, Error, InternalSnafu, InvalidQuerySnafu, Result, UnexpectedResultSnafu,
 };
 use crate::prom_store::{FIELD_COLUMN_NAME, METRIC_NAME_LABEL, TIMESTAMP_COLUMN_NAME};
-
-pub const PROMETHEUS_API_VERSION: &str = "v1";
-
-pub type PrometheusHandlerRef = Arc<dyn PrometheusHandler + Send + Sync>;
-
-#[async_trait]
-pub trait PrometheusHandler {
-    async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
-
-    fn catalog_manager(&self) -> CatalogManagerRef;
-}
+use crate::prometheus_handler::PrometheusHandlerRef;
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct PromSeries {

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -35,7 +35,7 @@ pub mod opentsdb;
 pub mod otlp;
 pub mod postgres;
 pub mod prom_store;
-pub mod prometheus;
+pub mod prometheus_handler;
 pub mod query_handler;
 pub mod server;
 mod shutdown;

--- a/src/servers/src/prometheus_handler.rs
+++ b/src/servers/src/prometheus_handler.rs
@@ -1,0 +1,36 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! prom supply the prometheus HTTP API Server compliance
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use catalog::CatalogManagerRef;
+use common_query::Output;
+use query::parser::PromQuery;
+use session::context::QueryContextRef;
+
+use crate::error::Result;
+
+pub const PROMETHEUS_API_VERSION: &str = "v1";
+
+pub type PrometheusHandlerRef = Arc<dyn PrometheusHandler + Send + Sync>;
+
+#[async_trait]
+pub trait PrometheusHandler {
+    async fn do_query(&self, query: &PromQuery, query_ctx: QueryContextRef) -> Result<Output>;
+
+    fn catalog_manager(&self) -> CatalogManagerRef;
+}

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -26,6 +26,7 @@ use servers::http::{
     JsonOutput,
 };
 use servers::metrics_handler::MetricsHandler;
+use session::context::QueryContext;
 use table::test_util::MemTable;
 
 use crate::{
@@ -36,13 +37,15 @@ use crate::{
 #[tokio::test]
 async fn test_sql_not_provided() {
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
+    let ctx = QueryContext::arc();
+    ctx.set_current_user(Some(auth::userinfo_by_name(None)));
     let Json(json) = http_handler::sql(
         State(ApiState {
             sql_handler,
             script_handler: None,
         }),
         Query(http_handler::SqlQuery::default()),
-        axum::Extension(auth::userinfo_by_name(None)),
+        axum::Extension(ctx),
         Form(http_handler::SqlQuery::default()),
     )
     .await;
@@ -61,13 +64,15 @@ async fn test_sql_output_rows() {
     let query = create_query();
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
+    let ctx = QueryContext::arc();
+    ctx.set_current_user(Some(auth::userinfo_by_name(None)));
     let Json(json) = http_handler::sql(
         State(ApiState {
             sql_handler,
             script_handler: None,
         }),
         query,
-        axum::Extension(auth::userinfo_by_name(None)),
+        axum::Extension(ctx),
         Form(http_handler::SqlQuery::default()),
     )
     .await;
@@ -107,13 +112,16 @@ async fn test_sql_form() {
     let form = create_form();
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
+    let ctx = QueryContext::arc();
+    ctx.set_current_user(Some(auth::userinfo_by_name(None)));
+
     let Json(json) = http_handler::sql(
         State(ApiState {
             sql_handler,
             script_handler: None,
         }),
         Query(http_handler::SqlQuery::default()),
-        axum::Extension(auth::userinfo_by_name(None)),
+        axum::Extension(ctx),
         form,
     )
     .await;

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -24,7 +24,7 @@ use client::{Client, Database, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::consts::{MIN_USER_TABLE_ID, MITO_ENGINE};
 use common_query::Output;
 use common_recordbatch::RecordBatches;
-use servers::prometheus::{PromData, PromSeries, PrometheusJsonResponse, PrometheusResponse};
+use servers::http::prometheus::{PromData, PromSeries, PrometheusJsonResponse, PrometheusResponse};
 use servers::server::Server;
 use tests_integration::test_util::{
     setup_grpc_server, setup_grpc_server_with_user_provider, StorageType,

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -20,8 +20,8 @@ use axum_test_helper::TestClient;
 use common_error::status_code::StatusCode as ErrorCode;
 use serde_json::json;
 use servers::http::handler::HealthResponse;
+use servers::http::prometheus::{PrometheusJsonResponse, PrometheusResponse};
 use servers::http::{JsonOutput, JsonResponse};
-use servers::prometheus::{PrometheusJsonResponse, PrometheusResponse};
 use tests_integration::test_util::{
     setup_test_http_app, setup_test_http_app_with_frontend,
     setup_test_http_app_with_frontend_and_user_provider, setup_test_prom_app_with_frontend,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly does
1. change from `Extension<UserInfoRef>` to `Extension<QueryContextRef>` in http Axum handler's signature. `QueryContext` shouldn't be constructed in normal logic code, it should be setup carefully in framework code.
2. move Axum handler related code from `servers/src/prometheus` to `servers/src/http/prometheus` and rename origin file to `prometheus_handler`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
