### PR TITLE
feat(frontend): reorg insert converters and introduce stmt_to_region

### DIFF
--- a/src/api/src/helper.rs
+++ b/src/api/src/helper.rs
@@ -810,50 +810,54 @@ pub fn vectors_to_rows<'a>(
     let mut rows = vec![Row { values: vec![] }; row_count];
     for column in columns {
         for (row_index, row) in rows.iter_mut().enumerate() {
-            row.values.push(GrpcValue {
-                value_data: match column.get(row_index) {
-                    Value::Null => None,
-                    Value::Boolean(v) => Some(ValueData::BoolValue(v)),
-                    Value::UInt8(v) => Some(ValueData::U8Value(v as _)),
-                    Value::UInt16(v) => Some(ValueData::U16Value(v as _)),
-                    Value::UInt32(v) => Some(ValueData::U32Value(v)),
-                    Value::UInt64(v) => Some(ValueData::U64Value(v)),
-                    Value::Int8(v) => Some(ValueData::I8Value(v as _)),
-                    Value::Int16(v) => Some(ValueData::I16Value(v as _)),
-                    Value::Int32(v) => Some(ValueData::I32Value(v)),
-                    Value::Int64(v) => Some(ValueData::I64Value(v)),
-                    Value::Float32(v) => Some(ValueData::F32Value(*v)),
-                    Value::Float64(v) => Some(ValueData::F64Value(*v)),
-                    Value::String(v) => Some(ValueData::StringValue(v.as_utf8().to_string())),
-                    Value::Binary(v) => Some(ValueData::BinaryValue(v.to_vec())),
-                    Value::Date(v) => Some(ValueData::DateValue(v.val())),
-                    Value::DateTime(v) => Some(ValueData::DatetimeValue(v.val())),
-                    Value::Timestamp(v) => Some(match v.unit() {
-                        TimeUnit::Second => ValueData::TimeSecondValue(v.value()),
-                        TimeUnit::Millisecond => ValueData::TimeMillisecondValue(v.value()),
-                        TimeUnit::Microsecond => ValueData::TimeMicrosecondValue(v.value()),
-                        TimeUnit::Nanosecond => ValueData::TimeNanosecondValue(v.value()),
-                    }),
-                    Value::Time(v) => Some(match v.unit() {
-                        TimeUnit::Second => ValueData::TimeSecondValue(v.value()),
-                        TimeUnit::Millisecond => ValueData::TimeMillisecondValue(v.value()),
-                        TimeUnit::Microsecond => ValueData::TimeMicrosecondValue(v.value()),
-                        TimeUnit::Nanosecond => ValueData::TimeNanosecondValue(v.value()),
-                    }),
-                    Value::Interval(v) => Some(match v.unit() {
-                        IntervalUnit::YearMonth => ValueData::IntervalYearMonthValues(v.to_i32()),
-                        IntervalUnit::DayTime => ValueData::IntervalDayTimeValues(v.to_i64()),
-                        IntervalUnit::MonthDayNano => ValueData::IntervalMonthDayNanoValues(
-                            convert_i128_to_interval(v.to_i128()),
-                        ),
-                    }),
-                    Value::List(_) => unreachable!(),
-                },
-            })
+            row.values.push(value_to_grpc_value(column.get(row_index)))
         }
     }
 
     rows
+}
+
+pub fn value_to_grpc_value(value: Value) -> GrpcValue {
+    GrpcValue {
+        value_data: match value {
+            Value::Null => None,
+            Value::Boolean(v) => Some(ValueData::BoolValue(v)),
+            Value::UInt8(v) => Some(ValueData::U8Value(v as _)),
+            Value::UInt16(v) => Some(ValueData::U16Value(v as _)),
+            Value::UInt32(v) => Some(ValueData::U32Value(v)),
+            Value::UInt64(v) => Some(ValueData::U64Value(v)),
+            Value::Int8(v) => Some(ValueData::I8Value(v as _)),
+            Value::Int16(v) => Some(ValueData::I16Value(v as _)),
+            Value::Int32(v) => Some(ValueData::I32Value(v)),
+            Value::Int64(v) => Some(ValueData::I64Value(v)),
+            Value::Float32(v) => Some(ValueData::F32Value(*v)),
+            Value::Float64(v) => Some(ValueData::F64Value(*v)),
+            Value::String(v) => Some(ValueData::StringValue(v.as_utf8().to_string())),
+            Value::Binary(v) => Some(ValueData::BinaryValue(v.to_vec())),
+            Value::Date(v) => Some(ValueData::DateValue(v.val())),
+            Value::DateTime(v) => Some(ValueData::DatetimeValue(v.val())),
+            Value::Timestamp(v) => Some(match v.unit() {
+                TimeUnit::Second => ValueData::TimeSecondValue(v.value()),
+                TimeUnit::Millisecond => ValueData::TimeMillisecondValue(v.value()),
+                TimeUnit::Microsecond => ValueData::TimeMicrosecondValue(v.value()),
+                TimeUnit::Nanosecond => ValueData::TimeNanosecondValue(v.value()),
+            }),
+            Value::Time(v) => Some(match v.unit() {
+                TimeUnit::Second => ValueData::TimeSecondValue(v.value()),
+                TimeUnit::Millisecond => ValueData::TimeMillisecondValue(v.value()),
+                TimeUnit::Microsecond => ValueData::TimeMicrosecondValue(v.value()),
+                TimeUnit::Nanosecond => ValueData::TimeNanosecondValue(v.value()),
+            }),
+            Value::Interval(v) => Some(match v.unit() {
+                IntervalUnit::YearMonth => ValueData::IntervalYearMonthValues(v.to_i32()),
+                IntervalUnit::DayTime => ValueData::IntervalDayTimeValues(v.to_i64()),
+                IntervalUnit::MonthDayNano => {
+                    ValueData::IntervalMonthDayNanoValues(convert_i128_to_interval(v.to_i128()))
+                }
+            }),
+            Value::List(_) => unreachable!(),
+        },
+    }
 }
 
 /// Returns true if the column type is equal to expected type.

--- a/src/frontend/src/inserter.rs
+++ b/src/frontend/src/inserter.rs
@@ -33,8 +33,7 @@ use snafu::prelude::*;
 use table::engine::TableReference;
 use table::TableRef;
 
