### PR TITLE
ci: refine the process of releasing dev-builder images

### DIFF
--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -15,19 +15,6 @@ inputs:
     description: The dockerhub namespace of the image registry to store the images
     required: false
     default: greptime
-  acr-image-registry:
-    description: The ACR image registry to store the images
-    required: true
-  acr-image-registry-username:
-    description: The ACR username to login to the image registry
-    required: true
-  acr-image-registry-password:
-    description: The ACR password to login to the image registry
-    required: true
-  acr-image-namespace:
-    description: The ACR namespace of the image registry to store the images
-    required: false
-    default: greptime
   version:
     description: Version of the dev-builder
     required: false
@@ -62,45 +49,28 @@ runs:
     - name: Build and push dev-builder-ubuntu image
       shell: bash
       if: ${{ inputs.build-dev-builder-ubuntu == 'true' }}
-      env:
-        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
-        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
       run: |
         make dev-builder \
           BASE_IMAGE=ubuntu \
           BUILDX_MULTI_PLATFORM_BUILD=true \
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
-          IMAGE_TAG=${{ inputs.version }} && \
-        
-        skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }} \
-          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-          docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
+          IMAGE_TAG=${{ inputs.version }}
 
     - name: Build and push dev-builder-centos image
       shell: bash
       if: ${{ inputs.build-dev-builder-centos == 'true' }}
-      env:
-        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
-        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
       run: |
         make dev-builder \
           BASE_IMAGE=centos \
           BUILDX_MULTI_PLATFORM_BUILD=true \
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
-          IMAGE_TAG=${{ inputs.version }} && \
-        
-        skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-centos:${{ inputs.version }} \
-          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-          docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-centos:${{ inputs.version }}
+          IMAGE_TAG=${{ inputs.version }}
 
     - name: Build and push dev-builder-android image # Only build image for amd64 platform.
       shell: bash
       if: ${{ inputs.build-dev-builder-android == 'true' }}
-      env:
-        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
-        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
       run: |
         make dev-builder \
           BASE_IMAGE=android \
@@ -108,8 +78,4 @@ runs:
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }} && \
         
-        docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} && \
-
-        skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} \
-          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-          docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-android:${{ inputs.version }}
+        docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -33,15 +33,15 @@ inputs:
     required: false
     default: latest
   build-dev-builder-ubuntu:
-    describtion: Build dev-builder-ubuntu image
+    description: Build dev-builder-ubuntu image
     required: false
     default: 'true'
   build-dev-builder-centos:
-    describtion: Build dev-builder-centos image
+    description: Build dev-builder-centos image
     required: false
     default: 'true'
   build-dev-builder-android:
-    describtion: Build dev-builder-android image
+    description: Build dev-builder-android image
     required: false
     default: 'true'
 runs:
@@ -89,7 +89,7 @@ runs:
           --dest-creds "${{ inputs.acr-image-registry-username }}":"${{ inputs.acr-image-registry-password }}" \
           docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-centos:${{ inputs.version }}
 
-    - name: Build and push dev-builder-android image # Only build amd64 platform.
+    - name: Build and push dev-builder-android image # Only build image for amd64 platform.
       shell: bash
       if: ${{ inputs.build-dev-builder-android == 'true' }}
       run:
@@ -99,6 +99,8 @@ runs:
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }} && \
         
+        docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} && \
+
         skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} \
           --dest-creds "${{ inputs.acr-image-registry-username }}":"${{ inputs.acr-image-registry-password }}" \
           docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -34,11 +34,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install skopeo
-      shell: bash
-      run: |
-        sudo apt update && sudo apt install -y skopeo
-
     - name: Login to Dockerhub
       uses: docker/login-action@v2
       with:

--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -62,7 +62,10 @@ runs:
     - name: Build and push dev-builder-ubuntu image
       shell: bash
       if: ${{ inputs.build-dev-builder-ubuntu == 'true' }}
-      run:
+      env:
+        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
+        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
+      run: |
         make dev-builder \
           BASE_IMAGE=ubuntu \
           BUILDX_MULTI_PLATFORM_BUILD=true \
@@ -71,13 +74,16 @@ runs:
           IMAGE_TAG=${{ inputs.version }} && \
         
         skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }} \
-          --dest-creds "${{ inputs.acr-image-registry-username }}":"${{ inputs.acr-image-registry-password }}" \
+          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
           docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
 
     - name: Build and push dev-builder-centos image
       shell: bash
       if: ${{ inputs.build-dev-builder-centos == 'true' }}
-      run:
+      env:
+        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
+        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
+      run: |
         make dev-builder \
           BASE_IMAGE=centos \
           BUILDX_MULTI_PLATFORM_BUILD=true \
