### PR TITLE
fix: update several sqlness results

### DIFF
--- a/tests/cases/distributed/optimizer/order_by.result
+++ b/tests/cases/distributed/optimizer/order_by.result
@@ -1,67 +1,67 @@
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers;
 
-+---------------+-------------------------------------------+
-| plan_type     | plan                                      |
-+---------------+-------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]          |
-| physical_plan | MergeScanExec: REDACTED
-|               |                                           |
-+---------------+-------------------------------------------+
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                  |
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                                                                                                                                                      |
+| physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
+|               |                                                                                                                                                                                       |
++---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number desc;
 
-+---------------+---------------------------------------------+
-| plan_type     | plan                                        |
-+---------------+---------------------------------------------+
-| logical_plan  | Sort: numbers.number DESC NULLS FIRST       |
-|               |   MergeScan [is_placeholder=false]          |
-| physical_plan | SortExec: expr=[number@0 DESC]              |
-|               |   MergeScanExec: REDACTED
-|               |                                             |
-+---------------+---------------------------------------------+
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                    |
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: numbers.number DESC NULLS FIRST                                                                                                                                                   |
+|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
+| physical_plan | SortExec: expr=[number@0 DESC]                                                                                                                                                          |
+|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
+|               |                                                                                                                                                                                         |
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number asc;
 
-+---------------+---------------------------------------------+
-| plan_type     | plan                                        |
-+---------------+---------------------------------------------+
-| logical_plan  | Sort: numbers.number ASC NULLS LAST         |
-|               |   MergeScan [is_placeholder=false]          |
-| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]    |
-|               |   MergeScanExec: REDACTED
-|               |                                             |
-+---------------+---------------------------------------------+
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                    |
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Sort: numbers.number ASC NULLS LAST                                                                                                                                                     |
+|               |   MergeScan [is_placeholder=false]                                                                                                                                                      |
+| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                                                                                                                                                |
+|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
+|               |                                                                                                                                                                                         |
++---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number desc limit 10;
 
-+---------------+---------------------------------------------------+
-| plan_type     | plan                                              |
-+---------------+---------------------------------------------------+
-| logical_plan  | Limit: skip=0, fetch=10                           |
-|               |   Sort: numbers.number DESC NULLS FIRST, fetch=10 |
-|               |     MergeScan [is_placeholder=false]              |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                 |
-|               |   SortExec: fetch=10, expr=[number@0 DESC]        |
-|               |     MergeScanExec: REDACTED
-|               |                                                   |
-+---------------+---------------------------------------------------+
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                      |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
+|               |   Sort: numbers.number DESC NULLS FIRST, fetch=10                                                                                                                                         |
+|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
+|               |   SortExec: fetch=10, expr=[number@0 DESC]                                                                                                                                                |
+|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
+|               |                                                                                                                                                                                           |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number asc limit 10;
 
-+---------------+------------------------------------------------------+
-| plan_type     | plan                                                 |
-+---------------+------------------------------------------------------+
-| logical_plan  | Limit: skip=0, fetch=10                              |
-|               |   Sort: numbers.number ASC NULLS LAST, fetch=10      |
-|               |     MergeScan [is_placeholder=false]                 |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                    |
-|               |   SortExec: fetch=10, expr=[number@0 ASC NULLS LAST] |
-|               |     MergeScanExec: REDACTED
-|               |                                                      |
-+---------------+------------------------------------------------------+
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| plan_type     | plan                                                                                                                                                                                      |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| logical_plan  | Limit: skip=0, fetch=10                                                                                                                                                                   |
+|               |   Sort: numbers.number ASC NULLS LAST, fetch=10                                                                                                                                           |
+|               |     MergeScan [is_placeholder=false]                                                                                                                                                      |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                                                                                                                                                         |
+|               |   SortExec: fetch=10, expr=[number@0 ASC NULLS LAST]                                                                                                                                      |
+|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>", schema: [Field { name: "number", data_type: UInt32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }] } |
+|               |                                                                                                                                                                                           |
++---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/tests/cases/distributed/show/show_create.result
+++ b/tests/cases/distributed/show/show_create.result
@@ -3,12 +3,11 @@ CREATE TABLE system_metrics (
   host STRING,
   cpu DOUBLE,
   disk FLOAT,
-  n INT COMMENT 'range key',
   ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
   TIME INDEX (ts),
   PRIMARY KEY (id, host)
 )