-use self::req_convert::column_to_row::ColumnToRow;
-use self::req_convert::row_to_region::RowToRegion;
+use self::req_convert::{ColumnToRow, RowToRegion};
 use crate::error::{
     CatalogSnafu, EmptyDataSnafu, Error, FindNewColumnsOnInsertionSnafu, InvalidInsertRequestSnafu,
     Result,

--- a/src/frontend/src/inserter.rs
+++ b/src/frontend/src/inserter.rs
@@ -12,41 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+pub(crate) mod req_convert;
 
-use api::helper::ColumnDataTypeWrapper;
 use api::v1::alter_expr::Kind;
 use api::v1::ddl_request::Expr as DdlExpr;
 use api::v1::greptime_request::Request;
-use api::v1::region::{
-    region_request, InsertRequest as RegionInsertRequest, InsertRequests as RegionInsertRequests,
-};
-use api::v1::value::ValueData;
+use api::v1::region::region_request;
 use api::v1::{
-    AlterExpr, Column, ColumnDataType, ColumnSchema, DdlRequest, InsertRequest, InsertRequests,
-    Row, RowInsertRequest, RowInsertRequests, Rows, SemanticType, Value,
+    AlterExpr, ColumnSchema, DdlRequest, InsertRequests, RowInsertRequest, RowInsertRequests,
 };
 use catalog::CatalogManagerRef;
-use common_base::BitVec;
 use common_catalog::consts::default_engine;
 use common_grpc_expr::util::{extract_new_columns, ColumnExpr};
 use common_query::Output;
 use common_telemetry::info;
 use datatypes::schema::Schema;
-use datatypes::vectors::VectorRef;
 use servers::query_handler::grpc::GrpcQueryHandlerRef;
 use session::context::QueryContextRef;
 use snafu::prelude::*;
-use store_api::storage::RegionId;
 use table::engine::TableReference;
-use table::metadata::TableInfoRef;
-use table::requests::InsertRequest as TableInsertRequest;
 use table::TableRef;
 
+use self::req_convert::column_to_row::ColumnToRow;
+use self::req_convert::row_to_region::RowToRegion;
 use crate::error::{
-    CatalogSnafu, ColumnDataTypeSnafu, ColumnNotFoundSnafu, EmptyDataSnafu, Error,
-    FindNewColumnsOnInsertionSnafu, InvalidInsertRequestSnafu, MissingTimeIndexColumnSnafu, Result,
-    TableNotFoundSnafu,
+    CatalogSnafu, EmptyDataSnafu, Error, FindNewColumnsOnInsertionSnafu, InvalidInsertRequestSnafu,
+    Result,
 };
 use crate::expr_factory::CreateExprFactory;
 use crate::instance::region_handler::RegionRequestHandlerRef;
@@ -78,7 +69,7 @@ impl<'a> Inserter<'a> {
         requests: InsertRequests,
         ctx: QueryContextRef,
     ) -> Result<Output> {
-        let row_inserts = requests_column_to_row(requests)?;
+        let row_inserts = ColumnToRow::convert(requests)?;
         self.handle_row_inserts(row_inserts, ctx).await
     }
 
@@ -97,28 +88,15 @@ impl<'a> Inserter<'a> {
 
         self.create_or_alter_tables_on_demand(&requests, &ctx)
             .await?;
-        let region_request = self.convert_req_row_to_region(requests, &ctx).await?;
+        let region_request = RowToRegion::new(self.catalog_manager.as_ref(), &ctx)
+            .convert(requests)
+            .await?;
+        let region_request = region_request::Body::Inserts(region_request);
         let response = self
             .region_request_handler
             .handle(region_request, ctx)
             .await?;
         Ok(Output::AffectedRows(response.affected_rows as _))
-    }
-
-    pub fn convert_req_table_to_region(
-        table_info: &TableInfoRef,
-        insert: TableInsertRequest,
-    ) -> Result<RegionInsertRequests> {
-        let region_id = RegionId::new(table_info.table_id(), insert.region_number).into();
-        let row_count = row_count(&insert.columns_values)?;
-        let schema = column_schema(table_info, &insert.columns_values)?;
-        let rows = api::helper::vectors_to_rows(insert.columns_values.values(), row_count);
-        Ok(RegionInsertRequests {
-            requests: vec![RegionInsertRequest {
-                region_id,
-                rows: Some(Rows { schema, rows }),
-            }],
-        })
     }
 }
 
@@ -226,171 +204,6 @@ impl<'a> Inserter<'a> {
 
         Ok(())
     }
-
-    async fn convert_req_row_to_region(
-        &self,
-        requests: RowInsertRequests,
-        ctx: &QueryContextRef,
-    ) -> Result<region_request::Body> {
-        let mut region_request = Vec::with_capacity(requests.inserts.len());
-        for request in requests.inserts {
-            let table = self.get_table(&request, ctx).await?;
-            let table = table.with_context(|| TableNotFoundSnafu {
-                table_name: request.table_name.clone(),
-            })?;
-
-            let region_id = RegionId::new(table.table_info().table_id(), request.region_number);
-            let insert_request = RegionInsertRequest {
-                region_id: region_id.into(),
-                rows: request.rows,
-            };
-            region_request.push(insert_request);
-        }
-
-        Ok(region_request::Body::Inserts(RegionInsertRequests {
-            requests: region_request,
-        }))
-    }
-}
-
-fn requests_column_to_row(requests: InsertRequests) -> Result<RowInsertRequests> {
-    requests
-        .inserts
-        .into_iter()
-        .map(request_column_to_row)
-        .collect::<Result<Vec<_>>>()
-        .map(|inserts| RowInsertRequests { inserts })
-}
-
-fn request_column_to_row(request: InsertRequest) -> Result<RowInsertRequest> {
-    let row_count = request.row_count as usize;
-    let column_count = request.columns.len();
-    let mut schema = Vec::with_capacity(column_count);
-    let mut rows = vec![
-        Row {
-            values: Vec::with_capacity(column_count)
-        };
-        row_count
-    ];
-    for column in request.columns {
-        let column_schema = ColumnSchema {
-            column_name: column.column_name.clone(),
-            datatype: column.datatype,
-            semantic_type: column.semantic_type,
-        };
-        schema.push(column_schema);
-
-        push_column_to_rows(column, &mut rows)?;
-    }
-
-    Ok(RowInsertRequest {
-        table_name: request.table_name,
-        rows: Some(Rows { schema, rows }),
-        region_number: request.region_number,
-    })
-}
-
-fn push_column_to_rows(column: Column, rows: &mut [Row]) -> Result<()> {
-    let null_mask = BitVec::from_vec(column.null_mask);
-    let column_type = ColumnDataTypeWrapper::try_new(column.datatype)
-        .context(ColumnDataTypeSnafu)?
-        .datatype();
-    let column_values = column.values.unwrap_or_default();
-
-    macro_rules! push_column_values_match_types {
-        ($( ($arm:tt, $value_data_variant:tt, $field_name:tt), )*) => { match column_type { $(
-
-        ColumnDataType::$arm => {
-            let row_count = rows.len();
-            let actual_row_count = null_mask.count_ones() + column_values.$field_name.len();
-            ensure!(
-                actual_row_count == row_count,
-                InvalidInsertRequestSnafu {
-                    reason: format!(
-                        "Expecting {} rows of data for column '{}', but got {}.",
-                        row_count, column.column_name, actual_row_count
-                    ),
-                }
-            );
-
-            let mut null_mask_iter = null_mask.into_iter();
-            let mut values_iter = column_values.$field_name.into_iter();
-
-            for row in rows {
-                let value_is_null = null_mask_iter.next();
-                if value_is_null == Some(true) {
-                    row.values.push(Value { value_data: None });
-                } else {
-                    // previous check ensures that there is a value for each row
-                    let value = values_iter.next().unwrap();
-                    row.values.push(Value {
-                        value_data: Some(ValueData::$value_data_variant(value)),
-                    });
-                }
-            }
-        }
-
-        )* }}
-    }
-
-    push_column_values_match_types!(
-        (Boolean, BoolValue, bool_values),
-        (Int8, I8Value, i8_values),
-        (Int16, I16Value, i16_values),
-        (Int32, I32Value, i32_values),
-        (Int64, I64Value, i64_values),
-        (Uint8, U8Value, u8_values),
-        (Uint16, U16Value, u16_values),
-        (Uint32, U32Value, u32_values),
-        (Uint64, U64Value, u64_values),
-        (Float32, F32Value, f32_values),
-        (Float64, F64Value, f64_values),
-        (Binary, BinaryValue, binary_values),
-        (String, StringValue, string_values),
-        (Date, DateValue, date_values),
-        (Datetime, DatetimeValue, datetime_values),
-        (TimestampSecond, TsSecondValue, ts_second_values),
-        (
-            TimestampMillisecond,
-            TsMillisecondValue,
-            ts_millisecond_values
-        ),
-        (
-            TimestampMicrosecond,
-            TsMicrosecondValue,
-            ts_microsecond_values
-        ),
-        (TimestampNanosecond, TsNanosecondValue, ts_nanosecond_values),
-        (TimeSecond, TimeSecondValue, time_second_values),
-        (
-            TimeMillisecond,
-            TimeMillisecondValue,
-            time_millisecond_values
-        ),
-        (
-            TimeMicrosecond,
-            TimeMicrosecondValue,
-            time_microsecond_values
-        ),
-        (TimeNanosecond, TimeNanosecondValue, time_nanosecond_values),
-        (
-            IntervalYearMonth,
-            IntervalYearMonthValues,
-            interval_year_month_values
-        ),
-        (
-            IntervalDayTime,
-            IntervalDayTimeValues,
-            interval_day_time_values
-        ),
-        (
-            IntervalMonthDayNano,
-            IntervalMonthDayNanoValues,
-            interval_month_day_nano_values
-        ),
-    );
-
-    Ok(())
 }
 
 fn validate_request_with_table(req: &RowInsertRequest, table: &TableRef) -> Result<()> {
@@ -422,81 +235,10 @@ fn validate_required_columns(request_schema: &[ColumnSchema], table_schema: &Sch
     Ok(())
 }
 
-fn row_count(columns: &HashMap<String, VectorRef>) -> Result<usize> {
-    let mut columns_iter = columns.values();
-
-    let len = columns_iter
-        .next()
-        .map(|column| column.len())
-        .unwrap_or_default();
-    ensure!(
-        columns_iter.all(|column| column.len() == len),
-        InvalidInsertRequestSnafu {
-            reason: "The row count of columns is not the same."
-        }
-    );
-
-    Ok(len)
-}
-
-fn column_schema(
-    table_info: &TableInfoRef,
-    columns: &HashMap<String, VectorRef>,
-) -> Result<Vec<ColumnSchema>> {
-    let table_meta = &table_info.meta;
-    let mut schema = vec![];
-
-    for (column_name, vector) in columns {
-        let time_index_column = &table_meta
-            .schema
-            .timestamp_column()
-            .with_context(|| table::error::MissingTimeIndexColumnSnafu {
-                table_name: table_info.name.to_string(),
-            })
-            .context(MissingTimeIndexColumnSnafu)?
-            .name;
-        let semantic_type = if column_name == time_index_column {
-            SemanticType::Timestamp
-        } else {
-            let column_index = table_meta
-                .schema
-                .column_index_by_name(column_name)
-                .context(ColumnNotFoundSnafu {
-                    msg: format!("unable to find column {column_name} in table schema"),
-                })?;
-            if table_meta.primary_key_indices.contains(&column_index) {
-                SemanticType::Tag
-            } else {
-                SemanticType::Field
-            }
-        };
-
-        let datatype: ColumnDataTypeWrapper =
-            vector.data_type().try_into().context(ColumnDataTypeSnafu)?;
-
-        schema.push(ColumnSchema {
-            column_name: column_name.clone(),
-            datatype: datatype.datatype().into(),
-            semantic_type: semantic_type.into(),
-        });
-    }
-
-    Ok(schema)
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use api::v1::column::Values;
-    use api::v1::SemanticType;
-    use common_base::bit_vec::prelude::*;
-    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use datatypes::prelude::{ConcreteDataType, Value as DtValue};
-    use datatypes::scalars::ScalarVectorBuilder;
     use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema as DtColumnSchema};
-    use datatypes::vectors::{Int16VectorBuilder, MutableVector, StringVectorBuilder};
-    use table::metadata::{TableInfoBuilder, TableMetaBuilder};
 
     use super::*;
 
@@ -539,243 +281,5 @@ mod tests {
         }];
         // Neither of the above cases.
         assert!(validate_required_columns(request_schema, &schema).is_err());
