### PR TITLE
fix: align region numbers to real regions

### DIFF
--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -394,10 +394,12 @@ fn column_qualified_name(table_name: &str, region_name: &str, column_name: &str)
 
 impl<R: Region> MitoTable<R> {
     pub(crate) fn new(
-        table_info: TableInfo,
+        mut table_info: TableInfo,
         regions: HashMap<RegionNumber, R>,
         manifest: TableManifest,
     ) -> Self {
+        // `TableInfo` is recovered from the file, which may contain incorrect content. We align it to real regions.
+        table_info.meta.region_numbers = regions.keys().copied().collect::<Vec<_>>();
         Self {
             table_info: ArcSwap::new(Arc::new(table_info)),
             regions: ArcSwap::new(Arc::new(regions)),
@@ -567,6 +569,16 @@ impl<R: Region> MitoTable<R> {
             Arc::new(regions)
         });
 
+        let _ = self.table_info.rcu(|info| {
+            let mut info = TableInfo::clone(info);
+
+            info.meta
+                .region_numbers
+                .retain(|r| !region_numbers.contains(r));
+
+            Arc::new(info)
+        });
+
         Ok(removed)
     }
 
@@ -644,6 +656,14 @@ impl<R: Region> MitoTable<R> {
                 .or_insert_with(|| region.clone());
 
             Arc::new(regions)
+        });
+
+        let _ = self.table_info.rcu(|info| {
+            let mut info = TableInfo::clone(info);
+
+            info.meta.region_numbers.push(region_number);
+
+            Arc::new(info)
         });
 
         info!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Align region numbers to real regions

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
