### PR TITLE
test: revert ignored tests

### DIFF
--- a/tests-integration/src/opentsdb.rs
+++ b/tests-integration/src/opentsdb.rs
@@ -38,7 +38,6 @@ mod tests {
         test_exec(instance).await;
     }
 
-    #[ignore = "https://github.com/GreptimeTeam/greptimedb/issues/1681"]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_distributed_exec() {
         let distributed = tests::create_distributed_instance("test_distributed_exec").await;

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -1249,7 +1249,6 @@ async fn test_create_table_after_rename_table(instance: Arc<dyn MockInstance>) {
     check_output_stream(output, expect).await;
 }
 
-#[ignore = "https://github.com/GreptimeTeam/greptimedb/issues/1681"]
 #[apply(both_instances_cases)]
 async fn test_alter_table(instance: Arc<dyn MockInstance>) {
     let instance = instance.frontend();
@@ -1271,7 +1270,7 @@ async fn test_alter_table(instance: Arc<dyn MockInstance>) {
             "insert into demo(host, cpu, memory, ts) values ('host1', 1.1, 100, 1000)",
         )
         .await,
-        Output::AffectedRows(0)
+        Output::AffectedRows(1)
     ));
 
     // Add column


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Revert two ignored tests.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#2401 
