### PR TITLE
feat: renaming kv directory to metadata

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -18,7 +18,7 @@ use catalog::kvbackend::KvBackendCatalogManager;
 use catalog::CatalogManagerRef;
 use clap::Parser;
 use common_base::Plugins;
-use common_config::{kv_store_dir, KvStoreConfig, WalConfig};
+use common_config::{metadata_store_dir, KvStoreConfig, WalConfig};
 use common_meta::cache_invalidator::DummyKvCacheInvalidator;
 use common_meta::kv_backend::KvBackendRef;
 use common_procedure::ProcedureManagerRef;
@@ -310,9 +310,9 @@ impl StartCommand {
             fe_opts, dn_opts
         );
 
-        let kv_dir = kv_store_dir(&opts.data_home);
+        let metadata_dir = metadata_store_dir(&opts.data_home);
         let (kv_store, procedure_manager) =
-            FeInstance::try_build_standalone_components(kv_dir, opts.kv_store, opts.procedure)
+            FeInstance::try_build_standalone_components(metadata_dir, opts.kv_store, opts.procedure)
                 .await
                 .context(StartFrontendSnafu)?;
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -311,10 +311,13 @@ impl StartCommand {
         );
 
         let metadata_dir = metadata_store_dir(&opts.data_home);
-        let (kv_store, procedure_manager) =
-            FeInstance::try_build_standalone_components(metadata_dir, opts.kv_store, opts.procedure)
-                .await
-                .context(StartFrontendSnafu)?;
+        let (kv_store, procedure_manager) = FeInstance::try_build_standalone_components(
+            metadata_dir,
+            opts.kv_store,
+            opts.procedure,
+        )
+        .await
+        .context(StartFrontendSnafu)?;
 
         let datanode =
             DatanodeBuilder::new(dn_opts.clone(), Some(kv_store.clone()), Default::default())

--- a/src/common/config/src/lib.rs
+++ b/src/common/config/src/lib.rs
@@ -45,7 +45,7 @@ impl Default for WalConfig {
     }
 }
 
-pub fn kv_store_dir(store_dir: &str) -> String {
+pub fn metadata_store_dir(store_dir: &str) -> String {
     format!("{store_dir}/metadata")
 }
 

--- a/src/common/config/src/lib.rs
+++ b/src/common/config/src/lib.rs
@@ -46,7 +46,7 @@ impl Default for WalConfig {
 }
 
 pub fn kv_store_dir(store_dir: &str) -> String {
-    format!("{store_dir}/kv")
+    format!("{store_dir}/metadata")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
The KV directory has been renamed to metadata to provide more useful info for users.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

#2493 