-    }
-
-    #[test]
-    fn test_request_column_to_row() {
-        let insert_request = InsertRequest {
-            table_name: String::from("test_table"),
-            row_count: 3,
-            region_number: 1,
-            columns: vec![
-                Column {
-                    column_name: String::from("col1"),
-                    datatype: ColumnDataType::Int32.into(),
-                    semantic_type: SemanticType::Field.into(),
-                    null_mask: bitvec![u8, Lsb0; 1, 0, 1].into_vec(),
-                    values: Some(Values {
-                        i32_values: vec![42],
-                        ..Default::default()
-                    }),
-                },
-                Column {
-                    column_name: String::from("col2"),
-                    datatype: ColumnDataType::String.into(),
-                    semantic_type: SemanticType::Tag.into(),
-                    null_mask: vec![],
-                    values: Some(Values {
-                        string_values: vec![
-                            String::from("value1"),
-                            String::from("value2"),
-                            String::from("value3"),
-                        ],
-                        ..Default::default()
-                    }),
-                },
-            ],
-        };
-
-        let result = request_column_to_row(insert_request);
-        let row_insert_request = result.unwrap();
-        assert_eq!(row_insert_request.table_name, "test_table");
-        assert_eq!(row_insert_request.region_number, 1);
-        let rows = row_insert_request.rows.unwrap();
-        assert_eq!(
-            rows.schema,
-            vec![
-                ColumnSchema {
-                    column_name: String::from("col1"),
-                    datatype: ColumnDataType::Int32.into(),
-                    semantic_type: SemanticType::Field.into(),
-                },
-                ColumnSchema {
-                    column_name: String::from("col2"),
-                    datatype: ColumnDataType::String.into(),
-                    semantic_type: SemanticType::Tag.into(),
-                },
-            ]
-        );
-        assert_eq!(
-            rows.rows,
-            vec![
-                Row {
-                    values: vec![
-                        Value { value_data: None },
-                        Value {
-                            value_data: Some(ValueData::StringValue(String::from("value1"))),
-                        },
-                    ],
-                },
-                Row {
-                    values: vec![
-                        Value {
-                            value_data: Some(ValueData::I32Value(42)),
-                        },
-                        Value {
-                            value_data: Some(ValueData::StringValue(String::from("value2"))),
-                        },
-                    ],
-                },
-                Row {
-                    values: vec![
-                        Value { value_data: None },
-                        Value {
-                            value_data: Some(ValueData::StringValue(String::from("value3"))),
-                        },
-                    ],
-                },
-            ]
-        );
-
-        let invalid_request_with_wrong_type = InsertRequest {
-            table_name: String::from("test_table"),
-            row_count: 3,
-            region_number: 1,
-            columns: vec![Column {
-                column_name: String::from("col1"),
-                datatype: ColumnDataType::Int32.into(),
-                semantic_type: SemanticType::Field.into(),
-                null_mask: bitvec![u8, Lsb0; 1, 0, 1].into_vec(),
-                values: Some(Values {
-                    i8_values: vec![42],
-                    ..Default::default()
-                }),
-            }],
-        };
-        assert!(request_column_to_row(invalid_request_with_wrong_type).is_err());
-
-        let invalid_request_with_wrong_row_count = InsertRequest {
-            table_name: String::from("test_table"),
-            row_count: 3,
-            region_number: 1,
-            columns: vec![Column {
-                column_name: String::from("col1"),
-                datatype: ColumnDataType::Int32.into(),
-                semantic_type: SemanticType::Field.into(),
-                null_mask: bitvec![u8, Lsb0; 0, 0, 1].into_vec(),
-                values: Some(Values {
-                    i32_values: vec![42],
-                    ..Default::default()
-                }),
-            }],
-        };
-        assert!(request_column_to_row(invalid_request_with_wrong_row_count).is_err());
-
-        let invalid_request_with_wrong_row_count = InsertRequest {
-            table_name: String::from("test_table"),
-            row_count: 3,
-            region_number: 1,
-            columns: vec![Column {
-                column_name: String::from("col1"),
-                datatype: ColumnDataType::Int32.into(),
-                semantic_type: SemanticType::Field.into(),
-                null_mask: vec![],
-                values: Some(Values {
-                    i32_values: vec![42],
-                    ..Default::default()
-                }),
-            }],
-        };
-        assert!(request_column_to_row(invalid_request_with_wrong_row_count).is_err());
-    }
-
-    #[test]
-    fn test_insert_request_table_to_region() {
-        let schema = Schema::new(vec![
-            DtColumnSchema::new("ts", ConcreteDataType::int64_datatype(), false)
-                .with_time_index(true),
-            DtColumnSchema::new("id", ConcreteDataType::int16_datatype(), false),
-            DtColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
-        ]);
-
-        let table_meta = TableMetaBuilder::default()
-            .schema(Arc::new(schema))
-            .primary_key_indices(vec![2])
-            .next_column_id(3)
-            .build()
-            .unwrap();
-
-        let table_info = Arc::new(
-            TableInfoBuilder::default()
-                .name("demo")
-                .meta(table_meta)
-                .table_id(1)
-                .build()
-                .unwrap(),
-        );
-
-        let insert_request = mock_insert_request();
-        let mut request =
-            Inserter::convert_req_table_to_region(&table_info, insert_request).unwrap();
-
-        assert_eq!(request.requests.len(), 1);
-        verify_region_insert_request(request.requests.pop().unwrap());
-    }
-
-    fn mock_insert_request() -> TableInsertRequest {
-        let mut builder = StringVectorBuilder::with_capacity(3);
-        builder.push(Some("host1"));
-        builder.push(None);
-        builder.push(Some("host3"));
-        let host = builder.to_vector();
-
-        let mut builder = Int16VectorBuilder::with_capacity(3);
-        builder.push(Some(1_i16));
-        builder.push(Some(2_i16));
-        builder.push(Some(3_i16));
-        let id = builder.to_vector();
-
-        let columns_values = HashMap::from([("host".to_string(), host), ("id".to_string(), id)]);
-
-        TableInsertRequest {
-            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
-            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
-            table_name: "demo".to_string(),
-            columns_values,
-            region_number: 0,
-        }
-    }
-
-    fn verify_region_insert_request(request: RegionInsertRequest) {
-        assert_eq!(request.region_id, RegionId::new(1, 0).as_u64());
-
-        let rows = request.rows.unwrap();
-        for (i, column) in rows.schema.iter().enumerate() {
-            let name = &column.column_name;
-            if name == "id" {
-                assert_eq!(ColumnDataType::Int16 as i32, column.datatype);
-                assert_eq!(SemanticType::Field as i32, column.semantic_type);
-                let values = rows
-                    .rows
-                    .iter()
-                    .map(|row| row.values[i].value_data.clone())
-                    .collect::<Vec<_>>();
-                assert_eq!(
-                    vec![
-                        Some(ValueData::I16Value(1)),
-                        Some(ValueData::I16Value(2)),
-                        Some(ValueData::I16Value(3))
-                    ],
-                    values
-                );
-            }
-            if name == "host" {
-                assert_eq!(ColumnDataType::String as i32, column.datatype);
-                assert_eq!(SemanticType::Tag as i32, column.semantic_type);
-                let values = rows
-                    .rows
-                    .iter()
-                    .map(|row| row.values[i].value_data.clone())
-                    .collect::<Vec<_>>();
-                assert_eq!(
-                    vec![
-                        Some(ValueData::StringValue("host1".to_string())),
-                        None,
-                        Some(ValueData::StringValue("host3".to_string()))
-                    ],
-                    values
-                );
-            }
-        }
     }
 }

