### PR TITLE
feat: region storage path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=d9390db43083844991887401c830bda8a974acd9#d9390db43083844991887401c830bda8a974acd9"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e81a60e817a348ee5b7dfbd991f86d35cd068ce5#e81a60e817a348ee5b7dfbd991f86d35cd068ce5"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,7 +4103,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=81495b166b2c8909f05b3fcaa09eb299bb43a995#81495b166b2c8909f05b3fcaa09eb299bb43a995"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=d9390db43083844991887401c830bda8a974acd9#d9390db43083844991887401c830bda8a974acd9"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "d9390db43083844991887401c830bda8a974acd9" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e81a60e817a348ee5b7dfbd991f86d35cd068ce5" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "81495b166b2c8909f05b3fcaa09eb299bb43a995" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "d9390db43083844991887401c830bda8a974acd9" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -29,7 +29,7 @@ use strum::AsRefStr;
 use table::engine::TableReference;
 use table::metadata::{RawTableInfo, TableId};
 
-use crate::ddl::utils::{handle_operate_region_error, handle_retry_error};
+use crate::ddl::utils::{handle_operate_region_error, handle_retry_error, region_storage_path};
 use crate::ddl::DdlContext;
 use crate::error::{self, Result};
 use crate::key::table_name::TableNameKey;
@@ -161,8 +161,7 @@ impl CreateTableProcedure {
             column_defs,
             primary_key,
             create_if_not_exists: true,
-            catalog: String::new(),
-            schema: String::new(),
+            path: String::new(),
             options: create_table_expr.table_options.clone(),
         })
     }
@@ -174,6 +173,7 @@ impl CreateTableProcedure {
         let create_table_expr = &create_table_data.task.create_table;
         let catalog = &create_table_expr.catalog_name;
         let schema = &create_table_expr.schema_name;
+        let storage_path = region_storage_path(catalog, schema);
 
         let request_template = self.create_region_request_template()?;
 
@@ -191,9 +191,7 @@ impl CreateTableProcedure {
 
                     let mut create_region_request = request_template.clone();
                     create_region_request.region_id = region_id.as_u64();
-                    create_region_request.catalog = catalog.to_string();
-                    create_region_request.schema = schema.to_string();
-
+                    create_region_request.path = storage_path.clone();
                     PbRegionRequest::Create(create_region_request)
                 })
                 .collect::<Vec<_>>();

--- a/src/common/meta/src/ddl/utils.rs
+++ b/src/common/meta/src/ddl/utils.rs
@@ -42,3 +42,8 @@ pub fn handle_retry_error(e: Error) -> ProcedureError {
         ProcedureError::external(e)
     }
 }
