### PR TITLE
feat(mito): Implements compaction scheduler

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -309,8 +309,10 @@ impl CompactionStatus {
         let mut req = CompactionRequest {
             current_version,
             access_layer: self.access_layer.clone(),
-            ttl: None,                    // TODO(hl): get TTL info from region metadata
-            compaction_time_window: None, // TODO(hl): get persisted region compaction time window
+            // TODO(hl): get TTL info from region metadata
+            ttl: None,
+            // TODO(hl): get persisted region compaction time window
+            compaction_time_window: None,
             request_sender: request_sender.clone(),
             waiters: Vec::new(),
             file_purger: self.file_purger.clone(),

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -121,7 +121,7 @@ impl CompactionScheduler {
     }
 
     /// Notifies the scheduler that the compaction job is finished successfully.
-    pub(crate) fn on_compaction_success(&mut self, region_id: RegionId) {
+    pub(crate) fn on_compaction_finished(&mut self, region_id: RegionId) {
         let Some(status) = self.region_status.get_mut(&region_id) else {
             return;
         };

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -116,6 +116,8 @@ impl CompactionScheduler {
 
         // The region can compact directly.
         let request = status.new_compaction_request(self.request_sender.clone(), waiter);
+        // Mark the region as compacting.
+        status.compacting = true;
         self.schedule_compaction_request(request)
     }
 

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -100,3 +100,15 @@ impl CompactionScheduler {
         }))
     }
 }
+
+/// Status of running and pending region compaction tasks.
+struct CompactionStatus {
+    // Request waiting for compaction.
+    pending_request: Option<CompactionRequest>,
+}
+
+impl CompactionStatus {
+    fn merge_request(&mut self, request: CompactionRequest) {
+        unimplemented!()
+    }
+}

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -126,6 +126,8 @@ impl CompactionScheduler {
             return;
         };
 
