### PR TITLE
fix: update sqlness result for order_by

### DIFF
--- a/tests/cases/standalone/optimizer/order_by.result
+++ b/tests/cases/standalone/optimizer/order_by.result
@@ -3,7 +3,7 @@ explain select * from numbers;
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | plan_type     | plan                                                                                                                                                                                  |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | TableScan: numbers projection=[number]                                                                                                                                                |
+| logical_plan  | MergeScan [is_placeholder=false]                                                                                                                                                      |
 | physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                       |
 +---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -14,7 +14,7 @@ explain select * from numbers order by number desc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number DESC NULLS FIRST                                                                                                                                                   |
-|               |   TableScan: numbers projection=[number]                                                                                                                                                |
+|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
 | physical_plan | SortExec: expr=[number@0 DESC]                                                                                                                                                          |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -26,7 +26,7 @@ explain select * from numbers order by number asc;
 | plan_type     | plan                                                                                                                                                                                    |
 +---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Sort: numbers.number ASC NULLS LAST                                                                                                                                                     |
-|               |   TableScan: numbers projection=[number]                                                                                                                                                |
+|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
 | physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                                                                                                                                                |
 |               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
 |               |                                                                                                                                                                                         |
@@ -39,7 +39,7 @@ explain select * from numbers order by number desc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number DESC NULLS FIRST, fetch=10                                                                                                                                         |
-|               |     TableScan: numbers projection=[number]                                                                                                                                                |
+|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 DESC]                                                                                                                                                |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
@@ -53,7 +53,7 @@ explain select * from numbers order by number asc limit 10;
 +---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
 |               |   Sort: numbers.number ASC NULLS LAST, fetch=10                                                                                                                                           |
-|               |     TableScan: numbers projection=[number]                                                                                                                                                |
+|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
 | physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
 |               |   SortExec: fetch=10, expr=[number@0 ASC NULLS LAST]                                                                                                                                      |
 |               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


this order_by case works after https://github.com/GreptimeTeam/greptimedb/pull/2388.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2367