### PR TITLE
feat: update proto and remove create_if_not_exists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,7 +4186,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=9d3f28d07d29607d0e3c1823f4a4d2bc229d05b9#9d3f28d07d29607d0e3c1823f4a4d2bc229d05b9"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=115c1080773be8a819e50b257fece9f839a0c836#115c1080773be8a819e50b257fece9f839a0c836"
 dependencies = [
  "prost",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ datafusion-substrait = { git = "https://github.com/waynexia/arrow-datafusion.git
 derive_builder = "0.12"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "9d3f28d07d29607d0e3c1823f4a4d2bc229d05b9" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "115c1080773be8a819e50b257fece9f839a0c836" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -161,7 +161,6 @@ impl CreateTableProcedure {
             engine: create_table_expr.engine.to_string(),
             column_defs,
             primary_key,
-            create_if_not_exists: true,
             path: String::new(),
             options: create_table_expr.table_options.clone(),
         })

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -33,8 +33,7 @@ use tokio::sync::{Mutex, RwLock};
 
 use crate::config::EngineConfig;
 use crate::error::{
-    RegionExistsSnafu, RegionNotFoundSnafu, Result as EngineResult, UnexpectedEngineSnafu,
-    UnsupportedSnafu,
+    RegionNotFoundSnafu, Result as EngineResult, UnexpectedEngineSnafu, UnsupportedSnafu,
 };
 use crate::region::{FileRegion, FileRegionRef};
 
@@ -168,11 +167,7 @@ impl EngineInner {
         );
 
         if self.exists(region_id).await {
-            return if request.create_if_not_exists {
-                Ok(Output::AffectedRows(0))
-            } else {
-                RegionExistsSnafu { region_id }.fail()
-            };
+            return Ok(Output::AffectedRows(0));
         }
 
         info!("Try to create region, region_id: {}", region_id);
@@ -180,11 +175,7 @@ impl EngineInner {
         let _lock = self.region_mutex.lock().await;
         // Check again after acquiring the lock
         if self.exists(region_id).await {
-            return if request.create_if_not_exists {
-                Ok(Output::AffectedRows(0))
-            } else {
-                RegionExistsSnafu { region_id }.fail()
-            };
+            return Ok(Output::AffectedRows(0));
         }
 
         let res = FileRegion::create(region_id, request, &self.object_store).await;

--- a/src/file-engine/src/error.rs
+++ b/src/file-engine/src/error.rs
@@ -40,12 +40,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} already exists", region_id))]
-    RegionExists {
-        region_id: RegionId,
-        location: Location,
-    },
-
     #[snafu(display("Region not found, region_id: {}", region_id))]
     RegionNotFound {
         region_id: RegionId,
@@ -191,7 +185,6 @@ impl ErrorExt for Error {
             | CreateDefault { .. }
             | MissingColumnNoDefault { .. } => StatusCode::InvalidArguments,
 
-            RegionExists { .. } => StatusCode::RegionAlreadyExists,
             RegionNotFound { .. } => StatusCode::RegionNotFound,
 
             BuildBackend { source, .. } => source.status_code(),

--- a/src/file-engine/src/region.rs
+++ b/src/file-engine/src/region.rs
@@ -112,7 +112,6 @@ mod tests {
             engine: "file".to_string(),
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
-            create_if_not_exists: true,
             options: new_test_options(),
             region_dir: "create_region_dir/".to_string(),
         };
@@ -151,7 +150,6 @@ mod tests {
             engine: "file".to_string(),
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
-            create_if_not_exists: true,
             options: new_test_options(),
             region_dir: region_dir.clone(),
         };
@@ -189,7 +187,6 @@ mod tests {
             engine: "file".to_string(),
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
-            create_if_not_exists: true,
             options: new_test_options(),
             region_dir: region_dir.clone(),
         };

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -151,7 +151,6 @@ fn test_create_region_request_template() {
             },
         ],
         primary_key: vec![2, 1],
-        create_if_not_exists: true,
         path: String::new(),
         options: HashMap::new(),
     };

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -98,12 +98,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} already exists", region_id))]
-    RegionExists {
-        region_id: RegionId,
-        location: Location,
-    },
-
     #[snafu(display("Failed to create RecordBatch from vectors"))]
     NewRecordBatch {
         location: Location,
@@ -405,7 +399,6 @@ impl ErrorExt for Error {
             | CreateDefault { .. }
             | InvalidParquet { .. } => StatusCode::Unexpected,
             RegionNotFound { .. } => StatusCode::RegionNotFound,
-            RegionExists { .. } => StatusCode::RegionAlreadyExists,
             InvalidScanIndex { .. }
             | InvalidMeta { .. }
             | InvalidRequest { .. }

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -304,7 +304,6 @@ impl CreateRequestBuilder {
             column_metadatas,
             primary_key: self.primary_key.clone().unwrap_or(primary_key),
             options: self.options.clone(),
-            create_if_not_exists: false,
             region_dir: self.region_dir.clone(),
         }
     }

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -79,7 +79,6 @@ impl RegionRequest {
                         engine: create.engine,
                         column_metadatas,
                         primary_key: create.primary_key,
-                        create_if_not_exists: create.create_if_not_exists,
                         options: create.options,
                         region_dir,
                     }),
@@ -150,9 +149,6 @@ pub struct RegionCreateRequest {
     pub column_metadatas: Vec<ColumnMetadata>,
     /// Columns in the primary key.
     pub primary_key: Vec<ColumnId>,
-    /// Create region if not exists.
-    // TODO(yingwen): Remove this.
-    pub create_if_not_exists: bool,
     /// Options of the created region.
     pub options: HashMap<String, String>,
     /// Directory for region's data home. Usually is composed by catalog and table id


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR updates proto and removes create_if_not_exists from RegionCreateRequest. 

Creating a region needs to be idempotent so `create_if_not_exists` is always `true`, we don't need a flag for this.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
