### PR TITLE
feat: estimate region wal size

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -95,6 +95,11 @@ impl MitoEngine {
     pub(crate) fn get_region(&self, id: RegionId) -> Option<crate::region::MitoRegionRef> {
         self.inner.workers.get_region(id)
     }
+
+    /// Returns the estimated size of the region's WAL.
+    pub fn get_region_wal_size(&self, id: RegionId) -> Result<usize> {
+        self.inner.get_region_wal_size(id)
+    }
 }
 
 /// Inner struct of [MitoEngine].
@@ -171,6 +176,16 @@ impl EngineInner {
 
         region.set_writable(writable);
         Ok(())
+    }
+
+    /// Returns the estimated size of the region's WAL.
+    fn get_region_wal_size(&self, region_id: RegionId) -> Result<usize> {
+        let region = self
+            .workers
+            .get_region(region_id)
+            .context(RegionNotFoundSnafu { region_id })?;
+
+        Ok(region.estimated_wal_size())
     }
 }
 

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -95,11 +95,6 @@ impl MitoEngine {
     pub(crate) fn get_region(&self, id: RegionId) -> Option<crate::region::MitoRegionRef> {
         self.inner.workers.get_region(id)
     }
-
-    /// Returns the estimated size of the region's WAL.
-    pub fn get_region_wal_size(&self, id: RegionId) -> Result<usize> {
-        self.inner.get_region_wal_size(id)
-    }
 }
 
 /// Inner struct of [MitoEngine].
@@ -176,16 +171,6 @@ impl EngineInner {
 
         region.set_writable(writable);
         Ok(())
-    }
-
-    /// Returns the estimated size of the region's WAL.
-    fn get_region_wal_size(&self, region_id: RegionId) -> Result<usize> {
-        let region = self
-            .workers
-            .get_region(region_id)
-            .context(RegionNotFoundSnafu { region_id })?;
-
-        Ok(region.estimated_wal_size())
     }
 }
 

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -480,7 +480,7 @@ async fn test_estimated_wal_size() {
     put_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 119);
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 124);
 
     let rows = Rows {
         schema: column_schemas.clone(),
@@ -489,7 +489,7 @@ async fn test_estimated_wal_size() {
     put_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 238);
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 249);
 
     // Delete (a, 0), (a, 1), (a, 2)
     let rows = Rows {
@@ -505,5 +505,5 @@ async fn test_estimated_wal_size() {
     delete_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 272);
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 292);
 }

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -457,3 +457,53 @@ async fn test_absent_and_invalid_columns() {
         .unwrap_err();
     assert_eq!(StatusCode::InvalidArguments, err.status_code());
 }
+
+#[tokio::test]
+async fn test_estimated_wal_size() {
+    let mut env = TestEnv::with_prefix("estimate-region-wal-size");
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new().build();
+
+    let column_schemas = rows_schema(&request);
+    let delete_schema = delete_rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("a", 0, 10, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    // check wal size
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 119);
+
+    let rows = Rows {
+        schema: column_schemas.clone(),
+        rows: build_rows_for_key("b", 0, 10, 0),
+    };
+    put_rows(&engine, region_id, rows).await;
+
+    // check wal size
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 238);
+
+    // Delete (a, 0), (a, 1), (a, 2)
+    let rows = Rows {
+        schema: delete_schema.clone(),
+        rows: build_delete_rows_for_key("a", 0, 3),
+    };
+    delete_rows(&engine, region_id, rows).await;
+    // Delete (b, 0), (b, 1)
+    let rows = Rows {
+        schema: delete_schema,
+        rows: build_delete_rows_for_key("b", 0, 2),
+    };
+    delete_rows(&engine, region_id, rows).await;
+
+    // check wal size
+    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 272);
+}

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -480,7 +480,8 @@ async fn test_estimated_wal_size() {
     put_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 124);
