### PR TITLE
fix(mito): compaction scheduler schedules more tasks than expected

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -42,7 +42,6 @@ use crate::sst::file_purger::FilePurgerRef;
 pub struct CompactionRequest {
     pub(crate) current_version: VersionRef,
     pub(crate) access_layer: AccessLayerRef,
-    pub(crate) compaction_time_window: Option<i64>,
     /// Sender to send notification to the region worker.
     pub(crate) request_sender: mpsc::Sender<WorkerRequest>,
     /// Waiters of the compaction request.
@@ -299,8 +298,6 @@ impl CompactionStatus {
         let mut req = CompactionRequest {
             current_version,
             access_layer: self.access_layer.clone(),
-            // TODO(hl): get persisted region compaction time window
-            compaction_time_window: None,
             request_sender: request_sender.clone(),
             waiters: Vec::new(),
             file_purger: self.file_purger.clone(),

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -150,7 +150,7 @@ async fn manager_with_checkpoint_distance_1() {
         .await
         .unwrap();
     let raw_json = std::str::from_utf8(&raw_bytes).unwrap();
-    let expected_json = "{\"size\":816,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
+    let expected_json = "{\"size\":846,\"version\":9,\"checksum\":null,\"extend_metadata\":{}}";
     assert_eq!(expected_json, raw_json);
 
     // reopen the manager

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -218,6 +218,7 @@ impl RegionOpener {
             .flushed_entry_id(manifest.flushed_entry_id)
             .flushed_sequence(manifest.flushed_sequence)
             .truncated_entry_id(manifest.truncated_entry_id)
+            .compaction_time_window(manifest.compaction_time_window)
             .options(options)
             .build();
         let flushed_entry_id = version.flushed_entry_id;

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -16,6 +16,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use api::helper::{
     is_column_type_value_eq, is_semantic_type_eq, proto_value_type, to_column_data_type,
@@ -640,6 +641,8 @@ pub(crate) struct CompactionFinished {
     pub(crate) senders: Vec<OutputTx>,
     /// File purger for cleaning files on failure.
     pub(crate) file_purger: FilePurgerRef,
+    /// Inferred Compaction time window.
+    pub(crate) compaction_time_window: Option<Duration>,
 }
 
 impl CompactionFinished {

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -52,6 +52,12 @@ impl SchedulerEnv {
         }
     }
 
+    /// Set scheduler.
+    pub(crate) fn scheduler(mut self, scheduler: SchedulerRef) -> Self {
+        self.scheduler = Some(scheduler);
+        self
+    }
+
     /// Creates a new compaction scheduler.
     pub(crate) fn mock_compaction_scheduler(
         &self,

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -61,7 +61,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let edit = RegionEdit {
             files_to_add: std::mem::take(&mut request.compaction_outputs),
             files_to_remove: std::mem::take(&mut request.compacted_files),
-            compaction_time_window: None, // TODO(hl): update window maybe
+            compaction_time_window: request.compaction_time_window,
             flushed_entry_id: None,
             flushed_sequence: None,
         };

--- a/tests/cases/standalone/common/select/like.result
+++ b/tests/cases/standalone/common/select/like.result
@@ -14,6 +14,7 @@ INSERT INTO TABLE host VALUES
 
 Affected Rows: 4
 
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM host WHERE host LIKE '%+%';
 
 +-------------------------+------+-----+

--- a/tests/cases/standalone/common/select/like.sql
+++ b/tests/cases/standalone/common/select/like.sql
@@ -10,6 +10,7 @@ INSERT INTO TABLE host VALUES
     (2, 'a', 3.0),
     (3, 'c', 4.0);
 
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM host WHERE host LIKE '%+%';
 
 DROP TABLE host;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Fix the issue that the compaction scheduler may schedule more tasks than expected
- When a compaction task is finished, `on_compaction_finished()` tries to schedule the next job but doesn't mark the region as compacting.
- Next time we invoke `schedule_compaction()` will trigger one more compaction task.


This PR removes `compacting` since the region status map containing the region already indicates whether the region is compacting.

### Compaction Time Window
This PR also stores the compaction time window to the manifest and recovers it while opening the region. If we don't keep the inferred time window in the version, the region may always infer a larger time window than the last compaction.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
