### PR TITLE
feat: implement `HistogramFold` plan for prometheus histogram type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,6 +7032,7 @@ dependencies = [
  "common-catalog",
  "common-error",
  "common-macro",
+ "common-recordbatch",
  "common-telemetry",
  "datafusion",
  "datatypes",

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -12,6 +12,7 @@ catalog = { workspace = true }
 common-catalog = { workspace = true }
 common-error = { workspace = true }
 common-macro = { workspace = true }
+common-recordbatch = { workspace = true }
 common-telemetry = { workspace = true }
 datafusion.workspace = true
 datatypes = { workspace = true }

--- a/src/promql/src/extension_plan.rs
+++ b/src/promql/src/extension_plan.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod empty_metric;
+mod histogram_fold;
 mod instant_manipulate;
 mod normalize;
 mod planner;

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -61,6 +61,8 @@ use crate::functions::{
 
 /// `time()` function in PromQL.
 const SPECIAL_TIME_FUNCTION: &str = "time";
+/// `histogram_quantile` function in PromQL
+const SPECIAL_HISTOGRAM_QUANTILE: &str = "histogram_quantile";
 
 const DEFAULT_TIME_INDEX_COLUMN: &str = "time";
 
@@ -438,6 +440,10 @@ impl PromPlanner {
                             .context(DataFusionPlanningSnafu)?,
                         ),
                     }));
+                }
+
+                if func.name == SPECIAL_HISTOGRAM_QUANTILE {
+                    todo!()
                 }
 
                 let args = self.create_function_args(&args.args)?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Part one of prometheus histogram. The next part is about planner and quantile.

### `HistogramFold`

`HistogramFold` will fold the conventional (non-native) histogram ([1]) for later
computing. Specifically, it will transform the `le` and `field` column into a complex
type, and samples on other tag columns:
- `le` will become a [ListArray] of [f64]. With each bucket bound parsed
- `field` will become a [ListArray] of [f64]
- other columns will be sampled every `bucket_num` element, but their types won't change.

Due to the folding or sampling, the output rows number will become `input_rows` / `bucket_num`.

`le` should be the same across the entire metric. Thus it can be a `Dict<List<f64>>` to reduce size. However this is not viable at present because I cannot construct such a dict array 🥲

### Requirement
- Input should be sorted on `<tag list>, le ASC, ts`.
- The value set of `le` should be same. I.e., buckets of every series should be same.

[1]: https://prometheus.io/docs/concepts/metric_types/#histogram

### Result

It's output looks like 
```sql
+--------+---------------------------------+--------------------------------+
| host   | le                              | val                            |
+--------+---------------------------------+--------------------------------+
| host_1 | [0.001, 0.1, 10.0, 1000.0, inf] | [0.0, 1.0, 1.0, 5.0, 5.0]      |
| host_1 | [0.001, 0.1, 10.0, 1000.0, inf] | [0.0, 20.0, 60.0, 70.0, 100.0] |
| host_1 | [0.001, 0.1, 10.0, 1000.0, inf] | [1.0, 1.0, 1.0, 1.0, 1.0]      |
| host_2 | [0.001, 0.1, 10.0, 1000.0, inf] | [0.0, 0.0, 0.0, 0.0, 0.0]      |
| host_2 | [0.001, 0.1, 10.0, 1000.0, inf] | [0.0, 1.0, 2.0, 3.0, 4.0]      |
+--------+---------------------------------+--------------------------------+
```


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- related to #1042