### PR TITLE
refactor: unify table metadata cache invalidator

### DIFF
--- a/src/catalog/src/kvbackend.rs
+++ b/src/catalog/src/kvbackend.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 pub use client::{CachedMetaKvBackend, MetaKvBackend};
 
 mod client;
@@ -22,18 +20,3 @@ mod manager;
 #[cfg(feature = "testing")]
 pub mod mock;
 pub use manager::KvBackendCatalogManager;
-
-/// KvBackend cache invalidator
-#[async_trait::async_trait]
-pub trait KvCacheInvalidator: Send + Sync {
-    async fn invalidate_key(&self, key: &[u8]);
-}
-
-pub type KvCacheInvalidatorRef = Arc<dyn KvCacheInvalidator>;
-
-pub struct DummyKvCacheInvalidator;
-
-#[async_trait::async_trait]
-impl KvCacheInvalidator for DummyKvCacheInvalidator {
-    async fn invalidate_key(&self, _key: &[u8]) {}
-}

--- a/src/catalog/src/kvbackend/client.rs
+++ b/src/catalog/src/kvbackend/client.rs
@@ -29,7 +29,7 @@ use common_meta::rpc::store::{
     RangeRequest, RangeResponse,
 };
 use common_meta::rpc::KeyValue;
-use common_telemetry::timer;
+use common_telemetry::{debug, timer};
 use meta_client::client::MetaClient;
 use moka::future::{Cache, CacheBuilder};
 use snafu::{OptionExt, ResultExt};
