### PR TITLE
refactor: clean unnecessary disabled lints

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -92,8 +92,6 @@ impl MitoEngine {
 struct EngineInner {
     /// Region workers group.
     workers: WorkerGroup,
-    /// Shared object store of all regions.
-    object_store: ObjectStore,
 }
 
 impl EngineInner {
@@ -105,7 +103,6 @@ impl EngineInner {
     ) -> EngineInner {
         EngineInner {
             workers: WorkerGroup::start(config, log_store, object_store.clone()),
-            object_store,
         }
     }
 

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -23,7 +23,6 @@ pub mod test_util;
 #[allow(dead_code)]
 mod access_layer;
 pub mod config;
-#[allow(dead_code)]
 pub mod engine;
 pub mod error;
 #[allow(dead_code)]

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -37,7 +37,6 @@ mod region_write_ctx;
 #[allow(dead_code)]
 pub mod request;
 mod row_converter;
-#[allow(dead_code)]
 pub(crate) mod schedule;
 #[allow(dead_code)]
 pub mod sst;

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -20,7 +20,6 @@
 pub mod test_util;
 
 // TODO(yingwen): Remove all `allow(dead_code)` after finish refactoring mito.
-#[allow(dead_code)]
 mod access_layer;
 pub mod config;
 pub mod engine;

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -33,7 +33,6 @@ pub mod memtable;
 mod metrics;
 #[allow(dead_code)]
 pub mod read;
-#[allow(dead_code)]
 mod region;
 mod region_write_ctx;
 #[allow(dead_code)]

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -41,7 +41,6 @@ pub(crate) mod schedule;
 #[allow(dead_code)]
 pub mod sst;
 pub mod wal;
-#[allow(dead_code)]
 mod worker;
 
 #[cfg_attr(doc, aquamarine::aquamarine)]

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -36,7 +36,6 @@ mod region;
 mod region_write_ctx;
 #[allow(dead_code)]
 pub mod request;
-#[allow(dead_code)]
 mod row_converter;
 #[allow(dead_code)]
 pub(crate) mod schedule;

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -28,8 +28,6 @@ pub mod engine;
 pub mod error;
 #[allow(dead_code)]
 mod flush;
-#[allow(dead_code)]
-#[allow(unused_variables)]
 pub mod manifest;
 #[allow(dead_code)]
 pub mod memtable;

--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -15,7 +15,6 @@
 //! manifest storage
 
 pub mod action;
-#[allow(unused_variables)]
 pub mod manager;
 pub mod storage;
 #[cfg(test)]

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -273,7 +273,7 @@ impl RegionManifestManagerInner {
                     RegionMetaAction::Edit(action) => {
                         manifest_builder.apply_edit(manifest_version, action);
                     }
-                    RegionMetaAction::Remove(_) | RegionMetaAction::Protocol(_) => {
+                    RegionMetaAction::Remove(_) => {
                         debug!(
                             "Unhandled action in {}, action: {:?}",
                             options.manifest_dir, action
@@ -323,7 +323,7 @@ impl RegionManifestManagerInner {
                 RegionMetaAction::Edit(action) => {
                     manifest_builder.apply_edit(version, action);
                 }
-                RegionMetaAction::Remove(_) | RegionMetaAction::Protocol(_) => {
+                RegionMetaAction::Remove(_) => {
                     debug!(
                         "Unhandled action for region {}, action: {:?}",
                         self.manifest.metadata.region_id, action
@@ -394,7 +394,7 @@ impl RegionManifestManagerInner {
                     RegionMetaAction::Edit(action) => {
                         manifest_builder.apply_edit(version, action);
                     }
-                    RegionMetaAction::Remove(_) | RegionMetaAction::Protocol(_) => {
+                    RegionMetaAction::Remove(_) => {
                         debug!(
                             "Unhandled action for region {}, action: {:?}",
                             self.manifest.metadata.region_id, action

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -436,7 +436,7 @@ impl RegionManifestManagerInner {
     ) -> Result<Option<RegionCheckpoint>> {
         let last_checkpoint = store.load_last_checkpoint().await?;
 
-        if let Some((version, bytes)) = last_checkpoint {
+        if let Some((_, bytes)) = last_checkpoint {
             let checkpoint = RegionCheckpoint::decode(&bytes)?;
             Ok(Some(checkpoint))
         } else {

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -66,7 +66,7 @@ async fn manager_without_checkpoint() {
     let (_env, manager) = build_manager(0, CompressionType::Uncompressed).await;
 
     // apply 10 actions
-    for i in 0..10 {
+    for _ in 0..10 {
         manager.update(nop_action()).await.unwrap();
     }
 
@@ -110,7 +110,7 @@ async fn manager_with_checkpoint_distance_1() {
     let (env, manager) = build_manager(1, CompressionType::Uncompressed).await;
 
     // apply 10 actions
-    for i in 0..10 {
+    for _ in 0..10 {
         manager.update(nop_action()).await.unwrap();
     }
 
@@ -194,7 +194,7 @@ async fn generate_checkpoint_with_compression_types(
     compress_type: CompressionType,
     actions: Vec<RegionMetaActionList>,
 ) -> RegionCheckpoint {
-    let (env, manager) = build_manager(1, CompressionType::Uncompressed).await;
+    let (_env, manager) = build_manager(1, compress_type).await;
 
     for action in actions {
         manager.update(action).await.unwrap();

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -32,9 +32,6 @@ use crate::manifest::manager::RegionManifestManager;
 use crate::region::version::{VersionControlRef, VersionRef};
 use crate::sst::file_purger::FilePurgerRef;
 
-/// Type to store region version.
-pub type VersionNumber = u32;
-
 /// Metadata and runtime status of a region.
 ///
 /// Writing and reading a region follow a single-writer-multi-reader rule:

--- a/src/mito2/src/schedule/scheduler.rs
+++ b/src/mito2/src/schedule/scheduler.rs
@@ -105,7 +105,7 @@ impl LocalScheduler {
     }
 
     #[inline]
-    fn running(&self) -> bool {
+    fn is_running(&self) -> bool {
         self.state.load(Ordering::Relaxed) == STATE_RUNNING
     }
 }
@@ -113,10 +113,7 @@ impl LocalScheduler {
 #[async_trait::async_trait]
 impl Scheduler for LocalScheduler {
     fn schedule(&self, job: Job) -> Result<()> {
-        ensure!(
-            self.state.load(Ordering::Relaxed) == STATE_RUNNING,
-            InvalidSchedulerStateSnafu
-        );
+        ensure!(self.is_running(), InvalidSchedulerStateSnafu);
 
         self.sender
             .read()
@@ -129,10 +126,7 @@ impl Scheduler for LocalScheduler {
 
     /// if await_termination is true, scheduler will wait all tasks finished before stopping
     async fn stop(&self, await_termination: bool) -> Result<()> {
-        ensure!(
-            self.state.load(Ordering::Relaxed) == STATE_RUNNING,
-            InvalidSchedulerStateSnafu
-        );
+        ensure!(self.is_running(), InvalidSchedulerStateSnafu);
         let state = if await_termination {
             STATE_AWAIT_TERMINATION
         } else {

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -59,6 +59,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         region
             .version_control
             .apply_edit(edit, region.file_purger.clone());
+        region.update_flush_millis();
 
         // Delete wal.
         info!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Remove `#[allow(xxx)]` in mito2 as much as possible

Fix: update region flushed time on flush is finished.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