--- a/src/frontend/src/inserter/req_convert.rs
+++ b/src/frontend/src/inserter/req_convert.rs
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod column_to_row;
-pub mod row_to_region;
-pub mod stmt_to_region;
-pub mod table_to_region;
+mod column_to_row;
+mod row_to_region;
+mod stmt_to_region;
+mod table_to_region;
 
 use api::helper::ColumnDataTypeWrapper;
 use api::v1::{ColumnDataType, SemanticType};
+pub use column_to_row::ColumnToRow;
 use datatypes::prelude::ConcreteDataType;
+pub use row_to_region::RowToRegion;
 use snafu::{OptionExt, ResultExt};
+pub use stmt_to_region::StatementToRegion;
 use table::metadata::TableInfo;
+pub use table_to_region::TableToRegion;
 
 use crate::error::{ColumnDataTypeSnafu, ColumnNotFoundSnafu, MissingTimeIndexColumnSnafu, Result};
 

--- a/src/frontend/src/inserter/req_convert.rs
+++ b/src/frontend/src/inserter/req_convert.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod column_to_row;
+pub mod row_to_region;
+pub mod stmt_to_region;
+pub mod table_to_region;
+
+use api::helper::ColumnDataTypeWrapper;
+use api::v1::{ColumnDataType, SemanticType};
+use datatypes::prelude::ConcreteDataType;
+use snafu::{OptionExt, ResultExt};
+use table::metadata::TableInfo;
+
+use crate::error::{ColumnDataTypeSnafu, ColumnNotFoundSnafu, MissingTimeIndexColumnSnafu, Result};
+
+fn semantic_type(table_info: &TableInfo, column: &str) -> Result<SemanticType> {
+    let table_meta = &table_info.meta;
+    let table_schema = &table_meta.schema;
+
+    let time_index_column = &table_schema
+        .timestamp_column()
+        .with_context(|| table::error::MissingTimeIndexColumnSnafu {
+            table_name: table_info.name.to_string(),
+        })
+        .context(MissingTimeIndexColumnSnafu)?
+        .name;
+
+    let semantic_type = if column == time_index_column {
+        SemanticType::Timestamp
+    } else {
+        let column_index = table_schema.column_index_by_name(column);
+        let column_index = column_index.context(ColumnNotFoundSnafu {
+            msg: format!("unable to find column {column} in table schema"),
+        })?;
+
+        if table_meta.primary_key_indices.contains(&column_index) {
+            SemanticType::Tag
+        } else {
+            SemanticType::Field
+        }
+    };
+
+    Ok(semantic_type)
+}
+
+fn data_type(data_type: ConcreteDataType) -> Result<ColumnDataType> {
+    let datatype: ColumnDataTypeWrapper = data_type.try_into().context(ColumnDataTypeSnafu)?;
+    Ok(datatype.datatype())
+}

