### PR TITLE
feat(mito): Integrate access layer and file purger to region

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -28,25 +28,30 @@ pub type AccessLayerRef = Arc<AccessLayer>;
 
 /// A layer to access SST files under the same directory.
 pub struct AccessLayer {
-    sst_dir: String,
+    region_dir: String,
     object_store: ObjectStore,
 }
 
 impl std::fmt::Debug for AccessLayer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AccessLayer")
-            .field("sst_dir", &self.sst_dir)
+            .field("region_dir", &self.region_dir)
             .finish()
     }
 }
 
 impl AccessLayer {
-    /// Returns a new [AccessLayer] for specific `sst_dir`.
-    pub fn new(sst_dir: impl Into<String>, object_store: ObjectStore) -> AccessLayer {
+    /// Returns a new [AccessLayer] for specific `region_dir`.
+    pub fn new(region_dir: impl Into<String>, object_store: ObjectStore) -> AccessLayer {
         AccessLayer {
-            sst_dir: sst_dir.into(),
+            region_dir: region_dir.into(),
             object_store,
         }
+    }
+
+    /// Returns the directory of the region.
+    pub fn region_dir(&self) -> &str {
+        &self.region_dir
     }
 
     /// Deletes a SST file with given file id.
@@ -60,7 +65,7 @@ impl AccessLayer {
 
     /// Returns a reader builder for specific `file`.
     pub(crate) fn read_sst(&self, file: FileHandle) -> ParquetReaderBuilder {
-        ParquetReaderBuilder::new(self.sst_dir.clone(), file, self.object_store.clone())
+        ParquetReaderBuilder::new(self.region_dir.clone(), file, self.object_store.clone())
     }
 
     /// Returns a new parquet writer to write the SST for specific `file_id`.
@@ -76,6 +81,6 @@ impl AccessLayer {
 
     /// Returns the `file_path` for the `file_name` in the object store.
     fn sst_file_path(&self, file_name: &str) -> String {
-        util::join_path(&self.sst_dir, file_name)
+        util::join_path(&self.region_dir, file_name)
     }
 }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -54,6 +54,11 @@ impl AccessLayer {
         &self.region_dir
     }
 
+    /// Returns the object store of the layer.
+    pub fn object_store(&self) -> &ObjectStore {
+        &self.object_store
+    }
+
     /// Deletes a SST file with given file id.
     pub(crate) async fn delete_sst(&self, file_id: FileId) -> Result<()> {
         let path = self.sst_file_path(&file_id.as_parquet());

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -16,13 +16,17 @@ use std::sync::Arc;
 
 use object_store::{util, ObjectStore};
 use snafu::ResultExt;
+use store_api::metadata::RegionMetadataRef;
 
 use crate::error::{DeleteSstSnafu, Result};
-use crate::sst::file::FileId;
+use crate::read::Source;
+use crate::sst::file::{FileHandle, FileId};
+use crate::sst::parquet::reader::ParquetReaderBuilder;
+use crate::sst::parquet::writer::ParquetWriter;
 
 pub type AccessLayerRef = Arc<AccessLayer>;
 
-/// Sst access layer.
+/// A layer to access SST files under the same directory.
 pub struct AccessLayer {
     sst_dir: String,
     object_store: ObjectStore,
@@ -37,23 +41,41 @@ impl std::fmt::Debug for AccessLayer {
 }
 
 impl AccessLayer {
-    pub fn new(sst_dir: &str, object_store: ObjectStore) -> AccessLayer {
+    /// Returns a new [AccessLayer] for specific `sst_dir`.
+    pub fn new(sst_dir: impl Into<String>, object_store: ObjectStore) -> AccessLayer {
         AccessLayer {
-            sst_dir: sst_dir.to_string(),
+            sst_dir: sst_dir.into(),
             object_store,
         }
     }
 
-    fn sst_file_path(&self, file_name: &str) -> String {
-        util::join_path(&self.sst_dir, file_name)
-    }
-
     /// Deletes a SST file with given file id.
-    pub async fn delete_sst(&self, file_id: FileId) -> Result<()> {
+    pub(crate) async fn delete_sst(&self, file_id: FileId) -> Result<()> {
         let path = self.sst_file_path(&file_id.as_parquet());
         self.object_store
             .delete(&path)
             .await
             .context(DeleteSstSnafu { file_id })
+    }
+
+    /// Returns a reader builder for specific `file`.
+    pub(crate) fn read_sst(&self, file: FileHandle) -> ParquetReaderBuilder {
+        ParquetReaderBuilder::new(self.sst_dir.clone(), file, self.object_store.clone())
+    }
+
+    /// Returns a new parquet writer to write the SST for specific `file_id`.
+    pub(crate) fn write_sst(
+        &self,
+        file_id: FileId,
+        metadata: RegionMetadataRef,
+        source: Source,
+    ) -> ParquetWriter {
+        let path = self.sst_file_path(&file_id.as_parquet());
+        ParquetWriter::new(path, metadata, source, self.object_store.clone())
+    }
+
+    /// Returns the `file_path` for the `file_name` in the object store.
+    fn sst_file_path(&self, file_name: &str) -> String {
+        util::join_path(&self.sst_dir, file_name)
     }
 }

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -20,6 +20,8 @@ use common_telemetry::warn;
 
 /// Default region worker num.
 const DEFAULT_NUM_WORKERS: usize = 1;
+/// Default max running background job.
+const DEFAULT_MAX_BG_JOB: usize = 4;
 /// Default region write buffer size.
 pub(crate) const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(32);
 
@@ -40,6 +42,10 @@ pub struct MitoConfig {
     pub manifest_checkpoint_distance: u64,
     /// Manifest compression type (default uncompressed).
     pub manifest_compress_type: CompressionType,
+
+    // Background job configs:
+    /// Max number of running background jobs.
+    pub max_background_jobs: usize,
 }
 
 impl Default for MitoConfig {
@@ -50,6 +56,7 @@ impl Default for MitoConfig {
             worker_request_batch_size: 64,
             manifest_checkpoint_distance: 10,
             manifest_compress_type: CompressionType::Uncompressed,
+            max_background_jobs: DEFAULT_MAX_BG_JOB,
         }
     }
 }
@@ -74,6 +81,11 @@ impl MitoConfig {
         if self.worker_channel_size == 0 {
             warn!("Sanitize channel size 0 to 1");
             self.worker_channel_size = 1;
+        }
+
+        if self.max_background_jobs == 0 {
+            warn!("Sanitize max background jobs 0 to {}", DEFAULT_MAX_BG_JOB);
+            self.max_background_jobs = DEFAULT_MAX_BG_JOB;
         }
     }
 }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -144,12 +144,7 @@ impl EngineInner {
             .get_region(region_id)
             .context(RegionNotFoundSnafu { region_id })?;
         let version = region.version();
-        let scan_region = ScanRegion::new(
-            version,
-            region.region_dir.clone(),
-            self.object_store.clone(),
-            request,
-        );
+        let scan_region = ScanRegion::new(version, region.access_layer.clone(), request);
 
         scan_region.scanner()
     }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -33,7 +33,6 @@ use store_api::storage::{RegionId, ScanRequest};
 
 use crate::config::MitoConfig;
 use crate::error::{RecvSnafu, RegionNotFoundSnafu, Result};
-use crate::flush::WriteBufferManagerImpl;
 use crate::read::scan_region::{ScanRegion, Scanner};
 use crate::request::WorkerRequest;
 use crate::worker::WorkerGroup;
@@ -106,15 +105,8 @@ impl EngineInner {
         log_store: Arc<S>,
         object_store: ObjectStore,
     ) -> EngineInner {
-        let write_buffer_manager = Arc::new(WriteBufferManagerImpl {});
-
         EngineInner {
-            workers: WorkerGroup::start(
-                config,
-                log_store,
-                object_store.clone(),
-                write_buffer_manager,
-            ),
+            workers: WorkerGroup::start(config, log_store, object_store.clone()),
             object_store,
         }
     }

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -43,7 +43,7 @@ pub mod request;
 #[allow(dead_code)]
 mod row_converter;
 #[allow(dead_code)]
-mod schedule;
+pub(crate) mod schedule;
 #[allow(dead_code)]
 pub mod sst;
 pub mod wal;

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -24,6 +24,7 @@ use common_telemetry::info;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::RegionId;
 
+use crate::access_layer::AccessLayerRef;
 use crate::error::Result;
 use crate::manifest::manager::RegionManifestManager;
 use crate::region::version::{VersionControlRef, VersionRef};
@@ -46,8 +47,8 @@ pub(crate) struct MitoRegion {
 
     /// Version controller for this region.
     pub(crate) version_control: VersionControlRef,
-    /// Data directory of the region.
-    pub(crate) region_dir: String,
+    /// SSTs accessor for this region.
+    pub(crate) access_layer: AccessLayerRef,
     /// Manager to maintain manifest for this region.
     manifest_manager: RegionManifestManager,
 }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -18,6 +18,7 @@ pub(crate) mod opener;
 pub(crate) mod version;
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicI64;
 use std::sync::{Arc, RwLock};
 
 use common_telemetry::info;
@@ -28,6 +29,7 @@ use crate::access_layer::AccessLayerRef;
 use crate::error::Result;
 use crate::manifest::manager::RegionManifestManager;
 use crate::region::version::{VersionControlRef, VersionRef};
+use crate::sst::file_purger::FilePurgerRef;
 
 /// Type to store region version.
 pub type VersionNumber = u32;
@@ -50,7 +52,11 @@ pub(crate) struct MitoRegion {
     /// SSTs accessor for this region.
     pub(crate) access_layer: AccessLayerRef,
     /// Manager to maintain manifest for this region.
-    manifest_manager: RegionManifestManager,
+    pub(crate) manifest_manager: RegionManifestManager,
+    /// SST file purger.
+    pub(crate) file_purger: FilePurgerRef,
+    /// Last flush time in millis.
+    last_flush_millis: AtomicI64,
 }
 
 pub(crate) type MitoRegionRef = Arc<MitoRegion>;

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -14,9 +14,11 @@
 
 //! Region opener.
 
+use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
 
 use common_telemetry::info;
+use common_time::util::current_time_millis;
 use futures::StreamExt;
 use object_store::util::join_dir;
 use object_store::ObjectStore;
@@ -33,6 +35,8 @@ use crate::memtable::MemtableBuilderRef;
 use crate::region::version::{VersionBuilder, VersionControl, VersionControlRef};
 use crate::region::MitoRegion;
 use crate::region_write_ctx::RegionWriteCtx;
+use crate::schedule::scheduler::SchedulerRef;
+use crate::sst::file_purger::LocalFilePurger;
 use crate::wal::{EntryId, Wal};
 
 /// Builder to create a new [MitoRegion] or open an existing one.
@@ -42,6 +46,7 @@ pub(crate) struct RegionOpener {
     memtable_builder: MemtableBuilderRef,
     object_store: ObjectStore,
     region_dir: String,
+    scheduler: SchedulerRef,
 }
 
 impl RegionOpener {
@@ -50,6 +55,7 @@ impl RegionOpener {
         region_id: RegionId,
         memtable_builder: MemtableBuilderRef,
         object_store: ObjectStore,
+        scheduler: SchedulerRef,
     ) -> RegionOpener {
         RegionOpener {
             region_id,
@@ -57,6 +63,7 @@ impl RegionOpener {
             memtable_builder,
             object_store,
             region_dir: String::new(),
+            scheduler,
         }
     }
 
@@ -94,12 +101,15 @@ impl RegionOpener {
 
         let version = VersionBuilder::new(metadata, mutable).build();
         let version_control = Arc::new(VersionControl::new(version));
+        let access_layer = Arc::new(AccessLayer::new(self.region_dir, self.object_store.clone()));
 
         Ok(MitoRegion {
             region_id,
             version_control,
-            access_layer: Arc::new(AccessLayer::new(self.region_dir, self.object_store.clone())),
+            access_layer: access_layer.clone(),
             manifest_manager,
+            file_purger: Arc::new(LocalFilePurger::new(self.scheduler, access_layer)),
+            last_flush_millis: AtomicI64::new(current_time_millis()),
         })
     }
 
@@ -141,12 +151,15 @@ impl RegionOpener {
         let flushed_sequence = version.flushed_entry_id;
         let version_control = Arc::new(VersionControl::new(version));
         replay_memtable(wal, region_id, flushed_sequence, &version_control).await?;
+        let access_layer = Arc::new(AccessLayer::new(self.region_dir, self.object_store.clone()));
 
         let region = MitoRegion {
             region_id: self.region_id,
             version_control,
-            access_layer: Arc::new(AccessLayer::new(self.region_dir, self.object_store)),
+            access_layer: access_layer.clone(),
             manifest_manager,
+            file_purger: Arc::new(LocalFilePurger::new(self.scheduler, access_layer)),
+            last_flush_millis: AtomicI64::new(current_time_millis()),
         };
         Ok(region)
     }

--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -36,7 +36,7 @@ const STATE_AWAIT_TERMINATION: u8 = 2;
 
 /// [Scheduler] defines a set of API to schedule Jobs
 #[async_trait::async_trait]
-pub trait Scheduler {
+pub trait Scheduler: Send + Sync {
     /// Schedules a Job
     fn schedule(&self, job: Job) -> Result<()>;
 
@@ -44,7 +44,7 @@ pub trait Scheduler {
     async fn stop(&self, await_termination: bool) -> Result<()>;
 }
 
-type SchedulerRef = Arc<dyn Scheduler + Send>;
+pub type SchedulerRef = Arc<dyn Scheduler>;
 
 /// Request scheduler based on local state.
 pub struct LocalScheduler {

--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -158,7 +158,7 @@ impl Drop for LocalScheduler {
         if self.state.load(Ordering::Relaxed) != STATE_STOP {
             logging::warn!("scheduler should be stopped before dropping, which means the state of scheduler must be STATE_STOP");
 
-            // We didn't call `stop()` so we cancel all background workers here..
+            // We didn't call `stop()` so we cancel all background workers here.
             self.sender.write().unwrap().take();
             self.cancel_token.cancel();
         }

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -31,9 +31,9 @@ use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
 use crate::sst::stream_writer::BufferedWriter;
 
 /// Parquet SST writer.
-pub struct ParquetWriter<'a> {
+pub struct ParquetWriter {
     /// SST output file path.
-    file_path: &'a str,
+    file_path: String,
     /// Input data source.
     source: Source,
     /// Region metadata of the source and the target SST.
@@ -41,10 +41,10 @@ pub struct ParquetWriter<'a> {
     object_store: ObjectStore,
 }
 
-impl<'a> ParquetWriter<'a> {
+impl ParquetWriter {
     /// Creates a new parquet SST writer.
     pub fn new(
-        file_path: &'a str,
+        file_path: String,
         metadata: RegionMetadataRef,
         source: Source,
         object_store: ObjectStore,
@@ -87,7 +87,7 @@ impl<'a> ParquetWriter<'a> {
 
         let write_format = WriteFormat::new(self.metadata.clone());
         let mut buffered_writer = BufferedWriter::try_new(
-            self.file_path.to_string(),
+            self.file_path.clone(),
             self.object_store.clone(),
             write_format.arrow_schema(),
             Some(writer_props),

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -35,7 +35,6 @@ use store_api::region_request::RegionCreateRequest;
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
 use crate::error::Result;
-use crate::flush::WriteBufferManagerImpl;
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
 use crate::read::{Batch, BatchBuilder, BatchReader};
 use crate::worker::WorkerGroup;
@@ -95,12 +94,7 @@ impl TestEnv {
     pub(crate) async fn create_worker_group(&self, config: MitoConfig) -> WorkerGroup {
         let (log_store, object_store) = self.create_log_and_object_store().await;
 
-        WorkerGroup::start(
-            config,
-            Arc::new(log_store),
-            object_store,
-            Arc::new(WriteBufferManagerImpl {}),
-        )
+        WorkerGroup::start(config, Arc::new(log_store), object_store)
     }
 
     async fn create_log_and_object_store(&self) -> (RaftEngineLogStore, ObjectStore) {

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -194,6 +194,7 @@ impl<S: LogStore> WorkerStarter<S> {
             object_store: self.object_store,
             running: running.clone(),
             memtable_builder: Arc::new(TimeSeriesMemtableBuilder::default()),
+            scheduler: self.scheduler.clone(),
             write_buffer_manager: self.write_buffer_manager,
             flush_scheduler: FlushScheduler::new(self.scheduler),
         };
@@ -311,7 +312,8 @@ struct RegionWorkerLoop<S> {
     running: Arc<AtomicBool>,
     /// Memtable builder for each region.
     memtable_builder: MemtableBuilderRef,
-
+    /// Background job scheduler.
+    scheduler: SchedulerRef,
     /// Engine write buffer manager.
     write_buffer_manager: WriteBufferManagerRef,
     /// Schedules background flush requests.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -37,11 +37,12 @@ use tokio::sync::{mpsc, Mutex};
 
 use crate::config::MitoConfig;
 use crate::error::{JoinSnafu, Result, WorkerStoppedSnafu};
-use crate::flush::{FlushScheduler, WriteBufferManagerRef};
+use crate::flush::{FlushScheduler, WriteBufferManagerImpl, WriteBufferManagerRef};
 use crate::memtable::time_series::TimeSeriesMemtableBuilder;
 use crate::memtable::MemtableBuilderRef;
 use crate::region::{MitoRegionRef, RegionMap, RegionMapRef};
 use crate::request::{BackgroundNotify, DdlRequest, SenderDdlRequest, WorkerRequest};
+use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
 use crate::wal::Wal;
 
 /// Identifier for a worker.
@@ -84,9 +85,9 @@ pub(crate) type WorkerId = u32;
 /// Chan0 --> Buffer0
 /// Chan1 --> WorkerThread1
 /// ```
-#[derive(Debug)]
 pub(crate) struct WorkerGroup {
     workers: Vec<RegionWorker>,
+    scheduler: SchedulerRef,
 }
 
 impl WorkerGroup {
@@ -97,24 +98,27 @@ impl WorkerGroup {
         config: MitoConfig,
         log_store: Arc<S>,
         object_store: ObjectStore,
-        write_buffer_manager: WriteBufferManagerRef,
     ) -> WorkerGroup {
         assert!(config.num_workers.is_power_of_two());
         let config = Arc::new(config);
+        let write_buffer_manager = Arc::new(WriteBufferManagerImpl {});
+        let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
 
         let workers = (0..config.num_workers)
             .map(|id| {
-                RegionWorker::start(
-                    id as WorkerId,
-                    config.clone(),
-                    log_store.clone(),
-                    object_store.clone(),
-                    write_buffer_manager.clone(),
-                )
+                WorkerStarter {
+                    id: id as WorkerId,
+                    config: config.clone(),
+                    log_store: log_store.clone(),
+                    object_store: object_store.clone(),
+                    write_buffer_manager: write_buffer_manager.clone(),
+                    scheduler: scheduler.clone(),
+                }
+                .start()
             })
             .collect();
 
-        WorkerGroup { workers }
+        WorkerGroup { workers, scheduler }
     }
 
     /// Stop the worker group.
@@ -122,6 +126,8 @@ impl WorkerGroup {
         info!("Stop region worker group");
 
         try_join_all(self.workers.iter().map(|worker| worker.stop())).await?;
+
+        self.scheduler.stop(true).await?;
 
         Ok(())
     }
@@ -162,8 +168,50 @@ fn value_to_index(value: usize, num_workers: usize) -> usize {
     value & (num_workers - 1)
 }
 
+/// Worker start config.
+struct WorkerStarter<S> {
+    id: WorkerId,
+    config: Arc<MitoConfig>,
+    log_store: Arc<S>,
+    object_store: ObjectStore,
+    write_buffer_manager: WriteBufferManagerRef,
+    scheduler: SchedulerRef,
+}
+
+impl<S: LogStore> WorkerStarter<S> {
+    /// Start a region worker and its background thread.
+    fn start(self) -> RegionWorker {
+        let regions = Arc::new(RegionMap::default());
+        let (sender, receiver) = mpsc::channel(self.config.worker_channel_size);
+
+        let running = Arc::new(AtomicBool::new(true));
+        let mut worker_thread = RegionWorkerLoop {
+            id: self.id,
+            config: self.config,
+            regions: regions.clone(),
+            receiver,
+            wal: Wal::new(self.log_store),
+            object_store: self.object_store,
+            running: running.clone(),
+            memtable_builder: Arc::new(TimeSeriesMemtableBuilder::default()),
+            write_buffer_manager: self.write_buffer_manager,
+            flush_scheduler: FlushScheduler::new(self.scheduler),
+        };
+        let handle = common_runtime::spawn_write(async move {
+            worker_thread.run().await;
+        });
+
+        RegionWorker {
+            id: self.id,
+            regions,
+            sender,
+            handle: Mutex::new(Some(handle)),
+            running,
+        }
+    }
+}
+
 /// Worker to write and alter regions bound to it.
-#[derive(Debug)]
 pub(crate) struct RegionWorker {
     /// Id of the worker.
     id: WorkerId,
@@ -178,43 +226,6 @@ pub(crate) struct RegionWorker {
 }
 
 impl RegionWorker {
-    /// Start a region worker and its background thread.
-    fn start<S: LogStore>(
-        id: WorkerId,
-        config: Arc<MitoConfig>,
-        log_store: Arc<S>,
-        object_store: ObjectStore,
-        write_buffer_manager: WriteBufferManagerRef,
-    ) -> RegionWorker {
-        let regions = Arc::new(RegionMap::default());
-        let (sender, receiver) = mpsc::channel(config.worker_channel_size);
-
-        let running = Arc::new(AtomicBool::new(true));
-        let mut worker_thread = RegionWorkerLoop {
-            id,
-            config,
-            regions: regions.clone(),
-            receiver,
-            wal: Wal::new(log_store),
-            object_store,
-            running: running.clone(),
-            memtable_builder: Arc::new(TimeSeriesMemtableBuilder::default()),
-            write_buffer_manager,
-            flush_scheduler: FlushScheduler::default(),
-        };
-        let handle = common_runtime::spawn_write(async move {
-            worker_thread.run().await;
-        });
-
-        RegionWorker {
-            id,
-            regions,
-            sender,
-            handle: Mutex::new(Some(handle)),
-            running,
-        }
-    }
-
     /// Submit request to background worker thread.
     async fn submit_request(&self, request: WorkerRequest) -> Result<()> {
         ensure!(self.is_running(), WorkerStoppedSnafu { id: self.id });

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -58,6 +58,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             region_id,
             self.memtable_builder.clone(),
             self.object_store.clone(),
+            self.scheduler.clone(),
         )
         .metadata(metadata)
         .region_dir(&request.region_dir)

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -43,6 +43,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             region_id,
             self.memtable_builder.clone(),
             self.object_store.clone(),
+            self.scheduler.clone(),
         )
         .region_dir(&request.region_dir)
         .open(&self.config, &self.wal)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR integrates `AccessLayer` and `FilePurger` to each mito region.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 