### PR TITLE
feat: memtable filter push down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5500,6 +5500,7 @@ dependencies = [
  "anymap",
  "api",
  "aquamarine",
+ "arc-swap",
  "async-channel",
  "async-compat",
  "async-stream",

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -9,10 +9,10 @@ default = []
 test = ["common-test-util"]
 
 [dependencies]
-arc-swap = "1.6"
 anymap = "1.0.0-beta.2"
 api.workspace = true
 aquamarine.workspace = true
+arc-swap = "1.6"
 async-channel = "1.9"
 async-compat = "0.2"
 async-stream.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test = ["common-test-util"]
 
 [dependencies]
+arc-swap = "1.6"
 anymap = "1.0.0-beta.2"
 api.workspace = true
 aquamarine.workspace = true

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -287,7 +287,7 @@ impl RegionFlushTask {
             }
 
             let file_id = FileId::random();
-            let iter = mem.iter(None, &[]);
+            let iter = mem.iter(None, None);
             let source = Source::Iter(iter);
             let mut writer = self
                 .access_layer

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -23,7 +23,6 @@ use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use common_query::logical_plan::Expr;
 use common_time::Timestamp;
 use metrics::{decrement_gauge, increment_gauge};
 use store_api::metadata::RegionMetadataRef;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -28,6 +28,7 @@ use common_time::Timestamp;
 use metrics::{decrement_gauge, increment_gauge};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
+use table::predicate::Predicate;
 
 use crate::error::Result;
 use crate::flush::WriteBufferManagerRef;
@@ -73,7 +74,11 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Scans the memtable.
     /// `projection` selects columns to read, `None` means reading all columns.
     /// `filters` are the predicates to be pushed down to memtable.
-    fn iter(&self, projection: Option<&[ColumnId]>, filters: &[Expr]) -> BoxedBatchIterator;
+    fn iter(
+        &self,
+        projection: Option<&[ColumnId]>,
+        predicate: Option<Predicate>,
+    ) -> BoxedBatchIterator;
 
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -19,7 +19,6 @@ use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 
 use api::v1::OpType;
-use common_query::logical_plan::Expr;
 use common_telemetry::debug;
 use datatypes::arrow;
 use datatypes::arrow::array::ArrayRef;

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -388,6 +388,10 @@ fn prune_primary_key(
     pk_schema: arrow::datatypes::SchemaRef,
     predicate: &Predicate,
 ) -> bool {
+    // no primary key, we simply return true.
+    if pk_schema.fields().is_empty() {
+        return true;
+    }
     let Ok(pk_record_batch) = pk_to_record_batch(codec, pk, builders, pk_schema) else {
         return true;
     };

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -135,7 +135,6 @@ impl SeqScan {
         // Scans all memtables and SSTs. Builds a merge reader to merge results.
         let mut builder = MergeReaderBuilder::new();
         for mem in &self.memtables {
-            // TODO(hl): pass filters once memtable supports filter pushdown.
             let iter = mem.iter(Some(self.mapper.column_ids()), self.predicate.clone());
             builder.push_batch_iter(iter);
         }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -136,7 +136,7 @@ impl SeqScan {
         let mut builder = MergeReaderBuilder::new();
         for mem in &self.memtables {
             // TODO(hl): pass filters once memtable supports filter pushdown.
-            let iter = mem.iter(Some(self.mapper.column_ids()), &[]);
+            let iter = mem.iter(Some(self.mapper.column_ids()), self.predicate.clone());
             builder.push_batch_iter(iter);
         }
         for file in &self.files {

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use common_query::logical_plan::Expr;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
+use table::predicate::Predicate;
 
 use crate::error::Result;
 use crate::memtable::{
@@ -50,7 +51,11 @@ impl Memtable for EmptyMemtable {
         Ok(())
     }
 
-    fn iter(&self, _projection: Option<&[ColumnId]>, _filters: &[Expr]) -> BoxedBatchIterator {
+    fn iter(
+        &self,
+        _projection: Option<&[ColumnId]>,
+        _filters: Option<Predicate>,
+    ) -> BoxedBatchIterator {
         Box::new(std::iter::empty())
     }
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -17,7 +17,6 @@
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
-use common_query::logical_plan::Expr;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
 use table::predicate::Predicate;

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -140,7 +140,7 @@ impl Predicate {
                 // result was a column
                 ColumnarValue::Scalar(ScalarValue::Boolean(v)) => v.unwrap_or(true),
                 _ => {
-                    unreachable!()
+                    unreachable!("Unexpected primary key record batch evaluation result: {:?}, primary key: {:?}", eva, primary_key);
                 }
             };
             debug!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR enables filter pushdown for memtable so that irrelavant time series can be skipped.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