--- a/src/frontend/src/inserter/req_convert/column_to_row.rs
+++ b/src/frontend/src/inserter/req_convert/column_to_row.rs
@@ -1,0 +1,304 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::helper::ColumnDataTypeWrapper;
+use api::v1::value::ValueData;
+use api::v1::{
+    Column, ColumnDataType, ColumnSchema, InsertRequest, InsertRequests, Row, RowInsertRequest,
+    RowInsertRequests, Rows, Value,
+};
+use common_base::BitVec;
+use snafu::prelude::*;
+use snafu::ResultExt;
+
+use crate::error::{ColumnDataTypeSnafu, InvalidInsertRequestSnafu, Result};
+
+pub struct ColumnToRow;
+
+impl ColumnToRow {
+    pub fn convert(requests: InsertRequests) -> Result<RowInsertRequests> {
+        requests
+            .inserts
+            .into_iter()
+            .map(request_column_to_row)
+            .collect::<Result<Vec<_>>>()
+            .map(|inserts| RowInsertRequests { inserts })
+    }
+}
+
+fn request_column_to_row(request: InsertRequest) -> Result<RowInsertRequest> {
+    let row_count = request.row_count as usize;
+    let column_count = request.columns.len();
+    let mut schema = Vec::with_capacity(column_count);
+    let mut rows = vec![
+        Row {
+            values: Vec::with_capacity(column_count)
+        };
+        row_count
+    ];
+    for column in request.columns {
+        let column_schema = ColumnSchema {
+            column_name: column.column_name.clone(),
+            datatype: column.datatype,
+            semantic_type: column.semantic_type,
+        };
+        schema.push(column_schema);
+
+        push_column_to_rows(column, &mut rows)?;
+    }
+
+    Ok(RowInsertRequest {
+        table_name: request.table_name,
+        rows: Some(Rows { schema, rows }),
+        region_number: request.region_number,
+    })
+}
+
+fn push_column_to_rows(column: Column, rows: &mut [Row]) -> Result<()> {
+    let null_mask = BitVec::from_vec(column.null_mask);
+    let column_type = ColumnDataTypeWrapper::try_new(column.datatype)
+        .context(ColumnDataTypeSnafu)?
+        .datatype();
+    let column_values = column.values.unwrap_or_default();
+
+    macro_rules! push_column_values_match_types {
+        ($( ($arm:tt, $value_data_variant:tt, $field_name:tt), )*) => { match column_type { $(
+
+        ColumnDataType::$arm => {
+            let row_count = rows.len();
+            let actual_row_count = null_mask.count_ones() + column_values.$field_name.len();
+            ensure!(
+                actual_row_count == row_count,
+                InvalidInsertRequestSnafu {
+                    reason: format!(
+                        "Expecting {} rows of data for column '{}', but got {}.",
+                        row_count, column.column_name, actual_row_count
+                    ),
+                }
+            );
+
+            let mut null_mask_iter = null_mask.into_iter();
+            let mut values_iter = column_values.$field_name.into_iter();
+
+            for row in rows {
+                let value_is_null = null_mask_iter.next();
+                if value_is_null == Some(true) {
+                    row.values.push(Value { value_data: None });
+                } else {
+                    // previous check ensures that there is a value for each row
+                    let value = values_iter.next().unwrap();
+                    row.values.push(Value {
+                        value_data: Some(ValueData::$value_data_variant(value)),
+                    });
+                }
+            }
+        }
+
+        )* }}
+    }
+
+    push_column_values_match_types!(
+        (Boolean, BoolValue, bool_values),
+        (Int8, I8Value, i8_values),
+        (Int16, I16Value, i16_values),
+        (Int32, I32Value, i32_values),
+        (Int64, I64Value, i64_values),
+        (Uint8, U8Value, u8_values),
+        (Uint16, U16Value, u16_values),
+        (Uint32, U32Value, u32_values),
+        (Uint64, U64Value, u64_values),
+        (Float32, F32Value, f32_values),
+        (Float64, F64Value, f64_values),
+        (Binary, BinaryValue, binary_values),
+        (String, StringValue, string_values),
+        (Date, DateValue, date_values),
+        (Datetime, DatetimeValue, datetime_values),
+        (TimestampSecond, TsSecondValue, ts_second_values),
+        (
+            TimestampMillisecond,
+            TsMillisecondValue,
+            ts_millisecond_values
+        ),
+        (
+            TimestampMicrosecond,
+            TsMicrosecondValue,
+            ts_microsecond_values
+        ),
+        (TimestampNanosecond, TsNanosecondValue, ts_nanosecond_values),
+        (TimeSecond, TimeSecondValue, time_second_values),
+        (
+            TimeMillisecond,
+            TimeMillisecondValue,
+            time_millisecond_values
+        ),
+        (
+            TimeMicrosecond,
+            TimeMicrosecondValue,
+            time_microsecond_values
+        ),
+        (TimeNanosecond, TimeNanosecondValue, time_nanosecond_values),
+        (
+            IntervalYearMonth,
+            IntervalYearMonthValues,
+            interval_year_month_values
+        ),
+        (
+            IntervalDayTime,
+            IntervalDayTimeValues,
+            interval_day_time_values
+        ),
+        (
+            IntervalMonthDayNano,
+            IntervalMonthDayNanoValues,
+            interval_month_day_nano_values
+        ),
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use api::v1::column::Values;
+    use api::v1::SemanticType;
+    use common_base::bit_vec::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn test_request_column_to_row() {
+        let insert_request = InsertRequest {
+            table_name: String::from("test_table"),
+            row_count: 3,
+            region_number: 1,
+            columns: vec![
+                Column {
+                    column_name: String::from("col1"),
+                    datatype: ColumnDataType::Int32.into(),
+                    semantic_type: SemanticType::Field.into(),
+                    null_mask: bitvec![u8, Lsb0; 1, 0, 1].into_vec(),
+                    values: Some(Values {
+                        i32_values: vec![42],
+                        ..Default::default()
+                    }),
+                },
+                Column {
+                    column_name: String::from("col2"),
+                    datatype: ColumnDataType::String.into(),
+                    semantic_type: SemanticType::Tag.into(),
+                    null_mask: vec![],
+                    values: Some(Values {
+                        string_values: vec![
+                            String::from("value1"),
+                            String::from("value2"),
+                            String::from("value3"),
+                        ],
+                        ..Default::default()
+                    }),
+                },
+            ],
+        };
+
+        let result = request_column_to_row(insert_request);
+        let row_insert_request = result.unwrap();
+        assert_eq!(row_insert_request.table_name, "test_table");
+        assert_eq!(row_insert_request.region_number, 1);
+        let rows = row_insert_request.rows.unwrap();
+
+        assert_eq!(rows.schema.len(), 2);
+        assert_eq!(rows.schema[0].column_name, "col1");
+        assert_eq!(rows.schema[0].datatype, ColumnDataType::Int32 as i32);
+        assert_eq!(rows.schema[0].semantic_type, SemanticType::Field as i32);
+        assert_eq!(rows.schema[1].column_name, "col2");
+        assert_eq!(rows.schema[1].datatype, ColumnDataType::String as i32);
+        assert_eq!(rows.schema[1].semantic_type, SemanticType::Tag as i32);
+
+        assert_eq!(rows.rows.len(), 3);
+
+        assert_eq!(rows.rows[0].values.len(), 2);
+        assert_eq!(rows.rows[0].values[0].value_data, None);
+        assert_eq!(
+            rows.rows[0].values[1].value_data,
+            Some(ValueData::StringValue(String::from("value1")))
+        );
+
+        assert_eq!(rows.rows[1].values.len(), 2);
+        assert_eq!(
+            rows.rows[1].values[0].value_data,
+            Some(ValueData::I32Value(42))
+        );
+        assert_eq!(
+            rows.rows[1].values[1].value_data,
+            Some(ValueData::StringValue(String::from("value2")))
+        );
+
+        assert_eq!(rows.rows[2].values.len(), 2);
+        assert_eq!(rows.rows[2].values[0].value_data, None);
+        assert_eq!(
+            rows.rows[2].values[1].value_data,
+            Some(ValueData::StringValue(String::from("value3")))
+        );
+
+        let invalid_request_with_wrong_type = InsertRequest {
+            table_name: String::from("test_table"),
+            row_count: 3,
+            region_number: 1,
+            columns: vec![Column {
+                column_name: String::from("col1"),
+                datatype: ColumnDataType::Int32.into(),
+                semantic_type: SemanticType::Field.into(),
+                null_mask: bitvec![u8, Lsb0; 1, 0, 1].into_vec(),
+                values: Some(Values {
+                    i8_values: vec![42],
+                    ..Default::default()
+                }),
+            }],
+        };
+        assert!(request_column_to_row(invalid_request_with_wrong_type).is_err());
+
+        let invalid_request_with_wrong_row_count = InsertRequest {
+            table_name: String::from("test_table"),
+            row_count: 3,
+            region_number: 1,
+            columns: vec![Column {
+                column_name: String::from("col1"),
+                datatype: ColumnDataType::Int32.into(),
+                semantic_type: SemanticType::Field.into(),
+                null_mask: bitvec![u8, Lsb0; 0, 0, 1].into_vec(),
+                values: Some(Values {
+                    i32_values: vec![42],
+                    ..Default::default()
+                }),
+            }],
+        };
+        assert!(request_column_to_row(invalid_request_with_wrong_row_count).is_err());
+
+        let invalid_request_with_wrong_row_count = InsertRequest {
+            table_name: String::from("test_table"),
+            row_count: 3,
+            region_number: 1,
+            columns: vec![Column {
+                column_name: String::from("col1"),
+                datatype: ColumnDataType::Int32.into(),
+                semantic_type: SemanticType::Field.into(),
+                null_mask: vec![],
+                values: Some(Values {
+                    i32_values: vec![42],
+                    ..Default::default()
+                }),
+            }],
+        };
+        assert!(request_column_to_row(invalid_request_with_wrong_row_count).is_err());
+    }
+}

--- a/src/frontend/src/inserter/req_convert/row_to_region.rs
+++ b/src/frontend/src/inserter/req_convert/row_to_region.rs
@@ -1,0 +1,69 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::region::{
+    InsertRequest as RegionInsertRequest, InsertRequests as RegionInsertRequests,
+};
+use api::v1::RowInsertRequests;
+use catalog::CatalogManager;
+use session::context::QueryContext;
+use snafu::{OptionExt, ResultExt};
+use store_api::storage::RegionId;
+use table::TableRef;
+
+use crate::error::{CatalogSnafu, Result, TableNotFoundSnafu};
+
+pub struct RowToRegion<'a> {
+    catalog_manager: &'a dyn CatalogManager,
+    ctx: &'a QueryContext,
+}
+
+impl<'a> RowToRegion<'a> {
+    pub fn new(catalog_manager: &'a dyn CatalogManager, ctx: &'a QueryContext) -> Self {
+        Self {
+            catalog_manager,
+            ctx,
+        }
+    }
+
+    pub async fn convert(&self, requests: RowInsertRequests) -> Result<RegionInsertRequests> {
+        let mut region_request = Vec::with_capacity(requests.inserts.len());
+        for request in requests.inserts {
+            let table = self.get_table(&request.table_name).await?;
+
+            let region_id = RegionId::new(table.table_info().table_id(), request.region_number);
+            let insert_request = RegionInsertRequest {
+                region_id: region_id.into(),
+                rows: request.rows,
+            };
+            region_request.push(insert_request);
+        }
+
+        Ok(RegionInsertRequests {
+            requests: region_request,
+        })
+    }
+
+    async fn get_table(&self, table_name: &str) -> Result<TableRef> {
+        let catalog_name = self.ctx.current_catalog();
+        let schema_name = self.ctx.current_schema();
+        self.catalog_manager
+            .table(catalog_name, schema_name, table_name)
+            .await
+            .context(CatalogSnafu)?
+            .with_context(|| TableNotFoundSnafu {
+                table_name: format!("{}.{}.{}", catalog_name, schema_name, table_name),
+            })
+    }
+}

