### PR TITLE
feat: type conversion between Values

### DIFF
--- a/src/common/time/src/date.rs
+++ b/src/common/time/src/date.rs
@@ -82,6 +82,10 @@ impl Date {
     pub fn to_chrono_date(&self) -> Option<NaiveDate> {
         NaiveDate::from_num_days_from_ce_opt(UNIX_EPOCH_FROM_CE + self.0)
     }
+
+    pub fn to_secs(&self) -> i64 {
+        self.0 as i64 * 24 * 3600
+    }
 }
 
 #[cfg(test)]

--- a/src/common/time/src/date.rs
+++ b/src/common/time/src/date.rs
@@ -84,7 +84,7 @@ impl Date {
     }
 
     pub fn to_secs(&self) -> i64 {
-        self.0 as i64 * 24 * 3600
+        (self.0 as i64) * 24 * 3600
     }
 }
 

--- a/src/common/time/src/date.rs
+++ b/src/common/time/src/date.rs
@@ -136,4 +136,14 @@ mod tests {
         let d: Date = 42.into();
         assert_eq!(42, d.val());
     }
+
+    #[test]
+    fn test_to_secs() {
+        let d = Date::from_str("1970-01-01").unwrap();
+        assert_eq!(d.to_secs(), 0);
+        let d = Date::from_str("1970-01-02").unwrap();
+        assert_eq!(d.to_secs(), 24 * 3600);
+        let d = Date::from_str("1970-01-03").unwrap();
+        assert_eq!(d.to_secs(), 2 * 24 * 3600);
+    }
 }

--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -50,6 +50,12 @@ impl From<DateTime> for serde_json::Value {
     }
 }
 
+impl From<NaiveDateTime> for DateTime {
+    fn from(value: NaiveDateTime) -> Self {
+        DateTime::from(value.timestamp_millis())
+    }
+}
+
 impl FromStr for DateTime {
     type Err = Error;
 

--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -52,7 +52,7 @@ impl From<DateTime> for serde_json::Value {
 
 impl From<NaiveDateTime> for DateTime {
     fn from(value: NaiveDateTime) -> Self {
-        DateTime::from(value.timestamp_millis())
+        DateTime::from(value.timestamp())
     }
 }
 
@@ -94,7 +94,7 @@ impl DateTime {
     }
 
     pub fn to_chrono_datetime(&self) -> Option<NaiveDateTime> {
-        NaiveDateTime::from_timestamp_millis(self.0)
+        NaiveDateTime::from_timestamp_opt(self.0, 0)
     }
 }
 

--- a/src/common/time/src/time.rs
+++ b/src/common/time/src/time.rs
@@ -77,6 +77,19 @@ impl Time {
         self.value
     }
 
+    /// Convert a time to given time unit.
+    /// Return `None` if conversion causes overflow.
+    pub fn convert_to(&self, unit: TimeUnit) -> Option<Time> {
+        if self.unit().factor() >= unit.factor() {
+            let mul = self.unit().factor() / unit.factor();
+            let value = self.value.checked_mul(mul as i64)?;
+            Some(Time::new(value, unit))
+        } else {
+            let mul = unit.factor() / self.unit().factor();
+            Some(Time::new(self.value.div_euclid(mul as i64), unit))
+        }
+    }
+
     /// Split a [Time] into seconds part and nanoseconds part.
     /// Notice the seconds part of split result is always rounded down to floor.
     fn split(&self) -> (i64, u32) {

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -20,7 +20,9 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use arrow::datatypes::TimeUnit as ArrowTimeUnit;
-use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone as ChronoTimeZone, Utc};
+use chrono::{
+    DateTime, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, TimeZone as ChronoTimeZone, Utc,
+};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 
@@ -250,10 +252,24 @@ impl Timestamp {
         NaiveDateTime::from_timestamp_opt(sec, nsec)
     }
 
+    /// Convert timestamp to chrono date.
+    pub fn to_chrono_date(&self) -> Option<NaiveDate> {
+        self.to_chrono_datetime().map(|ndt| ndt.date())
+    }
+
+    /// Convert timestamp to chrono time.
+    pub fn to_chrono_time(&self) -> Option<NaiveTime> {
+        self.to_chrono_datetime().map(|ndt| ndt.time())
+    }
+
     pub fn from_chrono_datetime(ndt: NaiveDateTime) -> Option<Self> {
         let sec = ndt.timestamp();
         let nsec = ndt.timestamp_subsec_nanos();
         Timestamp::from_splits(sec, nsec)
+    }
+
+    pub fn from_chrono_date(nd: NaiveDate) -> Option<Self> {
+        Timestamp::from_chrono_datetime(nd.and_time(NaiveTime::default()))
     }
 }
 

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -268,8 +268,8 @@ impl Timestamp {
         Timestamp::from_splits(sec, nsec)
     }
 
-    pub fn from_chrono_date(nd: NaiveDate) -> Option<Self> {
-        Timestamp::from_chrono_datetime(nd.and_time(NaiveTime::default()))
+    pub fn from_chrono_date(date: NaiveDate) -> Option<Self> {
+        Timestamp::from_chrono_datetime(date.and_time(NaiveTime::default()))
     }
 }
 

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -457,6 +457,8 @@ pub trait DataType: std::fmt::Debug + Send + Sync {
     /// use it as a timestamp.
     fn is_timestamp_compatible(&self) -> bool;
 
+    /// Casts the value to this DataType.
+    /// Return None if cast failed.
     fn cast(&self, from: Value) -> Option<Value>;
 }
 

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -459,7 +459,7 @@ pub trait DataType: std::fmt::Debug + Send + Sync {
 
     /// Casts the value to this DataType.
     /// Return None if cast failed.
-    fn cast(&self, from: Value) -> Option<Value>;
+    fn try_cast(&self, from: Value) -> Option<Value>;
 }
 
 pub type DataTypeRef = Arc<dyn DataType>;

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -456,6 +456,8 @@ pub trait DataType: std::fmt::Debug + Send + Sync {
     /// Returns true if the data type is compatible with timestamp type so we can
     /// use it as a timestamp.
     fn is_timestamp_compatible(&self) -> bool;
+
+    fn cast(&self, from: Value) -> Option<Value>;
 }
 
 pub type DataTypeRef = Arc<dyn DataType>;

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -120,6 +120,10 @@ impl ConcreteDataType {
         matches!(self, ConcreteDataType::Boolean(_))
     }
 
+    pub fn is_string(&self) -> bool {
+        matches!(self, ConcreteDataType::String(_))
+    }
+
     pub fn is_stringifiable(&self) -> bool {
         matches!(
             self,
@@ -156,6 +160,22 @@ impl ConcreteDataType {
                 | ConcreteDataType::UInt16(_)
                 | ConcreteDataType::UInt32(_)
                 | ConcreteDataType::UInt64(_)
+        )
+    }
+
+    pub fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            ConcreteDataType::Int8(_)
+                | ConcreteDataType::Int16(_)
+                | ConcreteDataType::Int32(_)
+                | ConcreteDataType::Int64(_)
+                | ConcreteDataType::UInt8(_)
+                | ConcreteDataType::UInt16(_)
+                | ConcreteDataType::UInt32(_)
+                | ConcreteDataType::UInt64(_)
+                | ConcreteDataType::Float32(_)
+                | ConcreteDataType::Float64(_)
         )
     }
 
@@ -457,7 +477,7 @@ pub trait DataType: std::fmt::Debug + Send + Sync {
     /// use it as a timestamp.
     fn is_timestamp_compatible(&self) -> bool;
 
-    /// Casts the value to this DataType.
+    /// Casts the value to specific DataType.
     /// Return None if cast failed.
     fn try_cast(&self, from: Value) -> Option<Value>;
 }

--- a/src/datatypes/src/types.rs
+++ b/src/datatypes/src/types.rs
@@ -14,6 +14,7 @@
 
 mod binary_type;
 mod boolean_type;
+pub mod cast;
 mod date_type;
 mod datetime_type;
 mod dictionary_type;
@@ -28,6 +29,7 @@ mod timestamp_type;
 
 pub use binary_type::BinaryType;
 pub use boolean_type::BooleanType;
+pub use cast::can_cast_type;
 pub use date_type::DateType;
 pub use datetime_type::DateTimeType;
 pub use dictionary_type::DictionaryType;

--- a/src/datatypes/src/types.rs
+++ b/src/datatypes/src/types.rs
@@ -29,7 +29,7 @@ mod timestamp_type;
 
 pub use binary_type::BinaryType;
 pub use boolean_type::BooleanType;
-pub use cast::can_cast_type;
+pub use cast::cast_with_opt;
 pub use date_type::DateType;
 pub use datetime_type::DateTimeType;
 pub use dictionary_type::DictionaryType;

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -57,4 +57,8 @@ impl DataType for BinaryType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, _: Value) -> Option<Value> {
+        unimplemented!()
+    }
 }

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -58,7 +58,7 @@ impl DataType for BinaryType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Binary(v) => Some(Value::Binary(v)),
             _ => None,

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -58,7 +58,10 @@ impl DataType for BinaryType {
         false
     }
 
-    fn cast(&self, _: Value) -> Option<Value> {
-        unimplemented!()
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Binary(v) => Some(Value::Binary(v)),
+            _ => None,
+        }
     }
 }

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -61,6 +61,7 @@ impl DataType for BinaryType {
     fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Binary(v) => Some(Value::Binary(v)),
+            Value::String(v) => Some(Value::Binary(Bytes::from(v.as_utf8().as_bytes()))),
             _ => None,
         }
     }

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -58,7 +58,7 @@ impl DataType for BooleanType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Boolean(v) => Some(Value::Boolean(v)),
             Value::UInt8(v) => numeric_to_bool(v),
