### PR TITLE
fix: deregister table after keeper closes table

### DIFF
--- a/src/catalog/src/remote/manager.rs
+++ b/src/catalog/src/remote/manager.rs
@@ -226,7 +226,7 @@ async fn register_table(
             engine: table_info.meta.engine.clone(),
         };
         region_alive_keepers
-            .register_table(table_ident, table)
+            .register_table(table_ident, table, memory_catalog_manager.clone())
             .await?;
     }
 

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -274,7 +274,7 @@ impl RegionAliveKeeper {
                         ident.table_id
                     );
                 } else {
-                    warn!("Countdown task returns: {result:?}");
+                    debug!("Countdown task returns: {result:?}");
                 }
                 on_task_finished
             },
@@ -578,9 +578,7 @@ mod test {
             table_options: TableOptions::default(),
             engine: "MockTableEngine".to_string(),
         }));
-        let catalog_manager = MemoryCatalogManager::try_new_with_table(table.clone())
-            .await
-            .unwrap();
+        let catalog_manager = MemoryCatalogManager::new_with_table(table.clone());
         keepers
             .register_table(table_ident.clone(), table, catalog_manager)
             .await

--- a/src/catalog/src/remote/region_alive_keeper.rs
+++ b/src/catalog/src/remote/region_alive_keeper.rs
@@ -37,6 +37,8 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
 
 use crate::error::{Result, TableEngineNotFoundSnafu};
