### PR TITLE
feat(mito): Add cache manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
  "log-store",
  "meta-client",
  "metrics",
- "moka 0.11.3",
+ "moka",
  "object-store",
  "parking_lot 0.12.1",
  "partition",
@@ -1544,7 +1544,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "enum_dispatch",
  "futures-util",
- "moka 0.9.9",
+ "moka",
  "parking_lot 0.12.1",
  "prost",
  "rand",
@@ -3347,7 +3347,7 @@ dependencies = [
  "meta-client",
  "meta-srv",
  "metrics",
- "moka 0.9.9",
+ "moka",
  "object-store",
  "openmetrics-parser",
  "opentelemetry-proto",
@@ -5571,32 +5571,6 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28455ac4363046076054a7e9cfbd7f168019c29dba32a625f59fc0aeffaaea4"
-dependencies = [
- "async-io",
- "async-lock",
- "crossbeam-channel",
- "crossbeam-epoch",
- "crossbeam-utils",
- "futures-util",
- "num_cpus",
- "once_cell",
- "parking_lot 0.12.1",
- "quanta 0.11.1",
- "rustc_version",
- "scheduled-thread-pool",
- "skeptic",
- "smallvec",
- "tagptr",
- "thiserror",
- "triomphe",
- "uuid",
-]
-
-[[package]]
-name = "moka"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa6e72583bf6830c956235bff0d5afec8cf2952f579ebad18ae7821a917d950f"
@@ -6511,7 +6485,7 @@ dependencies = [
  "datafusion-expr",
  "datatypes",
  "meta-client",
- "moka 0.9.9",
+ "moka",
  "serde",
  "serde_json",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5551,6 +5551,7 @@ dependencies = [
  "log-store",
  "memcomparable",
  "metrics",
+ "moka",
  "object-store",
  "parquet",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", r
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"
+moka = { version = "0.11" }
 once_cell = "1.18"
 opentelemetry-proto = { version = "0.2", features = ["gen-tonic", "metrics"] }
 parquet = "43.0"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -30,7 +30,7 @@ futures-util.workspace = true
 lazy_static.workspace = true
 meta-client = { workspace = true }
 metrics.workspace = true
-moka = { version = "0.11", features = ["future"] }
+moka = { workspace = true, features = ["future"] }
 parking_lot = "0.12"
 partition.workspace = true
 regex.workspace = true

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -26,7 +26,7 @@ datatypes = { workspace = true }
 derive_builder.workspace = true
 enum_dispatch = "0.3"
 futures-util.workspace = true
-moka = { version = "0.9", features = ["future"] }
+moka = { workspace = true, features = ["future"] }
 parking_lot = "0.12"
 prost.workspace = true
 rand.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -50,7 +50,7 @@ meta-client = { workspace = true }
 raft-engine = { workspace = true }
 # Although it is not used, please do not delete it.
 metrics.workspace = true
-moka = { version = "0.9", features = ["future"] }
+moka = { workspace = true, features = ["future"] }
 object-store = { workspace = true }
 openmetrics-parser = "0.4"
 opentelemetry-proto.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -39,6 +39,7 @@ humantime-serde = { workspace = true }
 lazy_static = "1.4"
 memcomparable = "0.2"
 metrics.workspace = true
+moka.workspace = true
 object-store = { workspace = true }
 parquet = { workspace = true, features = ["async"] }
 paste.workspace = true

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -98,9 +98,15 @@ mod tests {
     use crate::cache::test_util::parquet_meta;
 
     #[test]
-    fn test_capacity_zero() {
+    fn test_disable_meta_cache() {
         let cache = CacheManager::new(0);
         assert!(cache.sst_meta_cache.is_none());
+
+        let region_id = RegionId::new(1, 1);
+        let file_id = FileId::random();
+        let metadata = parquet_meta();
+        cache.put_parquet_meta_data(region_id, file_id, metadata);
+        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
     }
 
     #[test]

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -106,7 +106,7 @@ impl CacheValue {
     /// Returns memory used by the value (estimated).
     fn estimated_size(&self) -> usize {
         let inner_size = match self {
-            CacheValue::ParquetMeta(meta) => parquet_meta_size(&meta),
+            CacheValue::ParquetMeta(meta) => parquet_meta_size(meta),
         };
         inner_size + mem::size_of::<CacheValue>()
     }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -16,6 +16,11 @@
 
 use std::sync::Arc;
 
+use parquet::file::metadata::ParquetMetaData;
+use store_api::storage::RegionId;
+
+use crate::sst::file::FileId;
+
 /// Manages cached data for the engine.
 pub struct CacheManager {}
 
@@ -30,5 +35,25 @@ impl CacheManager {
         } else {
             Some(CacheManager {})
         }
+    }
+
+    /// Gets cached [ParquetMetaData].
+    pub fn get_parquet_meta_data(
+        &self,
+        _region_id: RegionId,
+        _file_id: FileId,
+    ) -> Option<Arc<ParquetMetaData>> {
+        // TODO(yingwen): Implements it.
+        None
+    }
+
+    /// Puts [ParquetMetaData] into the cache.
+    pub fn put_parquet_meta_data(
+        &self,
+        _region_id: RegionId,
+        _file_id: FileId,
+        _metadata: Arc<ParquetMetaData>,
+    ) {
+        // TODO(yingwen): Implements it.
     }
 }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -15,6 +15,8 @@
 //! Cache for the engine.
 
 mod cache_size;
+#[cfg(test)]
+pub(crate) mod test_util;
 
 use std::mem;
 use std::sync::Arc;
@@ -114,5 +116,27 @@ impl CacheValue {
         match self {
             CacheValue::ParquetMeta(meta) => Some(meta),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::test_util::parquet_meta;
+
+    #[test]
+    fn test_capacity_zero() {
+        assert!(CacheManager::new(0).is_none());
+    }
+
+    #[test]
+    fn test_parquet_meta_cache() {
+        let cache = CacheManager::new(2000).unwrap();
+        let region_id = RegionId::new(1, 1);
+        let file_id = FileId::random();
+        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+        let metadata = parquet_meta();
+        cache.put_parquet_meta_data(region_id, file_id, metadata);
+        assert!(cache.get_parquet_meta_data(region_id, file_id).is_some());
     }
 }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -77,6 +77,13 @@ impl CacheManager {
             cache.insert(SstMetaKey(region_id, file_id), metadata);
         }
     }
+
+    /// Removes [ParquetMetaData] from the cache.
+    pub fn remove_parquet_meta_data(&self, region_id: RegionId, file_id: FileId) {
+        if let Some(cache) = &self.sst_meta_cache {
+            cache.remove(&SstMetaKey(region_id, file_id));
+        }
+    }
 }
 
 /// Cache key for SST meta.
@@ -118,5 +125,7 @@ mod tests {
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
         assert!(cache.get_parquet_meta_data(region_id, file_id).is_some());
+        cache.remove_parquet_meta_data(region_id, file_id);
+        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
     }
 }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -1,0 +1,34 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cache for the engine.
+
+use std::sync::Arc;
+
+/// Manages cached data for the engine.
+pub struct CacheManager {}
+
+pub type CacheManagerRef = Arc<CacheManager>;
+
+impl CacheManager {
+    /// Creates a new manager with specific cache capacity in bytes.
+    /// Returns `None` if `capacity` is 0.
+    pub fn new(capacity: usize) -> Option<CacheManager> {
+        if capacity == 0 {
+            None
+        } else {
+            Some(CacheManager {})
+        }
+    }
+}

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -16,24 +16,32 @@
 
 use std::sync::Arc;
 
+use moka::sync::Cache;
 use parquet::file::metadata::ParquetMetaData;
 use store_api::storage::RegionId;
 
 use crate::sst::file::FileId;
 
 /// Manages cached data for the engine.
-pub struct CacheManager {}
+pub struct CacheManager {
+    cache: Cache<String, CacheValue>,
+}
 
 pub type CacheManagerRef = Arc<CacheManager>;
 
 impl CacheManager {
     /// Creates a new manager with specific cache capacity in bytes.
     /// Returns `None` if `capacity` is 0.
-    pub fn new(capacity: usize) -> Option<CacheManager> {
+    pub fn new(capacity: u64) -> Option<CacheManager> {
         if capacity == 0 {
             None
         } else {
-            Some(CacheManager {})
+            let cache = Cache::builder()
+                .max_capacity(capacity)
+                .build();
+            Some(CacheManager {
+                cache,
+            })
         }
     }
 
@@ -56,4 +64,12 @@ impl CacheManager {
     ) {
         // TODO(yingwen): Implements it.
     }
+}
+
+/// Cached value.
+/// It can hold different kinds of data.
+#[derive(Clone)]
+enum CacheValue {
+    /// Parquet meta data.
+    ParquetMeta(Arc<ParquetMetaData>),
 }

--- a/src/mito2/src/cache/cache_size.rs
+++ b/src/mito2/src/cache/cache_size.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Cache size of different cache value.
+
+use std::mem;
+
+use parquet::file::metadata::{
+    ColumnChunkMetaData, FileMetaData, ParquetColumnIndex, ParquetMetaData, ParquetOffsetIndex,
+    RowGroupMetaData,
+};
+use parquet::file::page_index::index::Index;
+use parquet::format::{ColumnOrder, KeyValue, PageLocation};
+use parquet::schema::types::{ColumnDescriptor, SchemaDescriptor, Type};
+
+/// Returns estimated size of [ParquetMetaData].
+pub fn parquet_meta_size(meta: &ParquetMetaData) -> usize {
+    // struct size
+    let mut size = mem::size_of::<ParquetMetaData>();
+    // file_metadata
+    size += file_meta_heap_size(meta.file_metadata());
+    // row_groups
+    size += meta
+        .row_groups()
+        .iter()
+        .map(|row_group| row_group_meta_heap_size(row_group))
+        .sum::<usize>();
+    // column_index
+    size += meta
+        .column_index()
+        .map(|index| parquet_column_index_heap_size(index))
+        .unwrap_or(0);
+    // offset_index
+    size += meta
+        .offset_index()
+        .map(|index| parquet_offset_index_heap_size(index))
+        .unwrap_or(0);
+
+    size
+}
+
+/// Returns estimated size of [FileMetaData] allocated from heap.
+fn file_meta_heap_size(meta: &FileMetaData) -> usize {
+    // created_by
+    let mut size = meta.created_by().map(|s| s.len()).unwrap_or(0);
+    // key_value_metadata
+    size += meta
+        .key_value_metadata()
+        .map(|kvs| {
+            kvs.iter()
+                .map(|kv| {
+                    kv.key.len()
+                        + kv.value.as_ref().map(|v| v.len()).unwrap_or(0)
+                        + mem::size_of::<KeyValue>()
+                })
+                .sum()
+        })
+        .unwrap_or(0);
+    // schema_descr (It's a ptr so we also add size of SchemaDescriptor).
+    size += mem::size_of::<SchemaDescriptor>();
+    size += schema_descr_heap_size(meta.schema_descr());
+    // column_orders
+    size += meta
+        .column_orders()
+        .map(|orders| orders.len() * mem::size_of::<ColumnOrder>())
+        .unwrap_or(0);
+
+    size
+}
+
+/// Returns estimated size of [SchemaDescriptor] allocated from heap.
+fn schema_descr_heap_size(descr: &SchemaDescriptor) -> usize {
+    // schema
+    let mut size = mem::size_of::<Type>();
+    // leaves
+    size += descr
+        .columns()
+        .iter()
+        .map(|descr| mem::size_of::<ColumnDescriptor>() + column_descr_heap_size(&descr))
+        .sum::<usize>();
+    // leaf_to_base
+    size += descr.num_columns() * mem::size_of::<usize>();
+
+    size
+}
+
+/// Returns estimated size of [ColumnDescriptor] allocated from heap.
+fn column_descr_heap_size(descr: &ColumnDescriptor) -> usize {
+    descr.path().parts().iter().map(|s| s.len()).sum()
+}
+
+/// Returns estimated size of [ColumnDescriptor] allocated from heap.
+fn row_group_meta_heap_size(meta: &RowGroupMetaData) -> usize {
+    meta.columns().len() * mem::size_of::<ColumnChunkMetaData>()
+}
+
+/// Returns estimated size of [ParquetColumnIndex] allocated from heap.
+fn parquet_column_index_heap_size(column_index: &ParquetColumnIndex) -> usize {
+    column_index.iter().map(|index| index.len()).sum::<usize>() * mem::size_of::<Index>()
+}
+
+/// Returns estimated size of [ParquetOffsetIndex] allocated from heap.
+fn parquet_offset_index_heap_size(offset_index: &ParquetOffsetIndex) -> usize {
+    offset_index
+        .iter()
+        .map(|index| index.iter().map(|index| index.len()).sum::<usize>())
+        .sum::<usize>()
+        * mem::size_of::<PageLocation>()
+}

--- a/src/mito2/src/cache/cache_size.rs
+++ b/src/mito2/src/cache/cache_size.rs
@@ -17,8 +17,7 @@
 use std::mem;
 
 use parquet::file::metadata::{
-    ColumnChunkMetaData, FileMetaData, ParquetColumnIndex, ParquetMetaData, ParquetOffsetIndex,
-    RowGroupMetaData,
+    FileMetaData, ParquetColumnIndex, ParquetMetaData, ParquetOffsetIndex, RowGroupMetaData,
 };
 use parquet::file::page_index::index::Index;
 use parquet::format::{ColumnOrder, KeyValue, PageLocation};
@@ -34,17 +33,17 @@ pub fn parquet_meta_size(meta: &ParquetMetaData) -> usize {
     size += meta
         .row_groups()
         .iter()
-        .map(|row_group| row_group_meta_heap_size(row_group))
+        .map(row_group_meta_heap_size)
         .sum::<usize>();
     // column_index
     size += meta
         .column_index()
-        .map(|index| parquet_column_index_heap_size(index))
+        .map(parquet_column_index_heap_size)
         .unwrap_or(0);
     // offset_index
     size += meta
         .offset_index()
-        .map(|index| parquet_offset_index_heap_size(index))
+        .map(parquet_offset_index_heap_size)
         .unwrap_or(0);
 
     size
@@ -87,7 +86,7 @@ fn schema_descr_heap_size(descr: &SchemaDescriptor) -> usize {
     size += descr
         .columns()
         .iter()
-        .map(|descr| mem::size_of::<ColumnDescriptor>() + column_descr_heap_size(&descr))
+        .map(|descr| mem::size_of::<ColumnDescriptor>() + column_descr_heap_size(descr))
         .sum::<usize>();
     // leaf_to_base
     size += descr.num_columns() * mem::size_of::<usize>();
@@ -102,7 +101,7 @@ fn column_descr_heap_size(descr: &ColumnDescriptor) -> usize {
 
 /// Returns estimated size of [ColumnDescriptor] allocated from heap.
 fn row_group_meta_heap_size(meta: &RowGroupMetaData) -> usize {
-    meta.columns().len() * mem::size_of::<ColumnChunkMetaData>()
+    mem::size_of_val(meta.columns())
 }
 
 /// Returns estimated size of [ParquetColumnIndex] allocated from heap.

--- a/src/mito2/src/cache/cache_size.rs
+++ b/src/mito2/src/cache/cache_size.rs
@@ -118,3 +118,16 @@ fn parquet_offset_index_heap_size(offset_index: &ParquetOffsetIndex) -> usize {
         .sum::<usize>()
         * mem::size_of::<PageLocation>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::test_util::parquet_meta;
+
+    #[test]
+    fn test_parquet_meta_size() {
+        let metadata = parquet_meta();
+
+        assert_eq!(948, parquet_meta_size(&metadata));
+    }
+}

--- a/src/mito2/src/cache/test_util.rs
+++ b/src/mito2/src/cache/test_util.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for testing cache.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use datatypes::arrow::array::{ArrayRef, Int64Array};
+use datatypes::arrow::record_batch::RecordBatch;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use parquet::arrow::ArrowWriter;
+use parquet::file::metadata::ParquetMetaData;
+
+/// Returns a parquet meta data.
+pub(crate) fn parquet_meta() -> Arc<ParquetMetaData> {
+    let file_data = parquet_file_data();
+    let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::from(file_data)).unwrap();
+    builder.metadata().clone()
+}
+
+/// Write a test parquet file to a buffer
+fn parquet_file_data() -> Vec<u8> {
+    let col = Arc::new(Int64Array::from_iter_values([1, 2, 3])) as ArrayRef;
+    let to_write = RecordBatch::try_from_iter([("col", col)]).unwrap();
+
+    let mut buffer = Vec::new();
+    let mut writer = ArrowWriter::try_new(&mut buffer, to_write.schema(), None).unwrap();
+    writer.write(&to_write).unwrap();
+    writer.close().unwrap();
+
+    buffer
+}

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -56,6 +56,10 @@ pub struct MitoConfig {
     pub global_write_buffer_size: ReadableSize,
     /// Global write buffer size threshold to reject write requests (default 2G).
     pub global_write_buffer_reject_size: ReadableSize,
+
+    // Cache configs:
+    /// Total size for cache (default 512MB). Setting it to 0 to disable cache.
+    pub cache_size: ReadableSize,
 }
 
 impl Default for MitoConfig {
@@ -70,6 +74,7 @@ impl Default for MitoConfig {
             auto_flush_interval: Duration::from_secs(30 * 60),
             global_write_buffer_size: ReadableSize::gb(1),
             global_write_buffer_reject_size: ReadableSize::gb(2),
+            cache_size: ReadableSize::mb(512),
         }
     }
 }

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -58,8 +58,8 @@ pub struct MitoConfig {
     pub global_write_buffer_reject_size: ReadableSize,
 
     // Cache configs:
-    /// Total size for cache (default 512MB). Setting it to 0 to disable cache.
-    pub cache_size: ReadableSize,
+    /// Cache size for SST metadata (default 128MB). Setting it to 0 to disable cache.
+    pub sst_meta_cache_size: ReadableSize,
 }
 
 impl Default for MitoConfig {
@@ -74,7 +74,7 @@ impl Default for MitoConfig {
             auto_flush_interval: Duration::from_secs(30 * 60),
             global_write_buffer_size: ReadableSize::gb(1),
             global_write_buffer_reject_size: ReadableSize::gb(2),
-            cache_size: ReadableSize::mb(512),
+            sst_meta_cache_size: ReadableSize::mb(128),
         }
     }
 }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -144,7 +144,10 @@ impl EngineInner {
             .get_region(region_id)
             .context(RegionNotFoundSnafu { region_id })?;
         let version = region.version();
-        let scan_region = ScanRegion::new(version, region.access_layer.clone(), request);
+        // Get cache.
+        let cache_manager = self.workers.cache_manager();
+        let scan_region =
+            ScanRegion::new(version, region.access_layer.clone(), request, cache_manager);
 
         scan_region.scanner()
     }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -146,8 +146,12 @@ impl EngineInner {
         let version = region.version();
         // Get cache.
         let cache_manager = self.workers.cache_manager();
-        let scan_region =
-            ScanRegion::new(version, region.access_layer.clone(), request, cache_manager);
+        let scan_region = ScanRegion::new(
+            version,
+            region.access_layer.clone(),
+            request,
+            Some(cache_manager),
+        );
 
         scan_region.scanner()
     }

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod test_util;
 
 mod access_layer;
+mod cache;
 mod compaction;
 pub mod config;
 pub mod engine;

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -22,6 +22,7 @@ use store_api::storage::ScanRequest;
 use table::predicate::{Predicate, TimeRangePredicateBuilder};
 
 use crate::access_layer::AccessLayerRef;
+use crate::cache::CacheManagerRef;
 use crate::error::{BuildPredicateSnafu, Result};
 use crate::read::projection::ProjectionMapper;
 use crate::read::seq_scan::SeqScan;
@@ -113,6 +114,8 @@ pub(crate) struct ScanRegion {
     access_layer: AccessLayerRef,
     /// Scan request.
     request: ScanRequest,
+    /// Cache.
+    cache_manager: Option<CacheManagerRef>,
 }
 
 impl ScanRegion {
@@ -121,11 +124,13 @@ impl ScanRegion {
         version: VersionRef,
         access_layer: AccessLayerRef,
         request: ScanRequest,
+        cache_manager: Option<CacheManagerRef>,
     ) -> ScanRegion {
         ScanRegion {
             version,
             access_layer,
             request,
+            cache_manager,
         }
     }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -186,7 +186,8 @@ impl ScanRegion {
             .with_time_range(Some(time_range))
             .with_predicate(Some(predicate))
             .with_memtables(memtables)
-            .with_files(files);
+            .with_files(files)
+            .with_cache(self.cache_manager);
 
         Ok(seq_scan)
     }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -65,7 +65,7 @@ impl SeqScan {
             predicate: None,
             memtables: Vec::new(),
             files: Vec::new(),
-            cache_manager,
+            cache_manager: None,
         }
     }
 
@@ -139,6 +139,7 @@ impl SeqScan {
                 .predicate(self.predicate.clone())
                 .time_range(self.time_range)
                 .projection(Some(self.mapper.column_ids().to_vec()))
+                .cache(self.cache_manager.clone())
                 .build()
                 .await?;
             if compat::has_same_columns(self.mapper.metadata(), reader.metadata()) {

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -25,6 +25,7 @@ use snafu::ResultExt;
 use table::predicate::Predicate;
 
 use crate::access_layer::AccessLayerRef;
+use crate::cache::CacheManagerRef;
 use crate::error::Result;
 use crate::memtable::MemtableRef;
 use crate::read::compat::{self, CompatReader};
@@ -49,6 +50,8 @@ pub struct SeqScan {
     memtables: Vec<MemtableRef>,
     /// Handles to SST files to scan.
     files: Vec<FileHandle>,
+    /// Cache.
+    cache_manager: Option<CacheManagerRef>,
 }
 
 impl SeqScan {
@@ -62,34 +65,41 @@ impl SeqScan {
             predicate: None,
             memtables: Vec::new(),
             files: Vec::new(),
+            cache_manager,
         }
     }
 
-    /// Set time range filter for time index.
+    /// Sets time range filter for time index.
     #[must_use]
     pub(crate) fn with_time_range(mut self, time_range: Option<TimestampRange>) -> Self {
         self.time_range = time_range;
         self
     }
 
-    /// Set predicate to push down.
+    /// Sets predicate to push down.
     #[must_use]
     pub(crate) fn with_predicate(mut self, predicate: Option<Predicate>) -> Self {
         self.predicate = predicate;
         self
     }
 
-    /// Set memtables to read.
+    /// Sets memtables to read.
     #[must_use]
     pub(crate) fn with_memtables(mut self, memtables: Vec<MemtableRef>) -> Self {
         self.memtables = memtables;
         self
     }
 
-    /// Set files to read.
+    /// Sets files to read.
     #[must_use]
     pub(crate) fn with_files(mut self, files: Vec<FileHandle>) -> Self {
         self.files = files;
+        self
+    }
+
+    /// Sets cache for this query.
+    pub(crate) fn with_cache(mut self, cache: Option<CacheManagerRef>) -> Self {
+        self.cache_manager = cache;
         self
     }
 

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -118,6 +118,12 @@ impl FileHandle {
             inner: Arc::new(FileHandleInner::new(meta, file_purger)),
         }
     }
+
+    /// Returns the region id of the file.
+    pub fn region_id(&self) -> RegionId {
+        self.inner.meta.region_id
+    }
+
     /// Returns the file id.
     pub fn file_id(&self) -> FileId {
         self.inner.meta.file_id

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -137,6 +137,7 @@ impl ParquetReaderBuilder {
         let reader = BufReader::new(reader);
         let reader = AsyncFileReaderCache {
             reader,
+            // TODO(yingwen): Sets the metadata when we implement row group level reader.
             metadata: None,
             cache: self.cache_manager.clone(),
             region_id: self.file_handle.region_id(),

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -32,6 +32,7 @@ use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 use tokio::io::BufReader;
 
+use crate::cache::CacheManagerRef;
 use crate::error::{
     InvalidMetadataSnafu, InvalidParquetSnafu, OpenDalSnafu, ReadParquetSnafu, Result,
 };
@@ -55,6 +56,8 @@ pub struct ParquetReaderBuilder {
     /// `None` reads all columns. Due to schema change, the projection
     /// can contain columns not in the parquet file.
     projection: Option<Vec<ColumnId>>,
+    /// Manager that caches SST data.
+    cache_manager: Option<CacheManagerRef>,
 }
 
 impl ParquetReaderBuilder {
@@ -71,6 +74,7 @@ impl ParquetReaderBuilder {
             predicate: None,
             time_range: None,
             projection: None,
+            cache_manager: None,
         }
     }
 
@@ -91,6 +95,12 @@ impl ParquetReaderBuilder {
     /// The reader only applies the projection to fields.
     pub fn projection(mut self, projection: Option<Vec<ColumnId>>) -> ParquetReaderBuilder {
         self.projection = projection;
+        self
+    }
+
+    /// Attaches the cache to the builder.
+    pub fn cache(mut self, cache: Option<CacheManagerRef>) -> ParquetReaderBuilder {
+        self.cache_manager = cache;
         self
     }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -101,7 +101,7 @@ pub(crate) struct WorkerGroup {
     /// Global background job scheduelr.
     scheduler: SchedulerRef,
     /// Cache.
-    cache_manager: Option<CacheManagerRef>,
+    cache_manager: CacheManagerRef,
 }
 
 impl WorkerGroup {
@@ -119,7 +119,7 @@ impl WorkerGroup {
             config.global_write_buffer_size.as_bytes() as usize,
         ));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = CacheManager::new(config.cache_size.as_bytes()).map(Arc::new);
+        let cache_manager = Arc::new(CacheManager::new(config.sst_meta_cache_size.as_bytes()));
 
         let workers = (0..config.num_workers)
             .map(|id| {
@@ -177,7 +177,7 @@ impl WorkerGroup {
     }
 
     /// Returns cache of the group.
-    pub(crate) fn cache_manager(&self) -> Option<CacheManagerRef> {
+    pub(crate) fn cache_manager(&self) -> CacheManagerRef {
         self.cache_manager.clone()
     }
 
@@ -208,7 +208,7 @@ impl WorkerGroup {
         assert!(config.num_workers.is_power_of_two());
         let config = Arc::new(config);
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = CacheManager::new(config.cache_size.as_bytes()).map(Arc::new);
+        let cache_manager = Arc::new(CacheManager::new(config.sst_meta_cache_size.as_bytes()));
 
         let workers = (0..config.num_workers)
             .map(|id| {

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -119,7 +119,7 @@ impl WorkerGroup {
             config.global_write_buffer_size.as_bytes() as usize,
         ));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = CacheManager::new(config.cache_size.as_bytes() as usize).map(Arc::new);
+        let cache_manager = CacheManager::new(config.cache_size.as_bytes()).map(Arc::new);
 
         let workers = (0..config.num_workers)
             .map(|id| {
@@ -208,7 +208,7 @@ impl WorkerGroup {
         assert!(config.num_workers.is_power_of_two());
         let config = Arc::new(config);
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = CacheManager::new(config.cache_size.as_bytes() as usize).map(Arc::new);
+        let cache_manager = CacheManager::new(config.cache_size.as_bytes()).map(Arc::new);
 
         let workers = (0..config.num_workers)
             .map(|id| {

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -131,6 +131,7 @@ impl WorkerGroup {
                     write_buffer_manager: write_buffer_manager.clone(),
                     scheduler: scheduler.clone(),
                     listener: WorkerListener::default(),
+                    cache_manager: cache_manager.clone(),
                 }
                 .start()
             })
@@ -220,6 +221,7 @@ impl WorkerGroup {
                     write_buffer_manager: write_buffer_manager.clone(),
                     scheduler: scheduler.clone(),
                     listener: WorkerListener::new(listener.clone()),
+                    cache_manager: cache_manager.clone(),
                 }
                 .start()
             })
@@ -246,6 +248,7 @@ struct WorkerStarter<S> {
     write_buffer_manager: WriteBufferManagerRef,
     scheduler: SchedulerRef,
     listener: WorkerListener,
+    cache_manager: CacheManagerRef,
 }
 
 impl<S: LogStore> WorkerStarter<S> {
@@ -274,6 +277,7 @@ impl<S: LogStore> WorkerStarter<S> {
             compaction_scheduler: CompactionScheduler::new(self.scheduler, sender.clone()),
             stalled_requests: StalledRequests::default(),
             listener: self.listener,
+            cache_manager: self.cache_manager,
         };
         let handle = common_runtime::spawn_write(async move {
             worker_thread.run().await;
@@ -428,6 +432,8 @@ struct RegionWorkerLoop<S> {
     stalled_requests: StalledRequests,
     /// Event listener for tests.
     listener: WorkerListener,
+    /// Cache.
+    cache_manager: CacheManagerRef,
 }
 
 impl<S: LogStore> RegionWorkerLoop<S> {

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -65,6 +65,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         )
         .metadata(metadata)
         .options(request.options)
+        .cache(Some(self.cache_manager.clone()))
         .create_or_open(&self.config, &self.wal)
         .await?;
 

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -63,6 +63,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             self.scheduler.clone(),
         )
         .options(request.options)
+        .cache(Some(self.cache_manager.clone()))
         .open(&self.config, &self.wal)
         .await?;
 

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -19,7 +19,7 @@ datafusion-expr.workspace = true
 datafusion.workspace = true
 datatypes = { workspace = true }
 meta-client = { workspace = true }
-moka = { version = "0.9", features = ["future"] }
+moka = { workspace = true, features = ["future"] }
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -662,6 +662,7 @@ max_background_jobs = 4
 auto_flush_interval = "30m"
 global_write_buffer_size = "1GiB"
 global_write_buffer_reject_size = "2GiB"
+cache_size = "512MiB"
 
 [[region_engine]]
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -662,7 +662,7 @@ max_background_jobs = 4
 auto_flush_interval = "30m"
 global_write_buffer_size = "1GiB"
 global_write_buffer_reject_size = "2GiB"
-cache_size = "512MiB"
+sst_meta_cache_size = "128MiB"
 
 [[region_engine]]
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a manager `CacheManager` to cache data for the mito engine. This is the first step to implement a cache component for the engine.

It implements a cache layer `AsyncFileReaderCache` for parquet's `AsyncFileReader` trait so we can return our cached metadata to `ParquetRecordBatchStreamBuilder`. The `AsyncFileReaderCache` also has local cached metadata. It is unused now but is useful when we implement row group readers that require building `ParquetRecordBatchStreamBuilder` multiple times.

Now the `CacheManager` only caches metadata of the parquet file. This might provide less improvement in performance. I'll start refactoring our `ParquetReader` to support caching other data after this PR is merged.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
