### PR TITLE
refactor: remove region id, rename types, remove table ident

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=1969b5d610209ad1c2ad8e4cd3e9c3c24e40f1c2#1969b5d610209ad1c2ad8e4cd3e9c3c24e40f1c2"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=81495b166b2c8909f05b3fcaa09eb299bb43a995#81495b166b2c8909f05b3fcaa09eb299bb43a995"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "1969b5d610209ad1c2ad8e4cd3e9c3c24e40f1c2" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "81495b166b2c8909f05b3fcaa09eb299bb43a995" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -105,7 +105,6 @@ async fn write_data(
         let (columns, row_count) = convert_record_batch(record_batch);
         let request = InsertRequest {
             table_name: TABLE_NAME.to_string(),
-            region_number: 0,
             columns,
             row_count,
         };
@@ -189,7 +188,7 @@ fn build_values(column: &ArrayRef) -> (Values, ColumnDataType) {
             let values = array.values();
             (
                 Values {
-                    ts_microsecond_values: values.to_vec(),
+                    timestamp_microsecond_values: values.to_vec(),
                     ..Default::default()
                 },
                 ColumnDataType::TimestampMicrosecond,
@@ -389,7 +388,6 @@ fn create_table_expr() -> CreateTableExpr {
         primary_keys: vec!["VendorID".to_string()],
         create_if_not_exists: false,
         table_options: Default::default(),
-        region_numbers: vec![0],
         table_id: None,
         engine: "mito".to_string(),
     }

--- a/src/catalog/src/system.rs
+++ b/src/catalog/src/system.rs
@@ -262,7 +262,6 @@ pub fn build_insert_request(entry_type: EntryType, key: &[u8], value: &[u8]) -> 
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name: SYSTEM_CATALOG_TABLE_NAME.to_string(),
         columns_values,
-        region_number: 0, // system catalog table has only one region
     }
 }
 

--- a/src/client/examples/logical.rs
+++ b/src/client/examples/logical.rs
@@ -66,7 +66,6 @@ async fn run() {
         create_if_not_exists: false,
         table_options: Default::default(),
         table_id: Some(TableId { id: 1024 }),
-        region_numbers: vec![0],
         engine: MITO_ENGINE.to_string(),
     };
 

