### PR TITLE
chore: add `#[serde(default)]` to new added `engine` field

### DIFF
--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -85,6 +85,7 @@ impl TableMetaKey for DatanodeTableKey {
 pub struct DatanodeTableValue {
     pub table_id: TableId,
     pub regions: Vec<RegionNumber>,
+    #[serde(default)]
     pub engine: String,
     version: u64,
 }
@@ -254,6 +255,11 @@ mod tests {
 
         let actual = DatanodeTableValue::try_from_raw_value(literal).unwrap();
         assert_eq!(actual, value);
+
+        // test serde default
+        let raw_str = br#"{"table_id":42,"regions":[1,2,3],"version":1}"#;
+        let parsed = DatanodeTableValue::try_from_raw_value(raw_str);
+        assert!(parsed.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This is a compatible patch to #2395 for upgrading with existing meta values.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
