### PR TITLE
fix: make nyc-taxi bench work again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ name = "benchmarks"
 version = "0.4.0"
 dependencies = [
  "arrow",
+ "chrono",
  "clap 4.4.1",
  "client",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,6 +845,7 @@ dependencies = [
  "chrono",
  "clap 4.4.1",
  "client",
+ "futures-util",
  "indicatif",
  "itertools 0.10.5",
  "parquet",

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 arrow.workspace = true
+chrono.workspace = true
 clap = { version = "4.0", features = ["derive"] }
 client = { workspace = true }
 indicatif = "0.17.1"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,6 +9,7 @@ arrow.workspace = true
 chrono.workspace = true
 clap = { version = "4.0", features = ["derive"] }
 client = { workspace = true }
+futures-util.workspace = true
 indicatif = "0.17.1"
 itertools.workspace = true
 parquet.workspace = true

--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -152,7 +152,6 @@ fn convert_record_batch(record_batch: RecordBatch) -> (Vec<Column>, u32) {
                 .unwrap_or_default(),
             datatype: datatype.into(),
             semantic_type: semantic_type as i32,
-            ..Default::default()
         };
         columns.push(column);
     }

--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -37,7 +37,6 @@ use tokio::task::JoinSet;
 
 const CATALOG_NAME: &str = "greptime";
 const SCHEMA_NAME: &str = "public";
-const TABLE_NAME_PREFIX: &str = "nyc_taxi";
 
 #[derive(Parser)]
 #[command(name = "NYC benchmark runner")]
@@ -76,7 +75,7 @@ fn get_file_list<P: AsRef<Path>>(path: P) -> Vec<PathBuf> {
 }
 
 fn new_table_name() -> String {
-    format!("{}_{}", TABLE_NAME_PREFIX, chrono::Utc::now().timestamp())
+    format!("nyc_taxi_{}", chrono::Utc::now().timestamp())
 }
 
 async fn write_data(

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -26,6 +26,8 @@ use api::v1::greptime_response::Response;
 use api::v1::{AffectedRows, GreptimeResponse};
 pub use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::status_code::StatusCode;
+pub use common_query::Output;
+pub use common_recordbatch::{RecordBatches, SendableRecordBatchStream};
 use snafu::OptionExt;
 
 pub use self::client::Client;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
The request created by the nyc-taxi bench is invalid under 0.4. This PR fixes the issue and appends a timestamp to the table name to avoid table name conflicts.


Here is my test result on mbp 14 2021
```
[00:00:04] ############################################################ 2463931/2463931 file "/Users/evenyag/codes/greptime/greptimedb/benchmarks/data/yellow_tripdata_2022-01.parquet" done in 4048msRunning query: SELECT passenger_count, MIN(fare_amount), MAX(fare_amount), SUM(fare_amount) FROM nyc_taxi_1697182595 GROUP BY passenger_count
query fare_amt_by_passenger, iteration 0: 269ms
query fare_amt_by_passenger, iteration 1: 188ms
query fare_amt_by_passenger, iteration 2: 153ms
Running query: SELECT COUNT(*) FROM nyc_taxi_1697182595;
query count_all, iteration 0: 126ms
query count_all, iteration 1: 121ms
query count_all, iteration 2: 121ms
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