@@ -86,13 +92,16 @@ runs:
           IMAGE_TAG=${{ inputs.version }} && \
         
         skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-centos:${{ inputs.version }} \
-          --dest-creds "${{ inputs.acr-image-registry-username }}":"${{ inputs.acr-image-registry-password }}" \
+          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
           docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-centos:${{ inputs.version }}
 
     - name: Build and push dev-builder-android image # Only build image for amd64 platform.
       shell: bash
       if: ${{ inputs.build-dev-builder-android == 'true' }}
-      run:
+      env:
+        DST_REGISTRY_USERNAME: ${{ inputs.acr-image-registry-username }}
+        DST_REGISTRY_PASSWORD: ${{ inputs.acr-image-registry-password }}
+      run: |
         make dev-builder \
           BASE_IMAGE=android \
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
@@ -102,5 +111,5 @@ runs:
         docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} && \
 
         skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} \
-          --dest-creds "${{ inputs.acr-image-registry-username }}":"${{ inputs.acr-image-registry-password }}" \
+          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
           docker://${{ inputs.acr-image-registry }}/${{ inputs.acr-image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -3,6 +3,10 @@ name: Release dev-builder images
 on:
   workflow_dispatch: # Allows you to run this workflow manually.
     inputs:
+      version:
+        description: Version of the dev-builder
+        required: false
+        default: latest
       release_dev_builder_ubuntu_image:
         type: boolean
         description: Release dev-builder-ubuntu images
@@ -16,6 +20,11 @@ on:
       release_dev_builder_android_image:
         type: boolean
         description: Release dev-builder-android images
+        required: false
+        default: false
+      release_dev_builder_images_cn:
+        type: boolean
+        description: Release dev-builder images to CN region
         required: false
         default: false
 
@@ -33,11 +42,52 @@ jobs:
       - name: Build and push dev builder images
         uses: ./.github/actions/build-dev-builder-images
         with:
+          version: ${{ inputs.version }}
           dockerhub-image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-image-registry-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          acr-image-registry: ${{ vars.ACR_IMAGE_REGISTRY }}
-          acr-image-registry-username: ${{ secrets.ALICLOUD_USERNAME }}
-          acr-image-registry-password: ${{ secrets.ALICLOUD_PASSWORD }}
           build-dev-builder-ubuntu: ${{ inputs.release_dev_builder_ubuntu_image }}
           build-dev-builder-centos: ${{ inputs.release_dev_builder_centos_image }}
           build-dev-builder-android: ${{ inputs.release_dev_builder_android_image }}
+
+  release-dev-builder-images-cn:
+    name: Release dev builder images to CN region
+    runs-on: ubuntu-latest
+    if: ${{ inputs.release_dev_builder_images_cn }}
+    steps:
+      - name: Install skopeo
+        shell: bash
+        run: |
+          sudo apt update && sudo apt install -y skopeo
+
+      - name: Push dev-builder-ubuntu image
+        shell: bash
+        if: ${{ inputs.release_dev_builder_ubuntu_image }}
+        env:
+          DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
+          DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
+        run: |
+          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }} \
+            --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
+
+      - name: Push dev-builder-centos image
+        shell: bash
+        if: ${{ inputs.release_dev_builder_centos_image }}
+        env:
+          DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
+          DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
+        run: |
+          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-centos:${{ inputs.version }} \
+            --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-centos:${{ inputs.version }}
+
+      - name: Push dev-builder-android image
+        shell: bash
+        if: ${{ inputs.release_dev_builder_android_image }}
+        env:
+          DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
+          DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
+        run: |
+          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} \
+            --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -9,27 +9,17 @@ on:
         default: latest
       release_dev_builder_ubuntu_image:
         type: boolean
-        description: Release dev-builder-ubuntu images
+        description: Release dev-builder-ubuntu image
         required: false
         default: false
       release_dev_builder_centos_image:
         type: boolean
-        description: Release dev-builder-centos images
+        description: Release dev-builder-centos image
         required: false
         default: false
       release_dev_builder_android_image:
         type: boolean
-        description: Release dev-builder-android images
-        required: false
-        default: false
-      release_dev_builder_images_cn:
-        type: boolean
-        description: Release dev-builder images to CN region
-        required: false
-        default: false
-      disable_building_images:
-        type: boolean
-        description: Disable building images
+        description: Release dev-builder-android image
         required: false
         default: false
 
@@ -54,14 +44,16 @@ jobs:
           build-dev-builder-centos: ${{ inputs.release_dev_builder_centos_image }}
           build-dev-builder-android: ${{ inputs.release_dev_builder_android_image }}
 
