### PR TITLE
refactor: script table creation

### DIFF
--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -238,9 +238,6 @@ pub enum Error {
     #[snafu(display("Illegal access to catalog: {} and schema: {}", catalog, schema))]
     QueryAccessDenied { catalog: String, schema: String },
 
-    #[snafu(display("Invalid system table definition: {err_msg}"))]
-    InvalidSystemTableDef { err_msg: String, location: Location },
-
     #[snafu(display("{}: {}", msg, source))]
     Datafusion {
         msg: String,
@@ -275,7 +272,6 @@ impl ErrorExt for Error {
             | Error::IllegalManagerState { .. }
             | Error::CatalogNotFound { .. }
             | Error::InvalidEntryType { .. }
-            | Error::InvalidSystemTableDef { .. }
             | Error::ParallelOpenTable { .. } => StatusCode::Unexpected,
 
             Error::SystemCatalog { .. }

--- a/src/catalog/src/local/manager.rs
+++ b/src/catalog/src/local/manager.rs
@@ -517,20 +517,6 @@ impl CatalogManager for LocalCatalogManager {
         .fail()
     }
 
-    async fn register_system_table(&self, request: RegisterSystemTableRequest) -> Result<()> {
-        let catalog_name = request.create_table_request.catalog_name.clone();
-        let schema_name = request.create_table_request.schema_name.clone();
-
-        let mut sys_table_requests = self.system_table_requests.lock().await;
-        sys_table_requests.push(request);
-        increment_gauge!(
-            crate::metrics::METRIC_CATALOG_MANAGER_TABLE_COUNT,
-            1.0,
-            &[crate::metrics::db_label(&catalog_name, &schema_name)],
-        );
-        Ok(())
-    }
-
     async fn schema_exist(&self, catalog: &str, schema: &str) -> Result<bool> {
         self.catalogs.schema_exist(catalog, schema).await
     }

--- a/src/catalog/src/local/memory.rs
+++ b/src/catalog/src/local/memory.rs
@@ -33,7 +33,7 @@ use crate::error::{
 use crate::information_schema::InformationSchemaProvider;
 use crate::{
     CatalogManager, DeregisterSchemaRequest, DeregisterTableRequest, RegisterSchemaRequest,
-    RegisterSystemTableRequest, RegisterTableRequest, RenameTableRequest,
+    RegisterTableRequest, RenameTableRequest,
 };
 
 type SchemaEntries = HashMap<String, HashMap<String, TableRef>>;
@@ -130,11 +130,6 @@ impl CatalogManager for MemoryCatalogManager {
             &[crate::metrics::db_label(&request.catalog, &request.schema)],
         );
         Ok(true)
-    }
-
-    async fn register_system_table(&self, _request: RegisterSystemTableRequest) -> Result<()> {
-        // TODO(ruihang): support register system table request
-        Ok(())
     }
 
     async fn schema_exist(&self, catalog: &str, schema: &str) -> Result<bool> {

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -155,7 +155,10 @@ pub enum Error {
     #[snafu(display("Invalid DeleteRequest, reason: {}", reason))]
     InvalidDeleteRequest { reason: String, location: Location },
 
-    #[snafu(display("Table not found: {}", table_name))]
+    #[snafu(display("Invalid system table definition: {err_msg}, at {location}"))]
+    InvalidSystemTableDef { err_msg: String, location: Location },
+
+    #[snafu(display("Table not found: '{}', at {location}", table_name))]
     TableNotFound {
         table_name: String,
         location: Location,
@@ -739,6 +742,7 @@ impl ErrorExt for Error {
 
             Error::IncompleteGrpcResult { .. }
             | Error::ContextValueNotFound { .. }
+            | Error::InvalidSystemTableDef { .. }
             | Error::EncodeJson { .. } => StatusCode::Unexpected,
 
             Error::TableNotFound { .. } => StatusCode::TableNotFound,

--- a/src/frontend/src/script.rs
+++ b/src/frontend/src/script.rs
@@ -183,7 +183,7 @@ mod python {
                 catalog_name: request.catalog_name,
                 schema_name: request.schema_name,
                 table_name: request.table_name,
-                desc: request.desc.unwrap_or("".to_string()),
+                desc: request.desc.unwrap_or_default(),
                 column_defs,
                 time_index,
                 primary_keys,

--- a/src/frontend/src/script.rs
+++ b/src/frontend/src/script.rs
@@ -34,6 +34,10 @@ mod dummy {
             Ok(Self {})
         }
 
+        pub async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+
         pub async fn insert_script(
             &self,
             _schema: &str,
@@ -56,12 +60,23 @@ mod dummy {
 
 #[cfg(feature = "python")]
 mod python {
+    use api::v1::ddl_request::Expr;
+    use api::v1::greptime_request::Request;
+    use api::v1::{CreateTableExpr, DdlRequest};
+    use catalog::RegisterSystemTableRequest;
     use common_error::ext::BoxedError;
+    use common_meta::table_name::TableName;
     use common_telemetry::logging::error;
     use script::manager::ScriptManager;
-    use snafu::ResultExt;
+    use servers::query_handler::grpc::GrpcQueryHandler;
+    use session::context::QueryContext;
+    use snafu::{OptionExt, ResultExt};
+    use table::requests::CreateTableRequest;
 
     use super::*;
+    use crate::error::{CatalogSnafu, InvalidSystemTableDefSnafu, TableNotFoundSnafu};
+    use crate::expr_factory;
+    use crate::instance::Instance;
 
     pub struct ScriptExecutor {
         script_manager: ScriptManager,
@@ -76,6 +91,107 @@ mod python {
                 script_manager: ScriptManager::new(catalog_manager, query_engine)
                     .await
                     .context(crate::error::StartScriptManagerSnafu)?,
+            })
+        }
+
+        pub async fn start(&self, instance: &Instance) -> Result<()> {
+            let RegisterSystemTableRequest {
+                create_table_request: request,
+                open_hook,
+            } = self.script_manager.create_table_request();
+
+            if let Some(table) = instance
+                .catalog_manager()
+                .table(
+                    &request.catalog_name,
+                    &request.schema_name,
+                    &request.table_name,
+                )
+                .await
+                .context(CatalogSnafu)?
+            {
+                if let Some(open_hook) = open_hook {
+                    (open_hook)(table).await.context(CatalogSnafu)?;
+                }
+
+                return Ok(());
+            }
+
+            let table_name = TableName::new(
+                &request.catalog_name,
+                &request.schema_name,
+                &request.table_name,
+            );
+
+            let expr = Self::create_table_expr(request)?;
+
+            let _ = instance
+                .do_query(
+                    Request::Ddl(DdlRequest {
+                        expr: Some(Expr::CreateTable(expr)),
+                    }),
+                    QueryContext::arc(),
+                )
+                .await?;
+
+            let table = instance
+                .catalog_manager()
+                .table(
+                    &table_name.catalog_name,
+                    &table_name.schema_name,
+                    &table_name.table_name,
+                )
+                .await
+                .context(CatalogSnafu)?
+                .with_context(|| TableNotFoundSnafu {
+                    table_name: table_name.to_string(),
+                })?;
+
+            if let Some(open_hook) = open_hook {
+                (open_hook)(table).await.context(CatalogSnafu)?;
+            }
+
+            Ok(())
+        }
+
+        fn create_table_expr(request: CreateTableRequest) -> Result<CreateTableExpr> {
+            let column_schemas = request.schema.column_schemas;
+
+            let time_index = column_schemas
+                .iter()
+                .find_map(|x| {
+                    if x.is_time_index() {
+                        Some(x.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .context(InvalidSystemTableDefSnafu {
+                    err_msg: "Time index is not defined.",
+                })?;
+
+            let primary_keys = request
+                .primary_key_indices
+                .iter()
+                // Indexing has to be safe because the create script table request is pre-defined.
+                .map(|i| column_schemas[*i].name.clone())
+                .collect::<Vec<_>>();
+
+            let column_defs = expr_factory::column_schemas_to_defs(column_schemas, &primary_keys)?;
+
+            Ok(CreateTableExpr {
+                catalog_name: request.catalog_name,
+                schema_name: request.schema_name,
+                table_name: request.table_name,
+                desc: request.desc.unwrap_or("".to_string()),
+                column_defs,
+                time_index,
+                primary_keys,
+                create_if_not_exists: request.create_if_not_exists,
+                table_options: (&request.table_options).into(),
+                table_id: None, // Should and will be assigned by Meta.
+                region_numbers: vec![0],
+                engine: request.engine,
             })
         }
 

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -16,20 +16,27 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use catalog::CatalogManagerRef;
+use catalog::{CatalogManagerRef, OpenSystemTableHook, RegisterSystemTableRequest};
+use common_catalog::consts::{
+    default_engine, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, SCRIPTS_TABLE_ID,
+};
 use common_query::Output;
 use common_telemetry::logging;
+use futures::future::FutureExt;
 use query::QueryEngineRef;
 use snafu::{OptionExt, ResultExt};
+use table::requests::{CreateTableRequest, TableOptions};
+use table::TableRef;
 
 use crate::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use crate::error::{CompilePythonSnafu, ExecutePythonSnafu, Result, ScriptNotFoundSnafu};
 use crate::python::{PyEngine, PyScript};
-use crate::table::ScriptsTable;
+use crate::table::{build_scripts_schema, ScriptsTable, SCRIPTS_TABLE_NAME};
 
 pub struct ScriptManager {
     compiled: RwLock<HashMap<String, Arc<PyScript>>>,
     py_engine: PyEngine,
+    query_engine: QueryEngineRef,
     table: ScriptsTable,
 }
 
@@ -41,8 +48,39 @@ impl ScriptManager {
         Ok(Self {
             compiled: RwLock::new(HashMap::default()),
             py_engine: PyEngine::new(query_engine.clone()),
-            table: ScriptsTable::new_empty(catalog_manager, query_engine)?,
+            query_engine: query_engine.clone(),
+            table: ScriptsTable::new(catalog_manager, query_engine).await?,
         })
+    }
+
+    pub fn create_table_request(&self) -> RegisterSystemTableRequest {
+        let request = CreateTableRequest {
+            id: SCRIPTS_TABLE_ID,
+            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+            table_name: SCRIPTS_TABLE_NAME.to_string(),
+            desc: Some("GreptimeDB scripts table for Python".to_string()),
+            schema: build_scripts_schema(),
+            region_numbers: vec![0],
+            // 'schema' and 'name' are primary keys
+            primary_key_indices: vec![0, 1],
+            create_if_not_exists: true,
+            table_options: TableOptions::default(),
+            engine: default_engine().to_string(),
+        };
+
+        let query_engine = self.query_engine.clone();
+
+        let hook: OpenSystemTableHook = Box::new(move |table: TableRef| {
+            let query_engine = query_engine.clone();
+            async move { ScriptsTable::recompile_register_udf(table, query_engine.clone()).await }
+                .boxed()
+        });
+
+        RegisterSystemTableRequest {
+            create_table_request: request,
+            open_hook: Some(hook),
+        }
     }
 
     /// compile script, and register them to the query engine and UDF registry

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -17,10 +17,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use catalog::error::CompileScriptInternalSnafu;
-use catalog::{CatalogManagerRef, OpenSystemTableHook, RegisterSystemTableRequest};
-use common_catalog::consts::{
-    DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, MITO_ENGINE, SCRIPTS_TABLE_ID,
-};
+use catalog::CatalogManagerRef;
+use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
 use common_query::Output;
@@ -38,16 +36,15 @@ use query::plan::LogicalPlan;
 use query::QueryEngineRef;
 use session::context::QueryContextBuilder;
 use snafu::{ensure, OptionExt, ResultExt};
-use table::requests::{CreateTableRequest, InsertRequest, TableOptions};
+use table::requests::InsertRequest;
 use table::table::adapter::DfTableProviderAdapter;
 use table::TableRef;
 
 use crate::error::{
     BuildDfLogicalPlanSnafu, CastTypeSnafu, CollectRecordsSnafu, ExecuteInternalStatementSnafu,
     FindColumnInScriptsTableSnafu, FindScriptSnafu, FindScriptsTableSnafu, InsertScriptSnafu,
-    RegisterScriptsTableSnafu, Result, ScriptNotFoundSnafu, ScriptsTableNotFoundSnafu,
+    Result, ScriptNotFoundSnafu, ScriptsTableNotFoundSnafu,
 };
-use crate::python::utils::block_on_async;
 use crate::python::PyScript;
 
 pub const SCRIPTS_TABLE_NAME: &str = "scripts";
@@ -151,40 +148,6 @@ impl ScriptsTable {
         catalog_manager: CatalogManagerRef,
         query_engine: QueryEngineRef,
     ) -> Result<Self> {
-        let schema = build_scripts_schema();
-        // TODO(dennis): we put scripts table into default catalog and schema.
-        // maybe put into system catalog?
-        let request = CreateTableRequest {
-            id: SCRIPTS_TABLE_ID,
-            catalog_name: DEFAULT_CATALOG_NAME.to_string(),
-            schema_name: DEFAULT_SCHEMA_NAME.to_string(),
-            table_name: SCRIPTS_TABLE_NAME.to_string(),
-            desc: Some("Scripts table".to_string()),
-            schema,
-            region_numbers: vec![0],
-            //schema and name as primary key
-            primary_key_indices: vec![0, 1],
-            create_if_not_exists: true,
-            table_options: TableOptions::default(),
-            engine: MITO_ENGINE.to_string(),
-        };
-        let callback_query_engine = query_engine.clone();
-        let script_recompile_callback: OpenSystemTableHook = Arc::new(move |table: TableRef| {
-            let callback_query_engine = callback_query_engine.clone();
-            block_on_async(async move {
-                Self::recompile_register_udf(table, callback_query_engine.clone()).await
-            })
-            .unwrap()
-        });
-
-        catalog_manager
-            .register_system_table(RegisterSystemTableRequest {
-                create_table_request: request,
-                open_hook: Some(script_recompile_callback),
-            })
-            .await
-            .context(RegisterScriptsTableSnafu)?;
-
         Ok(Self {
             catalog_manager,
             query_engine,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR: 
1. remove method `register_system_table` from CatalogManager
2. the creation of ScriptTable (as a system table) is removed from CatalogManager. Instead, the ScriptTable is created when Frontend instance is starting; and is created by calling Frontend instance's grpc handler.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
