### PR TITLE
ci: the 'publish-github-release' and 'release-cn-artifacts' have to wait for all the artifacts are built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,8 +302,12 @@ jobs:
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
+    needs: [ # The job have to wait for all the artifacts are built.
       allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+      build-macos-artifacts,
+      build-windows-artifacts,
       release-images-to-dockerhub,
     ]
     runs-on: ubuntu-20.04
@@ -338,11 +342,12 @@ jobs:
   publish-github-release:
     name: Create GitHub release and upload artifacts
     if: ${{ inputs.publish_github_release || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
+    needs: [ # The job have to wait for all the artifacts are built.
       allocate-runners,
       build-linux-amd64-artifacts,
       build-linux-arm64-artifacts,
       build-macos-artifacts,
+      build-windows-artifacts,
       release-images-to-dockerhub,
     ]
     runs-on: ubuntu-20.04


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

ci: the 'publish-github-release' and 'release-cn-artifacts' have to wait for all the artifacts are built

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
