### PR TITLE
ci: expand upload retry timeout

### DIFF
--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -37,7 +37,7 @@ inputs:
   upload-retry-timeout:
     description: Timeout for uploading artifacts to S3
     required: false
-    default: "10" # minutes
+    default: "30" # minutes
   working-dir:
     description: Working directory to upload the artifacts
     required: false


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

ci: expand upload retry timeout

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
