### PR TITLE
fix(mito): fix region drop task runs multiple times but never clean the dir

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -230,7 +230,7 @@ impl MitoEngine {
         mut config: MitoConfig,
         log_store: Arc<S>,
         object_store: ObjectStore,
-        write_buffer_manager: crate::flush::WriteBufferManagerRef,
+        write_buffer_manager: Option<crate::flush::WriteBufferManagerRef>,
         listener: Option<crate::engine::listener::EventListenerRef>,
     ) -> MitoEngine {
         config.sanitize();

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -12,19 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+use std::time::Duration;
+
+use api::v1::Rows;
 use object_store::util::join_path;
 use store_api::region_engine::RegionEngine;
 use store_api::region_request::{RegionDropRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use crate::config::MitoConfig;
-use crate::test_util::{CreateRequestBuilder, TestEnv};
+use crate::engine::listener::DropListener;
+use crate::test_util::{
+    build_rows_for_key, flush_region, put_rows, rows_schema, CreateRequestBuilder, TestEnv,
+};
 use crate::worker::DROPPING_MARKER_FILE;
 
 #[tokio::test]
 async fn test_engine_drop_region() {
+    common_telemetry::init_default_ut_logging();
+
     let mut env = TestEnv::with_prefix("drop");
-    let engine = env.create_engine(MitoConfig::default()).await;
+    let listener = Arc::new(DropListener::new(Duration::from_millis(100)));
+    let engine = env
+        .create_engine_with(MitoConfig::default(), None, Some(listener.clone()))
+        .await;
 
     let region_id = RegionId::new(1, 1);
     // It's okay to drop a region doesn't exist.
@@ -34,13 +46,14 @@ async fn test_engine_drop_region() {
         .unwrap_err();
 
     let request = CreateRequestBuilder::new().build();
+    let column_schemas = rows_schema(&request);
     engine
         .handle_request(region_id, RegionRequest::Create(request))
         .await
         .unwrap();
 
     let region = engine.get_region(region_id).unwrap();
-    let region_dir = region.access_layer.region_dir().to_owned();
+    let region_dir = region.access_layer.region_dir().to_string();
     // no dropping marker file
     assert!(!env
         .get_object_store()
@@ -49,12 +62,12 @@ async fn test_engine_drop_region() {
         .await
         .unwrap());
 
-    // create a parquet file
-    env.get_object_store()
-        .unwrap()
-        .write(&join_path(&region_dir, "blabla.parquet"), vec![])
-        .await
-        .unwrap();
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 2, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+    flush_region(&engine, region_id).await;
 
     // drop the created region.
     engine
@@ -62,11 +75,10 @@ async fn test_engine_drop_region() {
         .await
         .unwrap();
     assert!(!engine.is_region_exists(region_id));
-    // the drop marker is not removed yet
-    assert!(env
-        .get_object_store()
-        .unwrap()
-        .is_exist(&join_path(&region_dir, DROPPING_MARKER_FILE))
-        .await
-        .unwrap());
+
+    // Wait for drop task.
+    listener.wait().await;
+
+    let object_store = env.get_object_store().unwrap();
+    assert!(!object_store.is_exist(&region_dir).await.unwrap());
 }

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -76,7 +76,7 @@ async fn test_flush_engine() {
     let engine = env
         .create_engine_with(
             MitoConfig::default(),
-            write_buffer_manager.clone(),
+            Some(write_buffer_manager.clone()),
             Some(listener.clone()),
         )
         .await;
@@ -135,7 +135,7 @@ async fn test_write_stall() {
     let engine = env
         .create_engine_with(
             MitoConfig::default(),
-            write_buffer_manager.clone(),
+            Some(write_buffer_manager.clone()),
             Some(listener.clone()),
         )
         .await;
@@ -197,7 +197,11 @@ async fn test_flush_empty() {
     let mut env = TestEnv::new();
     let write_buffer_manager = Arc::new(MockWriteBufferManager::default());
     let engine = env
-        .create_engine_with(MitoConfig::default(), write_buffer_manager.clone(), None)
+        .create_engine_with(
+            MitoConfig::default(),
+            Some(write_buffer_manager.clone()),
+            None,
+        )
         .await;
 
     let region_id = RegionId::new(1, 1);

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -270,7 +270,7 @@ async fn test_engine_truncate_during_flush() {
     let engine = env
         .create_engine_with(
             MitoConfig::default(),
-            write_buffer_manager.clone(),
+            Some(write_buffer_manager),
             Some(listener.clone()),
         )
         .await;

--- a/src/mito2/src/sst/version.rs
+++ b/src/mito2/src/sst/version.rs
@@ -75,9 +75,9 @@ impl SstVersion {
         }
     }
 
-    /// Mark all SSTs in this version as deleted.
+    /// Marks all SSTs in this version as deleted.
     pub(crate) fn mark_all_deleted(&self) {
-        for level_meta in self.levels.iter() {
+        for level_meta in &self.levels {
             for file_handle in level_meta.files.values() {
                 file_handle.mark_deleted();
             }

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -120,7 +120,7 @@ impl TestEnv {
     pub async fn create_engine_with(
         &mut self,
         config: MitoConfig,
-        manager: WriteBufferManagerRef,
+        manager: Option<WriteBufferManagerRef>,
         listener: Option<EventListenerRef>,
     ) -> MitoEngine {
         let (log_store, object_store) = self.create_log_and_object_store().await;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes the following issues while dropping a region
- background later drop task never exits until it exceeds max retry times
- the dropping region map keeps the region that references all SSTs thus we can't purge them. This PR reset the `Version` so the region releases the references to SSTs and purges them.

It also adds a test to check whether the region directory is removed as expected.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
closes #2501