### PR TITLE
fix: dn doesn't have chance to send a heartbeat to the new leader

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -20,6 +20,8 @@ interval_millis = 3000
 [meta_client]
 # Metasrv address list.
 metasrv_addrs = ["127.0.0.1:3002"]
+# Heartbeat timeout in milliseconds, 500 by default.
+heartbeat_timeout_millis = 500
 # Operation timeout in milliseconds, 3000 by default.
 timeout_millis = 3000
 # Connect server timeout in milliseconds, 5000 by default.

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -13,8 +13,8 @@ rpc_runtime_size = 8
 require_lease_before_startup = false
 
 [heartbeat]
-# Interval for sending heartbeat messages to the Metasrv in milliseconds, 5000 by default.
-interval_millis = 5000
+# Interval for sending heartbeat messages to the Metasrv in milliseconds, 3000 by default.
+interval_millis = 3000
 
 # Metasrv client options.
 [meta_client]

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -255,6 +255,7 @@ mod tests {
             connect_timeout_millis,
             tcp_nodelay,
             ddl_timeout_millis,
+            ..
         } = options.meta_client.unwrap();
 
         assert_eq!(vec!["127.0.0.1:3002".to_string()], metasrv_addr);

--- a/src/common/meta/src/distributed_time_constants.rs
+++ b/src/common/meta/src/distributed_time_constants.rs
@@ -29,3 +29,9 @@ pub const REGION_LEASE_SECS: u64 =
 /// When creating table or region failover, a target node needs to be selected.
 /// If the node's lease has expired, the `Selector` will not select it.
 pub const DATANODE_LEASE_SECS: u64 = REGION_LEASE_SECS;
