### PR TITLE
feat(mito): Cache repeated vector for tags

### DIFF
--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -104,11 +104,18 @@ impl CacheManager {
         }
     }
 
-    /// Get a repeated vector for specific `value`.
-    pub fn get_repeated_vector(&self, value: &Value) -> Option<VectorRef> {
+    /// Gets a vector with repeated value for specific `key`.
+    pub fn get_repeated_vector(&self, key: &Value) -> Option<VectorRef> {
         self.vector_cache
             .as_ref()
-            .and_then(|vector_cache| vector_cache.get(value))
+            .and_then(|vector_cache| vector_cache.get(key))
+    }
+
+    /// Puts a vector with repeated value into the cache.
+    pub fn put_repeated_vector(&self, key: Value, vector: VectorRef) {
+        if let Some(cache) = &self.vector_cache {
+            cache.insert(key, vector);
+        }
     }
 }
 

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -152,7 +152,7 @@ mod tests {
         assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
 
         let value = Value::Int64(10);
-        let vector: VectorRef = Arc::new(Int64Vector::from_slice(&[10, 10, 10, 10]));
+        let vector: VectorRef = Arc::new(Int64Vector::from_slice([10, 10, 10, 10]));
         cache.put_repeated_vector(value.clone(), vector.clone());
         assert!(cache.get_repeated_vector(&value).is_none());
     }
@@ -175,7 +175,7 @@ mod tests {
         let cache = CacheManager::new(0, 4096);
         let value = Value::Int64(10);
         assert!(cache.get_repeated_vector(&value).is_none());
-        let vector: VectorRef = Arc::new(Int64Vector::from_slice(&[10, 10, 10, 10]));
+        let vector: VectorRef = Arc::new(Int64Vector::from_slice([10, 10, 10, 10]));
         cache.put_repeated_vector(value.clone(), vector.clone());
         let cached = cache.get_repeated_vector(&value).unwrap();
         assert_eq!(vector, cached);

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -135,6 +135,8 @@ type VectorCache = Cache<Value, VectorRef>;
 
 #[cfg(test)]
 mod tests {
+    use datatypes::vectors::Int64Vector;
+
     use super::*;
     use crate::cache::test_util::parquet_meta;
 
@@ -148,6 +150,11 @@ mod tests {
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
         assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+
+        let value = Value::Int64(10);
+        let vector: VectorRef = Arc::new(Int64Vector::from_slice(&[10, 10, 10, 10]));
+        cache.put_repeated_vector(value.clone(), vector.clone());
+        assert!(cache.get_repeated_vector(&value).is_none());
     }
 
     #[test]
@@ -161,5 +168,16 @@ mod tests {
         assert!(cache.get_parquet_meta_data(region_id, file_id).is_some());
         cache.remove_parquet_meta_data(region_id, file_id);
         assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+    }
+
+    #[test]
+    fn test_repeated_vector_cache() {
+        let cache = CacheManager::new(0, 4096);
+        let value = Value::Int64(10);
+        assert!(cache.get_repeated_vector(&value).is_none());
+        let vector: VectorRef = Arc::new(Int64Vector::from_slice(&[10, 10, 10, 10]));
+        cache.put_repeated_vector(value.clone(), vector.clone());
+        let cached = cache.get_repeated_vector(&value).unwrap();
+        assert_eq!(vector, cached);
     }
 }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -119,7 +119,7 @@ impl CacheManager {
     }
 }
 
-/// Cache key for SST meta.
+/// Cache key (region id, file id) for SST meta.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct SstMetaKey(RegionId, FileId);
 
@@ -130,7 +130,11 @@ impl SstMetaKey {
     }
 }
 
+/// Maps (region id, file id) to [ParquetMetaData].
 type SstMetaCache = Cache<SstMetaKey, Arc<ParquetMetaData>>;
