### PR TITLE
fix: don't raise an error when manifest directory is not created

### DIFF
--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -171,7 +171,7 @@ impl ManifestObjectStore {
         let streamer = match self.object_store.list(&self.path).await {
             Ok(streamer) => streamer,
             Err(e) if e.kind() == ErrorKind::NotFound => {
-                debug!("Manifest directory is not exists: {}", self.path);
+                debug!("Manifest directory does not exists: {}", self.path);
                 return Ok(vec![]);
             }
             Err(e) => Err(e).context(OpenDalSnafu)?,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Return an empty result if the manifest directory is not created when scanning actions.

Try to fix #2288 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Close #2288 
