### PR TITLE
feat: impl ObjectStoreManager for custom_storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5965,6 +5965,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
+ "common-error",
+ "common-macro",
  "common-runtime",
  "common-telemetry",
  "common-test-util",
@@ -5973,6 +5975,7 @@ dependencies = [
  "metrics",
  "moka",
  "opendal",
+ "snafu",
  "tokio",
  "uuid",
 ]

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -7,6 +7,8 @@ license.workspace = true
 [dependencies]
 async-trait = "0.1"
 bytes = "1.4"
+common-error.workspace = true
+common-macro.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true
 futures.workspace = true
@@ -17,6 +19,7 @@ opendal = { version = "0.40", features = [
     "layers-tracing",
     "layers-metrics",
 ] }
+snafu.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/src/object-store/src/error.rs
+++ b/src/object-store/src/error.rs
@@ -35,7 +35,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            Error::DefaultStorageNotFound { .. } => StatusCode::StorageUnavailable,
+            Error::DefaultStorageNotFound { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/object-store/src/error.rs
+++ b/src/object-store/src/error.rs
@@ -1,0 +1,45 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
+use common_macro::stack_trace_debug;
+use snafu::{Location, Snafu};
+
+#[derive(Snafu)]
+#[snafu(visibility(pub))]
+#[stack_trace_debug]
+pub enum Error {
+    #[snafu(display("Global storage not found: {}", global_object_store))]
+    GlobalStorageNotFound {
+        location: Location,
+        global_object_store: String,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl ErrorExt for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::GlobalStorageNotFound { .. } => StatusCode::StorageUnavailable,
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/object-store/src/error.rs
+++ b/src/object-store/src/error.rs
@@ -23,10 +23,10 @@ use snafu::{Location, Snafu};
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
-    #[snafu(display("Global storage not found: {}", global_object_store))]
-    GlobalStorageNotFound {
+    #[snafu(display("Default storage not found: {}", default_object_store))]
+    DefaultStorageNotFound {
         location: Location,
-        global_object_store: String,
+        default_object_store: String,
     },
 }
 
@@ -35,7 +35,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl ErrorExt for Error {
     fn status_code(&self) -> StatusCode {
         match self {
-            Error::GlobalStorageNotFound { .. } => StatusCode::StorageUnavailable,
+            Error::DefaultStorageNotFound { .. } => StatusCode::StorageUnavailable,
         }
     }
 

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -19,7 +19,9 @@ pub use opendal::{
     Operator as ObjectStore, Reader, Result, Writer,
 };
 
+pub mod error;
 pub mod layers;
 mod metrics;
+pub mod object_store_manager;
 pub mod test_util;
 pub mod util;

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -21,7 +21,7 @@ pub use opendal::{
 
 pub mod error;
 pub mod layers;
+pub mod manager;
 mod metrics;
-pub mod object_store_manager;
 pub mod test_util;
 pub mod util;

--- a/src/object-store/src/manager.rs
+++ b/src/object-store/src/manager.rs
@@ -19,6 +19,8 @@ use snafu::ensure;
 use crate::error::Result;
 use crate::{error, ObjectStore};
 
+/// Manages multiple object stores so that users can configure a storage for each table.
+/// This struct certainly have one default object storage, and can have zero or more object stores.
 pub struct ObjectStoreManager {
     stores: HashMap<String, ObjectStore>,
     default_object_store: String,

--- a/src/object-store/src/manager.rs
+++ b/src/object-store/src/manager.rs
@@ -20,10 +20,10 @@ use crate::error::Result;
 use crate::{error, ObjectStore};
 
 /// Manages multiple object stores so that users can configure a storage for each table.
-/// This struct certainly have one default object storage, and can have zero or more object stores.
+/// This struct certainly have one default object store, and can have zero or more custom object stores.
 pub struct ObjectStoreManager {
     stores: HashMap<String, ObjectStore>,
-    default_object_store: String,
+    default_object_store: ObjectStore,
 }
 
 impl ObjectStoreManager {
@@ -38,9 +38,11 @@ impl ObjectStoreManager {
             }
         );
 
+        // Safety: We've already checked in the above place whether this exists.
+        let default_object_store = stores.get(default_object_store).unwrap().clone();
         Ok(ObjectStoreManager {
             stores,
-            default_object_store: default_object_store.to_string(),
+            default_object_store,
         })
     }
 
@@ -49,11 +51,7 @@ impl ObjectStoreManager {
     }
 
     pub fn default_object_store(&self) -> ObjectStore {
-        // Safety: We've already checked in the new method whether this exists.
-        self.stores
-            .get(&self.default_object_store)
-            .cloned()
-            .unwrap()
+        self.default_object_store.clone()
     }
 }
 

--- a/src/object-store/src/manager.rs
+++ b/src/object-store/src/manager.rs
@@ -19,7 +19,6 @@ use snafu::ensure;
 use crate::error::Result;
 use crate::{error, ObjectStore};
 
-#[derive(Clone)]
 pub struct ObjectStoreManager {
     stores: HashMap<String, ObjectStore>,
     global_object_store: String,

--- a/src/object-store/src/object_store_manager.rs
+++ b/src/object-store/src/object_store_manager.rs
@@ -1,0 +1,108 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use snafu::ensure;
+
+use crate::error::Result;
+use crate::{error, ObjectStore};
+
+#[derive(Clone)]
+pub struct ObjectStoreManager {
+    stores: HashMap<String, ObjectStore>,
+    global_object_store: String,
+}
+
+impl ObjectStoreManager {
+    pub fn try_new(
+        stores: HashMap<String, ObjectStore>,
+        global_object_store: &str,
+    ) -> Result<Self> {
+        ensure!(
+            stores.keys().any(|key| key == global_object_store),
+            error::GlobalStorageNotFoundSnafu {
+                global_object_store: global_object_store.to_string()
+            }
+        );
+
+        Ok(ObjectStoreManager {
+            stores,
+            global_object_store: global_object_store.to_string(),
+        })
+    }
+    pub fn find(&self, name: &str) -> Option<ObjectStore> {
+        self.stores.get(name).cloned()
+    }
+    pub fn global_object_store(&self) -> ObjectStore {
+        // Safety: We've already checked in the new method whether this exists.
+        self.stores.get(&self.global_object_store).cloned().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use common_test_util::temp_dir::{create_temp_dir, TempDir};
+
+    use super::ObjectStoreManager;
+    use crate::error::Error;
+    use crate::services::Fs as Builder;
+    use crate::ObjectStore;
+
+    fn new_object_store(dir: &TempDir) -> ObjectStore {
+        let store_dir = dir.path().to_str().unwrap();
+        let mut builder = Builder::default();
+        let _ = builder.root(store_dir);
+        ObjectStore::new(builder).unwrap().finish()
+    }
+
+    #[test]
+    fn test_new_returns_err_when_global_store_not_exist() {
+        let dir = create_temp_dir("new");
+        let object_store = new_object_store(&dir);
+        let stores: HashMap<String, ObjectStore> = vec![
+            ("File".to_string(), object_store.clone()),
+            ("S3".to_string(), object_store.clone()),
+        ]
+        .into_iter()
+        .collect();
+
+        assert!(matches!(
+            ObjectStoreManager::try_new(stores, "Gcs"),
+            Err(Error::GlobalStorageNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn test_new_returns_ok() {
+        let dir = create_temp_dir("new");
+        let object_store = new_object_store(&dir);
+        let stores: HashMap<String, ObjectStore> = vec![
+            ("File".to_string(), object_store.clone()),
+            ("S3".to_string(), object_store.clone()),
+        ]
+        .into_iter()
+        .collect();
+        let object_store_manager = ObjectStoreManager::try_new(stores, "File").unwrap();
+        assert_eq!(object_store_manager.stores.len(), 2);
+        assert!(object_store_manager.find("File").is_some());
+        assert!(object_store_manager.find("S3").is_some());
+        assert!(object_store_manager.find("Gcs").is_none());
+
+        // Panic should not happen.
+        object_store_manager.global_object_store();
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR implements `ObjectStoreManager`, which manages multiple object stores. 

I'll implement #919 at a high level like the below code, and this PR is a first step of this plan:

```rust
impl<S: LogStore> RegionWorkerLoop<S> {
    pub(crate) async fn handle_create_request(
        ~
        let object_store = if let Some(storage) = request.options.get(STORAGE_KEY) {
            self.object_storage_manager: 
                .find(storage)
        ~
        } else {
            self.object_storage_manager.global_object_store()
        };
        // Create a MitoRegion from the RegionMetadata.
        let region = RegionOpener::new(
       ~
            object_store, 
       ~
        )
      ~
```


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Part of https://github.com/GreptimeTeam/greptimedb/issues/919