### PR TITLE
feat: remove memtable request

### DIFF
--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use common_query::Output;
 use common_telemetry::{error, info};
 use snafu::ResultExt;
-use store_api::storage::{RegionId, ScanRequest};
+use store_api::storage::RegionId;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::access_layer::AccessLayerRef;
@@ -190,7 +190,7 @@ impl RegionFlushTask {
             }
 
             let file_id = FileId::random();
-            let iter = mem.iter(ScanRequest::default());
+            let iter = mem.iter(None, &[]);
             let source = Source::Iter(iter);
             let mut writer = self
                 .access_layer

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -64,7 +64,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Write key values into the memtable.
     fn write(&self, kvs: &KeyValues) -> Result<()>;
 
-    /// Scans the memtable for `req`.
+    /// Scans the memtable.
     /// `projection` selects columns to read, `None` means reading all columns.
     /// `filters` are the predicates to be pushed down to memtable.
     fn iter(&self, projection: Option<&[ColumnId]>, filters: &[Expr]) -> BoxedBatchIterator;

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -107,7 +107,7 @@ impl SeqScan {
         // Scans all memtables and SSTs. Builds a merge reader to merge results.
         let mut builder = MergeReaderBuilder::new();
         for mem in &self.memtables {
-            let iter = mem.iter(self.request.clone());
+            let iter = mem.iter(Some(self.mapper.column_ids()), &self.request.filters);
             builder.push_batch_iter(iter);
         }
         for file in &self.files {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove ScanRequest from Memtable API

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