--- a/src/client/examples/stream_ingest.rs
+++ b/src/client/examples/stream_ingest.rs
@@ -131,7 +131,7 @@ fn to_insert_request(records: Vec<WeatherRecord>) -> InsertRequest {
         Column {
             column_name: "ts".to_owned(),
             values: Some(column::Values {
-                ts_millisecond_values: timestamp_millis,
+                timestamp_millisecond_values: timestamp_millis,
                 ..Default::default()
             }),
             semantic_type: SemanticType::Timestamp as i32,
@@ -177,6 +177,5 @@ fn to_insert_request(records: Vec<WeatherRecord>) -> InsertRequest {
         table_name: "weather_demo".to_owned(),
         columns,
         row_count: rows as u32,
-        ..Default::default()
     }
 }

--- a/src/common/grpc-expr/src/alter.rs
+++ b/src/common/grpc-expr/src/alter.rs
@@ -18,18 +18,15 @@ use api::v1::{
     column_def, AddColumnLocation as Location, AlterExpr, CreateTableExpr, DropColumns,
     RenameTable, SemanticType,
 };
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_query::AddColumnLocation;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use snafu::{ensure, OptionExt, ResultExt};
 use table::metadata::TableId;
-use table::requests::{
-    AddColumnRequest, AlterKind, AlterTableRequest, CreateTableRequest, TableOptions,
-};
+use table::requests::{AddColumnRequest, AlterKind, AlterTableRequest};
 
 use crate::error::{
-    ColumnNotFoundSnafu, InvalidColumnDefSnafu, MissingFieldSnafu, MissingTimestampColumnSnafu,
-    Result, UnknownLocationTypeSnafu, UnrecognizedTableOptionSnafu,
+    InvalidColumnDefSnafu, MissingFieldSnafu, MissingTimestampColumnSnafu, Result,
+    UnknownLocationTypeSnafu,
 };
 
 const LOCATION_TYPE_FIRST: i32 = LocationType::First as i32;
@@ -119,65 +116,6 @@ pub fn create_table_schema(expr: &CreateTableExpr, require_time_index: bool) -> 
         .collect::<Vec<_>>();
 
     Ok(RawSchema::new(column_schemas))
-}
-
-pub fn create_expr_to_request(
-    table_id: TableId,
-    expr: CreateTableExpr,
-    require_time_index: bool,
-) -> Result<CreateTableRequest> {
-    let schema = create_table_schema(&expr, require_time_index)?;
-    let primary_key_indices = expr
-        .primary_keys
-        .iter()
-        .map(|key| {
-            // We do a linear search here.
-            schema
-                .column_schemas
-                .iter()
-                .position(|column_schema| column_schema.name == *key)
-                .context(ColumnNotFoundSnafu {
-                    column_name: key,
-                    table_name: &expr.table_name,
-                })
-        })
-        .collect::<Result<Vec<usize>>>()?;
-
-    let mut catalog_name = expr.catalog_name;
-    if catalog_name.is_empty() {
-        catalog_name = DEFAULT_CATALOG_NAME.to_string();
-    }
-    let mut schema_name = expr.schema_name;
-    if schema_name.is_empty() {
-        schema_name = DEFAULT_SCHEMA_NAME.to_string();
-    }
-    let desc = if expr.desc.is_empty() {
-        None
-    } else {
-        Some(expr.desc)
-    };
-
-    let region_numbers = if expr.region_numbers.is_empty() {
-        vec![0]
-    } else {
-        expr.region_numbers
-    };
-
-    let table_options =
-        TableOptions::try_from(&expr.table_options).context(UnrecognizedTableOptionSnafu)?;
-    Ok(CreateTableRequest {
-        id: table_id,
-        catalog_name,
-        schema_name,
-        table_name: expr.table_name,
-        desc,
-        schema,
-        region_numbers,
-        primary_key_indices,
-        create_if_not_exists: expr.create_if_not_exists,
-        table_options,
-        engine: expr.engine,
-    })
 }
 
 fn parse_location(location: Option<Location>) -> Result<Option<AddColumnLocation>> {

--- a/src/common/grpc-expr/src/delete.rs
+++ b/src/common/grpc-expr/src/delete.rs
@@ -79,7 +79,6 @@ mod tests {
     fn test_to_table_delete_request() {
         let grpc_request = GrpcDeleteRequest {
             table_name: "foo".to_string(),
-            region_number: 0,
             key_columns: vec![
                 Column {
                     column_name: "id".to_string(),

--- a/src/common/grpc-expr/src/error.rs
+++ b/src/common/grpc-expr/src/error.rs
@@ -55,6 +55,7 @@ pub enum Error {
 
     #[snafu(display("Invalid column proto: {}", err_msg))]
     InvalidColumnProto { err_msg: String, location: Location },
+
     #[snafu(display("Failed to create vector, source: {}", source))]
     CreateVector {
         location: Location,

--- a/src/common/grpc-expr/src/insert.rs
+++ b/src/common/grpc-expr/src/insert.rs
@@ -96,7 +96,6 @@ pub fn to_table_insert_request(
         schema_name: schema_name.to_string(),
         table_name: table_name.to_string(),
         columns_values,
-        region_number: request.region_number,
     })
 }
 
@@ -363,7 +362,6 @@ mod tests {
             table_name: "demo".to_string(),
             columns,
             row_count,
-            region_number: 0,
         };
         let insert_req = to_table_insert_request("greptime", "public", request).unwrap();
 
@@ -476,7 +474,7 @@ mod tests {
         };
 
         let ts_vals = Values {
-            ts_millisecond_values: vec![100, 101],
+            timestamp_millisecond_values: vec![100, 101],
             ..Default::default()
         };
         let ts_column = Column {

--- a/src/common/grpc-expr/src/lib.rs
+++ b/src/common/grpc-expr/src/lib.rs
@@ -18,5 +18,5 @@ pub mod error;
 pub mod insert;
 pub mod util;
 
-pub use alter::{alter_expr_to_request, create_expr_to_request, create_table_schema};
+pub use alter::{alter_expr_to_request, create_table_schema};
 pub use insert::{build_create_expr_from_insertion, find_new_columns};

--- a/src/common/grpc-expr/src/util.rs
+++ b/src/common/grpc-expr/src/util.rs
@@ -139,8 +139,6 @@ pub fn build_create_table_expr(
         create_if_not_exists: true,
         table_options: Default::default(),
         table_id: table_id.map(|id| api::v1::TableId { id }),
-        // TODO(hl): region number should be allocated by frontend
-        region_numbers: vec![0],
         engine: engine.to_string(),
     };
 

--- a/src/common/grpc/src/select.rs
+++ b/src/common/grpc/src/select.rs
@@ -150,25 +150,25 @@ pub fn values(arrays: &[VectorRef]) -> Result<Values> {
         (
             ConcreteDataType::Timestamp(TimestampType::Second(_)),
             TimestampSecondVector,
-            ts_second_values,
+            timestamp_second_values,
             |x| { x.into_native() }
         ),
         (
             ConcreteDataType::Timestamp(TimestampType::Millisecond(_)),
             TimestampMillisecondVector,
-            ts_millisecond_values,
+            timestamp_millisecond_values,
             |x| { x.into_native() }
         ),
         (
             ConcreteDataType::Timestamp(TimestampType::Microsecond(_)),
             TimestampMicrosecondVector,
-            ts_microsecond_values,
+            timestamp_microsecond_values,
             |x| { x.into_native() }
         ),
         (
             ConcreteDataType::Timestamp(TimestampType::Nanosecond(_)),
             TimestampNanosecondVector,
-            ts_nanosecond_values,
+            timestamp_nanosecond_values,
             |x| { x.into_native() }
         ),
         (

--- a/src/common/grpc/src/writer.rs
+++ b/src/common/grpc/src/writer.rs
@@ -62,7 +62,7 @@ impl LinesWriter {
         // It is safe to use unwrap here, because values has been initialized in mut_column()
         let values = column.values.as_mut().unwrap();
         values
-            .ts_millisecond_values
+            .timestamp_millisecond_values
             .push(to_ms_ts(value.1, value.0));
         self.null_masks[idx].push(false);
         Ok(())
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(SemanticType::Timestamp as i32, column.semantic_type);
         assert_eq!(
             vec![101011000, 102011001, 103011002],
-            column.values.as_ref().unwrap().ts_millisecond_values
+            column.values.as_ref().unwrap().timestamp_millisecond_values
         );
         verify_null_mask(&column.null_mask, vec![false, false, false]);
 

--- a/src/common/meta/src/ident.rs
+++ b/src/common/meta/src/ident.rs
@@ -14,12 +14,8 @@
 
 use std::fmt::{Display, Formatter};
 
-use api::v1::meta::{TableIdent as RawTableIdent, TableName};
 use serde::{Deserialize, Serialize};
-use snafu::OptionExt;
 use table::engine::TableReference;
-
-use crate::error::{Error, InvalidProtoMsgSnafu};
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TableIdent {
@@ -43,36 +39,5 @@ impl Display for TableIdent {
             "Table(id={}, name='{}.{}.{}', engine='{}')",
             self.table_id, self.catalog, self.schema, self.table, self.engine,
         )
-    }
-}
-
-impl TryFrom<RawTableIdent> for TableIdent {
-    type Error = Error;
-
-    fn try_from(value: RawTableIdent) -> Result<Self, Self::Error> {
-        let table_name = value.table_name.context(InvalidProtoMsgSnafu {
-            err_msg: "'table_name' is missing in TableIdent",
-        })?;
-        Ok(Self {
-            catalog: table_name.catalog_name,
-            schema: table_name.schema_name,
-            table: table_name.table_name,
-            table_id: value.table_id,
-            engine: value.engine,
-        })
-    }
-}
-
-impl From<TableIdent> for RawTableIdent {
-    fn from(table_ident: TableIdent) -> Self {
-        Self {
-            table_id: table_ident.table_id,
-            engine: table_ident.engine,
-            table_name: Some(TableName {
-                catalog_name: table_ident.catalog,
-                schema_name: table_ident.schema,
-                table_name: table_ident.table,
-            }),
-        }
     }
 }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -164,6 +164,9 @@ pub enum Error {
         source: table::error::Error,
     },
 
+    #[snafu(display("Missing request header"))]
+    MissingRequestHeader { location: Location },
+
     #[snafu(display("Table not found: {}", table_name))]
     TableNotFound {
         table_name: String,
@@ -628,7 +631,8 @@ impl ErrorExt for Error {
             | MissingWalDirConfig { .. }
             | PrepareImmutableTable { .. }
             | InvalidInsertRowLen { .. }
-            | ColumnDataType { .. } => StatusCode::InvalidArguments,
+            | ColumnDataType { .. }
+            | MissingRequestHeader { .. } => StatusCode::InvalidArguments,
 
             EncodeJson { .. } | DecodeJson { .. } | PayloadNotExist { .. } | Unexpected { .. } => {
                 StatusCode::Unexpected

--- a/src/datanode/src/instance/grpc.rs
+++ b/src/datanode/src/instance/grpc.rs
@@ -864,7 +864,7 @@ mod test {
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672384140000, 1672384141000, 1672384142000],
+                        timestamp_millisecond_values: vec![1672384140000, 1672384141000, 1672384142000],
                         ..Default::default()
                     }),
                     semantic_type: SemanticType::Timestamp as i32,
@@ -937,7 +937,7 @@ mod test {
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672201026000],
+                        timestamp_millisecond_values: vec![1672201026000],
                         ..Default::default()
                     }),
                     datatype: ColumnDataType::TimestampMillisecond as i32,
@@ -962,7 +962,7 @@ mod test {
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672201026000],
+                        timestamp_millisecond_values: vec![1672201026000],
                         ..Default::default()
                     }),
                     datatype: ColumnDataType::TimestampMillisecond as i32,

--- a/src/frontend/src/expr_factory.rs
+++ b/src/frontend/src/expr_factory.rs
@@ -119,7 +119,6 @@ pub(crate) async fn create_external_expr(
         create_if_not_exists: create.if_not_exists,
         table_options: options,
         table_id: None,
-        region_numbers: vec![],
         engine: create.engine.to_string(),
     };
     Ok(expr)
@@ -151,7 +150,6 @@ pub fn create_to_expr(create: &CreateTable, query_ctx: QueryContextRef) -> Resul
         create_if_not_exists: create.if_not_exists,
         table_options,
         table_id: None,
-        region_numbers: vec![],
         engine: create.engine.to_string(),
     };
     Ok(expr)

--- a/src/frontend/src/req_convert/common.rs
+++ b/src/frontend/src/req_convert/common.rs
@@ -114,18 +114,26 @@ fn push_column_to_rows(column: Column, rows: &mut [Row]) -> Result<()> {
         (String, StringValue, string_values),
         (Date, DateValue, date_values),
         (Datetime, DatetimeValue, datetime_values),
-        (TimestampSecond, TsSecondValue, ts_second_values),
+        (
+            TimestampSecond,
+            TimestampSecondValue,
+            timestamp_second_values
+        ),
         (
             TimestampMillisecond,
-            TsMillisecondValue,
-            ts_millisecond_values
+            TimestampMillisecondValue,
+            timestamp_millisecond_values
         ),
         (
             TimestampMicrosecond,
-            TsMicrosecondValue,
-            ts_microsecond_values
+            TimestampMicrosecondValue,
+            timestamp_microsecond_values
         ),
-        (TimestampNanosecond, TsNanosecondValue, ts_nanosecond_values),
+        (
+            TimestampNanosecond,
+            TimestampNanosecondValue,
+            timestamp_nanosecond_values
+        ),
         (TimeSecond, TimeSecondValue, time_second_values),
         (
             TimeMillisecond,

--- a/src/frontend/src/req_convert/delete/column_to_row.rs
+++ b/src/frontend/src/req_convert/delete/column_to_row.rs
@@ -35,6 +35,5 @@ fn request_column_to_row(request: DeleteRequest) -> Result<RowDeleteRequest> {
     Ok(RowDeleteRequest {
         table_name: request.table_name,
         rows: Some(rows),
-        region_number: 0, // FIXME(zhongzc): deprecated field
     })
 }

--- a/src/frontend/src/req_convert/insert/column_to_row.rs
+++ b/src/frontend/src/req_convert/insert/column_to_row.rs
@@ -35,6 +35,5 @@ fn request_column_to_row(request: InsertRequest) -> Result<RowInsertRequest> {
     Ok(RowInsertRequest {
         table_name: request.table_name,
         rows: Some(rows),
-        region_number: 0, // FIXME(zhongzc): deprecated field
     })
 }

--- a/src/frontend/src/req_convert/insert/table_to_region.rs
+++ b/src/frontend/src/req_convert/insert/table_to_region.rs
@@ -145,7 +145,6 @@ mod tests {
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: "table_1".to_string(),
             columns_values: HashMap::from([("a".to_string(), vector)]),
-            region_number: 0,
         }
     }
 

--- a/src/frontend/src/script.rs
+++ b/src/frontend/src/script.rs
@@ -190,7 +190,6 @@ mod python {
                 create_if_not_exists: request.create_if_not_exists,
                 table_options: (&request.table_options).into(),
                 table_id: None, // Should and will be assigned by Meta.
-                region_numbers: vec![0],
                 engine: request.engine,
             })
         }

--- a/src/frontend/src/statement/copy_table_from.rs
+++ b/src/frontend/src/statement/copy_table_from.rs
@@ -333,7 +333,6 @@ impl StatementExecutor {
                         schema_name: req.schema_name.to_string(),
                         table_name: req.table_name.to_string(),
                         columns_values,
-                        region_number: 0,
                     },
                     query_ctx.clone(),
                 ));

--- a/src/frontend/src/statement/dml.rs
+++ b/src/frontend/src/statement/dml.rs
@@ -182,7 +182,6 @@ fn build_insert_request(
         schema_name: table_info.schema_name.clone(),
         table_name: table_info.name.clone(),
         columns_values,
-        region_number: 0,
     })
 }
 

