### PR TITLE
feat: engine name in heartbeat

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -438,9 +438,7 @@ impl Datanode {
             Mode::Standalone => None,
         };
         let heartbeat_task = match opts.mode {
-            Mode::Distributed => {
-                Some(HeartbeatTask::try_new(&opts, Some(region_server.clone())).await?)
-            }
+            Mode::Distributed => Some(HeartbeatTask::try_new(&opts, region_server.clone()).await?),
             Mode::Standalone => None,
         };
         let greptimedb_telemetry_task = get_greptimedb_telemetry_task(

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -88,8 +88,12 @@ impl RegionServer {
         self.inner.handle_read(request).await
     }
 
-    pub fn opened_region_ids(&self) -> Vec<RegionId> {
-        self.inner.region_map.iter().map(|e| *e.key()).collect()
+    pub fn opened_regions(&self) -> Vec<(RegionId, String)> {
+        self.inner
+            .region_map
+            .iter()
+            .map(|e| (*e.key(), e.value().name().to_string()))
+            .collect()
     }
 
     pub fn runtime(&self) -> Arc<Runtime> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Puts the correct engine name in the heartbeat packet

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