+use crate::local::MemoryCatalogManager;
+use crate::DeregisterTableRequest;
 
 /// [RegionAliveKeepers] manages all [RegionAliveKeeper] in a scope of tables.
 pub struct RegionAliveKeepers {
@@ -70,7 +72,12 @@ impl RegionAliveKeepers {
         self.keepers.lock().await.get(&table_id).cloned()
     }
 
-    pub async fn register_table(&self, table_ident: TableIdent, table: TableRef) -> Result<()> {
+    pub async fn register_table(
+        &self,
+        table_ident: TableIdent,
+        table: TableRef,
+        catalog_manager: Arc<MemoryCatalogManager>,
+    ) -> Result<()> {
         let table_id = table_ident.table_id;
         let keeper = self.find_keeper(table_id).await;
         if keeper.is_some() {
@@ -86,6 +93,7 @@ impl RegionAliveKeepers {
 
         let keeper = Arc::new(RegionAliveKeeper::new(
             table_engine,
+            catalog_manager,
             table_ident.clone(),
             self.heartbeat_interval_millis,
         ));
@@ -203,6 +211,7 @@ impl HeartbeatResponseHandler for RegionAliveKeepers {
 /// Datanode, it will "extend" the region's "lease", with a deadline for [RegionAliveKeeper] to
 /// countdown.
 pub struct RegionAliveKeeper {
+    catalog_manager: Arc<MemoryCatalogManager>,
     table_engine: TableEngineRef,
     table_ident: TableIdent,
     countdown_task_handles: Arc<Mutex<HashMap<RegionNumber, Arc<CountdownTaskHandle>>>>,
@@ -213,10 +222,12 @@ pub struct RegionAliveKeeper {
 impl RegionAliveKeeper {
     fn new(
         table_engine: TableEngineRef,
+        catalog_manager: Arc<MemoryCatalogManager>,
         table_ident: TableIdent,
         heartbeat_interval_millis: u64,
     ) -> Self {
         Self {
+            catalog_manager,
             table_engine,
             table_ident,
             countdown_task_handles: Arc::new(Mutex::new(HashMap::new())),
@@ -244,11 +255,29 @@ impl RegionAliveKeeper {
                 let _ = x.lock().await.remove(&region);
             } // Else the countdown task handles map could be dropped because the keeper is dropped.
         };
+        let catalog_manager = self.catalog_manager.clone();
+        let ident = self.table_ident.clone();
         let handle = Arc::new(CountdownTaskHandle::new(
             self.table_engine.clone(),
             self.table_ident.clone(),
             region,
-            || on_task_finished,
+            move |result: Option<CloseTableResult>| {
+                if matches!(result, Some(CloseTableResult::Released(_))) {
+                    let result = catalog_manager.deregister_table_sync(DeregisterTableRequest {
+                        catalog: ident.catalog.to_string(),
+                        schema: ident.schema.to_string(),
+                        table_name: ident.table.to_string(),
+                    });
+
+                    info!(
+                        "Deregister table: {} after countdown task finished, result: {result:?}",
+                        ident.table_id
+                    );
+                } else {
+                    warn!("Countdown task returns: {result:?}");
+                }
+                on_task_finished
+            },
         ));
 
         let mut handles = self.countdown_task_handles.lock().await;
@@ -347,7 +376,7 @@ impl CountdownTaskHandle {
         table_engine: TableEngineRef,
         table_ident: TableIdent,
         region: RegionNumber,
-        on_task_finished: impl FnOnce() -> Fut + Send + 'static,
+        on_task_finished: impl FnOnce(Option<CloseTableResult>) -> Fut + Send + 'static,
     ) -> Self
     where
         Fut: Future<Output = ()> + Send,
@@ -361,8 +390,8 @@ impl CountdownTaskHandle {
             rx,
         };
         let handler = common_runtime::spawn_bg(async move {
-            countdown_task.run().await;
-            on_task_finished().await;
+            let result = countdown_task.run().await;
+            on_task_finished(result).await;
         });
 
         Self {
@@ -414,7 +443,8 @@ struct CountdownTask {
 }
 
 impl CountdownTask {
-    async fn run(&mut self) {
+    // returns true if
+    async fn run(&mut self) -> Option<CloseTableResult> {
         // 30 years. See `Instant::far_future`.
         let far_future = Instant::now() + Duration::from_secs(86400 * 365 * 30);
 
@@ -468,10 +498,11 @@ impl CountdownTask {
                         "Region {region} of table {table_ident} is closed, result: {result:?}. \
                         RegionAliveKeeper out.",
                     );
-                    break;
+                    return Some(result);
                 }
             }
         }
+        None
     }
 
     async fn close_region(&self) -> CloseTableResult {
@@ -547,8 +578,11 @@ mod test {
             table_options: TableOptions::default(),
             engine: "MockTableEngine".to_string(),
         }));
+        let catalog_manager = MemoryCatalogManager::try_new_with_table(table.clone())
+            .await
+            .unwrap();
         keepers
-            .register_table(table_ident.clone(), table)
+            .register_table(table_ident.clone(), table, catalog_manager)
             .await
             .unwrap();
         assert!(keepers
@@ -684,7 +718,8 @@ mod test {
             table_id: 1024,
             engine: "mito".to_string(),
         };
-        let keeper = RegionAliveKeeper::new(table_engine, table_ident, 1000);
+        let catalog_manager = MemoryCatalogManager::with_default_setup();
+        let keeper = RegionAliveKeeper::new(table_engine, catalog_manager, table_ident, 1000);
 
         let region = 1;
         assert!(keeper.find_handle(&region).await.is_none());
@@ -727,7 +762,7 @@ mod test {
             table_engine.clone(),
             table_ident.clone(),
             1,
-            || async move { finished_clone.store(true, Ordering::Relaxed) },
+            |_| async move { finished_clone.store(true, Ordering::Relaxed) },
         );
         let tx = handle.tx.clone();
 
@@ -749,7 +784,7 @@ mod test {
 
         let finished = Arc::new(AtomicBool::new(false));
         let finished_clone = finished.clone();
-        let handle = CountdownTaskHandle::new(table_engine, table_ident, 1, || async move {
+        let handle = CountdownTaskHandle::new(table_engine, table_ident, 1, |_| async move {
             finished_clone.store(true, Ordering::Relaxed)
         });
         handle.tx.send(CountdownCommand::Start(100)).await.unwrap();

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -20,6 +20,7 @@ use api::v1::greptime_request::Request as GrpcRequest;
 use api::v1::meta::HeartbeatResponse;
 use api::v1::query_request::Query;
 use api::v1::QueryRequest;
+use catalog::local::MemoryCatalogManager;
 use catalog::remote::region_alive_keeper::RegionAliveKeepers;
 use catalog::CatalogManagerRef;
 use common_meta::heartbeat::handler::{
@@ -160,8 +161,10 @@ async fn test_open_region_handler() {
     let table_ident = &region_ident.table_ident;
 
     let table = prepare_table(instance.inner()).await;
+
+    let dummy_catalog_manager = MemoryCatalogManager::with_default_setup();
     region_alive_keepers
-        .register_table(table_ident.clone(), table)
+        .register_table(table_ident.clone(), table, dummy_catalog_manager)
         .await
         .unwrap();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Deregister table after keeper closes the table

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