+        // TODO(yingwen): We should always try to compact the region until picker
+        // returns None.
         if status.pending_compaction.is_none() {
             // The region doesn't have pending compaction request, we can remove it.
             self.region_status.remove(&region_id);

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -156,6 +156,8 @@ impl Picker for TwcsPicker {
         let outputs = self.build_output(&windows, active_window, time_window_size);
 
         if outputs.is_empty() && expired_ssts.is_empty() {
+            // FIXME(yingwen): Need to remove the region from the scheduler.
+
             // Nothing to compact, we are done. Notifies all waiters as we consume the compaction request.
             for waiter in waiters {
                 waiter.send(Ok(Output::AffectedRows(0)));

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -156,8 +156,6 @@ impl Picker for TwcsPicker {
         let outputs = self.build_output(&windows, active_window, time_window_size);
 
         if outputs.is_empty() && expired_ssts.is_empty() {
-            // FIXME(yingwen): Need to remove the region from the scheduler.
-
             // Nothing to compact, we are done. Notifies all waiters as we consume the compaction request.
             for waiter in waiters {
                 waiter.send(Ok(Output::AffectedRows(0)));

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -402,8 +402,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} is truncating, location: {}", region_id, location))]
-    RegionTruncating {
+    #[snafu(display("Region {} is truncated, location: {}", region_id, location))]
+    RegionTruncated {
         region_id: RegionId,
         location: Location,
     },
@@ -516,7 +516,7 @@ impl ErrorExt for Error {
             FlushRegion { source, .. } => source.status_code(),
             RegionDropped { .. } => StatusCode::Cancelled,
             RegionClosed { .. } => StatusCode::Cancelled,
-            RegionTruncating { .. } => StatusCode::Cancelled,
+            RegionTruncated { .. } => StatusCode::Cancelled,
             RejectWrite { .. } => StatusCode::StorageUnavailable,
             CompactRegion { source, .. } => source.status_code(),
             CompatReader { .. } => StatusCode::Unexpected,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -551,6 +551,7 @@ impl Drop for FlushScheduler {
 struct FlushStatus {
     /// Current region.
     region: MitoRegionRef,
+    // TODO(yingwen): We can remove this flag.
     /// There is a flush task running.
     flushing: bool,
     /// Task waiting for next flush.

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -551,7 +551,7 @@ impl Drop for FlushScheduler {
 struct FlushStatus {
     /// Current region.
     region: MitoRegionRef,
-    // TODO(yingwen): We can remove this flag.
+    // TODO(yingwen): Maybe we can remove this flag.
     /// There is a flush task running.
     flushing: bool,
     /// Task waiting for next flush.

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -59,6 +59,13 @@ impl Scanner {
             Scanner::Seq(seq_scan) => seq_scan.num_memtables(),
         }
     }
+
+    /// Returns SST file ids to scan.
+    pub(crate) fn file_ids(&self) -> Vec<crate::sst::file::FileId> {
+        match self {
+            Scanner::Seq(seq_scan) => seq_scan.file_ids(),
+        }
+    }
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -156,4 +156,9 @@ impl SeqScan {
     pub(crate) fn num_files(&self) -> usize {
         self.files.len()
     }
+
+    /// Returns SST file ids to scan.
+    pub(crate) fn file_ids(&self) -> Vec<crate::sst::file::FileId> {
+        self.files.iter().map(|file| file.file_id()).collect()
+    }
 }

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -14,6 +14,10 @@
 
 //! Utilities for testing.
 
+pub mod memtable_util;
+pub mod scheduler_util;
+pub mod version_util;
+
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -1,0 +1,81 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Memtable test utilities.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use common_query::logical_plan::Expr;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::ColumnId;
+
+use crate::error::Result;
+use crate::memtable::{
+    BoxedBatchIterator, KeyValues, Memtable, MemtableBuilder, MemtableId, MemtableRef,
+    MemtableStats,
+};
+
+/// Empty memtable for test.
+#[derive(Debug, Default)]
+pub(crate) struct EmptyMemtable {
+    /// Id of this memtable.
+    id: MemtableId,
+}
+
+impl EmptyMemtable {
+    /// Returns a new memtable with specific `id`.
+    pub(crate) fn new(id: MemtableId) -> EmptyMemtable {
+        EmptyMemtable { id }
+    }
+}
+
+impl Memtable for EmptyMemtable {
+    fn id(&self) -> MemtableId {
+        self.id
+    }
+
+    fn write(&self, _kvs: &KeyValues) -> Result<()> {
+        Ok(())
+    }
+
+    fn iter(&self, _projection: Option<&[ColumnId]>, _filters: &[Expr]) -> BoxedBatchIterator {
+        Box::new(std::iter::empty())
+    }
+
+    fn is_empty(&self) -> bool {
+        true
+    }
+
+    fn mark_immutable(&self) {}
+
+    fn stats(&self) -> MemtableStats {
+        MemtableStats::default()
+    }
+}
+
+/// Empty memtable builder.
+#[derive(Debug, Default)]
+pub(crate) struct EmptyMemtableBuilder {
+    /// Next memtable id.
+    next_id: AtomicU32,
+}
+
+impl MemtableBuilder for EmptyMemtableBuilder {
+    fn build(&self, _metadata: &RegionMetadataRef) -> MemtableRef {
+        Arc::new(EmptyMemtable::new(
+            self.next_id.fetch_add(1, Ordering::Relaxed),
+        ))
+    }
+}

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities to mock flush and compaction schedulers.
+
+use std::sync::Arc;
+
+use common_test_util::temp_dir::{create_temp_dir, TempDir};
+use object_store::services::Fs;
+use object_store::ObjectStore;
+use tokio::sync::mpsc::Sender;
+
+use crate::access_layer::{AccessLayer, AccessLayerRef};
+use crate::compaction::CompactionScheduler;
+use crate::flush::FlushScheduler;
+use crate::request::WorkerRequest;
+use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
+
+/// Scheduler mocker.
+pub(crate) struct SchedulerEnv {
+    #[allow(unused)]
+    path: TempDir,
+    /// Mock access layer for test.
+    pub(crate) access_layer: AccessLayerRef,
+    scheduler: Option<SchedulerRef>,
+}
+
+impl SchedulerEnv {
+    /// Creates a new mocker.
+    pub(crate) fn new() -> SchedulerEnv {
+        let path = create_temp_dir("");
+        let mut builder = Fs::default();
+        builder.root(path.path().to_str().unwrap());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
+        let access_layer = Arc::new(AccessLayer::new("", object_store.clone()));
+
+        SchedulerEnv {
+            path: create_temp_dir(""),
+            access_layer,
+            scheduler: None,
+        }
+    }
+
+    /// Creates a new compaction scheduler.
+    pub(crate) fn mock_compaction_scheduler(
+        &self,
+        request_sender: Sender<WorkerRequest>,
+    ) -> CompactionScheduler {
+        let scheduler = self.get_scheduler();
+
+        CompactionScheduler::new(scheduler, request_sender)
+    }
+
+    /// Creates a new flush scheduler.
+    pub(crate) fn mock_flush_scheduler(&self) -> FlushScheduler {
+        let scheduler = self.get_scheduler();
+
+        FlushScheduler::new(scheduler)
+    }
+
+    fn get_scheduler(&self) -> SchedulerRef {
+        self.scheduler
+            .clone()
+            .unwrap_or_else(|| Arc::new(LocalScheduler::new(1)))
+    }
+}

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -1,0 +1,115 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities to mock version.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use api::v1::SemanticType;
+use common_time::Timestamp;
+use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::ColumnSchema;
+use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
+use store_api::storage::RegionId;
+
+use crate::memtable::{MemtableBuilder, MemtableBuilderRef};
+use crate::region::version::{Version, VersionBuilder, VersionControl};
+use crate::sst::file::{FileId, FileMeta};
+use crate::sst::file_purger::FilePurgerRef;
+use crate::test_util::memtable_util::EmptyMemtableBuilder;
+use crate::test_util::new_noop_file_purger;
+
+fn new_region_metadata(region_id: RegionId) -> RegionMetadata {
+    let mut builder = RegionMetadataBuilder::new(region_id);
+    builder
+        .push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            semantic_type: SemanticType::Timestamp,
+            column_id: 1,
+        })
+        .push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new("tag_0", ConcreteDataType::string_datatype(), true),
+            semantic_type: SemanticType::Tag,
+            column_id: 2,
+        })
+        .primary_key(vec![2]);
+    builder.build().unwrap()
+}
+
+// Builder to mock a version control.
+pub(crate) struct VersionControlBuilder {
+    metadata: RegionMetadata,
+    file_purger: FilePurgerRef,
+    memtable_builder: Arc<EmptyMemtableBuilder>,
+    files: HashMap<FileId, FileMeta>,
+}
+
+impl VersionControlBuilder {
+    pub(crate) fn new() -> VersionControlBuilder {
+        VersionControlBuilder {
+            metadata: new_region_metadata(RegionId::new(1, 1)),
+            file_purger: new_noop_file_purger(),
+            memtable_builder: Arc::new(EmptyMemtableBuilder::default()),
+            files: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn region_id(&self) -> RegionId {
+        self.metadata.region_id
+    }
+
+    pub(crate) fn file_purger(&self) -> FilePurgerRef {
+        self.file_purger.clone()
+    }
+
+    pub(crate) fn memtable_builder(&self) -> MemtableBuilderRef {
+        self.memtable_builder.clone()
+    }
+
+    pub(crate) fn push_l0_file(&mut self, start_ms: i64, end_ms: i64) -> &mut Self {
+        let file_id = FileId::random();
+        self.files.insert(
+            file_id,
+            FileMeta {
+                region_id: self.metadata.region_id,
+                file_id,
+                time_range: (
+                    Timestamp::new_millisecond(start_ms),
+                    Timestamp::new_millisecond(end_ms),
+                ),
+                level: 0,
+                file_size: 0, // We don't care file size.
+            },
+        );
+        self
+    }
+
+    pub(crate) fn build_version(&self) -> Version {
+        let metadata = Arc::new(self.metadata.clone());
+        let mutable = self.memtable_builder.build(&metadata);
+        VersionBuilder::new(metadata, mutable)
+            .add_files(self.file_purger.clone(), self.files.values().cloned())
+            .build()
+    }
+
+    pub(crate) fn build(&self) -> VersionControl {
+        let version = self.build_version();
+        VersionControl::new(version)
+    }
+}

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -251,7 +251,7 @@ impl<S: LogStore> WorkerStarter<S> {
             scheduler: self.scheduler.clone(),
             write_buffer_manager: self.write_buffer_manager,
             flush_scheduler: FlushScheduler::new(self.scheduler.clone()),
-            compaction_scheduler: CompactionScheduler::new(self.scheduler),
+            compaction_scheduler: CompactionScheduler::new(self.scheduler, sender.clone()),
             stalled_requests: StalledRequests::default(),
             listener: self.listener,
         };

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -55,7 +55,10 @@ impl<S> RegionWorkerLoop<S> {
 
             // Try to submit a flush task.
             let task = self.new_flush_task(&region, FlushReason::Alter);
-            if let Err(e) = self.flush_scheduler.schedule_flush(&region, task) {
+            if let Err(e) =
+                self.flush_scheduler
+                    .schedule_flush(region.region_id, &region.version_control, task)
+            {
                 // Unable to flush the region, send error to waiter.
                 sender.send(Err(e));
                 return;

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -33,6 +33,8 @@ impl<S> RegionWorkerLoop<S> {
         self.regions.remove_region(region_id);
         // Clean flush status.
         self.flush_scheduler.on_region_closed(region_id);
+        // Clean compaction status.
+        self.compaction_scheduler.on_region_closed(region_id);
 
         info!("Region {} closed", region_id);
 

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -31,10 +31,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             return;
         };
 
-        if let Err(e) = self
-            .compaction_scheduler
-            .schedule_compaction(&region, sender)
-        {
+        if let Err(e) = self.compaction_scheduler.schedule_compaction(
+            region.region_id,
+            &region.version_control,
+            &region.access_layer,
+            &region.file_purger,
+            sender,
+        ) {
             error!(e; "Failed to schedule compaction task for region: {}", region_id);
         } else {
             info!(

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -52,6 +52,8 @@ impl<S> RegionWorkerLoop<S> {
         self.dropping_regions.insert_region(region.clone());
         // Notifies flush scheduler.
         self.flush_scheduler.on_region_dropped(region_id);
+        // Notifies compaction scheduler.
+        self.compaction_scheduler.on_region_dropped(region_id);
 
         // mark region version as dropped
         region.version_control.mark_dropped();

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -19,7 +19,7 @@ use common_time::util::current_time_millis;
 use store_api::logstore::LogStore;
 use store_api::storage::RegionId;
 
-use crate::error::{RegionTruncatingSnafu, Result};
+use crate::error::{RegionTruncatedSnafu, Result};
 use crate::flush::{FlushReason, RegionFlushTask};
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::region::MitoRegionRef;
@@ -152,7 +152,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let version_data = region.version_control.current();
         if let Some(truncated_entry_id) = version_data.version.truncated_entry_id {
             if truncated_entry_id >= request.flushed_entry_id {
-                request.on_failure(RegionTruncatingSnafu { region_id }.build());
+                request.on_failure(RegionTruncatedSnafu { region_id }.build());
                 return;
             }
         }

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -210,10 +210,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         self.handle_write_requests(stalled.requests, false).await;
 
         // Schedules compaction.
-        if let Err(e) = self
-            .compaction_scheduler
-            .schedule_compaction(&region, OptionOutputTx::none())
-        {
+        if let Err(e) = self.compaction_scheduler.schedule_compaction(
+            region.region_id,
+            &region.version_control,
+            &region.access_layer,
+            &region.file_purger,
+            OptionOutputTx::none(),
+        ) {
             warn!(
                 "Failed to schedule compaction after flush, region: {}, err: {}",
                 region.region_id, e

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -39,7 +39,10 @@ impl<S> RegionWorkerLoop<S> {
 
         let mut task = self.new_flush_task(&region, FlushReason::Manual);
         task.push_sender(sender);
-        if let Err(e) = self.flush_scheduler.schedule_flush(&region, task) {
+        if let Err(e) =
+            self.flush_scheduler
+                .schedule_flush(region.region_id, &region.version_control, task)
+        {
             error!(e; "Failed to schedule flush task for region {}", region.region_id);
         }
     }
@@ -90,7 +93,11 @@ impl<S> RegionWorkerLoop<S> {
             if region.last_flush_millis() < min_last_flush_time {
                 // If flush time of this region is earlier than `min_last_flush_time`, we can flush this region.
                 let task = self.new_flush_task(region, FlushReason::EngineFull);
-                self.flush_scheduler.schedule_flush(region, task)?;
+                self.flush_scheduler.schedule_flush(
+                    region.region_id,
+                    &region.version_control,
+                    task,
+                )?;
             }
         }
 
@@ -99,7 +106,11 @@ impl<S> RegionWorkerLoop<S> {
         if let Some(region) = max_mem_region {
             if !self.flush_scheduler.is_flush_requested(region.region_id) {
                 let task = self.new_flush_task(region, FlushReason::EngineFull);
-                self.flush_scheduler.schedule_flush(region, task)?;
+                self.flush_scheduler.schedule_flush(
+                    region.region_id,
+                    &region.version_control,
+                    task,
+                )?;
             }
         }
 

--- a/src/mito2/src/worker/handle_truncate.rs
+++ b/src/mito2/src/worker/handle_truncate.rs
@@ -44,8 +44,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         region.manifest_manager.update(action_list).await?;
 
         // Notifies flush scheduler.
-        self.flush_scheduler.on_region_truncating(region_id);
-        // TODO(DevilExileSu): Notifies compaction scheduler.
+        self.flush_scheduler.on_region_truncated(region_id);
+        // Notifies compaction scheduler.
+        self.compaction_scheduler.on_region_truncated(region_id);
 
         // Reset region's version and mark all SSTs deleted.
         region.version_control.truncate(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements the compaction scheduler for mito2. The `CompactionScheduler`
- tracks region that is compacting and its pending compaction requests
- ensures only one compaction task is running for a region, and merge compaction request waiters
- cancels compaction tasks and notifies waiters if compaction is failed or the region is dropped/closed/truncated

It adds some tests for compaction and flush schedulers. I'll add more tests in later PRs.

Other changes
- schedules compaction after a flush job is finished
- fixes an incorrect debug assertion in FlushScheduler

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869