### PR TITLE
feat: implement storage for OTLP histogram

### DIFF
--- a/src/frontend/src/instance/otlp.rs
+++ b/src/frontend/src/instance/otlp.rs
@@ -42,7 +42,7 @@ impl OpenTelemetryProtocolHandler for Instance {
             .context(AuthSnafu)?;
         let (requests, rows) = otlp::to_grpc_insert_requests(request)?;
         let _ = self
-            .handle_inserts(requests, ctx)
+            .handle_row_inserts(requests, ctx)
             .await
             .map_err(BoxedError::new)
             .context(error::ExecuteGrpcQuerySnafu)?;

--- a/src/servers/src/influxdb.rs
+++ b/src/servers/src/influxdb.rs
@@ -53,7 +53,7 @@ impl TryFrom<InfluxdbRequest> for RowInsertRequests {
 
             // tags
             if let Some(tags) = tags {
-                let kvs = tags.iter().map(|(k, v)| (k.as_str(), v.as_str()));
+                let kvs = tags.iter().map(|(k, v)| (k.to_string(), v.as_str()));
                 row_writer::write_tags(table_data, kvs, &mut one_row)?;
             }
 
@@ -69,7 +69,7 @@ impl TryFrom<InfluxdbRequest> for RowInsertRequests {
                     ),
                     FieldValue::Boolean(v) => (ColumnDataType::Boolean, ValueData::BoolValue(*v)),
                 };
-                (k.as_str(), datatype, value)
+                (k.to_string(), datatype, value)
             });
             row_writer::write_fields(table_data, fields, &mut one_row)?;
 

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -232,13 +232,13 @@ fn encode_sum(
     Ok(())
 }
 
-const HISTOGRAM_LE_COLUMN: &str = "le";
+const HISTOGRAM_LE_COLUMN: &str = "greptime_le";
 
 /// Encode histogram data. This function returns 3 insert requests for 3 tables.
 ///
 /// The implementation has been following Prometheus histogram table format:
 ///
