### PR TITLE
feat: adapt methods from RegionEngine for MitoEngine

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -57,6 +57,7 @@ pub enum StatusCode {
     TableColumnExists = 4003,
     DatabaseNotFound = 4004,
     RegionNotFound = 4005,
+    RegionAlreadyExists = 4006,
     // ====== End of catalog related status code =======
 
     // ====== Begin of storage related status code =====
@@ -115,6 +116,7 @@ impl StatusCode {
             | StatusCode::TableAlreadyExists
             | StatusCode::TableNotFound
             | StatusCode::RegionNotFound
+            | StatusCode::RegionAlreadyExists
             | StatusCode::TableColumnNotFound
             | StatusCode::TableColumnExists
             | StatusCode::DatabaseNotFound
@@ -148,6 +150,7 @@ impl StatusCode {
             | StatusCode::TableAlreadyExists
             | StatusCode::TableNotFound
             | StatusCode::RegionNotFound
+            | StatusCode::RegionAlreadyExists
             | StatusCode::TableColumnNotFound
             | StatusCode::TableColumnExists
             | StatusCode::DatabaseNotFound
@@ -177,6 +180,9 @@ impl StatusCode {
             v if v == StatusCode::TableAlreadyExists as u32 => Some(StatusCode::TableAlreadyExists),
             v if v == StatusCode::TableNotFound as u32 => Some(StatusCode::TableNotFound),
             v if v == StatusCode::RegionNotFound as u32 => Some(StatusCode::RegionNotFound),
+            v if v == StatusCode::RegionAlreadyExists as u32 => {
+                Some(StatusCode::RegionAlreadyExists)
+            }
             v if v == StatusCode::TableColumnNotFound as u32 => {
                 Some(StatusCode::TableColumnNotFound)
             }

--- a/src/mito2/src/engine/close_test.rs
+++ b/src/mito2/src/engine/close_test.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionCloseRequest, RegionRequest};
 use store_api::storage::RegionId;
 

--- a/src/mito2/src/engine/create_test.rs
+++ b/src/mito2/src/engine/create_test.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
+use store_api::region_engine::RegionEngine;
 use store_api::region_request::RegionRequest;
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
-use crate::error::Error;
 use crate::test_util::{CreateRequestBuilder, TestEnv};
 
 #[tokio::test]
@@ -71,7 +73,7 @@ async fn test_engine_create_existing_region() {
         .await
         .unwrap_err();
     assert!(
-        matches!(err, Error::RegionExists { .. }),
+        matches!(err.status_code(), StatusCode::RegionAlreadyExists),
         "unexpected err: {err}"
     );
 }

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use object_store::util::join_path;
+use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionDropRequest, RegionRequest};
 use store_api::storage::RegionId;
 

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -14,11 +14,13 @@
 
 use std::collections::HashMap;
 
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
+use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionCloseRequest, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
-use crate::error::Error;
 use crate::test_util::{CreateRequestBuilder, TestEnv};
 
 #[tokio::test]
@@ -38,7 +40,7 @@ async fn test_engine_open_empty() {
         .await
         .unwrap_err();
     assert!(
-        matches!(err, Error::RegionNotFound { .. }),
+        matches!(err.status_code(), StatusCode::RegionNotFound),
         "unexpected err: {err}"
     );
 }

--- a/src/mito2/src/engine/tests.rs
+++ b/src/mito2/src/engine/tests.rs
@@ -30,7 +30,6 @@ use store_api::region_request::{
 use store_api::storage::RegionId;
 
 use super::*;
-use crate::error::Error;
 use crate::region::version::VersionControlData;
 use crate::test_util::{CreateRequestBuilder, TestEnv};
 
@@ -224,8 +223,7 @@ async fn test_write_query_region() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let scanner = engine.scan(region_id, request).unwrap();
-    let stream = scanner.scan().await.unwrap();
+    let stream = engine.handle_query(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -445,12 +445,12 @@ impl ErrorExt for Error {
             | DecompressObject { .. }
             | SerdeJson { .. }
             | Utf8 { .. }
-            | RegionExists { .. }
             | NewRecordBatch { .. }
-            | RegionNotFound { .. }
             | RegionCorrupted { .. }
             | CreateDefault { .. }
             | InvalidParquet { .. } => StatusCode::Unexpected,
+            RegionNotFound { .. } => StatusCode::RegionNotFound,
+            RegionExists { .. } => StatusCode::RegionAlreadyExists,
             InvalidScanIndex { .. }
             | InvalidMeta { .. }
             | InvalidSchema { .. }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -465,7 +465,9 @@ pub fn status_to_tonic_code(status_code: StatusCode) -> Code {
         | StatusCode::EngineExecuteQuery => Code::Internal,
         StatusCode::InvalidArguments | StatusCode::InvalidSyntax => Code::InvalidArgument,
         StatusCode::Cancelled => Code::Cancelled,
-        StatusCode::TableAlreadyExists | StatusCode::TableColumnExists => Code::AlreadyExists,
+        StatusCode::TableAlreadyExists
+        | StatusCode::TableColumnExists
+        | StatusCode::RegionAlreadyExists => Code::AlreadyExists,
         StatusCode::TableNotFound
         | StatusCode::RegionNotFound
         | StatusCode::TableColumnNotFound


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Finish those todos in `impl RegionEngine for MitoEngine`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
