### PR TITLE
chore: show version report data only once at db startup

### DIFF
--- a/src/common/greptimedb-telemetry/src/lib.rs
+++ b/src/common/greptimedb-telemetry/src/lib.rs
@@ -210,6 +210,7 @@ pub struct GreptimeDBTelemetry {
     working_home: Option<String>,
     telemetry_url: &'static str,
     should_report: Arc<AtomicBool>,
+    report_times: usize,
 }
 
 #[async_trait::async_trait]
@@ -242,6 +243,7 @@ impl GreptimeDBTelemetry {
             client: client.ok(),
             telemetry_url: TELEMETRY_URL,
             should_report,
+            report_times: 0,
         }
     }
 
@@ -259,8 +261,11 @@ impl GreptimeDBTelemetry {
                 };
 
                 if let Some(client) = self.client.as_ref() {
-                    info!("reporting greptimedb version: {:?}", data);
+                    if self.report_times == 0 {
+                        info!("reporting greptimedb version: {:?}", data);
+                    }
                     let result = client.post(self.telemetry_url).json(&data).send().await;
+                    self.report_times += 1;
                     debug!("report version result: {:?}", result);
                     result.ok()
                 } else {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

* show version report data only once at db startup

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
