### PR TITLE
ci: fix skopeo running errors

### DIFF
--- a/.github/actions/release-cn-artifacts/action.yaml
+++ b/.github/actions/release-cn-artifacts/action.yaml
@@ -63,38 +63,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install skopeo
-      shell: bash
-      run: |
-        sudo apt update && sudo apt install -y skopeo
-
-    - name: Push images from Dockerhub to ACR
-      shell: bash
-      run: |
-        skopeo copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
-          --dest-creds "${{ inputs.image-registry-username }}":"${{ inputs.image-registry-password }}" \
-          docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}
-        
-        if [[ "${{ inputs.dev-mode }}" == "false" ]]; then
-          skopeo copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
-            --dest-creds "${{ inputs.image-registry-username }}":"${{ inputs.image-registry-password }}" \
-            docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}-centos:${{ inputs.version }}
-        fi
-
-    - name: Push latest images from Dockerhub to ACR
-      shell: bash
-      if: ${{ inputs.push-latest-tag == 'true' }}
-      run: |
-        skopeo copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
-          --dest-creds "${{ inputs.image-registry-username }}":"${{ inputs.image-registry-password }}" \
-          docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:latest
-
-        if [[ "${{ inputs.dev-mode }}" == "false" ]]; then
-          skopeo copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
-            --dest-creds "${{ inputs.image-registry-username }}":"${{ inputs.image-registry-password }}" \
-            docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}-centos:latest
-        fi
-
     - name: Download artifacts
       uses: actions/download-artifact@v3
       with:
@@ -136,3 +104,36 @@ runs:
         command: |
           echo "${{ inputs.version }}" > ${{ inputs.artifacts-dir }}/latest-version.txt && \
           aws cp ${{ inputs.artifacts-dir }}/latest-version.txt s3://${{ inputs.aws-cn-s3-bucket }}/releases/greptimedb/latest-version.txt
+
+    - name: Push images from Dockerhub to ACR
+      shell: bash
+      env:
+        DST_REGISTRY_USERNAME: ${{ inputs.image-registry-username }}
+        DST_REGISTRY_PASSWORD: ${{ inputs.image-registry-password }}
+      run: |
+        docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
+          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+          docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}
+        
+        if [[ "${{ inputs.dev-mode }}" == "false" ]]; then
+          docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
+            --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+            docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}-centos:${{ inputs.version }}
+        fi
+
+    - name: Push latest images from Dockerhub to ACR
+      shell: bash
+      if: ${{ inputs.push-latest-tag == 'true' }}
+      env:
+        DST_REGISTRY_USERNAME: ${{ inputs.image-registry-username }}
+        DST_REGISTRY_PASSWORD: ${{ inputs.image-registry-password }}
+      run: |
+        docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
+          --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+          docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:latest
+
+        if [[ "${{ inputs.dev-mode }}" == "false" ]]; then
+          docker run quay.io/skopeo/stable:latest copy -a docker://docker.io/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }} \
+            --dest-creds "$DST_REGISTRY_USERNAME":"$DST_REGISTRY_PASSWORD" \
+            docker://${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}-centos:latest
+        fi


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix skopeo running errors:

- Use env to inject credentials;

- Use skopeo latest stable container instead of installing from apt;

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
