### PR TITLE
feat: supports binary data type

### DIFF
--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -386,9 +386,10 @@ pub fn sql_data_type_to_concrete_data_type(data_type: &SqlDataType) -> Result<Co
         SqlDataType::Double => Ok(ConcreteDataType::float64_datatype()),
         SqlDataType::Boolean => Ok(ConcreteDataType::boolean_datatype()),
         SqlDataType::Date => Ok(ConcreteDataType::date_datatype()),
-        SqlDataType::Blob(_) | SqlDataType::Bytea | SqlDataType::Varbinary(_) => {
-            Ok(ConcreteDataType::binary_datatype())
-        }
+        SqlDataType::Binary(_)
+        | SqlDataType::Blob(_)
+        | SqlDataType::Bytea
+        | SqlDataType::Varbinary(_) => Ok(ConcreteDataType::binary_datatype()),
         SqlDataType::Datetime(_) => Ok(ConcreteDataType::datetime_datatype()),
         SqlDataType::Timestamp(precision, _) => Ok(precision
             .as_ref()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Supports binary sql data type.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