@@ -110,7 +110,7 @@ mod tests {
     macro_rules! test_cast_to_bool {
         ($value: expr, $expected: expr) => {
             let val = $value;
-            let b = ConcreteDataType::boolean_datatype().cast(val).unwrap();
+            let b = ConcreteDataType::boolean_datatype().try_cast(val).unwrap();
             assert_eq!(b, Value::Boolean($expected));
         };
     }
@@ -118,7 +118,7 @@ mod tests {
     macro_rules! test_cast_from_bool {
         ($value: expr, $datatype: expr, $expected: expr) => {
             let val = Value::Boolean($value);
-            let b = $datatype.cast(val).unwrap();
+            let b = $datatype.try_cast(val).unwrap();
             assert_eq!(b, $expected);
         };
     }

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -71,6 +71,7 @@ impl DataType for BooleanType {
             Value::Int64(v) => numeric_to_bool(v),
             Value::Float32(v) => numeric_to_bool(v),
             Value::Float64(v) => numeric_to_bool(v),
+            Value::String(v) => v.as_utf8().parse::<bool>().ok().map(Value::Boolean),
             _ => None,
         }
     }

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -106,7 +106,7 @@ mod tests {
     use super::*;
     use crate::data_type::ConcreteDataType;
 
-    macro_rules! test_bool {
+    macro_rules! test_cast_to_bool {
         ($value: expr, $expected: expr) => {
             let val = $value;
             let b = ConcreteDataType::boolean_datatype().cast(val).unwrap();
@@ -114,32 +114,79 @@ mod tests {
         };
     }
 
-    #[test]
-    fn test_other_type_cast_to_bool() {
-        // false cases
-        test_bool!(Value::UInt8(0), false);
-        test_bool!(Value::UInt16(0), false);
-        test_bool!(Value::UInt32(0), false);
-        test_bool!(Value::UInt64(0), false);
-        test_bool!(Value::Int8(0), false);
-        test_bool!(Value::Int16(0), false);
-        test_bool!(Value::Int32(0), false);
-        test_bool!(Value::Int64(0), false);
-        test_bool!(Value::Float32(OrderedFloat(0.0)), false);
-        test_bool!(Value::Float64(OrderedFloat(0.0)), false);
-        // true cases
-        test_bool!(Value::UInt8(1), true);
-        test_bool!(Value::UInt16(1), true);
-        test_bool!(Value::UInt32(1), true);
-        test_bool!(Value::UInt64(1), true);
-        test_bool!(Value::Int8(1), true);
-        test_bool!(Value::Int16(1), true);
-        test_bool!(Value::Int32(1), true);
-        test_bool!(Value::Int64(1), true);
-        test_bool!(Value::Float32(OrderedFloat(1.0)), true);
-        test_bool!(Value::Float64(OrderedFloat(1.0)), true);
+    macro_rules! test_cast_from_bool {
+        ($value: expr, $datatype: expr, $expected: expr) => {
+            let val = Value::Boolean($value);
+            let b = $datatype.cast(val).unwrap();
+            assert_eq!(b, $expected);
+        };
     }
 
     #[test]
-    fn test_bool_cast_to_other_type() {}
+    fn test_other_type_cast_to_bool() {
+        // false cases
+        test_cast_to_bool!(Value::UInt8(0), false);
+        test_cast_to_bool!(Value::UInt16(0), false);
+        test_cast_to_bool!(Value::UInt32(0), false);
+        test_cast_to_bool!(Value::UInt64(0), false);
+        test_cast_to_bool!(Value::Int8(0), false);
+        test_cast_to_bool!(Value::Int16(0), false);
+        test_cast_to_bool!(Value::Int32(0), false);
+        test_cast_to_bool!(Value::Int64(0), false);
+        test_cast_to_bool!(Value::Float32(OrderedFloat(0.0)), false);
+        test_cast_to_bool!(Value::Float64(OrderedFloat(0.0)), false);
+        // true cases
+        test_cast_to_bool!(Value::UInt8(1), true);
+        test_cast_to_bool!(Value::UInt16(1), true);
+        test_cast_to_bool!(Value::UInt32(1), true);
+        test_cast_to_bool!(Value::UInt64(1), true);
+        test_cast_to_bool!(Value::Int8(1), true);
+        test_cast_to_bool!(Value::Int16(1), true);
+        test_cast_to_bool!(Value::Int32(1), true);
+        test_cast_to_bool!(Value::Int64(1), true);
+        test_cast_to_bool!(Value::Float32(OrderedFloat(1.0)), true);
+        test_cast_to_bool!(Value::Float64(OrderedFloat(1.0)), true);
+    }
+
+    #[test]
+    fn test_bool_cast_to_other_type() {
+        // false cases
+        test_cast_from_bool!(false, ConcreteDataType::uint8_datatype(), Value::UInt8(0));
+        test_cast_from_bool!(false, ConcreteDataType::uint16_datatype(), Value::UInt16(0));
+        test_cast_from_bool!(false, ConcreteDataType::uint32_datatype(), Value::UInt32(0));
+        test_cast_from_bool!(false, ConcreteDataType::uint64_datatype(), Value::UInt64(0));
+        test_cast_from_bool!(false, ConcreteDataType::int8_datatype(), Value::Int8(0));
+        test_cast_from_bool!(false, ConcreteDataType::int16_datatype(), Value::Int16(0));
+        test_cast_from_bool!(false, ConcreteDataType::int32_datatype(), Value::Int32(0));
+        test_cast_from_bool!(false, ConcreteDataType::int64_datatype(), Value::Int64(0));
+        test_cast_from_bool!(
+            false,
+            ConcreteDataType::float32_datatype(),
+            Value::Float32(OrderedFloat(0.0))
+        );
+        test_cast_from_bool!(
+            false,
+            ConcreteDataType::float64_datatype(),
+            Value::Float64(OrderedFloat(0.0))
+        );
+        // true cases
+        test_cast_from_bool!(true, ConcreteDataType::uint8_datatype(), Value::UInt8(1));
+        test_cast_from_bool!(true, ConcreteDataType::uint16_datatype(), Value::UInt16(1));
+        test_cast_from_bool!(true, ConcreteDataType::uint32_datatype(), Value::UInt32(1));
+        test_cast_from_bool!(true, ConcreteDataType::uint64_datatype(), Value::UInt64(1));
+        test_cast_from_bool!(true, ConcreteDataType::int8_datatype(), Value::Int8(1));
+        test_cast_from_bool!(true, ConcreteDataType::int16_datatype(), Value::Int16(1));
+        test_cast_from_bool!(true, ConcreteDataType::int32_datatype(), Value::Int32(1));
+        test_cast_from_bool!(true, ConcreteDataType::int64_datatype(), Value::Int64(1));
+        test_cast_from_bool!(
+            true,
+            ConcreteDataType::float32_datatype(),
+            Value::Float32(OrderedFloat(1.0))
+        );
+        test_cast_from_bool!(
+            true,
+            ConcreteDataType::float64_datatype(),
+            Value::Float64(OrderedFloat(1.0))
+        );
+    }
 }

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -69,12 +69,14 @@ impl DataType for BooleanType {
             Value::Int16(v) => numeric_to_bool(v),
             Value::Int32(v) => numeric_to_bool(v),
             Value::Int64(v) => numeric_to_bool(v),
+            Value::Float32(v) => numeric_to_bool(v),
+            Value::Float64(v) => numeric_to_bool(v),
             _ => None,
         }
     }
 }
 
-fn numeric_to_bool<T>(num: T) -> Option<Value>
+pub fn numeric_to_bool<T>(num: T) -> Option<Value>
 where
     T: Num + Default,
 {
@@ -85,13 +87,26 @@ where
     }
 }
 
+pub fn bool_to_numeric<T>(value: bool) -> Option<T>
+where
+    T: Num,
+{
+    if value {
+        Some(T::one())
+    } else {
+        Some(T::zero())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+
+    use ordered_float::OrderedFloat;
 
     use super::*;
     use crate::data_type::ConcreteDataType;
 
-    macro_rules! test_bool_conversion {
+    macro_rules! test_bool {
         ($value: expr, $expected: expr) => {
             let val = $value;
             let b = ConcreteDataType::boolean_datatype().cast(val).unwrap();
@@ -100,25 +115,31 @@ mod tests {
     }
 
     #[test]
-    fn test_bool_cast() {
+    fn test_other_type_cast_to_bool() {
         // false cases
-        test_bool_conversion!(Value::UInt8(0), false);
-        test_bool_conversion!(Value::UInt16(0), false);
-        test_bool_conversion!(Value::UInt32(0), false);
-        test_bool_conversion!(Value::UInt64(0), false);
-        test_bool_conversion!(Value::Int8(0), false);
-        test_bool_conversion!(Value::Int16(0), false);
-        test_bool_conversion!(Value::Int32(0), false);
-        test_bool_conversion!(Value::Int64(0), false);
-
+        test_bool!(Value::UInt8(0), false);
+        test_bool!(Value::UInt16(0), false);
+        test_bool!(Value::UInt32(0), false);
+        test_bool!(Value::UInt64(0), false);
+        test_bool!(Value::Int8(0), false);
+        test_bool!(Value::Int16(0), false);
+        test_bool!(Value::Int32(0), false);
+        test_bool!(Value::Int64(0), false);
+        test_bool!(Value::Float32(OrderedFloat(0.0)), false);
+        test_bool!(Value::Float64(OrderedFloat(0.0)), false);
         // true cases
-        test_bool_conversion!(Value::UInt8(1), true);
-        test_bool_conversion!(Value::UInt16(1), true);
-        test_bool_conversion!(Value::UInt32(1), true);
-        test_bool_conversion!(Value::UInt64(1), true);
-        test_bool_conversion!(Value::Int8(1), true);
-        test_bool_conversion!(Value::Int16(1), true);
-        test_bool_conversion!(Value::Int32(1), true);
-        test_bool_conversion!(Value::Int64(1), true);
+        test_bool!(Value::UInt8(1), true);
+        test_bool!(Value::UInt16(1), true);
+        test_bool!(Value::UInt32(1), true);
+        test_bool!(Value::UInt64(1), true);
+        test_bool!(Value::Int8(1), true);
+        test_bool!(Value::Int16(1), true);
+        test_bool!(Value::Int32(1), true);
+        test_bool!(Value::Int64(1), true);
+        test_bool!(Value::Float32(OrderedFloat(1.0)), true);
+        test_bool!(Value::Float64(OrderedFloat(1.0)), true);
     }
+
+    #[test]
+    fn test_bool_cast_to_other_type() {}
 }

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -138,15 +138,15 @@ mod tests {
         test_cast_to_bool!(Value::Float64(OrderedFloat(0.0)), false);
         // true cases
         test_cast_to_bool!(Value::UInt8(1), true);
-        test_cast_to_bool!(Value::UInt16(1), true);
-        test_cast_to_bool!(Value::UInt32(1), true);
-        test_cast_to_bool!(Value::UInt64(1), true);
-        test_cast_to_bool!(Value::Int8(1), true);
-        test_cast_to_bool!(Value::Int16(1), true);
-        test_cast_to_bool!(Value::Int32(1), true);
-        test_cast_to_bool!(Value::Int64(1), true);
+        test_cast_to_bool!(Value::UInt16(2), true);
+        test_cast_to_bool!(Value::UInt32(3), true);
+        test_cast_to_bool!(Value::UInt64(4), true);
+        test_cast_to_bool!(Value::Int8(5), true);
+        test_cast_to_bool!(Value::Int16(6), true);
+        test_cast_to_bool!(Value::Int32(7), true);
+        test_cast_to_bool!(Value::Int64(8), true);
         test_cast_to_bool!(Value::Float32(OrderedFloat(1.0)), true);
-        test_cast_to_bool!(Value::Float64(OrderedFloat(1.0)), true);
+        test_cast_to_bool!(Value::Float64(OrderedFloat(2.0)), true);
     }
 
     #[test]

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -1,0 +1,314 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::data_type::ConcreteDataType;
+use crate::types::{IntervalType, TimeType};
+use crate::value::Value;
+
+// Return true if the src_value can be casted to dest_type,
+// Otherwise, return false.
+pub fn can_cast_type(src_value: &Value, dest_type: ConcreteDataType) -> bool {
+    use ConcreteDataType::*;
+    use IntervalType::*;
+    use TimeType::*;
+    let src_type = src_value.data_type();
+
+    if src_type == dest_type {
+        return true;
+    }
+
+    match (src_type, dest_type) {
+        (_, Null(_)) => true,
+        // numeric types
+        (
+            Boolean(_),
+            UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_) | Int32(_) | Int64(_)
+            | Float32(_) | Float64(_) | String(_),
+        ) => true,
+        (
+            UInt8(_),
+            Boolean(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int16(_) | Int32(_) | Int64(_)
+            | Float32(_) | Float64(_) | String(_),
+        ) => true,
+        (
+            UInt16(_),
+            Boolean(_) | UInt8(_) | UInt32(_) | UInt64(_) | Int32(_) | Int64(_) | Float32(_)
+            | Float64(_) | String(_),
+        ) => true,
+        (UInt32(_), Boolean(_) | UInt64(_) | Int64(_) | Float64(_) | String(_)) => true,
+        (UInt64(_), Boolean(_) | String(_)) => true,
+        (
+            Int8(_),
+            Boolean(_) | Int16(_) | Int32(_) | Int64(_) | Float32(_) | Float64(_) | String(_),
+        ) => true,
+        (Int16(_), Boolean(_) | Int32(_) | Int64(_) | Float32(_) | Float64(_) | String(_)) => true,
+        (Int32(_), Boolean(_) | Int64(_) | Float32(_) | Float64(_) | String(_) | Date(_)) => true,
+        (Int64(_), Boolean(_) | Float64(_) | String(_) | DateTime(_) | Timestamp(_) | Time(_)) => {
+            true
+        }
+        (
+            Float32(_),
+            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
+            | Int32(_) | Int64(_) | Float64(_) | String(_),
+        ) => true,
+        (
+            Float64(_),
+            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
+            | Int32(_) | Int64(_) | String(_),
+        ) => true,
+        (
+            String(_),
+            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
+            | Int32(_) | Int64(_) | Float32(_) | Float64(_) | Date(_) | DateTime(_) | Timestamp(_)
+            | Time(_) | Interval(_),
+        ) => true,
+        // temporal types
+        (Date(_), Int32(_) | Timestamp(_) | String(_)) => true,
+        (DateTime(_), Int64(_) | Timestamp(_) | String(_)) => true,
+        (Timestamp(_), Int64(_) | Date(_) | DateTime(_) | String(_)) => true,
+        (Time(_), String(_)) => true,
+        (Time(Second(_)), Int32(_)) => true,
+        (Time(Millisecond(_)), Int32(_)) => true,
+        (Time(Microsecond(_)), Int64(_)) => true,
+        (Time(Nanosecond(_)), Int64(_)) => true,
+        (Interval(_), String(_)) => true,
+        (Interval(YearMonth(_)), Int32(_)) => true,
+        (Interval(DayTime(_)), Int64(_)) => true,
+        (Interval(MonthDayNano(_)), _) => false,
+        // other situations return false
+        (_, _) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use common_base::bytes::StringBytes;
+    use common_time::time::Time;
+    use common_time::{Date, DateTime, Interval, Timestamp};
+    use ordered_float::OrderedFloat;
+
+    use super::*;
+
+    macro_rules! test_can_cast {
+        ($src_value: expr, $($dest_type: ident),*) => {
+            $(
+                let val = $src_value;
+                let t = ConcreteDataType::$dest_type();
+                assert_eq!(can_cast_type(&val, t), true);
+            )*
+        };
+    }
+
+    #[test]
+    fn test_can_cast_type() {
+        // uint8 -> other types
+        test_can_cast!(
+            Value::UInt8(0),
+            null_datatype,
+            uint8_datatype,
+            uint16_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // uint16 -> other types
+        test_can_cast!(
+            Value::UInt16(0),
+            null_datatype,
+            uint8_datatype,
+            uint16_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // uint32 -> other types
+        test_can_cast!(
+            Value::UInt32(0),
+            null_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int64_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // uint64 -> other types
+        test_can_cast!(
+            Value::UInt64(0),
+            null_datatype,
+            uint64_datatype,
+            string_datatype
+        );
+
+        // int8 -> other types
+        test_can_cast!(
+            Value::Int8(0),
+            null_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // int16 -> other types
+        test_can_cast!(
+            Value::Int16(0),
+            null_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // int32 -> other types
+        test_can_cast!(
+            Value::Int32(0),
+            null_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype,
+            date_datatype
+        );
+
+        // int64 -> other types
+        test_can_cast!(
+            Value::Int64(0),
+            null_datatype,
+            int64_datatype,
+            float64_datatype,
+            string_datatype,
+            datetime_datatype,
+            timestamp_second_datatype,
+            time_second_datatype
+        );
+
+        // float32 -> other types
+        test_can_cast!(
+            Value::Float32(OrderedFloat(0.0)),
+            null_datatype,
+            uint8_datatype,
+            uint16_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int8_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // float64 -> other types
+        test_can_cast!(
+            Value::Float64(OrderedFloat(0.0)),
+            null_datatype,
+            uint8_datatype,
+            uint16_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int8_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float64_datatype,
+            string_datatype
+        );
+
+        // string -> other types
+        test_can_cast!(
+            Value::String(StringBytes::from("0")),
+            null_datatype,
+            uint8_datatype,
+            uint16_datatype,
+            uint32_datatype,
+            uint64_datatype,
+            int8_datatype,
+            int16_datatype,
+            int32_datatype,
+            int64_datatype,
+            float32_datatype,
+            float64_datatype,
+            string_datatype,
+            date_datatype,
+            datetime_datatype,
+            timestamp_second_datatype,
+            time_second_datatype,
+            interval_year_month_datatype,
+            interval_day_time_datatype,
+            interval_month_day_nano_datatype
+        );
+
+        // date -> other types
+        test_can_cast!(
+            Value::Date(Date::from_str("2021-01-01").unwrap()),
+            null_datatype,
+            int32_datatype,
+            timestamp_second_datatype,
+            string_datatype
+        );
+
+        // datetime -> other types
+        test_can_cast!(
+            Value::DateTime(DateTime::from_str("2021-01-01 00:00:00").unwrap()),
+            null_datatype,
+            int64_datatype,
+            timestamp_second_datatype,
+            string_datatype
+        );
+
+        // timestamp -> other types
+        test_can_cast!(
+            Value::Timestamp(Timestamp::from_str("2021-01-01 00:00:00").unwrap()),
+            null_datatype,
+            int64_datatype,
+            date_datatype,
+            datetime_datatype,
+            string_datatype
+        );
+
+        // time -> other types
+        test_can_cast!(
+            Value::Time(Time::new_second(0)),
+            null_datatype,
+            string_datatype
+        );
+
+        // interval -> other types
+        test_can_cast!(
+            Value::Interval(Interval::from_year_month(0)),
+            null_datatype,
+            string_datatype
+        );
+    }
+}

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -115,8 +115,8 @@ pub fn can_cast_type(src_value: &Value, dest_type: &ConcreteDataType) -> bool {
         (Time(Microsecond(_)), Int64(_)) => true,
         (Time(Nanosecond(_)), Int64(_)) => true,
         // TODO(QuenKar): interval type cast
-        // (Interval(_), String(_)) => true,
-
+        (Interval(_), String(_)) => true,
+        (Duration(_), String(_)) => true,
         // other situations return false
         (_, _) => false,
     }

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -31,6 +31,17 @@ impl CastOption {
     }
 }
 
+/// Cast the value to dest_type with CastOption.
+///
+/// # Arguments
+/// * `src_value` - The value to be casted.
+/// * `dest_type` - The destination type.
+/// * `cast_option` - The CastOption.
+///
+/// # Returns
+/// If success, return the casted value.
+/// If CastOption's strict is true, return an error if the cast fails.
+/// If CastOption's strict is false, return NULL if the cast fails.
 pub fn cast_with_opt(
     src_value: Value,
     dest_type: &ConcreteDataType,
@@ -180,6 +191,7 @@ mod tests {
 
     #[test]
     fn test_cast_with_opt() {
+        std::env::set_var("TZ", "Asia/Shanghai");
         // non-strict mode
         let cast_option = CastOption { strict: false };
         let src_value = Value::Int8(-1);

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -12,82 +12,128 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::data_type::ConcreteDataType;
-use crate::types::{IntervalType, TimeType};
+use crate::data_type::{ConcreteDataType, DataType};
+use crate::error::{self, Error, Result};
+use crate::types::TimeType;
 use crate::value::Value;
+
+/// Cast options for cast functions.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+pub struct CastOption {
+    /// decide how to handle cast failures,
+    /// either return NULL (strict=false) or return ERR (strict=true)
+    pub strict: bool,
+}
+
+impl CastOption {
+    pub fn is_strict(&self) -> bool {
+        self.strict
+    }
+}
+
+pub fn cast_with_opt(
+    src_value: Value,
+    dest_type: &ConcreteDataType,
+    cast_option: &CastOption,
+) -> Result<Value> {
+    if !can_cast_type(&src_value, dest_type) {
+        if cast_option.strict {
+            return Err(invalid_type_cast(&src_value, dest_type));
+        } else {
+            return Ok(Value::Null);
+        }
+    }
+    let new_value = dest_type.try_cast(src_value.clone());
+    match new_value {
+        Some(v) => Ok(v),
+        None => {
+            if cast_option.strict {
+                Err(invalid_type_cast(&src_value, dest_type))
+            } else {
+                Ok(Value::Null)
+            }
+        }
+    }
+}
 
 // Return true if the src_value can be casted to dest_type,
 // Otherwise, return false.
-pub fn can_cast_type(src_value: &Value, dest_type: ConcreteDataType) -> bool {
+pub fn can_cast_type(src_value: &Value, dest_type: &ConcreteDataType) -> bool {
     use ConcreteDataType::*;
-    use IntervalType::*;
     use TimeType::*;
-    let src_type = src_value.data_type();
+    let src_type = &src_value.data_type();
 
     if src_type == dest_type {
         return true;
     }
 
     match (src_type, dest_type) {
+        // null type cast
         (_, Null(_)) => true,
-        // numeric types
+
+        // boolean type cast
+        (_, Boolean(_)) => src_type.is_numeric() || src_type.is_string(),
+        (Boolean(_), _) => dest_type.is_numeric() || dest_type.is_string(),
+
+        // numeric types cast
         (
-            Boolean(_),
+            UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_) | Int32(_) | Int64(_)
+            | Float32(_) | Float64(_) | String(_),
             UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_) | Int32(_) | Int64(_)
             | Float32(_) | Float64(_) | String(_),
         ) => true,
-        (
-            UInt8(_),
-            Boolean(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int16(_) | Int32(_) | Int64(_)
-            | Float32(_) | Float64(_) | String(_),
-        ) => true,
-        (
-            UInt16(_),
-            Boolean(_) | UInt8(_) | UInt32(_) | UInt64(_) | Int32(_) | Int64(_) | Float32(_)
-            | Float64(_) | String(_),
-        ) => true,
-        (UInt32(_), Boolean(_) | UInt64(_) | Int64(_) | Float64(_) | String(_)) => true,
-        (UInt64(_), Boolean(_) | String(_)) => true,
-        (
-            Int8(_),
-            Boolean(_) | Int16(_) | Int32(_) | Int64(_) | Float32(_) | Float64(_) | String(_),
-        ) => true,
-        (Int16(_), Boolean(_) | Int32(_) | Int64(_) | Float32(_) | Float64(_) | String(_)) => true,
-        (Int32(_), Boolean(_) | Int64(_) | Float32(_) | Float64(_) | String(_) | Date(_)) => true,
-        (Int64(_), Boolean(_) | Float64(_) | String(_) | DateTime(_) | Timestamp(_) | Time(_)) => {
-            true
-        }
-        (
-            Float32(_),
-            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
-            | Int32(_) | Int64(_) | Float64(_) | String(_),
-        ) => true,
-        (
-            Float64(_),
-            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
-            | Int32(_) | Int64(_) | String(_),
-        ) => true,
-        (
-            String(_),
-            Boolean(_) | UInt8(_) | UInt16(_) | UInt32(_) | UInt64(_) | Int8(_) | Int16(_)
-            | Int32(_) | Int64(_) | Float32(_) | Float64(_) | Date(_) | DateTime(_) | Timestamp(_)
-            | Time(_) | Interval(_),
-        ) => true,
-        // temporal types
+
+        (String(_), Binary(_)) => true,
+
+        // temporal types cast
+        // Date type
         (Date(_), Int32(_) | Timestamp(_) | String(_)) => true,
+        (Int32(_) | String(_) | Timestamp(_), Date(_)) => true,
+        // DateTime type
         (DateTime(_), Int64(_) | Timestamp(_) | String(_)) => true,
-        (Timestamp(_), Int64(_) | Date(_) | DateTime(_) | String(_)) => true,
+        (Int64(_) | Timestamp(_) | String(_), DateTime(_)) => true,
+        // Timestamp type
+        (Timestamp(_), Int64(_) | String(_)) => true,
+        (Int64(_) | String(_), Timestamp(_)) => true,
+        // Time type
         (Time(_), String(_)) => true,
         (Time(Second(_)), Int32(_)) => true,
         (Time(Millisecond(_)), Int32(_)) => true,
         (Time(Microsecond(_)), Int64(_)) => true,
         (Time(Nanosecond(_)), Int64(_)) => true,
-        (Interval(_), String(_)) => true,
-        (Interval(YearMonth(_)), Int32(_)) => true,
-        (Interval(DayTime(_)), Int64(_)) => true,
-        (Interval(MonthDayNano(_)), _) => false,
+        // TODO(QuenKar): interval type cast
+        // (Interval(_), String(_)) => true,
+
         // other situations return false
         (_, _) => false,
+    }
+}
+
+fn invalid_type_cast(src_value: &Value, dest_type: &ConcreteDataType) -> Error {
+    let src_type = src_value.data_type();
+    if src_type.is_string() {
+        error::CastTypeSnafu {
+            msg: format!("Could not parse string '{}' to {}", src_value, dest_type),
+        }
+        .build()
+    } else if src_type.is_numeric() && dest_type.is_numeric() {
+        error::CastTypeSnafu {
+            msg: format!(
+                "Type {} with value {} can't be cast because the value is out of range for the destination type {}",
+                src_type,
+                src_value,
+                dest_type
+            ),
+        }
+        .build()
+    } else {
+        error::CastTypeSnafu {
+            msg: format!(
+                "Type {} with value {} can't be cast to the destination type {}",
+                src_type, src_value, dest_type
+            ),
+        }
+        .build()
     }
 }
 
@@ -97,176 +143,107 @@ mod tests {
 
     use common_base::bytes::StringBytes;
     use common_time::time::Time;
-    use common_time::{Date, DateTime, Interval, Timestamp};
+    use common_time::{Date, DateTime, Timestamp};
     use ordered_float::OrderedFloat;
 
     use super::*;
 
     macro_rules! test_can_cast {
-        ($src_value: expr, $($dest_type: ident),*) => {
+        ($src_value: expr, $($dest_type: ident),+) => {
             $(
                 let val = $src_value;
                 let t = ConcreteDataType::$dest_type();
-                assert_eq!(can_cast_type(&val, t), true);
+                assert_eq!(can_cast_type(&val, &t), true);
+            )*
+        };
+    }
+
+    macro_rules! test_primitive_cast {
+        ($($value: expr),*) => {
+            $(
+                test_can_cast!(
+                    $value,
+                    uint8_datatype,
+                    uint16_datatype,
+                    uint32_datatype,
+                    uint64_datatype,
+                    int8_datatype,
+                    int16_datatype,
+                    int32_datatype,
+                    int64_datatype,
+                    float32_datatype,
+                    float64_datatype
+                );
             )*
         };
     }
 
     #[test]
+    fn test_cast_with_opt() {
+        // non-strict mode
+        let cast_option = CastOption { strict: false };
+        let src_value = Value::Int8(-1);
+        let dest_type = ConcreteDataType::uint8_datatype();
+        let res = cast_with_opt(src_value, &dest_type, &cast_option);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), Value::Null);
+
+        // strict mode
+        let cast_option = CastOption { strict: true };
+        let src_value = Value::Int8(-1);
+        let dest_type = ConcreteDataType::uint8_datatype();
+        let res = cast_with_opt(src_value, &dest_type, &cast_option);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Type Int8 with value -1 can't be cast because the value is out of range for the destination type UInt8"
+        );
+
+        let src_value = Value::String(StringBytes::from("abc"));
+        let dest_type = ConcreteDataType::uint8_datatype();
+        let res = cast_with_opt(src_value, &dest_type, &cast_option);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Could not parse string 'abc' to UInt8"
+        );
+
+        let src_value = Value::Timestamp(Timestamp::new_second(10));
+        let dest_type = ConcreteDataType::int8_datatype();
+        let res = cast_with_opt(src_value, &dest_type, &cast_option);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Type Timestamp with value 1970-01-01 08:00:10+0800 can't be cast to the destination type Int8"
+        );
+    }
+
+    #[test]
     fn test_can_cast_type() {
-        // uint8 -> other types
-        test_can_cast!(
+        // numeric cast
+        test_primitive_cast!(
             Value::UInt8(0),
-            null_datatype,
-            uint8_datatype,
-            uint16_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // uint16 -> other types
-        test_can_cast!(
-            Value::UInt16(0),
-            null_datatype,
-            uint8_datatype,
-            uint16_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // uint32 -> other types
-        test_can_cast!(
-            Value::UInt32(0),
-            null_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int64_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // uint64 -> other types
-        test_can_cast!(
-            Value::UInt64(0),
-            null_datatype,
-            uint64_datatype,
-            string_datatype
-        );
-
-        // int8 -> other types
-        test_can_cast!(
-            Value::Int8(0),
-            null_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // int16 -> other types
-        test_can_cast!(
-            Value::Int16(0),
-            null_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // int32 -> other types
-        test_can_cast!(
-            Value::Int32(0),
-            null_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype,
-            date_datatype
-        );
-
-        // int64 -> other types
-        test_can_cast!(
-            Value::Int64(0),
-            null_datatype,
-            int64_datatype,
-            float64_datatype,
-            string_datatype,
-            datetime_datatype,
-            timestamp_second_datatype,
-            time_second_datatype
-        );
-
-        // float32 -> other types
-        test_can_cast!(
-            Value::Float32(OrderedFloat(0.0)),
-            null_datatype,
-            uint8_datatype,
-            uint16_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int8_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype
-        );
-
-        // float64 -> other types
-        test_can_cast!(
-            Value::Float64(OrderedFloat(0.0)),
-            null_datatype,
-            uint8_datatype,
-            uint16_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int8_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float64_datatype,
-            string_datatype
+            Value::UInt16(1),
+            Value::UInt32(2),
+            Value::UInt64(3),
+            Value::Int8(4),
+            Value::Int16(5),
+            Value::Int32(6),
+            Value::Int64(7),
+            Value::Float32(OrderedFloat(8.0)),
+            Value::Float64(OrderedFloat(9.0)),
+            Value::String(StringBytes::from("10"))
         );
 
         // string -> other types
         test_can_cast!(
             Value::String(StringBytes::from("0")),
             null_datatype,
-            uint8_datatype,
-            uint16_datatype,
-            uint32_datatype,
-            uint64_datatype,
-            int8_datatype,
-            int16_datatype,
-            int32_datatype,
-            int64_datatype,
-            float32_datatype,
-            float64_datatype,
-            string_datatype,
+            boolean_datatype,
             date_datatype,
             datetime_datatype,
             timestamp_second_datatype,
-            time_second_datatype,
-            interval_year_month_datatype,
-            interval_day_time_datatype,
-            interval_month_day_nano_datatype
+            binary_datatype
         );
 
         // date -> other types
@@ -300,13 +277,6 @@ mod tests {
         // time -> other types
         test_can_cast!(
             Value::Time(Time::new_second(0)),
-            null_datatype,
-            string_datatype
-        );
-
-        // interval -> other types
-        test_can_cast!(
-            Value::Interval(Interval::from_year_month(0)),
             null_datatype,
             string_datatype
         );

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -67,8 +67,10 @@ pub fn cast_with_opt(
     }
 }
 
-// Return true if the src_value can be casted to dest_type,
-// Otherwise, return false.
+/// Return true if the src_value can be casted to dest_type,
+/// Otherwise, return false.
+/// Notice: this function does not promise that the `cast_with_opt` will succeed,
+/// it only checks whether the src_value can be casted to dest_type.
 pub fn can_cast_type(src_value: &Value, dest_type: &ConcreteDataType) -> bool {
     use ConcreteDataType::*;
     use TimeType::*;

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -56,7 +56,7 @@ impl DataType for DateType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Int32(v) => Some(Value::Date(Date::from(v))),
             Value::String(v) => Date::from_str(v.as_utf8()).map(Value::Date).ok(),
@@ -113,26 +113,26 @@ mod tests {
         std::env::set_var("TZ", "Asia/Shanghai");
         // timestamp -> date
         let ts = Value::Timestamp(Timestamp::from_str("2000-01-01 08:00:01").unwrap());
-        let date = ConcreteDataType::date_datatype().cast(ts).unwrap();
+        let date = ConcreteDataType::date_datatype().try_cast(ts).unwrap();
         assert_eq!(date, Value::Date(Date::from_str("2000-01-01").unwrap()));
 
         // this case bind with local timezone.
         let ts = Value::Timestamp(Timestamp::from_str("2000-01-02 07:59:59").unwrap());
-        let date = ConcreteDataType::date_datatype().cast(ts).unwrap();
+        let date = ConcreteDataType::date_datatype().try_cast(ts).unwrap();
         assert_eq!(date, Value::Date(Date::from_str("2000-01-01").unwrap()));
 
         // Int32 -> date
         let val = Value::Int32(0);
-        let date = ConcreteDataType::date_datatype().cast(val).unwrap();
+        let date = ConcreteDataType::date_datatype().try_cast(val).unwrap();
         assert_eq!(date, Value::Date(Date::from_str("1970-01-01").unwrap()));
 
         let val = Value::Int32(19614);
-        let date = ConcreteDataType::date_datatype().cast(val).unwrap();
+        let date = ConcreteDataType::date_datatype().try_cast(val).unwrap();
         assert_eq!(date, Value::Date(Date::from_str("2023-09-14").unwrap()));
 
         // String -> date
         let s = Value::String(StringBytes::from("1970-02-12"));
-        let date = ConcreteDataType::date_datatype().cast(s).unwrap();
+        let date = ConcreteDataType::date_datatype().try_cast(s).unwrap();
         assert_eq!(date, Value::Date(Date::from_str("1970-02-12").unwrap()));
     }
 }

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -59,10 +59,7 @@ impl DataType for DateType {
     fn cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Int32(v) => Some(Value::Date(Date::from(v))),
-            Value::String(v) => match Date::from_str(v.as_utf8()) {
-                Ok(d) => Some(Value::Date(d)),
-                Err(_) => None,
-            },
+            Value::String(v) => Date::from_str(v.as_utf8()).map(Value::Date).ok(),
             Value::Timestamp(v) => v.to_chrono_date().map(|date| Value::Date(date.into())),
             _ => None,
         }

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -113,6 +113,7 @@ mod tests {
 
     #[test]
     fn test_date_cast() {
+        std::env::set_var("TZ", "Asia/Shanghai");
         // timestamp -> date
         let ts = Value::Timestamp(Timestamp::from_str("2000-01-01 08:00:01").unwrap());
         let date = ConcreteDataType::date_datatype().cast(ts).unwrap();

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -63,7 +63,7 @@ impl DataType for DateType {
                 Ok(d) => Some(Value::Date(d)),
                 Err(_) => None,
             },
-            Value::Timestamp(v) => v.to_chrono_date().map(|nd| Value::Date(nd.into())),
+            Value::Timestamp(v) => v.to_chrono_date().map(|date| Value::Date(date.into())),
             _ => None,
         }
     }

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use arrow::datatypes::{DataType as ArrowDataType, Date32Type};
 use common_time::Date;
 use serde::{Deserialize, Serialize};
@@ -53,6 +55,18 @@ impl DataType for DateType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int32(v) => Some(Value::Date(Date::from(v))),
+            Value::String(v) => match Date::from_str(v.as_utf8()) {
+                Ok(d) => Some(Value::Date(d)),
+                Err(_) => None,
+            },
+            Value::Timestamp(v) => v.to_chrono_date().map(|nd| Value::Date(nd.into())),
+            _ => None,
+        }
+    }
 }
 
 impl LogicalPrimitiveType for DateType {
@@ -87,5 +101,40 @@ impl LogicalPrimitiveType for DateType {
             }
             .fail(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common_base::bytes::StringBytes;
+    use common_time::Timestamp;
+
+    use super::*;
+
+    #[test]
+    fn test_date_cast() {
+        // timestamp -> date
+        let ts = Value::Timestamp(Timestamp::from_str("2000-01-01 08:00:01").unwrap());
+        let date = ConcreteDataType::date_datatype().cast(ts).unwrap();
+        assert_eq!(date, Value::Date(Date::from_str("2000-01-01").unwrap()));
+
+        // this case bind with local timezone.
+        let ts = Value::Timestamp(Timestamp::from_str("2000-01-02 07:59:59").unwrap());
+        let date = ConcreteDataType::date_datatype().cast(ts).unwrap();
+        assert_eq!(date, Value::Date(Date::from_str("2000-01-01").unwrap()));
+
+        // Int32 -> date
+        let val = Value::Int32(0);
+        let date = ConcreteDataType::date_datatype().cast(val).unwrap();
+        assert_eq!(date, Value::Date(Date::from_str("1970-01-01").unwrap()));
+
+        let val = Value::Int32(19614);
+        let date = ConcreteDataType::date_datatype().cast(val).unwrap();
+        assert_eq!(date, Value::Date(Date::from_str("2023-09-14").unwrap()));
+
+        // String -> date
+        let s = Value::String(StringBytes::from("1970-02-12"));
+        let date = ConcreteDataType::date_datatype().cast(s).unwrap();
+        assert_eq!(date, Value::Date(Date::from_str("1970-02-12").unwrap()));
     }
 }

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -54,7 +54,7 @@ impl DataType for DateTimeType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Int64(v) => Some(Value::DateTime(DateTime::from(v))),
             Value::Timestamp(v) => v.to_chrono_datetime().map(|d| Value::DateTime(d.into())),
@@ -113,13 +113,13 @@ mod tests {
     fn test_datetime_cast() {
         // cast from Int64
         let val = Value::Int64(1000);
-        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        let dt = ConcreteDataType::datetime_datatype().try_cast(val).unwrap();
         assert_eq!(dt, Value::DateTime(DateTime::from(1000)));
 
         // cast from String
         std::env::set_var("TZ", "Asia/Shanghai");
         let val = Value::String("1970-01-01 00:00:00+0800".into());
-        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        let dt = ConcreteDataType::datetime_datatype().try_cast(val).unwrap();
         assert_eq!(
             dt,
             Value::DateTime(DateTime::from_str("1970-01-01 00:00:00+0800").unwrap())
@@ -127,7 +127,7 @@ mod tests {
 
         // cast from Timestamp
         let val = Value::Timestamp(Timestamp::from_str("2020-09-08 21:42:29.042+0800").unwrap());
-        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        let dt = ConcreteDataType::datetime_datatype().try_cast(val).unwrap();
         assert_eq!(
             dt,
             Value::DateTime(DateTime::from_str("2020-09-08 21:42:29+0800").unwrap())

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -58,10 +58,7 @@ impl DataType for DateTimeType {
         match from {
             Value::Int64(v) => Some(Value::DateTime(DateTime::from(v))),
             Value::Timestamp(v) => v.to_chrono_datetime().map(|d| Value::DateTime(d.into())),
-            Value::String(v) => match DateTime::from_str(v.as_utf8()) {
-                Ok(d) => Some(Value::DateTime(d)),
-                Err(_) => None,
-            },
+            Value::String(v) => DateTime::from_str(v.as_utf8()).map(Value::DateTime).ok(),
             _ => None,
         }
     }

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use arrow::datatypes::{DataType as ArrowDataType, Date64Type};
 use common_time::DateTime;
 use serde::{Deserialize, Serialize};
@@ -50,6 +52,17 @@ impl DataType for DateTimeType {
 
     fn is_timestamp_compatible(&self) -> bool {
         false
+    }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int64(v) => Some(Value::DateTime(DateTime::from(v))),
+            Value::String(v) => match DateTime::from_str(v.as_utf8()) {
+                Ok(d) => Some(Value::DateTime(d)),
+                Err(_) => None,
+            },
+            _ => None,
+        }
     }
 }
 

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -103,3 +103,25 @@ impl LogicalPrimitiveType for DateTimeType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_datetime_cast() {
+        // cast from Int64
+        let val = Value::Int64(1000);
+        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        assert_eq!(dt, Value::DateTime(DateTime::from(1000)));
+
+        // cast from String
+        std::env::set_var("TZ", "Asia/Shanghai");
+        let val = Value::String("1970-01-01 00:00:00+0800".into());
+        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        assert_eq!(
+            dt,
+            Value::DateTime(DateTime::from_str("1970-01-01 00:00:00+0800").unwrap())
+        )
+    }
+}

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -57,6 +57,7 @@ impl DataType for DateTimeType {
     fn cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Int64(v) => Some(Value::DateTime(DateTime::from(v))),
+            Value::Timestamp(v) => v.to_chrono_datetime().map(|d| Value::DateTime(d.into())),
             Value::String(v) => match DateTime::from_str(v.as_utf8()) {
                 Ok(d) => Some(Value::DateTime(d)),
                 Err(_) => None,
@@ -106,6 +107,9 @@ impl LogicalPrimitiveType for DateTimeType {
 
 #[cfg(test)]
 mod tests {
+
+    use common_time::Timestamp;
+
     use super::*;
 
     #[test]
@@ -122,6 +126,14 @@ mod tests {
         assert_eq!(
             dt,
             Value::DateTime(DateTime::from_str("1970-01-01 00:00:00+0800").unwrap())
-        )
+        );
+
+        // cast from Timestamp
+        let val = Value::Timestamp(Timestamp::from_str("2020-09-08 21:42:29.042+0800").unwrap());
+        let dt = ConcreteDataType::datetime_datatype().cast(val).unwrap();
+        assert_eq!(
+            dt,
+            Value::DateTime(DateTime::from_str("2020-09-08 21:42:29+0800").unwrap())
+        );
     }
 }

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -88,4 +88,8 @@ impl DataType for DictionaryType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, _: Value) -> Option<Value> {
+        unimplemented!()
+    }
 }

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -89,7 +89,7 @@ impl DataType for DictionaryType {
         false
     }
 
-    fn cast(&self, _: Value) -> Option<Value> {
+    fn try_cast(&self, _: Value) -> Option<Value> {
         unimplemented!()
     }
 }

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -90,6 +90,6 @@ impl DataType for DictionaryType {
     }
 
     fn try_cast(&self, _: Value) -> Option<Value> {
-        unimplemented!("Value does not support Dictionary type yet.")
+        None
     }
 }

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -90,6 +90,6 @@ impl DataType for DictionaryType {
     }
 
     fn try_cast(&self, _: Value) -> Option<Value> {
-        unimplemented!()
+        unimplemented!("Value does not support Dictionary type yet.")
     }
 }

--- a/src/datatypes/src/types/duration_type.rs
+++ b/src/datatypes/src/types/duration_type.rs
@@ -101,6 +101,11 @@ macro_rules! impl_data_type_for_duration {
                 fn is_timestamp_compatible(&self) -> bool {
                     false
                 }
+
+                fn try_cast(&self, _: Value) -> Option<Value> {
+                    // TODO(QuenKar): Implement casting for duration types.
+                    None
+                }
             }
 
             impl LogicalPrimitiveType for [<Duration $unit Type>] {

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -91,7 +91,8 @@ macro_rules! impl_data_type_for_interval {
                 }
 
                 fn try_cast(&self, _: Value) -> Option<Value> {
-                    unimplemented!("interval type cast not implemented yet")
+                    // TODO(QuenKar): Implement casting for interval types.
+                    None
                 }
             }
 

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -90,7 +90,7 @@ macro_rules! impl_data_type_for_interval {
                     false
                 }
 
-                fn cast(&self, _: Value) -> Option<Value> {
+                fn try_cast(&self, _: Value) -> Option<Value> {
                     unimplemented!("interval type cast not implemented yet")
                 }
             }

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -91,7 +91,7 @@ macro_rules! impl_data_type_for_interval {
                 }
 
                 fn cast(&self, _: Value) -> Option<Value> {
-                    unimplemented!()
+                    unimplemented!("interval type cast not implemented yet")
                 }
             }
 

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -89,6 +89,10 @@ macro_rules! impl_data_type_for_interval {
                 fn is_timestamp_compatible(&self) -> bool {
                     false
                 }
+
+                fn cast(&self, _: Value) -> Option<Value> {
+                    unimplemented!()
+                }
             }
 
             impl LogicalPrimitiveType for [<Interval $unit Type>] {

--- a/src/datatypes/src/types/list_type.rs
+++ b/src/datatypes/src/types/list_type.rs
@@ -79,6 +79,10 @@ impl DataType for ListType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, _: Value) -> Option<Value> {
+        unimplemented!()
+    }
 }
 
 #[cfg(test)]

--- a/src/datatypes/src/types/list_type.rs
+++ b/src/datatypes/src/types/list_type.rs
@@ -80,8 +80,11 @@ impl DataType for ListType {
         false
     }
 
-    fn cast(&self, _: Value) -> Option<Value> {
-        unimplemented!()
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::List(v) => Some(Value::List(v)),
+            _ => None,
+        }
     }
 }
 

--- a/src/datatypes/src/types/list_type.rs
+++ b/src/datatypes/src/types/list_type.rs
@@ -80,7 +80,7 @@ impl DataType for ListType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::List(v) => Some(Value::List(v)),
             _ => None,

--- a/src/datatypes/src/types/null_type.rs
+++ b/src/datatypes/src/types/null_type.rs
@@ -57,7 +57,7 @@ impl DataType for NullType {
     }
 
     // Unconditional cast other type to Value::Null
-    fn cast(&self, _from: Value) -> Option<Value> {
+    fn try_cast(&self, _from: Value) -> Option<Value> {
         Some(Value::Null)
     }
 }

--- a/src/datatypes/src/types/null_type.rs
+++ b/src/datatypes/src/types/null_type.rs
@@ -56,7 +56,8 @@ impl DataType for NullType {
         false
     }
 
-    fn cast(&self, _: Value) -> Option<Value> {
-        unimplemented!()
+    // Unconditional cast other type to Value::Null
+    fn cast(&self, _from: Value) -> Option<Value> {
+        Some(Value::Null)
     }
 }

--- a/src/datatypes/src/types/null_type.rs
+++ b/src/datatypes/src/types/null_type.rs
@@ -55,4 +55,8 @@ impl DataType for NullType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, _: Value) -> Option<Value> {
+        unimplemented!()
+    }
 }

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -289,19 +289,29 @@ macro_rules! define_non_timestamp_primitive {
     };
 }
 
-define_non_timestamp_primitive!(u8, UInt8, UInt8Type, UInt64Type, UInt8, Float32, Float64);
 define_non_timestamp_primitive!(
-    u16, UInt16, UInt16Type, UInt64Type, UInt8, UInt16, Float32, Float64
+    u8, UInt8, UInt8Type, UInt64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
 );
 define_non_timestamp_primitive!(
-    u32, UInt32, UInt32Type, UInt64Type, UInt8, UInt16, UInt32, Float32, Float64
+    u16, UInt16, UInt16Type, UInt64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
 );
 define_non_timestamp_primitive!(
-    u64, UInt64, UInt64Type, UInt64Type, UInt8, UInt16, UInt32, UInt64, Float32, Float64
+    u32, UInt32, UInt32Type, UInt64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
 );
-define_non_timestamp_primitive!(i8, Int8, Int8Type, Int64Type, Int8, Float32, Float64);
 define_non_timestamp_primitive!(
-    i16, Int16, Int16Type, Int64Type, Int8, Int16, UInt8, Float32, Float64
+    u64, UInt64, UInt64Type, UInt64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
+);
+define_non_timestamp_primitive!(
+    i8, Int8, Int8Type, Int64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
+);
+define_non_timestamp_primitive!(
+    i16, Int16, Int16Type, Int64Type, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64,
+    Float32, Float64
 );
 
 define_non_timestamp_primitive!(
@@ -309,27 +319,32 @@ define_non_timestamp_primitive!(
     Float32,
     Float32Type,
     Float64Type,
-    Float32,
-    UInt8,
-    UInt16,
     Int8,
     Int16,
-    Int32
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64
 );
 define_non_timestamp_primitive!(
     f64,
     Float64,
     Float64Type,
     Float64Type,
-    Float32,
-    Float64,
-    UInt8,
-    UInt16,
-    UInt32,
     Int8,
     Int16,
     Int32,
-    Int64
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64
 );
 
 // Timestamp primitive:
@@ -389,33 +404,26 @@ impl DataType for Int64Type {
 }
 
 impl DataType for Int32Type {
-    #[doc = " Name of this data type."]
     fn name(&self) -> &str {
         "Int32"
     }
 
-    #[doc = " Returns id of the Logical data type."]
     fn logical_type_id(&self) -> LogicalTypeId {
         LogicalTypeId::Int32
     }
 
-    #[doc = " Returns the default value of this type."]
     fn default_value(&self) -> Value {
         Value::Int32(0)
     }
 
-    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
     fn as_arrow_type(&self) -> ArrowDataType {
         ArrowDataType::Int32
     }
 
-    #[doc = " Creates a mutable vector with given `capacity` of this type."]
     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
         Box::new(PrimitiveVectorBuilder::<Int32Type>::with_capacity(capacity))
     }
 
-    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
-    #[doc = " use it as a timestamp."]
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
@@ -426,8 +434,11 @@ impl DataType for Int32Type {
             Value::Int8(v) => num::cast::cast(v).map(Value::Int32),
             Value::Int16(v) => num::cast::cast(v).map(Value::Int32),
             Value::Int32(v) => Some(Value::Int32(v)),
+            Value::Int64(v) => num::cast::cast(v).map(Value::Int64),
             Value::UInt8(v) => num::cast::cast(v).map(Value::Int32),
             Value::UInt16(v) => num::cast::cast(v).map(Value::Int32),
+            Value::UInt32(v) => num::cast::cast(v).map(Value::UInt32),
+            Value::UInt64(v) => num::cast::cast(v).map(Value::UInt64),
             Value::Float32(v) => num::cast::cast(v).map(Value::Int32),
             Value::Float64(v) => num::cast::cast(v).map(Value::Int32),
             Value::String(v) => v.as_utf8().parse::<i32>().map(Value::Int32).ok(),

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -275,7 +275,7 @@ macro_rules! define_non_timestamp_primitive {
                 false
             }
 
-            fn cast(&self, from: Value) -> Option<Value> {
+            fn try_cast(&self, from: Value) -> Option<Value> {
                 match from {
                     Value::Boolean(v) => bool_to_numeric(v).map(Value::$TypeId),
                     Value::String(v) => v.as_utf8().parse::<$Native>().map(|val| Value::from(val)).ok(),
@@ -362,7 +362,7 @@ impl DataType for Int64Type {
         true
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Boolean(v) => bool_to_numeric(v).map(Value::Int64),
             Value::Int8(v) => num::cast::cast(v).map(Value::Int64),
@@ -420,7 +420,7 @@ impl DataType for Int32Type {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         match from {
             Value::Boolean(v) => bool_to_numeric(v).map(Value::Int32),
             Value::Int8(v) => num::cast::cast(v).map(Value::Int32),
@@ -494,7 +494,7 @@ mod tests {
     macro_rules! assert_primitive_cast {
         ($value: expr, $datatype:expr, $expected: expr) => {
             let val = $value;
-            let b = $datatype.cast(val).unwrap();
+            let b = $datatype.try_cast(val).unwrap();
             assert_eq!(b, $expected);
         };
     }

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -300,7 +300,9 @@ define_non_timestamp_primitive!(
     u64, UInt64, UInt64Type, UInt64Type, UInt8, UInt16, UInt32, UInt64, Float32, Float64
 );
 define_non_timestamp_primitive!(i8, Int8, Int8Type, Int64Type, Int8, Float32, Float64);
-define_non_timestamp_primitive!(i16, Int16, Int16Type, Int64Type, Int8, Int16, Float32, Float64);
+define_non_timestamp_primitive!(
+    i16, Int16, Int16Type, Int64Type, Int8, Int16, UInt8, Float32, Float64
+);
 
 define_non_timestamp_primitive!(
     f32,
@@ -308,26 +310,22 @@ define_non_timestamp_primitive!(
     Float32Type,
     Float64Type,
     Float32,
-    Float64,
     UInt8,
     UInt16,
-    UInt32,
-    UInt64,
     Int8,
     Int16,
-    Int32,
-    Int64
+    Int32
 );
 define_non_timestamp_primitive!(
     f64,
     Float64,
     Float64Type,
     Float64Type,
+    Float32,
     Float64,
     UInt8,
     UInt16,
     UInt32,
-    UInt64,
     Int8,
     Int16,
     Int32,
@@ -371,6 +369,9 @@ impl DataType for Int64Type {
             Value::Int16(v) => num::cast::cast(v).map(Value::Int64),
             Value::Int32(v) => num::cast::cast(v).map(Value::Int64),
             Value::Int64(v) => Some(Value::Int64(v)),
+            Value::UInt8(v) => num::cast::cast(v).map(Value::Int64),
+            Value::UInt16(v) => num::cast::cast(v).map(Value::Int64),
+            Value::UInt32(v) => num::cast::cast(v).map(Value::Int64),
             Value::Float32(v) => num::cast::cast(v).map(Value::Int64),
             Value::Float64(v) => num::cast::cast(v).map(Value::Int64),
             Value::String(v) => v.as_utf8().parse::<i64>().map(Value::Int64).ok(),
@@ -425,6 +426,8 @@ impl DataType for Int32Type {
             Value::Int8(v) => num::cast::cast(v).map(Value::Int32),
             Value::Int16(v) => num::cast::cast(v).map(Value::Int32),
             Value::Int32(v) => Some(Value::Int32(v)),
+            Value::UInt8(v) => num::cast::cast(v).map(Value::Int32),
+            Value::UInt16(v) => num::cast::cast(v).map(Value::Int32),
             Value::Float32(v) => num::cast::cast(v).map(Value::Int32),
             Value::Float64(v) => num::cast::cast(v).map(Value::Int32),
             Value::String(v) => v.as_utf8().parse::<i32>().map(Value::Int32).ok(),
@@ -578,16 +581,6 @@ mod tests {
             Value::Float32(OrderedFloat(12.0))
         );
         assert_primitive_cast!(
-            Value::UInt32(12),
-            ConcreteDataType::float32_datatype(),
-            Value::Float32(OrderedFloat(12.0))
-        );
-        assert_primitive_cast!(
-            Value::UInt64(12),
-            ConcreteDataType::float32_datatype(),
-            Value::Float32(OrderedFloat(12.0))
-        );
-        assert_primitive_cast!(
             Value::Int8(12),
             ConcreteDataType::float32_datatype(),
             Value::Float32(OrderedFloat(12.0))
@@ -599,11 +592,6 @@ mod tests {
         );
         assert_primitive_cast!(
             Value::Int32(12),
-            ConcreteDataType::float32_datatype(),
-            Value::Float32(OrderedFloat(12.0))
-        );
-        assert_primitive_cast!(
-            Value::Int64(12),
             ConcreteDataType::float32_datatype(),
             Value::Float32(OrderedFloat(12.0))
         );
@@ -621,11 +609,6 @@ mod tests {
         );
         assert_primitive_cast!(
             Value::UInt32(12),
-            ConcreteDataType::float64_datatype(),
-            Value::Float64(OrderedFloat(12.0))
-        );
-        assert_primitive_cast!(
-            Value::UInt64(12),
             ConcreteDataType::float64_datatype(),
             Value::Float64(OrderedFloat(12.0))
         );

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -277,15 +277,11 @@ macro_rules! define_non_timestamp_primitive {
 
             fn cast(&self, from: Value) -> Option<Value> {
                 match from {
-                    Value::Boolean(v) => bool_to_numeric(v).map(|val|Value::$TypeId(val)),
-                    Value::String(v) => match v.as_utf8().parse::<$Native>(){
-                        Ok(val) => Some(Value::from(val)),
-                        Err(_)=> None,
-                    }
+                    Value::Boolean(v) => bool_to_numeric(v).map(Value::$TypeId),
+                    Value::String(v) => v.as_utf8().parse::<$Native>().map(|val| Value::from(val)).ok(),
                     $(
                         Value::$TargetType(v) => num::cast::cast(v).map(Value::$TypeId),
                     )*
-
                     _ => None,
                 }
             }
@@ -377,10 +373,7 @@ impl DataType for Int64Type {
             Value::Int64(v) => Some(Value::Int64(v)),
             Value::Float32(v) => num::cast::cast(v).map(Value::Int64),
             Value::Float64(v) => num::cast::cast(v).map(Value::Int64),
-            Value::String(v) => match v.as_utf8().parse::<i64>() {
-                Ok(val) => Some(Value::Int64(val)),
-                Err(_) => None,
-            },
+            Value::String(v) => v.as_utf8().parse::<i64>().map(Value::Int64).ok(),
             Value::DateTime(v) => Some(Value::Int64(v.val())),
             Value::Timestamp(v) => Some(Value::Int64(v.value())),
             Value::Time(v) => Some(Value::Int64(v.value())),
@@ -434,10 +427,7 @@ impl DataType for Int32Type {
             Value::Int32(v) => Some(Value::Int32(v)),
             Value::Float32(v) => num::cast::cast(v).map(Value::Int32),
             Value::Float64(v) => num::cast::cast(v).map(Value::Int32),
-            Value::String(v) => match v.as_utf8().parse::<i32>() {
-                Ok(val) => Some(Value::Int32(val)),
-                Err(_) => None,
-            },
+            Value::String(v) => v.as_utf8().parse::<i32>().map(Value::Int32).ok(),
             Value::Date(v) => Some(Value::Int32(v.val())),
             Value::Interval(v) => match v.unit() {
                 IntervalUnit::YearMonth => Some(Value::Int32(v.to_i32())),

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -272,6 +272,10 @@ macro_rules! define_non_timestamp_primitive {
             fn is_timestamp_compatible(&self) -> bool {
                 false
             }
+
+            fn cast(&self, _: Value) -> Option<Value> {
+                unimplemented!()
+            }
         }
     };
 }
@@ -312,6 +316,10 @@ impl DataType for Int64Type {
 
     fn is_timestamp_compatible(&self) -> bool {
         true
+    }
+
+    fn cast(&self, _: Value) -> Option<Value> {
+        unimplemented!()
     }
 }
 

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -57,4 +57,35 @@ impl DataType for StringType {
     fn is_timestamp_compatible(&self) -> bool {
         false
     }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        if from.logical_type_id() == self.logical_type_id() {
+            return Some(from);
+        }
+
+        match from {
+            Value::Null => Some(Value::String(StringBytes::from("null".to_string()))),
+
+            Value::Boolean(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::UInt8(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::UInt16(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::UInt32(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::UInt64(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Int8(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Int16(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Int32(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Int64(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Float32(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Float64(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::String(v) => Some(Value::String(v)),
+            Value::Date(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::DateTime(v) => Some(Value::String(StringBytes::from(v.to_string()))),
+            Value::Timestamp(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
+            Value::Time(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
+            Value::Interval(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
+
+            // StringBytes is only support for utf-8, Value::Binary is not allowed.
+            Value::Binary(_) | Value::List(_) => None,
+        }
+    }
 }

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -83,6 +83,7 @@ impl DataType for StringType {
             Value::Timestamp(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
             Value::Time(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
             Value::Interval(v) => Some(Value::String(StringBytes::from(v.to_iso8601_string()))),
+            Value::Duration(v) => Some(Value::String(StringBytes::from(v.to_string()))),
 
             // StringBytes is only support for utf-8, Value::Binary is not allowed.
             Value::Binary(_) | Value::List(_) => None,

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -58,7 +58,7 @@ impl DataType for StringType {
         false
     }
 
-    fn cast(&self, from: Value) -> Option<Value> {
+    fn try_cast(&self, from: Value) -> Option<Value> {
         if from.logical_type_id() == self.logical_type_id() {
             return Some(from);
         }

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_time_cast() {
-        // Int32 -> TiemSecondType
+        // Int32 -> TimeSecondType
         let val = Value::Int32(1000);
         let time = ConcreteDataType::time_second_datatype().cast(val).unwrap();
         assert_eq!(time, Value::Time(Time::new_second(1000)));

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -410,8 +410,8 @@ mod tests {
             .unwrap();
         assert_eq!(time, Value::Time(Time::new_nanosecond(4000)));
 
-        // Other situations will return None, such as Int64 -> TimeSecondType
-        // or Int32 -> TimeMicrosecondType etc.
+        // Other situations will return None, such as Int64 -> TimeSecondType or
+        // Int32 -> TimeMicrosecondType etc.
         let val = Value::Int64(123);
         let time = ConcreteDataType::time_second_datatype().cast(val);
         assert_eq!(time, None);

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -86,36 +86,44 @@ impl TimeType {
 }
 
 macro_rules! impl_data_type_for_time {
-    ($unit: ident,$arrow_type: ident, $type: ty) => {
+    ($unit: ident,$arrow_type: ident, $type: ty, $TargetType: ident) => {
         paste! {
             #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
             pub struct [<Time $unit Type>];
 
-            // impl DataType for [<Time $unit Type>] {
-            //     fn name(&self) -> &str {
-            //         stringify!([<Time $unit>])
-            //     }
+            impl DataType for [<Time $unit Type>] {
+                fn name(&self) -> &str {
+                    stringify!([<Time $unit>])
+                }
 
-            //     fn logical_type_id(&self) -> LogicalTypeId {
-            //         LogicalTypeId::[<Time $unit>]
-            //     }
+                fn logical_type_id(&self) -> LogicalTypeId {
+                    LogicalTypeId::[<Time $unit>]
+                }
 
-            //     fn default_value(&self) -> Value {
-            //         Value::Time(Time::new(0, TimeUnit::$unit))
-            //     }
+                fn default_value(&self) -> Value {
+                    Value::Time(Time::new(0, TimeUnit::$unit))
+                }
 
-            //     fn as_arrow_type(&self) -> ArrowDataType {
-            //         ArrowDataType::$arrow_type(ArrowTimeUnit::$unit)
-            //     }
+                fn as_arrow_type(&self) -> ArrowDataType {
+                    ArrowDataType::$arrow_type(ArrowTimeUnit::$unit)
+                }
 
-            //     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-            //         Box::new([<Time $unit Vector Builder>]::with_capacity(capacity))
-            //     }
+                fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+                    Box::new([<Time $unit Vector Builder>]::with_capacity(capacity))
+                }
 
-            //     fn is_timestamp_compatible(&self) -> bool {
-            //         false
-            //     }
-            // }
+                fn is_timestamp_compatible(&self) -> bool {
+                    false
+                }
+
+                fn cast(&self, from: Value) -> Option<Value> {
+                    match from {
+                        Value::$TargetType(v) => Some(Value::Time(Time::new(v as i64, TimeUnit::$unit))),
+                        Value::Time(v) => Some(Value::Time(v)),
+                        _ => None,
+                    }
+                }
+            }
 
             impl LogicalPrimitiveType for [<Time $unit Type>] {
                 type ArrowPrimitive = [<Arrow Time $unit Type>];
@@ -172,174 +180,10 @@ macro_rules! impl_data_type_for_time {
     }
 }
 
-impl_data_type_for_time!(Second, Time32, i32);
-impl_data_type_for_time!(Millisecond, Time32, i32);
-impl_data_type_for_time!(Nanosecond, Time64, i64);
-impl_data_type_for_time!(Microsecond, Time64, i64);
-
-impl DataType for TimeSecondType {
-    #[doc = " Name of this data type."]
-    fn name(&self) -> &str {
-        stringify!(TimeSecondType)
-    }
-
-    #[doc = " Returns id of the Logical data type."]
-    fn logical_type_id(&self) -> LogicalTypeId {
-        LogicalTypeId::TimeSecond
-    }
-
-    #[doc = " Returns the default value of this type."]
-    fn default_value(&self) -> Value {
-        Value::Time(Time::new_second(0))
-    }
-
-    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
-    fn as_arrow_type(&self) -> ArrowDataType {
-        ArrowDataType::Time32(ArrowTimeUnit::Second)
-    }
-
-    #[doc = " Creates a mutable vector with given `capacity` of this type."]
-    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-        Box::new(TimeSecondVectorBuilder::with_capacity(capacity))
-    }
-
-    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
-    #[doc = " use it as a timestamp."]
-    fn is_timestamp_compatible(&self) -> bool {
-        false
-    }
-
-    fn cast(&self, from: Value) -> Option<Value> {
-        match from {
-            Value::Int32(v) => Some(Value::Time(Time::new_second(v as i64))),
-            Value::Time(v) => Some(Value::Time(v)),
-            _ => None,
-        }
-    }
-}
-
-impl DataType for TimeMillisecondType {
-    #[doc = " Name of this data type."]
-    fn name(&self) -> &str {
-        stringify!(TimeMillisecondType)
-    }
-
-    #[doc = " Returns id of the Logical data type."]
-    fn logical_type_id(&self) -> LogicalTypeId {
-        LogicalTypeId::TimeMillisecond
-    }
-
-    #[doc = " Returns the default value of this type."]
-    fn default_value(&self) -> Value {
-        Value::Time(Time::new_millisecond(0))
-    }
-
-    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
-    fn as_arrow_type(&self) -> ArrowDataType {
-        ArrowDataType::Time32(ArrowTimeUnit::Millisecond)
-    }
-
-    #[doc = " Creates a mutable vector with given `capacity` of this type."]
-    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-        Box::new(TimeMillisecondVectorBuilder::with_capacity(capacity))
-    }
-
-    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
-    #[doc = " use it as a timestamp."]
-    fn is_timestamp_compatible(&self) -> bool {
-        false
-    }
-
-    fn cast(&self, from: Value) -> Option<Value> {
-        match from {
-            Value::Int32(v) => Some(Value::Time(Time::new_millisecond(v as i64))),
-            Value::Time(v) => Some(Value::Time(v)),
-            _ => None,
-        }
-    }
-}
-
-impl DataType for TimeMicrosecondType {
-    #[doc = " Name of this data type."]
-    fn name(&self) -> &str {
-        stringify!(TimeMicrosecondType)
-    }
-
-    #[doc = " Returns id of the Logical data type."]
-    fn logical_type_id(&self) -> LogicalTypeId {
-        LogicalTypeId::TimeMicrosecond
-    }
-
-    #[doc = " Returns the default value of this type."]
-    fn default_value(&self) -> Value {
-        Value::Time(Time::new_microsecond(0))
-    }
-
-    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
-    fn as_arrow_type(&self) -> ArrowDataType {
-        ArrowDataType::Time64(ArrowTimeUnit::Microsecond)
-    }
-
-    #[doc = " Creates a mutable vector with given `capacity` of this type."]
-    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-        Box::new(TimeMicrosecondVectorBuilder::with_capacity(capacity))
-    }
-
-    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
-    #[doc = " use it as a timestamp."]
-    fn is_timestamp_compatible(&self) -> bool {
-        false
-    }
-
-    fn cast(&self, from: Value) -> Option<Value> {
-        match from {
-            Value::Int64(v) => Some(Value::Time(Time::new_microsecond(v))),
-            Value::Time(v) => Some(Value::Time(v)),
-            _ => None,
-        }
-    }
-}
-
-impl DataType for TimeNanosecondType {
-    #[doc = " Name of this data type."]
-    fn name(&self) -> &str {
-        stringify!(TimeNanosecondType)
-    }
-
-    #[doc = " Returns id of the Logical data type."]
-    fn logical_type_id(&self) -> LogicalTypeId {
-        LogicalTypeId::TimeNanosecond
-    }
-
-    #[doc = " Returns the default value of this type."]
-    fn default_value(&self) -> Value {
-        Value::Time(Time::new_nanosecond(0))
-    }
-
-    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
-    fn as_arrow_type(&self) -> ArrowDataType {
-        ArrowDataType::Time64(ArrowTimeUnit::Nanosecond)
-    }
-
-    #[doc = " Creates a mutable vector with given `capacity` of this type."]
-    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-        Box::new(TimeNanosecondVectorBuilder::with_capacity(capacity))
-    }
-
-    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
-    #[doc = " use it as a timestamp."]
-    fn is_timestamp_compatible(&self) -> bool {
-        false
-    }
-
-    fn cast(&self, from: Value) -> Option<Value> {
-        match from {
-            Value::Int64(v) => Some(Value::Time(Time::new_nanosecond(v))),
-            Value::Time(v) => Some(Value::Time(v)),
-            _ => None,
-        }
-    }
-}
+impl_data_type_for_time!(Second, Time32, i32, Int32);
+impl_data_type_for_time!(Millisecond, Time32, i32, Int32);
+impl_data_type_for_time!(Nanosecond, Time64, i64, Int64);
+impl_data_type_for_time!(Microsecond, Time64, i64, Int64);
 
 #[cfg(test)]
 mod tests {

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -116,7 +116,7 @@ macro_rules! impl_data_type_for_time {
                     false
                 }
 
-                fn cast(&self, from: Value) -> Option<Value> {
+                fn try_cast(&self, from: Value) -> Option<Value> {
                     match from {
                         Value::$TargetType(v) => Some(Value::Time(Time::new(v as i64, TimeUnit::$unit))),
                         Value::Time(v) => v.convert_to(TimeUnit::$unit).map(Value::Time),
@@ -230,44 +230,46 @@ mod tests {
     fn test_time_cast() {
         // Int32 -> TimeSecondType
         let val = Value::Int32(1000);
-        let time = ConcreteDataType::time_second_datatype().cast(val).unwrap();
+        let time = ConcreteDataType::time_second_datatype()
+            .try_cast(val)
+            .unwrap();
         assert_eq!(time, Value::Time(Time::new_second(1000)));
 
         // Int32 -> TimeMillisecondType
         let val = Value::Int32(2000);
         let time = ConcreteDataType::time_millisecond_datatype()
-            .cast(val)
+            .try_cast(val)
             .unwrap();
         assert_eq!(time, Value::Time(Time::new_millisecond(2000)));
 
         // Int64 -> TimeMicrosecondType
         let val = Value::Int64(3000);
         let time = ConcreteDataType::time_microsecond_datatype()
-            .cast(val)
+            .try_cast(val)
             .unwrap();
         assert_eq!(time, Value::Time(Time::new_microsecond(3000)));
 
         // Int64 -> TimeNanosecondType
         let val = Value::Int64(4000);
         let time = ConcreteDataType::time_nanosecond_datatype()
-            .cast(val)
+            .try_cast(val)
             .unwrap();
         assert_eq!(time, Value::Time(Time::new_nanosecond(4000)));
 
         // Other situations will return None, such as Int64 -> TimeSecondType or
         // Int32 -> TimeMicrosecondType etc.
         let val = Value::Int64(123);
-        let time = ConcreteDataType::time_second_datatype().cast(val);
+        let time = ConcreteDataType::time_second_datatype().try_cast(val);
         assert_eq!(time, None);
 
         let val = Value::Int32(123);
-        let time = ConcreteDataType::time_microsecond_datatype().cast(val);
+        let time = ConcreteDataType::time_microsecond_datatype().try_cast(val);
         assert_eq!(time, None);
 
         // TimeSecond -> TimeMicroSecond
         let second = Value::Time(Time::new_second(2023));
         let microsecond = ConcreteDataType::time_microsecond_datatype()
-            .cast(second)
+            .try_cast(second)
             .unwrap();
         assert_eq!(
             microsecond,
@@ -276,7 +278,7 @@ mod tests {
 
         // test overflow
         let second = Value::Time(Time::new_second(i64::MAX));
-        let microsecond = ConcreteDataType::time_microsecond_datatype().cast(second);
+        let microsecond = ConcreteDataType::time_microsecond_datatype().try_cast(second);
         assert_eq!(microsecond, None);
     }
 }

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -91,31 +91,31 @@ macro_rules! impl_data_type_for_time {
             #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
             pub struct [<Time $unit Type>];
 
-            impl DataType for [<Time $unit Type>] {
-                fn name(&self) -> &str {
-                    stringify!([<Time $unit>])
-                }
+            // impl DataType for [<Time $unit Type>] {
+            //     fn name(&self) -> &str {
+            //         stringify!([<Time $unit>])
+            //     }
 
-                fn logical_type_id(&self) -> LogicalTypeId {
-                    LogicalTypeId::[<Time $unit>]
-                }
+            //     fn logical_type_id(&self) -> LogicalTypeId {
+            //         LogicalTypeId::[<Time $unit>]
+            //     }
 
-                fn default_value(&self) -> Value {
-                    Value::Time(Time::new(0, TimeUnit::$unit))
-                }
+            //     fn default_value(&self) -> Value {
+            //         Value::Time(Time::new(0, TimeUnit::$unit))
+            //     }
 
-                fn as_arrow_type(&self) -> ArrowDataType {
-                    ArrowDataType::$arrow_type(ArrowTimeUnit::$unit)
-                }
+            //     fn as_arrow_type(&self) -> ArrowDataType {
+            //         ArrowDataType::$arrow_type(ArrowTimeUnit::$unit)
+            //     }
 
-                fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
-                    Box::new([<Time $unit Vector Builder>]::with_capacity(capacity))
-                }
+            //     fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+            //         Box::new([<Time $unit Vector Builder>]::with_capacity(capacity))
+            //     }
 
-                fn is_timestamp_compatible(&self) -> bool {
-                    false
-                }
-            }
+            //     fn is_timestamp_compatible(&self) -> bool {
+            //         false
+            //     }
+            // }
 
             impl LogicalPrimitiveType for [<Time $unit Type>] {
                 type ArrowPrimitive = [<Arrow Time $unit Type>];
@@ -177,6 +177,170 @@ impl_data_type_for_time!(Millisecond, Time32, i32);
 impl_data_type_for_time!(Nanosecond, Time64, i64);
 impl_data_type_for_time!(Microsecond, Time64, i64);
 
+impl DataType for TimeSecondType {
+    #[doc = " Name of this data type."]
+    fn name(&self) -> &str {
+        stringify!(TimeSecondType)
+    }
+
+    #[doc = " Returns id of the Logical data type."]
+    fn logical_type_id(&self) -> LogicalTypeId {
+        LogicalTypeId::TimeSecond
+    }
+
+    #[doc = " Returns the default value of this type."]
+    fn default_value(&self) -> Value {
+        Value::Time(Time::new_second(0))
+    }
+
+    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
+    fn as_arrow_type(&self) -> ArrowDataType {
+        ArrowDataType::Time32(ArrowTimeUnit::Second)
+    }
+
+    #[doc = " Creates a mutable vector with given `capacity` of this type."]
+    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+        Box::new(TimeSecondVectorBuilder::with_capacity(capacity))
+    }
+
+    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
+    #[doc = " use it as a timestamp."]
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int32(v) => Some(Value::Time(Time::new_second(v as i64))),
+            Value::Time(v) => Some(Value::Time(v)),
+            _ => None,
+        }
+    }
+}
+
+impl DataType for TimeMillisecondType {
+    #[doc = " Name of this data type."]
+    fn name(&self) -> &str {
+        stringify!(TimeMillisecondType)
+    }
+
+    #[doc = " Returns id of the Logical data type."]
+    fn logical_type_id(&self) -> LogicalTypeId {
+        LogicalTypeId::TimeMillisecond
+    }
+
+    #[doc = " Returns the default value of this type."]
+    fn default_value(&self) -> Value {
+        Value::Time(Time::new_millisecond(0))
+    }
+
+    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
+    fn as_arrow_type(&self) -> ArrowDataType {
+        ArrowDataType::Time32(ArrowTimeUnit::Millisecond)
+    }
+
+    #[doc = " Creates a mutable vector with given `capacity` of this type."]
+    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+        Box::new(TimeMillisecondVectorBuilder::with_capacity(capacity))
+    }
+
+    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
+    #[doc = " use it as a timestamp."]
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int32(v) => Some(Value::Time(Time::new_millisecond(v as i64))),
+            Value::Time(v) => Some(Value::Time(v)),
+            _ => None,
+        }
+    }
+}
+
+impl DataType for TimeMicrosecondType {
+    #[doc = " Name of this data type."]
+    fn name(&self) -> &str {
+        stringify!(TimeMicrosecondType)
+    }
+
+    #[doc = " Returns id of the Logical data type."]
+    fn logical_type_id(&self) -> LogicalTypeId {
+        LogicalTypeId::TimeMicrosecond
+    }
+
+    #[doc = " Returns the default value of this type."]
+    fn default_value(&self) -> Value {
+        Value::Time(Time::new_microsecond(0))
+    }
+
+    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
+    fn as_arrow_type(&self) -> ArrowDataType {
+        ArrowDataType::Time64(ArrowTimeUnit::Microsecond)
+    }
+
+    #[doc = " Creates a mutable vector with given `capacity` of this type."]
+    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+        Box::new(TimeMicrosecondVectorBuilder::with_capacity(capacity))
+    }
+
+    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
+    #[doc = " use it as a timestamp."]
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int64(v) => Some(Value::Time(Time::new_microsecond(v))),
+            Value::Time(v) => Some(Value::Time(v)),
+            _ => None,
+        }
+    }
+}
+
+impl DataType for TimeNanosecondType {
+    #[doc = " Name of this data type."]
+    fn name(&self) -> &str {
+        stringify!(TimeNanosecondType)
+    }
+
+    #[doc = " Returns id of the Logical data type."]
+    fn logical_type_id(&self) -> LogicalTypeId {
+        LogicalTypeId::TimeNanosecond
+    }
+
+    #[doc = " Returns the default value of this type."]
+    fn default_value(&self) -> Value {
+        Value::Time(Time::new_nanosecond(0))
+    }
+
+    #[doc = " Convert this type as [arrow::datatypes::DataType]."]
+    fn as_arrow_type(&self) -> ArrowDataType {
+        ArrowDataType::Time64(ArrowTimeUnit::Nanosecond)
+    }
+
+    #[doc = " Creates a mutable vector with given `capacity` of this type."]
+    fn create_mutable_vector(&self, capacity: usize) -> Box<dyn MutableVector> {
+        Box::new(TimeNanosecondVectorBuilder::with_capacity(capacity))
+    }
+
+    #[doc = " Returns true if the data type is compatible with timestamp type so we can"]
+    #[doc = " use it as a timestamp."]
+    fn is_timestamp_compatible(&self) -> bool {
+        false
+    }
+
+    fn cast(&self, from: Value) -> Option<Value> {
+        match from {
+            Value::Int64(v) => Some(Value::Time(Time::new_nanosecond(v))),
+            Value::Time(v) => Some(Value::Time(v)),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +380,44 @@ mod tests {
             ArrowDataType::Time64(ArrowTimeUnit::Nanosecond),
             TimeNanosecondType.as_arrow_type()
         );
+    }
+
+    #[test]
+    fn test_time_cast() {
+        // Int32 -> TiemSecondType
+        let val = Value::Int32(1000);
+        let time = ConcreteDataType::time_second_datatype().cast(val).unwrap();
+        assert_eq!(time, Value::Time(Time::new_second(1000)));
+
+        // Int32 -> TimeMillisecondType
+        let val = Value::Int32(2000);
+        let time = ConcreteDataType::time_millisecond_datatype()
+            .cast(val)
+            .unwrap();
+        assert_eq!(time, Value::Time(Time::new_millisecond(2000)));
+
+        // Int64 -> TimeMicrosecondType
+        let val = Value::Int64(3000);
+        let time = ConcreteDataType::time_microsecond_datatype()
+            .cast(val)
+            .unwrap();
+        assert_eq!(time, Value::Time(Time::new_microsecond(3000)));
+
+        // Int64 -> TimeNanosecondType
+        let val = Value::Int64(4000);
+        let time = ConcreteDataType::time_nanosecond_datatype()
+            .cast(val)
+            .unwrap();
+        assert_eq!(time, Value::Time(Time::new_nanosecond(4000)));
+
+        // Other situations will return None, such as Int64 -> TimeSecondType
+        // or Int32 -> TimeMicrosecondType etc.
+        let val = Value::Int64(123);
+        let time = ConcreteDataType::time_second_datatype().cast(val);
+        assert_eq!(time, None);
+
+        let val = Value::Int32(123);
+        let time = ConcreteDataType::time_microsecond_datatype().cast(val);
+        assert_eq!(time, None);
     }
 }

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -242,6 +242,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_cast() {
+        std::env::set_var("TZ", "Asia/Shanghai");
         // string -> timestamp
         let s = Value::String("2021-01-01 01:02:03".to_string().into());
         let ts = ConcreteDataType::timestamp_second_datatype()
@@ -258,10 +259,10 @@ mod tests {
 
         // datetime -> timestamp
         let dt = Value::DateTime(DateTime::from(1234567));
-        let ts = ConcreteDataType::timestamp_millisecond_datatype()
+        let ts = ConcreteDataType::timestamp_second_datatype()
             .cast(dt)
             .unwrap();
-        assert_eq!(ts, Value::Timestamp(Timestamp::new_millisecond(1234567)));
+        assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1234567)));
 
         // date -> timestamp
         let d = Value::Date(Date::from_str("1970-01-01").unwrap());

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -133,7 +133,7 @@ macro_rules! impl_data_type_for_timestamp {
                     true
                 }
 
-                fn cast(&self, from: Value)-> Option<Value>{
+                fn try_cast(&self, from: Value)-> Option<Value>{
                     match from {
                         Value::Timestamp(v) => v.convert_to(TimeUnit::$unit).map(Value::Timestamp),
                         Value::String(v) => Timestamp::from_str(v.as_utf8()).map(Value::Timestamp).ok(),
@@ -237,39 +237,39 @@ mod tests {
         // String -> TimestampSecond
         let s = Value::String("2021-01-01 01:02:03".to_string().into());
         let ts = ConcreteDataType::timestamp_second_datatype()
-            .cast(s)
+            .try_cast(s)
             .unwrap();
         assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1609434123)));
         // String cast failed
         let s = Value::String("12345".to_string().into());
-        let ts = ConcreteDataType::timestamp_second_datatype().cast(s);
+        let ts = ConcreteDataType::timestamp_second_datatype().try_cast(s);
         assert_eq!(ts, None);
 
         let n = Value::Int64(1694589525);
         // Int64 -> TimestampSecond
         let ts = ConcreteDataType::timestamp_second_datatype()
-            .cast(n)
+            .try_cast(n)
             .unwrap();
         assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1694589525)));
 
         // Datetime -> TimestampSecond
         let dt = Value::DateTime(DateTime::from(1234567));
         let ts = ConcreteDataType::timestamp_second_datatype()
-            .cast(dt)
+            .try_cast(dt)
             .unwrap();
         assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1234567)));
 
         // Date -> TimestampMillisecond
         let d = Value::Date(Date::from_str("1970-01-01").unwrap());
         let ts = ConcreteDataType::timestamp_millisecond_datatype()
-            .cast(d)
+            .try_cast(d)
             .unwrap();
         assert_eq!(ts, Value::Timestamp(Timestamp::new_millisecond(0)));
 
         // TimestampSecond -> TimestampMicrosecond
         let second = Value::Timestamp(Timestamp::new_second(123));
         let microsecond = ConcreteDataType::timestamp_microsecond_datatype()
-            .cast(second)
+            .try_cast(second)
             .unwrap();
         assert_eq!(
             microsecond,

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str::FromStr;
+
 use arrow::datatypes::{
     DataType as ArrowDataType, TimeUnit as ArrowTimeUnit,
     TimestampMicrosecondType as ArrowTimestampMicrosecondType,
@@ -130,6 +132,26 @@ macro_rules! impl_data_type_for_timestamp {
                 fn is_timestamp_compatible(&self) -> bool {
                     true
                 }
+
+                fn cast(&self, from: Value)-> Option<Value>{
+                    match from {
+                        Value::Timestamp(v) => Some(Value::Timestamp(v)),
+                        Value::String(v) => match Timestamp::from_str(v.as_utf8()){
+                            Ok(ts) => Some(Value::Timestamp(ts)),
+                            Err(_) => None
+                        }
+                        Value::Int64(v) => Some(Value::Timestamp(Timestamp::new(v, TimeUnit::$unit))),
+                        Value::DateTime(v) => match v.to_chrono_datetime(){
+                            Some(dt) => Some(Value::Timestamp(Timestamp::from_chrono_datetime(dt)?)),
+                            None => None
+                        },
+                        Value::Date(v) => match v.to_chrono_date(){
+                            Some(d) => Some(Value::Timestamp(Timestamp::from_chrono_date(d)?)),
+                            None => None
+                        },
+                        _ => None
+                    }
+                }
             }
 
             impl LogicalPrimitiveType for [<Timestamp $unit Type>] {
@@ -194,6 +216,8 @@ impl_data_type_for_timestamp!(Microsecond);
 
 #[cfg(test)]
 mod tests {
+    use common_time::{Date, DateTime};
+
     use super::*;
 
     #[test]
@@ -214,5 +238,36 @@ mod tests {
             TimeUnit::Nanosecond,
             TimestampType::Nanosecond(TimestampNanosecondType).unit()
         );
+    }
+
+    #[test]
+    fn test_timestamp_cast() {
+        // string -> timestamp
+        let s = Value::String("2021-01-01 01:02:03".to_string().into());
+        let ts = ConcreteDataType::timestamp_second_datatype()
+            .cast(s)
+            .unwrap();
+        assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1609434123)));
+
+        let n = Value::Int64(1694589525);
+        // Int64 -> timestamp
+        let ts = ConcreteDataType::timestamp_second_datatype()
+            .cast(n)
+            .unwrap();
+        assert_eq!(ts, Value::Timestamp(Timestamp::new_second(1694589525)));
+
+        // datetime -> timestamp
+        let dt = Value::DateTime(DateTime::from(1234567));
+        let ts = ConcreteDataType::timestamp_millisecond_datatype()
+            .cast(dt)
+            .unwrap();
+        assert_eq!(ts, Value::Timestamp(Timestamp::new_millisecond(1234567)));
+
+        // date -> timestamp
+        let d = Value::Date(Date::from_str("1970-01-01").unwrap());
+        let ts = ConcreteDataType::timestamp_millisecond_datatype()
+            .cast(d)
+            .unwrap();
+        assert_eq!(ts, Value::Timestamp(Timestamp::new_millisecond(0)));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

### main changes
1. add `try_cast()` in `datatype` trait.
2. implement the cast for `date/time/timestamp/datetime` types.
3. implement primitive types `u8,u16,u32,u64,i8,i16,i32,i64,f32,f64` cast.
4. impl `cast_with_opt` method which supports two mode which can be set with `CastOption` for casting type(for cast failed: `strict mode` will return error and `non-strict` mode will return Null).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes https://github.com/GreptimeTeam/greptimedb/issues/2376