### PR TITLE
fix(mito): normalize region dir in RegionOpener

### DIFF
--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use common_telemetry::{debug, error, info, warn};
 use common_time::util::current_time_millis;
 use futures::StreamExt;
-use object_store::util::join_dir;
+use object_store::util::{join_dir, normalize_dir};
 use object_store::ObjectStore;
 use snafu::{ensure, OptionExt};
 use store_api::logstore::LogStore;
@@ -57,6 +57,7 @@ impl RegionOpener {
     /// Returns a new opener.
     pub(crate) fn new(
         region_id: RegionId,
+        region_dir: &str,
         memtable_builder: MemtableBuilderRef,
         object_store: ObjectStore,
         scheduler: SchedulerRef,
@@ -66,7 +67,7 @@ impl RegionOpener {
             metadata: None,
             memtable_builder,
             object_store,
-            region_dir: String::new(),
+            region_dir: normalize_dir(region_dir),
             scheduler,
             options: HashMap::new(),
         }
@@ -75,12 +76,6 @@ impl RegionOpener {
     /// Sets metadata of the region to create.
     pub(crate) fn metadata(mut self, metadata: RegionMetadata) -> Self {
         self.metadata = Some(metadata);
-        self
-    }
-
-    /// Sets the region dir.
-    pub(crate) fn region_dir(mut self, value: &str) -> Self {
-        self.region_dir = value.to_string();
         self
     }
 

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -58,12 +58,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         // Create a MitoRegion from the RegionMetadata.
         let region = RegionOpener::new(
             region_id,
+            &request.region_dir,
             self.memtable_builder.clone(),
             self.object_store.clone(),
             self.scheduler.clone(),
         )
         .metadata(metadata)
-        .region_dir(&request.region_dir)
         .options(request.options)
         .create_or_open(&self.config, &self.wal)
         .await?;

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -57,11 +57,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         // Open region from specific region dir.
         let region = RegionOpener::new(
             region_id,
+            &request.region_dir,
             self.memtable_builder.clone(),
             self.object_store.clone(),
             self.scheduler.clone(),
         )
-        .region_dir(&request.region_dir)
         .options(request.options)
         .open(&self.config, &self.wal)
         .await?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR normalizes region dir in RegionOpener to ensure `region_dir` is always valid.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