+    let region = engine.get_region(region_id).unwrap();
+    assert_eq!(region.estimated_wal_size(), 124);
 
     let rows = Rows {
         schema: column_schemas.clone(),
@@ -489,7 +490,7 @@ async fn test_estimated_wal_size() {
     put_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 249);
+    assert_eq!(region.estimated_wal_size(), 249);
 
     // Delete (a, 0), (a, 1), (a, 2)
     let rows = Rows {
@@ -505,5 +506,5 @@ async fn test_estimated_wal_size() {
     delete_rows(&engine, region_id, rows).await;
 
     // check wal size
-    assert_eq!(engine.get_region_wal_size(region_id).unwrap(), 292);
+    assert_eq!(region.estimated_wal_size(), 292);
 }

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -100,6 +100,14 @@ impl MemtableVersion {
         self.mutable.stats().estimated_bytes
     }
 
+    /// Returns the memory usage of the immutable memtables.
+    pub(crate) fn immutables_usage(&self) -> usize {
+        self.immutables
+            .iter()
+            .map(|mem| mem.stats().estimated_bytes)
+            .sum()
+    }
+
     /// Returns true if the memtable version is empty.
     ///
     /// The version is empty when mutable memtable is empty and there is no

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -35,9 +35,8 @@ use crate::region::version::{VersionControlRef, VersionRef};
 use crate::request::OnFailure;
 use crate::sst::file_purger::FilePurgerRef;
 
-/// This is the ratio of the size of memtables to the size of wal,
-/// It is a rough estimation of the size of wal.
-const ESTIMATED_WAL_FACTOR: f32 = 0.565642;
+/// This is the approximate factor to estimate the size of wal.
+const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
 
 /// Metadata and runtime status of a region.
 ///
@@ -115,7 +114,7 @@ impl MitoRegion {
     }
 
     /// Estimated WAL size in bytes.
-    /// Use the size of memtables to estimate the size of wal.
+    /// Use the memtables size to estimate the size of wal.
     pub(crate) fn estimated_wal_size(&self) -> usize {
         let memtables = &self.version().memtables;
         let memtable_size = memtables.mutable_usage() + memtables.immutables_usage();

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -115,6 +115,7 @@ impl MitoRegion {
 
     /// Estimated WAL size in bytes.
     /// Use the memtables size to estimate the size of wal.
+    // TODO(Quenkar): after impl region size, remove #[allow(dead_code)]
     #[allow(dead_code)]
     pub(crate) fn estimated_wal_size(&self) -> usize {
         let memtables = &self.version().memtables;

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -35,6 +35,10 @@ use crate::region::version::{VersionControlRef, VersionRef};
 use crate::request::OnFailure;
 use crate::sst::file_purger::FilePurgerRef;
 
+/// This is the ratio of the size of memtables to the size of wal,
+/// It is a rough estimation of the size of wal.
+const ESTIMATED_WAL_FACTOR: f32 = 0.565642;
+
 /// Metadata and runtime status of a region.
 ///
 /// Writing and reading a region follow a single-writer-multi-reader rule:
@@ -108,6 +112,14 @@ impl MitoRegion {
     /// Sets the writable flag.
     pub(crate) fn set_writable(&self, writable: bool) {
         self.writable.store(writable, Ordering::Relaxed);
+    }
+
+    /// Estimated WAL size in bytes.
+    /// Use the size of memtables to estimate the size of wal.
+    pub(crate) fn estimated_wal_size(&self) -> usize {
+        let memtables = &self.version().memtables;
+        let memtable_size = memtables.mutable_usage() + memtables.immutables_usage();
+        ((memtable_size as f32) * ESTIMATED_WAL_FACTOR) as usize
     }
 }
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -115,6 +115,7 @@ impl MitoRegion {
 
     /// Estimated WAL size in bytes.
     /// Use the memtables size to estimate the size of wal.
+    #[allow(dead_code)]
     pub(crate) fn estimated_wal_size(&self) -> usize {
         let memtables = &self.version().memtables;
         let memtable_size = memtables.mutable_usage() + memtables.immutables_usage();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- memtable size is more accurate (now include timestamp and op type size)
- use memtable size to estimate wal size.

#### details
1. construct different size of rows to insert into or delete from table, and record relevant memtable size and wal size.
2. compute linear regression of these data, and get a rough slope, and use regression line' slope to estimate wal size.

<img width="585" alt="SCR-20231024-sztu" src="https://github.com/GreptimeTeam/greptimedb/assets/47681251/7484ae59-78e4-4809-881d-929283f1a409">

the `slope` is not very accurate, and I also don't think about the `interception` because wal writes some metadata in `WalEntry`, and if the rows size is small, it's inaccurate.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2551