### PR TITLE
feat: clap wrapper around sqlness 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9019,6 +9019,7 @@ name = "sqlness-runner"
 version = "0.4.0-nightly"
 dependencies = [
  "async-trait",
+ "clap 4.4.1",
  "client",
  "common-base",
  "common-error",

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = "0.1"
+clap = { version = "4.0", features = ["derive"] }
 client = { workspace = true }
 common-base = { workspace = true }
 common-error = { workspace = true }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -29,16 +29,16 @@ struct Args {
     #[clap(short, long)]
     case_dir: Option<PathBuf>,
 
-    ///Fail this run as soon as one case fails if true
-    #[arg(short, long, action = clap::ArgAction::Count)]
-    fail_fast: u8,
+    /// Fail this run as soon as one case fails if true
+    #[arg(short, long, default_value = "false")]
+    fail_fast: bool,
 
-    ///Environment Configuration File
+    /// Environment Configuration File
     #[clap(short, long, default_value = "config.toml")]
     env_config_file: String,
 
-    ///Name of test case to be matched
-    #[clap(short, long, default_value = "")]
+    /// Name of test cases to run. Accept as a regexp.
+    #[clap(short, long, default_value = ".*")]
     test_filter: String,
 }
 
@@ -53,7 +53,7 @@ async fn main() {
 
     let config = ConfigBuilder::default()
         .case_dir(util::get_case_dir(args.case_dir))
-        .fail_fast(matches!(args.fail_fast, 0))
+        .fail_fast(args.fail_fast)
         .test_filter(args.test_filter)
         .follow_links(true)
         .env_config_file(args.env_config_file)

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -12,20 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::PathBuf;
+
+use clap::Parser;
 use env::Env;
 use sqlness::{ConfigBuilder, Runner};
 
 mod env;
 mod util;
 
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+/// SQL Harness for GrepTimeDB
+struct Args {
+    /// Directory of test cases
+    #[clap(short, long)]
+    case_dir: Option<PathBuf>,
+
+    ///Fail this run as soon as one case fails if true
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    fail_fast: u8,
+
+    ///Environment Configuration File
+    #[clap(short, long, default_value = "config.toml")]
+    env_config_file: String,
+
+    ///Name of test case to be matched
+    #[clap(short, long, default_value = "")]
+    test_filter: String,
+}
+
 #[tokio::main]
 async fn main() {
-    let mut args: Vec<String> = std::env::args().collect();
-    let test_filter = if args.len() > 1 {
-        args.pop().unwrap()
-    } else {
-        "".to_string()
-    };
+    let args = Args::parse();
 
     #[cfg(windows)]
     let data_home = std::env::temp_dir();
@@ -33,10 +52,11 @@ async fn main() {
     let data_home = std::path::PathBuf::from("/tmp");
 
     let config = ConfigBuilder::default()
-        .case_dir(util::get_case_dir())
-        .fail_fast(false)
-        .test_filter(test_filter)
+        .case_dir(util::get_case_dir(args.case_dir))
+        .fail_fast(matches!(args.fail_fast, 0))
+        .test_filter(args.test_filter)
         .follow_links(true)
+        .env_config_file(args.env_config_file)
         .build()
         .unwrap();
     let runner = Runner::new(config, Env::new(data_home));

--- a/tests/runner/src/util.rs
+++ b/tests/runner/src/util.rs
@@ -62,15 +62,20 @@ where
 
 /// Get the dir of test cases. This function only works when the runner is run
 /// under the project's dir because it depends on some envs set by cargo.
-pub fn get_case_dir() -> String {
-    // retrieve the manifest runner (./tests/runner)
-    let mut runner_crate_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+pub fn get_case_dir(case_dir: Option<PathBuf>) -> String {
+    let runner_path = match case_dir {
+        Some(path) => path,
+        None => {
+            // retrieve the manifest runner (./tests/runner)
+            let mut runner_crate_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            // change directory to cases' dir from runner's (should be runner/../cases)
+            let _ = runner_crate_path.pop();
+            runner_crate_path.push("cases");
+            runner_crate_path
+        }
+    };
 
-    // change directory to cases' dir from runner's (should be runner/../cases)
-    let _ = runner_crate_path.pop();
-    runner_crate_path.push("cases");
-
-    runner_crate_path.into_os_string().into_string().unwrap()
+    runner_path.into_os_string().into_string().unwrap()
 }
 
 /// Get the dir that contains workspace manifest (the top-level Cargo.toml).


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Added clap to the `sqlness` runner to improve the interface by providing help messages and allowing configurations.

Please explain IN DETAIL what the changes are in this PR and why they are needed:
`sqlness` can now accept arguments to be configured with when running tests. Below is the result of the help command after running: `cargo sqlness -h`
```
SQL Harness for GrepTimeDB

Usage: sqlness-runner [OPTIONS]

Options:
  -c, --case-dir <CASE_DIR>                Directory of test cases
  -f, --fail-fast...                       Fail this run as soon as one case fails if true
  -e, --env-config-file <ENV_CONFIG_FILE>  Environment Configuration File [default: config.toml]
  -t, --test-filter <TEST_FILTER>          Name of test case to be matched [default: ]
  -h, --help                               Print help
  -V, --version                            Print version
```
All arguments assume their default values when omitted from the command line. To use all arguments(or some):
```sh
cargo sqlness -f -c /path/to/testcase -e example.toml -t aggregation
```

## Checklist
- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

This PR references #2380 