### PR TITLE
feat: the schema of RegionMetadata is not output during debug

### DIFF
--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -38,7 +38,7 @@ use crate::types::{
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch(DataType)]
 pub enum ConcreteDataType {
     Null(NullType),
@@ -78,6 +78,35 @@ pub enum ConcreteDataType {
 }
 
 impl fmt::Display for ConcreteDataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConcreteDataType::Null(_) => write!(f, "Null"),
+            ConcreteDataType::Boolean(_) => write!(f, "Boolean"),
+            ConcreteDataType::Int8(_) => write!(f, "Int8"),
+            ConcreteDataType::Int16(_) => write!(f, "Int16"),
+            ConcreteDataType::Int32(_) => write!(f, "Int32"),
+            ConcreteDataType::Int64(_) => write!(f, "Int64"),
+            ConcreteDataType::UInt8(_) => write!(f, "UInt8"),
+            ConcreteDataType::UInt16(_) => write!(f, "UInt16"),
+            ConcreteDataType::UInt32(_) => write!(f, "UInt32"),
+            ConcreteDataType::UInt64(_) => write!(f, "UInt64"),
+            ConcreteDataType::Float32(_) => write!(f, "Float32"),
+            ConcreteDataType::Float64(_) => write!(f, "Float64"),
+            ConcreteDataType::Binary(_) => write!(f, "Binary"),
+            ConcreteDataType::String(_) => write!(f, "String"),
+            ConcreteDataType::Date(_) => write!(f, "Date"),
+            ConcreteDataType::DateTime(_) => write!(f, "DateTime"),
+            ConcreteDataType::Timestamp(_) => write!(f, "Timestamp"),
+            ConcreteDataType::Time(_) => write!(f, "Time"),
+            ConcreteDataType::List(_) => write!(f, "List"),
+            ConcreteDataType::Dictionary(_) => write!(f, "Dictionary"),
+            ConcreteDataType::Interval(_) => write!(f, "Interval"),
+            ConcreteDataType::Duration(_) => write!(f, "Duration"),
+        }
+    }
+}
+
+impl fmt::Debug for ConcreteDataType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConcreteDataType::Null(_) => write!(f, "Null"),

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
 use std::sync::Arc;
 
 use arrow::compute::cast as arrow_array_cast;
@@ -38,7 +37,7 @@ use crate::types::{
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch(DataType)]
 pub enum ConcreteDataType {
     Null(NullType),
@@ -78,35 +77,6 @@ pub enum ConcreteDataType {
 }
 
 impl fmt::Display for ConcreteDataType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ConcreteDataType::Null(_) => write!(f, "Null"),
-            ConcreteDataType::Boolean(_) => write!(f, "Boolean"),
-            ConcreteDataType::Int8(_) => write!(f, "Int8"),
-            ConcreteDataType::Int16(_) => write!(f, "Int16"),
-            ConcreteDataType::Int32(_) => write!(f, "Int32"),
-            ConcreteDataType::Int64(_) => write!(f, "Int64"),
-            ConcreteDataType::UInt8(_) => write!(f, "UInt8"),
-            ConcreteDataType::UInt16(_) => write!(f, "UInt16"),
-            ConcreteDataType::UInt32(_) => write!(f, "UInt32"),
-            ConcreteDataType::UInt64(_) => write!(f, "UInt64"),
-            ConcreteDataType::Float32(_) => write!(f, "Float32"),
-            ConcreteDataType::Float64(_) => write!(f, "Float64"),
-            ConcreteDataType::Binary(_) => write!(f, "Binary"),
-            ConcreteDataType::String(_) => write!(f, "String"),
-            ConcreteDataType::Date(_) => write!(f, "Date"),
-            ConcreteDataType::DateTime(_) => write!(f, "DateTime"),
-            ConcreteDataType::Timestamp(_) => write!(f, "Timestamp"),
-            ConcreteDataType::Time(_) => write!(f, "Time"),
-            ConcreteDataType::List(_) => write!(f, "List"),
-            ConcreteDataType::Dictionary(_) => write!(f, "Dictionary"),
-            ConcreteDataType::Interval(_) => write!(f, "Interval"),
-            ConcreteDataType::Duration(_) => write!(f, "Duration"),
-        }
-    }
-}
-
-impl fmt::Debug for ConcreteDataType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConcreteDataType::Null(_) => write!(f, "Null"),

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::sync::Arc;
 
 use arrow::compute::cast as arrow_array_cast;
