### PR TITLE
feat: enable no delay for mysql, opentsdb, http

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -728,7 +728,9 @@ impl Server for HttpServer {
                 app = configurator.config_http(app);
             }
             let app = self.build(app);
-            let server = axum::Server::bind(&listening).serve(app.into_make_service());
+            let server = axum::Server::bind(&listening)
+                .tcp_nodelay(true)
+                .serve(app.into_make_service());
 
             *shutdown_tx = Some(tx);
 

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -139,7 +139,7 @@ impl MysqlServer {
                     Err(error) => warn!("Broken pipe: {}", error), // IoError doesn't impl ErrorExt.
                     Ok(io_stream) => {
                         if let Err(e) = io_stream.set_nodelay(true) {
-                            error!(e;"Failed to set TCP nodelay");
+                            error!(e; "Failed to set TCP nodelay");
                         }
                         if let Err(error) =
                             Self::handle(io_stream, io_runtime, spawn_ref, spawn_config).await

--- a/src/servers/src/opentsdb.rs
+++ b/src/servers/src/opentsdb.rs
@@ -82,7 +82,7 @@ impl OpentsdbServer {
                 match stream {
                     Ok(stream) => {
                         if let Err(e) = stream.set_nodelay(true) {
-                            error!(e;"Failed to set TCP nodelay");
+                            error!(e; "Failed to set TCP nodelay");
                         }
                         let connection = Connection::new(stream);
                         let mut handler = Handler::new(query_handler, connection, shutdown);

--- a/src/servers/src/opentsdb.rs
+++ b/src/servers/src/opentsdb.rs
@@ -81,6 +81,9 @@ impl OpentsdbServer {
             async move {
                 match stream {
                     Ok(stream) => {
+                        if let Err(e) = stream.set_nodelay(true) {
+                            error!(e;"Failed to set TCP nodelay");
+                        }
                         let connection = Connection::new(stream);
                         let mut handler = Handler::new(query_handler, connection, shutdown);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Enable tcp no delay for mysql, opentsdb, http protocol

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #2528