### PR TITLE
feat: scope spawned task with trace id

### DIFF
--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -17,7 +17,7 @@ use std::vec;
 use api::v1::alter_expr::Kind;
 use api::v1::region::{
     alter_request, region_request, AddColumn, AddColumns, AlterRequest, DropColumn, DropColumns,
-    RegionColumnDef, RegionRequest,
+    RegionColumnDef, RegionRequest, RegionRequestHeader,
 };
 use api::v1::{AlterExpr, RenameTable};
 use async_trait::async_trait;
@@ -201,7 +201,10 @@ impl AlterTableProcedure {
                     let region_id = RegionId::new(table_id, region);
                     let request = self.create_alter_region_request(region_id)?;
                     let request = RegionRequest {
-                        header: None,
+                        header: Some(RegionRequestHeader {
+                            trace_id: common_telemetry::trace_id().unwrap_or_default(),
+                            ..Default::default()
+                        }),
                         body: Some(region_request::Body::Alter(request)),
                     };
                     debug!("Submitting {request:?} to {datanode}");

--- a/src/servers/src/grpc/flight/stream.rs
+++ b/src/servers/src/grpc/flight/stream.rs
@@ -18,7 +18,7 @@ use std::task::{Context, Poll};
 use arrow_flight::FlightData;
 use common_grpc::flight::{FlightEncoder, FlightMessage};
 use common_recordbatch::SendableRecordBatchStream;
-use common_telemetry::warn;
+use common_telemetry::{warn, TRACE_ID};
 use futures::channel::mpsc;
 use futures::channel::mpsc::Sender;
 use futures::{SinkExt, Stream, StreamExt};
@@ -39,12 +39,11 @@ pub struct FlightRecordBatchStream {
 }
 
 impl FlightRecordBatchStream {
-    pub fn new(recordbatches: SendableRecordBatchStream) -> Self {
+    pub fn new(recordbatches: SendableRecordBatchStream, trace_id: u64) -> Self {
         let (tx, rx) = mpsc::channel::<TonicResult<FlightMessage>>(1);
-        let join_handle =
-            common_runtime::spawn_read(
-                async move { Self::flight_data_stream(recordbatches, tx).await },
-            );
+        let join_handle = common_runtime::spawn_read(TRACE_ID.scope(trace_id, async move {
+            Self::flight_data_stream(recordbatches, tx).await
+        }));
         Self {
             rx,
             join_handle,
@@ -146,7 +145,7 @@ mod test {
         let recordbatches = RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()])
             .unwrap()
             .as_stream();
-        let mut stream = FlightRecordBatchStream::new(recordbatches);
+        let mut stream = FlightRecordBatchStream::new(recordbatches, 0);
 
         let mut raw_data = Vec::with_capacity(2);
         raw_data.push(stream.next().await.unwrap().unwrap());

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -27,7 +27,7 @@ use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
 use common_query::Output;
 use common_runtime::Runtime;
-use common_telemetry::logging;
+use common_telemetry::{logging, TRACE_ID};
 use metrics::{histogram, increment_counter};
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
@@ -74,6 +74,7 @@ impl GreptimeRequestHandler {
         let request_type = request_type(&query).to_string();
         let db = query_ctx.get_db_string();
         let timer = RequestTimer::new(db.clone(), request_type);
+        let trace_id = query_ctx.trace_id();
 
         // Executes requests in another runtime to
         // 1. prevent the execution from being cancelled unexpected by Tonic runtime;
@@ -82,7 +83,7 @@ impl GreptimeRequestHandler {
         //   - Obtaining a `JoinHandle` to get the panic message (if there's any).
         //     From its docs, `JoinHandle` is cancel safe. The task keeps running even it's handle been dropped.
         // 2. avoid the handler blocks the gRPC runtime incidentally.
-        let handle = self.runtime.spawn(async move {
+        let handle = self.runtime.spawn(TRACE_ID.scope(trace_id, async move {
             handler.do_query(query, query_ctx).await.map_err(|e| {
                 if e.status_code().should_log_error() {
                     logging::error!(e; "Failed to handle request");
@@ -92,7 +93,7 @@ impl GreptimeRequestHandler {
                 }
                 e
             })
-        });
+        }));
 
         handle.await.context(JoinTaskSnafu).map_err(|e| {
             timer.record(e.status_code());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your 

Scope some `spawn()`s with existing trace id. I don't find a good way to test this behavior. I'm afraid the only way is to find and add missing `.scope()` call on debugging 😖

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
