### PR TITLE
fix(mito): Stores and recovers flushed sequence

### DIFF
--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -14,7 +14,8 @@
 
 use std::collections::HashMap;
 
-use api::v1::{Rows, SemanticType};
+use api::v1::value::ValueData;
+use api::v1::{ColumnDataType, Row, Rows, SemanticType};
 use common_recordbatch::RecordBatches;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
@@ -27,7 +28,9 @@ use store_api::storage::{RegionId, ScanRequest};
 
 use crate::config::MitoConfig;
 use crate::engine::MitoEngine;
-use crate::test_util::{build_rows, put_rows, rows_schema, CreateRequestBuilder, TestEnv};
+use crate::test_util::{
+    build_rows, build_rows_for_key, put_rows, rows_schema, CreateRequestBuilder, TestEnv,
+};
 
 async fn scan_check_after_alter(engine: &MitoEngine, region_id: RegionId, expected: &str) {
     let request = ScanRequest::default();
@@ -37,6 +40,26 @@ async fn scan_check_after_alter(engine: &MitoEngine, region_id: RegionId, expect
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     assert_eq!(expected, batches.pretty_print().unwrap());
+}
+
+fn add_tag1() -> RegionAlterRequest {
+    RegionAlterRequest {
+        schema_version: 0,
+        kind: AlterKind::AddColumns {
+            columns: vec![AddColumn {
+                column_metadata: ColumnMetadata {
+                    column_schema: ColumnSchema::new(
+                        "tag_1",
+                        ConcreteDataType::string_datatype(),
+                        true,
+                    ),
+                    semantic_type: SemanticType::Tag,
+                    column_id: 3,
+                },
+                location: Some(AddColumnLocation::First),
+            }],
+        },
+    }
 }
 
 #[tokio::test]
@@ -62,23 +85,7 @@ async fn test_alter_region() {
     };
     put_rows(&engine, region_id, rows).await;
 
-    let request = RegionAlterRequest {
-        schema_version: 0,
-        kind: AlterKind::AddColumns {
-            columns: vec![AddColumn {
-                column_metadata: ColumnMetadata {
-                    column_schema: ColumnSchema::new(
-                        "tag_1",
-                        ConcreteDataType::string_datatype(),
-                        true,
-                    ),
-                    semantic_type: SemanticType::Tag,
-                    column_id: 3,
-                },
-                location: Some(AddColumnLocation::First),
-            }],
-        },
-    };
+    let request = add_tag1();
     engine
         .handle_request(region_id, RegionRequest::Alter(request))
         .await
@@ -119,4 +126,120 @@ async fn test_alter_region() {
         .unwrap();
     scan_check_after_alter(&engine, region_id, expected).await;
     check_region(&engine);
+}
+
+/// Build rows with schema (string, f64, ts_millis, string).
+fn build_rows_for_tags(
+    tag0: &str,
+    tag1: &str,
+    start: usize,
+    end: usize,
+    value_start: usize,
+) -> Vec<Row> {
+    (start..end)
+        .enumerate()
+        .map(|(idx, ts)| Row {
+            values: vec![
+                api::v1::Value {
+                    value_data: Some(ValueData::StringValue(tag0.to_string())),
+                },
+                api::v1::Value {
+                    value_data: Some(ValueData::F64Value((value_start + idx) as f64)),
+                },
+                api::v1::Value {
+                    value_data: Some(ValueData::TsMillisecondValue(ts as i64 * 1000)),
+                },
+                api::v1::Value {
+                    value_data: Some(ValueData::StringValue(tag1.to_string())),
+                },
+            ],
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn test_put_after_alter() {
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    let mut column_schemas = rows_schema(&request);
+    let region_dir = request.region_dir.clone();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("b", 0, 2, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    let request = add_tag1();
+    engine
+        .handle_request(region_id, RegionRequest::Alter(request))
+        .await
+        .unwrap();
+
+    let expected = "\
++-------+-------+---------+---------------------+
+| tag_1 | tag_0 | field_0 | ts                  |
++-------+-------+---------+---------------------+
+|       | b     | 0.0     | 1970-01-01T00:00:00 |
+|       | b     | 1.0     | 1970-01-01T00:00:01 |
++-------+-------+---------+---------------------+";
+    scan_check_after_alter(&engine, region_id, expected).await;
+
+    // Reopen region.
+    let engine = env.reopen_engine(engine, MitoConfig::default()).await;
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                region_dir,
+                options: HashMap::default(),
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Put with old schema.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("b", 2, 3, 2),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    // Push tag_1 to schema.
+    column_schemas.push(api::v1::ColumnSchema {
+        column_name: "tag_1".to_string(),
+        datatype: ColumnDataType::String as i32,
+        semantic_type: SemanticType::Tag as i32,
+    });
+    // Put with new schema.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_tags("a", "a", 0, 2, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    // Scan again.
+    let expected = "\
++-------+-------+---------+---------------------+
+| tag_1 | tag_0 | field_0 | ts                  |
++-------+-------+---------+---------------------+
+| a     | a     | 0.0     | 1970-01-01T00:00:00 |
+| a     | a     | 1.0     | 1970-01-01T00:00:01 |
+|       | b     | 0.0     | 1970-01-01T00:00:00 |
+|       | b     | 1.0     | 1970-01-01T00:00:01 |
+|       | b     | 2.0     | 1970-01-01T00:00:02 |
++-------+-------+---------+---------------------+";
+    let request = ScanRequest::default();
+    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(expected, batches.pretty_print().unwrap());
 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -93,6 +93,16 @@ async fn test_alter_region() {
 |       | 2     | 2.0     | 1970-01-01T00:00:02 |
 +-------+-------+---------+---------------------+";
     scan_check_after_alter(&engine, region_id, expected).await;
+    let check_region = |engine: &MitoEngine| {
+        let region = engine.get_region(region_id).unwrap();
+        let version_data = region.version_control.current();
+        assert_eq!(1, version_data.last_entry_id);
+        assert_eq!(3, version_data.committed_sequence);
+        assert_eq!(1, version_data.version.flushed_entry_id);
+        assert_eq!(1, version_data.version.flushed_entry_id);
+        assert_eq!(3, version_data.version.flushed_sequence);
+    };
+    check_region(&engine);
 
     // Reopen region.
     let engine = env.reopen_engine(engine, MitoConfig::default()).await;
@@ -108,4 +118,5 @@ async fn test_alter_region() {
         .await
         .unwrap();
     scan_check_after_alter(&engine, region_id, expected).await;
+    check_region(&engine);
 }

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -247,8 +247,8 @@ async fn test_flush_reopen_region() {
     let check_region = || {
         let region = engine.get_region(region_id).unwrap();
         let version_data = region.version_control.current();
-        assert_eq!(3, version_data.committed_sequence);
         assert_eq!(1, version_data.last_entry_id);
+        assert_eq!(3, version_data.committed_sequence);
         assert_eq!(1, version_data.version.flushed_entry_id);
     };
     check_region();

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -25,8 +25,8 @@ use store_api::storage::{RegionId, ScanRequest};
 use crate::config::MitoConfig;
 use crate::engine::listener::{FlushListener, StallListener};
 use crate::test_util::{
-    build_rows, build_rows_for_key, flush_region, put_rows, rows_schema, CreateRequestBuilder,
-    MockWriteBufferManager, TestEnv,
+    build_rows, build_rows_for_key, flush_region, put_rows, reopen_region, rows_schema,
+    CreateRequestBuilder, MockWriteBufferManager, TestEnv,
 };
 
 #[tokio::test]
@@ -220,4 +220,39 @@ async fn test_flush_empty() {
 ++
 ++";
     assert_eq!(expected, batches.pretty_print().unwrap());
+}
+
+#[tokio::test]
+async fn test_flush_reopen_region() {
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+    let region_dir = request.region_dir.clone();
+
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 3, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    flush_region(&engine, region_id).await;
+    let check_region = || {
+        let region = engine.get_region(region_id).unwrap();
+        let version_data = region.version_control.current();
+        assert_eq!(3, version_data.committed_sequence);
+        assert_eq!(1, version_data.last_entry_id);
+        assert_eq!(1, version_data.version.flushed_entry_id);
+    };
+    check_region();
+
+    reopen_region(&engine, region_id, region_dir).await;
+    check_region();
 }

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -250,9 +250,22 @@ async fn test_flush_reopen_region() {
         assert_eq!(1, version_data.last_entry_id);
         assert_eq!(3, version_data.committed_sequence);
         assert_eq!(1, version_data.version.flushed_entry_id);
+        assert_eq!(1, version_data.version.flushed_entry_id);
+        assert_eq!(3, version_data.version.flushed_sequence);
     };
     check_region();
 
     reopen_region(&engine, region_id, region_dir).await;
     check_region();
+
+    // Puts again.
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 2, 10),
+    };
+    put_rows(&engine, region_id, rows).await;
+    let region = engine.get_region(region_id).unwrap();
+    let version_data = region.version_control.current();
+    assert_eq!(2, version_data.last_entry_id);
+    assert_eq!(5, version_data.committed_sequence);
 }

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -17,11 +17,11 @@ use std::collections::HashMap;
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use store_api::region_engine::RegionEngine;
-use store_api::region_request::{RegionCloseRequest, RegionOpenRequest, RegionRequest};
+use store_api::region_request::{RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
-use crate::test_util::{CreateRequestBuilder, TestEnv};
+use crate::test_util::{reopen_region, CreateRequestBuilder, TestEnv};
 
 #[tokio::test]
 async fn test_engine_open_empty() {
@@ -84,23 +84,6 @@ async fn test_engine_reopen_region() {
         .await
         .unwrap();
 
-    // Close the region.
-    engine
-        .handle_request(region_id, RegionRequest::Close(RegionCloseRequest {}))
-        .await
-        .unwrap();
-
-    // Open the region again.
-    engine
-        .handle_request(
-            region_id,
-            RegionRequest::Open(RegionOpenRequest {
-                engine: String::new(),
-                region_dir,
-                options: HashMap::default(),
-            }),
-        )
-        .await
-        .unwrap();
+    reopen_region(&engine, region_id, region_dir).await;
     assert!(engine.is_region_exists(region_id));
 }

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -58,6 +58,7 @@ fn nop_action() -> RegionMetaActionList {
         files_to_remove: vec![],
         compaction_time_window: None,
         flushed_entry_id: None,
+        flushed_sequence: None,
     })])
 }
 
@@ -149,7 +150,7 @@ async fn manager_with_checkpoint_distance_1() {
         .await
         .unwrap();
     let raw_json = std::str::from_utf8(&raw_bytes).unwrap();
-    let expected_json = "{\"size\":769,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
+    let expected_json = "{\"size\":790,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
     assert_eq!(expected_json, raw_json);
 
     // reopen the manager
@@ -176,6 +177,7 @@ async fn checkpoint_with_different_compression_types() {
             files_to_remove: vec![],
             compaction_time_window: None,
             flushed_entry_id: None,
+            flushed_sequence: None,
         })]);
         actions.push(action);
     }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -152,6 +152,7 @@ impl RegionOpener {
         let version = VersionBuilder::new(metadata, mutable)
             .add_files(file_purger.clone(), manifest.files.values().cloned())
             .flushed_entry_id(manifest.flushed_entry_id)
+            .flushed_sequence(manifest.flushed_sequence)
             .build();
         let flushed_entry_id = version.flushed_entry_id;
         let version_control = Arc::new(VersionControl::new(version));

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -177,7 +177,9 @@ async fn replay_memtable<S: LogStore>(
     version_control: &VersionControlRef,
 ) -> Result<()> {
     let mut rows_replayed = 0;
-    let mut last_entry_id = EntryId::MIN;
+    // Last entry id should start from flushed entry id since there might be no
+    // data in the WAL.
+    let mut last_entry_id = flushed_entry_id;
     let mut region_write_ctx = RegionWriteCtx::new(region_id, version_control);
     let mut wal_stream = wal.scan(region_id, flushed_entry_id)?;
     while let Some(res) = wal_stream.next().await {

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -145,8 +145,12 @@ pub(crate) struct VersionControlData {
     /// Latest version.
     pub(crate) version: VersionRef,
     /// Sequence number of last committed data.
+    ///
+    /// Starts from 1 (zero means no data).
     pub(crate) committed_sequence: SequenceNumber,
     /// Last WAL entry Id.
+    ///
+    /// Starts from 1 (zero means no data).
     pub(crate) last_entry_id: EntryId,
     /// Marker of whether this region is dropped/dropping
     pub(crate) is_dropped: bool,

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -37,7 +37,7 @@ use store_api::region_request::{
     RegionAlterRequest, RegionCloseRequest, RegionCompactRequest, RegionCreateRequest,
     RegionDropRequest, RegionFlushRequest, RegionOpenRequest, RegionRequest,
 };
-use store_api::storage::{CompactionStrategy, RegionId};
+use store_api::storage::{CompactionStrategy, RegionId, SequenceNumber};
 use tokio::sync::oneshot::{self, Receiver, Sender};
 
 use crate::config::DEFAULT_WRITE_BUFFER_SIZE;
@@ -525,6 +525,8 @@ pub(crate) struct FlushFinished {
     pub(crate) file_metas: Vec<FileMeta>,
     /// Entry id of flushed data.
     pub(crate) flushed_entry_id: EntryId,
+    /// Sequence of flushed data.
+    pub(crate) flushed_sequence: SequenceNumber,
     /// Id of memtables to remove.
     pub(crate) memtables_to_remove: SmallVec<[MemtableId; 2]>,
     /// Flush result senders.

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -35,7 +35,8 @@ use object_store::ObjectStore;
 use store_api::metadata::{ColumnMetadata, RegionMetadataRef};
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{
-    RegionCreateRequest, RegionDeleteRequest, RegionFlushRequest, RegionPutRequest, RegionRequest,
+    RegionCloseRequest, RegionCreateRequest, RegionDeleteRequest, RegionFlushRequest,
+    RegionOpenRequest, RegionPutRequest, RegionRequest,
 };
 use store_api::storage::RegionId;
 
@@ -565,4 +566,26 @@ pub async fn flush_region(engine: &MitoEngine, region_id: RegionId) {
         unreachable!()
     };
     assert_eq!(0, rows);
+}
+
+/// Reopen a region.
+pub async fn reopen_region(engine: &MitoEngine, region_id: RegionId, region_dir: String) {
+    // Close the region.
+    engine
+        .handle_request(region_id, RegionRequest::Close(RegionCloseRequest {}))
+        .await
+        .unwrap();
+
+    // Open the region again.
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Open(RegionOpenRequest {
+                engine: String::new(),
+                region_dir,
+                options: HashMap::default(),
+            }),
+        )
+        .await
+        .unwrap();
 }

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -65,6 +65,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             files_to_remove: std::mem::take(&mut request.compacted_files),
             compaction_time_window: None, // TODO(hl): update window maybe
             flushed_entry_id: None,
+            flushed_sequence: None,
         };
         let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
         if let Err(e) = region.manifest_manager.update(action_list).await {

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -47,6 +47,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             files_to_remove: Vec::new(),
             compaction_time_window: None,
             flushed_entry_id: Some(request.flushed_entry_id),
+            flushed_sequence: Some(request.flushed_sequence),
         };
         let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
         if let Err(e) = region.manifest_manager.update(action_list).await {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes the issue that the engine doesn't store and recover the flushed sequence:
- If we only store the flushed entry in the manifest, we can't recover the committed sequence if there is no data in the WAL
- It maintains a flushed sequence in the version and recovers it from the manifest
- It adds a test to check this

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 