### PR TITLE
feat: drop distributed Mito2 table

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -56,6 +56,7 @@ pub enum StatusCode {
     TableColumnNotFound = 4002,
     TableColumnExists = 4003,
     DatabaseNotFound = 4004,
+    RegionNotFound = 4005,
     // ====== End of catalog related status code =======
 
     // ====== Begin of storage related status code =====
@@ -113,6 +114,7 @@ impl StatusCode {
             | StatusCode::EngineExecuteQuery
             | StatusCode::TableAlreadyExists
             | StatusCode::TableNotFound
+            | StatusCode::RegionNotFound
             | StatusCode::TableColumnNotFound
             | StatusCode::TableColumnExists
             | StatusCode::DatabaseNotFound
@@ -145,6 +147,7 @@ impl StatusCode {
             | StatusCode::InvalidSyntax
             | StatusCode::TableAlreadyExists
             | StatusCode::TableNotFound
+            | StatusCode::RegionNotFound
             | StatusCode::TableColumnNotFound
             | StatusCode::TableColumnExists
             | StatusCode::DatabaseNotFound
@@ -173,6 +176,7 @@ impl StatusCode {
             v if v == StatusCode::EngineExecuteQuery as u32 => Some(StatusCode::EngineExecuteQuery),
             v if v == StatusCode::TableAlreadyExists as u32 => Some(StatusCode::TableAlreadyExists),
             v if v == StatusCode::TableNotFound as u32 => Some(StatusCode::TableNotFound),
+            v if v == StatusCode::RegionNotFound as u32 => Some(StatusCode::RegionNotFound),
             v if v == StatusCode::TableColumnNotFound as u32 => {
                 Some(StatusCode::TableColumnNotFound)
             }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use client::region::RegionClientBuilderError;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_meta::peer::Peer;
@@ -561,6 +562,7 @@ impl ErrorExt for Error {
             | Error::ConvertGrpcExpr { .. }
             | Error::PublishMessage { .. }
             | Error::Join { .. }
+            | Error::BuildRegionClient { .. }
             | Error::Unsupported { .. } => StatusCode::Internal,
             Error::TableAlreadyExists { .. } => StatusCode::TableAlreadyExists,
             Error::EmptyKey { .. }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use client::region::RegionClientBuilderError;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_meta::peer::Peer;
@@ -562,7 +561,6 @@ impl ErrorExt for Error {
             | Error::ConvertGrpcExpr { .. }
             | Error::PublishMessage { .. }
             | Error::Join { .. }
-            | Error::BuildRegionClient { .. }
             | Error::Unsupported { .. } => StatusCode::Internal,
             Error::TableAlreadyExists { .. } => StatusCode::TableAlreadyExists,
             Error::EmptyKey { .. }

--- a/src/meta-srv/src/metrics.rs
+++ b/src/meta-srv/src/metrics.rs
@@ -20,3 +20,4 @@ pub(crate) const METRIC_META_HEARTBEAT_CONNECTION_NUM: &str = "meta.heartbeat_co
 pub(crate) const METRIC_META_HANDLER_EXECUTE: &str = "meta.handler_execute";
 
 pub(crate) const METRIC_META_PROCEDURE_CREATE_TABLE: &str = "meta.procedure.create_table";
+pub(crate) const METRIC_META_PROCEDURE_DROP_TABLE: &str = "meta.procedure.drop_table";

--- a/src/meta-srv/src/procedure/create_table.rs
+++ b/src/meta-srv/src/procedure/create_table.rs
@@ -372,14 +372,7 @@ mod test {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
 
-    use api::v1::{
-        ColumnDataType, ColumnDef as PbColumnDef, CreateTableExpr,
-    };
-    use chrono::DateTime;
-    use datatypes::prelude::ConcreteDataType;
-    use datatypes::schema::{ColumnSchema, RawSchema};
-    use table::metadata::{RawTableMeta, TableIdent, TableType};
-    use table::requests::TableOptions;
+    use api::v1::{ColumnDataType, ColumnDef as PbColumnDef, CreateTableExpr};
 
     use super::*;
     use crate::procedure::utils::mock::EchoRegionServer;
@@ -424,52 +417,6 @@ mod test {
             table_id: None,
             region_numbers: vec![1, 2, 3],
             engine: MITO2_ENGINE.to_string(),
-        };
-
-        let raw_table_info = RawTableInfo {
-            ident: TableIdent::new(42),
-            name: "my_table".to_string(),
-            desc: Some("blabla".to_string()),
-            catalog_name: "my_catalog".to_string(),
-            schema_name: "my_schema".to_string(),
-            meta: RawTableMeta {
-                schema: RawSchema {
-                    column_schemas: vec![
-                        ColumnSchema::new(
-                            "ts".to_string(),
-                            ConcreteDataType::timestamp_millisecond_datatype(),
-                            false,
-                        ),
-                        ColumnSchema::new(
-                            "my_tag1".to_string(),
-                            ConcreteDataType::string_datatype(),
-                            true,
-                        ),
-                        ColumnSchema::new(
-                            "my_tag2".to_string(),
-                            ConcreteDataType::string_datatype(),
-                            true,
-                        ),
-                        ColumnSchema::new(
-                            "my_field_column".to_string(),
-                            ConcreteDataType::int32_datatype(),
-                            true,
-                        ),
-                    ],
-                    timestamp_index: Some(0),
-                    version: 0,
-                },
-                primary_key_indices: vec![1, 2],
-                value_indices: vec![2],
-                engine: MITO2_ENGINE.to_string(),
-                next_column_id: 3,
-                region_numbers: vec![1, 2, 3],
-                engine_options: HashMap::new(),
-                options: TableOptions::default(),
-                created_on: DateTime::default(),
-                partition_key_indices: vec![],
-            },
-            table_type: TableType::Base,
         };
 
         CreateTableProcedure::new(

--- a/src/meta-srv/src/procedure/drop_table.rs
+++ b/src/meta-srv/src/procedure/drop_table.rs
@@ -187,7 +187,9 @@ impl DropTableProcedure {
                     let requester = RegionRequester::new(client);
 
                     if let Err(err) = requester.handle(request).await {
-                        return Err(handle_request_datanode_error(datanode)(err));
+                        if err.status_code() != StatusCode::RegionNotFound {
+                            return Err(handle_request_datanode_error(datanode)(err));
+                        }
                     }
                 }
                 Ok(())

--- a/src/meta-srv/src/procedure/drop_table.rs
+++ b/src/meta-srv/src/procedure/drop_table.rs
@@ -175,7 +175,7 @@ impl DropTableProcedure {
                 .map(|region_number| RegionId::new(table_id, *region_number))
                 .collect::<Vec<_>>();
 
-            drop_region_tasks.push(common_runtime::spawn_bg(async move {
+            drop_region_tasks.push(async move {
                 for region_id in region_ids {
                     debug!("Dropping region {region_id} on Datanode {datanode:?}");
 
@@ -193,13 +193,12 @@ impl DropTableProcedure {
                     }
                 }
                 Ok(())
-            }));
+            });
         }
 
         join_all(drop_region_tasks)
             .await
             .into_iter()
-            .map(|e| e.context(error::JoinSnafu).flatten())
             .collect::<Result<Vec<_>>>()?;
 
         Ok(Status::Done)

--- a/src/meta-srv/src/procedure/utils.rs
+++ b/src/meta-srv/src/procedure/utils.rs
@@ -42,3 +42,182 @@ pub fn handle_retry_error(e: Error) -> ProcedureError {
         ProcedureError::external(e)
     }
 }
+
+#[cfg(test)]
+pub mod mock {
+    use std::io::Error;
+    use std::sync::Arc;
+
+    use api::v1::region::region_request::Request as PbRegionRequest;
+    use api::v1::region::region_server_server::RegionServerServer;
+    use api::v1::region::RegionResponse;
+    use api::v1::{ResponseHeader, Status as PbStatus};
+    use async_trait::async_trait;
+    use client::Client;
+    use common_grpc::channel_manager::ChannelManager;
+    use common_meta::peer::Peer;
+    use common_runtime::{Builder as RuntimeBuilder, Runtime};
+    use servers::grpc::region_server::{RegionServerHandler, RegionServerRequestHandler};
+    use tokio::sync::mpsc;
+    use tonic::transport::Server;
+    use tower::service_fn;
+
+    /// An mock implementation of region server that simply echoes the request.
+    #[derive(Clone)]
+    pub struct EchoRegionServer {
+        runtime: Arc<Runtime>,
+        received_requests: mpsc::Sender<PbRegionRequest>,
+    }
+
+    impl EchoRegionServer {
+        pub fn new() -> (Self, mpsc::Receiver<PbRegionRequest>) {
+            let (tx, rx) = mpsc::channel(10);
+            (
+                Self {
+                    runtime: Arc::new(RuntimeBuilder::default().worker_threads(2).build().unwrap()),
+                    received_requests: tx,
+                },
+                rx,
+            )
+        }
+
+        pub fn new_client(&self, datanode: &Peer) -> Client {
+            let (client, server) = tokio::io::duplex(1024);
+
+            let handler =
+                RegionServerRequestHandler::new(Arc::new(self.clone()), None, self.runtime.clone());
+
+            tokio::spawn(async move {
+                Server::builder()
+                    .add_service(RegionServerServer::new(handler))
+                    .serve_with_incoming(futures::stream::iter(vec![Ok::<_, Error>(server)]))
+                    .await
+            });
+
+            let channel_manager = ChannelManager::new();
+            let mut client = Some(client);
+            channel_manager
+                .reset_with_connector(
+                    datanode.addr.clone(),
+                    service_fn(move |_| {
+                        let client = client.take().unwrap();
+                        async move { Ok::<_, Error>(client) }
+                    }),
+                )
+                .unwrap();
+            Client::with_manager_and_urls(channel_manager, vec![datanode.addr.clone()])
+        }
+    }
+
+    #[async_trait]
+    impl RegionServerHandler for EchoRegionServer {
+        async fn handle(&self, request: PbRegionRequest) -> servers::error::Result<RegionResponse> {
+            self.received_requests.send(request).await.unwrap();
+
+            Ok(RegionResponse {
+                header: Some(ResponseHeader {
+                    status: Some(PbStatus {
+                        status_code: 0,
+                        err_msg: "".to_string(),
+                    }),
+                }),
+                affected_rows: 0,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod test_data {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use chrono::DateTime;
+    use client::client_manager::DatanodeClients;
+    use common_catalog::consts::MITO2_ENGINE;
+    use common_meta::key::TableMetadataManager;
+    use common_meta::peer::Peer;
+    use common_meta::rpc::router::RegionRoute;
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::schema::{ColumnSchema, RawSchema};
+    use table::metadata::{RawTableInfo, RawTableMeta, TableIdent, TableType};
+    use table::requests::TableOptions;
+
+    use crate::ddl::DdlContext;
+    use crate::handler::{HeartbeatMailbox, Pushers};
+    use crate::sequence::Sequence;
+    use crate::service::store::kv::KvBackendAdapter;
+    use crate::service::store::memory::MemStore;
+    use crate::test_util::new_region_route;
+
+    pub fn new_region_routes() -> Vec<RegionRoute> {
+        let peers = vec![
+            Peer::new(1, "127.0.0.1:4001"),
+            Peer::new(2, "127.0.0.1:4002"),
+            Peer::new(3, "127.0.0.1:4003"),
+        ];
+        vec![
+            new_region_route(1, &peers, 3),
+            new_region_route(2, &peers, 2),
+            new_region_route(3, &peers, 1),
+        ]
+    }
+
+    pub fn new_table_info() -> RawTableInfo {
+        RawTableInfo {
+            ident: TableIdent::new(42),
+            name: "my_table".to_string(),
+            desc: Some("blabla".to_string()),
+            catalog_name: "my_catalog".to_string(),
+            schema_name: "my_schema".to_string(),
+            meta: RawTableMeta {
+                schema: RawSchema {
+                    column_schemas: vec![
+                        ColumnSchema::new(
+                            "ts".to_string(),
+                            ConcreteDataType::timestamp_millisecond_datatype(),
+                            false,
+                        ),
+                        ColumnSchema::new(
+                            "my_tag_column".to_string(),
+                            ConcreteDataType::string_datatype(),
+                            true,
+                        ),
+                        ColumnSchema::new(
+                            "my_field_column".to_string(),
+                            ConcreteDataType::int32_datatype(),
+                            true,
+                        ),
+                    ],
+                    timestamp_index: Some(0),
+                    version: 0,
+                },
+                primary_key_indices: vec![1],
+                value_indices: vec![2],
+                engine: MITO2_ENGINE.to_string(),
+                next_column_id: 3,
+                region_numbers: vec![1, 2, 3],
+                engine_options: HashMap::new(),
+                options: TableOptions::default(),
+                created_on: DateTime::default(),
+                partition_key_indices: vec![],
+            },
+            table_type: TableType::Base,
+        }
+    }
+
+    pub(crate) fn new_ddl_context() -> DdlContext {
+        let kv_store = Arc::new(MemStore::new());
+
+        let mailbox_sequence = Sequence::new("test_heartbeat_mailbox", 0, 100, kv_store.clone());
+        let mailbox = HeartbeatMailbox::create(Pushers::default(), mailbox_sequence);
+
+        let kv_backend = KvBackendAdapter::wrap(kv_store);
+        DdlContext {
+            datanode_clients: Arc::new(DatanodeClients::default()),
+            mailbox,
+            server_addr: "127.0.0.1:4321".to_string(),
+            table_metadata_manager: Arc::new(TableMetadataManager::new(kv_backend)),
+        }
+    }
+}

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -467,6 +467,7 @@ pub fn status_to_tonic_code(status_code: StatusCode) -> Code {
         StatusCode::Cancelled => Code::Cancelled,
         StatusCode::TableAlreadyExists | StatusCode::TableColumnExists => Code::AlreadyExists,
         StatusCode::TableNotFound
+        | StatusCode::RegionNotFound
         | StatusCode::TableColumnNotFound
         | StatusCode::DatabaseNotFound
         | StatusCode::UserNotFound => Code::NotFound,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Drop distributed Mito2 table.

If "`engine = mito2`" is in the table info, drop the Mito2 table. Otherwise drop the original Mito table.

Note that since the Mito2 region is not able to be actually created on Datanodes now, there are no complete drop Mito2 table tests. I only mock the region server's grpc interfaces in the unit tests. Once the region server is ready on Datanode, it's easy to really test it.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#2254