### PR TITLE
fix: human_time mismatch

### DIFF
--- a/src/meta-srv/src/service/admin/node_lease.rs
+++ b/src/meta-srv/src/service/admin/node_lease.rs
@@ -43,7 +43,7 @@ impl HttpHandler for NodeLeaseHandler {
             .into_iter()
             .map(|(k, v)| HumanLease {
                 name: k,
-                human_time: common_time::DateTime::new(v.timestamp_millis / 1000).to_string(),
+                human_time: common_time::DateTime::new(v.timestamp_millis).to_string(),
                 lease: v,
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

datetime is millisecond precision now(before is second)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/2469