### PR TITLE
chore: bump raft-engine to 22dfb4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7285,7 +7285,7 @@ dependencies = [
 [[package]]
 name = "raft-engine"
 version = "0.4.0"
-source = "git+https://github.com/tikv/raft-engine.git?rev=571462e36621407b9920465a1a15b8b01b929a7f#571462e36621407b9920465a1a15b8b01b929a7f"
+source = "git+https://github.com/tikv/raft-engine.git?rev=22dfb426cd994602b57725ef080287d3e53db479#22dfb426cd994602b57725ef080287d3e53db479"
 dependencies = [
  "byteorder",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,8 +153,7 @@ object-store = { path = "src/object-store" }
 partition = { path = "src/partition" }
 promql = { path = "src/promql" }
 query = { path = "src/query" }
-# TODO(weny): waits for https://github.com/tikv/raft-engine/pull/335
-raft-engine = { git = "https://github.com/tikv/raft-engine.git", rev = "571462e36621407b9920465a1a15b8b01b929a7f" }
+raft-engine = { git = "https://github.com/tikv/raft-engine.git", rev = "22dfb426cd994602b57725ef080287d3e53db479" }
 script = { path = "src/script" }
 servers = { path = "src/servers" }
 session = { path = "src/session" }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

bump raft-engine to 22dfb4

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
