### PR TITLE
fix: add serde default to MitoConfig

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -101,6 +101,10 @@ auto_flush_interval = "1h"
 global_write_buffer_size = "1GB"
 # Global write buffer size threshold to reject write requests (default 2G).
 global_write_buffer_reject_size = "2GB"
+# Cache size for SST metadata (default 128MB). Setting it to 0 to disable the cache.
+sst_meta_cache_size = "128MB"
+# Cache size for vectors and arrow arrays (default 512MB). Setting it to 0 to disable the cache.
+vector_cache_size = "512MB"
 
 # Log options
 # [logging]

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -28,6 +28,7 @@ const DEFAULT_MAX_BG_JOB: usize = 4;
 
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
 pub struct MitoConfig {
     // Worker configs:
     /// Number of region workers (default 1).


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR derives `serde(default)` for `MitoConfig`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
