### PR TITLE
fix: check version before alter region

### DIFF
--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -47,6 +47,19 @@ impl<S> RegionWorkerLoop<S> {
 
         // Get the version before alter.
         let version = region.version();
+<<<<<<< Updated upstream
+        if version.metadata.schema_version >= request.schema_version {
+=======
+        if version.metadata.schema_version > request.schema_version {
+            warn!(
+                "region schema version {} greater than request schema version {}",
+                version.metadata.schema_version, request.schema_version
+            );
+>>>>>>> Stashed changes
+            // Returns if it altered.
+            sender.send(Ok(Output::AffectedRows(0)));
+            return;
+        }
         // Checks whether we can alter the region directly.
         if !version.memtables.is_empty() {
             // If memtable is not empty, we can't alter it directly and need to flush

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use common_query::Output;
-use common_telemetry::{error, info};
+use common_telemetry::{error, info, warn};
 use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::region_request::RegionAlterRequest;
@@ -47,15 +47,11 @@ impl<S> RegionWorkerLoop<S> {
 
         // Get the version before alter.
         let version = region.version();
-<<<<<<< Updated upstream
-        if version.metadata.schema_version >= request.schema_version {
-=======
         if version.metadata.schema_version > request.schema_version {
             warn!(
-                "region schema version {} greater than request schema version {}",
-                version.metadata.schema_version, request.schema_version
+                "region id:{}, region schema version {} greater than request schema version {}",
+                region_id, version.metadata.schema_version, request.schema_version
             );
->>>>>>> Stashed changes
             // Returns if it altered.
             sender.send(Ok(Output::AffectedRows(0)));
             return;

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -49,7 +49,7 @@ impl<S> RegionWorkerLoop<S> {
         let version = region.version();
         if version.metadata.schema_version > request.schema_version {
             warn!(
-                "region id:{}, region schema version {} greater than request schema version {}",
+                "Ignored alert request, region id:{}, region schema version {} is greater than request schema version {}",
                 region_id, version.metadata.schema_version, request.schema_version
             );
             // Returns if it altered.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

check version before alter region

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
