### PR TITLE
feat(mito): Allow to retry create request and alter request

### DIFF
--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -250,7 +250,6 @@ async fn test_flush_reopen_region() {
         assert_eq!(1, version_data.last_entry_id);
         assert_eq!(3, version_data.committed_sequence);
         assert_eq!(1, version_data.version.flushed_entry_id);
-        assert_eq!(1, version_data.version.flushed_entry_id);
         assert_eq!(3, version_data.version.flushed_sequence);
     };
     check_region();

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -459,6 +459,17 @@ pub enum Error {
         source: serde_json::Error,
         location: Location,
     },
+
+    #[snafu(display(
+        "Empty region directory, region_id: {}, region_dir: {}",
+        region_id,
+        region_dir,
+    ))]
+    EmptyRegionDir {
+        region_id: RegionId,
+        region_dir: String,
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -529,6 +540,7 @@ impl ErrorExt for Error {
             InvalidRegionRequest { source, .. } => source.status_code(),
             RegionReadonly { .. } => StatusCode::RegionReadonly,
             JsonOptions { .. } => StatusCode::InvalidArguments,
+            EmptyRegionDir { .. } => StatusCode::RegionNotFound,
         }
     }
 

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -267,7 +267,7 @@ pub(crate) fn check_recovered_region(
                 recovered.region_id
             ),
         }
-        .fail()?;
+        .fail();
     }
     if recovered.column_metadatas != column_metadatas {
         error!(
@@ -279,7 +279,7 @@ pub(crate) fn check_recovered_region(
             region_id,
             reason: "recovered metadata has different schema",
         }
-        .fail()?;
+        .fail();
     }
     if recovered.primary_key != primary_key {
         error!(
@@ -291,7 +291,7 @@ pub(crate) fn check_recovered_region(
             region_id,
             reason: "recovered metadata has different primary key",
         }
-        .fail()?;
+        .fail();
     }
 
     Ok(())

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -42,7 +42,7 @@ use store_api::region_request::{
     RegionCloseRequest, RegionCreateRequest, RegionDeleteRequest, RegionFlushRequest,
     RegionOpenRequest, RegionPutRequest, RegionRequest,
 };
-use store_api::storage::RegionId;
+use store_api::storage::{ColumnId, RegionId};
 
 use crate::config::MitoConfig;
 use crate::engine::listener::EventListenerRef;
@@ -208,8 +208,8 @@ pub struct CreateRequestBuilder {
     region_dir: String,
     tag_num: usize,
     field_num: usize,
-    create_if_not_exists: bool,
     options: HashMap<String, String>,
+    primary_key: Option<Vec<ColumnId>>,
 }
 
 impl Default for CreateRequestBuilder {
@@ -218,34 +218,39 @@ impl Default for CreateRequestBuilder {
             region_dir: "test".to_string(),
             tag_num: 1,
             field_num: 1,
-            create_if_not_exists: false,
             options: HashMap::new(),
+            primary_key: None,
         }
     }
 }
 
 impl CreateRequestBuilder {
+    #[must_use]
     pub fn new() -> CreateRequestBuilder {
         CreateRequestBuilder::default()
     }
 
+    #[must_use]
     pub fn region_dir(mut self, value: &str) -> Self {
         self.region_dir = value.to_string();
         self
     }
 
+    #[must_use]
     pub fn tag_num(mut self, value: usize) -> Self {
         self.tag_num = value;
         self
     }
 
+    #[must_use]
     pub fn field_num(mut self, value: usize) -> Self {
         self.field_num = value;
         self
     }
 
-    pub fn create_if_not_exists(mut self, value: bool) -> Self {
-        self.create_if_not_exists = value;
+    #[must_use]
+    pub fn primary_key(mut self, primary_key: Vec<ColumnId>) -> Self {
+        self.primary_key = Some(primary_key);
         self
     }
 
@@ -297,9 +302,9 @@ impl CreateRequestBuilder {
             // We use empty engine name as we already locates the engine.
             engine: String::new(),
             column_metadatas,
-            primary_key,
-            create_if_not_exists: self.create_if_not_exists,
+            primary_key: self.primary_key.clone().unwrap_or(primary_key),
             options: self.options.clone(),
+            create_if_not_exists: false,
             region_dir: self.region_dir.clone(),
         }
     }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -56,6 +56,8 @@ impl<S> RegionWorkerLoop<S> {
             sender.send(Ok(Output::AffectedRows(0)));
             return;
         }
+        // TODO(yingwen): validate req here
+
         // Checks whether we can alter the region directly.
         if !version.memtables.is_empty() {
             // If memtable is not empty, we can't alter it directly and need to flush

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -18,14 +18,14 @@ use std::sync::Arc;
 
 use common_query::Output;
 use common_telemetry::info;
-use snafu::{ensure, ResultExt};
+use snafu::ResultExt;
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadataBuilder;
 use store_api::region_request::RegionCreateRequest;
 use store_api::storage::RegionId;
 
-use crate::error::{InvalidMetadataSnafu, RegionExistsSnafu, Result};
-use crate::region::opener::RegionOpener;
+use crate::error::{InvalidMetadataSnafu, Result};
+use crate::region::opener::{check_recovered_region, RegionOpener};
 use crate::worker::RegionWorkerLoop;
 
 impl<S: LogStore> RegionWorkerLoop<S> {
@@ -35,13 +35,15 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         request: RegionCreateRequest,
     ) -> Result<Output> {
         // Checks whether the table exists.
-        if self.regions.is_region_exists(region_id) {
-            ensure!(
-                request.create_if_not_exists,
-                RegionExistsSnafu { region_id }
-            );
-
+        if let Some(region) = self.regions.get_region(region_id) {
             // Region already exists.
+            check_recovered_region(
+                &region.metadata(),
+                region_id,
+                &request.column_metadatas,
+                &request.primary_key,
+            )?;
+
             return Ok(Output::AffectedRows(0));
         }
 
@@ -63,7 +65,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         .metadata(metadata)
         .region_dir(&request.region_dir)
         .options(request.options)
-        .create(&self.config)
+        .create_or_open(&self.config, &self.wal)
         .await?;
 
         // TODO(yingwen): Custom the Debug format for the metadata and also print it.

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -151,6 +151,7 @@ pub struct RegionCreateRequest {
     /// Columns in the primary key.
     pub primary_key: Vec<ColumnId>,
     /// Create region if not exists.
+    // TODO(yingwen): Remove this.
     pub create_if_not_exists: bool,
     /// Options of the created region.
     pub options: HashMap<String, String>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR allows the same `RegioniCreateRequest`/`RegionAlterRequest` to execute multiple times so creating/altering a region is idempotent.

Now the mito engine
- opens the region before creating a new region
- adds a new column if it does not exist
- drops a column if it exists

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- #1869 