### PR TITLE
fix: cache capacity unit in sample config

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -51,7 +51,7 @@ type = "File"
 # The local file cache directory
 # cache_path = "/path/local_cache"
 # The local file cache capacity in bytes.
-# cache_capacity = "256Mib"
+# cache_capacity = "256MB"
 
 # Compaction options, see `standalone.example.toml`.
 [storage.compaction]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -118,7 +118,7 @@ type = "File"
 # Cache configuration for object storage such as 'S3' etc.
 # cache_path = "/path/local_cache"
 # The local file cache capacity in bytes.
-# cache_capacity = "256Mib"
+# cache_capacity = "256MB"
 
 # Compaction options.
 [storage.compaction]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixed the unit in sample config.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
