### PR TITLE
feat: sync regions between RegionServer and RegionAliveKeeper

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -192,8 +192,6 @@ impl DatanodeBuilder {
 
         // build and initialize region server
         let log_store = Self::build_log_store(&self.opts).await?;
-        // TODO(weny): Adds a noop event listener for standalone mode.
-
         let (tx, region_event_receiver) = match mode {
             Mode::Distributed => {
                 let (tx, rx) = new_region_server_event_channel();

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -67,7 +67,7 @@ pub struct Datanode {
     opts: DatanodeOptions,
     services: Option<Services>,
     heartbeat_task: Option<HeartbeatTask>,
-    event_receiver: Option<RegionServerEventReceiver>,
+    region_event_receiver: Option<RegionServerEventReceiver>,
     region_server: RegionServer,
     greptimedb_telemetry_task: Arc<GreptimeDBTelemetryTask>,
 }
@@ -85,7 +85,7 @@ impl Datanode {
     pub async fn start_heartbeat(&mut self) -> Result<()> {
         if let Some(task) = &self.heartbeat_task {
             // Safety: The event_receiver must exist.
-            let receiver = self.event_receiver.take().unwrap();
+            let receiver = self.region_event_receiver.take().unwrap();
             task.start(receiver).await?;
         }
         Ok(())
@@ -194,7 +194,7 @@ impl DatanodeBuilder {
         let log_store = Self::build_log_store(&self.opts).await?;
         // TODO(weny): Adds a noop event listener for standalone mode.
 
-        let (tx, event_receiver) = match mode {
+        let (tx, region_event_receiver) = match mode {
             Mode::Distributed => {
                 let (tx, rx) = new_region_server_event_channel();
                 (Box::new(tx) as RegionServerEventListenerRef, Some(rx))
@@ -239,7 +239,7 @@ impl DatanodeBuilder {
             heartbeat_task,
             region_server,
             greptimedb_telemetry_task,
-            event_receiver,
+            region_event_receiver,
         })
     }
 

--- a/src/datanode/src/event_listener.rs
+++ b/src/datanode/src/event_listener.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_telemetry::error;
+use store_api::storage::RegionId;
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+pub enum RegionServerEvent {
+    Register(RegionId),
+    Deregister(RegionId),
+}
+
+pub trait RegionServerEventListener: Sync + Send {
+    /// Called *after* a new region was created/opened.
+    fn register_region(&self, _region_id: RegionId) {}
+
+    /// Called *after* a region was closed.
+    fn deregister_region(&self, _region_id: RegionId) {}
+}
+
+pub type RegionServerEventListenerRef = Box<dyn RegionServerEventListener>;
+
+pub struct NoopRegionServerEventListener;
+
+impl RegionServerEventListener for NoopRegionServerEventListener {}
+
+#[derive(Debug, Clone)]
+pub struct RegionServerEventSender(pub(crate) UnboundedSender<RegionServerEvent>);
+
+impl RegionServerEventListener for RegionServerEventSender {
+    fn register_region(&self, region_id: RegionId) {
+        if let Err(e) = self.0.send(RegionServerEvent::Register(region_id)) {
+            error!(
+                "Failed to send registering region: {region_id} event, source: {}",
+                e
+            );
+        }
+    }
+
+    fn deregister_region(&self, region_id: RegionId) {
+        if let Err(e) = self.0.send(RegionServerEvent::Deregister(region_id)) {
+            error!(
+                "Failed to send deregistering region: {region_id} event, source: {}",
+                e
+            );
+        }
+    }
+}
+
+pub struct RegionServerEventReceiver(pub(crate) UnboundedReceiver<RegionServerEvent>);
+
+pub fn new_region_server_event_channel() -> (RegionServerEventSender, RegionServerEventReceiver) {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    (RegionServerEventSender(tx), RegionServerEventReceiver(rx))
+}

--- a/src/datanode/src/event_listener.rs
+++ b/src/datanode/src/event_listener.rs
@@ -23,10 +23,10 @@ pub enum RegionServerEvent {
 
 pub trait RegionServerEventListener: Sync + Send {
     /// Called *after* a new region was created/opened.
-    fn register_region(&self, _region_id: RegionId) {}
+    fn on_register_region(&self, _region_id: RegionId) {}
 
     /// Called *after* a region was closed.
-    fn deregister_region(&self, _region_id: RegionId) {}
+    fn on_deregister_region(&self, _region_id: RegionId) {}
 }
 
 pub type RegionServerEventListenerRef = Box<dyn RegionServerEventListener>;
@@ -39,7 +39,7 @@ impl RegionServerEventListener for NoopRegionServerEventListener {}
 pub struct RegionServerEventSender(pub(crate) UnboundedSender<RegionServerEvent>);
 
 impl RegionServerEventListener for RegionServerEventSender {
-    fn register_region(&self, region_id: RegionId) {
+    fn on_register_region(&self, region_id: RegionId) {
         if let Err(e) = self.0.send(RegionServerEvent::Register(region_id)) {
             error!(
                 "Failed to send registering region: {region_id} event, source: {}",
@@ -48,7 +48,7 @@ impl RegionServerEventListener for RegionServerEventSender {
         }
     }
 
-    fn deregister_region(&self, region_id: RegionId) {
+    fn on_deregister_region(&self, region_id: RegionId) {
         if let Err(e) = self.0.send(RegionServerEvent::Deregister(region_id)) {
             error!(
                 "Failed to send deregistering region: {region_id} event, source: {}",

--- a/src/datanode/src/event_listener.rs
+++ b/src/datanode/src/event_listener.rs
@@ -17,16 +17,16 @@ use store_api::storage::RegionId;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
 pub enum RegionServerEvent {
-    Register(RegionId),
-    Deregister(RegionId),
+    Registered(RegionId),
+    Deregistered(RegionId),
 }
 
 pub trait RegionServerEventListener: Sync + Send {
     /// Called *after* a new region was created/opened.
-    fn on_register_region(&self, _region_id: RegionId) {}
+    fn on_region_registered(&self, _region_id: RegionId) {}
 
     /// Called *after* a region was closed.
-    fn on_deregister_region(&self, _region_id: RegionId) {}
+    fn on_region_deregistered(&self, _region_id: RegionId) {}
 }
 
 pub type RegionServerEventListenerRef = Box<dyn RegionServerEventListener>;
@@ -39,8 +39,8 @@ impl RegionServerEventListener for NoopRegionServerEventListener {}
 pub struct RegionServerEventSender(pub(crate) UnboundedSender<RegionServerEvent>);
 
 impl RegionServerEventListener for RegionServerEventSender {
-    fn on_register_region(&self, region_id: RegionId) {
-        if let Err(e) = self.0.send(RegionServerEvent::Register(region_id)) {
+    fn on_region_registered(&self, region_id: RegionId) {
+        if let Err(e) = self.0.send(RegionServerEvent::Registered(region_id)) {
             error!(
                 "Failed to send registering region: {region_id} event, source: {}",
                 e
@@ -48,8 +48,8 @@ impl RegionServerEventListener for RegionServerEventSender {
         }
     }
 
-    fn on_deregister_region(&self, region_id: RegionId) {
-        if let Err(e) = self.0.send(RegionServerEvent::Deregister(region_id)) {
+    fn on_region_deregistered(&self, region_id: RegionId) {
+        if let Err(e) = self.0.send(RegionServerEvent::Deregistered(region_id)) {
             error!(
                 "Failed to send deregistering region: {region_id} event, source: {}",
                 e

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -191,10 +191,10 @@ impl HeartbeatTask {
                 }
 
                 match event_receiver.0.recv().await {
-                    Some(RegionServerEvent::Register(region_id)) => {
+                    Some(RegionServerEvent::Registered(region_id)) => {
                         keeper.register_region(region_id).await;
                     }
-                    Some(RegionServerEvent::Deregister(region_id)) => {
+                    Some(RegionServerEvent::Deregistered(region_id)) => {
                         keeper.deregister_region(region_id).await;
                     }
                     None => {

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -35,6 +35,7 @@ use self::handler::RegionHeartbeatResponseHandler;
 use crate::alive_keeper::RegionAliveKeeper;
 use crate::config::DatanodeOptions;
 use crate::error::{self, MetaClientInitSnafu, Result};
+use crate::event_listener::{RegionServerEvent, RegionServerEventReceiver};
 use crate::region_server::RegionServer;
 
 pub(crate) mod handler;
@@ -136,7 +137,7 @@ impl HeartbeatTask {
     }
 
     /// Start heartbeat task, spawn background task.
-    pub async fn start(&self) -> Result<()> {
+    pub async fn start(&self, mut event_receiver: RegionServerEventReceiver) -> Result<()> {
         let running = self.running.clone();
         if running
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -179,6 +180,32 @@ impl HeartbeatTask {
             ..Default::default()
         });
         let epoch = self.region_alive_keeper.epoch();
+
+        let keeper = self.region_alive_keeper.clone();
+
+        common_runtime::spawn_bg(async move {
+            loop {
+                if !running.load(Ordering::Relaxed) {
+                    info!("shutdown heartbeat task");
+                    break;
+                }
+
+                match event_receiver.0.recv().await {
+                    Some(RegionServerEvent::Register(region_id)) => {
+                        keeper.register_region(region_id).await;
+                    }
+                    Some(RegionServerEvent::Deregister(region_id)) => {
+                        keeper.deregister_region(region_id).await;
+                    }
+                    None => {
+                        info!("region server event sender closed!");
+                        break;
+                    }
+                }
+            }
+        });
+
+        let running = self.running.clone();
 
         common_runtime::spawn_bg(async move {
             let sleep = tokio::time::sleep(Duration::from_millis(0));

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -21,6 +21,7 @@ pub mod alive_keeper;
 pub mod config;
 pub mod datanode;
 pub mod error;
+pub mod event_listener;
 mod greptimedb_telemetry;
 pub mod heartbeat;
 pub mod metrics;

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -266,14 +266,14 @@ impl RegionServerInner {
             RegionChange::Register(_) => {
                 info!("Region {region_id} is registered to engine {engine_type}");
                 self.region_map.insert(region_id, engine);
-                self.event_listener.register_region(region_id);
+                self.event_listener.on_register_region(region_id);
             }
             RegionChange::Deregisters => {
                 info!("Region {region_id} is deregistered from engine {engine_type}");
                 self.region_map
                     .remove(&region_id)
                     .map(|(id, engine)| engine.set_writable(id, false));
-                self.event_listener.deregister_region(region_id);
+                self.event_listener.on_deregister_region(region_id);
             }
         }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -266,14 +266,14 @@ impl RegionServerInner {
             RegionChange::Register(_) => {
                 info!("Region {region_id} is registered to engine {engine_type}");
                 self.region_map.insert(region_id, engine);
-                self.event_listener.on_register_region(region_id);
+                self.event_listener.on_region_registered(region_id);
             }
             RegionChange::Deregisters => {
                 info!("Region {region_id} is deregistered from engine {engine_type}");
                 self.region_map
                     .remove(&region_id)
                     .map(|(id, engine)| engine.set_writable(id, false));
-                self.event_listener.on_deregister_region(region_id);
+                self.event_listener.on_region_deregistered(region_id);
             }
         }
 

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -59,6 +59,7 @@ use crate::error::{
     GetRegionMetadataSnafu, HandleRegionRequestSnafu, RegionEngineNotFoundSnafu,
     RegionNotFoundSnafu, Result, StopRegionEngineSnafu, UnsupportedOutputSnafu,
 };
+use crate::event_listener::RegionServerEventListenerRef;
 
 #[derive(Clone)]
 pub struct RegionServer {
@@ -66,9 +67,17 @@ pub struct RegionServer {
 }
 
 impl RegionServer {
-    pub fn new(query_engine: QueryEngineRef, runtime: Arc<Runtime>) -> Self {
+    pub fn new(
+        query_engine: QueryEngineRef,
+        runtime: Arc<Runtime>,
+        event_listener: RegionServerEventListenerRef,
+    ) -> Self {
         Self {
-            inner: Arc::new(RegionServerInner::new(query_engine, runtime)),
+            inner: Arc::new(RegionServerInner::new(
+                query_engine,
+                runtime,
+                event_listener,
+            )),
         }
     }
 
@@ -185,15 +194,21 @@ struct RegionServerInner {
     region_map: DashMap<RegionId, RegionEngineRef>,
     query_engine: QueryEngineRef,
     runtime: Arc<Runtime>,
+    event_listener: RegionServerEventListenerRef,
 }
 
 impl RegionServerInner {
-    pub fn new(query_engine: QueryEngineRef, runtime: Arc<Runtime>) -> Self {
+    pub fn new(
+        query_engine: QueryEngineRef,
+        runtime: Arc<Runtime>,
+        event_listener: RegionServerEventListenerRef,
+    ) -> Self {
         Self {
             engines: RwLock::new(HashMap::new()),
             region_map: DashMap::new(),
             query_engine,
             runtime,
+            event_listener,
         }
     }
 
@@ -251,12 +266,14 @@ impl RegionServerInner {
             RegionChange::Register(_) => {
                 info!("Region {region_id} is registered to engine {engine_type}");
                 self.region_map.insert(region_id, engine);
+                self.event_listener.register_region(region_id);
             }
             RegionChange::Deregisters => {
                 info!("Region {region_id} is deregistered from engine {engine_type}");
                 self.region_map
                     .remove(&region_id)
                     .map(|(id, engine)| engine.set_writable(id, false));
+                self.event_listener.deregister_region(region_id);
             }
         }
 

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -36,6 +36,7 @@ use session::context::QueryContextRef;
 use table::TableRef;
 use tokio::sync::mpsc::{self, Receiver};
 
+use crate::event_listener::NoopRegionServerEventListener;
 use crate::region_server::RegionServer;
 use crate::Instance;
 
@@ -142,5 +143,6 @@ pub fn mock_region_server() -> RegionServer {
     RegionServer::new(
         Arc::new(MockQueryEngine),
         Arc::new(Runtime::builder().build().unwrap()),
+        Box::new(NoopRegionServerEventListener),
     )
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Add `RegionServerEventListener`
2. Sync `Region` between RegionServer and RegionAliveKeeper
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
