### PR TITLE
feat(mito): Implement skeleton for alteration

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -15,6 +15,8 @@
 //! Mito region engine.
 
 #[cfg(test)]
+mod alter_test;
+#[cfg(test)]
 mod close_test;
 #[cfg(test)]
 mod create_test;

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::{Rows, SemanticType};
+use common_recordbatch::RecordBatches;
+use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::ColumnSchema;
+use store_api::metadata::ColumnMetadata;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::{
+    AddColumn, AddColumnLocation, AlterKind, RegionAlterRequest, RegionRequest,
+};
+use store_api::storage::{RegionId, ScanRequest};
+
+use crate::config::MitoConfig;
+use crate::test_util::{build_rows, put_rows, rows_schema, CreateRequestBuilder, TestEnv};
+
+#[tokio::test]
+async fn test_alter_add_column() {
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas,
+        rows: build_rows(0, 3),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    let request = RegionAlterRequest {
+        schema_version: 0,
+        kind: AlterKind::AddColumns {
+            columns: vec![AddColumn {
+                column_metadata: ColumnMetadata {
+                    column_schema: ColumnSchema::new(
+                        "tag_1",
+                        ConcreteDataType::string_datatype(),
+                        true,
+                    ),
+                    semantic_type: SemanticType::Tag,
+                    column_id: 3,
+                },
+                location: Some(AddColumnLocation::First),
+            }],
+        },
+    };
+    engine
+        .handle_request(region_id, RegionRequest::Alter(request))
+        .await
+        .unwrap();
+
+    let request = ScanRequest::default();
+    let scanner = engine.scan(region_id, request).unwrap();
+    assert_eq!(0, scanner.num_memtables());
+    assert_eq!(1, scanner.num_files());
+    let stream = scanner.scan().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let expected = "\
++-------+-------+---------+---------------------+
+| tag_1 | tag_0 | field_0 | ts                  |
++-------+-------+---------+---------------------+
+|       | 0     | 0.0     | 1970-01-01T00:00:00 |
+|       | 1     | 1.0     | 1970-01-01T00:00:01 |
+|       | 2     | 2.0     | 1970-01-01T00:00:02 |
++-------+-------+---------+---------------------+";
+    assert_eq!(expected, batches.pretty_print().unwrap());
+}

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -53,6 +53,7 @@ async fn test_manual_flush() {
 
     let request = ScanRequest::default();
     let scanner = engine.scan(region_id, request).unwrap();
+    assert_eq!(0, scanner.num_memtables());
     assert_eq!(1, scanner.num_files());
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
@@ -98,7 +99,7 @@ async fn test_flush_engine() {
 
     write_buffer_manager.set_should_flush(true);
 
-    // Writes and triggers flush.
+    // Writes to the mutable memtable and triggers flush.
     let rows = Rows {
         schema: column_schemas.clone(),
         rows: build_rows_for_key("b", 0, 2, 0),
@@ -110,6 +111,7 @@ async fn test_flush_engine() {
 
     let request = ScanRequest::default();
     let scanner = engine.scan(region_id, request).unwrap();
+    assert_eq!(1, scanner.num_memtables());
     assert_eq!(1, scanner.num_files());
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
@@ -174,6 +176,7 @@ async fn test_write_stall() {
 
     let request = ScanRequest::default();
     let scanner = engine.scan(region_id, request).unwrap();
+    assert_eq!(1, scanner.num_memtables());
     assert_eq!(1, scanner.num_files());
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
@@ -209,6 +212,7 @@ async fn test_flush_empty() {
 
     let request = ScanRequest::default();
     let scanner = engine.scan(region_id, request).unwrap();
+    assert_eq!(0, scanner.num_memtables());
     assert_eq!(0, scanner.num_files());
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -446,6 +446,12 @@ pub enum Error {
         reason: String,
         location: Location,
     },
+
+    #[snafu(display("{}, location: {}", source, location))]
+    InvalidRegionRequest {
+        source: store_api::metadata::MetadataError,
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -513,6 +519,7 @@ impl ErrorExt for Error {
             RegionClosed { .. } => StatusCode::Cancelled,
             RejectWrite { .. } => StatusCode::StorageUnavailable,
             CompatReader { .. } => StatusCode::Unexpected,
+            InvalidRegionRequest { source, .. } => source.status_code(),
         }
     }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -479,8 +479,11 @@ impl FlushScheduler {
     }
 
     /// Returns true if the region has pending DDLs.
-    pub(crate) fn has_pending_ddls(&self, _region_id: RegionId) -> bool {
-        unimplemented!()
+    pub(crate) fn has_pending_ddls(&self, region_id: RegionId) -> bool {
+        self.region_status
+            .get(&region_id)
+            .map(|status| !status.pending_ddls.is_empty())
+            .unwrap_or(false)
     }
 
     /// Schedules a new flush task when the scheduler can submit next task.

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -474,12 +474,12 @@ impl FlushScheduler {
     ///
     /// # Panics
     /// Panics if region didn't request flush.
-    pub(crate) fn add_write_request_to_pending(&mut self, request: SenderWriteRequest) {
+    pub(crate) fn add_write_request_to_pending(&mut self, _request: SenderWriteRequest) {
         unimplemented!()
     }
 
     /// Returns true if the region has pending DDLs.
-    pub(crate) fn has_pending_ddls(&self, region_id: RegionId) -> bool {
+    pub(crate) fn has_pending_ddls(&self, _region_id: RegionId) -> bool {
         unimplemented!()
     }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -165,7 +165,8 @@ pub enum FlushReason {
     EngineFull,
     /// Manual flush.
     Manual,
-    // TODO(yingwen): Alter.
+    /// Flush to alter table.
+    Alter,
 }
 
 /// Task to flush a region.

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -360,13 +360,13 @@ impl FlushScheduler {
         // Checks whether we can flush the region now.
         if flush_status.flushing {
             // There is already a flush job running.
-            flush_status.push_task(task);
+            flush_status.merge_task(task);
             return Ok(());
         }
 
         // If there are pending tasks, then we should push it to pending list.
         if flush_status.pending_task.is_some() {
-            flush_status.push_task(task);
+            flush_status.merge_task(task);
             return Ok(());
         }
 
@@ -540,7 +540,8 @@ impl FlushStatus {
         }
     }
 
-    fn push_task(&mut self, task: RegionFlushTask) {
+    /// Merges the task to pending task.
+    fn merge_task(&mut self, task: RegionFlushTask) {
         if let Some(pending) = &mut self.pending_task {
             pending.merge(task);
         } else {

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -404,7 +404,7 @@ impl FlushScheduler {
         // This region doesn't have running flush job.
         flush_status.flushing = false;
 
-        let pending_ddls = if flush_status.pending_task.is_none() {
+        let pending_requests = if flush_status.pending_task.is_none() {
             // The region doesn't have any pending flush task.
             // Safety: The flush status exists.
             let flush_status = self.region_status.remove(&region_id).unwrap();
@@ -418,7 +418,7 @@ impl FlushScheduler {
             error!(e; "Flush of region {} is successful, but failed to schedule next flush", region_id);
         }
 
-        pending_ddls
+        pending_requests
     }
 
     /// Notifies the scheduler that the flush job is finished.
@@ -525,7 +525,7 @@ struct FlushStatus {
     pending_task: Option<RegionFlushTask>,
     /// Pending ddl requests.
     pending_ddls: Vec<SenderDdlRequest>,
-    /// Pending write requests.
+    /// Requests waiting to write after altering the region.
     pending_writes: Vec<SenderWriteRequest>,
 }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -474,8 +474,12 @@ impl FlushScheduler {
     ///
     /// # Panics
     /// Panics if region didn't request flush.
-    pub(crate) fn add_write_request_to_pending(&mut self, _request: SenderWriteRequest) {
-        unimplemented!()
+    pub(crate) fn add_write_request_to_pending(&mut self, request: SenderWriteRequest) {
+        let status = self
+            .region_status
+            .get_mut(&request.request.region_id)
+            .unwrap();
+        status.pending_writes.push(request);
     }
 
     /// Returns true if the region has pending DDLs.

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -232,7 +232,9 @@ mod tests {
                 {"column_schema":{"name":"a","data_type":{"Int64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Tag","column_id":1},{"column_schema":{"name":"b","data_type":{"Float64":{}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Field","column_id":2},{"column_schema":{"name":"c","data_type":{"Timestamp":{"Millisecond":null}},"is_nullable":false,"is_time_index":false,"default_constraint":null,"metadata":{}},"semantic_type":"Timestamp","column_id":3}
                 ],
                 "primary_key":[1],
-                "region_id":5299989648942}
+                "region_id":5299989648942,
+                "schema_version":0
+            }
             }"#;
         let _ = serde_json::from_str::<RegionChange>(region_change).unwrap();
 

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -149,7 +149,7 @@ async fn manager_with_checkpoint_distance_1() {
         .await
         .unwrap();
     let raw_json = std::str::from_utf8(&raw_bytes).unwrap();
-    let expected_json = "{\"size\":750,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
+    let expected_json = "{\"size\":769,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
     assert_eq!(expected_json, raw_json);
 
     // reopen the manager

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -99,4 +99,12 @@ impl MemtableVersion {
     pub(crate) fn mutable_usage(&self) -> usize {
         self.mutable.stats().estimated_bytes
     }
+
+    /// Returns true if the memtable version is empty.
+    ///
+    /// The version is empty when mutable memtable is empty and there is no
+    /// immutable memtables.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.mutable.is_empty() && self.immutables.is_empty()
+    }
 }

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -85,6 +85,8 @@ impl MemtableVersion {
         })
     }
 
+    // TODO(yingwen): Remove memtables on flush done.
+
     /// Returns the memory usage of the mutable memtable.
     pub(crate) fn mutable_usage(&self) -> usize {
         self.mutable.stats().estimated_bytes

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -18,10 +18,10 @@ use std::sync::Arc;
 
 use smallvec::SmallVec;
 
-use crate::memtable::MemtableRef;
+use crate::memtable::{MemtableId, MemtableRef};
 
 /// A version of current memtables in a region.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct MemtableVersion {
     /// Mutable memtable.
     pub(crate) mutable: MemtableRef,
@@ -85,7 +85,15 @@ impl MemtableVersion {
         })
     }
 
-    // TODO(yingwen): Remove memtables on flush done.
+    /// Removes memtables by ids from immutable memtables.
+    pub(crate) fn remove_memtables(&mut self, ids: &[MemtableId]) {
+        self.immutables = self
+            .immutables
+            .iter()
+            .filter(|mem| !ids.contains(&mem.id()))
+            .cloned()
+            .collect();
+    }
 
     /// Returns the memory usage of the mutable memtable.
     pub(crate) fn mutable_usage(&self) -> usize {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -52,6 +52,13 @@ impl Scanner {
             Scanner::Seq(seq_scan) => seq_scan.num_files(),
         }
     }
+
+    /// Returns number of memtables to scan.
+    pub(crate) fn num_memtables(&self) -> usize {
+        match self {
+            Scanner::Seq(seq_scan) => seq_scan.num_memtables(),
+        }
+    }
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -139,6 +146,11 @@ impl ScanRegion {
         }
 
         let memtables = self.version.memtables.list_memtables();
+        // Skip empty memtables.
+        let memtables: Vec<_> = memtables
+            .into_iter()
+            .filter(|mem| !mem.is_empty())
+            .collect();
 
         debug!(
             "Seq scan region {}, memtables: {}, ssts_to_read: {}, total_ssts: {}",

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -149,6 +149,11 @@ impl SeqScan {
 
 #[cfg(test)]
 impl SeqScan {
+    /// Returns number of memtables to scan.
+    pub(crate) fn num_memtables(&self) -> usize {
+        self.memtables.len()
+    }
+
     /// Returns number of SST files to scan.
     pub(crate) fn num_files(&self) -> usize {
         self.files.len()

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -113,7 +113,7 @@ impl VersionControl {
     ///
     /// It will replace existing mutable memtable with a memtable that uses the
     /// new schema.
-    pub(crate) fn alter_schema(&self, metadata: RegionMetadataRef, builder: &MemtableBuilderRef) {
+    pub(crate) fn alter_schema(&self, _metadata: RegionMetadataRef, _builder: &MemtableBuilderRef) {
         unimplemented!()
     }
 }

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -108,6 +108,14 @@ impl VersionControl {
         data.is_dropped = true;
         data.version.ssts.mark_all_deleted();
     }
+
+    /// Alter schema of the region.
+    ///
+    /// It will replace existing mutable memtable with a memtable that uses the
+    /// new schema.
+    pub(crate) fn alter_schema(&self, metadata: RegionMetadataRef, builder: &MemtableBuilderRef) {
+        unimplemented!()
+    }
 }
 
 pub(crate) type VersionControlRef = Arc<VersionControl>;

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -117,7 +117,7 @@ impl VersionControl {
 
     /// Alter schema of the region.
     ///
-    /// It will replace existing mutable memtable with a memtable that uses the
+    /// It replaces existing mutable memtable with a memtable that uses the
     /// new schema.
     pub(crate) fn alter_schema(&self, _metadata: RegionMetadataRef, _builder: &MemtableBuilderRef) {
         unimplemented!()

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -392,6 +392,8 @@ pub async fn check_reader_result<R: BatchReader>(reader: &mut R, expect: &[Batch
     }
 
     assert_eq!(expect, result);
+    // Next call to `next_batch()` still returns None.
+    assert!(reader.next_batch().await.unwrap().is_none());
 }
 
 /// A mock [WriteBufferManager] that supports controlling whether to flush/stall.

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -125,25 +125,6 @@ impl TestEnv {
         )
     }
 
-    /// Reopen the engine.
-    pub async fn reopen_engine_with(
-        &self,
-        engine: MitoEngine,
-        config: MitoConfig,
-        manager: WriteBufferManagerRef,
-        listener: Option<EventListenerRef>,
-    ) -> MitoEngine {
-        engine.stop().await.unwrap();
-
-        MitoEngine::new_for_test(
-            config,
-            self.logstore.clone().unwrap(),
-            self.object_store.clone().unwrap(),
-            manager,
-            listener,
-        )
-    }
-
     /// Creates a new [WorkerGroup] with specific config under this env.
     pub(crate) async fn create_worker_group(&self, config: MitoConfig) -> WorkerGroup {
         let (log_store, object_store) = self.create_log_and_object_store().await;

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -14,6 +14,7 @@
 
 //! Structs and utilities for writing regions.
 
+mod handle_alter;
 mod handle_close;
 mod handle_create;
 mod handle_drop;
@@ -484,7 +485,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 DdlRequest::Drop(_) => self.handle_drop_request(ddl.region_id).await,
                 DdlRequest::Open(req) => self.handle_open_request(ddl.region_id, req).await,
                 DdlRequest::Close(_) => self.handle_close_request(ddl.region_id).await,
-                DdlRequest::Alter(_) => todo!(),
+                DdlRequest::Alter(req) => {
+                    self.handle_alter_request(ddl.region_id, req, ddl.sender)
+                        .await;
+                    continue;
+                }
                 DdlRequest::Flush(_) => {
                     self.handle_flush_request(ddl.region_id, ddl.sender).await;
                     continue;

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Handling alter related requests.
+
+use common_query::Output;
+use common_telemetry::info;
+use store_api::metadata::RegionMetadata;
+use store_api::region_request::RegionAlterRequest;
+use store_api::storage::RegionId;
+use tokio::sync::oneshot;
+
+use crate::error::{RegionNotFoundSnafu, Result};
+use crate::region::version::Version;
+use crate::worker::RegionWorkerLoop;
+
+impl<S> RegionWorkerLoop<S> {
+    pub(crate) async fn handle_alter_request(
+        &mut self,
+        region_id: RegionId,
+        request: RegionAlterRequest,
+        sender: Option<oneshot::Sender<Result<Output>>>,
+    ) {
+        let Some(region) = self.regions.get_region(region_id) else {
+            if let Some(sender) = sender {
+                let _ = sender.send(RegionNotFoundSnafu { region_id }.fail());
+            }
+            return;
+        };
+
+        info!("Try to alter region: {}, request: {:?}", region_id, request);
+
+        // TODO(yingwen): We should remove immutable memtables on flush finished.
+        let version = region.version();
+        if !can_alter_directly(&version) {
+            // We need to flush all memtables first.
+            info!("Flush region: {} before alteration", region_id);
+
+            todo!()
+        }
+
+        // Now we can alter the region directly.
+        //
+
+        unimplemented!()
+    }
+}
+
+/// Checks whether all memtables are empty.
+fn can_alter_directly(version: &Version) -> bool {
+    unimplemented!()
+}
+
+/// Creates a metadata after applying the alter `request` to the old `metadata`.
+///
+/// Returns an error if the `request` is invalid.
+fn metadata_after_alteration(
+    metadata: &RegionMetadata,
+    request: RegionAlterRequest,
+) -> Result<RegionMetadata> {
+    unimplemented!()
+}

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -63,7 +63,7 @@ impl<S> RegionWorkerLoop<S> {
                 return;
             }
 
-            // TODO(yingwen): Maybe assert in add_ddl_request_to_pending instead returning result.
+            // Safety: We have requested flush.
             self.flush_scheduler
                 .add_ddl_request_to_pending(SenderDdlRequest {
                     region_id,

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -49,8 +49,9 @@ impl<S> RegionWorkerLoop<S> {
 
         let version = region.version();
         // Checks whether we can alter the region directly.
-        if !can_alter_directly(&version) {
-            // We need to flush all memtables first.
+        if !version.memtables.is_empty() {
+            // If memtable is not empty, we can't alter it directly and need to flush
+            // all memtables first.
             info!("Flush region: {} before alteration", region_id);
 
             // Try to submit a flush task.
@@ -106,11 +107,6 @@ async fn alter_region_schema(
     // Apply the metadata to region's version.
     region.version_control.alter_schema(new_meta, builder);
     Ok(())
-}
-
-/// Checks whether all memtables are empty.
-fn can_alter_directly(version: &Version) -> bool {
-    version.memtables.mutable.is_empty() && version.memtables.immutables().is_empty()
 }
 
 /// Creates a metadata after applying the alter `request` to the old `metadata`.

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -111,7 +111,7 @@ async fn alter_region_schema(
 }
 
 /// Checks whether all memtables are empty.
-fn can_alter_directly(version: &Version) -> bool {
+fn can_alter_directly(_version: &Version) -> bool {
     unimplemented!()
 }
 
@@ -119,8 +119,8 @@ fn can_alter_directly(version: &Version) -> bool {
 ///
 /// Returns an error if the `request` is invalid.
 fn metadata_after_alteration(
-    metadata: &RegionMetadata,
-    request: RegionAlterRequest,
+    _metadata: &RegionMetadata,
+    _request: RegionAlterRequest,
 ) -> Result<RegionMetadataRef> {
     unimplemented!()
 }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -47,6 +47,7 @@ impl<S> RegionWorkerLoop<S> {
 
         info!("Try to alter region: {}, request: {:?}", region_id, request);
 
+        // Get the version before alter.
         let version = region.version();
         // Checks whether we can alter the region directly.
         if !version.memtables.is_empty() {
@@ -82,7 +83,12 @@ impl<S> RegionWorkerLoop<S> {
             return;
         }
 
-        info!("Schema of region {} is altered", region_id);
+        info!(
+            "Schema of region {} is altered from {} to {}",
+            region_id,
+            version.metadata.schema_version,
+            region.metadata().schema_version
+        );
 
         // Notifies waiters.
         send_result(sender, Ok(Output::AffectedRows(0)));

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -16,12 +16,13 @@
 
 use common_query::Output;
 use common_telemetry::{error, info};
+use snafu::ensure;
 use store_api::metadata::{RegionMetadata, RegionMetadataRef};
-use store_api::region_request::RegionAlterRequest;
+use store_api::region_request::{AlterKind, RegionAlterRequest};
 use store_api::storage::RegionId;
 use tokio::sync::oneshot;
 
-use crate::error::{RegionNotFoundSnafu, Result};
+use crate::error::{InvalidRequestSnafu, RegionNotFoundSnafu, Result};
 use crate::flush::FlushReason;
 use crate::manifest::action::{RegionChange, RegionMetaAction, RegionMetaActionList};
 use crate::memtable::MemtableBuilderRef;
@@ -114,8 +115,10 @@ fn can_alter_directly(version: &Version) -> bool {
 ///
 /// Returns an error if the `request` is invalid.
 fn metadata_after_alteration(
-    _metadata: &RegionMetadata,
-    _request: RegionAlterRequest,
+    metadata: &RegionMetadata,
+    request: RegionAlterRequest,
 ) -> Result<RegionMetadataRef> {
+    //
+
     unimplemented!()
 }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -47,12 +47,11 @@ impl<S> RegionWorkerLoop<S> {
         info!("Try to alter region: {}, request: {:?}", region_id, request);
 
         let version = region.version();
+        // Checks whether memtables are empty.
         if !can_alter_directly(&version) {
             // We need to flush all memtables first.
+            // If no pending flush task, we must trigger a flush.
             info!("Flush region: {} before alteration", region_id);
-
-            // TODO(yingwen): Optimization: We don't need to submit a flush task again if the
-            // mutable memtable is empty.
 
             // Try to submit a flush task.
             let task = self.new_flush_task(&region, FlushReason::Alter);

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -64,16 +64,12 @@ impl<S> RegionWorkerLoop<S> {
             }
 
             // TODO(yingwen): Maybe assert in add_ddl_request_to_pending instead returning result.
-            if let Err(e) = self
-                .flush_scheduler
+            self.flush_scheduler
                 .add_ddl_request_to_pending(SenderDdlRequest {
                     region_id,
                     sender,
                     request: DdlRequest::Alter(request),
-                })
-            {
-                todo!()
-            }
+                });
 
             todo!()
         }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -38,9 +38,7 @@ impl<S> RegionWorkerLoop<S> {
         sender: Option<oneshot::Sender<Result<Output>>>,
     ) {
         let Some(region) = self.regions.get_region(region_id) else {
-            if let Some(sender) = sender {
-                let _ = sender.send(RegionNotFoundSnafu { region_id }.fail());
-            }
+            send_result(sender, RegionNotFoundSnafu { region_id }.fail());
             return;
         };
 

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -46,7 +46,6 @@ impl<S> RegionWorkerLoop<S> {
 
         info!("Try to alter region: {}, request: {:?}", region_id, request);
 
-        // TODO(yingwen): We should remove immutable memtables on flush finished.
         let version = region.version();
         if !can_alter_directly(&version) {
             // We need to flush all memtables first.

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -78,7 +78,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         // Apply edit to region's version.
         region
             .version_control
-            .apply_edit(edit, region.file_purger.clone());
+            .apply_edit(edit, &[], region.file_purger.clone());
         request.on_success();
     }
 

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -23,7 +23,7 @@ use crate::error::{RegionNotFoundSnafu, Result};
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::region::MitoRegionRef;
 use crate::request::{CompactionFailed, CompactionFinished};
-use crate::worker::RegionWorkerLoop;
+use crate::worker::{send_result, RegionWorkerLoop};
 
 impl<S: LogStore> RegionWorkerLoop<S> {
     /// Handles compaction request submitted to region worker.
@@ -33,9 +33,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         sender: Option<oneshot::Sender<Result<Output>>>,
     ) {
         let Some(region) = self.regions.get_region(region_id) else {
-            if let Some(sender) = sender {
-                let _ = sender.send(RegionNotFoundSnafu { region_id }.fail());
-            }
+            send_result(sender, RegionNotFoundSnafu { region_id }.fail());
             return;
         };
 

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -174,7 +174,12 @@ impl<S> RegionWorkerLoop<S> {
         Ok(())
     }
 
-    fn new_flush_task(&self, region: &MitoRegionRef, reason: FlushReason) -> RegionFlushTask {
+    /// Create a flush task with specific `reason` for the `region`.
+    pub(crate) fn new_flush_task(
+        &self,
+        region: &MitoRegionRef,
+        reason: FlushReason,
+    ) -> RegionFlushTask {
         // TODO(yingwen): metrics for flush requested.
         RegionFlushTask {
             region_id: region.region_id,

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -56,9 +56,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
 
         // Apply edit to region's version.
-        region
-            .version_control
-            .apply_edit(edit, region.file_purger.clone());
+        region.version_control.apply_edit(
+            edit,
+            &request.memtables_to_remove,
+            region.file_purger.clone(),
+        );
         region.update_flush_millis();
 
         // Delete wal.

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -26,7 +26,7 @@ use crate::flush::{FlushReason, RegionFlushTask};
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::region::MitoRegionRef;
 use crate::request::{FlushFailed, FlushFinished};
-use crate::worker::RegionWorkerLoop;
+use crate::worker::{send_result, RegionWorkerLoop};
 
 impl<S: LogStore> RegionWorkerLoop<S> {
     /// On region flush job finished.
@@ -104,9 +104,7 @@ impl<S> RegionWorkerLoop<S> {
         sender: Option<oneshot::Sender<Result<Output>>>,
     ) {
         let Some(region) = self.regions.get_region(region_id) else {
-            if let Some(sender) = sender {
-                let _ = sender.send(RegionNotFoundSnafu { region_id }.fail());
-            }
+            send_result(sender, RegionNotFoundSnafu { region_id }.fail());
             return;
         };
 

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -91,6 +91,8 @@ impl<S> RegionWorkerLoop<S> {
         for mut sender_req in write_requests {
             let region_id = sender_req.request.region_id;
 
+            // TODO(yingwen): If region is waiter for alter, add requests to pending writes.
+
             // Checks whether the region exists and is it stalling.
             if let hash_map::Entry::Vacant(e) = region_ctxs.entry(region_id) {
                 let Some(region) = self.regions.get_region(region_id) else {

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -91,7 +91,13 @@ impl<S> RegionWorkerLoop<S> {
         for mut sender_req in write_requests {
             let region_id = sender_req.request.region_id;
 
-            // TODO(yingwen): If region is waiter for alter, add requests to pending writes.
+            // If region is waiting for alteration, add requests to pending writes.
+            if self.flush_scheduler.has_pending_ddls(region_id) {
+                // TODO(yingwen): consider adding some metrics for this.
+                self.flush_scheduler
+                    .add_write_request_to_pending(sender_req);
+                continue;
+            }
 
             // Checks whether the region exists and is it stalling.
             if let hash_map::Entry::Vacant(e) = region_ctxs.entry(region_id) {

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -17,16 +17,14 @@
 use std::collections::{hash_map, HashMap};
 use std::sync::Arc;
 
-use common_query::Output;
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadata;
 use store_api::storage::RegionId;
-use tokio::sync::oneshot::Sender;
 
 use crate::error::{RegionNotFoundSnafu, RejectWriteSnafu, Result};
 use crate::region_write_ctx::RegionWriteCtx;
 use crate::request::{SenderWriteRequest, WriteRequest};
-use crate::worker::RegionWorkerLoop;
+use crate::worker::{send_result, RegionWorkerLoop};
 
 impl<S: LogStore> RegionWorkerLoop<S> {
     /// Takes and handles all write requests.
@@ -166,12 +164,4 @@ fn maybe_fill_missing_columns(request: &mut WriteRequest, metadata: &RegionMetad
     }
 
     Ok(())
-}
-
-/// Send result to the request.
-fn send_result(sender: Option<Sender<Result<Output>>>, res: Result<Output>) {
-    if let Some(sender) = sender {
-        // Ignore send result.
-        let _ = sender.send(res);
-    }
 }

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -94,6 +94,7 @@ impl<S> RegionWorkerLoop<S> {
             // If region is waiting for alteration, add requests to pending writes.
             if self.flush_scheduler.has_pending_ddls(region_id) {
                 // TODO(yingwen): consider adding some metrics for this.
+                // Safety: The region has pending ddls.
                 self.flush_scheduler
                     .add_write_request_to_pending(sender_req);
                 continue;

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -127,6 +127,7 @@ pub struct RegionMetadata {
 
     /// Immutable and unique id of a region.
     pub region_id: RegionId,
+    // TODO(yingwen): Add schema version.
 }
 
 pub type RegionMetadataRef = Arc<RegionMetadata>;

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -513,7 +513,7 @@ pub enum MetadataError {
     },
 
     #[snafu(display(
-        "Failed to convert with struct from datatypes, location: {}, source: {}",
+        "Failed to convert struct from datatypes, location: {}, source: {}",
         location,
         source
     ))]

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -522,8 +522,20 @@ pub enum MetadataError {
         source: datatypes::error::Error,
     },
 
-    #[snafu(display("Invalid raw region request: {err}, at {location}"))]
+    #[snafu(display("Invalid raw region request, err: {}, location: {}", err, location))]
     InvalidRawRegionRequest { err: String, location: Location },
+
+    #[snafu(display(
+        "Invalid region request, region_id: {}, err: {}, location: {}",
+        region_id,
+        err,
+        location
+    ))]
+    InvalidRegionRequest {
+        region_id: RegionId,
+        err: String,
+        location: Location,
+    },
 }
 
 impl ErrorExt for MetadataError {

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -461,10 +461,13 @@ impl RegionMetadataBuilder {
     fn add_columns(&mut self, columns: Vec<AddColumn>) -> Result<()> {
         for add_column in columns {
             match add_column.location {
-                AddColumnLocation::First => {
+                None => {
+                    self.column_metadatas.push(add_column.column_metadata);
+                },
+                Some(AddColumnLocation::First) => {
                     self.column_metadatas.insert(0, add_column.column_metadata);
-                }
-                AddColumnLocation::After { column_name } => {
+                },
+                Some(AddColumnLocation::After { column_name }) => {
                     let pos = self
                         .column_metadatas
                         .iter()
@@ -479,7 +482,7 @@ impl RegionMetadataBuilder {
                     // Insert after pos.
                     self.column_metadatas
                         .insert(pos + 1, add_column.column_metadata);
-                }
+                },
             }
         }
 

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -932,6 +932,7 @@ mod test {
 
     #[test]
     fn test_alter() {
+        // a (tag), b (field), c (ts)
         let metadata = build_test_region_metadata();
         let mut builder = RegionMetadataBuilder::from_existing(metadata);
         builder
@@ -944,7 +945,7 @@ mod test {
             .unwrap();
         let metadata = builder.build().unwrap();
         check_columns(&metadata, &["a", "b", "c", "d"]);
-        assert_eq!([2, 4], &metadata.primary_key[..]);
+        assert_eq!([1, 4], &metadata.primary_key[..]);
 
         let mut builder = RegionMetadataBuilder::from_existing(metadata);
         builder
@@ -994,5 +995,15 @@ mod test {
             .unwrap();
         let metadata = builder.build().unwrap();
         check_columns(&metadata, &["a", "b", "f", "c", "d"]);
+
+        let mut builder = RegionMetadataBuilder::from_existing(metadata);
+        builder
+            .alter(AlterKind::DropColumns {
+                names: vec!["a".to_string()],
+            })
+            .unwrap();
+        // Build returns error as the primary key has more columns.
+        let err = builder.build().unwrap_err();
+        assert_eq!(StatusCode::InvalidArguments, err.status_code());
     }
 }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -227,7 +227,7 @@ pub enum AlterKind {
         /// Columns to add.
         columns: Vec<AddColumn>,
     },
-    /// Drop columns from the region, only value columns are allowed to drop.
+    /// Drop columns from the region, only fields are allowed to drop.
     DropColumns {
         /// Name of columns to drop.
         names: Vec<String>,

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -306,13 +306,14 @@ impl TryFrom<alter_request::Kind> for AlterKind {
     }
 }
 
-/// Add a column.
+/// Adds a column.
 #[derive(Debug)]
 pub struct AddColumn {
     /// Metadata of the column to add.
     pub column_metadata: ColumnMetadata,
-    /// Location to add the column.
-    pub location: AddColumnLocation,
+    /// Location to add the column. If location is None, the region adds
+    /// the column to the last.
+    pub location: Option<AddColumnLocation>,
 }
 
 impl AddColumn {
@@ -361,10 +362,10 @@ impl TryFrom<v1::region::AddColumn> for AddColumn {
             })?;
 
         let column_metadata = ColumnMetadata::try_from_column_def(column_def)?;
-        let location = add_column.location.context(InvalidRawRegionRequestSnafu {
-            err: "missing location in AddColumn",
-        })?;
-        let location = AddColumnLocation::try_from(location)?;
+        let location = add_column
+            .location
+            .map(AddColumnLocation::try_from)
+            .transpose()?;
 
         Ok(AddColumn {
             column_metadata,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements a skeleton to alter a region. Steps to alter a region's schema are:
1. Flushes all memtables. It ensures no data with old schema in WAL and memtables so we don't need to deal with these data during replay
2. Writes the alteration to the manifest and applies it to the `Version` after the flush job is finished


Minor fixes
- Removes flushed memtables after a flush job is done.
- Compaction picker doesn't notify waiters if it returns None.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869
- closes https://github.com/GreptimeTeam/greptimedb/issues/1977
