### PR TITLE
feat: lookup manifest file size

### DIFF
--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -115,6 +115,7 @@ impl RegionManifestManager {
     /// Construct a region's manifest and persist it.
     pub async fn new(metadata: RegionMetadataRef, options: RegionManifestOptions) -> Result<Self> {
         let inner = RegionManifestManagerInner::new(metadata, options).await?;
+        debug!("new: total manifest size: {}", inner.manifest_size());
         Ok(Self {
             inner: RwLock::new(inner),
         })
@@ -123,6 +124,7 @@ impl RegionManifestManager {
     /// Open an existing manifest.
     pub async fn open(options: RegionManifestOptions) -> Result<Option<Self>> {
         if let Some(inner) = RegionManifestManagerInner::open(options).await? {
+            debug!("open: total manifest size: {}", inner.manifest_size());
             Ok(Some(Self {
                 inner: RwLock::new(inner),
             }))
@@ -134,13 +136,16 @@ impl RegionManifestManager {
     /// Stop background tasks gracefully.
     pub async fn stop(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
+        debug!("stop: total manifest size: {}", inner.manifest_size());
         inner.stop().await
     }
 
     /// Update the manifest. Return the current manifest version number.
     pub async fn update(&self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
         let mut inner = self.inner.write().await;
-        inner.update(action_list).await
+        let res = inner.update(action_list).await;
+        debug!("update: total manifest size: {}", inner.manifest_size());
+        res
     }
 
     /// Retrieve the current [RegionManifest].

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -115,7 +115,6 @@ impl RegionManifestManager {
     /// Construct a region's manifest and persist it.
     pub async fn new(metadata: RegionMetadataRef, options: RegionManifestOptions) -> Result<Self> {
         let inner = RegionManifestManagerInner::new(metadata, options).await?;
-        debug!("new: total manifest size: {}", inner.manifest_size());
         Ok(Self {
             inner: RwLock::new(inner),
         })
@@ -124,7 +123,6 @@ impl RegionManifestManager {
     /// Open an existing manifest.
     pub async fn open(options: RegionManifestOptions) -> Result<Option<Self>> {
         if let Some(inner) = RegionManifestManagerInner::open(options).await? {
-            debug!("open: total manifest size: {}", inner.manifest_size());
             Ok(Some(Self {
                 inner: RwLock::new(inner),
             }))
@@ -136,16 +134,13 @@ impl RegionManifestManager {
     /// Stop background tasks gracefully.
     pub async fn stop(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
-        debug!("stop: total manifest size: {}", inner.manifest_size());
         inner.stop().await
     }
 
     /// Update the manifest. Return the current manifest version number.
     pub async fn update(&self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
         let mut inner = self.inner.write().await;
-        let res = inner.update(action_list).await;
-        debug!("update: total manifest size: {}", inner.manifest_size());
-        res
+        inner.update(action_list).await
     }
 
     /// Retrieve the current [RegionManifest].
@@ -163,7 +158,7 @@ impl RegionManifestManager {
     /// Returns total manifest size.
     pub async fn manifest_size(&self) -> u64 {
         let inner = self.inner.read().await;
-        inner.manifest_size()
+        inner.total_manifest_size()
     }
 }
 
@@ -329,6 +324,7 @@ impl RegionManifestManagerInner {
         Ok(())
     }
 
+    /// Update the manifest. Return the current manifest version number.
     async fn update(&mut self, action_list: RegionMetaActionList) -> Result<ManifestVersion> {
         let version = self.increase_version();
         self.store.save(version, &action_list.encode()?).await?;
@@ -362,8 +358,8 @@ impl RegionManifestManagerInner {
     }
 
     /// Returns total manifest size.
-    pub(crate) fn manifest_size(&self) -> u64 {
-        self.store.get_manifest_size()
+    pub(crate) fn total_manifest_size(&self) -> u64 {
+        self.store.get_total_manifest_size()
     }
 }
 
@@ -461,7 +457,7 @@ impl RegionManifestManagerInner {
         Ok(Some(checkpoint))
     }
 
-    /// Fetch the last Checkpoint size and [RegionCheckpoint] from storage.
+    /// Fetch the last [RegionCheckpoint] from storage.
     pub(crate) async fn last_checkpoint(
         store: &mut ManifestObjectStore,
     ) -> Result<Option<RegionCheckpoint>> {
@@ -478,14 +474,16 @@ impl RegionManifestManagerInner {
 
 #[cfg(test)]
 mod test {
+
     use api::v1::SemanticType;
     use common_datasource::compression::CompressionType;
+    use common_test_util::temp_dir::create_temp_dir;
     use datatypes::prelude::ConcreteDataType;
     use datatypes::schema::ColumnSchema;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
 
     use super::*;
-    use crate::manifest::action::RegionChange;
+    use crate::manifest::action::{RegionChange, RegionEdit};
     use crate::manifest::tests::utils::basic_region_metadata;
     use crate::test_util::TestEnv;
 
@@ -569,10 +567,36 @@ mod test {
         manager.validate_manifest(&new_metadata, 1).await;
     }
 
+    /// Just for test, the manifest size is the sum of all checkpoint files and delta files,
+    /// refer to wal_dir_usage in src/store-api/src/logstore.rs.
+    async fn manifest_dir_usage(path: &str) -> u64 {
+        let mut size = 0;
+        let mut read_dir = tokio::fs::read_dir(path).await.unwrap();
+        while let Ok(dir_entry) = read_dir.next_entry().await {
+            let Some(entry) = dir_entry else {
+                break;
+            };
+            if entry.file_type().await.unwrap().is_file() {
+                let file_name = entry.file_name().into_string().unwrap();
+                if file_name.contains(".checkpoint") || file_name.contains(".json") {
+                    let file_size = entry.metadata().await.unwrap().len() as usize;
+                    debug!("File: {file_name:?}, size: {file_size}");
+                    size += file_size;
+                }
+            }
+        }
+        size as u64
+    }
+
     #[tokio::test]
     async fn test_manifest_size() {
         let metadata = Arc::new(basic_region_metadata());
-        let env = TestEnv::new();
+        let data_home = create_temp_dir("");
+        let data_home_path = data_home.path().to_str().unwrap().to_string();
+        let env = TestEnv::with_data_home(data_home);
+
+        let manifest_dir = format!("{}/manifest", data_home_path);
+
         let manager = env
             .create_manifest_manager(CompressionType::Uncompressed, 10, Some(metadata.clone()))
             .await
@@ -598,7 +622,27 @@ mod test {
 
         // get manifest size
         let manifest_size = manager.manifest_size().await;
-        assert_eq!(manifest_size, 1557);
+        assert_eq!(manifest_size, manifest_dir_usage(&manifest_dir).await);
+
+        // update 10 times nop_action to trigger checkpoint
+        for _ in 0..10 {
+            manager
+                .update(RegionMetaActionList::new(vec![RegionMetaAction::Edit(
+                    RegionEdit {
+                        files_to_add: vec![],
+                        files_to_remove: vec![],
+                        compaction_time_window: None,
+                        flushed_entry_id: None,
+                        flushed_sequence: None,
+                    },
+                )]))
+                .await
+                .unwrap();
+        }
+
+        // check manifest size again
+        let manifest_size = manager.manifest_size().await;
+        assert_eq!(manifest_size, 1453);
 
         // Reopen the manager.
         manager.stop().await.unwrap();
@@ -607,10 +651,10 @@ mod test {
             .await
             .unwrap()
             .unwrap();
-        manager.validate_manifest(&new_metadata, 1).await;
+        manager.validate_manifest(&new_metadata, 11).await;
 
         // get manifest size again
         let manifest_size = manager.manifest_size().await;
-        assert_eq!(manifest_size, 1557);
+        assert_eq!(manifest_size, manifest_dir_usage(&manifest_dir).await);
     }
 }

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -356,7 +356,7 @@ impl RegionManifestManagerInner {
 
     /// Returns total manifest size.
     pub(crate) fn total_manifest_size(&self) -> u64 {
-        self.store.get_total_manifest_size()
+        self.store.total_manifest_size()
     }
 }
 

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -84,7 +84,6 @@ pub fn file_version(path: &str) -> ManifestVersion {
 /// Just use for .json and .checkpoint file
 /// ### Panics
 /// Panics if the file path is not a valid delta or checkpoint file.
-#[inline]
 pub fn file_name(path: &str) -> String {
     let name = path.rsplit('/').next().unwrap_or("").to_string();
     if !is_checkpoint_file(&name) && !is_delta_file(&name) {
@@ -301,10 +300,10 @@ impl ManifestObjectStore {
         );
 
         // delete the manifest'size in paths
-        paths.iter().for_each(|path| {
+        for path in &paths {
             let name = file_name(path);
             self.manifest_size_map.remove(&name);
-        });
+        }
 
         self.object_store
             .remove(paths)

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -391,6 +391,7 @@ impl ManifestObjectStore {
                             compress_type: self.compress_type,
                             path: path.clone(),
                         })?;
+                // set the checkpoint size
                 self.set_manifest_size_by_path(&path, decompress_data.len() as u64);
                 Ok(Some(decompress_data))
             }

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -480,12 +480,6 @@ impl ManifestObjectStore {
         self.manifest_size_map.values().sum()
     }
 
-    /// Get the total size(Byte) of all manifest files.
-    pub async fn set_total_manifest_size(&mut self) -> Result<u64> {
-        self.set_manifest_size_until(ManifestVersion::MAX).await?;
-        Ok(self.get_total_manifest_size())
-    }
-
     /// Count the total size(Byte) of exist manifest files which satisfy:
     /// delta file version <= end and checkpoint file version < end.
     /// Notice: this function will read files from object store.

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -202,7 +202,7 @@ async fn generate_checkpoint_with_compression_types(
         manager.update(action).await.unwrap();
     }
 
-    RegionManifestManagerInner::last_checkpoint(&manager.store().await)
+    RegionManifestManagerInner::last_checkpoint(&mut manager.store().await)
         .await
         .unwrap()
         .unwrap()

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -99,6 +99,15 @@ impl TestEnv {
         }
     }
 
+    /// Returns a new env with specific `data_home` for test.
+    pub fn with_data_home(data_home: TempDir) -> TestEnv {
+        TestEnv {
+            data_home,
+            logstore: None,
+            object_store: None,
+        }
+    }
+
     pub fn get_logstore(&self) -> Option<Arc<RaftEngineLogStore>> {
         self.logstore.clone()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- use `HashMap<String, u64>` to keep track for every manifest file size in `ManifestObjectStore `.
- we can use `RegionManifestManager::manifest_size()` to get manifest files size.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2551