### PR TITLE
fix: print root cause error message to user facing interface

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -52,7 +52,7 @@ use futures::FutureExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use snafu::{ensure, ResultExt};
+use snafu::{ensure, ErrorCompat, ResultExt};
 use tokio::sync::oneshot::{self, Sender};
 use tokio::sync::Mutex;
 use tower::timeout::TimeoutLayer;
@@ -315,7 +315,7 @@ impl JsonResponse {
                 },
                 Err(e) => {
                     return Self::with_error(
-                        format!("Query engine output error: {e}"),
+                        e.iter_chain().last().unwrap().to_string(),
                         e.status_code(),
                     );
                 }

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -26,6 +26,7 @@ use opensrv_mysql::{
 };
 use session::context::QueryContextRef;
 use snafu::prelude::*;
+use snafu::ErrorCompat;
 use tokio::io::AsyncWrite;
 
 use crate::error::{self, Error, OtherSnafu, Result};
@@ -211,7 +212,8 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
         );
 
         let kind = ErrorKind::ER_INTERNAL_ERROR;
-        w.error(kind, error.to_string().as_bytes()).await?;
+        let error = error.iter_chain().last().unwrap().to_string();
+        w.error(kind, error.as_bytes()).await?;
         Ok(())
     }
 }

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -31,6 +31,7 @@ use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use query::query_engine::DescribeResult;
 use session::Session;
+use snafu::ErrorCompat;
 use sql::dialect::PostgreSqlDialect;
 use sql::parser::ParserContext;
 
@@ -90,7 +91,7 @@ fn output_to_query_response<'a>(
         Err(e) => Ok(Response::Error(Box::new(ErrorInfo::new(
             "ERROR".to_string(),
             "XX000".to_string(),
-            e.to_string(),
+            e.iter_chain().last().unwrap().to_string(),
         )))),
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

#2428 removes "source" from error, making user facing interfaces (mysql, pg and http) lack of root cause. 

Take mysql as an example, selecting an not existed table.

Before: 

ERROR 1815 (HY000): Failed to execute query, query: select * from monitor

After:

ERROR 1815 (HY000): Error during planning: Table not found: greptime.public.monitor

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