+/// Maps [Value] to a vector that holds this value repeatedly.
+///
+/// e.g. `"hello" => ["hello", "hello", "hello"]`
 type VectorCache = Cache<Value, VectorRef>;
 
 #[cfg(test)]

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -58,8 +58,10 @@ pub struct MitoConfig {
     pub global_write_buffer_reject_size: ReadableSize,
 
     // Cache configs:
-    /// Cache size for SST metadata (default 128MB). Setting it to 0 to disable cache.
+    /// Cache size for SST metadata (default 128MB). Setting it to 0 to disable the cache.
     pub sst_meta_cache_size: ReadableSize,
+    /// Cache size for vectors and arrow arrays (default 512MB). Setting it to 0 to disable the cache.
+    pub vector_cache_size: ReadableSize,
 }
 
 impl Default for MitoConfig {
@@ -75,6 +77,7 @@ impl Default for MitoConfig {
             global_write_buffer_size: ReadableSize::gb(1),
             global_write_buffer_reject_size: ReadableSize::gb(2),
             sst_meta_cache_size: ReadableSize::mb(128),
+            vector_cache_size: ReadableSize::mb(512),
         }
     }
 }

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -188,59 +188,21 @@ impl ReadRowHelper {
 mod tests {
     use api::v1;
     use api::v1::ColumnDataType;
-    use datatypes::prelude::ConcreteDataType;
-    use datatypes::schema::ColumnSchema;
-    use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
-    use store_api::storage::RegionId;
 
     use super::*;
     use crate::test_util::i64_value;
+    use crate::test_util::meta_util::TestRegionMetadataBuilder;
 
     const TS_NAME: &str = "ts";
     const START_SEQ: SequenceNumber = 100;
 
     /// Creates a region: `ts, k0, k1, ..., v0, v1, ...`
-    fn new_region_metadata(num_tag: usize, num_field: usize) -> RegionMetadata {
-        let mut builder = RegionMetadataBuilder::new(RegionId::new(1, 1));
-        let mut column_id = 0;
-        builder.push_column_metadata(ColumnMetadata {
-            column_schema: ColumnSchema::new(
-                TS_NAME,
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                false,
-            ),
-            semantic_type: SemanticType::Timestamp,
-            column_id,
-        });
-        // For simplicity, we use the same data type for tag/field columns.
-        let mut primary_key = Vec::with_capacity(num_tag);
-        for i in 0..num_tag {
-            column_id += 1;
-            builder.push_column_metadata(ColumnMetadata {
-                column_schema: ColumnSchema::new(
-                    format!("k{i}"),
-                    ConcreteDataType::int64_datatype(),
-                    true,
-                ),
-                semantic_type: SemanticType::Tag,
-                column_id,
-            });
-            primary_key.push(i as u32 + 1);
-        }
-        for i in 0..num_field {
-            column_id += 1;
-            builder.push_column_metadata(ColumnMetadata {
-                column_schema: ColumnSchema::new(
-                    format!("v{i}"),
-                    ConcreteDataType::int64_datatype(),
-                    true,
-                ),
-                semantic_type: SemanticType::Field,
-                column_id,
-            });
-        }
-        builder.primary_key(primary_key);
-        builder.build().unwrap()
+    fn new_region_metadata(num_tags: usize, num_fields: usize) -> RegionMetadata {
+        TestRegionMetadataBuilder::default()
+            .ts_name(TS_NAME)
+            .num_tags(num_tags)
+            .num_fields(num_fields)
+            .build()
     }
 
     /// Creates rows `[ 0, 1, ..., n ] x num_rows`

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -268,4 +268,37 @@ fn new_repeated_vector(
     Ok(base_vector.replicate(&[num_rows]))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::meta_util::TestRegionMetadataBuilder;
+
+    #[test]
+    fn test_projection_mapper_all() {
+        let metadata = Arc::new(
+            TestRegionMetadataBuilder::default()
+                .num_tags(2)
+                .num_fields(2)
+                .build(),
+        );
+        let mapper = ProjectionMapper::all(&metadata).unwrap();
+        assert_eq!([0, 1, 2, 3, 4], mapper.column_ids());
+        assert_eq!([3, 4], mapper.batch_fields());
+    }
+
+    #[test]
+    fn test_projection_mapper_with_projection() {
+        let metadata = Arc::new(
+            TestRegionMetadataBuilder::default()
+                .num_tags(2)
+                .num_fields(2)
+                .build(),
+        );
+        // Columns v1, k0
+        let mapper = ProjectionMapper::new(&metadata, [4, 1].into_iter()).unwrap();
+        assert_eq!([4, 1], mapper.column_ids());
+        assert_eq!([4], mapper.batch_fields());
+    }
+}
+
 // TODO(yingwen): Add tests for mapper.

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -15,6 +15,7 @@
 //! Utilities for testing.
 
 pub mod memtable_util;
+pub mod meta_util;
 pub mod scheduler_util;
 pub mod version_util;
 

--- a/src/mito2/src/test_util/meta_util.rs
+++ b/src/mito2/src/test_util/meta_util.rs
@@ -1,0 +1,107 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities to create a [RegionMetadata](store_api::metadata::RegionMetadata).
+
+use api::v1::SemanticType;
+use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::ColumnSchema;
+use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder};
+use store_api::storage::RegionId;
+
+/// Builder to builds a region with schema `ts, k0, k1, ..., v0, v1, ...`.
+///
+/// All tags and fields have int64 type.
+#[derive(Debug)]
+pub struct TestRegionMetadataBuilder {
+    region_id: RegionId,
+    ts_name: String,
+    num_tags: usize,
+    num_fields: usize,
+}
+
+impl Default for TestRegionMetadataBuilder {
+    fn default() -> Self {
+        Self {
+            region_id: RegionId::new(1, 1),
+            ts_name: "ts".to_string(),
+            num_tags: 1,
+            num_fields: 1,
+        }
+    }
+}
+
+impl TestRegionMetadataBuilder {
+    /// Sets ts name.
+    pub fn ts_name(&mut self, value: &str) -> &mut Self {
+        self.ts_name = value.to_string();
+        self
+    }
+
+    /// Sets tags num.
+    pub fn num_tags(&mut self, value: usize) -> &mut Self {
+        self.num_tags = value;
+        self
+    }
+
+    /// Sets fields num.
+    pub fn num_fields(&mut self, value: usize) -> &mut Self {
+        self.num_fields = value;
+        self
+    }
+
+    /// Builds a metadata.
+    pub fn build(&self) -> RegionMetadata {
+        let mut builder = RegionMetadataBuilder::new(self.region_id);
+        let mut column_id = 0;
+        builder.push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new(
+                &self.ts_name,
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            semantic_type: SemanticType::Timestamp,
+            column_id,
+        });
+        // For simplicity, we use the same data type for tag/field columns.
+        let mut primary_key = Vec::with_capacity(self.num_tags);
+        for i in 0..self.num_tags {
+            column_id += 1;
+            builder.push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    format!("k{i}"),
+                    ConcreteDataType::int64_datatype(),
+                    true,
+                ),
+                semantic_type: SemanticType::Tag,
+                column_id,
+            });
+            primary_key.push(i as u32 + 1);
+        }
+        for i in 0..self.num_fields {
+            column_id += 1;
+            builder.push_column_metadata(ColumnMetadata {
+                column_schema: ColumnSchema::new(
+                    format!("v{i}"),
+                    ConcreteDataType::int64_datatype(),
+                    true,
+                ),
+                semantic_type: SemanticType::Field,
+                column_id,
+            });
+        }
+        builder.primary_key(primary_key);
+        builder.build().unwrap()
+    }
+}

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -120,7 +120,10 @@ impl WorkerGroup {
             config.global_write_buffer_size.as_bytes() as usize,
         ));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = Arc::new(CacheManager::new(config.sst_meta_cache_size.as_bytes()));
