### PR TITLE
refactor: refactor raft engine backend and state store

### DIFF
--- a/src/catalog/src/remote/client.rs
+++ b/src/catalog/src/remote/client.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use common_error::ext::BoxedError;
 use common_meta::error::Error::{CacheNotGet, GetKvCache};
-use common_meta::error::{CacheNotGetSnafu, Error, MetaSrvSnafu, Result};
+use common_meta::error::{CacheNotGetSnafu, Error, ExternalSnafu, Result};
 use common_meta::kv_backend::{KvBackend, KvBackendRef, TxnService};
 use common_meta::rpc::store::{
     BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse, BatchPutRequest,
@@ -251,7 +251,7 @@ impl KvBackend for MetaKvBackend {
             .range(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn get(&self, key: &[u8]) -> Result<Option<KeyValue>> {
@@ -260,7 +260,7 @@ impl KvBackend for MetaKvBackend {
             .range(RangeRequest::new().with_key(key))
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)?;
+            .context(ExternalSnafu)?;
         Ok(response.take_kvs().get_mut(0).map(|kv| KeyValue {
             key: kv.take_key(),
             value: kv.take_value(),
@@ -272,7 +272,7 @@ impl KvBackend for MetaKvBackend {
             .batch_put(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn put(&self, req: PutRequest) -> Result<PutResponse> {
@@ -280,7 +280,7 @@ impl KvBackend for MetaKvBackend {
             .put(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn delete_range(&self, req: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
@@ -288,7 +288,7 @@ impl KvBackend for MetaKvBackend {
             .delete_range(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn batch_delete(&self, req: BatchDeleteRequest) -> Result<BatchDeleteResponse> {
@@ -296,7 +296,7 @@ impl KvBackend for MetaKvBackend {
             .batch_delete(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn batch_get(&self, req: BatchGetRequest) -> Result<BatchGetResponse> {
@@ -304,7 +304,7 @@ impl KvBackend for MetaKvBackend {
             .batch_get(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn compare_and_put(
@@ -315,7 +315,7 @@ impl KvBackend for MetaKvBackend {
             .compare_and_put(request)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse> {
@@ -323,7 +323,7 @@ impl KvBackend for MetaKvBackend {
             .move_value(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -49,7 +49,7 @@ impl Datanode for RegionRequester {
                     source: BoxedError::new(err),
                 }
             } else {
-                meta_error::Error::OperateRegion {
+                meta_error::Error::External {
                     source: BoxedError::new(err),
                     location: location!(),
                 }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -206,12 +206,6 @@ pub enum Error {
     #[snafu(display("Get null from cache, key: {}", key))]
     CacheNotGet { key: String, location: Location },
 
-    #[snafu(display("{source}"))]
-    MetaSrv {
-        source: BoxedError,
-        location: Location,
-    },
-
     #[snafu(display("Etcd txn error: {err_msg}"))]
     EtcdTxnOpResponse { err_msg: String, location: Location },
 
@@ -234,23 +228,14 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("External error: {}", err_msg))]
-    External { location: Location, err_msg: String },
+    #[snafu(display("{}", source))]
+    External {
+        location: Location,
+        source: BoxedError,
+    },
 
     #[snafu(display("Invalid heartbeat response, location: {}", location))]
     InvalidHeartbeatResponse { location: Location },
-
-    #[snafu(display("{}", source))]
-    OperateRegion {
-        location: Location,
-        source: BoxedError,
-    },
-
-    #[snafu(display("{}", source))]
-    ExecuteDdl {
-        location: Location,
-        source: BoxedError,
-    },
 
     #[snafu(display("Failed to operate on datanode: {}, source: {}", peer, source))]
     OperateDatanode {
@@ -278,7 +263,6 @@ impl ErrorExt for Error {
             | InvalidTableMetadata { .. }
             | MoveRegion { .. }
             | Unexpected { .. }
-            | External { .. }
             | TableInfoNotFound { .. }
             | NextSequence { .. }
             | SequenceOutOfRange { .. }
@@ -309,12 +293,10 @@ impl ErrorExt for Error {
 
             SubmitProcedure { source, .. } | WaitProcedure { source, .. } => source.status_code(),
             RegisterProcedureLoader { source, .. } => source.status_code(),
+            External { source, .. } => source.status_code(),
             OperateDatanode { source, .. } => source.status_code(),
             Table { source, .. } => source.status_code(),
             RetryLater { source, .. } => source.status_code(),
-            OperateRegion { source, .. } => source.status_code(),
-            ExecuteDdl { source, .. } => source.status_code(),
-            MetaSrv { source, .. } => source.status_code(),
             InvalidCatalogValue { source, .. } => source.status_code(),
             ConvertAlterTableRequest { source, .. } => source.status_code(),
         }

--- a/src/common/meta/src/lib.rs
+++ b/src/common/meta/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![feature(btree_extract_if)]
+#![feature(async_closure)]
 
 pub mod cache_invalidator;
 pub mod datanode_manager;
@@ -32,6 +33,7 @@ pub mod peer;
 pub mod range_stream;
 pub mod rpc;
 pub mod sequence;
+pub mod state_store;
 pub mod table_name;
 pub mod util;
 

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -187,7 +187,7 @@ impl DdlExecutor for MetaClient {
         self.submit_ddl_task(request)
             .await
             .map_err(BoxedError::new)
-            .context(meta_error::ExecuteDdlSnafu)
+            .context(meta_error::ExternalSnafu)
     }
 }
 

--- a/src/meta-srv/src/cache_invalidator.rs
+++ b/src/meta-srv/src/cache_invalidator.rs
@@ -59,6 +59,6 @@ impl CacheInvalidator for MetasrvCacheInvalidator {
             .broadcast(&BroadcastChannel::Frontend, msg)
             .await
             .map_err(BoxedError::new)
-            .context(meta_error::MetaSrvSnafu)
+            .context(meta_error::ExternalSnafu)
     }
 }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -21,6 +21,7 @@ use common_grpc::channel_manager::ChannelConfig;
 use common_meta::ddl_manager::{DdlManager, DdlManagerRef};
 use common_meta::key::{TableMetadataManager, TableMetadataManagerRef};
 use common_meta::sequence::{Sequence, SequenceRef};
+use common_meta::state_store::KvStateStore;
 use common_procedure::local::{LocalManager, ManagerConfig};
 use common_procedure::ProcedureManagerRef;
 
@@ -47,11 +48,11 @@ use crate::metasrv::{
     ElectionRef, MetaSrv, MetaSrvOptions, MetasrvInfo, SelectorContext, SelectorRef, TABLE_ID_SEQ,
 };
 use crate::procedure::region_failover::RegionFailoverManager;
-use crate::procedure::state_store::MetaStateStore;
 use crate::pubsub::{PublishRef, SubscribeManagerRef};
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::{CheckLeader, LeaderCachedKvStore};
+use crate::service::store::etcd::MAX_TXN_SIZE;
 use crate::service::store::kv::{KvBackendAdapter, KvStoreRef, ResettableKvStoreRef};
 use crate::service::store::memory::MemStore;
 use crate::table_creator::MetaSrvTableCreator;
@@ -329,7 +330,10 @@ fn build_procedure_manager(options: &MetaSrvOptions, kv_store: &KvStoreRef) -> P
         retry_delay: options.procedure.retry_delay,
         ..Default::default()
     };
-    let state_store = Arc::new(MetaStateStore::new(kv_store.clone()));
+    let state_store = Arc::new(KvStateStore::new(
+        KvBackendAdapter::wrap(kv_store.clone()),
+        MAX_TXN_SIZE,
+    ));
     Arc::new(LocalManager::new(manager_config, state_store))
 }
 

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -52,7 +52,6 @@ use crate::pubsub::{PublishRef, SubscribeManagerRef};
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::{CheckLeader, LeaderCachedKvStore};
-use crate::service::store::etcd::MAX_TXN_SIZE;
 use crate::service::store::kv::{KvBackendAdapter, KvStoreRef, ResettableKvStoreRef};
 use crate::service::store::memory::MemStore;
 use crate::table_creator::MetaSrvTableCreator;
@@ -330,10 +329,7 @@ fn build_procedure_manager(options: &MetaSrvOptions, kv_store: &KvStoreRef) -> P
         retry_delay: options.procedure.retry_delay,
         ..Default::default()
     };
-    let state_store = Arc::new(KvStateStore::new(
-        KvBackendAdapter::wrap(kv_store.clone()),
-        MAX_TXN_SIZE,
-    ));
+    let state_store = Arc::new(KvStateStore::new(KvBackendAdapter::wrap(kv_store.clone())));
     Arc::new(LocalManager::new(manager_config, state_store))
 }
 

--- a/src/meta-srv/src/procedure.rs
+++ b/src/meta-srv/src/procedure.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 pub mod region_failover;
-pub(crate) mod state_store;
 #[cfg(test)]
 mod tests;
 mod utils;

--- a/src/meta-srv/src/service/store/etcd.rs
+++ b/src/meta-srv/src/service/store/etcd.rs
@@ -41,7 +41,7 @@ use crate::service::store::kv::KvStoreRef;
 // The etcd default configuration's `--max-txn-ops` is 128.
 //
 // For more detail, see: https://etcd.io/docs/v3.5/op-guide/configuration/
-pub const MAX_TXN_SIZE: usize = 128;
+const MAX_TXN_SIZE: usize = 128;
 
 pub struct EtcdStore {
     client: Client,

--- a/src/meta-srv/src/service/store/etcd.rs
+++ b/src/meta-srv/src/service/store/etcd.rs
@@ -41,7 +41,7 @@ use crate::service::store::kv::KvStoreRef;
 // The etcd default configuration's `--max-txn-ops` is 128.
 //
 // For more detail, see: https://etcd.io/docs/v3.5/op-guide/configuration/
-const MAX_TXN_SIZE: usize = 128;
+pub const MAX_TXN_SIZE: usize = 128;
 
 pub struct EtcdStore {
     client: Client,

--- a/src/meta-srv/src/service/store/kv.rs
+++ b/src/meta-srv/src/service/store/kv.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_error::ext::BoxedError;
-use common_meta::error::MetaSrvSnafu;
+use common_meta::error::ExternalSnafu;
 use common_meta::kv_backend::txn::{Txn, TxnResponse};
 use common_meta::kv_backend::{KvBackend, KvBackendRef, TxnService};
 use common_meta::rpc::store::{
@@ -55,7 +55,7 @@ impl TxnService for KvBackendAdapter {
             .txn(txn)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 }
 
@@ -74,7 +74,7 @@ impl KvBackend for KvBackendAdapter {
             .range(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn put(&self, req: PutRequest) -> Result<PutResponse, Self::Error> {
@@ -82,7 +82,7 @@ impl KvBackend for KvBackendAdapter {
             .put(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn batch_put(&self, req: BatchPutRequest) -> Result<BatchPutResponse, Self::Error> {
@@ -90,7 +90,7 @@ impl KvBackend for KvBackendAdapter {
             .batch_put(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn batch_get(&self, req: BatchGetRequest) -> Result<BatchGetResponse, Self::Error> {
@@ -98,7 +98,7 @@ impl KvBackend for KvBackendAdapter {
             .batch_get(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn compare_and_put(
@@ -109,7 +109,7 @@ impl KvBackend for KvBackendAdapter {
             .compare_and_put(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn delete_range(
@@ -120,7 +120,7 @@ impl KvBackend for KvBackendAdapter {
             .delete_range(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn batch_delete(
@@ -131,7 +131,7 @@ impl KvBackend for KvBackendAdapter {
             .batch_delete(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 
     async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse, Self::Error> {
@@ -139,6 +139,6 @@ impl KvBackend for KvBackendAdapter {
             .move_value(req)
             .await
             .map_err(BoxedError::new)
-            .context(MetaSrvSnafu)
+            .context(ExternalSnafu)
     }
 }

--- a/src/meta-srv/src/table_creator.rs
+++ b/src/meta-srv/src/table_creator.rs
@@ -65,7 +65,7 @@ impl TableCreator for MetaSrvTableCreator {
         )
         .await
         .map_err(BoxedError::new)
-        .context(meta_error::MetaSrvSnafu)
+        .context(meta_error::ExternalSnafu)
     }
 }
 

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -27,7 +27,6 @@ use crate::lock::memory::MemLock;
 use crate::metasrv::SelectorContext;
 use crate::procedure::region_failover::RegionFailoverManager;
 use crate::selector::lease_based::LeaseBasedSelector;
-use crate::service::store::etcd::MAX_TXN_SIZE;
 use crate::service::store::kv::KvBackendAdapter;
 use crate::service::store::memory::MemStore;
 
@@ -58,10 +57,7 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
     );
     let mailbox = HeartbeatMailbox::create(pushers, mailbox_sequence);
 
-    let state_store = Arc::new(KvStateStore::new(
-        KvBackendAdapter::wrap(kv_store.clone()),
-        MAX_TXN_SIZE,
-    ));
+    let state_store = Arc::new(KvStateStore::new(KvBackendAdapter::wrap(kv_store.clone())));
     let procedure_manager = Arc::new(LocalManager::new(ManagerConfig::default(), state_store));
 
     let in_memory = Arc::new(MemStore::new());

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -18,6 +18,7 @@ use common_meta::key::TableMetadataManager;
 use common_meta::peer::Peer;
 use common_meta::rpc::router::{Region, RegionRoute};
 use common_meta::sequence::Sequence;
+use common_meta::state_store::KvStateStore;
 use common_procedure::local::{LocalManager, ManagerConfig};
 
 use crate::cluster::MetaPeerClientBuilder;
@@ -25,8 +26,8 @@ use crate::handler::{HeartbeatMailbox, Pushers};
 use crate::lock::memory::MemLock;
 use crate::metasrv::SelectorContext;
 use crate::procedure::region_failover::RegionFailoverManager;
-use crate::procedure::state_store::MetaStateStore;
 use crate::selector::lease_based::LeaseBasedSelector;
+use crate::service::store::etcd::MAX_TXN_SIZE;
 use crate::service::store::kv::KvBackendAdapter;
 use crate::service::store::memory::MemStore;
 
@@ -57,7 +58,10 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
     );
     let mailbox = HeartbeatMailbox::create(pushers, mailbox_sequence);
 
-    let state_store = Arc::new(MetaStateStore::new(kv_store.clone()));
+    let state_store = Arc::new(KvStateStore::new(
+        KvBackendAdapter::wrap(kv_store.clone()),
+        MAX_TXN_SIZE,
+    ));
     let procedure_manager = Arc::new(LocalManager::new(ManagerConfig::default(), state_store));
 
     let in_memory = Arc::new(MemStore::new());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. refactor RaftEngineBackend Error to common_meta::error::Error
2. refactor state store

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
