### PR TITLE
feat!: add gt prefix

### DIFF
--- a/docs/rfcs/2023-08-13-metadata-txn.md
+++ b/docs/rfcs/2023-08-13-metadata-txn.md
@@ -16,7 +16,7 @@ Now we have the following table metadata keys:
 
 **TableInfo** 
 ```rust
-// __table_info/{table_id}
+// gt__table_info/{table_id}
 pub struct TableInfoKey {
     table_id: TableId,
 }
@@ -29,7 +29,7 @@ pub struct TableInfoValue {
 
 **TableRoute** 
 ```rust
-// __table_route/{table_id}
+// gt__table_route/{table_id}
 pub struct NextTableRouteKey {
     table_id: TableId,
 }
@@ -40,7 +40,7 @@ pub struct TableRoute {
 ```
 **DatanodeTable**
 ```rust
-// __table_route/{datanode_id}/{table_id}
+// gt__table_route/{datanode_id}/{table_id}
 pub struct DatanodeTableKey {
     datanode_id: DatanodeId,
     table_id: TableId,
@@ -55,7 +55,7 @@ pub struct DatanodeTableValue {
 
 **TableNameKey**
 ```rust
-// __table_name/{CatalogName}/{SchemaName}/{TableName}
+// gt__table_name/{CatalogName}/{SchemaName}/{TableName}
 pub struct TableNameKey<'a> {
     pub catalog: &'a str,
     pub schema: &'a str,
@@ -80,7 +80,7 @@ Creates all of the above keys. `TableRoute`, `TableInfo`, should be empty.
 The **TableNameKey**'s lock will be held by the procedure framework.
 ## Drop Table DDL
 
-`TableInfoKey` and `NextTableRouteKey` will be added with  `__removed-` prefix, and the other above keys will be deleted.  The transaction will not compare any keys.
+`TableInfoKey` and `NextTableRouteKey` will be added with  `gt__removed-` prefix, and the other above keys will be deleted.  The transaction will not compare any keys.
 ## Alter Table DDL
 
 1. Rename table, updates `TableInfo` and `TableName`. Compares `TableInfo`, and the new `TableNameKey` should be empty, and TableInfo should equal the Snapshot when submitting DDL.

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -15,24 +15,24 @@
 //! This mod defines all the keys used in the metadata store (Metasrv).
 //! Specifically, there are these kinds of keys:
 //!
-//! 1. Datanode table key: `__dn_table/{datanode_id}/{table_id}`
+//! 1. Datanode table key: `gt__dn_table/{datanode_id}/{table_id}`
 //!     - The value is a [DatanodeTableValue] struct; it contains `table_id` and the regions that
 //!       belong to this Datanode.
 //!     - This key is primary used in the startup of Datanode, to let Datanode know which tables
 //!       and regions it should open.
 //!
-//! 2. Table info key: `__table_info/{table_id}`
+//! 2. Table info key: `gt__table_info/{table_id}`
 //!     - The value is a [TableInfoValue] struct; it contains the whole table info (like column
 //!       schemas).
 //!     - This key is mainly used in constructing the table in Datanode and Frontend.
 //!
-//! 3. Catalog name key: `__catalog_name/{catalog_name}`
+//! 3. Catalog name key: `gt__catalog_name/{catalog_name}`
 //!     - Indices all catalog names
 //!
-//! 4. Schema name key: `__schema_name/{catalog_name}/{schema_name}`
+//! 4. Schema name key: `gt__schema_name/{catalog_name}/{schema_name}`
 //!     - Indices all schema names belong to the {catalog_name}
 //!
-//! 5. Table name key: `__table_name/{catalog_name}/{schema_name}/{table_name}`
+//! 5. Table name key: `gt__table_name/{catalog_name}/{schema_name}/{table_name}`
 //!     - The value is a [TableNameValue] struct; it contains the table id.
 //!     - Used in the table name to table id lookup.
 //!
@@ -78,16 +78,16 @@ use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute};
 use crate::DatanodeId;
 
-pub const REMOVED_PREFIX: &str = "__removed";
+pub const REMOVED_PREFIX: &str = "gt__removed";
 
 const NAME_PATTERN: &str = "[a-zA-Z_:-][a-zA-Z0-9_:-]*";
 
-const DATANODE_TABLE_KEY_PREFIX: &str = "__dn_table";
-const TABLE_INFO_KEY_PREFIX: &str = "__table_info";
-const TABLE_NAME_KEY_PREFIX: &str = "__table_name";
-const TABLE_REGION_KEY_PREFIX: &str = "__table_region";
-const CATALOG_NAME_KEY_PREFIX: &str = "__catalog_name";
-const SCHEMA_NAME_KEY_PREFIX: &str = "__schema_name";
+const DATANODE_TABLE_KEY_PREFIX: &str = "gt__dn_table";
+const TABLE_INFO_KEY_PREFIX: &str = "gt__table_info";
+const TABLE_NAME_KEY_PREFIX: &str = "gt__table_name";
+const TABLE_REGION_KEY_PREFIX: &str = "gt__table_region";
+const CATALOG_NAME_KEY_PREFIX: &str = "gt__catalog_name";
+const SCHEMA_NAME_KEY_PREFIX: &str = "gt__schema_name";
 
 pub type RegionDistribution = BTreeMap<DatanodeId, Vec<RegionNumber>>;
 
@@ -525,7 +525,7 @@ mod tests {
     #[test]
     fn test_to_removed_key() {
         let key = "test_key";
-        let removed = "__removed-test_key";
+        let removed = "gt__removed-test_key";
         assert_eq!(removed, to_removed_key(key));
     }
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -88,6 +88,7 @@ const TABLE_NAME_KEY_PREFIX: &str = "gt__table_name";
 const TABLE_REGION_KEY_PREFIX: &str = "gt__table_region";
 const CATALOG_NAME_KEY_PREFIX: &str = "gt__catalog_name";
 const SCHEMA_NAME_KEY_PREFIX: &str = "gt__schema_name";
+const NEXT_TABLE_ROUTE_PREFIX: &str = "gt__table_route";
 
 pub type RegionDistribution = BTreeMap<DatanodeId, Vec<RegionNumber>>;
 

--- a/src/common/meta/src/key/catalog_name.rs
+++ b/src/common/meta/src/key/catalog_name.rs
@@ -142,9 +142,9 @@ mod tests {
     fn test_serialization() {
         let key = CatalogNameKey::new("my-catalog");
 
-        assert_eq!(key.to_string(), "__catalog_name/my-catalog");
+        assert_eq!(key.to_string(), "gt__catalog_name/my-catalog");
 
-        let parsed: CatalogNameKey = "__catalog_name/my-catalog".try_into().unwrap();
+        let parsed: CatalogNameKey = "gt__catalog_name/my-catalog".try_into().unwrap();
 
         assert_eq!(key, parsed);
     }

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -234,7 +234,7 @@ mod tests {
             table_id: 2,
         };
         let raw_key = key.as_raw_key();
-        assert_eq!(raw_key, b"__dn_table/1/2");
+        assert_eq!(raw_key, b"gt__dn_table/1/2");
 
         let value = DatanodeTableValue {
             table_id: 42,
@@ -260,13 +260,13 @@ mod tests {
         test_err(b"");
         test_err(vec![0u8, 159, 146, 150].as_slice()); // invalid UTF8 string
         test_err(b"invalid_prefix/1/2");
-        test_err(b"__dn_table/");
-        test_err(b"__dn_table/invalid_len_1");
-        test_err(b"__dn_table/invalid_len_3/1/2");
-        test_err(b"__dn_table/invalid_node_id/2");
-        test_err(b"__dn_table/1/invalid_table_id");
+        test_err(b"gt__dn_table/");
+        test_err(b"gt__dn_table/invalid_len_1");
+        test_err(b"gt__dn_table/invalid_len_3/1/2");
+        test_err(b"gt__dn_table/invalid_node_id/2");
+        test_err(b"gt__dn_table/1/invalid_table_id");
 
-        let table_id = DatanodeTableKey::strip_table_id(b"__dn_table/1/2").unwrap();
+        let table_id = DatanodeTableKey::strip_table_id(b"gt__dn_table/1/2").unwrap();
         assert_eq!(table_id, 2);
     }
 }

--- a/src/common/meta/src/key/schema_name.rs
+++ b/src/common/meta/src/key/schema_name.rs
@@ -192,9 +192,9 @@ mod tests {
     #[test]
     fn test_serialization() {
         let key = SchemaNameKey::new("my-catalog", "my-schema");
-        assert_eq!(key.to_string(), "__schema_name/my-catalog/my-schema");
+        assert_eq!(key.to_string(), "gt__schema_name/my-catalog/my-schema");
 
-        let parsed: SchemaNameKey<'_> = "__schema_name/my-catalog/my-schema".try_into().unwrap();
+        let parsed: SchemaNameKey<'_> = "gt__schema_name/my-catalog/my-schema".try_into().unwrap();
         assert_eq!(key, parsed);
 
         let value = SchemaNameValue {

--- a/src/common/meta/src/key/table_info.rs
+++ b/src/common/meta/src/key/table_info.rs
@@ -112,7 +112,7 @@ impl TableInfoManager {
         (txn, Self::build_decode_fn(raw_key))
     }
 
-    /// Builds a create table info transaction, it expected the `__table_info/{table_id}` wasn't occupied.
+    /// Builds a create table info transaction, it expected the `gt__table_info/{table_id}` wasn't occupied.
     pub(crate) fn build_create_txn(
         &self,
         table_id: TableId,
@@ -248,7 +248,7 @@ mod tests {
     fn test_key_serde() {
         let key = TableInfoKey::new(42);
         let raw_key = key.as_raw_key();
-        assert_eq!(raw_key, b"__table_info/42");
+        assert_eq!(raw_key, b"gt__table_info/42");
     }
 
     #[test]

--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -248,19 +248,19 @@ mod tests {
         test_err(b"");
         test_err(vec![0u8, 159, 146, 150].as_slice()); // invalid UTF8 string
         test_err(b"invalid_prefix/my_catalog/my_schema/my_table");
-        test_err(b"__table_name/");
-        test_err(b"__table_name/invalid_len_1");
-        test_err(b"__table_name/invalid_len_2/x");
-        test_err(b"__table_name/invalid_len_4/x/y/z");
-        test_err(b"__table_name/000_invalid_catalog/y/z");
-        test_err(b"__table_name/x/000_invalid_schema/z");
-        test_err(b"__table_name/x/y/000_invalid_table");
+        test_err(b"gt__table_name/");
+        test_err(b"gt__table_name/invalid_len_1");
+        test_err(b"gt__table_name/invalid_len_2/x");
+        test_err(b"gt__table_name/invalid_len_4/x/y/z");
+        test_err(b"gt__table_name/000_invalid_catalog/y/z");
+        test_err(b"gt__table_name/x/000_invalid_schema/z");
+        test_err(b"gt__table_name/x/y/000_invalid_table");
 
         fn test_ok(table_name: &str) {
             assert_eq!(
                 table_name,
                 TableNameKey::strip_table_name(
-                    format!("__table_name/my_catalog/my_schema/{}", table_name).as_bytes()
+                    format!("gt__table_name/my_catalog/my_schema/{}", table_name).as_bytes()
                 )
                 .unwrap()
             );
@@ -275,7 +275,7 @@ mod tests {
         let key = TableNameKey::new("my_catalog", "my_schema", "my_table");
         let raw_key = key.as_raw_key();
         assert_eq!(
-            b"__table_name/my_catalog/my_schema/my_table",
+            b"gt__table_name/my_catalog/my_schema/my_table",
             raw_key.as_slice()
         );
 

--- a/src/common/meta/src/key/table_region.rs
+++ b/src/common/meta/src/key/table_region.rs
@@ -78,7 +78,7 @@ mod tests {
     fn test_serde() {
         let key = TableRegionKey::new(1);
         let raw_key = key.as_raw_key();
-        assert_eq!(raw_key, b"__table_region/1");
+        assert_eq!(raw_key, b"gt__table_region/1");
 
         let value = TableRegionValue {
             region_distribution: RegionDistribution::from([(1, vec![1, 2, 3]), (2, vec![4, 5, 6])]),

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -26,7 +26,7 @@ use crate::rpc::router::{region_distribution, RegionRoute};
 
 pub const TABLE_ROUTE_PREFIX: &str = "__meta_table_route";
 
-pub const NEXT_TABLE_ROUTE_PREFIX: &str = "__table_route";
+pub const NEXT_TABLE_ROUTE_PREFIX: &str = "gt__table_route";
 
 // TODO(weny): Renames it to TableRouteKey.
 pub struct NextTableRouteKey {
@@ -96,7 +96,7 @@ impl TableRouteManager {
         (txn, Self::build_decode_fn(raw_key))
     }
 
-    /// Builds a create table route transaction. it expected the `__table_route/{table_id}` wasn't occupied.
+    /// Builds a create table route transaction. it expected the `gt__table_route/{table_id}` wasn't occupied.
     pub(crate) fn build_create_txn(
         &self,
         table_id: TableId,
@@ -281,7 +281,7 @@ mod tests {
 
         let removed = key.removed_key();
         assert_eq!(
-            "__removed-__meta_table_route-greptime-public-demo-123",
+            "gt__removed-__meta_table_route-greptime-public-demo-123",
             removed
         );
     }

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -19,14 +19,12 @@ use serde::{Deserialize, Serialize};
 use table::metadata::TableId;
 
 use crate::error::Result;
-use crate::key::{to_removed_key, RegionDistribution, TableMetaKey};
+use crate::key::{to_removed_key, RegionDistribution, TableMetaKey, NEXT_TABLE_ROUTE_PREFIX};
 use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp, TxnOpResponse};
 use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute};
 
 pub const TABLE_ROUTE_PREFIX: &str = "__meta_table_route";
-
-pub const NEXT_TABLE_ROUTE_PREFIX: &str = "gt__table_route";
 
 // TODO(weny): Renames it to TableRouteKey.
 pub struct NextTableRouteKey {

--- a/src/common/meta/src/sequence.rs
+++ b/src/common/meta/src/sequence.rs
@@ -24,7 +24,7 @@ use crate::rpc::store::CompareAndPutRequest;
 
 pub type SequenceRef = Arc<Sequence>;
 
-pub(crate) const SEQ_PREFIX: &str = "__meta_seq";
+pub(crate) const SEQ_PREFIX: &str = "gt__meta_seq";
 
 pub struct Sequence {
     inner: Mutex<Inner>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The `RaftEngine` reserves `__` prefix for internal usage. Let's add `gt` prefix for metadata keys.

By the way, we need to migrate `__table_seq` key as well. cc @shuiyisong 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
