### PR TITLE
fix: compiler errors under `pprof` and `mem-prof` features

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -335,7 +335,9 @@ pub enum Error {
 
     #[cfg(feature = "pprof")]
     #[snafu(display("Failed to dump pprof data"))]
-    DumpPprof { source: common_pprof::Error },
+    DumpPprof {
+        source: crate::http::pprof::nix::Error,
+    },
 
     #[snafu(display(""))]
     Metrics { source: BoxedError },

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -278,8 +278,7 @@ pub enum Error {
     #[snafu(display("Failed to dump profile data"))]
     DumpProfileData {
         location: Location,
-        #[snafu(source)]
-        error: common_mem_prof::error::Error,
+        source: common_mem_prof::error::Error,
     },
 
     #[snafu(display("Invalid prepare statement: {}", err_msg))]

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -19,7 +19,7 @@ pub mod influxdb;
 pub mod mem_prof;
 pub mod opentsdb;
 pub mod otlp;
-mod pprof;
+pub mod pprof;
 pub mod prom_store;
 pub mod prometheus;
 pub mod script;

--- a/src/servers/src/http/pprof.rs
+++ b/src/servers/src/http/pprof.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(feature = "pprof")]
-mod nix;
+pub(crate) mod nix;
 
 #[cfg(feature = "pprof")]
 pub mod handler {

--- a/src/servers/src/http/pprof/nix.rs
+++ b/src/servers/src/http/pprof/nix.rs
@@ -17,32 +17,38 @@ use std::time::Duration;
 
 use common_error::ext::ErrorExt;
 use common_error::status_code::StatusCode;
+use common_macro::stack_trace_debug;
 use prost::Message;
 use snafu::{Location, ResultExt, Snafu};
 
-#[derive(Debug, Snafu)]
+#[derive(Snafu)]
+#[stack_trace_debug]
 pub enum Error {
     #[snafu(display("Failed to create profiler guard"))]
     CreateGuard {
-        source: pprof::Error,
+        #[snafu(source)]
+        error: pprof::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to create report"))]
     CreateReport {
-        source: pprof::Error,
+        #[snafu(source)]
+        error: pprof::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to create flamegraph"))]
     CreateFlamegraph {
-        source: pprof::Error,
+        #[snafu(source)]
+        error: pprof::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to create pprof report"))]
     ReportPprof {
-        source: pprof::Error,
+        #[snafu(source)]
+        error: pprof::Error,
         location: Location,
     },
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes the compiler errors under `pprof` and `mem-prof` features

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
