### PR TITLE
refactor: remove move_value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,7 +3635,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=365922c3581ad954b3b3851af522b0ed0096970c#365922c3581ad954b3b3851af522b0ed0096970c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=1d7dc6f18b310355a4c16fb453d3ca7ed09f048d#1d7dc6f18b310355a4c16fb453d3ca7ed09f048d"
 dependencies = [
  "prost 0.12.1",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5658,8 +5658,9 @@ checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
 
 [[package]]
 name = "orc-rust"
-version = "0.2.42"
-source = "git+https://github.com/WenyXu/orc-rs.git?rev=5f6399f759ba30cb46610d06027b507949a117ca#5f6399f759ba30cb46610d06027b507949a117ca"
+version = "0.2.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900310981898f6e3877286f1272b75f5c4a604628594a0a7026311b93a2aa5e6"
 dependencies = [
  "arrow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ derive_builder = "0.12"
 etcd-client = "0.11"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "365922c3581ad954b3b3851af522b0ed0096970c" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "1d7dc6f18b310355a4c16fb453d3ca7ed09f048d" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -25,7 +25,7 @@ derive_builder.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
 object-store = { workspace = true }
-orc-rust = { git = "https://github.com/WenyXu/orc-rs.git", rev = "5f6399f759ba30cb46610d06027b507949a117ca" }
+orc-rust = "0.2"
 paste = "1.0"
 regex = "1.7"
 serde.workspace = true

--- a/src/common/meta/src/kv_backend.rs
+++ b/src/common/meta/src/kv_backend.rs
@@ -27,8 +27,7 @@ use crate::error::Error;
 use crate::rpc::store::{
     BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse, BatchPutRequest,
     BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse, DeleteRangeRequest,
-    DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest, PutResponse,
-    RangeRequest, RangeResponse,
+    DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
 };
 use crate::rpc::KeyValue;
 
@@ -65,9 +64,6 @@ where
         &self,
         req: BatchDeleteRequest,
     ) -> Result<BatchDeleteResponse, Self::Error>;
-
-    /// MoveValue atomically renames the key to the given updated key.
-    async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse, Self::Error>;
 
     // The following methods are implemented based on the above methods,
     // and a higher-level interface is provided for to simplify usage.

--- a/src/common/meta/src/sequence.rs
+++ b/src/common/meta/src/sequence.rs
@@ -166,8 +166,7 @@ mod tests {
     use crate::rpc::store::{
         BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse,
         BatchPutRequest, BatchPutResponse, CompareAndPutResponse, DeleteRangeRequest,
-        DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest, PutResponse,
-        RangeRequest, RangeResponse,
+        DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
     };
 
     #[tokio::test]
@@ -245,10 +244,6 @@ mod tests {
             }
 
             async fn batch_delete(&self, _: BatchDeleteRequest) -> Result<BatchDeleteResponse> {
-                unreachable!()
-            }
-
-            async fn move_value(&self, _: MoveValueRequest) -> Result<MoveValueResponse> {
                 unreachable!()
             }
         }

--- a/src/log-store/src/raft_engine/backend.rs
+++ b/src/log-store/src/raft_engine/backend.rs
@@ -25,8 +25,7 @@ use common_meta::kv_backend::{KvBackend, TxnService};
 use common_meta::rpc::store::{
     BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse, BatchPutRequest,
     BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse, DeleteRangeRequest,
-    DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest, PutResponse,
-    RangeRequest, RangeResponse,
+    DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
 };
 use common_meta::rpc::KeyValue;
 use common_meta::util::get_next_prefix_key;
@@ -341,10 +340,6 @@ impl KvBackend for RaftEngineBackend {
             .map_err(BoxedError::new)
             .context(meta_error::ExternalSnafu)?;
         Ok(BatchDeleteResponse { prev_kvs })
-    }
-
-    async fn move_value(&self, _req: MoveValueRequest) -> Result<MoveValueResponse, Self::Error> {
-        unimplemented!()
     }
 
     async fn get(&self, key: &[u8]) -> Result<Option<KeyValue>, Self::Error> {

--- a/src/meta-client/src/client/store.rs
+++ b/src/meta-client/src/client/store.rs
@@ -19,8 +19,7 @@ use api::v1::meta::store_client::StoreClient;
 use api::v1::meta::{
     BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse, BatchPutRequest,
     BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse, DeleteRangeRequest,
-    DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest, PutResponse,
-    RangeRequest, RangeResponse, Role,
+    DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse, Role,
 };
 use common_grpc::channel_manager::ChannelManager;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -98,11 +97,6 @@ impl Client {
     pub async fn delete_range(&self, req: DeleteRangeRequest) -> Result<DeleteRangeResponse> {
         let inner = self.inner.read().await;
         inner.delete_range(req).await
-    }
-
-    pub async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse> {
-        let inner = self.inner.read().await;
-        inner.move_value(req).await
     }
 }
 
@@ -197,14 +191,6 @@ impl Inner {
         let mut client = self.random_client()?;
         req.set_header(self.id, self.role);
         let res = client.delete_range(req).await.map_err(error::Error::from)?;
-
-        Ok(res.into_inner())
-    }
-
-    async fn move_value(&self, mut req: MoveValueRequest) -> Result<MoveValueResponse> {
-        let mut client = self.random_client()?;
-        req.set_header(self.id, self.role);
-        let res = client.move_value(req).await.map_err(error::Error::from)?;
 
         Ok(res.into_inner())
     }

--- a/src/meta-srv/src/service/store/kv.rs
+++ b/src/meta-srv/src/service/store/kv.rs
@@ -23,8 +23,7 @@ use common_meta::kv_backend::{KvBackend, KvBackendRef, TxnService};
 use common_meta::rpc::store::{
     BatchDeleteRequest, BatchDeleteResponse, BatchGetRequest, BatchGetResponse, BatchPutRequest,
     BatchPutResponse, CompareAndPutRequest, CompareAndPutResponse, DeleteRangeRequest,
-    DeleteRangeResponse, MoveValueRequest, MoveValueResponse, PutRequest, PutResponse,
-    RangeRequest, RangeResponse,
+    DeleteRangeResponse, PutRequest, PutResponse, RangeRequest, RangeResponse,
 };
 use snafu::ResultExt;
 
@@ -129,14 +128,6 @@ impl KvBackend for KvBackendAdapter {
     ) -> Result<BatchDeleteResponse, Self::Error> {
         self.0
             .batch_delete(req)
-            .await
-            .map_err(BoxedError::new)
-            .context(ExternalSnafu)
-    }
-
-    async fn move_value(&self, req: MoveValueRequest) -> Result<MoveValueResponse, Self::Error> {
-        self.0
-            .move_value(req)
             .await
             .map_err(BoxedError::new)
             .context(ExternalSnafu)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

remove KvBackend's `move_value` method

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
