### PR TITLE
chore: bump opendal to 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6052,8 +6052,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.39.0"
-source = "git+https://github.com/apache/incubator-opendal.git?rev=7d5524f35f29f7eda8131e8b0873590b7cbe34ab#7d5524f35f29f7eda8131e8b0873590b7cbe34ab"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddba7299bab261d3ae2f37617fb7f45b19ed872752bb4e22cf93a69d979366c5"
 dependencies = [
  "anyhow",
  "async-compat",

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -11,7 +11,7 @@ futures = { version = "0.3" }
 lru = "0.9"
 md5 = "0.7"
 metrics.workspace = true
-opendal = { git = "https://github.com/apache/incubator-opendal.git", rev = "7d5524f35f29f7eda8131e8b0873590b7cbe34ab", features = [
+opendal = { version = "0.40", features = [
     "layers-tracing",
     "layers-metrics",
 ] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

bump opendal to 0.40

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- https://github.com/apache/incubator-opendal/issues/2788 