### PR TITLE
feat!: add engine name to DatanodeTableValue

### DIFF
--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -386,6 +386,7 @@ impl MigrateTableMetadata {
 
     async fn create_datanode_table_keys(&self, value: &TableGlobalValue) {
         let table_id = value.table_id();
+        let engine = value.table_info.meta.engine.as_str();
         let region_distribution: RegionDistribution =
             value.regions_id_map.clone().into_iter().collect();
 
@@ -394,7 +395,10 @@ impl MigrateTableMetadata {
             .map(|(datanode_id, regions)| {
                 let k = DatanodeTableKey::new(datanode_id, table_id);
                 info!("Creating DatanodeTableKey '{k}' => {regions:?}");
-                (k, DatanodeTableValue::new(table_id, regions))
+                (
+                    k,
+                    DatanodeTableValue::new(table_id, regions, engine.to_string()),
+                )
             })
             .collect::<Vec<_>>();
 

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -247,7 +247,6 @@ mod tests {
             engine: Default::default(),
             version: 1,
         };
-        print!("{value:?}");
         let literal = br#"{"table_id":42,"regions":[1,2,3],"engine":"","version":1}"#;
 
         let raw_value = value.try_as_raw_value().unwrap();

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -85,14 +85,16 @@ impl TableMetaKey for DatanodeTableKey {
 pub struct DatanodeTableValue {
     pub table_id: TableId,
     pub regions: Vec<RegionNumber>,
+    pub engine: String,
     version: u64,
 }
 
 impl DatanodeTableValue {
-    pub fn new(table_id: TableId, regions: Vec<RegionNumber>) -> Self {
+    pub fn new(table_id: TableId, regions: Vec<RegionNumber>, engine: String) -> Self {
         Self {
             table_id,
             regions,
+            engine,
             version: 0,
         }
     }
@@ -143,13 +145,14 @@ impl DatanodeTableManager {
     pub fn build_create_txn(
         &self,
         table_id: TableId,
+        engine: &str,
         distribution: RegionDistribution,
     ) -> Result<Txn> {
         let txns = distribution
             .into_iter()
             .map(|(datanode_id, regions)| {
                 let key = DatanodeTableKey::new(datanode_id, table_id);
-                let val = DatanodeTableValue::new(table_id, regions);
+                let val = DatanodeTableValue::new(table_id, regions, engine.to_string());
 
                 Ok(TxnOp::Put(key.as_raw_key(), val.try_as_raw_value()?))
             })
@@ -164,6 +167,7 @@ impl DatanodeTableManager {
     pub(crate) fn build_update_txn(
         &self,
         table_id: TableId,
+        engine: &str,
         current_region_distribution: RegionDistribution,
         new_region_distribution: RegionDistribution,
     ) -> Result<Txn> {
@@ -184,14 +188,16 @@ impl DatanodeTableManager {
                 if *current_region != regions {
                     let key = DatanodeTableKey::new(datanode, table_id);
                     let raw_key = key.as_raw_key();
-                    let val = DatanodeTableValue::new(table_id, regions).try_as_raw_value()?;
+                    let val = DatanodeTableValue::new(table_id, regions, engine.to_string())
+                        .try_as_raw_value()?;
                     opts.push(TxnOp::Put(raw_key, val));
                 }
             } else {
                 // New datanodes
                 let key = DatanodeTableKey::new(datanode, table_id);
                 let raw_key = key.as_raw_key();
-                let val = DatanodeTableValue::new(table_id, regions).try_as_raw_value()?;
+                let val = DatanodeTableValue::new(table_id, regions, engine.to_string())
+                    .try_as_raw_value()?;
                 opts.push(TxnOp::Put(raw_key, val));
             }
         }
@@ -224,7 +230,6 @@ impl DatanodeTableManager {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]
@@ -239,9 +244,11 @@ mod tests {
         let value = DatanodeTableValue {
             table_id: 42,
             regions: vec![1, 2, 3],
+            engine: Default::default(),
             version: 1,
         };
-        let literal = br#"{"table_id":42,"regions":[1,2,3],"version":1}"#;
+        print!("{value:?}");
+        let literal = br#"{"table_id":42,"regions":[1,2,3],"engine":"","version":1}"#;
 
         let raw_value = value.try_as_raw_value().unwrap();
         assert_eq!(raw_value, literal);

--- a/src/meta-srv/src/procedure/region_failover/update_metadata.rs
+++ b/src/meta-srv/src/procedure/region_failover/update_metadata.rs
@@ -58,6 +58,7 @@ impl UpdateRegionMetadata {
         failed_region: &RegionIdent,
     ) -> Result<()> {
         let table_id = failed_region.table_ident.table_id;
+        let engine = failed_region.table_ident.engine.as_str();
 
         let table_route_value = ctx
             .table_metadata_manager
@@ -85,7 +86,7 @@ impl UpdateRegionMetadata {
         );
 
         ctx.table_metadata_manager
-            .update_table_route(table_id, table_route_value, new_region_routes)
+            .update_table_route(table_id, engine, table_route_value, new_region_routes)
             .await
             .context(error::UpdateTableRouteSnafu)?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add the engine name to DatanodeTableValue because datanodes do not know how to open a region upon start.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
