### PR TITLE
fix: support multi addrs while using etcd

### DIFF
--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -169,8 +169,13 @@ pub async fn build_meta_srv(opts: &MetaSrvOptions, plugins: Plugins) -> Result<M
             Some(Arc::new(MemLock::default()) as _),
         )
     } else {
-        let etcd_endpoints = [&opts.store_addr];
-        let etcd_client = Client::connect(etcd_endpoints, None)
+        let etcd_endpoints = opts
+            .store_addr
+            .split(',')
+            .map(|x| x.trim())
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>();
+        let etcd_client = Client::connect(&etcd_endpoints, None)
             .await
             .context(error::ConnectEtcdSnafu)?;
         (

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -72,7 +72,7 @@ impl Default for MetaSrvOptions {
             store_addr: "127.0.0.1:2379".to_string(),
             selector: SelectorType::default(),
             use_memory_store: false,
-            enable_region_failover: true,
+            enable_region_failover: false,
             http: HttpOptions::default(),
             logging: LoggingOptions {
                 dir: format!("{METASRV_HOME}/logs"),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

As the title said.

It also disables region failover feature by default.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