--- a/src/frontend/src/inserter/req_convert/stmt_to_region.rs
+++ b/src/frontend/src/inserter/req_convert/stmt_to_region.rs
@@ -63,7 +63,7 @@ impl<'a> StatementToRegion<'a> {
         ensure!(
             sql_rows.iter().all(|row| row.len() == column_count),
             InvalidSqlSnafu {
-                err_msg: format!("The column count of the row is not the same as columns.")
+                err_msg: "The column count of the row is not the same as columns."
             }
         );
 

--- a/src/frontend/src/inserter/req_convert/stmt_to_region.rs
+++ b/src/frontend/src/inserter/req_convert/stmt_to_region.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::helper::value_to_grpc_value;
+use api::v1::region::{
+    InsertRequest as RegionInsertRequest, InsertRequests as RegionInsertRequests,
+};
+use api::v1::{ColumnSchema as GrpcColumnSchema, Row, Rows, Value as GrpcValue};
+use catalog::CatalogManager;
+use datatypes::schema::{ColumnSchema, SchemaRef};
+use session::context::QueryContext;
+use snafu::{OptionExt, ResultExt};
+use sql::statements;
+use sql::statements::insert::Insert;
+use sqlparser::ast::{ObjectName, Value as SqlValue};
+use store_api::storage::RegionId;
+use table::TableRef;
+
+use super::{data_type, semantic_type};
+use crate::error::{
+    CatalogSnafu, ColumnDefaultValueSnafu, ColumnNoneDefaultValueSnafu, ColumnNotFoundSnafu,
+    InvalidSqlSnafu, MissingInsertBodySnafu, ParseSqlSnafu, Result, TableNotFoundSnafu,
+};
+
+const DEFAULT_PLACEHOLDER_VALUE: &str = "default";
+
+pub struct StatementToRegion<'a> {
+    catalog_manager: &'a dyn CatalogManager,
+    ctx: &'a QueryContext,
+}
+
+impl<'a> StatementToRegion<'a> {
+    pub fn new(catalog_manager: &'a dyn CatalogManager, ctx: &'a QueryContext) -> Self {
+        Self {
+            catalog_manager,
+            ctx,
+        }
+    }
+
+    pub async fn convert(&self, stmt: &Insert) -> Result<RegionInsertRequests> {
+        let (catalog, schema, table_name) = self.get_full_name(stmt.table_name())?;
+        let table = self.get_table(&catalog, &schema, &table_name).await?;
+        let table_schema = table.schema();
+        let table_info = table.table_info();
+
+        let column_names = column_names(stmt, &table_schema);
+        let column_count = column_names.len();
+
+        let sql_values = stmt.values_body().context(MissingInsertBodySnafu)?;
+        let row_count = sql_values.len();
+
+        let mut schema = Vec::with_capacity(column_count);
+        let mut rows = vec![
+            Row {
+                values: Vec::with_capacity(column_count)
+            };
+            row_count
+        ];
+
+        for (i, column_name) in column_names.into_iter().enumerate() {
+            let column_schema = table_schema
+                .column_schema_by_name(column_name)
+                .with_context(|| ColumnNotFoundSnafu {
+                    msg: format!("Column {} not found in table {}", column_name, &table_name),
+                })?;
+
+            let datatype = data_type(column_schema.data_type.clone())?;
+            let semantic_type = semantic_type(&table_info, column_name)?;
+
+            let grpc_column_schema = GrpcColumnSchema {
+                column_name: column_name.clone(),
+                datatype: datatype.into(),
+                semantic_type: semantic_type.into(),
+            };
+            schema.push(grpc_column_schema);
+
+            for sql_value in sql_values.iter().map(|row| &row[i]) {
+                let value = sql_value_to_grpc_value(column_schema, sql_value)?;
+                rows[i].values.push(value);
+            }
+        }
+
+        Ok(RegionInsertRequests {
+            requests: vec![RegionInsertRequest {
+                region_id: RegionId::new(table_info.table_id(), 0).into(),
+                rows: Some(Rows { schema, rows }),
+            }],
+        })
+    }
+
+    async fn get_table(&self, catalog: &str, schema: &str, table: &str) -> Result<TableRef> {
+        self.catalog_manager
+            .table(catalog, schema, table)
+            .await
+            .context(CatalogSnafu)?
+            .with_context(|| TableNotFoundSnafu {
+                table_name: format!("{}.{}.{}", catalog, schema, table),
+            })
+    }
+
+    fn get_full_name(&self, obj_name: &ObjectName) -> Result<(String, String, String)> {
+        match &obj_name.0[..] {
+            [table] => Ok((
+                self.ctx.current_catalog().to_owned(),
+                self.ctx.current_schema().to_owned(),
+                table.value.clone(),
+            )),
+            [schema, table] => Ok((
+                self.ctx.current_catalog().to_owned(),
+                schema.value.clone(),
+                table.value.clone(),
+            )),
+            [catalog, schema, table] => Ok((
+                catalog.value.clone(),
+                schema.value.clone(),
+                table.value.clone(),
+            )),
+            _ => InvalidSqlSnafu {
+                err_msg: format!(
+                    "expect table name to be <catalog>.<schema>.<table>, <schema>.<table> or <table>, actual: {obj_name}",
+                ),
+            }.fail(),
+        }
+    }
+}
+
+fn column_names<'a>(stmt: &'a Insert, table_schema: &'a SchemaRef) -> Vec<&'a String> {
+    if !stmt.columns().is_empty() {
+        stmt.columns()
+    } else {
+        table_schema
+            .column_schemas()
+            .iter()
+            .map(|column| &column.name)
+            .collect()
+    }
+}
+
+fn sql_value_to_grpc_value(column_schema: &ColumnSchema, sql_val: &SqlValue) -> Result<GrpcValue> {
+    let column = &column_schema.name;
+    let value = if replace_default(sql_val) {
+        let default_value = column_schema
+            .create_default()
+            .context(ColumnDefaultValueSnafu {
+                column: column.clone(),
+            })?;
+
+        default_value.context(ColumnNoneDefaultValueSnafu {
+            column: column.clone(),
+        })?
+    } else {
+        statements::sql_value_to_value(column, &column_schema.data_type, sql_val)
+            .context(ParseSqlSnafu)?
+    };
+
+    let grpc_value = value_to_grpc_value(value);
+    Ok(grpc_value)
+}
+
+fn replace_default(sql_val: &SqlValue) -> bool {
+    matches!(sql_val, SqlValue::Placeholder(s) if s.to_lowercase() == DEFAULT_PLACEHOLDER_VALUE)
+}

