### PR TITLE
refactor(mito): remove #[allow(dead_code)]

### DIFF
--- a/src/mito2/src/compaction/output.rs
+++ b/src/mito2/src/compaction/output.rs
@@ -29,10 +29,6 @@ pub(crate) struct CompactionOutput {
     pub output_file_id: FileId,
     /// Compaction output file level.
     pub output_level: Level,
-    /// The left bound of time window.
-    pub time_window_bound: i64,
-    /// Time window size in seconds.
-    pub time_window_sec: i64,
     /// Compaction input files.
     pub inputs: Vec<FileHandle>,
 }

--- a/src/mito2/src/compaction/picker.rs
+++ b/src/mito2/src/compaction/picker.rs
@@ -29,19 +29,3 @@ pub trait CompactionTask: Debug + Send + Sync + 'static {
 pub trait Picker: Debug + Send + 'static {
     fn pick(&self, req: CompactionRequest) -> Option<Box<dyn CompactionTask>>;
 }
-
-pub struct PickerContext {
-    compaction_time_window: Option<i64>,
-}
-
-impl PickerContext {
-    pub fn with(compaction_time_window: Option<i64>) -> Self {
-        Self {
-            compaction_time_window,
-        }
-    }
-
-    pub fn compaction_time_window(&self) -> Option<i64> {
-        self.compaction_time_window
-    }
-}

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -22,6 +22,7 @@ use common_query::Output;
 use common_telemetry::{error, info};
 use snafu::ResultExt;
 use store_api::storage::RegionId;
+use strum::AsRefStr;
 use tokio::sync::mpsc;
 
 use crate::access_layer::AccessLayerRef;
@@ -97,7 +98,7 @@ impl WriteBufferManagerImpl {
     }
 
     /// Returns memory usage of mutable memtables.
-    pub(crate) fn mutable_usage(&self) -> usize {
+    pub fn mutable_usage(&self) -> usize {
         self.memory_active.load(Ordering::Relaxed)
     }
 
@@ -162,6 +163,7 @@ impl WriteBufferManager for WriteBufferManagerImpl {
 }
 
 /// Reason of a flush task.
+#[derive(Debug, AsRefStr)]
 pub enum FlushReason {
     /// Other reasons.
     Others,
@@ -302,8 +304,10 @@ impl RegionFlushTask {
 
         let file_ids: Vec<_> = file_metas.iter().map(|f| f.file_id).collect();
         info!(
-            "Successfully flush memtables, region: {}, files: {:?}",
-            version.metadata.region_id, file_ids
+            "Successfully flush memtables, region: {}, reason: {}, files: {:?}",
+            version.metadata.region_id,
+            self.reason.as_ref(),
+            file_ids
         );
 
         Ok(file_metas)

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -21,28 +21,21 @@
 #[cfg(any(test, feature = "test"))]
 pub mod test_util;
 
-// TODO(yingwen): Remove all `allow(dead_code)` after finish refactoring mito.
 mod access_layer;
-#[allow(dead_code)]
 mod compaction;
 pub mod config;
 pub mod engine;
 pub mod error;
-#[allow(dead_code)]
-mod flush;
+pub mod flush;
 pub mod manifest;
-#[allow(dead_code)]
 pub mod memtable;
 mod metrics;
-#[allow(dead_code)]
 pub mod read;
 pub mod region;
 mod region_write_ctx;
-#[allow(dead_code)]
 pub mod request;
 mod row_converter;
 pub(crate) mod schedule;
-#[allow(dead_code)]
 pub mod sst;
 pub mod wal;
 mod worker;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -42,15 +42,21 @@ pub type MemtableId = u32;
 
 #[derive(Debug, Default)]
 pub struct MemtableStats {
-    /// The  estimated bytes allocated by this memtable from heap.
+    /// The estimated bytes allocated by this memtable from heap.
     estimated_bytes: usize,
     /// The time range that this memtable contains.
     time_range: Option<(Timestamp, Timestamp)>,
 }
 
 impl MemtableStats {
+    /// Returns the estimated bytes allocated by this memtable.
     pub fn bytes_allocated(&self) -> usize {
         self.estimated_bytes
+    }
+
+    /// Returns the time range of the memtable.
+    pub fn time_range(&self) -> Option<(Timestamp, Timestamp)> {
+        self.time_range
     }
 }
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -293,11 +293,6 @@ impl SeriesSet {
             last_key: None,
         }
     }
-
-    /// Returns if series set is empty.
-    fn is_empty(&self) -> bool {
-        self.series.read().unwrap().is_empty()
-    }
 }
 
 struct Iter {
@@ -326,37 +321,6 @@ impl Iterator for Iter {
         } else {
             None
         }
-    }
-}
-
-/// Bucket holds a set of [Series] which alleviate lock contention between series.
-struct Bucket {
-    region_metadata: RegionMetadataRef,
-    series: RwLock<Vec<Arc<RwLock<Series>>>>,
-}
-
-impl Bucket {
-    fn new(region_metadata: RegionMetadataRef) -> Self {
-        Self {
-            region_metadata,
-            series: Default::default(),
-        }
-    }
-
-    /// Returns the series at given index.
-    /// Returns None if series not found.
-    #[inline]
-    fn get_series(&self, idx: usize) -> Option<Arc<RwLock<Series>>> {
-        self.series.read().unwrap().get(idx).cloned()
-    }
-
-    /// Adds series to bucket and returns the index inside the bucket.
-    #[inline]
-    fn add_series(&self, s: Arc<RwLock<Series>>) -> usize {
-        let mut series = self.series.write().unwrap();
-        let idx = series.len();
-        series.push(s);
-        idx
     }
 }
 

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -125,7 +125,7 @@ impl WriteRequest {
     }
 
     /// Gets column index by name.
-    pub(crate) fn column_index_by_name(&self, name: &str) -> Option<usize> {
+    pub fn column_index_by_name(&self, name: &str) -> Option<usize> {
         self.name_to_index.get(name).copied()
     }
 
@@ -411,11 +411,6 @@ impl OptionOutputTx {
         if let Some(sender) = self.0.take() {
             sender.send(result);
         }
-    }
-
-    /// Takes the sender.
-    pub(crate) fn take(&mut self) -> OptionOutputTx {
-        OptionOutputTx(self.0.take())
     }
 
     /// Takes the inner sender.

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -103,7 +103,7 @@ impl ParquetReaderBuilder {
 
         Ok(ParquetReader {
             file_path,
-            file_handle: self.file_handle,
+            _file_handle: self.file_handle,
             stream,
             read_format,
             batches: Vec::new(),
@@ -208,7 +208,7 @@ pub struct ParquetReader {
     /// SST file to read.
     ///
     /// Holds the file handle to avoid the file purge purge it.
-    file_handle: FileHandle,
+    _file_handle: FileHandle,
     /// Inner parquet record batch stream.
     stream: BoxedRecordBatchStream,
     /// Helper to read record batches.

--- a/src/mito2/src/sst/stream_writer.rs
+++ b/src/mito2/src/sst/stream_writer.rs
@@ -32,7 +32,6 @@ use crate::error::WriteParquetSnafu;
 /// storage by chunks to reduce memory consumption.
 pub struct BufferedWriter {
     inner: InnerBufferedWriter,
-    arrow_schema: SchemaRef,
 }
 
 type InnerBufferedWriter = LazyBufferedWriter<
@@ -79,7 +78,6 @@ impl BufferedWriter {
                     })
                 }),
             ),
-            arrow_schema,
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Remove allow dead_code attributes and remove unused code

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