--- a/src/frontend/src/table.rs
+++ b/src/frontend/src/table.rs
@@ -509,7 +509,6 @@ pub(crate) mod test {
             schema_name: "public".to_string(),
             table_name: "numbers".to_string(),
             columns_values: Default::default(),
-            region_number: 0,
         };
         meter_insert_request!(req);
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -80,7 +80,6 @@ fn create_table_task() -> CreateTableTask {
         create_if_not_exists: false,
         table_options: HashMap::new(),
         table_id: None,
-        region_numbers: vec![1, 2, 3],
         engine: MITO2_ENGINE.to_string(),
     };
 

--- a/src/mito/src/table.rs
+++ b/src/mito/src/table.rs
@@ -92,14 +92,14 @@ impl<R: Region> Table for MitoTable<R> {
         }
         let regions = self.regions.load();
         let region = regions
-            .get(&request.region_number)
+            .get(&0)
             .with_context(|| RegionNotFoundSnafu {
                 table: common_catalog::format_full_table_name(
                     &request.catalog_name,
                     &request.schema_name,
                     &request.table_name,
                 ),
-                region: request.region_number,
+                region: 0u32,
             })
             .map_err(BoxedError::new)
             .context(table_error::TableOperationSnafu)?;

--- a/src/mito/src/table/test_util.rs
+++ b/src/mito/src/table/test_util.rs
@@ -52,7 +52,6 @@ pub fn new_insert_request(
         schema_name: DEFAULT_SCHEMA_NAME.to_string(),
         table_name,
         columns_values,
-        region_number: 0,
     }
 }
 

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -147,7 +147,7 @@ fn build_rows_for_tags(
                     value_data: Some(ValueData::F64Value((value_start + idx) as f64)),
                 },
                 api::v1::Value {
-                    value_data: Some(ValueData::TsMillisecondValue(ts as i64 * 1000)),
+                    value_data: Some(ValueData::TimestampMillisecondValue(ts as i64 * 1000)),
                 },
                 api::v1::Value {
                     value_data: Some(ValueData::StringValue(tag1.to_string())),

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -795,7 +795,7 @@ mod tests {
                         value_data: Some(ValueData::I64Value(k1)),
                     },
                     api::v1::Value {
-                        value_data: Some(ValueData::TsMillisecondValue(i as i64)),
+                        value_data: Some(ValueData::TimestampMillisecondValue(i as i64)),
                     },
                     api::v1::Value {
                         value_data: Some(ValueData::I64Value(i as i64)),

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -305,7 +305,7 @@ pub(crate) fn i64_value(data: i64) -> v1::Value {
 #[cfg(test)]
 pub(crate) fn ts_ms_value(data: i64) -> v1::Value {
     v1::Value {
-        value_data: Some(ValueData::TsMillisecondValue(data)),
+        value_data: Some(ValueData::TimestampMillisecondValue(data)),
     }
 }
 
@@ -465,7 +465,7 @@ pub fn build_rows(start: usize, end: usize) -> Vec<Row> {
                     value_data: Some(ValueData::F64Value(i as f64)),
                 },
                 api::v1::Value {
-                    value_data: Some(ValueData::TsMillisecondValue(i as i64 * 1000)),
+                    value_data: Some(ValueData::TimestampMillisecondValue(i as i64 * 1000)),
                 },
             ],
         })
