### PR TITLE
fix(mito): pruning for mito2

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -35,6 +35,8 @@ mod open_test;
 #[cfg(test)]
 mod projection_test;
 #[cfg(test)]
+mod prune_test;
+#[cfg(test)]
 mod truncate_test;
 
 use std::sync::Arc;

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -44,7 +44,12 @@ async fn put_and_flush(
     put_rows(engine, region_id, rows).await;
 
     let Output::AffectedRows(rows) = engine
-        .handle_request(region_id, RegionRequest::Flush(RegionFlushRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Flush(RegionFlushRequest {
+                row_group_size: None,
+            }),
+        )
         .await
         .unwrap()
     else {
@@ -79,7 +84,12 @@ async fn delete_and_flush(
     assert_eq!(row_cnt, rows_affected);
 
     let Output::AffectedRows(rows) = engine
-        .handle_request(region_id, RegionRequest::Flush(RegionFlushRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Flush(RegionFlushRequest {
+                row_group_size: None,
+            }),
+        )
         .await
         .unwrap()
     else {

--- a/src/mito2/src/engine/drop_test.rs
+++ b/src/mito2/src/engine/drop_test.rs
@@ -67,7 +67,7 @@ async fn test_engine_drop_region() {
         rows: build_rows_for_key("a", 0, 2, 0),
     };
     put_rows(&engine, region_id, rows).await;
-    flush_region(&engine, region_id).await;
+    flush_region(&engine, region_id, None).await;
 
     // drop the created region.
     engine

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -49,7 +49,7 @@ async fn test_manual_flush() {
     };
     put_rows(&engine, region_id, rows).await;
 
-    flush_region(&engine, region_id).await;
+    flush_region(&engine, region_id, None).await;
 
     let request = ScanRequest::default();
     let scanner = engine.scanner(region_id, request).unwrap();
@@ -164,7 +164,7 @@ async fn test_write_stall() {
     tokio::spawn(async move {
         listener.wait().await;
 
-        flush_region(&engine_cloned, region_id).await;
+        flush_region(&engine_cloned, region_id, None).await;
     });
 
     // Triggers write stall.
@@ -212,7 +212,7 @@ async fn test_flush_empty() {
         .await
         .unwrap();
 
-    flush_region(&engine, region_id).await;
+    flush_region(&engine, region_id, None).await;
 
     let request = ScanRequest::default();
     let scanner = engine.scanner(region_id, request).unwrap();
@@ -247,7 +247,7 @@ async fn test_flush_reopen_region() {
     };
     put_rows(&engine, region_id, rows).await;
 
-    flush_region(&engine, region_id).await;
+    flush_region(&engine, region_id, None).await;
     let check_region = || {
         let region = engine.get_region(region_id).unwrap();
         let version_data = region.version_control.current();

--- a/src/mito2/src/engine/prune_test.rs
+++ b/src/mito2/src/engine/prune_test.rs
@@ -1,0 +1,102 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::Rows;
+use common_query::logical_plan::DfExpr;
+use common_query::prelude::Expr;
+use common_recordbatch::RecordBatches;
+use datafusion_common::ScalarValue;
+use datafusion_expr::lit;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::RegionRequest;
+use store_api::storage::{RegionId, ScanRequest};
+
+use crate::config::MitoConfig;
+use crate::test_util::{
+    build_rows, flush_region, put_rows, rows_schema, CreateRequestBuilder, TestEnv,
+};
+
+async fn check_prune_row_groups(expr: DfExpr, expected: &str) {
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    let column_schemas = rows_schema(&request);
+
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(0, 10),
+        },
+    )
+    .await;
+    flush_region(&engine, region_id, Some(5)).await;
+
+    let stream = engine
+        .handle_query(
+            region_id,
+            ScanRequest {
+                filters: vec![Expr::from(expr)],
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    assert_eq!(expected, batches.pretty_print().unwrap());
+}
+
+#[tokio::test]
+async fn test_read_parquet_stats() {
+    common_telemetry::init_default_ut_logging();
+
+    check_prune_row_groups(
+        datafusion_expr::col("ts").gt(lit(ScalarValue::TimestampMillisecond(Some(4000), None))),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 5     | 5.0     | 1970-01-01T00:00:05 |
+| 6     | 6.0     | 1970-01-01T00:00:06 |
+| 7     | 7.0     | 1970-01-01T00:00:07 |
+| 8     | 8.0     | 1970-01-01T00:00:08 |
+| 9     | 9.0     | 1970-01-01T00:00:09 |
++-------+---------+---------------------+",
+    )
+    .await;
+
+    check_prune_row_groups(
+        datafusion_expr::col("tag_0").gt(lit(ScalarValue::Utf8(Some("4".to_string())))),
+        "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 5     | 5.0     | 1970-01-01T00:00:05 |
+| 6     | 6.0     | 1970-01-01T00:00:06 |
+| 7     | 7.0     | 1970-01-01T00:00:07 |
+| 8     | 8.0     | 1970-01-01T00:00:08 |
+| 9     | 9.0     | 1970-01-01T00:00:09 |
++-------+---------+---------------------+",
+    )
+    .await;
+}

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -167,7 +167,12 @@ async fn test_engine_truncate_after_flush() {
 
     // Flush the region.
     engine
-        .handle_request(region_id, RegionRequest::Flush(RegionFlushRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Flush(RegionFlushRequest {
+                row_group_size: None,
+            }),
+        )
         .await
         .unwrap();
 
@@ -304,7 +309,12 @@ async fn test_engine_truncate_during_flush() {
     let flush_task = tokio::spawn(async move {
         info!("do flush task!!!!");
         engine_cloned
-            .handle_request(region_id, RegionRequest::Flush(RegionFlushRequest {}))
+            .handle_request(
+                region_id,
+                RegionRequest::Flush(RegionFlushRequest {
+                    row_group_size: None,
+                }),
+            )
             .await
     });
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -165,8 +165,9 @@ impl ScanRegion {
             .collect();
 
         debug!(
-            "Seq scan region {}, memtables: {}, ssts_to_read: {}, total_ssts: {}",
+            "Seq scan region {}, request: {:?}, memtables: {}, ssts_to_read: {}, total_ssts: {}",
             self.version.metadata.region_id,
+            self.request,
             memtables.len(),
             files.len(),
             total_ssts

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -16,6 +16,7 @@
 
 mod format;
 pub mod reader;
+mod stats;
 pub mod writer;
 
 use common_base::readable_size::ReadableSize;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -14,6 +14,7 @@
 
 //! Parquet reader.
 
+use std::collections::HashSet;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -151,6 +152,19 @@ impl ParquetReaderBuilder {
         // Decode region metadata.
         let key_value_meta = builder.metadata().file_metadata().key_value_metadata();
         let region_meta = self.get_region_metadata(file_path, key_value_meta)?;
+
+        let column_ids: HashSet<_> = self
+            .projection
+            .as_ref()
+            .map(|p| p.iter().cloned().collect())
+            .unwrap_or_else(|| {
+                region_meta
+                    .column_metadatas
+                    .iter()
+                    .map(|c| c.column_id)
+                    .collect()
+            });
+
         let read_format = ReadFormat::new(Arc::new(region_meta));
         // The arrow schema converted from the region meta should be the same as parquet's.
         // We only compare fields to avoid schema's metadata breaks the comparison.
@@ -171,7 +185,7 @@ impl ParquetReaderBuilder {
             let stats = RowGroupPruningStats::new(
                 builder.metadata().row_groups(),
                 &read_format,
-                self.projection.as_ref().map(|ids| ids.as_slice()),
+                column_ids,
             );
             let pruned_row_groups = predicate
                 .prune_with_stats(&stats)

--- a/src/mito2/src/sst/parquet/stats.rs
+++ b/src/mito2/src/sst/parquet/stats.rs
@@ -34,17 +34,16 @@ pub(crate) struct RowGroupPruningStats<'a> {
     ///
     /// We need column ids to distinguish different columns with the same name.
     /// e.g. Drops and then adds a column again.
-    column_ids: Option<HashSet<ColumnId>>,
+    column_ids: HashSet<ColumnId>,
 }
 
 impl<'a> RowGroupPruningStats<'a> {
-    /// Creates a new staticstics to prune specific `row_groups`.
+    /// Creates a new statistics to prune specific `row_groups`.
     pub(crate) fn new(
         row_groups: &'a [RowGroupMetaData],
         read_format: &'a ReadFormat,
-        column_ids: Option<&[ColumnId]>,
+        column_ids: HashSet<ColumnId>,
     ) -> Self {
-        let column_ids = column_ids.map(|ids| ids.iter().copied().collect());
         Self {
             row_groups,
             read_format,
@@ -58,11 +57,7 @@ impl<'a> RowGroupPruningStats<'a> {
         self.read_format
             .metadata()
             .column_by_name(name)
-            .and_then(|col| {
-                self.column_ids
-                    .as_ref()
-                    .and_then(|ids| ids.get(&col.column_id).copied())
-            })
+            .and_then(|col| self.column_ids.get(&col.column_id).copied())
     }
 }
 

--- a/src/mito2/src/sst/parquet/stats.rs
+++ b/src/mito2/src/sst/parquet/stats.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Statistics of parquet SSTs.
+
+use std::collections::HashSet;
+
+use datafusion::physical_optimizer::pruning::PruningStatistics;
+use datafusion_common::Column;
+use datatypes::arrow::array::ArrayRef;
+use parquet::file::metadata::RowGroupMetaData;
+use store_api::storage::ColumnId;
+
+use crate::sst::parquet::format::ReadFormat;
+
+/// Statistics for pruning row groups.
+pub(crate) struct RowGroupPruningStats<'a> {
+    /// Metadata of SST row groups.
+    row_groups: &'a [RowGroupMetaData],
+    /// Helper to read the SST.
+    read_format: &'a ReadFormat,
+    /// Projected column ids to read.
+    ///
+    /// We need column ids to distinguish different columns with the same name.
+    /// e.g. Drops and then adds a column again.
+    column_ids: Option<HashSet<ColumnId>>,
+}
+
+impl<'a> RowGroupPruningStats<'a> {
+    /// Creates a new staticstics to prune specific `row_groups`.
+    pub(crate) fn new(
+        row_groups: &'a [RowGroupMetaData],
+        read_format: &'a ReadFormat,
+        column_ids: Option<&[ColumnId]>,
+    ) -> Self {
+        let column_ids = column_ids.map(|ids| ids.iter().copied().collect());
+        Self {
+            row_groups,
+            read_format,
+            column_ids,
+        }
+    }
+
+    /// Returns the column id of specific column name if we need to read it.
+    fn column_id_to_prune(&self, name: &str) -> Option<ColumnId> {
+        // Only use stats when the column to read has the same id as the column in the SST.
+        self.read_format
+            .metadata()
+            .column_by_name(name)
+            .and_then(|col| {
+                self.column_ids
+                    .as_ref()
+                    .and_then(|ids| ids.get(&col.column_id).copied())
+            })
+    }
+}
+
+impl<'a> PruningStatistics for RowGroupPruningStats<'a> {
+    fn min_values(&self, column: &Column) -> Option<ArrayRef> {
+        let column_id = self.column_id_to_prune(&column.name)?;
+        self.read_format.min_values(self.row_groups, column_id)
+    }
+
+    fn max_values(&self, column: &Column) -> Option<ArrayRef> {
+        let column_id = self.column_id_to_prune(&column.name)?;
+        self.read_format.max_values(self.row_groups, column_id)
+    }
+
+    fn num_containers(&self) -> usize {
+        self.row_groups.len()
+    }
+
+    fn null_counts(&self, column: &Column) -> Option<ArrayRef> {
+        let column_id = self.column_id_to_prune(&column.name)?;
+        self.read_format.null_counts(self.row_groups, column_id)
+    }
+}

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -574,9 +574,12 @@ pub async fn delete_rows(engine: &MitoEngine, region_id: RegionId, rows: Rows) {
 }
 
 /// Flush a region manually.
-pub async fn flush_region(engine: &MitoEngine, region_id: RegionId) {
+pub async fn flush_region(engine: &MitoEngine, region_id: RegionId, row_group_size: Option<usize>) {
     let Output::AffectedRows(rows) = engine
-        .handle_request(region_id, RegionRequest::Flush(RegionFlushRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Flush(RegionFlushRequest { row_group_size }),
+        )
         .await
         .unwrap()
     else {

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -529,7 +529,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                     continue;
                 }
                 DdlRequest::Flush(req) => {
-                    self.handle_flush_request(ddl.region_id, req.row_group_size, ddl.sender)
+                    self.handle_flush_request(ddl.region_id, req, ddl.sender)
                         .await;
                     continue;
                 }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -528,8 +528,9 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         .await;
                     continue;
                 }
-                DdlRequest::Flush(_) => {
-                    self.handle_flush_request(ddl.region_id, ddl.sender).await;
+                DdlRequest::Flush(req) => {
+                    self.handle_flush_request(ddl.region_id, req.row_group_size, ddl.sender)
+                        .await;
                     continue;
                 }
                 DdlRequest::Compact(_) => {

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -80,7 +80,7 @@ impl<S> RegionWorkerLoop<S> {
             info!("Flush region: {} before alteration", region_id);
 
             // Try to submit a flush task.
-            let task = self.new_flush_task(&region, FlushReason::Alter);
+            let task = self.new_flush_task(&region, FlushReason::Alter, None);
             if let Err(e) =
                 self.flush_scheduler
                     .schedule_flush(region.region_id, &region.version_control, task)

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -110,7 +110,9 @@ impl RegionRequest {
             )]),
             region_request::Body::Flush(flush) => Ok(vec![(
                 flush.region_id.into(),
-                Self::Flush(RegionFlushRequest {}),
+                Self::Flush(RegionFlushRequest {
+                    row_group_size: None,
+                }),
             )]),
             region_request::Body::Compact(compact) => Ok(vec![(
                 compact.region_id.into(),
@@ -415,8 +417,10 @@ impl TryFrom<v1::AddColumnLocation> for AddColumnLocation {
     }
 }
 
-#[derive(Debug)]
-pub struct RegionFlushRequest {}
+#[derive(Debug, Default)]
+pub struct RegionFlushRequest {
+    pub row_group_size: Option<usize>,
+}
 
 #[derive(Debug)]
 pub struct RegionCompactRequest {}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements row group pruning for the new mito engine.

Previous implementation uses the schema of the region to find the index of a column, which is incorrect under the new SST format. Due to the restriction that the row group metadata only contains the min/max values of primary keys, not tags, the `ParquetReader` can only use the first tag in the primary key to prune row groups.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #2524