### PR TITLE
fix(mito): Do not write to memtables if writing wal is failed

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -44,4 +44,6 @@ pub const WRITE_REJECT_TOTAL: &str = "mito.write.reject_total";
 pub const WRITE_STAGE_ELAPSED: &str = "mito.write.stage_elapsed";
 /// Stage label.
 pub const STAGE_LABEL: &str = "stage";
+/// Counter of rows to write.
+pub const WRITE_ROWS_TOTAL: &str = "mito.write.rows_total";
 // ------ End of write related metrics

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -97,9 +97,9 @@ pub(crate) struct RegionWriteCtx {
 
     // Metrics:
     /// Rows to put.
-    put_num: usize,
+    pub(crate) put_num: usize,
     /// Rows to delete.
-    delete_num: usize,
+    pub(crate) delete_num: usize,
 }
 
 impl RegionWriteCtx {

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -30,7 +30,6 @@ use crate::storage::{ColumnId, RegionId, ScanRequest};
 
 #[derive(Debug, IntoStaticStr)]
 pub enum RegionRequest {
-    // TODO: rename to InsertRequest
     Put(RegionPutRequest),
     Delete(RegionDeleteRequest),
     Create(RegionCreateRequest),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a flag to the `RegionWriteCtx` to avoid writing to the mutable memtable if the region fails to write to the WAL. The worker sets the flag in `set_error()`.
https://github.com/GreptimeTeam/greptimedb/blob/8bdef9a348d997c51ebf1c2a1626f02cf6296403/src/mito2/src/worker/handle_write.rs#L67-L80

It adds some metrics about the number of rows written.

I removed one TODO about the naming as Put is a common operation in NoSQL databases which is different from `Insert` in relational databases.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
