### PR TITLE
fix: add slash after generated region_dir

### DIFF
--- a/src/store-api/src/path_utils.rs
+++ b/src/store-api/src/path_utils.rs
@@ -60,7 +60,7 @@ mod tests {
         let region_id = RegionId::new(42, 1);
         assert_eq!(
             region_dir("my_catalog/my_schema", region_id),
-            "data/my_catalog/my_schema/42/42_0000000001"
+            "data/my_catalog/my_schema/42/42_0000000001/"
         );
     }
 }

--- a/src/store-api/src/path_utils.rs
+++ b/src/store-api/src/path_utils.rs
@@ -45,7 +45,7 @@ pub fn table_dir(path: &str, table_id: TableId) -> String {
 
 pub fn region_dir(path: &str, region_id: RegionId) -> String {
     format!(
-        "{}{}",
+        "{}{}/",
         table_dir(path, region_id.table_id()),
         region_name(region_id.table_id(), region_id.region_number())
     )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


```sql
MySQL [(none)]> show tables;
+---------+
| Tables  |
+---------+
| numbers |
| scripts |
| t       |
+---------+
3 rows in set (0.013 sec)

MySQL [(none)]> drop table t;
Query OK, 1 row affected (0.004 sec)

MySQL [(none)]> show tables;
+---------+
| Tables  |
+---------+
| numbers |
| scripts |
+---------+
2 rows in set (0.001 sec)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
closes https://github.com/GreptimeTeam/greptimedb/issues/2457