### PR TITLE
feat!: unify naming with options

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -14,7 +14,7 @@ rpc_runtime_size = 8
 interval_millis = 5000
 
 # Metasrv client options.
-[meta_client_options]
+[meta_client]
 # Metasrv address list.
 metasrv_addrs = ["127.0.0.1:3002"]
 # Operation timeout in milliseconds, 3000 by default.

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -14,50 +14,50 @@ timeout = "30s"
 body_limit = "64MB"
 
 # gRPC server options, see `standalone.example.toml`.
-[grpc_options]
+[grpc]
 addr = "127.0.0.1:4001"
 runtime_size = 8
 
 # MySQL server options, see `standalone.example.toml`.
-[mysql_options]
+[mysql]
 enable = true
 addr = "127.0.0.1:4002"
 runtime_size = 2
 
 # MySQL server TLS options, see `standalone.example.toml`.
-[mysql_options.tls]
+[mysql.tls]
 mode = "disable"
 cert_path = ""
 key_path = ""
 
 # PostgresSQL server options, see `standalone.example.toml`.
-[postgres_options]
+[postgres]
 enable = true
 addr = "127.0.0.1:4003"
 runtime_size = 2
 
 # PostgresSQL server TLS options, see `standalone.example.toml`.
-[postgres_options.tls]
+[postgres.tls]
 mode = "disable"
 cert_path = ""
 key_path = ""
 
 # OpenTSDB protocol options, see `standalone.example.toml`.
-[opentsdb_options]
+[opentsdb]
 enable = true
 addr = "127.0.0.1:4242"
 runtime_size = 2
 
 # InfluxDB protocol options, see `standalone.example.toml`.
-[influxdb_options]
+[influxdb]
 enable = true
 
 # Prometheus remote storage options, see `standalone.example.toml`.
-[prom_store_options]
+[prom_store]
 enable = true
 
 # Metasrv client options, see `datanode.example.toml`.
-[meta_client_options]
+[meta_client]
 metasrv_addrs = ["127.0.0.1:3002"]
 timeout_millis = 3000
 # DDL timeouts options.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -4,7 +4,7 @@ mode = "standalone"
 enable_telemetry = true
 
 # HTTP server options.
-[http_options]
+[http]
 # Server address, "127.0.0.1:4000" by default.
 addr = "127.0.0.1:4000"
 # HTTP request timeout, 30s by default.
@@ -14,14 +14,14 @@ timeout = "30s"
 body_limit = "64MB"
 
 # gRPC server options.
-[grpc_options]
+[grpc]
 # Server address, "127.0.0.1:4001" by default.
 addr = "127.0.0.1:4001"
 # The number of server worker threads, 8 by default.
 runtime_size = 8
 
 # MySQL server options.
-[mysql_options]
+[mysql]
 # Whether to enable
 enable = true
 # Server address, "127.0.0.1:4002" by default.
@@ -30,7 +30,7 @@ addr = "127.0.0.1:4002"
 runtime_size = 2
 
 # MySQL server TLS options.
-[mysql_options.tls]
+[mysql.tls]
 # TLS mode, refer to https://www.postgresql.org/docs/current/libpq-ssl.html
 # - "disable" (default value)
 # - "prefer"
@@ -44,7 +44,7 @@ cert_path = ""
 key_path = ""
 
 # PostgresSQL server options.
-[postgres_options]
+[postgres]
 # Whether to enable
 enable = true
 # Server address, "127.0.0.1:4003" by default.
@@ -53,7 +53,7 @@ addr = "127.0.0.1:4003"
 runtime_size = 2
 
 # PostgresSQL server TLS options, see `[mysql_options.tls]` section.
-[postgres_options.tls]
+[postgres.tls]
 # TLS mode.
 mode = "disable"
 # certificate file path.
@@ -62,7 +62,7 @@ cert_path = ""
 key_path = ""
 
 # OpenTSDB protocol options.
-[opentsdb_options]
+[opentsdb]
 # Whether to enable
 enable = true
 # OpenTSDB telnet API server address, "127.0.0.1:4242" by default.
