### PR TITLE
perf(mito): Use a heap to merge batches for the same key

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -396,7 +396,7 @@ impl Batch {
             other => panic!("timestamps in a Batch has other type {:?}", other),
         };
 
-        Some(&**&values)
+        Some(values)
     }
 
     /// Takes the batch in place.

--- a/src/mito2/src/read/merge.rs
+++ b/src/mito2/src/read/merge.rs
@@ -305,8 +305,9 @@ impl BatchMerger {
 /// Skips first `num_to_skip` rows from the batch and pushes remaining batch into the heap if the batch
 /// is still not empty.
 fn push_remaining_to_heap(heap: &mut BinaryHeap<CompareTimeSeq>, batch: Batch, num_to_skip: usize) {
+    debug_assert!(batch.num_rows() >= num_to_skip);
     let remaining = batch.num_rows() - num_to_skip;
-    if remaining <= 0 {
+    if remaining == 0 {
         // Nothing remains.
         return;
     }

--- a/src/mito2/src/read/merge.rs
+++ b/src/mito2/src/read/merge.rs
@@ -235,7 +235,7 @@ impl BatchMerger {
         }
 
         // Slow path. We need to merge overlapping batches.
-        // Contructs a heap from batches. Batches in the heap is not empty, we need to check
+        // Constructs a heap from batches. Batches in the heap is not empty, we need to check
         // this before pushing a batch into the heap.
         let mut heap = BinaryHeap::from_iter(self.batches.drain(..).map(CompareTimeSeq));
         // Reset merger as sorted as we have cleared batches.
@@ -282,10 +282,10 @@ impl BatchMerger {
                         // Keeps the timestamp in top and skips the first timestamp in the `next`
                         // batch.
                         push_remaining_to_heap(&mut heap, next, 1);
-                        // Skips already outputed timestamps.
+                        // Skips already outputted timestamps.
                         push_remaining_to_heap(&mut heap, top, pos);
                     } else {
-                        // Keeps timestamp in next and skips the duplicated timestamp and already outputed
+                        // Keeps timestamp in next and skips the duplicated timestamp and already outputted
                         // timestamp in top.
                         push_remaining_to_heap(&mut heap, top, pos + 1);
                     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR uses a heap to merge sorted batches in the `BatchMerger` instead of concatenating these batches and uses `sort_and_dedup()`. It also avoids concatenating batches as it introduces additional overhead.

These changes can speed up the merge reader when input batches don't have too many overlapping rows.

On Apple M1 Pro, merging 148797 sorted batches with 100,000,000+ rows took 2.2s before and 358ms now. Note that this only considers the cost of `BatchMerger`, not the whole `MergeReader`.

|  Before  | After |
|  ----  | ----  |
| 2.2s | 358ms |

It also fixes an issue that if a batch is empty after `filter_deleted()`, the reader will return `None` even if there are remaining batches.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
