### PR TITLE
fix: querying temporary table

### DIFF
--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -175,14 +175,15 @@ impl TreeNodeVisitor for TableNameExtractor {
                         .downcast_ref::<DfTableProviderAdapter>()
                     {
                         if provider.table().table_type() == TableType::Base {
+                            common_telemetry::info!("[DEBUG] is base table");
                             let info = provider.table().table_info();
                             self.table_name = Some(TableName::new(
                                 info.catalog_name.clone(),
                                 info.schema_name.clone(),
                                 info.name.clone(),
                             ));
-                            return Ok(VisitRecursion::Stop);
                         }
+                        return Ok(VisitRecursion::Stop);
                     }
                 }
                 match &scan.table_name {

--- a/src/query/src/dist_plan/planner.rs
+++ b/src/query/src/dist_plan/planner.rs
@@ -175,7 +175,6 @@ impl TreeNodeVisitor for TableNameExtractor {
                         .downcast_ref::<DfTableProviderAdapter>()
                     {
                         if provider.table().table_type() == TableType::Base {
-                            common_telemetry::info!("[DEBUG] is base table");
                             let info = provider.table().table_info();
                             self.table_name = Some(TableName::new(
                                 info.catalog_name.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch fixes `information_schema` doesn't return anything.

It might also fix errors on `numbers` table.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2367