+        let cache_manager = Arc::new(CacheManager::new(
+            config.sst_meta_cache_size.as_bytes(),
+            config.vector_cache_size.as_bytes(),
+        ));
 
         let workers = (0..config.num_workers)
             .map(|id| {
@@ -215,7 +218,10 @@ impl WorkerGroup {
             ))
         });
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = Arc::new(CacheManager::new(config.sst_meta_cache_size.as_bytes()));
+        let cache_manager = Arc::new(CacheManager::new(
+            config.sst_meta_cache_size.as_bytes(),
+            config.vector_cache_size.as_bytes(),
+        ));
 
         let workers = (0..config.num_workers)
             .map(|id| {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -663,6 +663,7 @@ auto_flush_interval = "30m"
 global_write_buffer_size = "1GiB"
 global_write_buffer_reject_size = "2GiB"
 sst_meta_cache_size = "128MiB"
+vector_cache_size = "512MiB"
 
 [[region_engine]]
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a cache for repeated vectors created in `ProjectionMapper::convert()`.

While returning tags to users, the mito engine needs to flatten tag values into vectors for each primary key. This is CPU expensive.

Before adding the cache, converting `140000+` batches (`700` rows on average) for `4000` timeseries takes `6.8s`. With vector cache, it takes `560ms`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
