### PR TITLE
fix: schema validation is skipped once we need to fill a column

### DIFF
--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -26,7 +26,6 @@ use store_api::region_request::{RegionOpenRequest, RegionPutRequest};
 use store_api::storage::RegionId;
 
 use super::*;
-use crate::error::Error;
 use crate::region::version::VersionControlData;
 use crate::test_util::{
     build_delete_rows_for_key, build_rows, build_rows_for_key, delete_rows, delete_rows_schema,

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -169,6 +169,7 @@ impl ReadRowHelper {
             .unwrap();
         indices.push(*ts_index);
         // Iterate columns and find field columns.
+        // TODO(yingwen): use `field_columns()`
         for column in metadata.column_metadatas.iter() {
             if column.semantic_type == SemanticType::Field {
                 // Get index in request for each field column.

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use api::v1::{Mutation, OpType, Row, Rows, SemanticType};
+use api::v1::{Mutation, OpType, Row, Rows};
 use datatypes::value::ValueRef;
 use store_api::metadata::RegionMetadata;
 use store_api::storage::SequenceNumber;
@@ -169,13 +169,10 @@ impl ReadRowHelper {
             .unwrap();
         indices.push(*ts_index);
         // Iterate columns and find field columns.
-        // TODO(yingwen): use `field_columns()`
-        for column in metadata.column_metadatas.iter() {
-            if column.semantic_type == SemanticType::Field {
-                // Get index in request for each field column.
-                let index = name_to_index.get(&column.column_schema.name).unwrap();
-                indices.push(*index);
-            }
+        for column in metadata.field_columns() {
+            // Get index in request for each field column.
+            let index = name_to_index.get(&column.column_schema.name).unwrap();
+            indices.push(*index);
         }
 
         ReadRowHelper {
@@ -187,8 +184,7 @@ impl ReadRowHelper {
 
 #[cfg(test)]
 mod tests {
-    use api::v1;
-    use api::v1::ColumnDataType;
+    use api::v1::{self, ColumnDataType, SemanticType};
 
     use super::*;
     use crate::test_util::i64_value;

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -683,6 +683,7 @@ pub(crate) struct CompactionFailed {
 
 #[cfg(test)]
 mod tests {
+    use api::v1::value::ValueData;
     use api::v1::{Row, SemanticType};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnDefaultConstraint;
@@ -950,7 +951,7 @@ mod tests {
         assert_eq!(expect_rows, request.rows);
     }
 
-    fn region_metadata_for_delete() -> RegionMetadata {
+    fn region_metadata_two_fields() -> RegionMetadata {
         let mut builder = RegionMetadataBuilder::new(RegionId::new(1, 1));
         builder
             .push_column_metadata(ColumnMetadata {
@@ -1010,7 +1011,7 @@ mod tests {
                 values: vec![ts_ms_value(1)],
             }],
         };
-        let metadata = region_metadata_for_delete();
+        let metadata = region_metadata_two_fields();
 
         let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Delete, rows).unwrap();
         let err = request.check_schema(&metadata).unwrap_err();
@@ -1077,5 +1078,35 @@ mod tests {
         let mut request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows).unwrap();
         let err = request.fill_missing_columns(&metadata).unwrap_err();
         check_invalid_request(&err, "column ts does not have default value");
+    }
+
+    #[test]
+    fn test_missing_and_invalid() {
+        // Missing f0 and f1 has invalid type (string).
+        let rows = Rows {
+            schema: vec![
+                new_column_schema("k0", ColumnDataType::Int64, SemanticType::Tag),
+                new_column_schema(
+                    "ts",
+                    ColumnDataType::TimestampMillisecond,
+                    SemanticType::Timestamp,
+                ),
+                new_column_schema("f1", ColumnDataType::String, SemanticType::Field),
+            ],
+            rows: vec![Row {
+                values: vec![
+                    i64_value(100),
+                    ts_ms_value(1),
+                    Value {
+                        value_data: Some(ValueData::StringValue("xxxxx".to_string())),
+                    },
+                ],
+            }],
+        };
+        let metadata = region_metadata_two_fields();
+
+        let request = WriteRequest::new(RegionId::new(1, 1), OpType::Put, rows).unwrap();
+        let err = request.check_schema(&metadata).unwrap_err();
+        check_invalid_request(&err, "xxx");
     }
 }

--- a/tests/cases/standalone/common/insert/insert_different_order.result
+++ b/tests/cases/standalone/common/insert/insert_different_order.result
@@ -1,0 +1,44 @@
+CREATE TABLE different_order(k0 STRING, k1 STRING, v0 INTEGER, v1 INTEGER, t TIMESTAMP, time index(t), primary key(k0, k1));
+
+Affected Rows: 0
+
+INSERT INTO different_order (v1, k1, k0, t, v0) VALUES (11, 'b0', 'a0', 1, 1);
+
+Affected Rows: 1
+
+INSERT INTO different_order (v1, v0, k0, t) VALUES (12, 2, 'a1', 2);
+
+Affected Rows: 1
+
+INSERT INTO different_order (t, v1, k0, k1) VALUES (3, 13, 'a2', 'b1');
+
+Affected Rows: 1
+
+INSERT INTO different_order (t, k0, k1) VALUES (4, 'a2', 'b1');
+
+Affected Rows: 1
+
+SELECT * from different_order order by t;
+
++----+----+----+----+-------------------------+
+| k0 | k1 | v0 | v1 | t                       |
++----+----+----+----+-------------------------+
+| a0 | b0 | 1  | 11 | 1970-01-01T00:00:00.001 |
+| a1 |    | 2  | 12 | 1970-01-01T00:00:00.002 |
+| a2 | b1 |    | 13 | 1970-01-01T00:00:00.003 |
+| a2 | b1 |    |    | 1970-01-01T00:00:00.004 |
++----+----+----+----+-------------------------+
+
+SELECT * from different_order WHERE k0 = 'a2' order by t;
+
++----+----+----+----+-------------------------+
+| k0 | k1 | v0 | v1 | t                       |
++----+----+----+----+-------------------------+
+| a2 | b1 |    | 13 | 1970-01-01T00:00:00.003 |
+| a2 | b1 |    |    | 1970-01-01T00:00:00.004 |
++----+----+----+----+-------------------------+
+
+DROP TABLE different_order;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/insert/insert_different_order.sql
+++ b/tests/cases/standalone/common/insert/insert_different_order.sql
@@ -1,0 +1,15 @@
+CREATE TABLE different_order(k0 STRING, k1 STRING, v0 INTEGER, v1 INTEGER, t TIMESTAMP, time index(t), primary key(k0, k1));
+
+INSERT INTO different_order (v1, k1, k0, t, v0) VALUES (11, 'b0', 'a0', 1, 1);
+
+INSERT INTO different_order (v1, v0, k0, t) VALUES (12, 2, 'a1', 2);
+
+INSERT INTO different_order (t, v1, k0, k1) VALUES (3, 13, 'a2', 'b1');
+
+INSERT INTO different_order (t, k0, k1) VALUES (4, 'a2', 'b1');
+
+SELECT * from different_order order by t;
+
+SELECT * from different_order WHERE k0 = 'a2' order by t;
+
+DROP TABLE different_order;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes an issue that `WriteRequest::check_schema()` doesn't check the schema of remaining columns in `rows` if it finds out that a column is absent but has a default value.

It uses a flag to store whether rows have such a column instead of returning directly.

It also adds some tests for input rows with different column order than the region.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #2547 