### PR TITLE
feat: Impl write buffer manager for mito2

### DIFF
--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -66,7 +66,7 @@ pub type WriteBufferManagerRef = Arc<dyn WriteBufferManager>;
 /// Default [WriteBufferManager] implementation.
 ///
 /// Inspired by RocksDB's WriteBufferManager.
-/// <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/write_buffer_manager.h#L94>
+/// <https://github.com/facebook/rocksdb/blob/main/include/rocksdb/write_buffer_manager.h>
 #[derive(Debug)]
 pub struct WriteBufferManagerImpl {
     /// Write buffer size for the engine.

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -86,8 +86,7 @@ impl MemtableVersion {
     }
 
     /// Returns the memory usage of the mutable memtable.
-    pub(crate) fn mutable_bytes_usage(&self) -> usize {
-        // TODO(yingwen): Get memtable usage.
-        0
+    pub(crate) fn mutable_usage(&self) -> usize {
+        self.mutable.stats().estimated_bytes
     }
 }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -104,7 +104,9 @@ impl WorkerGroup {
     ) -> WorkerGroup {
         assert!(config.num_workers.is_power_of_two());
         let config = Arc::new(config);
-        let write_buffer_manager = Arc::new(WriteBufferManagerImpl {});
+        let write_buffer_manager = Arc::new(WriteBufferManagerImpl::new(
+            config.global_write_buffer_size.as_bytes() as usize,
+        ));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
 
         let workers = (0..config.num_workers)

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -198,7 +198,9 @@ impl<S: LogStore> WorkerStarter<S> {
             wal: Wal::new(self.log_store),
             object_store: self.object_store,
             running: running.clone(),
-            memtable_builder: Arc::new(TimeSeriesMemtableBuilder::default()),
+            memtable_builder: Arc::new(TimeSeriesMemtableBuilder::new(Some(
+                self.write_buffer_manager.clone(),
+            ))),
             scheduler: self.scheduler.clone(),
             write_buffer_manager: self.write_buffer_manager,
             flush_scheduler: FlushScheduler::new(self.scheduler),

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -140,7 +140,7 @@ impl<S> RegionWorkerLoop<S> {
             }
 
             let version = region.version();
-            let region_mutable_size = version.memtables.mutable_bytes_usage();
+            let region_mutable_size = version.memtables.mutable_usage();
             // Tracks region with max mutable memtable size.
             if region_mutable_size > max_mutable_size {
                 max_mem_region = Some(region);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR ports the `WriteBufferManager` from the old mito engine to mito2.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 