### PR TITLE
fix: alter table procedure panics while renaming table

### DIFF
--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -195,9 +195,10 @@ mod test {
             r"
 CREATE TABLE {table_name} (
     a INT,
-    b STRING PRIMARY KEY,
+    b STRING,
     ts TIMESTAMP,
-    TIME INDEX (ts)
+    TIME INDEX (ts),
+    PRIMARY KEY (a, b)
 ) PARTITION BY RANGE COLUMNS(a) (
     PARTITION r0 VALUES LESS THAN (10),
     PARTITION r1 VALUES LESS THAN (20),

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -334,7 +334,7 @@ CREATE TABLE {table_name} (
                         ..Default::default()
                     }),
                     null_mask: vec![32, 0],
-                    semantic_type: SemanticType::Field as i32,
+                    semantic_type: SemanticType::Tag as i32,
                     datatype: ColumnDataType::Int32 as i32,
                 },
                 Column {
@@ -412,7 +412,7 @@ CREATE TABLE {table_name} (
             key_columns: vec![
                 Column {
                     column_name: "a".to_string(),
-                    semantic_type: SemanticType::Field as i32,
+                    semantic_type: SemanticType::Tag as i32,
                     values: Some(Values {
                         i32_values: a,
                         ..Default::default()

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -191,7 +191,7 @@ fn expect_data() -> (Column, Column, Column, Column) {
                 .collect(),
             ..Default::default()
         }),
-        semantic_type: SemanticType::Field as i32,
+        semantic_type: SemanticType::Tag as i32,
         datatype: ColumnDataType::String as i32,
         ..Default::default()
     };
@@ -363,14 +363,14 @@ fn testing_create_expr() -> CreateTableExpr {
         ColumnDef {
             name: "ts".to_string(),
             data_type: ColumnDataType::TimestampMillisecond as i32, // timestamp
-            is_nullable: true,
+            is_nullable: false,
             default_constraint: vec![],
             semantic_type: SemanticType::Timestamp as i32,
         },
     ];
     CreateTableExpr {
-        catalog_name: "".to_string(),
-        schema_name: "".to_string(),
+        catalog_name: "greptime".to_string(),
+        schema_name: "public".to_string(),
         table_name: "demo".to_string(),
         desc: "blabla little magic fairy".to_string(),
         column_defs,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes panics while using the `AlterTableProcedure` to rename a table.

It fixes integration tests for renaming. It also fixes grpc tests that use incorrect semantic type. Now the following tests pass:
- test_create_table_after_rename_table
- test_rename_table
- test_standalone_insert_and_query
- test_distributed_insert_delete_and_query

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2386