### PR TITLE
feat: add invalidate key cache in atomic operation

### DIFF
--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [features]
 testing = []
+# async_closure = [] # unstable feature!
 
 [dependencies]
 api = { workspace = true }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add support for invalidate key(s) in an atomic operation.
- [x]  `invalidate_keys(vec![key1,key2]);`
- [ ]  `invalidate_with(|kv_guard| kv_guard.remove(key1); kv_guard.remove(key2));`: experimenting.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
resolve #2369