@@ -517,7 +517,7 @@ pub fn build_rows_for_key(key: &str, start: usize, end: usize, value_start: usiz
                     value_data: Some(ValueData::F64Value((value_start + idx) as f64)),
                 },
                 api::v1::Value {
-                    value_data: Some(ValueData::TsMillisecondValue(ts as i64 * 1000)),
+                    value_data: Some(ValueData::TimestampMillisecondValue(ts as i64 * 1000)),
                 },
             ],
         })
@@ -533,7 +533,7 @@ pub fn build_delete_rows_for_key(key: &str, start: usize, end: usize) -> Vec<Row
                     value_data: Some(ValueData::StringValue(key.to_string())),
                 },
                 api::v1::Value {
-                    value_data: Some(ValueData::TsMillisecondValue(ts as i64 * 1000)),
+                    value_data: Some(ValueData::TimestampMillisecondValue(ts as i64 * 1000)),
                 },
             ],
         })

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -203,7 +203,7 @@ mod tests {
                         value_data: Some(value::ValueData::StringValue(str_col.to_string())),
                     },
                     Value {
-                        value_data: Some(value::ValueData::TsMillisecondValue(*int_col)),
+                        value_data: Some(value::ValueData::TimestampMillisecondValue(*int_col)),
                     },
                 ];
                 Row { values }

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -191,7 +191,6 @@ impl DatafusionQueryEngine {
             schema_name: table_name.schema.to_string(),
             table_name: table_name.table.to_string(),
             columns_values: column_vectors,
-            region_number: 0,
         };
 
         table

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -36,7 +36,7 @@ use datafusion_expr::{Extension, LogicalPlan, UserDefinedLogicalNodeCore};
 use datafusion_physical_expr::PhysicalSortExpr;
 use datatypes::schema::{Schema, SchemaRef};
 use futures_util::StreamExt;