--- a/src/frontend/src/inserter/req_convert/table_to_region.rs
+++ b/src/frontend/src/inserter/req_convert/table_to_region.rs
@@ -1,0 +1,201 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use api::v1::region::{
+    InsertRequest as RegionInsertRequest, InsertRequests as RegionInsertRequests,
+};
+use api::v1::{ColumnSchema, Rows};
+use datatypes::vectors::VectorRef;
+use snafu::prelude::*;
+use store_api::storage::RegionId;
+use table::metadata::TableInfo;
+use table::requests::InsertRequest as TableInsertRequest;
+
+use super::{data_type, semantic_type};
+use crate::error::{InvalidInsertRequestSnafu, Result};
+
+pub struct TableToRegion<'a> {
+    table_info: &'a TableInfo,
+}
+
+impl<'a> TableToRegion<'a> {
+    pub fn new(table_info: &'a TableInfo) -> Self {
+        Self { table_info }
+    }
+
+    pub fn convert(&self, request: TableInsertRequest) -> Result<RegionInsertRequests> {
+        let region_id = RegionId::new(self.table_info.table_id(), request.region_number).into();
+        let row_count = row_count(&request.columns_values)?;
+        let schema = column_schema(self.table_info, &request.columns_values)?;
+        let rows = api::helper::vectors_to_rows(request.columns_values.values(), row_count);
+        Ok(RegionInsertRequests {
+            requests: vec![RegionInsertRequest {
+                region_id,
+                rows: Some(Rows { schema, rows }),
+            }],
+        })
+    }
+}
+
+fn row_count(columns: &HashMap<String, VectorRef>) -> Result<usize> {
+    let mut columns_iter = columns.values();
+
+    let len = columns_iter
+        .next()
+        .map(|column| column.len())
+        .unwrap_or_default();
+    ensure!(
+        columns_iter.all(|column| column.len() == len),
+        InvalidInsertRequestSnafu {
+            reason: "The row count of columns is not the same."
+        }
+    );
+
+    Ok(len)
+}
+
+fn column_schema(
+    table_info: &TableInfo,
+    columns: &HashMap<String, VectorRef>,
+) -> Result<Vec<ColumnSchema>> {
+    columns
+        .iter()
+        .map(|(column_name, vector)| {
+            Ok(ColumnSchema {
+                column_name: column_name.clone(),
+                datatype: data_type(vector.data_type())?.into(),
+                semantic_type: semantic_type(table_info, column_name)?.into(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use api::v1::value::ValueData;
+    use api::v1::{ColumnDataType, SemanticType};
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use datatypes::prelude::ConcreteDataType;
+    use datatypes::scalars::ScalarVectorBuilder;
+    use datatypes::schema::{ColumnSchema as DtColumnSchema, Schema};
+    use datatypes::vectors::{Int16VectorBuilder, MutableVector, StringVectorBuilder};
+    use table::metadata::{TableInfoBuilder, TableMetaBuilder};
+
+    use super::*;
+
+    #[test]
+    fn test_insert_request_table_to_region() {
+        let schema = Schema::new(vec![
+            DtColumnSchema::new("ts", ConcreteDataType::int64_datatype(), false)
+                .with_time_index(true),
+            DtColumnSchema::new("id", ConcreteDataType::int16_datatype(), false),
+            DtColumnSchema::new("host", ConcreteDataType::string_datatype(), false),
+        ]);
+
+        let table_meta = TableMetaBuilder::default()
+            .schema(Arc::new(schema))
+            .primary_key_indices(vec![2])
+            .next_column_id(3)
+            .build()
+            .unwrap();
+
+        let table_info = Arc::new(
+            TableInfoBuilder::default()
+                .name("demo")
+                .meta(table_meta)
+                .table_id(1)
+                .build()
+                .unwrap(),
+        );
+
+        let insert_request = mock_insert_request();
+        let mut request = TableToRegion::new(&table_info)
+            .convert(insert_request)
+            .unwrap();
+
+        assert_eq!(request.requests.len(), 1);
+        verify_region_insert_request(request.requests.pop().unwrap());
+    }
+
+    fn mock_insert_request() -> TableInsertRequest {
+        let mut builder = StringVectorBuilder::with_capacity(3);
+        builder.push(Some("host1"));
+        builder.push(None);
+        builder.push(Some("host3"));
+        let host = builder.to_vector();
+
+        let mut builder = Int16VectorBuilder::with_capacity(3);
+        builder.push(Some(1_i16));
+        builder.push(Some(2_i16));
+        builder.push(Some(3_i16));
+        let id = builder.to_vector();
+
+        let columns_values = HashMap::from([("host".to_string(), host), ("id".to_string(), id)]);
+
+        TableInsertRequest {
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: "demo".to_string(),
+            columns_values,
+            region_number: 0,
+        }
+    }
+
+    fn verify_region_insert_request(request: RegionInsertRequest) {
+        assert_eq!(request.region_id, RegionId::new(1, 0).as_u64());
+
+        let rows = request.rows.unwrap();
+        for (i, column) in rows.schema.iter().enumerate() {
+            let name = &column.column_name;
+            if name == "id" {
+                assert_eq!(ColumnDataType::Int16 as i32, column.datatype);
+                assert_eq!(SemanticType::Field as i32, column.semantic_type);
+                let values = rows
+                    .rows
+                    .iter()
+                    .map(|row| row.values[i].value_data.clone())
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    vec![
+                        Some(ValueData::I16Value(1)),
+                        Some(ValueData::I16Value(2)),
+                        Some(ValueData::I16Value(3))
+                    ],
+                    values
+                );
+            }
+            if name == "host" {
+                assert_eq!(ColumnDataType::String as i32, column.datatype);
+                assert_eq!(SemanticType::Tag as i32, column.semantic_type);
+                let values = rows
+                    .rows
+                    .iter()
+                    .map(|row| row.values[i].value_data.clone())
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    vec![
+                        Some(ValueData::StringValue("host1".to_string())),
+                        None,
+                        Some(ValueData::StringValue("host3".to_string()))
+                    ],
+                    values
+                );
+            }
+        }
+    }
+}

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -39,7 +39,6 @@ use common_meta::table_name::TableName;
 use common_query::Output;
 use common_telemetry::info;
 use datanode::instance::sql::table_idents_to_full_name;
-use datanode::sql::SqlHandler;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::RawSchema;
 use partition::manager::PartitionInfo;
@@ -61,11 +60,12 @@ use super::region_handler::RegionRequestHandler;
 use crate::catalog::FrontendCatalogManager;
 use crate::error::{
     self, AlterExprToRequestSnafu, CatalogSnafu, ColumnDataTypeSnafu, ColumnNotFoundSnafu,
-    DeserializePartitionSnafu, InvokeDatanodeSnafu, NotSupportedSnafu, ParseSqlSnafu, Result,
-    SchemaExistsSnafu, SchemaNotFoundSnafu, TableAlreadyExistSnafu, TableMetadataManagerSnafu,
-    TableNotFoundSnafu, UnrecognizedTableOptionSnafu,
+    DeserializePartitionSnafu, NotSupportedSnafu, ParseSqlSnafu, Result, SchemaExistsSnafu,
+    SchemaNotFoundSnafu, TableAlreadyExistSnafu, TableMetadataManagerSnafu, TableNotFoundSnafu,
+    UnrecognizedTableOptionSnafu,
 };
 use crate::expr_factory;
+use crate::inserter::req_convert::stmt_to_region::StatementToRegion;
 use crate::instance::distributed::deleter::DistDeleter;
 use crate::instance::distributed::inserter::DistInserter;
 use crate::table::DistTable;
@@ -271,13 +271,11 @@ impl DistInstance {
                 self.drop_table(table_name).await
             }
             Statement::Insert(insert) => {
-                let insert_request =
-                    SqlHandler::insert_to_request(self.catalog_manager.clone(), &insert, query_ctx)
-                        .await
-                        .context(InvokeDatanodeSnafu)?;
-
+                let request = StatementToRegion::new(self.catalog_manager.as_ref(), &query_ctx)
+                    .convert(&insert)
+                    .await?;
                 let inserter = DistInserter::new(&self.catalog_manager);
-                let affected_rows = inserter.insert_table_request(insert_request).await?;
+                let affected_rows = inserter.insert(request).await?;
                 Ok(Output::AffectedRows(affected_rows as usize))
             }
             Statement::ShowCreateTable(show) => {
@@ -612,7 +610,7 @@ impl RegionRequestHandler for DistRegionRequestHandler {
             region_request::Body::Inserts(inserts) => {
                 let inserter =
                     DistInserter::new(&self.catalog_manager).with_trace_id(ctx.trace_id());
-                let affected_rows = inserter.insert_region_requests(inserts).await? as _;
+                let affected_rows = inserter.insert(inserts).await? as _;
                 Ok(RegionResponse {
                     header: Some(Default::default()),
                     affected_rows,

--- a/src/frontend/src/instance/distributed.rs
+++ b/src/frontend/src/instance/distributed.rs
@@ -65,7 +65,7 @@ use crate::error::{
     UnrecognizedTableOptionSnafu,
 };
 use crate::expr_factory;
-use crate::inserter::req_convert::stmt_to_region::StatementToRegion;
+use crate::inserter::req_convert::StatementToRegion;
 use crate::instance::distributed::deleter::DistDeleter;
 use crate::instance::distributed::inserter::DistInserter;
 use crate::table::DistTable;

--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -51,7 +51,7 @@ use crate::error::{
     self, CatalogSnafu, ExecLogicalPlanSnafu, ExecuteStatementSnafu, ExternalSnafu, InsertSnafu,
     PlanStatementSnafu, Result, TableNotFoundSnafu,
 };
-use crate::inserter::req_convert::table_to_region::TableToRegion;
+use crate::inserter::req_convert::TableToRegion;
 use crate::instance::distributed::deleter::DistDeleter;
 use crate::instance::region_handler::RegionRequestHandlerRef;
 use crate::statement::backup::{COPY_DATABASE_TIME_END_KEY, COPY_DATABASE_TIME_START_KEY};

--- a/src/frontend/src/statement.rs
+++ b/src/frontend/src/statement.rs
@@ -51,7 +51,7 @@ use crate::error::{
     self, CatalogSnafu, ExecLogicalPlanSnafu, ExecuteStatementSnafu, ExternalSnafu, InsertSnafu,
     PlanStatementSnafu, Result, TableNotFoundSnafu,
 };
-use crate::inserter::Inserter;
+use crate::inserter::req_convert::table_to_region::TableToRegion;
 use crate::instance::distributed::deleter::DistDeleter;
 use crate::instance::region_handler::RegionRequestHandlerRef;
 use crate::statement::backup::{COPY_DATABASE_TIME_END_KEY, COPY_DATABASE_TIME_START_KEY};
@@ -184,7 +184,7 @@ impl StatementExecutor {
         let table = self.get_table(&table_ref).await?;
         let table_info = table.table_info();
 
-        let request = Inserter::convert_req_table_to_region(&table_info, request)?;
+        let request = TableToRegion::new(&table_info).convert(request)?;
         let region_response = self
             .region_request_handler
             .handle(region_request::Body::Inserts(request), query_ctx)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* Move all converters of insert request to `frontend::inserter::req_convert::*`
* Add Statement to Region Request converter

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/2318#discussion_r1314519281