### PR TITLE
feat: introduce the peer state

### DIFF
--- a/src/cmd/src/cli/bench.rs
+++ b/src/cmd/src/cli/bench.rs
@@ -155,6 +155,7 @@ fn create_region_routes() -> Vec<RegionRoute> {
             leader_peer: Some(Peer {
                 id: rng.gen_range(0..10),
                 addr: String::new(),
+                ..Default::default()
             }),
             follower_peers: vec![],
         });

--- a/src/common/meta/src/peer.rs
+++ b/src/common/meta/src/peer.rs
@@ -17,11 +17,50 @@ use std::fmt::{Display, Formatter};
 use api::v1::meta::Peer as PbPeer;
 use serde::{Deserialize, Serialize};
 
+/// The State of the [Peer].
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
+pub enum PeerState {
+    /// The following cases in which the [Peer] will be downgraded.
+    ///
+    /// - The [Peer] or [Region][crate::rpc::router::Region] on the [Peer] is unavailable(e.g., Crashed, Network disconnected).
+    /// - The [Region][crate::rpc::router::Region] on the [Peer] was planned to migrate to another [Peer].
+    Downgraded,
+}
+
 #[derive(Debug, Default, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Peer {
     /// Node identifier. Unique in a cluster.
     pub id: u64,
     pub addr: String,
+    /// `None` by default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<PeerState>,
+}
+
+impl Peer {
+    /// Returns true if the [Peer] is downgraded.
+    ///
+    /// The following cases in which the [Peer] will be downgraded.
+    ///
+    /// - The [Peer] or [Region][crate::rpc::router::Region] on the [Peer] is unavailable(e.g., Crashed, Network disconnected).
+    /// - The [Region][crate::rpc::router::Region] on the [Peer] was planned to migrate to another [Peer].
+    ///
+    pub fn is_downgraded(&self) -> bool {
+        matches!(self.state, Some(PeerState::Downgraded))
+    }
+
+    /// Marks the [Peer] as downgraded.
+    ///
+    /// We should downgrade a [Peer] before deactivating a [Region][crate::rpc::router::Region] on it:
+    ///
+    /// - During the [Region][crate::rpc::router::Region] Failover Procedure.
+    /// - Migrating a [Region][crate::rpc::router::Region].
+    ///
+    /// **Notes:** Meta Server will stop renewing the lease for a [Region][crate::rpc::router::Region] on the downgraded [Peer].
+    ///
+    pub fn downgrade(&mut self) {
+        self.state = Some(PeerState::Downgraded)
+    }
 }
 
 impl From<PbPeer> for Peer {
@@ -29,6 +68,7 @@ impl From<PbPeer> for Peer {
         Self {
             id: p.id,
             addr: p.addr,
+            state: None,
         }
     }
 }
@@ -47,6 +87,7 @@ impl Peer {
         Self {
             id,
             addr: addr.into(),
+            state: None,
         }
     }
 }
@@ -54,5 +95,36 @@ impl Peer {
 impl Display for Peer {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "peer-{}({})", self.id, self.addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::Peer;
+
+    #[test]
+    fn test_peer_serde() {
+        let peer = Peer::new(2, "test");
+
+        let serialized = serde_json::to_string(&peer).unwrap();
+
+        let expected = r#"{"id":2,"addr":"test"}"#;
+        assert_eq!(serialized, expected);
+
+        let decoded: Peer = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(peer, decoded);
+    }
+
+    #[test]
+    fn test_peer_is_downgraded() {
+        let mut peer = Peer::new(2, "test");
+
+        assert!(!peer.is_downgraded());
+
+        peer.downgrade();
+
+        assert!(peer.is_downgraded());
     }
 }

--- a/src/meta-srv/src/procedure/region_failover/activate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/activate_region.rs
@@ -279,7 +279,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{next_state:?}"),
-            r#"UpdateRegionMetadata { candidate: Peer { id: 2, addr: "" }, region_storage_path: "greptime/public", region_options: {} }"#
+            r#"UpdateRegionMetadata { candidate: Peer { id: 2, addr: "", state: None }, region_storage_path: "greptime/public", region_options: {} }"#
         );
     }
 

--- a/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
@@ -226,7 +226,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             format!("{next_state:?}"),
-            r#"ActivateRegion { candidate: Peer { id: 2, addr: "" }, remark_inactive_region: false, region_storage_path: None, region_options: None }"#
+            r#"ActivateRegion { candidate: Peer { id: 2, addr: "", state: None }, remark_inactive_region: false, region_storage_path: None, region_options: None }"#
         );
     }
 
@@ -268,7 +268,7 @@ mod tests {
         // Timeout or not, proceed to `ActivateRegion`.
         assert_eq!(
             format!("{next_state:?}"),
-            r#"ActivateRegion { candidate: Peer { id: 2, addr: "" }, remark_inactive_region: false, region_storage_path: None, region_options: None }"#
+            r#"ActivateRegion { candidate: Peer { id: 2, addr: "", state: None }, remark_inactive_region: false, region_storage_path: None, region_options: None }"#
         );
     }
 }

--- a/src/meta-srv/src/table_routes.rs
+++ b/src/meta-srv/src/table_routes.rs
@@ -118,6 +118,7 @@ pub(crate) mod tests {
             leader_peer: Some(Peer {
                 id: peer,
                 addr: String::new(),
+                state: None,
             }),
             follower_peers: vec![],
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Introduces the peer state. By default, the peer's state is None. 

We should downgrade a Peer before deactivating a Region on it:

- During the Region Failover Procedure (Region on the Peer is unavailable).
- Migrating a Region (Region on the Peer was planned to migrate to another Peer).

**Notes:** Meta Server will stop renewing the lease for a Region on the downgraded Peer.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2638