### PR TITLE
feat: introduce the region role

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,7 +3635,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=20cdc57c3f320345b122eea43bc549a19d342e51#20cdc57c3f320345b122eea43bc549a19d342e51"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=3137cd184770e03f6a4dc191deaf02beb11fae7d#3137cd184770e03f6a4dc191deaf02beb11fae7d"
 dependencies = [
  "prost 0.12.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ derive_builder = "0.12"
 etcd-client = "0.11"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "20cdc57c3f320345b122eea43bc549a19d342e51" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "3137cd184770e03f6a4dc191deaf02beb11fae7d" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -107,7 +107,7 @@ impl RegionServer {
         self.inner
             .region_map
             .iter()
-            .flat_map(|e| {
+            .filter_map(|e| {
                 let region_id = *e.key();
                 // Filters out any regions whose role equals None.
                 e.role(region_id).map(|role| RegionStat {

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -37,7 +37,7 @@ use query::query_engine::DescribeResult;
 use query::QueryEngine;
 use session::context::QueryContextRef;
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_engine::RegionEngine;
+use store_api::region_engine::{RegionEngine, RegionRole};
 use store_api::region_request::RegionRequest;
 use store_api::storage::{RegionId, ScanRequest};
 use table::TableRef;
@@ -189,5 +189,9 @@ impl RegionEngine for MockRegionEngine {
 
     fn set_writable(&self, _region_id: RegionId, _writable: bool) -> Result<(), BoxedError> {
         Ok(())
+    }
+
+    fn role(&self, _region_id: RegionId) -> Option<RegionRole> {
+        Some(RegionRole::Leader)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Introduce the region's role. Now, we only have two role:

The `RegionRole::Follower`:  Readonly Region(mito2), Readonly Region(file).
The `RegionRole::Leader`: Writable Region(mito2).

**Notes**: We treat all File Region as `RegionRole::Follower`, even if it's the leader peer in the region routes.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2639