### PR TITLE
fix: remove StatusCode::Unexpected from masked error code set

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -187,8 +187,8 @@ impl StartCommand {
         Ok(Options::Frontend(Box::new(opts)))
     }
 
-    async fn build(self, mut opts: FrontendOptions) -> Result<Instance> {
-        let plugins = plugins::setup_frontend_plugins(&mut opts)
+    async fn build(self, opts: FrontendOptions) -> Result<Instance> {
+        let plugins = plugins::setup_frontend_plugins(&opts)
             .await
             .context(StartFrontendSnafu)?;
 
@@ -303,7 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_from_start_command_to_anymap() {
-        let mut fe_opts = FrontendOptions {
+        let fe_opts = FrontendOptions {
             http: HttpOptions {
                 disable_dashboard: false,
                 ..Default::default()
@@ -312,7 +312,7 @@ mod tests {
             ..Default::default()
         };
 
-        let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
+        let plugins = plugins::setup_frontend_plugins(&fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();
         let result = provider

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -316,8 +316,8 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     async fn build(self, opts: MixOptions) -> Result<Instance> {
-        let mut fe_opts = opts.frontend;
-        let fe_plugins = plugins::setup_frontend_plugins(&mut fe_opts)
+        let fe_opts = opts.frontend;
+        let fe_plugins = plugins::setup_frontend_plugins(&fe_opts)
             .await
             .context(StartFrontendSnafu)?;
 
@@ -421,12 +421,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_from_start_command_to_anymap() {
-        let mut fe_opts = FrontendOptions {
+        let fe_opts = FrontendOptions {
             user_provider: Some("static_user_provider:cmd:test=test".to_string()),
             ..Default::default()
         };
 
-        let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
+        let plugins = plugins::setup_frontend_plugins(&fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();
         let result = provider

--- a/src/common/error/src/ext.rs
+++ b/src/common/error/src/ext.rs
@@ -40,7 +40,7 @@ pub trait ErrorExt: StackError {
         Self: Sized,
     {
         match self.status_code() {
-            StatusCode::Unknown | StatusCode::Unexpected | StatusCode::Internal => {
+            StatusCode::Unknown | StatusCode::Internal => {
                 // masks internal error from end user
                 format!("Internal error: {}", self.status_code() as u32)
             }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -1047,6 +1047,6 @@ mod tests {
         // Run the runner and execute the procedure.
         runner.run().await;
         let err = meta.state().error().unwrap().output_msg();
-        assert!(err.contains("Internal error"), "{err}");
+        assert!(err.contains("subprocedure failed"), "{err}");
     }
 }

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -556,11 +556,12 @@ impl ErrorExt for Error {
 
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
 
-            Error::JoinTask { .. }
-            | Error::BuildParquetRecordBatchStream { .. }
-            | Error::ReadDfRecordBatch { .. }
+            Error::JoinTask { .. } => StatusCode::Internal,
+
+            Error::BuildParquetRecordBatchStream { .. }
             | Error::BuildFileStream { .. }
             | Error::WriteStreamToFile { .. }
+            | Error::ReadDfRecordBatch { .. }
             | Error::Unexpected { .. } => StatusCode::Unexpected,
 
             Error::Catalog { source, .. } => source.status_code(),

--- a/src/plugins/src/frontend.rs
+++ b/src/plugins/src/frontend.rs
@@ -18,7 +18,7 @@ use frontend::error::{IllegalAuthConfigSnafu, Result};
 use frontend::frontend::FrontendOptions;
 use snafu::ResultExt;
 
-pub async fn setup_frontend_plugins(opts: &mut FrontendOptions) -> Result<Plugins> {
+pub async fn setup_frontend_plugins(opts: &FrontendOptions) -> Result<Plugins> {
     let plugins = Plugins::new();
 
     if let Some(user_provider) = opts.user_provider.as_ref() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch remove `StatusCode::Unexpected` from masked error code because we are using it for the semantics of *unexpected* input. 

This patch also fixes some lint issue on newer version of rust.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
