### PR TITLE
fix: alter table procedure forgets to update next column id

### DIFF
--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -134,7 +134,7 @@ impl DdlManager {
         let context = self.create_context();
 
         let procedure =
-            AlterTableProcedure::new(cluster_id, alter_table_task, table_info_value, context);
+            AlterTableProcedure::new(cluster_id, alter_table_task, table_info_value, context)?;
 
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
 

--- a/src/frontend/src/statement/ddl.rs
+++ b/src/frontend/src/statement/ddl.rs
@@ -259,6 +259,12 @@ impl StatementExecutor {
         let engine = table.table_info().meta.engine.to_string();
         self.verify_alter(table_id, table.table_info(), expr.clone())?;
 
+        info!(
+            "Table info before alter is {:?}, expr: {:?}",
+            table.table_info(),
+            expr
+        );
+
         let req = SubmitDdlTaskRequest {
             task: DdlTask::new_alter_table(expr.clone()),
         };

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -295,7 +295,8 @@ fn test_create_alter_region_request() {
         alter_table_task,
         TableInfoValue::new(test_data::new_table_info()),
         test_data::new_ddl_context(Arc::new(DatanodeClients::default())),
-    );
+    )
+    .unwrap();
 
     let region_id = RegionId::new(42, 1);
     let alter_region_request = procedure.create_alter_region_request(region_id).unwrap();
@@ -358,7 +359,8 @@ async fn test_submit_alter_region_requests() {
         alter_table_task,
         TableInfoValue::new(table_info),
         context,
-    );
+    )
+    .unwrap();
 
     let expected_altered_regions = Arc::new(Mutex::new(HashSet::from([
         RegionId::new(42, 1),

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -186,12 +186,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(
-        "Invalid request to region {}, location: {}, reason: {}",
-        region_id,
-        location,
-        reason
-    ))]
+    #[snafu(display("Invalid request to region {}, reason: {}", region_id, reason))]
     InvalidRequest {
         region_id: RegionId,
         reason: String,

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -808,7 +808,7 @@ mod tests {
 
         let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
-        check_invalid_request(&err, "column ts is not null");
+        check_invalid_request(&err, "column ts is not null but input has null");
     }
 
     #[test]

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -213,7 +213,10 @@ impl WriteRequest {
                     !has_null || column.column_schema.is_nullable(),
                     InvalidRequestSnafu {
                         region_id,
-                        reason: format!("column {} is not null", column.column_schema.name),
+                        reason: format!(
+                            "column {} is not null but input has null",
+                            column.column_schema.name
+                        ),
                     }
                 );
             } else {

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Unsupported expr in default constraint: {} for column: {}",
+        "Unsupported expr in default constraint: {:?} for column: {}",
         expr,
         column_name
     ))]

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -255,8 +255,8 @@ impl RegionMetadata {
                 !id_names.contains_key(&col.column_id),
                 InvalidMetaSnafu {
                     reason: format!(
-                        "column {} and {} have the same column id",
-                        id_names[&col.column_id], col.column_schema.name
+                        "column {} and {} have the same column id {}",
+                        id_names[&col.column_id], col.column_schema.name, col.column_id,
                     ),
                 }
             );

--- a/tests/cases/standalone/common/alter/add_col.result
+++ b/tests/cases/standalone/common/alter/add_col.result
@@ -2,6 +2,15 @@ CREATE TABLE test(i INTEGER, j TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
+DESC TABLE test;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
++--------+----------------------+-----+------+---------+---------------+
+
 INSERT INTO test VALUES (1, 1), (2, 2);
 
 Affected Rows: 2
@@ -18,6 +27,65 @@ SELECT * FROM test;
 | 1 | 1970-01-01T00:00:00.001 |   |
 | 2 | 1970-01-01T00:00:00.002 |   |
 +---+-------------------------+---+
+
+DESC TABLE test;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| k      | Int32                |     | YES  |         | FIELD         |
++--------+----------------------+-----+------+---------+---------------+
+
+ALTER TABLE test ADD COLUMN host STRING PRIMARY KEY;
+
+Affected Rows: 0
+
+SELECT * FROM test;
+
++---+-------------------------+---+------+
+| i | j                       | k | host |
++---+-------------------------+---+------+
+| 1 | 1970-01-01T00:00:00.001 |   |      |
+| 2 | 1970-01-01T00:00:00.002 |   |      |
++---+-------------------------+---+------+
+
+DESC TABLE test;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| k      | Int32                |     | YES  |         | FIELD         |
+| host   | String               |     | YES  |         | FIELD         |
++--------+----------------------+-----+------+---------+---------------+
+
+ALTER TABLE test ADD COLUMN idc STRING default 'idc' PRIMARY KEY;
+
+Affected Rows: 0
+
+SELECT * FROM test;
+
++---+-------------------------+---+------+-----+
+| i | j                       | k | host | idc |
++---+-------------------------+---+------+-----+
+| 1 | 1970-01-01T00:00:00.001 |   |      | idc |
+| 2 | 1970-01-01T00:00:00.002 |   |      | idc |
++---+-------------------------+---+------+-----+
+
+DESC TABLE test;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| k      | Int32                |     | YES  |         | FIELD         |
+| host   | String               |     | YES  |         | FIELD         |
+| idc    | String               |     | YES  | idc     | FIELD         |
++--------+----------------------+-----+------+---------+---------------+
 
 DROP TABLE test;
 

--- a/tests/cases/standalone/common/alter/add_col.sql
+++ b/tests/cases/standalone/common/alter/add_col.sql
@@ -16,7 +16,7 @@ SELECT * FROM test;
 
 DESC TABLE test;
 
-ALTER TABLE test ADD COLUMN idc STRING default "idc" PRIMARY KEY;
+ALTER TABLE test ADD COLUMN idc STRING default 'idc' PRIMARY KEY;
 
 SELECT * FROM test;
 

--- a/tests/cases/standalone/common/alter/drop_col_not_null_next.result
+++ b/tests/cases/standalone/common/alter/drop_col_not_null_next.result
@@ -19,9 +19,10 @@ ALTER TABLE test DROP COLUMN j;
 
 Affected Rows: 0
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
 INSERT INTO test VALUES (3, NULL);
 
-Error: 1004(InvalidArguments), Column k is not null but input has null
+Error: 1004(InvalidArguments), Invalid request to region, reason: column k is not null but input has null
 
 INSERT INTO test VALUES (3, 13);
 

--- a/tests/cases/standalone/common/alter/drop_col_not_null_next.sql
+++ b/tests/cases/standalone/common/alter/drop_col_not_null_next.sql
@@ -6,6 +6,7 @@ SELECT * FROM test;
 
 ALTER TABLE test DROP COLUMN j;
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
 INSERT INTO test VALUES (3, NULL);
 
 INSERT INTO test VALUES (3, 13);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR stores the next column id in the `AlterTableProcedure` and updates `next_column_id` of the table meta.

It fixes the issue that the frontend always assigns the same column id to a new column.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #2367