-use greptime_proto::v1::region::QueryRequest;
+use greptime_proto::v1::region::{QueryRequest, RegionRequestHeader};
 use snafu::ResultExt;
 use store_api::storage::RegionId;
 
@@ -161,7 +161,12 @@ impl MergeScanExec {
             let mut first_consume_timer = Some(metric.first_consume_time().timer());
 
             for region_id in regions {
+                let header = RegionRequestHeader {
+                    trace_id: common_telemetry::trace_id().unwrap_or_default(),
+                    span_id: 0,
+                };
                 let request = QueryRequest {
+                    header: Some(header),
                     region_id: region_id.into(),
                     plan: substrait_plan.clone(),
                 };

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -207,7 +207,6 @@ impl ScriptsTable {
                 schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                 table_name: SCRIPTS_TABLE_NAME.to_string(),
                 columns_values,
-                region_number: 0,
             })
             .await
             .context(InsertScriptSnafu { name })?;

--- a/src/servers/src/influxdb.rs
+++ b/src/servers/src/influxdb.rs
@@ -125,7 +125,6 @@ impl TryFrom<InfluxdbRequest> for InsertRequests {
                 let (columns, row_count) = writer.finish();
                 GrpcInsertRequest {
                     table_name,
-                    region_number: 0,
                     columns,
                     row_count,
                 }
@@ -284,7 +283,7 @@ monitor2,host=host4 cpu=66.3,memory=1029 1663840496400340003";
             SemanticType::Timestamp,
             Vec::new(),
             Values {
-                ts_millisecond_values: vec![1663840496100, 1663840496400],
+                timestamp_millisecond_values: vec![1663840496100, 1663840496400],
                 ..Default::default()
             },
         );
@@ -323,7 +322,7 @@ monitor2,host=host4 cpu=66.3,memory=1029 1663840496400340003";
             SemanticType::Timestamp,
             Vec::new(),
             Values {
-                ts_millisecond_values: vec![1663840496100, 1663840496400],
+                timestamp_millisecond_values: vec![1663840496100, 1663840496400],
                 ..Default::default()
             },
         );
