### PR TITLE
chore: add integration test for issue2437

### DIFF
--- a/tests/cases/standalone/common/alter/add_incorrect_col.result
+++ b/tests/cases/standalone/common/alter/add_incorrect_col.result
@@ -1,0 +1,25 @@
+CREATE TABLE table_should_not_break_after_incorrect_alter(i INTEGER, j TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+ALTER TABLE table_should_not_break_after_incorrect_alter ADD column k string NOT NULL;
+
+Error: 1004(InvalidArguments), Invalid alter table(table_should_not_break_after_incorrect_alter) request: no default value for column k
+
+INSERT INTO table_should_not_break_after_incorrect_alter VALUES (1, 1), (2, 2);
+
+Affected Rows: 2
+
+SELECT * FROM table_should_not_break_after_incorrect_alter;
+
++---+-------------------------+
+| i | j                       |
++---+-------------------------+
+| 1 | 1970-01-01T00:00:00.001 |
+| 2 | 1970-01-01T00:00:00.002 |
++---+-------------------------+
+
+DROP TABLE table_should_not_break_after_incorrect_alter;
+
+Affected Rows: 1
+

--- a/tests/cases/standalone/common/alter/add_incorrect_col.sql
+++ b/tests/cases/standalone/common/alter/add_incorrect_col.sql
@@ -1,0 +1,9 @@
+CREATE TABLE table_should_not_break_after_incorrect_alter(i INTEGER, j TIMESTAMP TIME INDEX);
+
+ALTER TABLE table_should_not_break_after_incorrect_alter ADD column k string NOT NULL;
+
+INSERT INTO table_should_not_break_after_incorrect_alter VALUES (1, 1), (2, 2);
+
+SELECT * FROM table_should_not_break_after_incorrect_alter;
+
+DROP TABLE table_should_not_break_after_incorrect_alter;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds a integration test for issue2437. Very trivial.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

Related to https://github.com/GreptimeTeam/greptimedb/pull/2437#discussion_r1329871864