### PR TITLE
fix: use RegionId region number instead

### DIFF
--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -745,7 +745,7 @@ fn create_partitions_stmt(partitions: Vec<PartitionInfo>) -> Result<Option<Parti
         .into_iter()
         .map(|info| {
             // Generated the partition name from id
-            let name = &format!("r{}", info.id.as_u64());
+            let name = &format!("r{}", info.id.region_number());
             let bounds = info.partition.partition_bounds();
             let value_list = bounds
                 .iter()

--- a/src/meta-srv/src/procedure/region_failover/update_metadata.rs
+++ b/src/meta-srv/src/procedure/region_failover/update_metadata.rs
@@ -72,7 +72,7 @@ impl UpdateRegionMetadata {
         let mut new_region_routes = table_route_value.region_routes.clone();
 
         for region_route in new_region_routes.iter_mut() {
-            if region_route.region.id == failed_region.region_number as u64 {
+            if region_route.region.id.region_number() == failed_region.region_number {
                 region_route.leader_peer = Some(self.candidate.clone());
                 break;
             }

--- a/src/meta-srv/src/service/ddl.rs
+++ b/src/meta-srv/src/service/ddl.rs
@@ -178,8 +178,8 @@ async fn handle_create_region_routes(
     // If the peers are not enough, some peers will be used for multiple partitions.
     peers.truncate(partitions.len());
 
-    let id = table_id_sequence.next().await?;
-    table_info.ident.table_id = id as u32;
+    let table_id = table_id_sequence.next().await? as u32;
+    table_info.ident.table_id = table_id;
 
     ensure!(
         partitions.len() <= MAX_REGION_SEQ as usize,
@@ -191,7 +191,7 @@ async fn handle_create_region_routes(
         .enumerate()
         .map(|(i, partition)| {
             let region = Region {
-                id: RegionId::from_u64(i as u64),
+                id: RegionId::new(table_id, i as u32),
                 partition: Some(partition.into()),
                 ..Default::default()
             };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

use RegionId region number instead

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