+
+#[inline]
+pub fn region_storage_path(catalog: &str, schema: &str) -> String {
+    format!("{}/{}", catalog, schema)
+}

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -86,6 +86,7 @@ pub struct DatanodeTableValue {
     pub table_id: TableId,
     pub regions: Vec<RegionNumber>,
     pub engine: String,
+    #[serde(default)]
     pub region_storage_path: String,
     version: u64,
 }

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -85,6 +85,7 @@ impl TableMetaKey for DatanodeTableKey {
 pub struct DatanodeTableValue {
     pub table_id: TableId,
     pub regions: Vec<RegionNumber>,
+    #[serde(default)]
     pub engine: String,
     #[serde(default)]
     pub region_storage_path: String,

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -86,15 +86,22 @@ pub struct DatanodeTableValue {
     pub table_id: TableId,
     pub regions: Vec<RegionNumber>,
     pub engine: String,
+    pub region_storage_path: String,
     version: u64,
 }
 
 impl DatanodeTableValue {
-    pub fn new(table_id: TableId, regions: Vec<RegionNumber>, engine: String) -> Self {
+    pub fn new(
+        table_id: TableId,
+        regions: Vec<RegionNumber>,
+        engine: String,
+        region_storage_path: String,
+    ) -> Self {
         Self {
             table_id,
             regions,
             engine,
+            region_storage_path,
             version: 0,
         }
     }
@@ -146,13 +153,19 @@ impl DatanodeTableManager {
         &self,
         table_id: TableId,
         engine: &str,
+        region_storage_path: &str,
         distribution: RegionDistribution,
     ) -> Result<Txn> {
         let txns = distribution
             .into_iter()
             .map(|(datanode_id, regions)| {
                 let key = DatanodeTableKey::new(datanode_id, table_id);
-                let val = DatanodeTableValue::new(table_id, regions, engine.to_string());
+                let val = DatanodeTableValue::new(
+                    table_id,
+                    regions,
+                    engine.to_string(),
+                    region_storage_path.to_string(),
+                );
 
                 Ok(TxnOp::Put(key.as_raw_key(), val.try_as_raw_value()?))
             })
@@ -168,6 +181,7 @@ impl DatanodeTableManager {
         &self,
         table_id: TableId,
         engine: &str,
+        region_storage_path: &str,
         current_region_distribution: RegionDistribution,
         new_region_distribution: RegionDistribution,
     ) -> Result<Txn> {
@@ -188,16 +202,26 @@ impl DatanodeTableManager {
                 if *current_region != regions {
                     let key = DatanodeTableKey::new(datanode, table_id);
                     let raw_key = key.as_raw_key();
-                    let val = DatanodeTableValue::new(table_id, regions, engine.to_string())
-                        .try_as_raw_value()?;
+                    let val = DatanodeTableValue::new(
+                        table_id,
+                        regions,
+                        engine.to_string(),
+                        region_storage_path.to_string(),
+                    )
+                    .try_as_raw_value()?;
                     opts.push(TxnOp::Put(raw_key, val));
                 }
             } else {
                 // New datanodes
                 let key = DatanodeTableKey::new(datanode, table_id);
                 let raw_key = key.as_raw_key();
-                let val = DatanodeTableValue::new(table_id, regions, engine.to_string())
-                    .try_as_raw_value()?;
+                let val = DatanodeTableValue::new(
+                    table_id,
+                    regions,
+                    engine.to_string(),
+                    region_storage_path.to_string(),
+                )
+                .try_as_raw_value()?;
                 opts.push(TxnOp::Put(raw_key, val));
             }
         }
@@ -245,9 +269,10 @@ mod tests {
             table_id: 42,
             regions: vec![1, 2, 3],
             engine: Default::default(),
+            region_storage_path: Default::default(),
             version: 1,
         };
-        let literal = br#"{"table_id":42,"regions":[1,2,3],"engine":"","version":1}"#;
+        let literal = br#"{"table_id":42,"regions":[1,2,3],"engine":"","region_storage_path":"","version":1}"#;
 
         let raw_value = value.try_as_raw_value().unwrap();
         assert_eq!(raw_value, literal);

--- a/src/file-table-engine/src/engine/immutable.rs
+++ b/src/file-table-engine/src/engine/immutable.rs
@@ -23,7 +23,7 @@ use common_telemetry::{debug, logging};
 use datatypes::schema::Schema;
 use object_store::ObjectStore;
 use snafu::ResultExt;
-use store_api::path_utils::table_dir;
+use store_api::path_utils::table_dir_with_catalog_and_schema;
 use table::engine::{EngineContext, TableEngine, TableEngineProcedure, TableReference};
 use table::error::TableOperationSnafu;
 use table::metadata::{TableId, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
@@ -245,7 +245,7 @@ impl EngineInner {
         let table_schema =
             Arc::new(Schema::try_from(request.schema).context(InvalidRawSchemaSnafu)?);
 
-        let table_dir = table_dir(&catalog_name, &schema_name, table_id);
+        let table_dir = table_dir_with_catalog_and_schema(&catalog_name, &schema_name, table_id);
 
         let table_full_name = table_ref.to_string();
 
@@ -345,7 +345,8 @@ impl EngineInner {
             }
 
             let table_id = request.table_id;
-            let table_dir = table_dir(&catalog_name, &schema_name, table_id);
+            let table_dir =
+                table_dir_with_catalog_and_schema(&catalog_name, &schema_name, table_id);
 
             let (metadata, table_info) = self
                 .recover_table_manifest_and_info(&table_full_name, &table_dir)
@@ -388,7 +389,8 @@ impl EngineInner {
         let _lock = self.table_mutex.lock().await;
         if let Some(table) = self.get_table(req.table_id) {
             let table_id = table.table_info().ident.table_id;
-            let table_dir = table_dir(&req.catalog_name, &req.schema_name, table_id);
+            let table_dir =
+                table_dir_with_catalog_and_schema(&req.catalog_name, &req.schema_name, table_id);
 
             delete_table_manifest(
                 &table_full_name,

--- a/src/file-table-engine/src/test_util.rs
+++ b/src/file-table-engine/src/test_util.rs
@@ -20,7 +20,7 @@ use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, RawSchema, Schema, SchemaBuilder, SchemaRef};
 use object_store::services::Fs;
 use object_store::ObjectStore;
-use store_api::path_utils::table_dir;
+use store_api::path_utils::table_dir_with_catalog_and_schema;
 use table::engine::{EngineContext, TableEngine};
 use table::metadata::{RawTableInfo, TableInfo, TableInfoBuilder, TableMetaBuilder, TableType};
 use table::requests::{self, CreateTableRequest, TableOptions};
@@ -143,7 +143,7 @@ pub async fn setup_test_engine_and_table(prefix: &str) -> TestEngineComponents {
 
     let table_info = table_ref.table_info();
 
-    let table_dir = table_dir(
+    let table_dir = table_dir_with_catalog_and_schema(
         &table_info.catalog_name,
         &table_info.schema_name,
         table_info.ident.table_id,

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -253,9 +253,9 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Table info not found: {}", table_name))]
+    #[snafu(display("Table info not found: {}", table_id))]
     TableInfoNotFound {
-        table_name: String,
+        table_id: TableId,
         location: Location,
     },
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -144,8 +144,7 @@ fn test_create_region_request_template() {
         ],
         primary_key: vec![2, 1],
         create_if_not_exists: true,
-        catalog: String::new(),
-        schema: String::new(),
+        path: String::new(),
         options: HashMap::new(),
     };
     assert_eq!(template, expected);

--- a/src/mito/src/engine.rs
+++ b/src/mito/src/engine.rs
@@ -31,7 +31,7 @@ use key_lock::KeyLock;
 use object_store::ObjectStore;
 use snafu::{ensure, OptionExt, ResultExt};
 use storage::manifest::manifest_compress_type;
-use store_api::path_utils::{region_name, table_dir};
+use store_api::path_utils::{region_name, table_dir_with_catalog_and_schema};
 use store_api::storage::{
     CloseOptions, ColumnDescriptorBuilder, ColumnFamilyDescriptor, ColumnFamilyDescriptorBuilder,
     ColumnId, CompactionStrategy, EngineContext as StorageEngineContext, OpenOptions, RegionNumber,
@@ -433,7 +433,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
 
         let table_id = request.table_id;
         let engine_ctx = StorageEngineContext::default();
-        let table_dir = table_dir(catalog_name, schema_name, table_id);
+        let table_dir = table_dir_with_catalog_and_schema(catalog_name, schema_name, table_id);
 
         let Some((manifest, table_info)) = self
             .recover_table_manifest_and_info(table_name, &table_dir)
@@ -523,7 +523,7 @@ impl<S: StorageEngine> MitoEngineInner<S> {
         let name = &table_info.name;
         let table_id = table_info.ident.table_id;
 
-        let table_dir = table_dir(catalog, schema, table_id);
+        let table_dir = table_dir_with_catalog_and_schema(catalog, schema, table_id);
         let table_ref = TableReference {
             catalog,
             schema,

--- a/src/mito/src/engine/procedure/create.rs
+++ b/src/mito/src/engine/procedure/create.rs
@@ -23,7 +23,7 @@ use common_telemetry::metric::Timer;
 use datatypes::schema::{Schema, SchemaRef};
 use serde::{Deserialize, Serialize};
 use snafu::{ensure, ResultExt};
-use store_api::path_utils::table_dir;
+use store_api::path_utils::table_dir_with_catalog_and_schema;
 use store_api::storage::{
     ColumnId, CompactionStrategy, CreateOptions, EngineContext, OpenOptions,
     RegionDescriptorBuilder, RegionId, RegionNumber, StorageEngine,
@@ -208,7 +208,7 @@ impl<S: StorageEngine> TableCreator<S> {
     /// - Callers MUST acquire the table lock first.
     /// - The procedure may call this method multiple times.
     pub(crate) async fn create_table(&mut self) -> Result<TableRef> {
-        let table_dir = table_dir(
+        let table_dir = table_dir_with_catalog_and_schema(
             &self.data.request.catalog_name,
             &self.data.request.schema_name,
             self.data.request.id,

--- a/src/mito/src/engine/tests.rs
+++ b/src/mito/src/engine/tests.rs
@@ -29,6 +29,7 @@ use storage::config::EngineConfig as StorageEngineConfig;
 use storage::region::RegionImpl;
 use storage::EngineImpl;
 use store_api::manifest::Manifest;
+use store_api::path_utils::table_dir_with_catalog_and_schema;
 use store_api::storage::{ReadContext, ScanRequest};
 use table::metadata::TableType;
 use table::requests::{
@@ -176,11 +177,11 @@ fn test_region_name() {
 fn test_table_dir() {
     assert_eq!(
         "data/greptime/public/1024/",
-        table_dir("greptime", "public", 1024)
+        table_dir_with_catalog_and_schema("greptime", "public", 1024)
     );
     assert_eq!(
         "data/0x4354a1/prometheus/1024/",
-        table_dir("0x4354a1", "prometheus", 1024)
+        table_dir_with_catalog_and_schema("0x4354a1", "prometheus", 1024)
     );
 }
 
@@ -880,7 +881,11 @@ async fn test_flush_table_all_regions() {
     let region_name = region_name(table_id, 0);
 
     let table_info = table.table_info();
-    let table_dir = table_dir(&table_info.catalog_name, &table_info.schema_name, table_id);
+    let table_dir = table_dir_with_catalog_and_schema(
+        &table_info.catalog_name,
+        &table_info.schema_name,
+        table_id,
+    );
 
     let region_dir = format!(
         "{}/{}/{}",
@@ -914,7 +919,11 @@ async fn test_flush_table_with_region_id() {
     let region_name = region_name(table_id, 0);
 
     let table_info = table.table_info();
-    let table_dir = table_dir(&table_info.catalog_name, &table_info.schema_name, table_id);
+    let table_dir = table_dir_with_catalog_and_schema(
+        &table_info.catalog_name,
+        &table_info.schema_name,
+        table_id,
+    );
 
     let region_dir = format!(
         "{}/{}/{}",

--- a/src/store-api/src/path_utils.rs
+++ b/src/store-api/src/path_utils.rs
@@ -32,15 +32,21 @@ pub fn region_name(table_id: TableId, region_number: RegionNumber) -> String {
     format!("{table_id}_{region_number:010}")
 }
 
-#[inline]
-pub fn table_dir(catalog_name: &str, schema_name: &str, table_id: TableId) -> String {
-    format!("{DATA_DIR}{catalog_name}/{schema_name}/{table_id}/")
+// TODO(jeremy): There are still some dependencies on it. Someone will be here soon to remove it.
+pub fn table_dir_with_catalog_and_schema(catalog: &str, schema: &str, table_id: TableId) -> String {
+    let path = format!("{}/{}", catalog, schema);
+    table_dir(&path, table_id)
 }
 
-pub fn region_dir(catalog_name: &str, schema_name: &str, region_id: RegionId) -> String {
+#[inline]
+pub fn table_dir(path: &str, table_id: TableId) -> String {
+    format!("{DATA_DIR}{path}/{table_id}/")
+}
+
+pub fn region_dir(path: &str, region_id: RegionId) -> String {
     format!(
         "{}{}",
-        table_dir(catalog_name, schema_name, region_id.table_id()),
+        table_dir(path, region_id.table_id()),
         region_name(region_id.table_id(), region_id.region_number())
     )
 }
@@ -53,7 +59,7 @@ mod tests {
     fn test_region_dir() {
         let region_id = RegionId::new(42, 1);
         assert_eq!(
-            region_dir("my_catalog", "my_schema", region_id),
+            region_dir("my_catalog/my_schema", region_id),
             "data/my_catalog/my_schema/42/42_0000000001"
         );
     }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -70,7 +70,7 @@ impl RegionRequest {
                     .map(ColumnMetadata::try_from_column_def)
                     .collect::<Result<Vec<_>>>()?;
                 let region_id = create.region_id.into();
-                let region_dir = region_dir(&create.catalog, &create.schema, region_id);
+                let region_dir = region_dir(&create.path, region_id);
                 Ok(vec![(
                     region_id,
                     Self::Create(RegionCreateRequest {
@@ -89,7 +89,7 @@ impl RegionRequest {
             )]),
             region_request::Body::Open(open) => {
                 let region_id = open.region_id.into();
-                let region_dir = region_dir(&open.catalog, &open.schema, region_id);
+                let region_dir = region_dir(&open.path, region_id);
                 Ok(vec![(
                     region_id,
                     Self::Open(RegionOpenRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

In the past, we put the `catalog` and `schema` into the `CreateRegionRequest` and sent the request to the datanode to create regions, but in fact the datanode does not understand the meaning of the catalog and schema, it just uses this information to create the storage directory, we should directly pass in the "path"

Upgrade the Proto synchronously : https://github.com/GreptimeTeam/greptime-proto/pull/102

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
