### PR TITLE
fix: flume bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compat"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,19 +3185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,7 +4699,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -5431,6 +5429,7 @@ dependencies = [
  "api",
  "aquamarine",
  "arc-swap",
+ "async-channel",
  "async-compat",
  "async-stream",
  "async-trait",
@@ -5452,7 +5451,6 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datatypes",
- "flume",
  "futures",
  "lazy_static",
  "log-store",
@@ -5660,15 +5658,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -7627,7 +7616,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin 0.5.2",
+ "spin",
  "untrusted",
  "web-sys",
  "winapi",
@@ -8956,15 +8945,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -13,6 +13,7 @@ anymap = "1.0.0-beta.2"
 api.workspace = true
 aquamarine = "0.3"
 arc-swap = "1.0"
+async-channel = "1.9"
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
@@ -33,7 +34,6 @@ dashmap = "5.4"
 datafusion-common.workspace = true
 datafusion.workspace = true
 datatypes = { workspace = true }
-flume = "0.10"
 futures.workspace = true
 lazy_static = "1.4"
 log-store = { workspace = true }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -367,8 +367,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Invalid flume sender, location: {}", location,))]
-    InvalidFlumeSender { location: Location },
+    #[snafu(display("Invalid sender, location: {}", location,))]
+    InvalidSender { location: Location },
 
     #[snafu(display("Invalid scheduler state, location: {}", location))]
     InvalidSchedulerState { location: Location },
@@ -452,7 +452,7 @@ impl ErrorExt for Error {
             ComputeArrow { .. } => StatusCode::Internal,
             ComputeVector { .. } => StatusCode::Internal,
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,
-            InvalidFlumeSender { .. } => StatusCode::InvalidArguments,
+            InvalidSender { .. } => StatusCode::InvalidArguments,
             InvalidSchedulerState { .. } => StatusCode::InvalidArguments,
             StopScheduler { .. } => StatusCode::Internal,
             BuildPredicate { source, .. } => source.status_code(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Replace flume with async channel. `flume` might lose the last message and hang the test `test_scheduler_many()`. See https://github.com/zesterer/flume/issues/124 for a similar issue.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- https://github.com/zesterer/flume/issues/124