@@ -197,7 +197,8 @@ impl KvBackend for CachedMetaKvBackend {
 #[async_trait::async_trait]
 impl KvCacheInvalidator for CachedMetaKvBackend {
     async fn invalidate_key(&self, key: &[u8]) {
-        self.cache.invalidate(key).await
+        self.cache.invalidate(key).await;
+        debug!("invalidated cache key: {}", String::from_utf8_lossy(key));
     }
 }
 

--- a/src/catalog/src/kvbackend/client.rs
+++ b/src/catalog/src/kvbackend/client.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use common_error::ext::BoxedError;
+use common_meta::cache_invalidator::KvCacheInvalidator;
 use common_meta::error::Error::{CacheNotGet, GetKvCache};
 use common_meta::error::{CacheNotGetSnafu, Error, ExternalSnafu, Result};
 use common_meta::kv_backend::{KvBackend, KvBackendRef, TxnService};
@@ -33,7 +34,6 @@ use meta_client::client::MetaClient;
 use moka::future::{Cache, CacheBuilder};
 use snafu::{OptionExt, ResultExt};
 
-use super::KvCacheInvalidator;
 use crate::metrics::{METRIC_CATALOG_KV_GET, METRIC_CATALOG_KV_REMOTE_GET};
 
 const CACHE_MAX_CAPACITY: u64 = 10000;

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -14,11 +14,12 @@
 
 use std::sync::Arc;
 
-use catalog::kvbackend::{DummyKvCacheInvalidator, KvBackendCatalogManager};
+use catalog::kvbackend::KvBackendCatalogManager;
 use catalog::CatalogManagerRef;
 use clap::Parser;
 use common_base::Plugins;
 use common_config::{kv_store_dir, KvStoreConfig, WalConfig};
+use common_meta::cache_invalidator::DummyKvCacheInvalidator;
 use common_meta::kv_backend::KvBackendRef;
 use common_procedure::ProcedureManagerRef;
 use common_telemetry::info;

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -14,10 +14,10 @@
 
 use std::sync::Arc;
 
-use common_telemetry::debug;
 use table::metadata::TableId;
 
 use crate::error::Result;
+use crate::key::schema_name::SchemaNameKey;
 use crate::key::table_info::TableInfoKey;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteKey;
@@ -75,6 +75,11 @@ impl TableMetadataCacheInvalidator {
     pub fn new(kv_cache_invalidator: KvCacheInvalidatorRef) -> Self {
         Self(kv_cache_invalidator)
     }
+
+    pub async fn invalidate_schema(&self, catalog: &str, schema: &str) {
+        let key = SchemaNameKey::new(catalog, schema).as_raw_key();
+        self.0.invalidate_key(&key).await;
+    }
 }
 
 #[async_trait::async_trait]
@@ -83,10 +88,6 @@ impl CacheInvalidator for TableMetadataCacheInvalidator {
         let key: TableNameKey = (&table_name).into();
 
         self.0.invalidate_key(&key.as_raw_key()).await;
-        debug!(
-            "invalidated cache key: {}",
-            String::from_utf8_lossy(&key.as_raw_key())
-        );
 
         Ok(())
     }
@@ -94,17 +95,9 @@ impl CacheInvalidator for TableMetadataCacheInvalidator {
     async fn invalidate_table_id(&self, _ctx: &Context, table_id: TableId) -> Result<()> {
         let key = TableInfoKey::new(table_id);
         self.0.invalidate_key(&key.as_raw_key()).await;
-        debug!(
-            "invalidated cache key: {}",
-            String::from_utf8_lossy(&key.as_raw_key())
-        );
 
         let key = &TableRouteKey { table_id };
         self.0.invalidate_key(&key.as_raw_key()).await;
-        debug!(
-            "invalidated cache key: {}",
-            String::from_utf8_lossy(&key.as_raw_key())
-        );
 
         Ok(())
     }

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -14,10 +14,30 @@
 
 use std::sync::Arc;
 
+use common_telemetry::debug;
 use table::metadata::TableId;
 
 use crate::error::Result;
+use crate::key::table_info::TableInfoKey;
+use crate::key::table_name::TableNameKey;
+use crate::key::table_route::TableRouteKey;
+use crate::key::TableMetaKey;
 use crate::table_name::TableName;
+
+/// KvBackend cache invalidator
+#[async_trait::async_trait]
+pub trait KvCacheInvalidator: Send + Sync {
+    async fn invalidate_key(&self, key: &[u8]);
+}
+
+pub type KvCacheInvalidatorRef = Arc<dyn KvCacheInvalidator>;
+
+pub struct DummyKvCacheInvalidator;
+
+#[async_trait::async_trait]
+impl KvCacheInvalidator for DummyKvCacheInvalidator {
+    async fn invalidate_key(&self, _key: &[u8]) {}
+}
 
 /// Places context of invalidating cache. e.g., span id, trace id etc.
 #[derive(Default)]
@@ -44,6 +64,48 @@ impl CacheInvalidator for DummyCacheInvalidator {
     }
 
     async fn invalidate_table_name(&self, _ctx: &Context, _table_name: TableName) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct TableMetadataCacheInvalidator(KvCacheInvalidatorRef);
+
+impl TableMetadataCacheInvalidator {
+    pub fn new(kv_cache_invalidator: KvCacheInvalidatorRef) -> Self {
+        Self(kv_cache_invalidator)
+    }
+}
+
+#[async_trait::async_trait]
+impl CacheInvalidator for TableMetadataCacheInvalidator {
+    async fn invalidate_table_name(&self, _ctx: &Context, table_name: TableName) -> Result<()> {
+        let key: TableNameKey = (&table_name).into();
+
+        self.0.invalidate_key(&key.as_raw_key()).await;
+        debug!(
+            "invalidated cache key: {}",
+            String::from_utf8_lossy(&key.as_raw_key())
+        );
+
+        Ok(())
+    }
+
+    async fn invalidate_table_id(&self, _ctx: &Context, table_id: TableId) -> Result<()> {
+        let key = TableInfoKey::new(table_id);
+        self.0.invalidate_key(&key.as_raw_key()).await;
+        debug!(
+            "invalidated cache key: {}",
+            String::from_utf8_lossy(&key.as_raw_key())
+        );
+
+        let key = &TableRouteKey { table_id };
+        self.0.invalidate_key(&key.as_raw_key()).await;
+        debug!(
+            "invalidated cache key: {}",
+            String::from_utf8_lossy(&key.as_raw_key())
+        );
+
         Ok(())
     }
 }

--- a/src/frontend/src/heartbeat/handler/tests.rs
+++ b/src/frontend/src/heartbeat/handler/tests.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use api::v1::meta::HeartbeatResponse;
-use catalog::kvbackend::KvCacheInvalidator;
+use common_meta::cache_invalidator::KvCacheInvalidator;
 use common_meta::heartbeat::handler::{
     HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutor,
 };

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -14,9 +14,10 @@
 
 use std::sync::Arc;
 
-use catalog::kvbackend::{DummyKvCacheInvalidator, KvBackendCatalogManager};
+use catalog::kvbackend::KvBackendCatalogManager;
 use common_base::Plugins;
 use common_config::KvStoreConfig;
+use common_meta::cache_invalidator::DummyKvCacheInvalidator;
 use common_procedure::options::ProcedureConfig;
 use datanode::config::DatanodeOptions;
 use datanode::datanode::DatanodeBuilder;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

unify table metadata cache invalidator

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
