### PR TITLE
fix: pass datanode config file in distributed mode sqlness

### DIFF
--- a/tests/conf/datanode-test.toml.template
+++ b/tests/conf/datanode-test.toml.template
@@ -4,12 +4,11 @@ require_lease_before_startup = true
 rpc_addr = '127.0.0.1:4100'
 rpc_hostname = '127.0.0.1'
 rpc_runtime_size = 8
-require_lease_before_startup = true
 
 [wal]
 file_size = '1GB'
 purge_interval = '10m'
-purge_threshold = '50GB'
+purge_threshold = '10GB'
 read_batch_size = 128
 sync_write = false
 

--- a/tests/conf/standalone-test.toml.template
+++ b/tests/conf/standalone-test.toml.template
@@ -5,7 +5,7 @@ require_lease_before_startup = true
 [wal]
 file_size = '1GB'
 purge_interval = '10m'
-purge_threshold = '50GB'
+purge_threshold = '10GB'
 read_batch_size = 128
 sync_write = false
 

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -235,6 +235,8 @@ impl Env {
         args.push(format!("--http-addr=127.0.0.1:430{id}"));
         args.push(format!("--data-home={}", data_home.display()));
         args.push(format!("--node-id={id}"));
+        args.push(format!("-c"));
+        args.push(self.generate_config_file(subcommand, db_ctx));
         args.push("--metasrv-addr=127.0.0.1:3002".to_string());
         (args, format!("127.0.0.1:410{id}"))
     }

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -235,7 +235,7 @@ impl Env {
         args.push(format!("--http-addr=127.0.0.1:430{id}"));
         args.push(format!("--data-home={}", data_home.display()));
         args.push(format!("--node-id={id}"));
-        args.push(format!("-c"));
+        args.push("-c".to_string());
         args.push(self.generate_config_file(subcommand, db_ctx));
         args.push("--metasrv-addr=127.0.0.1:3002".to_string());
         (args, format!("127.0.0.1:410{id}"))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Pass config file of datanode in distributed mode with `-c xxx.toml`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
