### PR TITLE
refactor: check push result out of loop

### DIFF
--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -149,17 +149,24 @@ impl Pushers {
             .range(range)
             .map(|(_, value)| value)
             .collect::<Vec<_>>();
+        let mut results = Vec::with_capacity(pushers.len());
+
         for pusher in pushers {
             let mut mailbox_message = mailbox_message.clone();
             mailbox_message.id = 0; // one-way message
-            pusher
-                .push(HeartbeatResponse {
-                    header: Some(pusher.header()),
-                    mailbox_message: Some(mailbox_message),
-                    ..Default::default()
-                })
-                .await?;
+
+            results.push(
+                pusher
+                    .push(HeartbeatResponse {
+                        header: Some(pusher.header()),
+                        mailbox_message: Some(mailbox_message),
+                        ..Default::default()
+                    })
+                    .await,
+            )
         }
+
+        results.into_iter().collect::<Result<Vec<_>>>()?;
 
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`Receiver` may be closed unexpectedly. It shouldn't be handled in fail fast. Let's check the push result out of the loop.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
