### PR TITLE
refactor: remove SqlStatementExecutor

### DIFF
--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -15,8 +15,6 @@
 #![feature(assert_matches)]
 #![feature(trait_upcasting)]
 
-use query::query_engine::SqlStatementExecutor;
-
 pub mod alive_keeper;
 pub mod config;
 pub mod datanode;
@@ -31,17 +29,3 @@ mod store;
 #[cfg(test)]
 #[allow(dead_code)]
 mod tests;
-
-// TODO(ruihang): remove this
-pub struct Instance;
-
-#[async_trait::async_trait]
-impl SqlStatementExecutor for Instance {
-    async fn execute_sql(
-        &self,
-        _stmt: sql::statements::statement::Statement,
-        _query_ctx: session::context::QueryContextRef,
-    ) -> query::error::Result<common_query::Output> {
-        unreachable!()
-    }
-}

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -23,7 +23,7 @@ use common_meta::heartbeat::handler::{
     HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutor,
 };
 use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MessageMeta};
-use common_meta::instruction::{Instruction, InstructionReply, OpenRegion, RegionIdent};
+use common_meta::instruction::{Instruction, OpenRegion, RegionIdent};
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
 use common_runtime::Runtime;
@@ -34,29 +34,9 @@ use query::query_engine::DescribeResult;
 use query::QueryEngine;
 use session::context::QueryContextRef;
 use table::TableRef;
-use tokio::sync::mpsc::{self, Receiver};
 
 use crate::event_listener::NoopRegionServerEventListener;
 use crate::region_server::RegionServer;
-use crate::Instance;
-
-struct HandlerTestGuard {
-    instance: Instance,
-    mailbox: Arc<HeartbeatMailbox>,
-    rx: Receiver<(MessageMeta, InstructionReply)>,
-}
-
-async fn prepare_handler_test(_name: &str) -> HandlerTestGuard {
-    let instance = Instance;
-    let (tx, rx) = mpsc::channel(8);
-    let mailbox = Arc::new(HeartbeatMailbox::new(tx));
-
-    HandlerTestGuard {
-        instance,
-        mailbox,
-        rx,
-    }
-}
 
 pub fn test_message_meta(id: u64, subject: &str, to: &str, from: &str) -> MessageMeta {
     MessageMeta {

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -28,7 +28,6 @@ use common_query::prelude::ScalarUdf;
 use common_query::Output;
 use datatypes::schema::Schema;
 use session::context::QueryContextRef;
-use sql::statements::statement::Statement;
 use table::TableRef;
 
 use crate::dataframe::DataFrame;
@@ -40,8 +39,6 @@ pub use crate::query_engine::context::QueryEngineContext;
 pub use crate::query_engine::state::QueryEngineState;
 use crate::region_query::RegionQueryHandlerRef;
 
-pub type SqlStatementExecutorRef = Arc<dyn SqlStatementExecutor>;
-
 /// Describe statement result
 #[derive(Debug)]
 pub struct DescribeResult {
@@ -49,11 +46,6 @@ pub struct DescribeResult {
     pub schema: Schema,
     /// The logical plan for statement
     pub logical_plan: LogicalPlan,
-}
-
-#[async_trait]
-pub trait SqlStatementExecutor: Send + Sync {
-    async fn execute_sql(&self, stmt: Statement, query_ctx: QueryContextRef) -> Result<Output>;
 }
 
 #[async_trait]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


`SqlStatementExecutor` is no longer needed

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
