### PR TITLE
refactor: manifest checkpoint and json file

### DIFF
--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -357,7 +357,7 @@ impl RegionManifestManagerInner {
             && self.options.checkpoint_distance != 0
         {
             debug!(
-                "Going to do checkpoint for version [{} ~ {}]",
+                "Going to do checkpoint for version [{} ~ {})",
                 self.last_checkpoint_version, version
             );
             if let Some(checkpoint) = self.do_checkpoint().await? {
@@ -430,7 +430,9 @@ impl RegionManifestManagerInner {
             .save_checkpoint(last_version, &checkpoint.encode()?)
             .await?;
         // TODO(ruihang): this task can be detached
-        self.store.delete_until(last_version, true).await?;
+        // delete old delta manifest files, we should last_version + 1, because delete_until is
+        // exclusive `end`.
+        self.store.delete_until(last_version + 1, true).await?;
 
         info!(
             "Done manifest checkpoint for region {}, version: [{}, {}], current latest version: {}, compacted {} actions.",

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -355,7 +355,7 @@ impl RegionManifestManagerInner {
     pub(crate) async fn may_do_checkpoint(&mut self, version: ManifestVersion) -> Result<()> {
         // For case where there is no checkpoint.
         let start_version = if self.last_checkpoint_version == 0 {
-            self.last_checkpoint_version
+            0
         } else {
             self.last_checkpoint_version + 1
         };

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -215,7 +215,7 @@ impl ManifestObjectStore {
     pub async fn delete_until(
         &self,
         end: ManifestVersion,
-        keep_last_checkpoint: bool,
+        keep_max_version_checkpoint: bool,
     ) -> Result<usize> {
         // Stores (entry, is_checkpoint, version) in a Vec.
         let entries: Vec<_> = self
@@ -231,7 +231,7 @@ impl ManifestObjectStore {
                 None
             })
             .await?;
-        let checkpoint_version = if keep_last_checkpoint {
+        let checkpoint_version = if keep_max_version_checkpoint {
             // Note that the order of entries is unspecific.
             entries
                 .iter()
@@ -253,7 +253,7 @@ impl ManifestObjectStore {
             .filter(|(_e, is_checkpoint, version)| {
                 if let Some(max_version) = checkpoint_version {
                     if *is_checkpoint {
-                        // We need to keep the checkpoint file.
+                        // We need to keep the max version checkpoint file.
                         version < max_version
                     } else {
                         // We can delete the log file with max_version as the checkpoint
@@ -272,7 +272,7 @@ impl ManifestObjectStore {
             "Deleting {} logs from manifest storage path {} until {}, checkpoint: {:?}, paths: {:?}",
             ret,
             self.path,
-            end,
+            end - 1,
             checkpoint_version,
             paths,
         );

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -261,6 +261,7 @@ impl ManifestObjectStore {
                         version <= max_version
                     }
                 } else {
+                    // We will delete all file that version < end
                     true
                 }
             })

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -128,8 +128,6 @@ async fn manager_with_checkpoint_distance_1() {
     let mut expected = vec![
         "00000000000000000009.checkpoint",
         "00000000000000000010.json",
-        "00000000000000000008.checkpoint",
-        "00000000000000000009.json",
         "_last_checkpoint",
     ];
     expected.sort_unstable();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

### main change:
- delete the extra manifest
- make some debug infos more accurate

### details
Before this pr, the manifest dir looks like this, it has 2 checkpoint files and both have `00000000000000000018.checkpoint` and `00000000000000000018.json` file. however, the `18.checkpoint` already has `18.json` information.
here is an example, `checkpoint_distance` is 10.
```sh
/tmp/greptimedb/data/greptime/public/1025/1025_0000000000/manifest ❯ ls -al                                                                                                                Py base 11:06:24
total 120
drwxr-xr-x  16 zouwei  wheel   512 10 12 11:07 .
drwxr-xr-x   3 zouwei  wheel    96 10 12 10:45 ..
-rw-r--r--   1 zouwei  wheel  2308 10 12 10:54 00000000000000000009.checkpoint
-rw-r--r--   1 zouwei  wheel  2334 10 12 10:54 00000000000000000010.json
-rw-r--r--   1 zouwei  wheel  2519 10 12 10:57 00000000000000000011.json
-rw-r--r--   1 zouwei  wheel  2704 10 12 11:05 00000000000000000012.json
-rw-r--r--   1 zouwei  wheel  2889 10 12 11:05 00000000000000000013.json
-rw-r--r--   1 zouwei  wheel  3074 10 12 11:05 00000000000000000014.json
-rw-r--r--   1 zouwei  wheel  3259 10 12 11:06 00000000000000000015.json
-rw-r--r--   1 zouwei  wheel  3444 10 12 11:07 00000000000000000016.json
-rw-r--r--   1 zouwei  wheel  3629 10 12 11:07 00000000000000000017.json
-rw-r--r--   1 zouwei  wheel  3975 10 12 11:07 00000000000000000018.checkpoint
-rw-r--r--   1 zouwei  wheel  3814 10 12 11:07 00000000000000000018.json
-rw-r--r--   1 zouwei  wheel  3999 10 12 11:07 00000000000000000019.json
-rw-r--r--   1 zouwei  wheel  4184 10 12 11:07 00000000000000000020.json
-rw-r--r--   1 zouwei  wheel    63 10 12 11:07 _last_checkpoint
```
After this pr
```sh
/tmp/greptimedb/data/greptime/public/1115/1115_0000000000/manifest ❯ ls -al                                                                                                                Py base 16:52:12
total 96
drwxr-xr-x  14 zouwei  wheel   448 10 13 16:52 .
drwxr-xr-x   3 zouwei  wheel    96 10 13 16:50 ..
-rw-r--r--   1 zouwei  wheel  2308 10 13 16:51 00000000000000000009.checkpoint
-rw-r--r--   1 zouwei  wheel  2334 10 13 16:51 00000000000000000010.json
-rw-r--r--   1 zouwei  wheel  2519 10 13 16:52 00000000000000000011.json
-rw-r--r--   1 zouwei  wheel  2704 10 13 16:52 00000000000000000012.json
-rw-r--r--   1 zouwei  wheel  2889 10 13 16:52 00000000000000000013.json
-rw-r--r--   1 zouwei  wheel  3074 10 13 16:52 00000000000000000014.json
-rw-r--r--   1 zouwei  wheel  3259 10 13 16:52 00000000000000000015.json
-rw-r--r--   1 zouwei  wheel  3444 10 13 16:52 00000000000000000016.json
-rw-r--r--   1 zouwei  wheel  3629 10 13 16:52 00000000000000000017.json
-rw-r--r--   1 zouwei  wheel  3814 10 13 16:52 00000000000000000018.json
-rw-r--r--   1 zouwei  wheel  3999 10 13 16:52 00000000000000000019.json
-rw-r--r--   1 zouwei  wheel    62 10 13 16:51 _last_checkpoint

/tmp/greptimedb/data/greptime/public/1115/1115_0000000000/manifest ❯ ls -al                                                                                                                Py base 16:52:28
total 40
drwxr-xr-x  5 zouwei  wheel   160 10 13 16:52 .
drwxr-xr-x  3 zouwei  wheel    96 10 13 16:50 ..
-rw-r--r--  1 zouwei  wheel  4161 10 13 16:52 00000000000000000019.checkpoint
-rw-r--r--  1 zouwei  wheel  4184 10 13 16:52 00000000000000000020.json
-rw-r--r--  1 zouwei  wheel    63 10 13 16:52 _last_checkpoint
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
