### PR TITLE
chore: change version to 0.4.0-nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "common-base",
  "common-error",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arrow",
  "clap 4.3.21",
@@ -1228,7 +1228,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "arc-swap",
@@ -1511,7 +1511,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "client"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1537,7 +1537,7 @@ dependencies = [
  "prost",
  "rand",
  "snafu",
- "substrait 0.3.2",
+ "substrait 0.4.0-nightly",
  "substrait 0.7.5",
  "tokio",
  "tokio-stream",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1612,7 +1612,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.3.2",
+ "substrait 0.4.0-nightly",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1645,7 +1645,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "chrono",
  "common-error",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "snafu",
  "strum 0.24.1",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arc-swap",
  "chrono-tz 0.6.3",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "common-function-macro"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arc-swap",
  "backtrace",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "common-error",
  "snafu",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-stream",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "common-error",
  "datafusion",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "once_cell",
  "rand",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arrow",
  "chrono",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "build-data",
 ]
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2678,7 +2678,7 @@ dependencies = [
  "sql",
  "storage",
  "store-api",
- "substrait 0.3.2",
+ "substrait 0.4.0-nightly",
  "table",
  "table-procedure",
  "tokio",
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3152,7 +3152,7 @@ dependencies = [
 
 [[package]]
 name = "file-table-engine"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "common-catalog",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-compat",
@@ -3332,7 +3332,7 @@ dependencies = [
  "storage",
  "store-api",
  "strfmt",
- "substrait 0.3.2",
+ "substrait 0.4.0-nightly",
  "table",
  "tokio",
  "toml 0.7.6",
@@ -4999,7 +4999,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",
@@ -5303,7 +5303,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "api",
@@ -5493,7 +5493,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "arc-swap",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "api",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6466,7 +6466,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",
@@ -7044,7 +7044,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -7305,7 +7305,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "ahash 0.8.3",
  "approx_eq",
@@ -7361,7 +7361,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.3.2",
+ "substrait 0.4.0-nightly",
  "table",
  "tokio",
  "tokio-stream",
@@ -8595,7 +8595,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -8842,7 +8842,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "aide",
  "api",
@@ -8934,7 +8934,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "arc-swap",
  "auth",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "common-base",
@@ -9267,7 +9267,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "client",
@@ -9472,7 +9472,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "arc-swap",
@@ -9524,7 +9524,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "aquamarine",
@@ -9684,7 +9684,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9841,7 +9841,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9876,7 +9876,7 @@ dependencies = [
 
 [[package]]
 name = "table-procedure"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
  "catalog",
@@ -9969,7 +9969,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.3.2"
+version = "0.4.0-nightly"
 dependencies = [
  "api",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0-nightly"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -351,15 +351,17 @@ mod test {
         }
 
         let query = "select version()";
-        let expected = format!(
-            r#"+----------------+
-| version()      |
-+----------------+
-| {}-greptime |
-+----------------+"#,
-            env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string())
-        );
-        test(query, &expected);
+        let version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_string());
+        let output = check(query, QueryContext::arc());
+        match output.unwrap() {
+            Output::RecordBatches(r) => {
+                assert!(&r
+                    .pretty_print()
+                    .unwrap()
+                    .contains(&format!("{version}-greptime")));
+            }
+            _ => unreachable!(),
+        }
 
         let query = "SELECT @@version_comment LIMIT 1";
         let expected = "\


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change the db version in develop branch to `0.4.0-nightly`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
