### PR TITLE
refactor: simplify `warn!` and `error!` macros

### DIFF
--- a/src/common/telemetry/src/macros.rs
+++ b/src/common/telemetry/src/macros.rs
@@ -38,35 +38,19 @@ macro_rules! error {
 
     // error!(e; target: "my_target", "a {} event", "log")
     ($e:expr; target: $target:expr, $($arg:tt)+) => ({
-        use $crate::common_error::ext::ErrorExt;
-        use $crate::common_error::ext::StackError;
-
-        let mut stacks = vec![];
-        $e.debug_fmt(0, &mut stacks);
-        let stacks = stacks.join("\n");
-
         $crate::log!(
             target: $target,
             $crate::logging::Level::ERROR,
-            err.msg = %stacks,
-            err.code = %$e.status_code(),
+            err.msg = ?$e,
             $($arg)+
         )
     });
 
     // error!(e; "a {} event", "log")
     ($e:expr; $($arg:tt)+) => ({
-        use $crate::common_error::ext::ErrorExt;
-        use $crate::common_error::ext::StackError;
-
-        let mut stacks = vec![];
-        $e.debug_fmt(0, &mut stacks);
-        let stacks = stacks.join("\n");
-
         $crate::log!(
             $crate::logging::Level::ERROR,
-            err.msg = %stacks,
-            err.code = %$e.status_code(),
+            err.msg = ?$e,
             $($arg)+
         )
     });
@@ -87,17 +71,9 @@ macro_rules! warn {
 
     // warn!(e; "a {} event", "log")
     ($e:expr; $($arg:tt)+) => ({
-        use $crate::common_error::ext::ErrorExt;
-        use $crate::common_error::ext::StackError;
-
-        let mut stacks = vec![];
-        $e.debug_fmt(0, &mut stacks);
-        let stacks = stacks.join("\n");
-
         $crate::log!(
             $crate::logging::Level::WARN,
-            err.msg = %$e,
-            err.code = %$e.status_code(),
+            err.msg = ?$e,
             $($arg)+
         )
     });

--- a/src/common/telemetry/src/macros.rs
+++ b/src/common/telemetry/src/macros.rs
@@ -41,7 +41,7 @@ macro_rules! error {
         $crate::log!(
             target: $target,
             $crate::logging::Level::ERROR,
-            err.msg = ?$e,
+            err = ?$e,
             $($arg)+
         )
     });
@@ -51,7 +51,7 @@ macro_rules! error {
         $crate::log!(
             target: $target,
             $crate::logging::Level::ERROR,
-            err.msg = %$e,
+            err = %$e,
             $($arg)+
         )
     });
@@ -60,7 +60,7 @@ macro_rules! error {
     ($e:expr; $($arg:tt)+) => ({
         $crate::log!(
             $crate::logging::Level::ERROR,
-            err.msg = ?$e,
+            err = ?$e,
             $($arg)+
         )
     });
@@ -69,7 +69,7 @@ macro_rules! error {
     (%$e:expr; $($arg:tt)+) => ({
         $crate::log!(
             $crate::logging::Level::ERROR,
-            err.msg = %$e,
+            err = %$e,
             $($arg)+
         )
     });
@@ -92,7 +92,7 @@ macro_rules! warn {
     ($e:expr; $($arg:tt)+) => ({
         $crate::log!(
             $crate::logging::Level::WARN,
-            err.msg = ?$e,
+            err = ?$e,
             $($arg)+
         )
     });
@@ -101,7 +101,7 @@ macro_rules! warn {
     (%$e:expr; $($arg:tt)+) => ({
         $crate::log!(
             $crate::logging::Level::WARN,
-            err.msg = %$e,
+            err = %$e,
             $($arg)+
         )
     });

--- a/src/common/telemetry/src/macros.rs
+++ b/src/common/telemetry/src/macros.rs
@@ -46,11 +46,30 @@ macro_rules! error {
         )
     });
 
+    // error!(%e; target: "my_target", "a {} event", "log")
+    (%$e:expr; target: $target:expr, $($arg:tt)+) => ({
+        $crate::log!(
+            target: $target,
+            $crate::logging::Level::ERROR,
+            err.msg = %$e,
+            $($arg)+
+        )
+    });
+
     // error!(e; "a {} event", "log")
     ($e:expr; $($arg:tt)+) => ({
         $crate::log!(
             $crate::logging::Level::ERROR,
             err.msg = ?$e,
+            $($arg)+
+        )
+    });
+
+    // error!(%e; "a {} event", "log")
+    (%$e:expr; $($arg:tt)+) => ({
+        $crate::log!(
+            $crate::logging::Level::ERROR,
+            err.msg = %$e,
             $($arg)+
         )
     });
@@ -74,6 +93,15 @@ macro_rules! warn {
         $crate::log!(
             $crate::logging::Level::WARN,
             err.msg = ?$e,
+            $($arg)+
+        )
+    });
+
+    // warn!(%e; "a {} event", "log")
+    (%$e:expr; $($arg:tt)+) => ({
+        $crate::log!(
+            $crate::logging::Level::WARN,
+            err.msg = %$e,
             $($arg)+
         )
     });
@@ -197,8 +225,10 @@ mod tests {
         error!(target: "my_target", "hello {}", "world");
         // Supports both owned and reference type.
         error!(err; target: "my_target", "hello {}", "world");
+        error!(%err; target: "my_target", "hello {}", "world");
         error!(err_ref; target: "my_target", "hello {}", "world");
         error!(err_ref2; "hello {}", "world");
+        error!(%err_ref2; "hello {}", "world");
         error!("hello {}", "world");
 
         let root_err = MockError::with_source(err);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Simplify the implementation. Use debug format by default and remove the status code. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
closes https://github.com/GreptimeTeam/greptimedb/issues/2502