### PR TITLE
feat: add metric and manage tool for InactiveRegionKey

### DIFF
--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -15,6 +15,7 @@
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
+use store_api::storage::RegionId;
 
 use crate::ident::TableIdent;
 use crate::{ClusterId, DatanodeId};
@@ -25,6 +26,12 @@ pub struct RegionIdent {
     pub datanode_id: DatanodeId,
     pub table_ident: TableIdent,
     pub region_number: u32,
+}
+
+impl RegionIdent {
+    pub fn get_region_id(&self) -> RegionId {
+        RegionId::new(self.table_ident.table_id, self.region_number)
+    }
 }
 
 impl Display for RegionIdent {

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -156,6 +156,9 @@ pub enum Error {
     #[snafu(display("Invalid datanode stat key: {}", key))]
     InvalidStatKey { key: String, location: Location },
 
+    #[snafu(display("Invalid inactive region key: {}", key))]
+    InvalidInactiveRegionKey { key: String, location: Location },
+
     #[snafu(display("Failed to parse datanode lease key from utf8: {}", source))]
     LeaseKeyFromUtf8 {
         source: std::string::FromUtf8Error,
@@ -176,6 +179,12 @@ pub enum Error {
 
     #[snafu(display("Failed to parse datanode stat value from utf8: {}", source))]
     StatValueFromUtf8 {
+        source: std::string::FromUtf8Error,
+        location: Location,
+    },
+
+    #[snafu(display("Failed to parse invalid region key from utf8: {}", source))]
+    InvalidRegionKeyFromUtf8 {
         source: std::string::FromUtf8Error,
         location: Location,
     },
@@ -556,6 +565,7 @@ impl ErrorExt for Error {
             | Error::EmptyTableName { .. }
             | Error::InvalidLeaseKey { .. }
             | Error::InvalidStatKey { .. }
+            | Error::InvalidInactiveRegionKey { .. }
             | Error::ParseNum { .. }
             | Error::UnsupportedSelectorType { .. }
             | Error::InvalidArguments { .. }
@@ -565,6 +575,7 @@ impl ErrorExt for Error {
             | Error::LeaseValueFromUtf8 { .. }
             | Error::StatKeyFromUtf8 { .. }
             | Error::StatValueFromUtf8 { .. }
+            | Error::InvalidRegionKeyFromUtf8 { .. }
             | Error::UnexpectedSequenceValue { .. }
             | Error::TableRouteNotFound { .. }
             | Error::TableInfoNotFound { .. }

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 
 use crate::error::Result;
 use crate::handler::{HeartbeatAccumulator, HeartbeatHandler};
-use crate::inactive_node_manager::InactiveNodeManager;
+use crate::inactive_region_manager::InactiveRegionManager;
 use crate::metasrv::Context;
 
 pub struct RegionLeaseHandler {
@@ -50,8 +50,8 @@ impl HeartbeatHandler for RegionLeaseHandler {
 
         let mut region_ids = stat.region_ids();
 
-        let inactive_node_manager = InactiveNodeManager::new(&ctx.in_memory);
-        let inactive_region_ids = inactive_node_manager
+        let inactive_region_manager = InactiveRegionManager::new(&ctx.in_memory);
+        let inactive_region_ids = inactive_region_manager
             .retain_active_regions(stat.cluster_id, stat.id, &mut region_ids)
             .await?;
 
@@ -126,8 +126,8 @@ mod test {
             ..Default::default()
         });
 
-        let inactive_node_manager = InactiveNodeManager::new(&ctx.in_memory);
-        inactive_node_manager
+        let inactive_region_manager = InactiveRegionManager::new(&ctx.in_memory);
+        inactive_region_manager
             .register_inactive_region(&RegionIdent {
                 cluster_id: 1,
                 datanode_id: 1,
@@ -139,7 +139,7 @@ mod test {
             })
             .await
             .unwrap();
-        inactive_node_manager
+        inactive_region_manager
             .register_inactive_region(&RegionIdent {
                 cluster_id: 1,
                 datanode_id: 1,

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -40,7 +40,7 @@ pub mod table_routes;
 
 pub use crate::error::Result;
 
-mod inactive_node_manager;
+mod inactive_region_manager;
 
 mod greptimedb_telemetry;
 

--- a/src/meta-srv/src/procedure/region_failover/activate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/activate_region.rs
@@ -29,7 +29,7 @@ use crate::error::{
     Error, Result, RetryLaterSnafu, SerializeToJsonSnafu, UnexpectedInstructionReplySnafu,
 };
 use crate::handler::HeartbeatMailbox;
-use crate::inactive_node_manager::InactiveNodeManager;
+use crate::inactive_region_manager::InactiveRegionManager;
 use crate::procedure::region_failover::OPEN_REGION_MESSAGE_TIMEOUT;
 use crate::service::mailbox::{Channel, MailboxReceiver};
 
@@ -76,7 +76,7 @@ impl ActivateRegion {
             datanode_id: self.candidate.id,
             ..failed_region.clone()
         };
-        InactiveNodeManager::new(&ctx.in_memory)
+        InactiveRegionManager::new(&ctx.in_memory)
             .deregister_inactive_region(&candidate)
             .await?;
 

--- a/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
@@ -29,7 +29,7 @@ use crate::error::{
     Error, Result, RetryLaterSnafu, SerializeToJsonSnafu, UnexpectedInstructionReplySnafu,
 };
 use crate::handler::HeartbeatMailbox;
-use crate::inactive_node_manager::InactiveNodeManager;
+use crate::inactive_region_manager::InactiveRegionManager;
 use crate::service::mailbox::{Channel, MailboxReceiver};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -62,7 +62,7 @@ impl DeactivateRegion {
 
         let ch = Channel::Datanode(failed_region.datanode_id);
         // Mark the region as inactive
-        InactiveNodeManager::new(&ctx.in_memory)
+        InactiveRegionManager::new(&ctx.in_memory)
             .register_inactive_region(failed_region)
             .await?;
         // We first marked the region as inactive, which means that the failed region cannot
@@ -93,7 +93,7 @@ impl DeactivateRegion {
                     .fail();
                 };
                 if result {
-                    InactiveNodeManager::new(&ctx.in_memory)
+                    InactiveRegionManager::new(&ctx.in_memory)
                         .deregister_inactive_region(failed_region)
                         .await?;
 

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -14,10 +14,12 @@
 
 mod health;
 mod heartbeat;
+mod inactive_regions;
 mod leader;
 mod meta;
 mod node_lease;
 mod route;
+mod util;
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -86,6 +88,20 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         "/route",
         route::RouteHandler {
             kv_store: meta_srv.kv_store().clone(),
+        },
+    );
+
+    let router = router.route(
+        "/inactive-regions/view",
+        inactive_regions::ViewInactiveRegionsHandler {
+            store: meta_srv.in_memory().clone(),
+        },
+    );
+
+    let router = router.route(
+        "/inactive-regions/clear",
+        inactive_regions::ClearInactiveRegionsHandler {
+            store: meta_srv.in_memory().clone(),
         },
     );
 

--- a/src/meta-srv/src/service/admin/inactive_regions.rs
+++ b/src/meta-srv/src/service/admin/inactive_regions.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -63,9 +64,9 @@ impl HttpHandler for ClearInactiveRegionsHandler {
         let cluster_id = util::extract_cluster_id(params)?;
 
         let inactive_region_manager = InactiveRegionManager::new(&self.store);
-        let _ = inactive_region_manager
+        inactive_region_manager
             .clear_all_inactive_regions(cluster_id)
-            .await;
+            .await?;
 
         Ok(http::Response::builder()
             .status(http::StatusCode::OK)

--- a/src/meta-srv/src/service/admin/inactive_regions.rs
+++ b/src/meta-srv/src/service/admin/inactive_regions.rs
@@ -1,0 +1,91 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tonic::codegen::http;
+
+use crate::error::{self, Result};
+use crate::inactive_region_manager::InactiveRegionManager;
+use crate::keys::InactiveRegionKey;
+use crate::service::admin::{util, HttpHandler};
+use crate::service::store::kv::ResettableKvStoreRef;
+
+pub struct ViewInactiveRegionsHandler {
+    pub store: ResettableKvStoreRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for ViewInactiveRegionsHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let cluster_id = util::extract_cluster_id(params)?;
+
+        let inactive_region_manager = InactiveRegionManager::new(&self.store);
+        let inactive_regions = inactive_region_manager
+            .scan_all_inactive_regions(cluster_id)
+            .await?;
+        let result = InactiveRegions { inactive_regions }.try_into()?;
+
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(result)
+            .context(error::InvalidHttpBodySnafu)
+    }
+}
+
+pub struct ClearInactiveRegionsHandler {
+    pub store: ResettableKvStoreRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for ClearInactiveRegionsHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let cluster_id = util::extract_cluster_id(params)?;
+
+        let inactive_region_manager = InactiveRegionManager::new(&self.store);
+        let _ = inactive_region_manager
+            .clear_all_inactive_regions(cluster_id)
+            .await;
+
+        Ok(http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body("Success\n".to_owned())
+            .unwrap())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+struct InactiveRegions {
+    inactive_regions: Vec<InactiveRegionKey>,
+}
+
+impl TryFrom<InactiveRegions> for String {
+    type Error = error::Error;
+
+    fn try_from(value: InactiveRegions) -> Result<Self> {
+        serde_json::to_string(&value).context(error::SerializeToJsonSnafu {
+            input: format!("{value:?}"),
+        })
+    }
+}

--- a/src/meta-srv/src/service/admin/util.rs
+++ b/src/meta-srv/src/service/admin/util.rs
@@ -12,10 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) const METRIC_META_CREATE_CATALOG: &str = "meta.create_catalog";
-pub(crate) const METRIC_META_CREATE_SCHEMA: &str = "meta.create_schema";
-pub(crate) const METRIC_META_KV_REQUEST: &str = "meta.kv_request";
-pub(crate) const METRIC_META_ROUTE_REQUEST: &str = "meta.route_request";
-pub(crate) const METRIC_META_HEARTBEAT_CONNECTION_NUM: &str = "meta.heartbeat_connection_num";
-pub(crate) const METRIC_META_HANDLER_EXECUTE: &str = "meta.handler_execute";
-pub const METRIC_META_INACTIVE_REGIONS: &str = "meta.inactive_regions";
+use std::collections::HashMap;
+
+use snafu::{OptionExt, ResultExt};
+
+use crate::error::{self, Result};
+
+pub fn extract_cluster_id(params: &HashMap<String, String>) -> Result<u64> {
+    params
+        .get("cluster_id")
+        .map(|id| id.parse::<u64>())
+        .context(error::MissingRequiredParameterSnafu {
+            param: "cluster_id",
+        })?
+        .context(error::ParseNumSnafu {
+            err_msg: "`cluster_id` is not a valid number",
+        })
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


1. Add metric for InactiveRegionKey
2. Add admin(http api) for view and clear

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
