### PR TITLE
feat: stop the procedure manager if a new leader is elected

### DIFF
--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -49,12 +49,6 @@ pub enum Error {
         source: common_procedure::error::Error,
     },
 
-    #[snafu(display("Failed to start procedures"))]
-    RecoverProcedures {
-        location: Location,
-        source: common_procedure::error::Error,
-    },
-
     #[snafu(display("Failed to start datanode"))]
     StartDatanode {
         location: Location,
@@ -260,9 +254,7 @@ impl ErrorExt for Error {
             | Error::EmptyResult { .. }
             | Error::InvalidDatabaseName { .. } => StatusCode::InvalidArguments,
             Error::StartProcedureManager { source, .. }
-            | Error::StopProcedureManager { source, .. }
-            | Error::RecoverProcedures { source, .. } => source.status_code(),
-
+            | Error::StopProcedureManager { source, .. } => source.status_code(),
             Error::ReplCreation { .. } | Error::Readline { .. } => StatusCode::Internal,
             Error::RequestDatabase { source, .. } => source.status_code(),
             Error::CollectRecordBatches { source, .. }

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -37,6 +37,24 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
+    #[snafu(display("Failed to start procedure manager"))]
+    StartProcedureManager {
+        location: Location,
+        source: common_procedure::error::Error,
+    },
+
+    #[snafu(display("Failed to stop procedure manager"))]
+    StopProcedureManager {
+        location: Location,
+        source: common_procedure::error::Error,
+    },
+
+    #[snafu(display("Failed to start procedures"))]
+    RecoverProcedures {
+        location: Location,
+        source: common_procedure::error::Error,
+    },
+
     #[snafu(display("Failed to start datanode"))]
     StartDatanode {
         location: Location,
@@ -241,6 +259,9 @@ impl ErrorExt for Error {
             | Error::CreateDir { .. }
             | Error::EmptyResult { .. }
             | Error::InvalidDatabaseName { .. } => StatusCode::InvalidArguments,
+            Error::StartProcedureManager { source, .. }
+            | Error::StopProcedureManager { source, .. }
+            | Error::RecoverProcedures { source, .. } => source.status_code(),
 
             Error::ReplCreation { .. } | Error::Readline { .. } => StatusCode::Internal,
             Error::RequestDatabase { source, .. } => source.status_code(),

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -42,9 +42,9 @@ use servers::Mode;
 use snafu::ResultExt;
 
 use crate::error::{
-    CreateDirSnafu, IllegalConfigSnafu, InitMetadataSnafu, RecoverProceduresSnafu, Result,
-    ShutdownDatanodeSnafu, ShutdownFrontendSnafu, StartDatanodeSnafu, StartFrontendSnafu,
-    StartProcedureManagerSnafu, StopProcedureManagerSnafu,
+    CreateDirSnafu, IllegalConfigSnafu, InitMetadataSnafu, Result, ShutdownDatanodeSnafu,
+    ShutdownFrontendSnafu, StartDatanodeSnafu, StartFrontendSnafu, StartProcedureManagerSnafu,
+    StopProcedureManagerSnafu,
 };
 use crate::options::{MixOptions, Options, TopLevelOptions};
 
@@ -175,12 +175,8 @@ impl Instance {
 
         self.procedure_manager
             .start()
-            .context(StartProcedureManagerSnafu)?;
-
-        self.procedure_manager
-            .recover()
             .await
-            .context(RecoverProceduresSnafu)?;
+            .context(StartProcedureManagerSnafu)?;
 
         self.frontend.start().await.context(StartFrontendSnafu)?;
         Ok(())

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -258,7 +258,6 @@ impl<T: Serialize + DeserializeOwned> DeserializedValueWithBytes<T> {
         self.bytes.to_vec()
     }
 
-    #[cfg(feature = "testing")]
     /// Notes: used for test purpose.
     pub fn from_inner(inner: T) -> Self {
         let bytes = serde_json::to_vec(&inner).unwrap();

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     LoaderConflict { name: String, location: Location },
 
     #[snafu(display("Procedure Manager is stopped"))]
-    ProcedureManagerStop { location: Location },
+    ProcedureManagerNotStart { location: Location },
 
     #[snafu(display("Failed to serialize to json"))]
     ToJson {
@@ -152,7 +152,7 @@ impl ErrorExt for Error {
             | Error::RetryTimesExceeded { .. }
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
-            | Error::ProcedureManagerStop { .. } => StatusCode::Internal,
+            | Error::ProcedureManagerNotStart { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
     #[snafu(display("Loader {} is already registered", name))]
     LoaderConflict { name: String, location: Location },
 
+    #[snafu(display("Procedure Manager is stopped"))]
+    ProcedureManagerStop { location: Location },
+
     #[snafu(display("Failed to serialize to json"))]
     ToJson {
         #[snafu(source)]
@@ -148,7 +151,8 @@ impl ErrorExt for Error {
             | Error::FromJson { .. }
             | Error::RetryTimesExceeded { .. }
             | Error::RetryLater { .. }
-            | Error::WaitWatcher { .. } => StatusCode::Internal,
+            | Error::WaitWatcher { .. }
+            | Error::ProcedureManagerStop { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -35,7 +35,7 @@ pub enum Error {
     LoaderConflict { name: String, location: Location },
 
     #[snafu(display("Procedure Manager is stopped"))]
-    ProcedureManagerNotStart { location: Location },
+    ManagerNotStart { location: Location },
 
     #[snafu(display("Failed to serialize to json"))]
     ToJson {
@@ -152,7 +152,7 @@ impl ErrorExt for Error {
             | Error::RetryTimesExceeded { .. }
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
-            | Error::ProcedureManagerNotStart { .. } => StatusCode::Internal,
+            | Error::ManagerNotStart { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/lib.rs
+++ b/src/common/procedure/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Common traits and structures for the procedure framework.
 
+#![feature(assert_matches)]
+
 pub mod error;
 pub mod local;
 pub mod options;

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -532,6 +532,10 @@ impl ProcedureManager for LocalManager {
     async fn start(&self) -> Result<()> {
         let mut task = self.remove_outdated_meta_task.lock().await;
 
+        if task.is_some() {
+            return Ok(());
+        }
+
         let task_inner = self.build_remove_outdated_meta_task();
 
         task_inner

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -201,7 +201,7 @@ impl Runner {
             // Don't store state if `ProcedureManager` is stopped.
             if !self.running() {
                 self.meta.set_state(ProcedureState::Failed {
-                    error: Arc::new(error::ProcedureManagerStopSnafu {}.build()),
+                    error: Arc::new(error::ProcedureManagerNotStartSnafu {}.build()),
                 });
                 return;
             }
@@ -260,7 +260,7 @@ impl Runner {
                 // Don't store state if `ProcedureManager` is stopped.
                 if !self.running() {
                     self.meta.set_state(ProcedureState::Failed {
-                        error: Arc::new(error::ProcedureManagerStopSnafu {}.build()),
+                        error: Arc::new(error::ProcedureManagerNotStartSnafu {}.build()),
                     });
                     return ExecResult::Failed;
                 }
@@ -307,7 +307,7 @@ impl Runner {
                 // Don't store state if `ProcedureManager` is stopped.
                 if !self.running() {
                     self.meta.set_state(ProcedureState::Failed {
-                        error: Arc::new(error::ProcedureManagerStopSnafu {}.build()),
+                        error: Arc::new(error::ProcedureManagerNotStartSnafu {}.build()),
                     });
                     return ExecResult::Failed;
                 }

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -279,19 +279,20 @@ pub trait ProcedureManager: Send + Sync + 'static {
     /// Registers loader for specific procedure type `name`.
     fn register_loader(&self, name: &str, loader: BoxedProcedureLoader) -> Result<()>;
 
-    fn start(&self) -> Result<()>;
+    /// Starts the background GC task.
+    ///
+    /// Recovers unfinished procedures and reruns them.
+    ///
+    /// Callers should ensure all loaders are registered.
+    async fn start(&self) -> Result<()>;
 
+    /// Stops the background GC task.
     async fn stop(&self) -> Result<()>;
 
     /// Submits a procedure to execute.
     ///
     /// Returns a [Watcher] to watch the created procedure.
     async fn submit(&self, procedure: ProcedureWithId) -> Result<Watcher>;
-
-    /// Recovers unfinished procedures and reruns them.
-    ///
-    /// Callers should ensure all loaders are registered.
-    async fn recover(&self) -> Result<()>;
 
     /// Query the procedure state.
     ///

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -71,6 +71,7 @@ mod tests {
         };
         let state_store = Arc::new(ObjectStateStore::new(test_util::new_object_store(&dir)));
         let manager = LocalManager::new(config, state_store);
+        manager.set_running();
 
         #[derive(Debug)]
         struct MockProcedure {

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -71,7 +71,7 @@ mod tests {
         };
         let state_store = Arc::new(ObjectStateStore::new(test_util::new_object_store(&dir)));
         let manager = LocalManager::new(config, state_store);
-        manager.set_running();
+        manager.start().await.unwrap();
 
         #[derive(Debug)]
         struct MockProcedure {

--- a/src/datanode/src/greptimedb_telemetry.rs
+++ b/src/datanode/src/greptimedb_telemetry.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -60,6 +61,8 @@ pub async fn get_greptimedb_telemetry_task(
     if !enable || cfg!(test) || cfg!(debug_assertions) {
         return Arc::new(GreptimeDBTelemetryTask::disable());
     }
+    // Always enable.
+    let should_report = Arc::new(AtomicBool::new(true));
 
     match mode {
         Mode::Standalone => Arc::new(GreptimeDBTelemetryTask::enable(
@@ -70,7 +73,9 @@ pub async fn get_greptimedb_telemetry_task(
                     uuid: default_get_uuid(&working_home),
                     retry: 0,
                 }),
+                should_report.clone(),
             )),
+            should_report,
         )),
         Mode::Distributed => Arc::new(GreptimeDBTelemetryTask::disable()),
     }

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -111,8 +111,7 @@ impl MetaSrvInstance {
                 .await
                 .context(error::SendShutdownSignalSnafu)?;
         }
-
-        self.meta_srv.shutdown();
+        self.meta_srv.shutdown().await?;
         self.http_srv
             .shutdown()
             .await

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -393,6 +393,18 @@ pub enum Error {
     #[snafu(display("Missing required parameter, param: {:?}", param))]
     MissingRequiredParameter { param: String },
 
+    #[snafu(display("Failed to start procedure manager"))]
+    StartProcedureManager {
+        location: Location,
+        source: common_procedure::Error,
+    },
+
+    #[snafu(display("Failed to stop procedure manager"))]
+    StopProcedureManager {
+        location: Location,
+        source: common_procedure::Error,
+    },
+
     #[snafu(display("Failed to recover procedure"))]
     RecoverProcedure {
         location: Location,
@@ -622,6 +634,8 @@ impl ErrorExt for Error {
             Error::ShutdownServer { source, .. } | Error::StartHttp { source, .. } => {
                 source.status_code()
             }
+            Error::StartProcedureManager { source, .. }
+            | Error::StopProcedureManager { source, .. } => source.status_code(),
 
             Error::ListCatalogs { source, .. } | Error::ListSchemas { source, .. } => {
                 source.status_code()

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -405,12 +405,6 @@ pub enum Error {
         source: common_procedure::Error,
     },
 
-    #[snafu(display("Failed to recover procedure"))]
-    RecoverProcedure {
-        location: Location,
-        source: common_procedure::Error,
-    },
-
     #[snafu(display("Failed to wait procedure done"))]
     WaitProcedure {
         location: Location,
@@ -628,9 +622,9 @@ impl ErrorExt for Error {
             Error::RequestDatanode { source, .. } => source.status_code(),
             Error::InvalidCatalogValue { source, .. }
             | Error::InvalidFullTableName { source, .. } => source.status_code(),
-            Error::RecoverProcedure { source, .. }
-            | Error::SubmitProcedure { source, .. }
-            | Error::WaitProcedure { source, .. } => source.status_code(),
+            Error::SubmitProcedure { source, .. } | Error::WaitProcedure { source, .. } => {
+                source.status_code()
+            }
             Error::ShutdownServer { source, .. } | Error::StartHttp { source, .. } => {
                 source.status_code()
             }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -41,6 +41,12 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
+    #[snafu(display("Failed to start telemetry task"))]
+    StartTelemetryTask {
+        location: Location,
+        source: common_runtime::error::Error,
+    },
+
     #[snafu(display("Failed to submit ddl task"))]
     SubmitDdlTask {
         location: Location,
@@ -634,6 +640,7 @@ impl ErrorExt for Error {
             Error::ListCatalogs { source, .. } | Error::ListSchemas { source, .. } => {
                 source.status_code()
             }
+            Error::StartTelemetryTask { source, .. } => source.status_code(),
 
             Error::RegionFailoverCandidatesNotFound { .. } => StatusCode::RuntimeResourcesExhausted,
             Error::NextSequence { source, .. } => source.status_code(),

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -28,7 +28,7 @@ use common_meta::sequence::SequenceRef;
 use common_procedure::options::ProcedureConfig;
 use common_procedure::ProcedureManagerRef;
 use common_telemetry::logging::LoggingOptions;
-use common_telemetry::{debug, error, info, warn};
+use common_telemetry::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use servers::http::HttpOptions;
 use snafu::ResultExt;
@@ -38,7 +38,8 @@ use tokio::sync::broadcast::error::RecvError;
 use crate::cluster::MetaPeerClientRef;
 use crate::election::{Election, LeaderChangeMessage};
 use crate::error::{
-    InitMetadataSnafu, Result, StartProcedureManagerSnafu, StopProcedureManagerSnafu,
+    InitMetadataSnafu, Result, StartProcedureManagerSnafu, StartTelemetryTaskSnafu,
+    StopProcedureManagerSnafu,
 };
 use crate::handler::HeartbeatHandlerGroup;
 use crate::lock::DistLockRef;
@@ -171,6 +172,37 @@ pub struct SelectorContext {
 pub type SelectorRef = Arc<dyn Selector<Context = SelectorContext, Output = Vec<Peer>>>;
 pub type ElectionRef = Arc<dyn Election<Leader = LeaderValue>>;
 
+pub struct MetaStateHandler {
+    procedure_manager: ProcedureManagerRef,
+    subscribe_manager: Option<SubscribeManagerRef>,
+    greptimedb_telemetry_task: Arc<GreptimeDBTelemetryTask>,
+}
+
+impl MetaStateHandler {
+    pub async fn on_become_leader(&self) {
+        if let Err(e) = self.procedure_manager.start().await {
+            error!(e; "Failed to start procedure manager");
+        }
+        self.greptimedb_telemetry_task.should_report(true);
+    }
+
+    pub async fn on_become_follower(&self) {
+        // Stops the procedures.
+        if let Err(e) = self.procedure_manager.stop().await {
+            error!(e; "Failed to stop procedure manager");
+        }
+        // Suspends reporting.
+        self.greptimedb_telemetry_task.should_report(false);
+
+        if let Some(sub_manager) = self.subscribe_manager.clone() {
+            info!("Leader changed, un_subscribe all");
+            if let Err(e) = sub_manager.un_subscribe_all() {
+                error!("Failed to un_subscribe all, error: {}", e);
+            }
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct MetaSrv {
     started: Arc<AtomicBool>,
@@ -214,7 +246,15 @@ impl MetaSrv {
             let leader_cached_kv_store = self.leader_cached_kv_store.clone();
             let subscribe_manager = self.subscribe_manager();
             let mut rx = election.subscribe_leader_change();
-            let task_handler = self.greptimedb_telemetry_task.clone();
+            let greptimedb_telemetry_task = self.greptimedb_telemetry_task.clone();
+            greptimedb_telemetry_task
+                .start()
+                .context(StartTelemetryTaskSnafu)?;
+            let state_handler = MetaStateHandler {
+                greptimedb_telemetry_task,
+                subscribe_manager,
+                procedure_manager,
+            };
             let _handle = common_runtime::spawn_bg(async move {
                 loop {
                     match rx.recv().await {
@@ -227,31 +267,12 @@ impl MetaSrv {
                             );
                             match msg {
                                 LeaderChangeMessage::Elected(_) => {
-                                    if let Err(e) = procedure_manager.start().await {
-                                        error!(e; "Failed to start procedure manager");
-                                    }
-                                    let _ = task_handler.start().map_err(|e| {
-                                        debug!(
-                                            "Failed to start greptimedb telemetry task, error: {e}"
-                                        );
-                                    });
+                                    state_handler.on_become_leader().await;
                                 }
                                 LeaderChangeMessage::StepDown(leader) => {
-                                    if let Err(e) = procedure_manager.stop().await {
-                                        error!(e; "Failed to stop procedure manager");
-                                    }
-                                    if let Some(sub_manager) = subscribe_manager.clone() {
-                                        info!("Leader changed, un_subscribe all");
-                                        if let Err(e) = sub_manager.un_subscribe_all() {
-                                            error!("Failed to un_subscribe all, error: {}", e);
-                                        }
-                                    }
                                     error!("Leader :{:?} step down", leader);
-                                    let _ = task_handler.stop().await.map_err(|e| {
-                                        debug!(
-                                            "Failed to stop greptimedb telemetry task, error: {e}"
-                                        );
-                                    });
+
+                                    state_handler.on_become_follower().await;
                                 }
                             }
                         }
@@ -265,9 +286,7 @@ impl MetaSrv {
                     }
                 }
 
-                if let Err(e) = procedure_manager.stop().await {
-                    error!(e; "Failed to stop procedure manager");
-                }
+                state_handler.on_become_follower().await;
             });
 
             let election = election.clone();

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -59,6 +59,7 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
 
     let state_store = Arc::new(KvStateStore::new(KvBackendAdapter::wrap(kv_store.clone())));
     let procedure_manager = Arc::new(LocalManager::new(ManagerConfig::default(), state_store));
+    procedure_manager.set_running();
 
     let in_memory = Arc::new(MemStore::new());
     let meta_peer_client = MetaPeerClientBuilder::default()

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -59,7 +59,6 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
 
     let state_store = Arc::new(KvStateStore::new(KvBackendAdapter::wrap(kv_store.clone())));
     let procedure_manager = Arc::new(LocalManager::new(ManagerConfig::default(), state_store));
-    procedure_manager.set_running();
 
     let in_memory = Arc::new(MemStore::new());
     let meta_peer_client = MetaPeerClientBuilder::default()

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -92,7 +92,7 @@ impl GreptimeDbStandaloneBuilder {
             .init()
             .await
             .unwrap();
-        procedure_manager.start().unwrap();
+        procedure_manager.start().await.unwrap();
         let instance = Instance::try_new_standalone(
             kv_store,
             procedure_manager,

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -92,7 +92,7 @@ impl GreptimeDbStandaloneBuilder {
             .init()
             .await
             .unwrap();
-
+        procedure_manager.start().unwrap();
         let instance = Instance::try_new_standalone(
             kv_store,
             procedure_manager,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Add a `running` flag to `ManagerContext`.
2. Throw an error for the running procedures if `Runner` is stopped.
3. Stop `Procedure Manager` if a new leader is elected. 
4. Start `Procedure Manager` if the meta server becomes a leader.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close #1721