### PR TITLE
feat: push down filters to region engine

### DIFF
--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -36,7 +36,7 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DfResult;
 use datafusion::execution::context::SessionState;
 use datafusion_common::DataFusionError;
-use datafusion_expr::{Expr as DfExpr, TableType};
+use datafusion_expr::{Expr as DfExpr, TableProviderFilterPushDown, TableType};
 use datatypes::arrow::datatypes::SchemaRef;
 use futures_util::future::try_join_all;
 use prost::Message;
@@ -497,5 +497,12 @@ impl TableProvider for DummyTableProvider {
         Ok(Arc::new(DfPhysicalPlanAdapter(Arc::new(
             StreamScanAdapter::new(stream),
         ))))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&DfExpr],
+    ) -> DfResult<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Previous `TableProviderFilterPushDown::Unsupported` prevented pushdown

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