@@ -37,7 +38,7 @@ use crate::types::{
 use crate::value::Value;
 use crate::vectors::MutableVector;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[enum_dispatch::enum_dispatch(DataType)]
 pub enum ConcreteDataType {
     Null(NullType),

--- a/src/datatypes/src/schema.rs
+++ b/src/datatypes/src/schema.rs
@@ -17,6 +17,7 @@ mod constraint;
 mod raw;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema as ArrowSchema};
@@ -32,7 +33,7 @@ pub use crate::schema::raw::RawSchema;
 pub const VERSION_KEY: &str = "greptime:version";
 
 /// A common schema, should be immutable.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Schema {
     column_schemas: Vec<ColumnSchema>,
     name_to_index: HashMap<String, usize>,
@@ -46,6 +47,17 @@ pub struct Schema {
     ///
     /// Initial value is zero. The version should bump after altering schema.
     version: u32,
+}
+
+impl fmt::Debug for Schema {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Schema")
+            .field("column_schemas", &self.column_schemas)
+            .field("name_to_index", &self.name_to_index)
+            .field("timestamp_index", &self.timestamp_index)
+            .field("version", &self.version)
+            .finish()
+    }
 }
 
 impl Schema {

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -430,7 +430,7 @@ mod tests {
 
         let formatted_int8 = format!("{:?}", column_schema_int8);
         let formatted_int32 = format!("{:?}", column_schema_int32);
-        assert_eq!(formatted_int8, "test_column_1 Int8 nullable");
+        assert_eq!(formatted_int8, "test_column_1 Int8 null");
         assert_eq!(formatted_int32, "test_column_2 Int32 not null");
     }
 }

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -51,11 +51,7 @@ impl fmt::Debug for ColumnSchema {
             "{} {} {}",
             self.name,
             self.data_type,
-            if self.is_nullable {
-                "null"
-            } else {
-                "not null"
-            },
+            if self.is_nullable { "null" } else { "not null" },
         )?;
 
         // Add default constraint if present

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -52,7 +52,7 @@ impl fmt::Debug for ColumnSchema {
             self.name,
             self.data_type,
             if self.is_nullable {
-                "nullable"
+                "null"
             } else {
                 "not null"
             },

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use arrow::datatypes::Field;
 use serde::{Deserialize, Serialize};
@@ -33,7 +34,7 @@ pub const COMMENT_KEY: &str = "greptime:storage:comment";
 const DEFAULT_CONSTRAINT_KEY: &str = "greptime:default_constraint";
 
 /// Schema of a column, used as an immutable struct.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ColumnSchema {
     pub name: String,
     pub data_type: ConcreteDataType,
@@ -41,6 +42,34 @@ pub struct ColumnSchema {
     is_time_index: bool,
     default_constraint: Option<ColumnDefaultConstraint>,
     metadata: Metadata,
+}
+
+impl fmt::Debug for ColumnSchema {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut formatted = format!(
+            "{} {} {}",
+            self.name,
+            self.data_type,
+            if self.is_nullable {
+                "nullable"
+            } else {
+                "not null"
+            },
+        );
+
+        // Add default constraint if present
+        if let Some(default_constraint) = &self.default_constraint {
+            formatted.push_str(&format!(" default={:?}", default_constraint));
+        }
+
+        // Add metadata if present
+        if !self.metadata.is_empty() {
+            formatted.push_str(&format!(" metadata={:?}", self.metadata));
+        }
+
+        // Write the formatted string to the formatter
+        write!(f, "{}", formatted)
+    }
 }
 
 impl ColumnSchema {

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -426,9 +426,15 @@ mod tests {
 
     #[test]
     fn test_debug_for_column_schema() {
-        let column_schema = ColumnSchema::new("test_column", ConcreteDataType::int32_datatype(), false);
+        let column_schema_int8 =
+            ColumnSchema::new("test_column_1", ConcreteDataType::int8_datatype(), true);
 
-        let formated = format!("{:?}", column_schema);
-        assert_eq!(formated, "test_column Int32 not null");
+        let column_schema_int32 =
+            ColumnSchema::new("test_column_2", ConcreteDataType::int32_datatype(), false);
+
+        let formatted_int8 = format!("{:?}", column_schema_int8);
+        let formatted_int32 = format!("{:?}", column_schema_int32);
+        assert_eq!(formatted_int8, "test_column_1 Int8 nullable");
+        assert_eq!(formatted_int32, "test_column_2 Int32 not null");
     }
 }

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -46,7 +46,8 @@ pub struct ColumnSchema {
 
 impl fmt::Debug for ColumnSchema {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut formatted = format!(
+        write!(
+            f,
             "{} {} {}",
             self.name,
             self.data_type,
@@ -55,20 +56,19 @@ impl fmt::Debug for ColumnSchema {
             } else {
                 "not null"
             },
-        );
+        )?;
 
         // Add default constraint if present
         if let Some(default_constraint) = &self.default_constraint {
-            formatted.push_str(&format!(" default={:?}", default_constraint));
+            write!(f, " default={:?}", default_constraint)?;
         }
 
         // Add metadata if present
         if !self.metadata.is_empty() {
-            formatted.push_str(&format!(" metadata={:?}", self.metadata));
+            write!(f, " metadata={:?}", self.metadata)?;
         }
 
-        // Write the formatted string to the formatter
-        write!(f, "{}", formatted)
+        Ok(())
     }
 }
 
@@ -422,5 +422,13 @@ mod tests {
     fn test_column_schema_single_no_default() {
         let column_schema = ColumnSchema::new("test", ConcreteDataType::int32_datatype(), false);
         assert!(column_schema.create_default().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_debug_for_column_schema() {
+        let column_schema = ColumnSchema::new("test_column", ConcreteDataType::int32_datatype(), false);
+
+        let formated = format!("{:?}", column_schema);
+        assert_eq!(formated, "test_column Int32 not null");
     }
 }

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -39,7 +39,7 @@ use crate::storage::{ColumnId, RegionId};
 pub type Result<T> = std::result::Result<T, MetadataError>;
 
 /// Metadata of a column.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ColumnMetadata {
     /// Schema of this column. Is the same as `column_schema` in [SchemaRef].
     pub column_schema: ColumnSchema,
@@ -47,6 +47,17 @@ pub struct ColumnMetadata {
     pub semantic_type: SemanticType,
     /// Immutable and unique id of a region.
     pub column_id: ColumnId,
+}
+
+impl fmt::Debug for ColumnMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let formatted = format!(
+            "[{:?} {:?} {:?}]",
+            self.column_schema, self.semantic_type, self.column_id,
+        );
+        // Write the formatted string to the formatter
+        write!(f, "{}", formatted)
+    }
 }
 
 impl ColumnMetadata {

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -140,7 +140,6 @@ impl fmt::Debug for RegionMetadata {
         f.debug_struct("RegionMetadata")
             .field("column_metadatas", &self.column_metadatas)
             .field("time_index", &self.time_index)
-            .field("id_to_index", &self.id_to_index)
             .field("primary_key", &self.primary_key)
             .field("region_id", &self.region_id)
             .field("schema_version", &self.schema_version)

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -51,12 +51,11 @@ pub struct ColumnMetadata {
 
 impl fmt::Debug for ColumnMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let formatted = format!(
+        write!(
+            f,
             "[{:?} {:?} {:?}]",
             self.column_schema, self.semantic_type, self.column_id,
-        );
-        // Write the formatted string to the formatter
-        write!(f, "{}", formatted)
+        )
     }
 }
 
@@ -1129,5 +1128,12 @@ mod test {
                 .contains("internal column name that can not be used"),
             "unexpected err: {err}",
         );
+    }
+
+    #[test]
+    fn test_debug_for_column_metadata() {
+        let region_metadata = build_test_region_metadata();
+        let formated = format!("{:?}", region_metadata);
+        assert_eq!(formated, "RegionMetadata { column_metadatas: [[a Int64 not null Tag 1], [b Float64 not null Field 2], [c Timestamp not null Timestamp 3]], time_index: 3, primary_key: [1], region_id: 5299989648942(1234, 5678), schema_version: 0 }");
     }
 }

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -1133,7 +1133,7 @@ mod test {
     #[test]
     fn test_debug_for_column_metadata() {
         let region_metadata = build_test_region_metadata();
-        let formated = format!("{:?}", region_metadata);
-        assert_eq!(formated, "RegionMetadata { column_metadatas: [[a Int64 not null Tag 1], [b Float64 not null Field 2], [c Timestamp not null Timestamp 3]], time_index: 3, primary_key: [1], region_id: 5299989648942(1234, 5678), schema_version: 0 }");
+        let formatted = format!("{:?}", region_metadata);
+        assert_eq!(formatted, "RegionMetadata { column_metadatas: [[a Int64 not null Tag 1], [b Float64 not null Field 2], [c Timestamp not null Timestamp 3]], time_index: 3, primary_key: [1], region_id: 5299989648942(1234, 5678), schema_version: 0 }");
     }
 }

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -18,6 +18,7 @@
 
 use std::any::Any;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::sync::Arc;
 
 use api::helper::ColumnDataTypeWrapper;
@@ -105,7 +106,7 @@ impl ColumnMetadata {
 /// RegionMetadata o-- ColumnMetadata
 /// ColumnMetadata o-- SemanticType
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, PartialEq, Eq, Serialize)]
 pub struct RegionMetadata {
     /// Latest schema constructed from [column_metadatas](RegionMetadata::column_metadatas).
     #[serde(skip)]
@@ -132,6 +133,19 @@ pub struct RegionMetadata {
     ///
     /// The version starts from 0. Altering the schema bumps the version.
     pub schema_version: u64,
+}
+
+impl fmt::Debug for RegionMetadata {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("RegionMetadata")
+            .field("column_metadatas", &self.column_metadatas)
+            .field("time_index", &self.time_index)
+            .field("id_to_index", &self.id_to_index)
+            .field("primary_key", &self.primary_key)
+            .field("region_id", &self.region_id)
+            .field("schema_version", &self.schema_version)
+            .finish()
+    }
 }
 
 pub type RegionMetadataRef = Arc<RegionMetadata>;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- `schema` and `column_metadatas`(in `struct RegionMetadata`) contain the same information for column schma
- the content of `column_schemas` and `arrow_schema`(in `struct Schema`) are very similar
- In debugg, reduce redundant information in the output

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
