### PR TITLE
refactor: datetime time unit

### DIFF
--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -155,4 +155,11 @@ mod tests {
             .val();
         assert_eq!(28800000, ts);
     }
+
+    #[test]
+    fn test_from_max_date() {
+        let date = Date::new(i32::MAX);
+        let datetime = DateTime::from(date);
+        assert_eq!(datetime.val(), 185542587100800000);
+    }
 }

--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -105,7 +105,7 @@ impl DateTime {
         NaiveDateTime::from_timestamp_opt(self.0, 0)
     }
 
-    pub fn date(&self) -> Option<Date> {
+    pub fn to_date(&self) -> Option<Date> {
         self.to_chrono_datetime().map(|d| Date::from(d.date()))
     }
 }

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -126,7 +126,7 @@ mod tests {
         );
 
         // cast from Timestamp
-        let val = Value::Timestamp(Timestamp::from_str("2020-09-08 21:42:29.042+0800").unwrap());
+        let val = Value::Timestamp(Timestamp::from_str("2020-09-08 21:42:29+0800").unwrap());
         let dt = ConcreteDataType::datetime_datatype().try_cast(val).unwrap();
         assert_eq!(
             dt,

--- a/src/datatypes/src/vectors/datetime.rs
+++ b/src/datatypes/src/vectors/datetime.rs
@@ -38,7 +38,7 @@ mod tests {
     #[test]
     fn test_datetime_vector() {
         std::env::set_var("TZ", "Asia/Shanghai");
-        let v = DateTimeVector::new(PrimitiveArray::from(vec![1, 2, 3]));
+        let v = DateTimeVector::new(PrimitiveArray::from(vec![1000, 2000, 3000]));
         assert_eq!(ConcreteDataType::datetime_datatype(), v.data_type());
         assert_eq!(3, v.len());
         assert_eq!("DateTimeVector", v.vector_type_name());
@@ -47,19 +47,19 @@ mod tests {
             v.to_arrow_array().data_type()
         );
 
-        assert_eq!(Some(DateTime::new(1)), v.get_data(0));
-        assert_eq!(Value::DateTime(DateTime::new(1)), v.get(0));
-        assert_eq!(ValueRef::DateTime(DateTime::new(1)), v.get_ref(0));
+        assert_eq!(Some(DateTime::new(1000)), v.get_data(0));
+        assert_eq!(Value::DateTime(DateTime::new(1000)), v.get(0));
+        assert_eq!(ValueRef::DateTime(DateTime::new(1000)), v.get_ref(0));
 
         let mut iter = v.iter_data();
-        assert_eq!(Some(DateTime::new(1)), iter.next().unwrap());
-        assert_eq!(Some(DateTime::new(2)), iter.next().unwrap());
-        assert_eq!(Some(DateTime::new(3)), iter.next().unwrap());
+        assert_eq!(Some(DateTime::new(1000)), iter.next().unwrap());
+        assert_eq!(Some(DateTime::new(2000)), iter.next().unwrap());
+        assert_eq!(Some(DateTime::new(3000)), iter.next().unwrap());
         assert!(!v.is_null(0));
         assert_eq!(24, v.memory_size());
 
         if let Value::DateTime(d) = v.get(0) {
-            assert_eq!(1, d.val());
+            assert_eq!(1000, d.val());
         } else {
             unreachable!()
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

- change datetime's default time unit from second to millisecond

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