@@ -71,12 +71,12 @@ addr = "127.0.0.1:4242"
 runtime_size = 2
 
 # InfluxDB protocol options.
-[influxdb_options]
+[influxdb]
 # Whether to enable InfluxDB protocol in HTTP API, true by default.
 enable = true
 
 # Prometheus remote storage options
-[prom_store_options]
+[prom_store]
 # Whether to enable Prometheus remote write and read in HTTP API, true by default.
 enable = true
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -128,7 +128,7 @@ impl StartCommand {
         }
 
         if let Some(metasrv_addrs) = &self.metasrv_addr {
-            opts.meta_client_options
+            opts.meta_client
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs = metasrv_addrs.clone();
             opts.mode = Mode::Distributed;
@@ -146,15 +146,15 @@ impl StartCommand {
         }
 
         if let Some(http_addr) = &self.http_addr {
-            opts.http_opts.addr = http_addr.clone();
+            opts.http.addr = http_addr.clone();
         }
 
         if let Some(http_timeout) = self.http_timeout {
-            opts.http_opts.timeout = Duration::from_secs(http_timeout)
+            opts.http.timeout = Duration::from_secs(http_timeout)
         }
 
         // Disable dashboard in datanode.
-        opts.http_opts.disable_dashboard = true;
+        opts.http.disable_dashboard = true;
 
         Ok(Options::Datanode(Box::new(opts)))
     }
@@ -196,7 +196,7 @@ mod tests {
             rpc_hostname = "127.0.0.1"
             rpc_runtime_size = 8
 
-            [meta_client_options]
+            [meta_client]
             metasrv_addrs = ["127.0.0.1:3002"]
             timeout_millis = 3000
             connect_timeout_millis = 5000
@@ -255,7 +255,7 @@ mod tests {
             connect_timeout_millis,
             tcp_nodelay,
             ddl_timeout_millis,
-        } = options.meta_client_options.unwrap();
+        } = options.meta_client.unwrap();
 
         assert_eq!(vec!["127.0.0.1:3002".to_string()], metasrv_addr);
         assert_eq!(5000, connect_timeout_millis);
