### PR TITLE
fix: timestamp range filter

### DIFF
--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -149,7 +149,7 @@ async fn test_range_filter() {
     tester
         .check(
             "select * from m where ts > 1000;",
-            TimestampRange::from_start(Timestamp::new(1000, TimeUnit::Millisecond)),
+            TimestampRange::from_start(Timestamp::new(1001, TimeUnit::Millisecond)),
         )
         .await;
 
@@ -163,7 +163,7 @@ async fn test_range_filter() {
     tester
         .check(
             "select * from m where ts > 1000 and ts < 2000;",
-            TimestampRange::with_unit(1000, 2000, TimeUnit::Millisecond).unwrap(),
+            TimestampRange::with_unit(1001, 2000, TimeUnit::Millisecond).unwrap(),
         )
         .await;
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -184,8 +184,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 .and_then(|(ts, _)| ts.convert_to(self.ts_col_unit))
                 .map(TimestampRange::single),
             Operator::Lt => {
-                let Some((ts, reverse)) = self
-                    .get_timestamp_filter(left, right)else {
+                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
                     return None;
                 };
                 if reverse {
@@ -202,8 +201,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::LtEq => {
-                let Some((ts, reverse)) = self
-                    .get_timestamp_filter(left, right)else {
+                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
                     return None;
                 };
                 if reverse {
@@ -217,8 +215,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::Gt => {
-                let Some((ts, reverse)) = self
-                    .get_timestamp_filter(left, right)else {
+                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
                     return None;
                 };
                 if reverse {
@@ -235,8 +232,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::GtEq => {
-                let Some((ts, reverse)) = self
-                    .get_timestamp_filter(left, right)else {
+                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
                     return None;
                 };
                 if reverse {

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -184,9 +184,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 .and_then(|(ts, _)| ts.convert_to(self.ts_col_unit))
                 .map(TimestampRange::single),
             Operator::Lt => {
-                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
-                    return None;
-                };
+                let (ts, reverse) = self.get_timestamp_filter(left, right)?;
                 if reverse {
                     // [lit] < ts_col
                     let ts_val = ts.convert_to(self.ts_col_unit)?.value();
@@ -201,9 +199,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::LtEq => {
-                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
-                    return None;
-                };
+                let (ts, reverse) = self.get_timestamp_filter(left, right)?;
                 if reverse {
                     // [lit] <= ts_col
                     ts.convert_to_ceil(self.ts_col_unit)
@@ -215,9 +211,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::Gt => {
-                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
-                    return None;
-                };
+                let (ts, reverse) = self.get_timestamp_filter(left, right)?;
                 if reverse {
                     // [lit] > ts_col
                     ts.convert_to_ceil(self.ts_col_unit)
@@ -232,9 +226,7 @@ impl<'a> TimeRangePredicateBuilder<'a> {
                 }
             }
             Operator::GtEq => {
-                let Some((ts, reverse)) = self.get_timestamp_filter(left, right) else {
-                    return None;
-                };
+                let (ts, reverse) = self.get_timestamp_filter(left, right)?;
                 if reverse {
                     // [lit] >= ts_col
                     ts.convert_to(self.ts_col_unit)
@@ -389,8 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_predicate() {
-        // operator GT
+    fn test_gt() {
         // ts > 1ms
         check_build_predicate(
             col("ts").gt(lit(ScalarValue::TimestampMillisecond(Some(1), None))),
@@ -426,8 +417,10 @@ mod tests {
             col("ts").gt(lit(ScalarValue::TimestampSecond(Some(1), None))),
             TimestampRange::from_start(Timestamp::new_millisecond(1001)),
         );
+    }
 
-        // operator GT_EQ
+    #[test]
+    fn test_gt_eq() {
         // ts >= 1ms
         check_build_predicate(
             col("ts").gt_eq(lit(ScalarValue::TimestampMillisecond(Some(1), None))),
@@ -463,8 +456,10 @@ mod tests {
             col("ts").gt_eq(lit(ScalarValue::TimestampSecond(Some(1), None))),
             TimestampRange::from_start(Timestamp::new_millisecond(1000)),
         );
+    }
 
-        // operator LT
+    #[test]
+    fn test_lt() {
         // ts < 1ms
         check_build_predicate(
             col("ts").lt(lit(ScalarValue::TimestampMillisecond(Some(1), None))),
@@ -500,8 +495,9 @@ mod tests {
             col("ts").lt(lit(ScalarValue::TimestampSecond(Some(1), None))),
             TimestampRange::until_end(Timestamp::new_millisecond(1000), false),
         );
-
-        // operator LT_EQ
+    }
+    #[test]
+    fn test_lt_eq() {
         // ts <= 1ms
         check_build_predicate(
             col("ts").lt_eq(lit(ScalarValue::TimestampMillisecond(Some(1), None))),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR fixes the bug in building timestamp range predicates when operators do not conform commutative property.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Fixes #2508
