### PR TITLE
fix: compile error after updating protos

### DIFF
--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -91,6 +91,7 @@ mod test {
                         is_nullable: true,
                         default_constraint: vec![],
                         semantic_type: SemanticType::Field as i32,
+                        ..Default::default()
                     },
                     ColumnDef {
                         name: "ts".to_string(),
@@ -98,6 +99,7 @@ mod test {
                         is_nullable: false,
                         default_constraint: vec![],
                         semantic_type: SemanticType::Timestamp as i32,
+                        ..Default::default()
                     },
                 ],
                 time_index: "ts".to_string(),
@@ -121,6 +123,7 @@ mod test {
                             is_nullable: true,
                             default_constraint: vec![],
                             semantic_type: SemanticType::Field as i32,
+                            ..Default::default()
                         }),
                         location: None,
                     }],

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -253,6 +253,7 @@ pub async fn test_insert_and_select(store_type: StorageType) {
         is_nullable: true,
         default_constraint: vec![],
         semantic_type: SemanticType::Field as i32,
+        ..Default::default()
     };
     let kind = Kind::AddColumns(AddColumns {
         add_columns: vec![AddColumn {
@@ -343,6 +344,7 @@ fn testing_create_expr() -> CreateTableExpr {
             is_nullable: false,
             default_constraint: vec![],
             semantic_type: SemanticType::Tag as i32,
+            ..Default::default()
         },
         ColumnDef {
             name: "cpu".to_string(),
@@ -350,6 +352,7 @@ fn testing_create_expr() -> CreateTableExpr {
             is_nullable: true,
             default_constraint: vec![],
             semantic_type: SemanticType::Field as i32,
+            ..Default::default()
         },
         ColumnDef {
             name: "memory".to_string(),
@@ -357,6 +360,7 @@ fn testing_create_expr() -> CreateTableExpr {
             is_nullable: true,
             default_constraint: vec![],
             semantic_type: SemanticType::Field as i32,
+            ..Default::default()
         },
         ColumnDef {
             name: "ts".to_string(),
@@ -364,6 +368,7 @@ fn testing_create_expr() -> CreateTableExpr {
             is_nullable: false,
             default_constraint: vec![],
             semantic_type: SemanticType::Timestamp as i32,
+            ..Default::default()
         },
     ];
     CreateTableExpr {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The `ColumnDef` has a new field `comment`, we have to resolve the compile errors.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