@@ -553,7 +552,7 @@ monitor2,host=host4 cpu=66.3,memory=1029 1663840496400340003";
 
     fn extract_ts_millis_value(value: &ValueData) -> i64 {
         match value {
-            ValueData::TsMillisecondValue(v) => *v,
+            ValueData::TimestampMillisecondValue(v) => *v,
             _ => panic!(),
         }
     }

--- a/src/servers/src/line_writer.rs
+++ b/src/servers/src/line_writer.rs
@@ -141,7 +141,6 @@ impl LineWriter {
             schema_name: self.db,
             table_name: self.table_name,
             columns_values,
-            region_number: 0, // TODO(hl): Check if assign 0 region is ok?
         }
     }
 }

--- a/src/servers/src/opentsdb/codec.rs
+++ b/src/servers/src/opentsdb/codec.rs
@@ -129,7 +129,7 @@ impl DataPoint {
         let ts_column = Column {
             column_name: OPENTSDB_TIMESTAMP_COLUMN_NAME.to_string(),
             values: Some(column::Values {
-                ts_millisecond_values: vec![self.ts_millis],
+                timestamp_millisecond_values: vec![self.ts_millis],
                 ..Default::default()
             }),
             semantic_type: SemanticType::Timestamp as i32,
@@ -165,7 +165,6 @@ impl DataPoint {
 
         GrpcInsertRequest {
             table_name: self.metric.clone(),
-            region_number: 0,
             columns,
             row_count: 1,
         }
@@ -268,7 +267,11 @@ mod test {
 
         assert_eq!(columns[0].column_name, OPENTSDB_TIMESTAMP_COLUMN_NAME);
         assert_eq!(
-            columns[0].values.as_ref().unwrap().ts_millisecond_values,
+            columns[0]
+                .values
+                .as_ref()
+                .unwrap()
+                .timestamp_millisecond_values,
             vec![1000]
         );
 

--- a/src/servers/src/otlp.rs
+++ b/src/servers/src/otlp.rs
@@ -176,7 +176,6 @@ fn encode_gauge(
     let (columns, row_count) = lines.finish();
     Ok(InsertRequest {
         table_name: normalize_otlp_name(name),
-        region_number: 0,
         columns,
         row_count,
     })
@@ -208,7 +207,6 @@ fn encode_sum(
     let (columns, row_count) = lines.finish();
     Ok(InsertRequest {
         table_name: normalize_otlp_name(name),
-        region_number: 0,
         columns,
         row_count,
     })
@@ -251,7 +249,6 @@ fn encode_histogram(name: &str, hist: &Histogram) -> Result<InsertRequest> {
     let (columns, row_count) = lines.finish();
     Ok(InsertRequest {
         table_name: normalize_otlp_name(name),
-        region_number: 0,
         columns,
         row_count,
     })
@@ -310,7 +307,6 @@ fn encode_exponential_histogram(name: &str, hist: &ExponentialHistogram) -> Resu
     let (columns, row_count) = lines.finish();
     Ok(InsertRequest {
         table_name: normalize_otlp_name(name),
-        region_number: 0,
         columns,
         row_count,
     })
@@ -351,7 +347,6 @@ fn encode_summary(
     let (columns, row_count) = lines.finish();
     Ok(InsertRequest {
         table_name: normalize_otlp_name(name),
-        region_number: 0,
         columns,
         row_count,
     })

--- a/src/servers/src/prom_store.rs
+++ b/src/servers/src/prom_store.rs
@@ -412,7 +412,6 @@ pub fn to_grpc_insert_requests(request: WriteRequest) -> Result<(InsertRequests,
             sample_counts += row_count as usize;
             GrpcInsertRequest {
                 table_name,
-                region_number: 0,
                 columns,
                 row_count,
             }
@@ -655,7 +654,9 @@ mod tests {
                     value_data: Some(api::v1::value::ValueData::F64Value(value)),
                 },
                 api::v1::Value {
-                    value_data: Some(api::v1::value::ValueData::TsMillisecondValue(timestamp)),
+                    value_data: Some(api::v1::value::ValueData::TimestampMillisecondValue(
+                        timestamp,
+                    )),
                 },
             ],
         }
@@ -674,7 +675,9 @@ mod tests {
                     value_data: Some(api::v1::value::ValueData::F64Value(value)),
                 },
                 api::v1::Value {
-                    value_data: Some(api::v1::value::ValueData::TsMillisecondValue(timestamp)),
+                    value_data: Some(api::v1::value::ValueData::TimestampMillisecondValue(
+                        timestamp,
+                    )),
                 },
             ],
         }
@@ -782,7 +785,11 @@ mod tests {
 
         assert_eq!(columns[0].column_name, TIMESTAMP_COLUMN_NAME);
         assert_eq!(
-            columns[0].values.as_ref().unwrap().ts_millisecond_values,
+            columns[0]
+                .values
+                .as_ref()
+                .unwrap()
+                .timestamp_millisecond_values,
             vec![1000, 2000]
         );
 
@@ -810,7 +817,11 @@ mod tests {
 
         assert_eq!(columns[0].column_name, TIMESTAMP_COLUMN_NAME);
         assert_eq!(
-            columns[0].values.as_ref().unwrap().ts_millisecond_values,
+            columns[0]
+                .values
+                .as_ref()
+                .unwrap()
+                .timestamp_millisecond_values,
             vec![1000, 2000]
         );
 
@@ -848,7 +859,11 @@ mod tests {
         );
         assert_eq!(columns[1].column_name, TIMESTAMP_COLUMN_NAME);
         assert_eq!(
-            columns[1].values.as_ref().unwrap().ts_millisecond_values,
+            columns[1]
+                .values
+                .as_ref()
+                .unwrap()
+                .timestamp_millisecond_values,
             vec![1000, 2000, 3000]
         );
 

--- a/src/servers/src/row_writer.rs
+++ b/src/servers/src/row_writer.rs
@@ -108,7 +108,6 @@ impl<'a> MultiTableData<'a> {
                 RowInsertRequest {
                     table_name: table_name.to_string(),
                     rows: Some(Rows { schema, rows }),
-                    ..Default::default()
                 }
             })
             .collect::<Vec<_>>();
@@ -227,14 +226,14 @@ pub fn write_ts_precision<'a>(
             datatype: ColumnDataType::TimestampMillisecond as i32,
             semantic_type: SemanticType::Timestamp as i32,
         });
-        one_row.push(ValueData::TsMillisecondValue(ts).into())
+        one_row.push(ValueData::TimestampMillisecondValue(ts).into())
     } else {
         check_schema(
             ColumnDataType::TimestampMillisecond,
             SemanticType::Timestamp,
             &schema[*index],
         )?;
-        one_row[*index].value_data = Some(ValueData::TsMillisecondValue(ts));
+        one_row[*index].value_data = Some(ValueData::TimestampMillisecondValue(ts));
     }
 
     Ok(())

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -54,7 +54,7 @@ impl GrpcQueryInterceptor for NoopInterceptor {
         match req {
             Request::Inserts(insert) => {
                 ensure!(
-                    insert.inserts.iter().all(|x| x.region_number == 0),
+                    insert.inserts.iter().all(|x| !x.table_name.is_empty()),
                     NotSupportedSnafu {
                         feat: "region not 0"
                     }
@@ -75,7 +75,6 @@ fn test_grpc_interceptor() {
 
     let req = Request::Inserts(InsertRequests {
         inserts: vec![InsertRequest {
-            region_number: 1,
             ..Default::default()
         }],
     });

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -62,6 +62,12 @@ impl QueryContext {
             .build()
     }
 
+    pub fn with_trace_id(trace_id: u64) -> QueryContextRef {
+        QueryContextBuilder::default()
+            .try_trace_id(Some(trace_id))
+            .build()
+    }
+
     pub fn with_db_name(db_name: Option<&String>) -> QueryContextRef {
         let (catalog, schema) = db_name
             .map(|db| {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -246,7 +246,6 @@ pub struct InsertRequest {
     pub schema_name: String,
     pub table_name: String,
     pub columns_values: HashMap<String, VectorRef>,
-    pub region_number: RegionNumber,
 }
 
 /// Delete (by primary key) request
@@ -327,7 +326,6 @@ macro_rules! meter_insert_request {
             $req.catalog_name.to_string(),
             $req.schema_name.to_string(),
             $req.table_name.to_string(),
-            $req.region_number,
             $req
         );
     };

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -301,7 +301,7 @@ CREATE TABLE {table_name} (
     }
 
     async fn test_insert_delete_and_query_on_existing_table(instance: &Instance, table_name: &str) {
-        let ts_millisecond_values = vec![
+        let timestamp_millisecond_values = vec![
             1672557972000,
             1672557973000,
             1672557974000,
@@ -335,7 +335,7 @@ CREATE TABLE {table_name} (
                 Column {
                     column_name: "b".to_string(),
                     values: Some(Values {
-                        string_values: ts_millisecond_values
+                        string_values: timestamp_millisecond_values
                             .iter()
                             .map(|x| format!("ts: {x}"))
                             .collect(),
@@ -348,7 +348,7 @@ CREATE TABLE {table_name} (
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values,
+                        timestamp_millisecond_values,
                         ..Default::default()
                     }),
                     semantic_type: SemanticType::Timestamp as i32,
@@ -429,7 +429,7 @@ CREATE TABLE {table_name} (
                     column_name: "ts".to_string(),
                     semantic_type: SemanticType::Timestamp as i32,
                     values: Some(Values {
-                        ts_millisecond_values: ts,
+                        timestamp_millisecond_values: ts,
                         ..Default::default()
                     }),
                     datatype: ColumnDataType::TimestampMillisecond as i32,
@@ -559,7 +559,7 @@ CREATE TABLE {table_name} (
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672557975000, 1672557976000, 1672557977000],
+                        timestamp_millisecond_values: vec![1672557975000, 1672557976000, 1672557977000],
                         ..Default::default()
                     }),
                     semantic_type: SemanticType::Timestamp as i32,
@@ -594,7 +594,7 @@ CREATE TABLE {table_name} (
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![1672557978000, 1672557979000, 1672557980000],
+                        timestamp_millisecond_values: vec![1672557978000, 1672557979000, 1672557980000],
                         ..Default::default()
                     }),
                     semantic_type: SemanticType::Timestamp as i32,
@@ -642,7 +642,7 @@ CREATE TABLE {table_name} (
             key_columns: vec![Column {
                 column_name: "ts".to_string(),
                 values: Some(Values {
-                    ts_millisecond_values: vec![1672557975000, 1672557979000],
+                    timestamp_millisecond_values: vec![1672557975000, 1672557979000],
                     ..Default::default()
                 }),
                 semantic_type: SemanticType::Timestamp as i32,
@@ -724,7 +724,7 @@ CREATE TABLE {table_name} (
                 Column {
                     column_name: "ts".to_string(),
                     values: Some(Values {
-                        ts_millisecond_values: vec![
+                        timestamp_millisecond_values: vec![
                             1672557972000,
                             1672557973000,
                             1672557974000,

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -218,7 +218,7 @@ fn expect_data() -> (Column, Column, Column, Column) {
     let expected_ts_col = Column {
         column_name: "ts".to_string(),
         values: Some(column::Values {
-            ts_millisecond_values: vec![100, 101, 102, 103],
+            timestamp_millisecond_values: vec![100, 101, 102, 103],
             ..Default::default()
         }),
         semantic_type: SemanticType::Timestamp as i32,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump greptime-proto to the latest commit https://github.com/GreptimeTeam/greptime-proto/commit/81495b166b2c8909f05b3fcaa09eb299bb43a995

Notable changes:
- remove region id / region number in Frontend services (Database)
- rename types, e.g., `ts_second` to `timestamp_second`
- remove table ident from proto


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
