### PR TITLE
refactor: collecting memory usage during scan

### DIFF
--- a/src/table/src/table.rs
+++ b/src/table/src/table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 pub mod adapter;
+mod metrics;
 pub mod numbers;
 pub mod scan;
 

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use datafusion::physical_plan::metrics::{
     ExecutionPlanMetricsSet, Gauge, MetricBuilder, Timestamp,
 };

--- a/src/table/src/table/metrics.rs
+++ b/src/table/src/table/metrics.rs
@@ -1,0 +1,39 @@
+use datafusion::physical_plan::metrics::{
+    ExecutionPlanMetricsSet, Gauge, MetricBuilder, Timestamp,
+};
+
+#[derive(Debug, Clone)]
+pub struct MemoryUsageMetrics {
+    end_time: Timestamp,
+    mem_used: Gauge,
+}
+
+impl MemoryUsageMetrics {
+    /// Create a new BaselineMetric structure, and set  `start_time` to now
+    pub fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        let start_time = MetricBuilder::new(metrics).start_timestamp(partition);
+        start_time.record();
+
+        Self {
+            end_time: MetricBuilder::new(metrics).end_timestamp(partition),
+            mem_used: MetricBuilder::new(metrics).gauge("mem_used", partition),
+        }
+    }
+
+    pub fn record_mem_usage(&self, mem_used: usize) {
+        self.mem_used.add(mem_used);
+    }
+
+    /// If not previously recorded `done()`, record
+    pub fn try_done(&self) {
+        if self.end_time.value().is_none() {
+            self.end_time.record()
+        }
+    }
+}
+
+impl Drop for MemoryUsageMetrics {
+    fn drop(&mut self) {
+        self.try_done()
+    }
+}

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -24,11 +24,13 @@ use common_query::physical_plan::{Partitioning, PhysicalPlan, PhysicalPlanRef};
 use common_recordbatch::error::Result as RecordBatchResult;
 use common_recordbatch::{RecordBatch, RecordBatchStream, SendableRecordBatchStream};
 use datafusion::execution::context::TaskContext;
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion_physical_expr::PhysicalSortExpr;
 use datatypes::schema::SchemaRef;
 use futures::{Stream, StreamExt};
 use snafu::OptionExt;
+
+use crate::table::metrics::MemoryUsageMetrics;
 
 /// Adapt greptime's [SendableRecordBatchStream] to GreptimeDB's [PhysicalPlan].
 pub struct StreamScanAdapter {
@@ -97,10 +99,10 @@ impl PhysicalPlan for StreamScanAdapter {
     ) -> QueryResult<SendableRecordBatchStream> {
         let mut stream = self.stream.lock().unwrap();
         let stream = stream.take().context(query_error::ExecuteRepeatedlySnafu)?;
-        let baseline_metric = BaselineMetrics::new(&self.metric, partition);
+        let mem_usage_metrics = MemoryUsageMetrics::new(&self.metric, partition);
         Ok(Box::pin(StreamWithMetricWrapper {
             stream,
-            metric: baseline_metric,
+            metric: mem_usage_metrics,
         }))
     }
 
@@ -111,7 +113,7 @@ impl PhysicalPlan for StreamScanAdapter {
 
 pub struct StreamWithMetricWrapper {
     stream: SendableRecordBatchStream,
-    metric: BaselineMetrics,
+    metric: MemoryUsageMetrics,
 }
 
 impl Stream for StreamWithMetricWrapper {
@@ -119,10 +121,16 @@ impl Stream for StreamWithMetricWrapper {
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-        let _timer = this.metric.elapsed_compute().timer();
+        // it's calling storage level api
+        // so we don't record time now
         let poll = this.stream.poll_next_unpin(cx);
         if let Poll::Ready(Option::Some(Result::Ok(record_batch))) = &poll {
-            this.metric.record_output(record_batch.num_rows());
+            let batch_mem_size = record_batch
+                .columns()
+                .iter()
+                .map(|vec_ref| vec_ref.memory_size())
+                .sum::<usize>();
+            this.metric.record_mem_usage(batch_mem_size);
         }
 
         poll


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr mainly replaces `BaselineMetrics` to a customized metrics struct in order to hold memory usage during scan plan, indicating the returning size of the dataset to the corresponding query request.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