-/// - A `%metric%_bucket` table including `le` tag that stores bucket upper
+/// - A `%metric%_bucket` table including `greptime_le` tag that stores bucket upper
 /// limit, and `greptime_value` for bucket count
 /// - A `%metric%_sum` table storing sum of samples
 /// -  A `%metric%_count` table storing count of samples.

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -259,23 +259,23 @@ fn encode_histogram(
     let mut count_lines = LinesWriter::with_lines(data_points_len);
 
     for data_point in &hist.data_points {
-        write_tags_and_timestamp(
-            &mut bucket_lines,
-            resource_attrs,
-            scope_attrs,
-            Some(data_point.attributes.as_ref()),
-            data_point.time_unix_nano as i64,
-        )?;
-
         for (idx, count) in data_point.bucket_counts.iter().enumerate() {
+            write_tags_and_timestamp(
+                &mut bucket_lines,
+                resource_attrs,
+                scope_attrs,
+                Some(data_point.attributes.as_ref()),
+                data_point.time_unix_nano as i64,
+            )?;
+
             if let Some(upper_bounds) = data_point.explicit_bounds.get(idx) {
                 bucket_lines
-                    .write_f64(HISTOGRAM_LE_COLUMN, *upper_bounds)
+                    .write_tag(HISTOGRAM_LE_COLUMN, &upper_bounds.to_string())
                     .context(error::OtlpMetricsWriteSnafu)?;
             } else if idx == data_point.explicit_bounds.len() {
                 // The last bucket
                 bucket_lines
-                    .write_f64(HISTOGRAM_LE_COLUMN, f64::INFINITY)
+                    .write_tag(HISTOGRAM_LE_COLUMN, &f64::INFINITY.to_string())
                     .context(error::OtlpMetricsWriteSnafu)?;
             }
 

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -258,6 +258,7 @@ fn encode_histogram(
     let mut sum_lines = LinesWriter::with_lines(data_points_len);
     let mut count_lines = LinesWriter::with_lines(data_points_len);
 
+    let mut accumulated_count = 0;
     for data_point in &hist.data_points {
         for (idx, count) in data_point.bucket_counts.iter().enumerate() {
             write_tags_and_timestamp(
@@ -279,8 +280,9 @@ fn encode_histogram(
                     .context(error::OtlpMetricsWriteSnafu)?;
             }
 
+            accumulated_count += count;
             bucket_lines
-                .write_u64(GREPTIME_VALUE, *count)
+                .write_u64(GREPTIME_VALUE, accumulated_count)
                 .context(error::OtlpMetricsWriteSnafu)?;
 
             bucket_lines.commit();

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -232,7 +232,7 @@ fn encode_sum(
     Ok(())
 }
 
-const HISTOGRAM_LE_COLUMN: &str = "greptime_le";
+const HISTOGRAM_LE_COLUMN: &str = "le";
 
 /// Encode histogram data. This function returns 3 insert requests for 3 tables.
 ///

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -334,7 +334,7 @@ pub fn to_grpc_row_insert_requests(request: WriteRequest) -> Result<(RowInsertRe
                 if label.name == METRIC_NAME_LABEL {
                     None
                 } else {
-                    Some((label.name.as_str(), label.value.as_str()))
+                    Some((label.name.to_string(), label.value.as_str()))
                 }
             });
             row_writer::write_tags(table_data, kvs, &mut one_row)?;

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -62,6 +62,11 @@ impl TableData {
         self.rows.push(Row { values })
     }
 
+    #[allow(dead_code)]
+    pub fn columns(&self) -> &Vec<ColumnSchema> {
+        &self.schema
+    }
+
     pub fn into_schema_and_rows(self) -> (Vec<ColumnSchema>, Vec<Row>) {
         (self.schema, self.rows)
     }
@@ -98,6 +103,11 @@ impl MultiTableData {
     pub fn add_table_data(&mut self, table_name: impl ToString, table_data: TableData) {
         self.table_data_map
             .insert(table_name.to_string(), table_data);
+    }
+
+    #[allow(dead_code)]
+    pub fn num_tables(&self) -> usize {
+        self.table_data_map.len()
     }
 
     /// Returns the request and number of rows in it.

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -71,6 +71,12 @@ pub struct MultiTableData<'a> {
     table_data_map: HashMap<&'a str, TableData<'a>>,
 }
 
+impl<'a> Default for MultiTableData<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> MultiTableData<'a> {
     pub fn new() -> Self {
         Self {
@@ -119,7 +125,7 @@ impl<'a> MultiTableData<'a> {
 
 pub fn write_tags<'a>(
     table_data: &mut TableData<'a>,
-    kvs: impl Iterator<Item = (&'a str, &'a str)>,
+    kvs: impl Iterator<Item = (&'a str, impl ToString)>,
     one_row: &mut Vec<Value>,
 ) -> Result<()> {
     let ktv_iter = kvs.map(|(k, v)| {
@@ -138,6 +144,24 @@ pub fn write_fields<'a>(
     one_row: &mut Vec<Value>,
 ) -> Result<()> {
     write_by_semantic_type(table_data, SemanticType::Field, fields, one_row)
+}
+
+pub fn write_tag<'a>(
+    table_data: &mut TableData<'a>,
+    name: &'a str,
+    value: impl ToString,
+    one_row: &mut Vec<Value>,
+) -> Result<()> {
+    write_by_semantic_type(
+        table_data,
+        SemanticType::Tag,
+        std::iter::once((
+            name,
+            ColumnDataType::String,
+            ValueData::StringValue(value.to_string()),
+        )),
+        one_row,
+    )
 }
 
 pub fn write_f64<'a>(

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -89,6 +89,66 @@ mod test {
 | greptimedb | otel  | java               | testsevrer | 1970-01-01T00:00:00 | 100.0          |
 +------------+-------+--------------------+------------+---------------------+----------------+",
         );
+
+        let mut output = instance
+            .do_query(
+                "SELECT greptime_le, greptime_value FROM my_test_histo_bucket order by greptime_le",
+                ctx.clone(),
+            )
+            .await;
+        let output = output.remove(0).unwrap();
+        let Output::Stream(stream) = output else {
+            unreachable!()
+        };
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        dbg!(&recordbatches);
+        assert_eq!(
+            recordbatches.pretty_print().unwrap(),
+            "\
++-------------+----------------+
+| greptime_le | greptime_value |
++-------------+----------------+
+| 1           | 1.0            |
+| 5           | 3.0            |
+| inf         | 4.0            |
++-------------+----------------+",
+        );
+
+        let mut output = instance
+            .do_query("SELECT * FROM my_test_histo_sum", ctx.clone())
+            .await;
+        let output = output.remove(0).unwrap();
+        let Output::Stream(stream) = output else {
+            unreachable!()
+        };
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        assert_eq!(
+            recordbatches.pretty_print().unwrap(),
+            "\
++------------+-------+--------------------+------------+---------------------+----------------+
+| resource   | scope | telemetry_sdk_name | host       | greptime_timestamp  | greptime_value |
++------------+-------+--------------------+------------+---------------------+----------------+
+| greptimedb | otel  | java               | testserver | 1970-01-01T00:00:00 | 51.0           |
++------------+-------+--------------------+------------+---------------------+----------------+",
+        );
+
+        let mut output = instance
+            .do_query("SELECT * FROM my_test_histo_count", ctx.clone())
+            .await;
+        let output = output.remove(0).unwrap();
+        let Output::Stream(stream) = output else {
+            unreachable!()
+        };
+        let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
+        assert_eq!(
+            recordbatches.pretty_print().unwrap(),
+            "\
++------------+-------+--------------------+------------+---------------------+----------------+
+| resource   | scope | telemetry_sdk_name | host       | greptime_timestamp  | greptime_value |
++------------+-------+--------------------+------------+---------------------+----------------+
+| greptimedb | otel  | java               | testserver | 1970-01-01T00:00:00 | 4.0            |
++------------+-------+--------------------+------------+---------------------+----------------+",
+        );
     }
 
     fn build_request() -> ExportMetricsServiceRequest {
@@ -108,15 +168,38 @@ mod test {
         ];
         let gauge = Gauge { data_points };
 
+        let histo_data_points = vec![HistogramDataPoint {
+            attributes: vec![keyvalue("host", "testserver")],
+            time_unix_nano: 100,
+            count: 4,
+            bucket_counts: vec![1, 2, 1],
+            explicit_bounds: vec![1.0f64, 5.0f64],
+            sum: Some(51f64),
+            ..Default::default()
+        }];
+
+        let histo = Histogram {
+            data_points: histo_data_points,
+            aggregation_temporality: 0,
+        };
+
         ExportMetricsServiceRequest {
             resource_metrics: vec![ResourceMetrics {
                 scope_metrics: vec![ScopeMetrics {
-                    metrics: vec![Metric {
-                        name: "my.test.metric".into(),
-                        description: "my ignored desc".into(),
-                        unit: "my ignored unit".into(),
-                        data: Some(metric::Data::Gauge(gauge)),
-                    }],
+                    metrics: vec![
+                        Metric {
+                            name: "my.test.metric".into(),
+                            description: "my ignored desc".into(),
+                            unit: "my ignored unit".into(),
+                            data: Some(metric::Data::Gauge(gauge)),
+                        },
+                        Metric {
+                            name: "my.test.histo".into(),
+                            description: "my ignored desc".into(),
+                            unit: "my ignored unit".into(),
+                            data: Some(metric::Data::Histogram(histo)),
+                        },
+                    ],
                     scope: Some(InstrumentationScope {
                         attributes: vec![
                             keyvalue("scope", "otel"),

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -92,7 +92,7 @@ mod test {
 
         let mut output = instance
             .do_query(
-                "SELECT greptime_le, greptime_value FROM my_test_histo_bucket order by greptime_le",
+                "SELECT le, greptime_value FROM my_test_histo_bucket order by le",
                 ctx.clone(),
             )
             .await;
@@ -101,17 +101,16 @@ mod test {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
-        dbg!(&recordbatches);
         assert_eq!(
             recordbatches.pretty_print().unwrap(),
             "\
-+-------------+----------------+
-| greptime_le | greptime_value |
-+-------------+----------------+
-| 1           | 1.0            |
-| 5           | 3.0            |
-| inf         | 4.0            |
-+-------------+----------------+",
++-----+----------------+
+| le  | greptime_value |
++-----+----------------+
+| 1   | 1.0            |
+| 5   | 3.0            |
+| inf | 4.0            |
++-----+----------------+",
         );
 
         let mut output = instance


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch adds OTLP histogram data type support, which was left blank in our initial release.

The implementation has been following Prometheus histogram table format:

- A `%metric%_bucket` table including `le` tag that stores bucket upper limit, and `greptime_value` for bucket count
- A `%metric%_sum` table storing sum of samples
- A `%metric%_count` table storing count of samples.

By its Prometheus compatibility, we hope to be able to use prometheus quantile functions on this table.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
