### PR TITLE
fix: generate region path with given prefix

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -38,7 +38,7 @@ use query::QueryEngineFactory;
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
 use store_api::logstore::LogStore;
-use store_api::path_utils::WAL_DIR;
+use store_api::path_utils::{region_dir, WAL_DIR};
 use store_api::region_engine::RegionEngineRef;
 use store_api::region_request::{RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
@@ -246,7 +246,8 @@ impl DatanodeBuilder {
 
         info!("going to open {} regions", regions.len());
 
-        for (region_id, engine, region_dir) in regions {
+        for (region_id, engine, store_path) in regions {
+            let region_dir = region_dir(&store_path, region_id);
             region_server
                 .handle_request(
                     region_id,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

https://github.com/GreptimeTeam/greptimedb/pull/2399 misuses the region storage path prefix. After this fix the server can re-open previous created regions:

```sql
MySQL [(none)]> show tables;
+---------+
| Tables  |
+---------+
| numbers |
| scripts |
+---------+
2 rows in set (0.013 sec)

MySQL [(none)]> create table t(ts timestamp time index);
Query OK, 0 rows affected (0.005 sec)

MySQL [(none)]> show tables;
+---------+
| Tables  |
+---------+
| numbers |
| scripts |
| t       |
+---------+
3 rows in set (0.001 sec)

MySQL [(none)]> show tables;
ERROR 2013 (HY000): Lost connection to server during query
MySQL [(none)]> show tables;
ERROR 2006 (HY000): Server has gone away
No connection. Trying to reconnect...
Connection id:    8
Current database: *** NONE ***

+---------+
| Tables  |
+---------+
| numbers |
| scripts |
| t       |
+---------+
3 rows in set (0.015 sec)

```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