-  release-dev-builder-images-cn:
+  release-dev-builder-images-cn: # Note: Be careful issue: https://github.com/containers/skopeo/issues/1874 and we decide to use the latest stable skopeo container.
     name: Release dev builder images to CN region
     runs-on: ubuntu-latest
-    if: ${{ inputs.release_dev_builder_images_cn }}
+    needs: [
+      release-dev-builder-images
+    ]
     steps:
       - name: Push dev-builder-ubuntu image
         shell: bash
-        if: ${{ inputs.release_dev_builder_ubuntu_image || inputs.disable_building_images }}
+        if: ${{ inputs.release_dev_builder_ubuntu_image }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
@@ -72,7 +64,7 @@ jobs:
 
       - name: Push dev-builder-centos image
         shell: bash
-        if: ${{ inputs.release_dev_builder_centos_image || inputs.disable_building_images }}
+        if: ${{ inputs.release_dev_builder_centos_image }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
@@ -83,7 +75,7 @@ jobs:
 
       - name: Push dev-builder-android image
         shell: bash
-        if: ${{ inputs.release_dev_builder_android_image || inputs.disable_building_images }}
+        if: ${{ inputs.release_dev_builder_android_image }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -71,9 +71,9 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }} \
+          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-ubuntu:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-ubuntu:${{ inputs.version }}
 
       - name: Push dev-builder-centos image
         shell: bash
@@ -82,9 +82,9 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-centos:${{ inputs.version }} \
+          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-centos:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-centos:${{ inputs.version }}
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-centos:${{ inputs.version }}
 
       - name: Push dev-builder-android image
         shell: bash
@@ -93,6 +93,6 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }} \
+          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-android:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
-            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ inputs.acr-image-namespace }}/dev-builder-android:${{ inputs.version }}
+            docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-android:${{ inputs.version }}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -27,6 +27,11 @@ on:
         description: Release dev-builder images to CN region
         required: false
         default: false
+      disable_building_images:
+        type: boolean
+        description: Disable building images
+        required: false
+        default: false
 
 jobs:
   release-dev-builder-images:
@@ -61,7 +66,7 @@ jobs:
 
       - name: Push dev-builder-ubuntu image
         shell: bash
-        if: ${{ inputs.release_dev_builder_ubuntu_image }}
+        if: ${{ inputs.release_dev_builder_ubuntu_image || inputs.disable_building_images }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
@@ -72,7 +77,7 @@ jobs:
 
       - name: Push dev-builder-centos image
         shell: bash
-        if: ${{ inputs.release_dev_builder_centos_image }}
+        if: ${{ inputs.release_dev_builder_centos_image || inputs.disable_building_images }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
@@ -83,7 +88,7 @@ jobs:
 
       - name: Push dev-builder-android image
         shell: bash
-        if: ${{ inputs.release_dev_builder_android_image }}
+        if: ${{ inputs.release_dev_builder_android_image || inputs.disable_building_images }}
         env:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -59,11 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.release_dev_builder_images_cn }}
     steps:
-      - name: Install skopeo
-        shell: bash
-        run: |
-          sudo apt update && sudo apt install -y skopeo
-
       - name: Push dev-builder-ubuntu image
         shell: bash
         if: ${{ inputs.release_dev_builder_ubuntu_image || inputs.disable_building_images }}
@@ -71,7 +66,7 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-ubuntu:${{ inputs.version }} \
+          docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-ubuntu:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
             docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-ubuntu:${{ inputs.version }}
 
@@ -82,7 +77,7 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-centos:${{ inputs.version }} \
+          docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-centos:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
             docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-centos:${{ inputs.version }}
 
@@ -93,6 +88,6 @@ jobs:
           DST_REGISTRY_USERNAME: ${{ secrets.ALICLOUD_USERNAME }}
           DST_REGISTRY_PASSWORD: ${{ secrets.ALICLOUD_PASSWORD }}
         run: |
-          skopeo copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-android:${{ inputs.version }} \
+          docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ vars.IMAGE_NAMESPACE }}/dev-builder-android:${{ inputs.version }} \
             --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
             docker://${{ vars.ACR_IMAGE_REGISTRY }}/${{ vars.IMAGE_NAMESPACE }}/dev-builder-android:${{ inputs.version }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Refine the process of releasing dev-builder images:

1. Add the new job `release-dev-builder-images-cn` to separate the process of using `skopeo` to push images to ACR;

2. Fix run `skopeo` errors:

   - `run:` -> `run: |`(What a stupid mistake);
   - Use skopeo stable latest container instead of installing from apt(the version is stale and will have some problems to work with buildx);
  

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
