### PR TITLE
Revert "ci: downgrade builder version: ubuntu 22.04 -> ubuntu 20.04 f…

### DIFF
--- a/docker/buildx/ubuntu/Dockerfile
+++ b/docker/buildx/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as builder
+FROM ubuntu:22.04 as builder
 
 ARG CARGO_PROFILE
 ARG FEATURES
@@ -6,11 +6,6 @@ ARG OUTPUT_DIR
 
 ENV LANG en_US.utf8
 WORKDIR /greptimedb
-
-# Add PPA for Python 3.10.
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa -y
 
 # Install dependencies.
 RUN --mount=type=cache,target=/var/cache/apt \

--- a/docker/dev-builder/ubuntu/Dockerfile
+++ b/docker/dev-builder/ubuntu/Dockerfile
@@ -1,12 +1,7 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV LANG en_US.utf8
 WORKDIR /greptimedb
-
-# Add PPA for Python 3.10.
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa -y
 
 # Install dependencies.
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
…or compatible with older version glibc(>=2.31) (#2592)"

This reverts commit 0a23b403212ed4d30be8fe2625d1c557f431a146.

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
