### PR TITLE
fix: remark region as inactive on leader changed

### DIFF
--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -270,6 +270,8 @@ trait State: Sync + Send + Debug {
     fn status(&self) -> Status {
         Status::executing(true)
     }
+
+    fn remark_inactive_region_if_needed(&mut self) {}
 }
 
 /// The states transition of region failover procedure:
@@ -339,7 +341,11 @@ impl RegionFailoverProcedure {
     }
 
     fn from_json(json: &str, context: RegionFailoverContext) -> ProcedureResult<Self> {
-        let node: Node = serde_json::from_str(json).context(FromJsonSnafu)?;
+        let mut node: Node = serde_json::from_str(json).context(FromJsonSnafu)?;
+        // If the meta leader node dies during the execution of the procedure,
+        // the new leader node needs to remark the failed region as "inactive"
+        // to prevent it from renewing the lease.
+        node.state.remark_inactive_region_if_needed();
         Ok(Self { node, context })
     }
 }

--- a/src/meta-srv/src/procedure/region_failover/activate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/activate_region.rs
@@ -45,10 +45,10 @@ pub(super) struct ActivateRegion {
 }
 
 impl ActivateRegion {
-    pub(super) fn new(candidate: Peer, remark_inactive_region: bool) -> Self {
+    pub(super) fn new(candidate: Peer) -> Self {
         Self {
             candidate,
-            remark_inactive_region,
+            remark_inactive_region: false,
             region_storage_path: None,
         }
     }
@@ -185,6 +185,10 @@ impl State for ActivateRegion {
 
         self.handle_response(mailbox_receiver, failed_region).await
     }
+
+    fn remark_inactive_region_if_needed(&mut self) {
+        self.remark_inactive_region = true;
+    }
 }
 
 #[cfg(test)]
@@ -203,7 +207,7 @@ mod tests {
         let failed_region = env.failed_region(1).await;
 
         let candidate = 2;
-        let mut state = ActivateRegion::new(Peer::new(candidate, ""), false);
+        let mut state = ActivateRegion::new(Peer::new(candidate, ""));
         let mailbox_receiver = state
             .send_open_region_message(&env.context, &failed_region, Duration::from_millis(100))
             .await
@@ -274,7 +278,7 @@ mod tests {
         let failed_region = env.failed_region(1).await;
 
         let candidate = 2;
-        let mut state = ActivateRegion::new(Peer::new(candidate, ""), false);
+        let mut state = ActivateRegion::new(Peer::new(candidate, ""));
         let mailbox_receiver = state
             .send_open_region_message(&env.context, &failed_region, Duration::from_millis(100))
             .await

--- a/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
@@ -97,7 +97,7 @@ impl DeactivateRegion {
                         .deregister_inactive_region(failed_region)
                         .await?;
 
-                    Ok(Box::new(ActivateRegion::new(self.candidate.clone(), false)))
+                    Ok(Box::new(ActivateRegion::new(self.candidate.clone())))
                 } else {
                     // Under rare circumstances would a Datanode fail to close a Region.
                     // So simply retry.
@@ -113,7 +113,7 @@ impl DeactivateRegion {
                 // the call and have disabled region lease renewal. Therefore, if a timeout error
                 // occurs, it can be concluded that the region has been closed. With this information,
                 // we can proceed confidently to the next step.
-                Ok(Box::new(ActivateRegion::new(self.candidate.clone(), true)))
+                Ok(Box::new(ActivateRegion::new(self.candidate.clone())))
             }
             Err(e) => Err(e),
         }
@@ -146,7 +146,7 @@ impl State for DeactivateRegion {
                 );
                 // See the mailbox received timeout situation comments above.
                 self.wait_for_region_lease_expiry(ctx).await;
-                return Ok(Box::new(ActivateRegion::new(self.candidate.clone(), true)));
+                return Ok(Box::new(ActivateRegion::new(self.candidate.clone())));
             }
             Err(e) => return Err(e),
         };
@@ -268,7 +268,7 @@ mod tests {
         // Timeout or not, proceed to `ActivateRegion`.
         assert_eq!(
             format!("{next_state:?}"),
-            r#"ActivateRegion { candidate: Peer { id: 2, addr: "" }, remark_inactive_region: true, region_storage_path: None }"#
+            r#"ActivateRegion { candidate: Peer { id: 2, addr: "" }, remark_inactive_region: false, region_storage_path: None }"#
         );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

If the meta leader node dies during the execution of the procedure, the new leader node needs to remark the failed region as "inactive" to prevent it from renewing the lease.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Close #2332 
