### PR TITLE
refactor: inactive node manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,7 +4072,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=ffc2bdfabea578b1d264a11b741df12395e89e87#ffc2bdfabea578b1d264a11b741df12395e89e87"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b585955dbbade25951d725251b66457fdd77143f#b585955dbbade25951d725251b66457fdd77143f"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "ffc2bdfabea578b1d264a11b741df12395e89e87" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b585955dbbade25951d725251b66457fdd77143f" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -56,6 +56,10 @@ impl Stat {
             node_id: self.id,
         }
     }
+
+    pub fn region_ids(&self) -> Vec<u64> {
+        self.region_stats.iter().map(|s| s.id).collect()
+    }
 }
 
 impl TryFrom<HeartbeatRequest> for Stat {

--- a/src/meta-srv/src/keys.rs
+++ b/src/meta-srv/src/keys.rs
@@ -19,7 +19,6 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt, ResultExt};
-use store_api::storage::RegionNumber;
 
 use crate::error;
 use crate::error::Result;
@@ -242,19 +241,14 @@ impl TryFrom<Vec<u8>> for StatValue {
 pub struct InactiveNodeKey {
     pub cluster_id: u64,
     pub node_id: u64,
-    pub table_id: u32,
-    pub region_number: RegionNumber,
+    pub region_id: u64,
 }
 
 impl From<InactiveNodeKey> for Vec<u8> {
     fn from(value: InactiveNodeKey) -> Self {
         format!(
-            "{}-{}-{}-{}-{}",
-            INACTIVE_NODE_PREFIX,
-            value.cluster_id,
-            value.node_id,
-            value.table_id,
-            value.region_number
+            "{}-{}-{}-{}",
+            INACTIVE_NODE_PREFIX, value.cluster_id, value.node_id, value.region_id
         )
         .into_bytes()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

use region_id instead of table_id&region_num

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