+
+/// The lease seconds of metasrv leader.
+pub const META_LEASE_SECS: u64 = 3;
+
+// In a lease, there are two opportunities for renewal.
+pub const META_KEEP_ALIVE_INTERVAL_SECS: u64 = META_LEASE_SECS / 2;

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 
 use api::v1::meta::{HeartbeatRequest, Peer, RegionStat, Role};
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
-use common_meta::distributed_time_constants::META_KEEP_ALIVE_INTERVAL_SECS;
 use common_meta::heartbeat::handler::parse_mailbox_message::ParseMailboxMessageHandler;
 use common_meta::heartbeat::handler::{
     HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutorRef,
@@ -30,7 +29,7 @@ use meta_client::client::{HeartbeatSender, MetaClient, MetaClientBuilder};
 use meta_client::MetaClientOptions;
 use snafu::ResultExt;
 use tokio::sync::{mpsc, Notify};
-use tokio::time::{timeout, Instant};
+use tokio::time::Instant;
 
 use self::handler::RegionHeartbeatResponseHandler;
 use crate::alive_keeper::RegionAliveKeeper;

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use api::v1::meta::{HeartbeatRequest, Peer, RegionStat, Role};
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
+use common_meta::distributed_time_constants::META_KEEP_ALIVE_INTERVAL_SECS;
 use common_meta::heartbeat::handler::parse_mailbox_message::ParseMailboxMessageHandler;
 use common_meta::heartbeat::handler::{
     HandlerGroupExecutor, HeartbeatResponseHandlerContext, HeartbeatResponseHandlerExecutorRef,
@@ -29,7 +30,7 @@ use meta_client::client::{HeartbeatSender, MetaClient, MetaClientBuilder};
 use meta_client::MetaClientOptions;
 use snafu::ResultExt;
 use tokio::sync::{mpsc, Notify};
-use tokio::time::Instant;
+use tokio::time::{timeout, Instant};
 
 use self::handler::RegionHeartbeatResponseHandler;
 use crate::alive_keeper::RegionAliveKeeper;

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -246,6 +246,8 @@ impl HeartbeatTask {
                             Ok(new_tx) => {
                                 info!("Reconnected to metasrv");
                                 tx = new_tx;
+                                // Triggers to send heartbeat immediately.
+                                sleep.as_mut().reset(Instant::now());
                             }
                             Err(e) => {
                                 error!(e;"Failed to reconnect to metasrv!");

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -62,6 +62,7 @@ pub struct MetaClientBuilder {
     enable_ddl: bool,
     channel_manager: Option<ChannelManager>,
     ddl_channel_manager: Option<ChannelManager>,
+    heartbeat_channel_manager: Option<ChannelManager>,
 }
 
 impl MetaClientBuilder {
@@ -122,6 +123,13 @@ impl MetaClientBuilder {
         }
     }
 
+    pub fn heartbeat_channel_manager(self, channel_manager: ChannelManager) -> Self {
+        Self {
+            heartbeat_channel_manager: Some(channel_manager),
+            ..self
+        }
+    }
+
     pub fn build(self) -> MetaClient {
         let mut client = if let Some(mgr) = self.channel_manager {
             MetaClient::with_channel_manager(self.id, mgr)
@@ -136,10 +144,11 @@ impl MetaClientBuilder {
         let mgr = client.channel_manager.clone();
 
         if self.enable_heartbeat {
+            let mgr = self.heartbeat_channel_manager.unwrap_or(mgr.clone());
             client.heartbeat = Some(HeartbeatClient::new(
                 self.id,
                 self.role,
-                mgr.clone(),
+                mgr,
                 DEFAULT_ASK_LEADER_MAX_RETRY,
             ));
         }

--- a/src/meta-client/src/error.rs
+++ b/src/meta-client/src/error.rs
@@ -33,6 +33,12 @@ pub enum Error {
     #[snafu(display("No leader, should ask leader first"))]
     NoLeader { location: Location },
 
+    #[snafu(display("Ask leader timeout"))]
+    AskLeaderTimeout {
+        location: Location,
+        source: tokio::time::error::Elapsed,
+    },
+
     #[snafu(display("Failed to create gRPC channel"))]
     CreateChannel {
         location: Location,
@@ -83,6 +89,7 @@ impl ErrorExt for Error {
             Error::IllegalGrpcClientState { .. }
             | Error::AskLeader { .. }
             | Error::NoLeader { .. }
+            | Error::AskLeaderTimeout { .. }
             | Error::NotStarted { .. }
             | Error::SendHeartbeat { .. }
             | Error::CreateHeartbeatStream { .. }

--- a/src/meta-client/src/lib.rs
+++ b/src/meta-client/src/lib.rs
@@ -22,10 +22,16 @@ pub mod error;
 pub struct MetaClientOptions {
     pub metasrv_addrs: Vec<String>,
     pub timeout_millis: u64,
+    #[serde(default = "default_heartbeat_timeout_millis")]
+    pub heartbeat_timeout_millis: u64,
     #[serde(default = "default_ddl_timeout_millis")]
     pub ddl_timeout_millis: u64,
     pub connect_timeout_millis: u64,
     pub tcp_nodelay: bool,
+}
+
+fn default_heartbeat_timeout_millis() -> u64 {
+    500u64
 }
 
 fn default_ddl_timeout_millis() -> u64 {
@@ -37,6 +43,7 @@ impl Default for MetaClientOptions {
         Self {
             metasrv_addrs: vec!["127.0.0.1:3002".to_string()],
             timeout_millis: 3_000u64,
+            heartbeat_timeout_millis: default_heartbeat_timeout_millis(),
             ddl_timeout_millis: default_ddl_timeout_millis(),
             connect_timeout_millis: 5_000u64,
             tcp_nodelay: true,

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -21,9 +21,6 @@ use tokio::sync::broadcast::Receiver;
 
 use crate::error::Result;
 
-pub const LEASE_SECS: i64 = 5;
-// In a lease, there are two opportunities for renewal.
-pub const KEEP_ALIVE_PERIOD_SECS: u64 = LEASE_SECS as u64 / 2;
 pub const ELECTION_KEY: &str = "__meta_srv_election";
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

If the metasrv leader is dead, the datanode only has a small window(`Datanode Lease - (<Heartbeat interval + Timeout> + <Meta Lease> + <Ask Leader Timeout + Connect Timeout>`)  to resend region stats. We must ensure the small window is greater than 0s. After this PR, the datanode will have a 5.5s~ (13s - 3.5s - 3s - 1s) window to resend the heartbeat.

1. refactor: set meta leader lease secs to 3s (origin: 5s)
2. fix: correct default heartbeat interval
3. refactor: ask the metasrv leader in parallel
4. feat: configure heartbeat client timeout to 500ms
5. fix: trigger to send heartbeat immediately after fail


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