@@ -353,7 +353,7 @@ mod tests {
             rpc_hostname = "127.0.0.1"
             rpc_runtime_size = 8
 
-            [meta_client_options]
+            [meta_client]
             timeout_millis = 3000
             connect_timeout_millis = 5000
             tcp_nodelay = true
@@ -406,10 +406,10 @@ mod tests {
                     Some("99"),
                 ),
                 (
-                    // meta_client_options.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
+                    // meta_client.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
                     [
                         env_prefix.to_string(),
-                        "meta_client_options".to_uppercase(),
+                        "meta_client".to_uppercase(),
                         "metasrv_addrs".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
@@ -435,7 +435,7 @@ mod tests {
                     Some(Duration::from_secs(9))
                 );
                 assert_eq!(
-                    opts.meta_client_options.unwrap().metasrv_addrs,
+                    opts.meta_client.unwrap().metasrv_addrs,
                     vec![
                         "127.0.0.1:3001".to_string(),
                         "127.0.0.1:3002".to_string(),

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -138,40 +138,40 @@ impl StartCommand {
         );
 
         if let Some(addr) = &self.http_addr {
-            opts.http_options.addr = addr.clone()
+            opts.http.addr = addr.clone()
         }
 
         if let Some(disable_dashboard) = self.disable_dashboard {
-            opts.http_options.disable_dashboard = disable_dashboard;
+            opts.http.disable_dashboard = disable_dashboard;
         }
 
         if let Some(addr) = &self.grpc_addr {
-            opts.grpc_options.addr = addr.clone()
+            opts.grpc.addr = addr.clone()
         }
 
         if let Some(addr) = &self.mysql_addr {
-            opts.mysql_options.enable = true;
-            opts.mysql_options.addr = addr.clone();
-            opts.mysql_options.tls = tls_opts.clone();
+            opts.mysql.enable = true;
+            opts.mysql.addr = addr.clone();
+            opts.mysql.tls = tls_opts.clone();
         }
 
         if let Some(addr) = &self.postgres_addr {
-            opts.postgres_options.enable = true;
-            opts.postgres_options.addr = addr.clone();
-            opts.postgres_options.tls = tls_opts;
+            opts.postgres.enable = true;
+            opts.postgres.addr = addr.clone();
+            opts.postgres.tls = tls_opts;
         }
 
         if let Some(addr) = &self.opentsdb_addr {
-            opts.opentsdb_options.enable = true;
-            opts.opentsdb_options.addr = addr.clone();
+            opts.opentsdb.enable = true;
+            opts.opentsdb.addr = addr.clone();
         }
 
         if let Some(enable) = self.influxdb_enable {
-            opts.influxdb_options.enable = enable;
+            opts.influxdb.enable = enable;
         }
 
         if let Some(metasrv_addrs) = &self.metasrv_addr {
-            opts.meta_client_options
+            opts.meta_client
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs = metasrv_addrs.clone();
             opts.mode = Mode::Distributed;
@@ -239,32 +239,29 @@ mod tests {
             unreachable!()
         };
 
-        assert_eq!(opts.http_options.addr, "127.0.0.1:1234");
-        assert_eq!(ReadableSize::mb(64), opts.http_options.body_limit);
-        assert_eq!(opts.mysql_options.addr, "127.0.0.1:5678");
-        assert_eq!(opts.postgres_options.addr, "127.0.0.1:5432");
-        assert_eq!(opts.opentsdb_options.addr, "127.0.0.1:4321");
+        assert_eq!(opts.http.addr, "127.0.0.1:1234");
+        assert_eq!(ReadableSize::mb(64), opts.http.body_limit);
+        assert_eq!(opts.mysql.addr, "127.0.0.1:5678");
+        assert_eq!(opts.postgres.addr, "127.0.0.1:5432");
+        assert_eq!(opts.opentsdb.addr, "127.0.0.1:4321");
 
         let default_opts = FrontendOptions::default();
 
-        assert_eq!(opts.grpc_options.addr, default_opts.grpc_options.addr);
-        assert!(opts.mysql_options.enable);
+        assert_eq!(opts.grpc.addr, default_opts.grpc.addr);
+        assert!(opts.mysql.enable);
+        assert_eq!(opts.mysql.runtime_size, default_opts.mysql.runtime_size);
+        assert!(opts.postgres.enable);
         assert_eq!(
-            opts.mysql_options.runtime_size,
-            default_opts.mysql_options.runtime_size
+            opts.postgres.runtime_size,
+            default_opts.postgres.runtime_size
         );
-        assert!(opts.postgres_options.enable);
+        assert!(opts.opentsdb.enable);
         assert_eq!(
-            opts.postgres_options.runtime_size,
-            default_opts.postgres_options.runtime_size
-        );
-        assert!(opts.opentsdb_options.enable);
-        assert_eq!(
-            opts.opentsdb_options.runtime_size,
-            default_opts.opentsdb_options.runtime_size
+            opts.opentsdb.runtime_size,
+            default_opts.opentsdb.runtime_size
         );
 
-        assert!(!opts.influxdb_options.enable);
+        assert!(!opts.influxdb.enable);
     }
 
     #[test]
@@ -273,7 +270,7 @@ mod tests {
         let toml_str = r#"
             mode = "distributed"
 
-            [http_options]
+            [http]
             addr = "127.0.0.1:4000"
             timeout = "30s"
             body_limit = "2GB"
@@ -295,10 +292,10 @@ mod tests {
             unreachable!()
         };
         assert_eq!(Mode::Distributed, fe_opts.mode);
-        assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http_options.addr);
-        assert_eq!(Duration::from_secs(30), fe_opts.http_options.timeout);
+        assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http.addr);
+        assert_eq!(Duration::from_secs(30), fe_opts.http.timeout);
 
-        assert_eq!(ReadableSize::gb(2), fe_opts.http_options.body_limit);
+        assert_eq!(ReadableSize::gb(2), fe_opts.http.body_limit);
 
         assert_eq!("debug", fe_opts.logging.level.as_ref().unwrap());
         assert_eq!("/tmp/greptimedb/test/logs".to_string(), fe_opts.logging.dir);
@@ -349,15 +346,15 @@ mod tests {
         let toml_str = r#"
             mode = "distributed"
 
-            [http_options]
+            [http]
             addr = "127.0.0.1:4000"
 
-            [meta_client_options]
+            [meta_client]
             timeout_millis = 3000
             connect_timeout_millis = 5000
             tcp_nodelay = true
 
-            [mysql_options]
+            [mysql]
             addr = "127.0.0.1:4002"
         "#;
         write!(file, "{}", toml_str).unwrap();
@@ -366,20 +363,20 @@ mod tests {
         temp_env::with_vars(
             [
                 (
-                    // mysql_options.addr = 127.0.0.1:14002
+                    // mysql.addr = 127.0.0.1:14002
                     [
                         env_prefix.to_string(),
-                        "mysql_options".to_uppercase(),
+                        "mysql".to_uppercase(),
                         "addr".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
                     Some("127.0.0.1:14002"),
                 ),
                 (
-                    // mysql_options.runtime_size = 11
+                    // mysql.runtime_size = 11
                     [
                         env_prefix.to_string(),
-                        "mysql_options".to_uppercase(),
+                        "mysql".to_uppercase(),
                         "runtime_size".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
@@ -389,17 +386,17 @@ mod tests {
                     // http_options.addr = 127.0.0.1:24000
                     [
                         env_prefix.to_string(),
-                        "http_options".to_uppercase(),
+                        "http".to_uppercase(),
                         "addr".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
                     Some("127.0.0.1:24000"),
                 ),
                 (
-                    // meta_client_options.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
+                    // meta_client.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
                     [
                         env_prefix.to_string(),
-                        "meta_client_options".to_uppercase(),
+                        "meta_client".to_uppercase(),
                         "metasrv_addrs".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
@@ -424,9 +421,9 @@ mod tests {
                 };
 
                 // Should be read from env, env > default values.
-                assert_eq!(fe_opts.mysql_options.runtime_size, 11);
+                assert_eq!(fe_opts.mysql.runtime_size, 11);
                 assert_eq!(
-                    fe_opts.meta_client_options.unwrap().metasrv_addrs,
+                    fe_opts.meta_client.unwrap().metasrv_addrs,
                     vec![
                         "127.0.0.1:3001".to_string(),
                         "127.0.0.1:3002".to_string(),
@@ -435,13 +432,13 @@ mod tests {
                 );
 
                 // Should be read from config file, config file > env > default values.
-                assert_eq!(fe_opts.mysql_options.addr, "127.0.0.1:4002");
+                assert_eq!(fe_opts.mysql.addr, "127.0.0.1:4002");
 
                 // Should be read from cli, cli > config file > env > default values.
-                assert_eq!(fe_opts.http_options.addr, "127.0.0.1:14000");
+                assert_eq!(fe_opts.http.addr, "127.0.0.1:14000");
 
                 // Should be default value.
-                assert_eq!(fe_opts.grpc_options.addr, GrpcOptions::default().addr);
+                assert_eq!(fe_opts.grpc.addr, GrpcOptions::default().addr);
             },
         );
     }

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -145,15 +145,15 @@ impl StartCommand {
         }
 
         if let Some(http_addr) = &self.http_addr {
-            opts.http_opts.addr = http_addr.clone();
+            opts.http.addr = http_addr.clone();
         }
 
         if let Some(http_timeout) = self.http_timeout {
-            opts.http_opts.timeout = Duration::from_secs(http_timeout);
+            opts.http.timeout = Duration::from_secs(http_timeout);
         }
 
         // Disable dashboard in metasrv.
-        opts.http_opts.disable_dashboard = true;
+        opts.http.disable_dashboard = true;
 
         Ok(Options::Metasrv(Box::new(opts)))
     }
@@ -266,7 +266,7 @@ mod tests {
             selector = "LeaseBased"
             use_memory_store = false
 
-            [http_options]
+            [http]
             addr = "127.0.0.1:4000"
 
             [logging]
@@ -289,10 +289,10 @@ mod tests {
                     Some("127.0.0.1:13002"),
                 ),
                 (
-                    // http_options.addr = 127.0.0.1:24000
+                    // http.addr = 127.0.0.1:24000
                     [
                         env_prefix.to_string(),
-                        "http_options".to_uppercase(),
+                        "http".to_uppercase(),
                         "addr".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
@@ -320,7 +320,7 @@ mod tests {
                 assert_eq!(opts.server_addr, "127.0.0.1:3002");
 
                 // Should be read from cli, cli > config file > env > default values.
-                assert_eq!(opts.http_opts.addr, "127.0.0.1:14000");
+                assert_eq!(opts.http.addr, "127.0.0.1:14000");
 
                 // Should be default value.
                 assert_eq!(opts.store_addr, "127.0.0.1:2379");

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -136,7 +136,7 @@ mod tests {
             mysql_addr = "127.0.0.1:4406"
             mysql_runtime_size = 2
 
-            [meta_client_options]
+            [meta_client]
             timeout_millis = 3000
             connect_timeout_millis = 5000
             tcp_nodelay = true
@@ -217,10 +217,10 @@ mod tests {
                     Some("/other/wal/dir"),
                 ),
                 (
-                    // meta_client_options.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
+                    // meta_client.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
                     [
                         env_prefix.to_string(),
-                        "meta_client_options".to_uppercase(),
+                        "meta_client".to_uppercase(),
                         "metasrv_addrs".to_uppercase(),
                     ]
                     .join(ENV_VAR_SEP),
@@ -248,7 +248,7 @@ mod tests {
                     Some(Duration::from_secs(42))
                 );
                 assert_eq!(
-                    opts.meta_client_options.unwrap().metasrv_addrs,
+                    opts.meta_client.unwrap().metasrv_addrs,
                     vec![
                         "127.0.0.1:3001".to_string(),
                         "127.0.0.1:3002".to_string(),

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -123,14 +123,14 @@ impl StandaloneOptions {
     fn frontend_options(self) -> FrontendOptions {
         FrontendOptions {
             mode: self.mode,
-            http_options: self.http_options,
-            grpc_options: self.grpc_options,
-            mysql_options: self.mysql_options,
-            postgres_options: self.postgres_options,
-            opentsdb_options: self.opentsdb_options,
-            influxdb_options: self.influxdb_options,
-            prom_store_options: self.prom_store_options,
-            meta_client_options: None,
+            http: self.http_options,
+            grpc: self.grpc_options,
+            mysql: self.mysql_options,
+            postgres: self.postgres_options,
+            opentsdb: self.opentsdb_options,
+            influxdb: self.influxdb_options,
+            prom_store: self.prom_store_options,
+            meta_client: None,
             logging: self.logging,
             ..Default::default()
         }
@@ -459,15 +459,15 @@ mod tests {
         let dn_opts = options.dn_opts;
         let logging_opts = options.logging_opts;
         assert_eq!(Mode::Standalone, fe_opts.mode);
-        assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http_options.addr);
-        assert_eq!(Duration::from_secs(30), fe_opts.http_options.timeout);
-        assert_eq!(ReadableSize::mb(128), fe_opts.http_options.body_limit);
-        assert_eq!("127.0.0.1:4001".to_string(), fe_opts.grpc_options.addr);
-        assert!(fe_opts.mysql_options.enable);
-        assert_eq!("127.0.0.1:4002", fe_opts.mysql_options.addr);
-        assert_eq!(2, fe_opts.mysql_options.runtime_size);
-        assert_eq!(None, fe_opts.mysql_options.reject_no_database);
-        assert!(fe_opts.influxdb_options.enable);
+        assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http.addr);
+        assert_eq!(Duration::from_secs(30), fe_opts.http.timeout);
+        assert_eq!(ReadableSize::mb(128), fe_opts.http.body_limit);
+        assert_eq!("127.0.0.1:4001".to_string(), fe_opts.grpc.addr);
+        assert!(fe_opts.mysql.enable);
+        assert_eq!("127.0.0.1:4002", fe_opts.mysql.addr);
+        assert_eq!(2, fe_opts.mysql.runtime_size);
+        assert_eq!(None, fe_opts.mysql.reject_no_database);
+        assert!(fe_opts.influxdb.enable);
 
         match &dn_opts.storage.store {
             datanode::config::ObjectStoreConfig::S3(s3_config) => {
@@ -512,7 +512,7 @@ mod tests {
         let toml_str = r#"
             mode = "standalone"
 
-            [http_options]
+            [http]
             addr = "127.0.0.1:4000"
 
             [logging]
@@ -544,7 +544,7 @@ mod tests {
                     Some("info"),
                 ),
                 (
-                    // http_options.addr = 127.0.0.1:24000
+                    // http.addr = 127.0.0.1:24000
                     [
                         env_prefix.to_string(),
                         "http_options".to_uppercase(),
@@ -578,11 +578,11 @@ mod tests {
                 assert_eq!(opts.logging_opts.level.as_ref().unwrap(), "debug");
 
                 // Should be read from cli, cli > config file > env > default values.
-                assert_eq!(opts.fe_opts.http_options.addr, "127.0.0.1:14000");
-                assert_eq!(ReadableSize::mb(64), opts.fe_opts.http_options.body_limit);
+                assert_eq!(opts.fe_opts.http.addr, "127.0.0.1:14000");
+                assert_eq!(ReadableSize::mb(64), opts.fe_opts.http.body_limit);
 
                 // Should be default value.
-                assert_eq!(opts.fe_opts.grpc_options.addr, GrpcOptions::default().addr);
+                assert_eq!(opts.fe_opts.grpc.addr, GrpcOptions::default().addr);
             },
         );
     }

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -323,8 +323,8 @@ pub struct DatanodeOptions {
     pub rpc_hostname: Option<String>,
     pub rpc_runtime_size: usize,
     pub heartbeat: HeartbeatOptions,
-    pub http_opts: HttpOptions,
-    pub meta_client_options: Option<MetaClientOptions>,
+    pub http: HttpOptions,
+    pub meta_client: Option<MetaClientOptions>,
     pub wal: WalConfig,
     pub storage: StorageConfig,
     /// Options for different store engines.
@@ -341,8 +341,8 @@ impl Default for DatanodeOptions {
             rpc_addr: "127.0.0.1:3001".to_string(),
             rpc_hostname: None,
             rpc_runtime_size: 8,
-            http_opts: HttpOptions::default(),
-            meta_client_options: None,
+            http: HttpOptions::default(),
+            meta_client: None,
             wal: WalConfig::default(),
             storage: StorageConfig::default(),
             region_engine: vec![RegionEngineConfig::Mito(MitoConfig::default())],
@@ -355,7 +355,7 @@ impl Default for DatanodeOptions {
 
 impl DatanodeOptions {
     pub fn env_list_keys() -> Option<&'static [&'static str]> {
-        Some(&["meta_client_options.metasrv_addrs"])
+        Some(&["meta_client.metasrv_addrs"])
     }
 
     pub fn to_toml_string(&self) -> String {

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -164,7 +164,7 @@ impl DatanodeBuilder {
 
                     let meta_config = self
                         .opts
-                        .meta_client_options
+                        .meta_client
                         .as_ref()
                         .context(MissingMetasrvOptsSnafu)?;
 

--- a/src/datanode/src/server.rs
+++ b/src/datanode/src/server.rs
@@ -49,7 +49,7 @@ impl Services {
                 None,
                 runtime,
             ),
-            http_server: HttpServerBuilder::new(opts.http_opts.clone())
+            http_server: HttpServerBuilder::new(opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
                 .with_greptime_config_options(opts.to_toml_string())
                 .build(),
@@ -60,8 +60,8 @@ impl Services {
         let grpc_addr: SocketAddr = opts.rpc_addr.parse().context(ParseAddrSnafu {
             addr: &opts.rpc_addr,
         })?;
-        let http_addr = opts.http_opts.addr.parse().context(ParseAddrSnafu {
-            addr: &opts.http_opts.addr,
+        let http_addr = opts.http.addr.parse().context(ParseAddrSnafu {
+            addr: &opts.http.addr,
         })?;
         let grpc = self.grpc_server.start(grpc_addr);
         let http = self.http_server.start(http_addr);

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -30,15 +30,15 @@ pub struct FrontendOptions {
     pub mode: Mode,
     pub node_id: Option<String>,
     pub heartbeat: HeartbeatOptions,
-    pub http_options: HttpOptions,
-    pub grpc_options: GrpcOptions,
-    pub mysql_options: MysqlOptions,
-    pub postgres_options: PostgresOptions,
-    pub opentsdb_options: OpentsdbOptions,
-    pub influxdb_options: InfluxdbOptions,
-    pub prom_store_options: PromStoreOptions,
-    pub otlp_options: OtlpOptions,
-    pub meta_client_options: Option<MetaClientOptions>,
+    pub http: HttpOptions,
+    pub grpc: GrpcOptions,
+    pub mysql: MysqlOptions,
+    pub postgres: PostgresOptions,
+    pub opentsdb: OpentsdbOptions,
+    pub influxdb: InfluxdbOptions,
+    pub prom_store: PromStoreOptions,
+    pub otlp: OtlpOptions,
+    pub meta_client: Option<MetaClientOptions>,
     pub logging: LoggingOptions,
     pub datanode: DatanodeOptions,
 }
@@ -49,15 +49,15 @@ impl Default for FrontendOptions {
             mode: Mode::Standalone,
             node_id: None,
             heartbeat: HeartbeatOptions::frontend_default(),
-            http_options: HttpOptions::default(),
-            grpc_options: GrpcOptions::default(),
-            mysql_options: MysqlOptions::default(),
-            postgres_options: PostgresOptions::default(),
-            opentsdb_options: OpentsdbOptions::default(),
-            influxdb_options: InfluxdbOptions::default(),
-            prom_store_options: PromStoreOptions::default(),
-            otlp_options: OtlpOptions::default(),
-            meta_client_options: None,
+            http: HttpOptions::default(),
+            grpc: GrpcOptions::default(),
+            mysql: MysqlOptions::default(),
+            postgres: PostgresOptions::default(),
+            opentsdb: OpentsdbOptions::default(),
+            influxdb: InfluxdbOptions::default(),
+            prom_store: PromStoreOptions::default(),
+            otlp: OtlpOptions::default(),
+            meta_client: None,
             logging: LoggingOptions::default(),
             datanode: DatanodeOptions::default(),
         }
@@ -66,7 +66,7 @@ impl Default for FrontendOptions {
 
 impl FrontendOptions {
     pub fn env_list_keys() -> Option<&'static [&'static str]> {
-        Some(&["meta_client_options.metasrv_addrs"])
+        Some(&["meta_client.metasrv_addrs"])
     }
 
     pub fn to_toml_string(&self) -> String {

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -224,10 +224,7 @@ impl Instance {
     }
 
     async fn create_meta_client(opts: &FrontendOptions) -> Result<Arc<MetaClient>> {
-        let meta_client_options = opts
-            .meta_client_options
-            .as_ref()
-            .context(MissingMetasrvOptsSnafu)?;
+        let meta_client_options = opts.meta_client.as_ref().context(MissingMetasrvOptsSnafu)?;
         info!(
             "Creating Frontend instance in distributed mode with Meta server addr {:?}",
             meta_client_options.metasrv_addrs

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -58,7 +58,7 @@ impl Services {
 
         {
             // Always init GRPC server
-            let opts = &opts.grpc_options;
+            let opts = &opts.grpc;
             let grpc_addr = parse_addr(&opts.addr)?;
 
             let grpc_runtime = Arc::new(
@@ -83,7 +83,7 @@ impl Services {
 
         {
             // Always init HTTP server
-            let http_options = &opts.http_options;
+            let http_options = &opts.http;
             let http_addr = parse_addr(&http_options.addr)?;
 
             let mut http_server_builder = HttpServerBuilder::new(http_options.clone());
@@ -95,21 +95,21 @@ impl Services {
                 let _ = http_server_builder.with_user_provider(user_provider);
             }
 
-            if opts.opentsdb_options.enable {
+            if opts.opentsdb.enable {
                 let _ = http_server_builder.with_opentsdb_handler(instance.clone());
             }
 
-            if opts.influxdb_options.enable {
+            if opts.influxdb.enable {
                 let _ = http_server_builder.with_influxdb_handler(instance.clone());
             }
 
-            if opts.prom_store_options.enable {
+            if opts.prom_store.enable {
                 let _ = http_server_builder
                     .with_prom_handler(instance.clone())
                     .with_prometheus_handler(instance.clone());
             }
 
-            if opts.otlp_options.enable {
+            if opts.otlp.enable {
                 let _ = http_server_builder.with_otlp_handler(instance.clone());
             }
 
@@ -122,9 +122,9 @@ impl Services {
             result.push((Box::new(http_server), http_addr));
         }
 
-        if opts.mysql_options.enable {
+        if opts.mysql.enable {
             // Init MySQL server
-            let opts = &opts.mysql_options;
+            let opts = &opts.mysql;
             let mysql_addr = parse_addr(&opts.addr)?;
 
             let mysql_io_runtime = Arc::new(
@@ -154,9 +154,9 @@ impl Services {
             result.push((mysql_server, mysql_addr));
         }
 
-        if opts.postgres_options.enable {
+        if opts.postgres.enable {
             // Init PosgresSQL Server
-            let opts = &opts.postgres_options;
+            let opts = &opts.postgres;
             let pg_addr = parse_addr(&opts.addr)?;
 
             let pg_io_runtime = Arc::new(
@@ -177,9 +177,9 @@ impl Services {
             result.push((pg_server, pg_addr));
         }
 
-        if opts.opentsdb_options.enable {
+        if opts.opentsdb.enable {
             // Init OpenTSDB server
-            let opts = &opts.opentsdb_options;
+            let opts = &opts.opentsdb;
             let addr = parse_addr(&opts.addr)?;
 
             let io_runtime = Arc::new(

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -60,7 +60,7 @@ impl MetaSrvInstance {
     pub async fn new(opts: MetaSrvOptions) -> Result<MetaSrvInstance> {
         let meta_srv = build_meta_srv(&opts).await?;
         let http_srv = Arc::new(
-            HttpServerBuilder::new(opts.http_opts.clone())
+            HttpServerBuilder::new(opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
                 .with_greptime_config_options(opts.to_toml_string())
                 .build(),
@@ -82,14 +82,9 @@ impl MetaSrvInstance {
 
         let meta_srv =
             bootstrap_meta_srv_with_router(&self.opts.bind_addr, router(self.meta_srv.clone()), rx);
-        let addr = self
-            .opts
-            .http_opts
-            .addr
-            .parse()
-            .context(error::ParseAddrSnafu {
-                addr: &self.opts.http_opts.addr,
-            })?;
+        let addr = self.opts.http.addr.parse().context(error::ParseAddrSnafu {
+            addr: &self.opts.http.addr,
+        })?;
         let http_srv = self.http_srv.start(addr);
         select! {
             v = meta_srv => v?,

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -62,7 +62,7 @@ pub struct MetaSrvOptions {
     pub selector: SelectorType,
     pub use_memory_store: bool,
     pub enable_region_failover: bool,
-    pub http_opts: HttpOptions,
+    pub http: HttpOptions,
     pub logging: LoggingOptions,
     pub procedure: ProcedureConfig,
     pub datanode: DatanodeOptions,
@@ -81,7 +81,7 @@ impl Default for MetaSrvOptions {
             selector: SelectorType::default(),
             use_memory_store: false,
             enable_region_failover: true,
-            http_opts: HttpOptions::default(),
+            http: HttpOptions::default(),
             logging: LoggingOptions {
                 dir: format!("{METASRV_HOME}/logs"),
                 ..Default::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Our current rules for naming options are highly inconsistent, with the presence of xxxOpts, xxxOptions, and simply xxx.
This PR will ensure a consistent usage of xxx throughout.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
