### PR TITLE
feat: re-support query engine execute dml

### DIFF
--- a/src/cmd/src/cli/repl.rs
+++ b/src/cmd/src/cli/repl.rs
@@ -261,6 +261,7 @@ async fn create_query_engine(meta_addr: &str) -> Result<DatafusionQueryEngine> {
     let state = Arc::new(QueryEngineState::new(
         catalog_list,
         None,
+        None,
         false,
         plugins.clone(),
     ));

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -338,6 +338,7 @@ impl DatanodeBuilder {
             // query engine in datanode only executes plan with resolved table source.
             MemoryCatalogManager::with_default_setup(),
             None,
+            None,
             false,
             plugins,
         );

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -53,7 +53,7 @@ use meta_client::client::{MetaClient, MetaClientBuilder};
 use operator::delete::{Deleter, DeleterRef};
 use operator::insert::{Inserter, InserterRef};
 use operator::statement::StatementExecutor;
-use operator::table::table_idents_to_full_name;
+use operator::table::{table_idents_to_full_name, TableMutationOperator};
 use partition::manager::PartitionRuleManager;
 use query::parser::{PromQuery, QueryLanguageParser, QueryStatement};
 use query::plan::LogicalPlan;
@@ -163,14 +163,6 @@ impl Instance {
             catalog_manager.datanode_manager().clone(),
         );
 
-        let query_engine = QueryEngineFactory::new_with_plugins(
-            catalog_manager.clone(),
-            Some(region_query_handler.clone()),
-            true,
-            plugins.clone(),
-        )
-        .query_engine();
-
         let inserter = Arc::new(Inserter::new(
             catalog_manager.clone(),
             partition_manager.clone(),
@@ -182,6 +174,20 @@ impl Instance {
             datanode_clients,
         ));
 
+        let table_mutation_handler = Arc::new(TableMutationOperator::new(
+            inserter.clone(),
+            deleter.clone(),
+        ));
+
+        let query_engine = QueryEngineFactory::new_with_plugins(
+            catalog_manager.clone(),
+            Some(region_query_handler.clone()),
+            Some(table_mutation_handler),
+            true,
+            plugins.clone(),
+        )
+        .query_engine();
+
         let statement_executor = Arc::new(StatementExecutor::new(
             catalog_manager.clone(),
             query_engine.clone(),
@@ -189,7 +195,6 @@ impl Instance {
             meta_backend.clone(),
             catalog_manager.clone(),
             inserter.clone(),
-            deleter.clone(),
         ));
 
         plugins.insert::<StatementExecutorRef>(statement_executor.clone());
@@ -301,9 +306,25 @@ impl Instance {
         let region_query_handler =
             FrontendRegionQueryHandler::arc(partition_manager.clone(), datanode_manager.clone());
 
+        let inserter = Arc::new(Inserter::new(
+            catalog_manager.clone(),
+            partition_manager.clone(),
+            datanode_manager.clone(),
+        ));
+        let deleter = Arc::new(Deleter::new(
+            catalog_manager.clone(),
+            partition_manager,
+            datanode_manager.clone(),
+        ));
+        let table_mutation_handler = Arc::new(TableMutationOperator::new(
+            inserter.clone(),
+            deleter.clone(),
+        ));
+
         let query_engine = QueryEngineFactory::new_with_plugins(
             catalog_manager.clone(),
             Some(region_query_handler),
+            Some(table_mutation_handler),
             true,
             plugins.clone(),
         )
@@ -317,23 +338,10 @@ impl Instance {
         let cache_invalidator = Arc::new(DummyCacheInvalidator);
         let ddl_executor = Arc::new(DdlManager::new(
             procedure_manager,
-            datanode_manager.clone(),
+            datanode_manager,
             cache_invalidator.clone(),
             table_metadata_manager.clone(),
             Arc::new(StandaloneTableMetadataCreator::new(kv_backend.clone())),
-        ));
-
-        let partition_manager = Arc::new(PartitionRuleManager::new(kv_backend.clone()));
-
-        let inserter = Arc::new(Inserter::new(
-            catalog_manager.clone(),
-            partition_manager.clone(),
-            datanode_manager.clone(),
-        ));
-        let deleter = Arc::new(Deleter::new(
-            catalog_manager.clone(),
-            partition_manager,
-            datanode_manager,
         ));
 
         let statement_executor = Arc::new(StatementExecutor::new(
@@ -343,7 +351,6 @@ impl Instance {
             kv_backend.clone(),
             cache_invalidator,
             inserter.clone(),
-            deleter.clone(),
         ));
 
         Ok(Instance {

--- a/src/operator/src/delete.rs
+++ b/src/operator/src/delete.rs
@@ -98,7 +98,7 @@ impl Deleter {
         &self,
         request: TableDeleteRequest,
         ctx: QueryContextRef,
-    ) -> Result<AffectedRows> {
+    ) -> Result<usize> {
         let catalog = request.catalog_name.as_str();
         let schema = request.schema_name.as_str();
         let table = request.table_name.as_str();
@@ -108,7 +108,9 @@ impl Deleter {
         let deletes = TableToRegion::new(&table_info, &self.partition_manager)
             .convert(request)
             .await?;
-        self.do_request(deletes, ctx.trace_id(), 0).await
+
+        let affected_rows = self.do_request(deletes, ctx.trace_id(), 0).await?;
+        Ok(affected_rows as _)
     }
 }
 

--- a/src/operator/src/req_convert/insert/table_to_region.rs
+++ b/src/operator/src/req_convert/insert/table_to_region.rs
@@ -145,7 +145,6 @@ mod tests {
             schema_name: DEFAULT_SCHEMA_NAME.to_string(),
             table_name: "table_1".to_string(),
             columns_values: HashMap::from([("a".to_string(), vector)]),
-            region_number: 0,
         }
     }
 

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -330,7 +330,6 @@ impl StatementExecutor {
                         schema_name: req.schema_name.to_string(),
                         table_name: req.table_name.to_string(),
                         columns_values,
-                        region_number: 0,
                     },
                     query_ctx.clone(),
                 ));

--- a/src/operator/src/statement/dml.rs
+++ b/src/operator/src/statement/dml.rs
@@ -12,30 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-
 use common_query::Output;
-use common_recordbatch::{RecordBatch, SendableRecordBatchStream};
-use datafusion_expr::{DmlStatement, LogicalPlan as DfLogicalPlan, WriteOp};
-use datatypes::schema::SchemaRef;
-use futures_util::StreamExt;
 use query::parser::QueryStatement;
-use query::plan::LogicalPlan;
 use session::context::QueryContextRef;
-use snafu::{ensure, OptionExt, ResultExt};
-use sql::statements::delete::Delete;
 use sql::statements::insert::Insert;
 use sql::statements::statement::Statement;
-use table::engine::TableReference;
-use table::metadata::TableInfoRef;
-use table::requests::{DeleteRequest, InsertRequest};
-use table::TableRef;
 
 use super::StatementExecutor;
-use crate::error::{
-    BuildColumnVectorsSnafu, ExecLogicalPlanSnafu, MissingTimeIndexColumnSnafu,
-    ReadRecordBatchSnafu, Result, UnexpectedSnafu,
-};
+use crate::error::Result;
 
 impl StatementExecutor {
     pub async fn insert(&self, insert: Box<Insert>, query_ctx: QueryContextRef) -> Result<Output> {
@@ -45,178 +29,9 @@ impl StatementExecutor {
                 .handle_statement_insert(insert.as_ref(), &query_ctx)
                 .await
         } else {
-            // Slow path: insert with subquery. Execute the subquery first, via query engine. Then
-            // insert the results by sending insert requests.
-
-            // 1. Plan the whole insert statement into a logical plan, then a wrong insert statement
-            //    will be caught and a plan error will be returned.
+            // Slow path: insert with subquery. Execute using query engine.
             let statement = QueryStatement::Sql(Statement::Insert(insert));
-            let logical_plan = self.plan(statement, query_ctx.clone()).await?;
-
-            // 2. Execute the subquery, get the results as a record batch stream.
-            let dml_statement = extract_dml_statement(logical_plan)?;
-            ensure!(
-                dml_statement.op == WriteOp::Insert,
-                UnexpectedSnafu {
-                    violated: "expected an INSERT plan"
-                }
-            );
-            let mut stream = self
-                .execute_dml_subquery(&dml_statement, query_ctx.clone())
-                .await?;
-
-            // 3. Send insert requests.
-            let mut affected_rows = 0;
-            let table = self.get_table_from_dml(dml_statement, &query_ctx).await?;
-            let table_info = table.table_info();
-            while let Some(batch) = stream.next().await {
-                let record_batch = batch.context(ReadRecordBatchSnafu)?;
-                let insert_request =
-                    build_insert_request(record_batch, table.schema(), &table_info)?;
-                affected_rows += self
-                    .inserter
-                    .handle_table_insert(insert_request, query_ctx.clone())
-                    .await?;
-            }
-
-            Ok(Output::AffectedRows(affected_rows))
+            self.plan_exec(statement, query_ctx).await
         }
     }
-
-    pub async fn delete(&self, delete: Box<Delete>, query_ctx: QueryContextRef) -> Result<Output> {
-        // 1. Plan the whole delete statement into a logical plan, then a wrong delete statement
-        //    will be caught and a plan error will be returned.
-        let statement = QueryStatement::Sql(Statement::Delete(delete));
-        let logical_plan = self.plan(statement, query_ctx.clone()).await?;
-
-        // 2. Execute the subquery, get the results as a record batch stream.
-        let dml_statement = extract_dml_statement(logical_plan)?;
-        ensure!(
-            dml_statement.op == WriteOp::Delete,
-            UnexpectedSnafu {
-                violated: "expected a DELETE plan"
-            }
-        );
-        let mut stream = self
-            .execute_dml_subquery(&dml_statement, query_ctx.clone())
-            .await?;
-
-        // 3. Send delete requests.
-        let mut affected_rows = 0;
-        let table = self.get_table_from_dml(dml_statement, &query_ctx).await?;
-        let table_info = table.table_info();
-        while let Some(batch) = stream.next().await {
-            let record_batch = batch.context(ReadRecordBatchSnafu)?;
-            let request = build_delete_request(record_batch, table.schema(), &table_info)?;
-            affected_rows += self
-                .deleter
-                .handle_table_delete(request, query_ctx.clone())
-                .await?;
-        }
-
-        Ok(Output::AffectedRows(affected_rows as _))
-    }
-
-    async fn execute_dml_subquery(
-        &self,
-        dml_statement: &DmlStatement,
-        query_ctx: QueryContextRef,
-    ) -> Result<SendableRecordBatchStream> {
-        let subquery_plan = LogicalPlan::from(dml_statement.input.as_ref().clone());
-        let output = self
-            .query_engine
-            .execute(subquery_plan, query_ctx)
-            .await
-            .context(ExecLogicalPlanSnafu)?;
-        match output {
-            Output::Stream(stream) => Ok(stream),
-            Output::RecordBatches(record_batches) => Ok(record_batches.as_stream()),
-            _ => UnexpectedSnafu {
-                violated: "expected a stream",
-            }
-            .fail(),
-        }
-    }
-
-    async fn get_table_from_dml(
-        &self,
-        dml_statement: DmlStatement,
-        query_ctx: &QueryContextRef,
-    ) -> Result<TableRef> {
-        let default_catalog = query_ctx.current_catalog().to_owned();
-        let default_schema = query_ctx.current_schema().to_owned();
-        let resolved_table_ref = dml_statement
-            .table_name
-            .resolve(&default_catalog, &default_schema);
-        let table_ref = TableReference::full(
-            &resolved_table_ref.catalog,
-            &resolved_table_ref.schema,
-            &resolved_table_ref.table,
-        );
-        self.get_table(&table_ref).await
-    }
-}
-
-fn extract_dml_statement(logical_plan: LogicalPlan) -> Result<DmlStatement> {
-    let LogicalPlan::DfPlan(df_plan) = logical_plan;
-    match df_plan {
-        DfLogicalPlan::Dml(dml) => Ok(dml),
-        _ => UnexpectedSnafu {
-            violated: "expected a DML plan",
-        }
-        .fail(),
-    }
-}
-
-fn build_insert_request(
-    record_batch: RecordBatch,
-    table_schema: SchemaRef,
-    table_info: &TableInfoRef,
-) -> Result<InsertRequest> {
-    let columns_values = record_batch
-        .column_vectors(&table_info.name, table_schema)
-        .context(BuildColumnVectorsSnafu)?;
-
-    Ok(InsertRequest {
-        catalog_name: table_info.catalog_name.clone(),
-        schema_name: table_info.schema_name.clone(),
-        table_name: table_info.name.clone(),
-        columns_values,
-        region_number: 0,
-    })
-}
-
-fn build_delete_request(
-    record_batch: RecordBatch,
-    table_schema: SchemaRef,
-    table_info: &TableInfoRef,
-) -> Result<DeleteRequest> {
-    let ts_column = table_schema
-        .timestamp_column()
-        .map(|x| x.name.clone())
-        .with_context(|| table::error::MissingTimeIndexColumnSnafu {
-            table_name: table_info.name.clone(),
-        })
-        .context(MissingTimeIndexColumnSnafu)?;
-
-    let column_vectors = record_batch
-        .column_vectors(&table_info.name, table_schema)
-        .context(BuildColumnVectorsSnafu)?;
-
-    let rowkey_columns = table_info
-        .meta
-        .row_key_column_names()
-        .collect::<Vec<&String>>();
-
-    let key_column_values = column_vectors
-        .into_iter()
-        .filter(|x| x.0 == ts_column || rowkey_columns.contains(&&x.0))
-        .collect::<HashMap<_, _>>();
-
-    Ok(DeleteRequest {
-        catalog_name: table_info.catalog_name.clone(),
-        schema_name: table_info.schema_name.clone(),
-        table_name: table_info.name.clone(),
-        key_column_values,
-    })
 }

--- a/src/operator/src/tests/partition_manager.rs
+++ b/src/operator/src/tests/partition_manager.rs
@@ -435,7 +435,6 @@ fn test_meter_insert_request() {
         schema_name: "public".to_string(),
         table_name: "numbers".to_string(),
         columns_values: Default::default(),
-        region_number: 0,
     };
     meter_insert_request!(req);
 

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -200,7 +200,6 @@ impl DatafusionQueryEngine {
             schema_name: table_name.schema.to_string(),
             table_name: table_name.table.to_string(),
             columns_values: column_vectors,
-            region_number: 0,
         };
 
         self.state

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -254,11 +254,20 @@ pub enum Error {
     #[snafu(display("Column schema has no default value, column: {}", column))]
     ColumnSchemaNoDefault { column: String, location: Location },
 
-    #[snafu(display("Region query error, source: {}", source))]
+    #[snafu(display("Region query error"))]
     RegionQuery {
         source: BoxedError,
         location: Location,
     },
+
+    #[snafu(display("Table mutation error"))]
+    TableMutation {
+        source: BoxedError,
+        location: Location,
+    },
+
+    #[snafu(display("Missing table mutation handler"))]
+    MissingTableMutationHandler { location: Location },
 }
 
 impl ErrorExt for Error {
@@ -305,7 +314,10 @@ impl ErrorExt for Error {
             RemoteRequest { source, .. } => source.status_code(),
             UnexpectedOutputKind { .. } => StatusCode::Unexpected,
             CreateSchema { source, .. } => source.status_code(),
+
             RegionQuery { source, .. } => source.status_code(),
+            TableMutation { source, .. } => source.status_code(),
+            MissingTableMutationHandler { .. } => StatusCode::Unexpected,
         }
     }
 

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -38,6 +38,7 @@ use crate::planner::LogicalPlanner;
 pub use crate::query_engine::context::QueryEngineContext;
 pub use crate::query_engine::state::QueryEngineState;
 use crate::region_query::RegionQueryHandlerRef;
+use crate::table_mutation::TableMutationHandlerRef;
 
 /// Describe statement result
 #[derive(Debug)]
@@ -80,11 +81,13 @@ impl QueryEngineFactory {
     pub fn new(
         catalog_manager: CatalogManagerRef,
         region_query_handler: Option<RegionQueryHandlerRef>,
+        table_mutation_handler: Option<TableMutationHandlerRef>,
         with_dist_planner: bool,
     ) -> Self {
         Self::new_with_plugins(
             catalog_manager,
             region_query_handler,
+            table_mutation_handler,
             with_dist_planner,
             Default::default(),
         )
@@ -93,12 +96,14 @@ impl QueryEngineFactory {
     pub fn new_with_plugins(
         catalog_manager: CatalogManagerRef,
         region_query_handler: Option<RegionQueryHandlerRef>,
+        table_mutation_handler: Option<TableMutationHandlerRef>,
         with_dist_planner: bool,
         plugins: Arc<Plugins>,
     ) -> Self {
         let state = Arc::new(QueryEngineState::new(
             catalog_manager,
             region_query_handler,
+            table_mutation_handler,
             with_dist_planner,
             plugins.clone(),
         ));
@@ -131,7 +136,7 @@ mod tests {
     #[test]
     fn test_query_engine_factory() {
         let catalog_list = catalog::memory::new_memory_catalog_manager().unwrap();
-        let factory = QueryEngineFactory::new(catalog_list, None, false);
+        let factory = QueryEngineFactory::new(catalog_list, None, None, false);
 
         let engine = factory.query_engine();
 

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -48,6 +48,7 @@ use crate::optimizer::type_conversion::TypeConversionRule;
 use crate::query_engine::options::QueryOptions;
 use crate::range_select::planner::RangeSelectPlanner;
 use crate::region_query::RegionQueryHandlerRef;
+use crate::table_mutation::TableMutationHandlerRef;
 
 /// Query engine global state
 // TODO(yingwen): This QueryEngineState still relies on datafusion, maybe we can define a trait for it,
@@ -57,6 +58,7 @@ use crate::region_query::RegionQueryHandlerRef;
 pub struct QueryEngineState {
     df_context: SessionContext,
     catalog_manager: CatalogManagerRef,
+    table_mutation_handler: Option<TableMutationHandlerRef>,
     aggregate_functions: Arc<RwLock<HashMap<String, AggregateFunctionMetaRef>>>,
     plugins: Arc<Plugins>,
 }
@@ -73,6 +75,7 @@ impl QueryEngineState {
     pub fn new(
         catalog_list: CatalogManagerRef,
         region_query_handler: Option<RegionQueryHandlerRef>,
+        table_mutation_handler: Option<TableMutationHandlerRef>,
         with_dist_planner: bool,
         plugins: Arc<Plugins>,
     ) -> Self {
@@ -123,6 +126,7 @@ impl QueryEngineState {
         Self {
             df_context,
             catalog_manager: catalog_list,
+            table_mutation_handler,
             aggregate_functions: Arc::new(RwLock::new(HashMap::new())),
             plugins,
         }
@@ -182,6 +186,11 @@ impl QueryEngineState {
     #[inline]
     pub fn catalog_manager(&self) -> &CatalogManagerRef {
         &self.catalog_manager
+    }
+
+    #[inline]
+    pub fn table_mutation_handler(&self) -> Option<&TableMutationHandlerRef> {
+        self.table_mutation_handler.as_ref()
     }
 
     pub(crate) fn disallow_cross_schema_query(&self) -> bool {

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -388,7 +388,7 @@ mod test {
                 table,
             })
             .is_ok());
-        QueryEngineFactory::new(catalog_list, None, false).query_engine()
+        QueryEngineFactory::new(catalog_list, None, None, false).query_engine()
     }
 
     async fn query_plan_compare(sql: &str, expected: String) {

--- a/src/query/src/region_query.rs
+++ b/src/query/src/region_query.rs
@@ -22,7 +22,6 @@ use crate::error::Result;
 
 #[async_trait]
 pub trait RegionQueryHandler: Send + Sync {
-    // TODO(ruihang): add trace id and span id in the request.
     async fn do_get(&self, request: QueryRequest) -> Result<SendableRecordBatchStream>;
 }
 

--- a/src/query/src/table_mutation.rs
+++ b/src/query/src/table_mutation.rs
@@ -12,32 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(let_chains)]
+use std::sync::Arc;
 
-pub mod dataframe;
-pub mod datafusion;
-pub mod dist_plan;
-pub mod error;
-pub mod executor;
-pub mod logical_optimizer;
-mod metrics;
-mod optimizer;
-pub mod parser;
-pub mod physical_optimizer;
-pub mod physical_planner;
-pub mod physical_wrapper;
-pub mod plan;
-pub mod planner;
-pub mod query_engine;
-mod range_select;
-pub mod region_query;
-pub mod sql;
-pub mod table_mutation;
+use async_trait::async_trait;
+use session::context::QueryContextRef;
+use table::requests::{DeleteRequest, InsertRequest};
 
-pub use crate::datafusion::DfContextProviderAdapter;
-pub use crate::query_engine::{
-    QueryEngine, QueryEngineContext, QueryEngineFactory, QueryEngineRef,
-};
+use crate::error::Result;
 
-#[cfg(test)]
-mod tests;
+pub type AffectedRows = usize;
+
+#[async_trait]
+pub trait TableMutationHandler: Send + Sync {
+    async fn insert(&self, request: InsertRequest, ctx: QueryContextRef) -> Result<AffectedRows>;
+
+    async fn delete(&self, request: DeleteRequest, ctx: QueryContextRef) -> Result<AffectedRows>;
+}
+
+pub type TableMutationHandlerRef = Arc<dyn TableMutationHandler>;

--- a/src/query/src/table_mutation.rs
+++ b/src/query/src/table_mutation.rs
@@ -22,10 +22,13 @@ use crate::error::Result;
 
 pub type AffectedRows = usize;
 
+/// A trait for handling table mutations in `QueryEngine`.
 #[async_trait]
 pub trait TableMutationHandler: Send + Sync {
+    /// Inserts rows into the table.
     async fn insert(&self, request: InsertRequest, ctx: QueryContextRef) -> Result<AffectedRows>;
 
+    /// Delete rows from the table.
     async fn delete(&self, request: DeleteRequest, ctx: QueryContextRef) -> Result<AffectedRows>;
 }
 

--- a/src/query/src/tests.rs
+++ b/src/query/src/tests.rs
@@ -51,5 +51,5 @@ async fn exec_selection(engine: QueryEngineRef, sql: &str) -> Vec<RecordBatch> {
 pub fn new_query_engine_with_table(table: TableRef) -> QueryEngineRef {
     let catalog_manager = MemoryCatalogManager::new_with_table(table);
 
-    QueryEngineFactory::new(catalog_manager, None, false).query_engine()
+    QueryEngineFactory::new(catalog_manager, None, None, false).query_engine()
 }

--- a/src/query/src/tests/query_engine_test.rs
+++ b/src/query/src/tests/query_engine_test.rs
@@ -47,7 +47,7 @@ async fn test_datafusion_query_engine() -> Result<()> {
     let catalog_list = catalog::memory::new_memory_catalog_manager()
         .map_err(BoxedError::new)
         .context(QueryExecutionSnafu)?;
-    let factory = QueryEngineFactory::new(catalog_list, None, false);
+    let factory = QueryEngineFactory::new(catalog_list, None, None, false);
     let engine = factory.query_engine();
 
     let column_schemas = vec![ColumnSchema::new(
@@ -129,7 +129,7 @@ async fn test_query_validate() -> Result<()> {
     });
     let plugins = Arc::new(plugins);
 
-    let factory = QueryEngineFactory::new_with_plugins(catalog_list, None, false, plugins);
+    let factory = QueryEngineFactory::new_with_plugins(catalog_list, None, None, false, plugins);
     let engine = factory.query_engine();
 
     let stmt = QueryLanguageParser::parse_sql("select number from public.numbers").unwrap();
@@ -153,7 +153,7 @@ async fn test_udf() -> Result<()> {
     common_telemetry::init_default_ut_logging();
     let catalog_list = catalog_manager()?;
 
-    let factory = QueryEngineFactory::new(catalog_list, None, false);
+    let factory = QueryEngineFactory::new(catalog_list, None, None, false);
     let engine = factory.query_engine();
 
     let pow = make_scalar_function(pow);

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -106,7 +106,7 @@ fn create_test_engine() -> TimeRangeTester {
     };
     let _ = catalog_manager.register_table_sync(req).unwrap();
 
-    let engine = QueryEngineFactory::new(catalog_manager, None, false).query_engine();
+    let engine = QueryEngineFactory::new(catalog_manager, None, None, false).query_engine();
     TimeRangeTester { engine, filter }
 }
 

--- a/src/script/benches/py_benchmark.rs
+++ b/src/script/benches/py_benchmark.rs
@@ -52,7 +52,7 @@ where
 pub(crate) fn sample_script_engine() -> PyEngine {
     let catalog_manager =
         MemoryCatalogManager::new_with_table(NumbersTable::table(NUMBERS_TABLE_ID));
-    let query_engine = QueryEngineFactory::new(catalog_manager, None, false).query_engine();
+    let query_engine = QueryEngineFactory::new(catalog_manager, None, None, false).query_engine();
 
     PyEngine::new(query_engine.clone())
 }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -375,7 +375,8 @@ mod tests {
     pub(crate) fn sample_script_engine() -> PyEngine {
         let catalog_manager =
             MemoryCatalogManager::new_with_table(NumbersTable::table(NUMBERS_TABLE_ID));
-        let query_engine = QueryEngineFactory::new(catalog_manager, None, false).query_engine();
+        let query_engine =
+            QueryEngineFactory::new(catalog_manager, None, None, false).query_engine();
 
         PyEngine::new(query_engine.clone())
     }

--- a/src/script/src/test.rs
+++ b/src/script/src/test.rs
@@ -56,7 +56,7 @@ pub async fn setup_scripts_manager(
 
     let catalog_manager = MemoryCatalogManager::new_with_table(table.clone());
 
-    let factory = QueryEngineFactory::new(catalog_manager.clone(), None, false);
+    let factory = QueryEngineFactory::new(catalog_manager.clone(), None, None, false);
     let query_engine = factory.query_engine();
     let mgr = ScriptManager::new(Arc::new(MockGrpcQueryHandler {}) as _, query_engine)
         .await

--- a/src/servers/src/line_writer.rs
+++ b/src/servers/src/line_writer.rs
@@ -141,7 +141,6 @@ impl LineWriter {
             schema_name: self.db,
             table_name: self.table_name,
             columns_values,
-            region_number: 0, // TODO(hl): Check if assign 0 region is ok?
         }
     }
 }

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -214,7 +214,7 @@ impl GrpcQueryHandler for DummyInstance {
 
 fn create_testing_instance(table: TableRef) -> DummyInstance {
     let catalog_manager = MemoryCatalogManager::new_with_table(table);
-    let query_engine = QueryEngineFactory::new(catalog_manager, None, false).query_engine();
+    let query_engine = QueryEngineFactory::new(catalog_manager, None, None, false).query_engine();
     DummyInstance::new(query_engine)
 }
 

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -246,7 +246,6 @@ pub struct InsertRequest {
     pub schema_name: String,
     pub table_name: String,
     pub columns_values: HashMap<String, VectorRef>,
-    pub region_number: RegionNumber,
 }
 
 /// Delete (by primary key) request
@@ -327,7 +326,6 @@ macro_rules! meter_insert_request {
             $req.catalog_name.to_string(),
             $req.schema_name.to_string(),
             $req.table_name.to_string(),
-            $req.region_number,
             $req
         );
     };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* Remove calling to table.insert and table.delete, and replace with `TableMutationHandler`
* Clean some dead code

Hopefully, after this patch and #2482, #2445 should done

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
