### PR TITLE
feat: avoid using vector to get default value

### DIFF
--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -54,6 +54,18 @@ impl Timestamp {
         }
     }
 
+    /// Creates current timestamp in specific time `unit`.
+    pub fn current_time(unit: TimeUnit) -> Timestamp {
+        let now = chrono::Utc::now();
+        let value = match unit {
+            TimeUnit::Second => now.timestamp(),
+            TimeUnit::Millisecond => now.timestamp_millis(),
+            TimeUnit::Microsecond => now.timestamp_micros(),
+            TimeUnit::Nanosecond => now.timestamp_nanos(),
+        };
+        Timestamp { value, unit }
+    }
+
     /// Subtracts a duration from timestamp.
     /// # Note
     /// The result time unit remains unchanged even if `duration` has a different unit with `self`.

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -161,8 +161,21 @@ impl ColumnSchema {
     ///
     /// If the column is `NOT NULL` but doesn't has `DEFAULT` value supplied, returns `Ok(None)`.
     pub fn create_default(&self) -> Result<Option<Value>> {
-        self.create_default_vector(1)
-            .map(|vec_ref_option| vec_ref_option.map(|vec_ref| vec_ref.get(0)))
+        match &self.default_constraint {
+            Some(c) => c
+                .create_default(&self.data_type, self.is_nullable)
+                .map(Some),
+            None => {
+                if self.is_nullable {
+                    // No default constraint, use null as default value.
+                    ColumnDefaultConstraint::null_value()
+                        .create_default(&self.data_type, self.is_nullable)
+                        .map(Some)
+                } else {
+                    Ok(None)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR avoids allocating a vector to get a default value for a column. It creates the default value directly.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
