### PR TITLE
chore(mito): change default batch size/row group size

### DIFF
--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -26,7 +26,10 @@ use crate::sst::file::FileTimeRange;
 /// Key of metadata in parquet SST.
 pub const PARQUET_METADATA_KEY: &str = "greptime:metadata";
 const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
-const DEFAULT_ROW_GROUP_SIZE: usize = 100000;
+/// Default batch size to read parquet files.
+pub(crate) const DEFAULT_READ_BATCH_SIZE: usize = 1024;
+/// Default row group size for parquet files.
+const DEFAULT_ROW_GROUP_SIZE: usize = 100 * DEFAULT_READ_BATCH_SIZE;
 
 /// Parquet write options.
 #[derive(Debug)]

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -46,7 +46,7 @@ use crate::read::{Batch, BatchReader};
 use crate::sst::file::{FileHandle, FileId};
 use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::stats::RowGroupPruningStats;
-use crate::sst::parquet::PARQUET_METADATA_KEY;
+use crate::sst::parquet::{DEFAULT_READ_BATCH_SIZE, PARQUET_METADATA_KEY};
 
 /// Parquet SST reader builder.
 pub struct ParquetReaderBuilder {
@@ -147,7 +147,8 @@ impl ParquetReaderBuilder {
         };
         let mut builder = ParquetRecordBatchStreamBuilder::new(reader)
             .await
-            .context(ReadParquetSnafu { path: file_path })?;
+            .context(ReadParquetSnafu { path: file_path })?
+            .with_batch_size(DEFAULT_READ_BATCH_SIZE);
 
         // Decode region metadata.
         let key_value_meta = builder.metadata().file_metadata().key_value_metadata();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Change default batch size and row group size to `1024` and `100 * 1024`.

Arrow aligns its buffer to a multiple of 64 so our old default batch size (1000) wastes some slots.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
