### PR TITLE
refactor: create_or_open always set writable

### DIFF
--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -119,7 +119,8 @@ impl RegionOpener {
                     &expect.column_metadatas,
                     &expect.primary_key,
                 )?;
-
+                // To keep consistence with Create behavior, set the opened Region writable.
+                region.set_writable(true);
                 return Ok(region);
             }
             Ok(None) => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`create_or_open` will always return a writable region now.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes https://github.com/GreptimeTeam/greptimedb/issues/2634