### PR TITLE
refactor: rename coordination to require_lease_before_startup

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -8,9 +8,9 @@ rpc_addr = "127.0.0.1:3001"
 rpc_hostname = "127.0.0.1"
 # The number of gRPC server worker threads, 8 by default.
 rpc_runtime_size = 8
-# Start services after regions are coordinated. 
-# It will block the datanode start if it can't receive the heartbeat from metasrv.
-coordination = false
+# Start services after regions have obtained leases.
+# It will block the datanode start if it can't receive leases in the heartbeat from metasrv.
+require_lease_before_startup = false
 
 [heartbeat]
 # Interval for sending heartbeat messages to the Metasrv in milliseconds, 5000 by default.

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -320,7 +320,7 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
 pub struct DatanodeOptions {
     pub mode: Mode,
     pub node_id: Option<u64>,
-    pub coordination: bool,
+    pub require_lease_before_startup: bool,
     pub rpc_addr: String,
     pub rpc_hostname: Option<String>,
     pub rpc_runtime_size: usize,
@@ -340,7 +340,7 @@ impl Default for DatanodeOptions {
         Self {
             mode: Mode::Standalone,
             node_id: None,
-            coordination: false,
+            require_lease_before_startup: false,
             rpc_addr: "127.0.0.1:3001".to_string(),
             rpc_hostname: None,
             rpc_runtime_size: 8,

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -47,6 +47,11 @@ impl<S> RegionWorkerLoop<S> {
 
         // Get the version before alter.
         let version = region.version();
+        if version.metadata.schema_version >= request.schema_version {
+            // Returns if it altered.
+            sender.send(Ok(Output::AffectedRows(0)));
+            return;
+        }
         // Checks whether we can alter the region directly.
         if !version.memtables.is_empty() {
             // If memtable is not empty, we can't alter it directly and need to flush

--- a/tests/conf/datanode-test.toml.template
+++ b/tests/conf/datanode-test.toml.template
@@ -3,7 +3,7 @@ mode = 'distributed'
 rpc_addr = '127.0.0.1:4100'
 rpc_hostname = '127.0.0.1'
 rpc_runtime_size = 8
-coordination = true
+require_lease_before_startup = true
 
 [wal]
 file_size = '1GB'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

rename coordination to require_lease_before_startup

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