-PARTITION BY RANGE COLUMNS (n) (
+PARTITION BY RANGE COLUMNS (id) (
     PARTITION r0 VALUES LESS THAN (5),
     PARTITION r1 VALUES LESS THAN (9),
     PARTITION r2 VALUES LESS THAN (MAXVALUE),
@@ -31,16 +30,15 @@ SHOW CREATE TABLE system_metrics;
 |                |   "host" STRING NULL,                                     |
 |                |   "cpu" DOUBLE NULL,                                      |
 |                |   "disk" FLOAT NULL,                                      |
-|                |   "n" INT NULL,                                           |
 |                |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
 |                |   TIME INDEX ("ts"),                                      |
 |                |   PRIMARY KEY ("id", "host")                              |
 |                | )                                                         |
-|                | PARTITION BY RANGE COLUMNS ("n") (                        |
-|                |                       PARTITION r0 VALUES LESS THAN (5),  |
+|                | PARTITION BY RANGE COLUMNS ("id") (                       |
+|                |   PARTITION r0 VALUES LESS THAN (5),                      |
 |                |   PARTITION r1 VALUES LESS THAN (9),                      |
 |                |   PARTITION r2 VALUES LESS THAN (MAXVALUE)                |
-|                |                 )                                         |
+|                | )                                                         |
 |                | ENGINE=mito                                               |
 |                | WITH(                                                     |
 |                |   regions = 3,                                            |
@@ -84,12 +82,11 @@ CREATE TABLE not_supported_table_options_keys (
   host STRING,
   cpu DOUBLE,
   disk FLOAT,
-  n INT COMMENT 'range key',
   ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
   TIME INDEX (ts),
   PRIMARY KEY (id, host)
 )
-PARTITION BY RANGE COLUMNS (n) (
+PARTITION BY RANGE COLUMNS (id) (
     PARTITION r0 VALUES LESS THAN (5),
     PARTITION r1 VALUES LESS THAN (9),
     PARTITION r2 VALUES LESS THAN (MAXVALUE),

--- a/tests/cases/distributed/show/show_create.sql
+++ b/tests/cases/distributed/show/show_create.sql
@@ -3,12 +3,11 @@ CREATE TABLE system_metrics (
   host STRING,
   cpu DOUBLE,
   disk FLOAT,
-  n INT COMMENT 'range key',
   ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
   TIME INDEX (ts),
   PRIMARY KEY (id, host)
 )
-PARTITION BY RANGE COLUMNS (n) (
+PARTITION BY RANGE COLUMNS (id) (
     PARTITION r0 VALUES LESS THAN (5),
     PARTITION r1 VALUES LESS THAN (9),
     PARTITION r2 VALUES LESS THAN (MAXVALUE),
@@ -36,12 +35,11 @@ CREATE TABLE not_supported_table_options_keys (
   host STRING,
   cpu DOUBLE,
   disk FLOAT,
-  n INT COMMENT 'range key',
   ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
   TIME INDEX (ts),
   PRIMARY KEY (id, host)
 )
-PARTITION BY RANGE COLUMNS (n) (
+PARTITION BY RANGE COLUMNS (id) (
     PARTITION r0 VALUES LESS THAN (5),
     PARTITION r1 VALUES LESS THAN (9),
     PARTITION r2 VALUES LESS THAN (MAXVALUE),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Numbers table is a temporary table and should be scanned locally. We don't support to define partition rule on non-primary keys.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #2367