### PR TITLE
feat: region disk usage statistic

### DIFF
--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -120,6 +120,13 @@ impl RegionServer {
         self.inner.runtime.clone()
     }
 
+    pub async fn region_disk_usage(&self, region_id: RegionId) -> Option<i64> {
+        match self.inner.region_map.get(&region_id) {
+            Some(e) => e.region_disk_usage(region_id).await,
+            None => None,
+        }
+    }
+
     /// Stop the region server.
     pub async fn stop(&self) -> Result<()> {
         self.inner.stop().await

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -179,6 +179,10 @@ impl RegionEngine for MockRegionEngine {
         unimplemented!()
     }
 
+    async fn region_disk_usage(&self, _region_id: RegionId) -> Option<i64> {
+        unimplemented!()
+    }
+
     async fn stop(&self) -> Result<(), BoxedError> {
         Ok(())
     }

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -94,7 +94,7 @@ impl RegionEngine for FileRegionEngine {
     }
 
     async fn region_disk_usage(&self, _: RegionId) -> Option<i64> {
-        unimplemented!("not implemented for file engine yet")
+        None
     }
 
     fn set_writable(&self, region_id: RegionId, writable: bool) -> Result<(), BoxedError> {

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -93,6 +93,10 @@ impl RegionEngine for FileRegionEngine {
         self.inner.stop().await.map_err(BoxedError::new)
     }
 
+    async fn region_disk_usage(&self, _: RegionId) -> Option<i64> {
+        unimplemented!("not implemented for file engine yet")
+    }
+
     fn set_writable(&self, region_id: RegionId, writable: bool) -> Result<(), BoxedError> {
         self.inner
             .set_writable(region_id, writable)

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -237,11 +237,9 @@ impl RegionEngine for MitoEngine {
         let size = self
             .get_region_usage(region_id)
             .await
-            .map(|usage| usage.disk_usage());
-        match size {
-            Ok(val) => val.try_into().ok(),
-            Err(_) => None,
-        }
+            .map(|usage| usage.disk_usage())
+            .ok()?;
+        size.try_into().ok()
     }
 
     fn set_writable(&self, region_id: RegionId, writable: bool) -> Result<(), BoxedError> {

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -58,6 +58,7 @@ use crate::config::MitoConfig;
 use crate::error::{RecvSnafu, RegionNotFoundSnafu, Result};
 use crate::metrics::{HANDLE_REQUEST_ELAPSED, TYPE_LABEL};
 use crate::read::scan_region::{ScanRegion, Scanner};
+use crate::region::RegionStat;
 use crate::request::WorkerRequest;
 use crate::worker::WorkerGroup;
 
@@ -84,6 +85,17 @@ impl MitoEngine {
     /// Returns true if the specific region exists.
     pub fn is_region_exists(&self, region_id: RegionId) -> bool {
         self.inner.workers.is_region_exists(region_id)
+    }
+
+    /// Returns the region disk/memory usage information.
+    pub async fn get_region_stat(&self, region_id: RegionId) -> Result<RegionStat> {
+        let region = self
+            .inner
+            .workers
+            .get_region(region_id)
+            .context(RegionNotFoundSnafu { region_id })?;
+
+        Ok(region.region_stat().await)
     }
 
     /// Returns a scanner to scan for `request`.

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -58,7 +58,7 @@ use crate::config::MitoConfig;
 use crate::error::{RecvSnafu, RegionNotFoundSnafu, Result};
 use crate::metrics::{HANDLE_REQUEST_ELAPSED, TYPE_LABEL};
 use crate::read::scan_region::{ScanRegion, Scanner};
-use crate::region::RegionStat;
+use crate::region::RegionUsage;
 use crate::request::WorkerRequest;
 use crate::worker::WorkerGroup;
 
@@ -88,14 +88,14 @@ impl MitoEngine {
     }
 
     /// Returns the region disk/memory usage information.
-    pub async fn get_region_stat(&self, region_id: RegionId) -> Result<RegionStat> {
+    pub async fn get_region_stat(&self, region_id: RegionId) -> Result<RegionUsage> {
         let region = self
             .inner
             .workers
             .get_region(region_id)
             .context(RegionNotFoundSnafu { region_id })?;
 
-        Ok(region.region_stat().await)
+        Ok(region.region_usage().await)
     }
 
     /// Returns a scanner to scan for `request`.

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -234,10 +234,14 @@ impl RegionEngine for MitoEngine {
     }
 
     async fn region_disk_usage(&self, region_id: RegionId) -> Option<i64> {
-        self.get_region_usage(region_id)
+        let size = self
+            .get_region_usage(region_id)
             .await
-            .map(|usage| usage.disk_usage() as i64)
-            .ok()
+            .map(|usage| usage.disk_usage());
+        match size {
+            Ok(val) => val.try_into().ok(),
+            Err(_) => None,
+        }
     }
 
     fn set_writable(&self, region_id: RegionId, writable: bool) -> Result<(), BoxedError> {

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -88,7 +88,7 @@ impl MitoEngine {
     }
 
     /// Returns the region disk/memory usage information.
-    pub async fn get_region_stat(&self, region_id: RegionId) -> Result<RegionUsage> {
+    pub async fn get_region_usage(&self, region_id: RegionId) -> Result<RegionUsage> {
         let region = self
             .inner
             .workers
@@ -231,6 +231,13 @@ impl RegionEngine for MitoEngine {
     /// automatically shutdown.)
     async fn stop(&self) -> std::result::Result<(), BoxedError> {
         self.inner.stop().await.map_err(BoxedError::new)
+    }
+
+    async fn region_disk_usage(&self, region_id: RegionId) -> Option<i64> {
+        self.get_region_usage(region_id)
+            .await
+            .map(|usage| usage.disk_usage() as i64)
+            .ok()
     }
 
     fn set_writable(&self, region_id: RegionId, writable: bool) -> Result<(), BoxedError> {

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -557,8 +557,8 @@ async fn test_region_usage() {
     let region_stat = region.region_stat().await;
     assert_eq!(region_stat.memtable_usage, 0);
     assert_eq!(region_stat.wal_usage, 0);
-    assert_eq!(region_stat.sst_usage, 2820);
+    assert_eq!(region_stat.sst_usage, 2827);
 
     // region total usage
-    assert_eq!(region_stat.total_usage(), 3826);
+    assert_eq!(region_stat.total_usage(), 3833);
 }

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -486,7 +486,7 @@ async fn test_region_usage() {
     put_rows(&engine, region_id, rows).await;
 
     let region_stat = region.region_usage().await;
-    assert_eq!(region_stat.wal_usage, 150);
+    assert!(region_stat.wal_usage > 0);
 
     // delete some rows
     let rows = Rows {
@@ -496,13 +496,13 @@ async fn test_region_usage() {
     delete_rows(&engine, region_id, rows).await;
 
     let region_stat = region.region_usage().await;
-    assert_eq!(region_stat.wal_usage, 150);
+    assert!(region_stat.wal_usage > 0);
 
     // flush region
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_usage().await;
-    assert_eq!(region_stat.wal_usage, 0);
+    assert!(region_stat.wal_usage == 0);
     assert_eq!(region_stat.sst_usage, 2827);
 
     // region total usage

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -474,9 +474,8 @@ async fn test_region_usage() {
         .unwrap();
     // region is empty now, check manifest size
     let region = engine.get_region(region_id).unwrap();
-    let region_stat = region.region_stat().await;
+    let region_stat = region.region_usage().await;
     assert_eq!(region_stat.manifest_usage, 686);
-    assert_eq!(region_stat.memtable_usage, 0);
 
     // put some rows
     let rows = Rows {
@@ -486,8 +485,8 @@ async fn test_region_usage() {
 
     put_rows(&engine, region_id, rows).await;
 
-    let region_stat = region.region_stat().await;
-    assert_eq!(region_stat.memtable_usage, 291);
+    let region_stat = region.region_usage().await;
+    assert_eq!(region_stat.wal_usage, 150);
 
     // delete some rows
     let rows = Rows {
@@ -496,18 +495,16 @@ async fn test_region_usage() {
     };
     delete_rows(&engine, region_id, rows).await;
 
-    let region_stat = region.region_stat().await;
-    assert_eq!(region_stat.memtable_usage, 351);
+    let region_stat = region.region_usage().await;
     assert_eq!(region_stat.wal_usage, 150);
 
     // flush region
     flush_region(&engine, region_id, None).await;
 
-    let region_stat = region.region_stat().await;
-    assert_eq!(region_stat.memtable_usage, 0);
+    let region_stat = region.region_usage().await;
     assert_eq!(region_stat.wal_usage, 0);
     assert_eq!(region_stat.sst_usage, 2827);
 
     // region total usage
-    assert_eq!(region_stat.total_usage(), 3833);
+    assert_eq!(region_stat.disk_usage(), 3833);
 }

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -459,57 +459,6 @@ async fn test_absent_and_invalid_columns() {
 }
 
 #[tokio::test]
-async fn test_estimated_wal_size() {
-    let mut env = TestEnv::with_prefix("estimate-region-wal-size");
-    let engine = env.create_engine(MitoConfig::default()).await;
-
-    let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
-
-    let column_schemas = rows_schema(&request);
-    let delete_schema = delete_rows_schema(&request);
-    engine
-        .handle_request(region_id, RegionRequest::Create(request))
-        .await
-        .unwrap();
-
-    let rows = Rows {
-        schema: column_schemas.clone(),
-        rows: build_rows_for_key("a", 0, 10, 0),
-    };
-    put_rows(&engine, region_id, rows).await;
-
-    // check wal size
-    let region = engine.get_region(region_id).unwrap();
-    assert_eq!(region.region_stat().await.wal_usage, 124);
-
-    let rows = Rows {
-        schema: column_schemas.clone(),
-        rows: build_rows_for_key("b", 0, 10, 0),
-    };
-    put_rows(&engine, region_id, rows).await;
-
-    // check wal size
-    assert_eq!(region.region_stat().await.wal_usage, 249);
-
-    // Delete (a, 0), (a, 1), (a, 2)
-    let rows = Rows {
-        schema: delete_schema.clone(),
-        rows: build_delete_rows_for_key("a", 0, 3),
-    };
-    delete_rows(&engine, region_id, rows).await;
-    // Delete (b, 0), (b, 1)
-    let rows = Rows {
-        schema: delete_schema,
-        rows: build_delete_rows_for_key("b", 0, 2),
-    };
-    delete_rows(&engine, region_id, rows).await;
-
-    // check wal size
-    assert_eq!(region.region_stat().await.wal_usage, 292);
-}
-
-#[tokio::test]
 async fn test_region_usage() {
     let mut env = TestEnv::with_prefix("region_usage");
     let engine = env.create_engine(MitoConfig::default()).await;

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -523,7 +523,7 @@ async fn test_region_usage() {
         .handle_request(region_id, RegionRequest::Create(request))
         .await
         .unwrap();
-    // region is empty now, we can check manifest size
+    // region is empty now, check manifest size
     let region = engine.get_region(region_id).unwrap();
     let region_stat = region.region_stat().await;
     assert_eq!(region_stat.manifest_usage, 686);
@@ -551,7 +551,7 @@ async fn test_region_usage() {
     assert_eq!(region_stat.memtable_usage, 351);
     assert_eq!(region_stat.wal_usage, 150);
 
-    // flush memtable
+    // flush region
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_stat().await;

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -156,7 +156,7 @@ impl RegionManifestManager {
     }
 
     /// Returns total manifest size.
-    pub async fn manifest_size(&self) -> u64 {
+    pub async fn manifest_usage(&self) -> u64 {
         let inner = self.inner.read().await;
         inner.total_manifest_size()
     }
@@ -617,7 +617,7 @@ mod test {
         manager.validate_manifest(&new_metadata, 1).await;
 
         // get manifest size
-        let manifest_size = manager.manifest_size().await;
+        let manifest_size = manager.manifest_usage().await;
         assert_eq!(manifest_size, manifest_dir_usage(&manifest_dir).await);
 
         // update 10 times nop_action to trigger checkpoint
@@ -637,7 +637,7 @@ mod test {
         }
 
         // check manifest size again
-        let manifest_size = manager.manifest_size().await;
+        let manifest_size = manager.manifest_usage().await;
         assert_eq!(manifest_size, manifest_dir_usage(&manifest_dir).await);
 
         // Reopen the manager,
@@ -651,7 +651,7 @@ mod test {
         manager.validate_manifest(&new_metadata, 11).await;
 
         // get manifest size again
-        let manifest_size = manager.manifest_size().await;
+        let manifest_size = manager.manifest_usage().await;
         assert_eq!(manifest_size, 1312);
     }
 }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -38,7 +38,7 @@ use crate::sst::file_purger::FilePurgerRef;
 /// This is the approximate factor to estimate the size of wal.
 const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
 
-/// Region status include region id, memtable size, sst size, wal size and manifest size.
+/// Region status include region id, memtable usage, sst usage, wal usage and manifest usage.
 #[derive(Debug)]
 pub struct RegionStat {
     pub region_id: RegionId,
@@ -129,8 +129,9 @@ impl MitoRegion {
         self.writable.store(writable, Ordering::Relaxed);
     }
 
-    /// Returns the region usage in bytes.
+    // TODO(QuenKar): remove this micro.
     #[allow(dead_code)]
+    /// Returns the region usage in bytes.
     pub(crate) async fn region_stat(&self) -> RegionStat {
         let region_id = self.region_id;
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -40,17 +40,16 @@ const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
 
 /// Region status include region id, memtable usage, sst usage, wal usage and manifest usage.
 #[derive(Debug)]
-pub struct RegionStat {
+pub struct RegionUsage {
     pub region_id: RegionId,
-    pub memtable_usage: u64,
     pub wal_usage: u64,
     pub sst_usage: u64,
     pub manifest_usage: u64,
 }
 
-impl RegionStat {
-    pub fn total_usage(&self) -> u64 {
-        self.memtable_usage + self.wal_usage + self.sst_usage + self.manifest_usage
+impl RegionUsage {
+    pub fn disk_usage(&self) -> u64 {
+        self.wal_usage + self.sst_usage + self.manifest_usage
     }
 }
 
@@ -130,7 +129,7 @@ impl MitoRegion {
     }
 
     /// Returns the region usage in bytes.
-    pub(crate) async fn region_stat(&self) -> RegionStat {
+    pub(crate) async fn region_usage(&self) -> RegionUsage {
         let region_id = self.region_id;
 
         let version = self.version();
@@ -143,9 +142,8 @@ impl MitoRegion {
 
         let manifest_usage = self.manifest_manager.manifest_usage().await;
 
-        RegionStat {
+        RegionUsage {
             region_id,
-            memtable_usage,
             wal_usage,
             sst_usage,
             manifest_usage,

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -129,8 +129,6 @@ impl MitoRegion {
         self.writable.store(writable, Ordering::Relaxed);
     }
 
-    // TODO(QuenKar): remove this micro.
-    #[allow(dead_code)]
     /// Returns the region usage in bytes.
     pub(crate) async fn region_stat(&self) -> RegionStat {
         let region_id = self.region_id;

--- a/src/mito2/src/sst/version.rs
+++ b/src/mito2/src/sst/version.rs
@@ -83,6 +83,20 @@ impl SstVersion {
             }
         }
     }
+
+    /// Returns SST files'space occupied in current version.
+    pub(crate) fn sst_usage(&self) -> u64 {
+        self.levels
+            .iter()
+            .map(|level_meta| {
+                level_meta
+                    .files
+                    .values()
+                    .map(|file_handle| file_handle.meta().file_size)
+                    .sum::<u64>()
+            })
+            .sum()
+    }
 }
 
 // We only has fixed number of level, so we use array to hold elements. This implementation

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -49,6 +49,9 @@ pub trait RegionEngine: Send + Sync {
     /// Retrieves region's metadata.
     async fn get_metadata(&self, region_id: RegionId) -> Result<RegionMetadataRef, BoxedError>;
 
+    /// Retrieves region's disk usage.
+    async fn region_disk_usage(&self, region_id: RegionId) -> Option<i64>;
+
     /// Stops the engine
     async fn stop(&self) -> Result<(), BoxedError>;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- region stat includes memtable(estimated), wal(estimated), sst(accurate), manifest(accurate) .
- engine can invoke `get_region_stat` to get specific region stat.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2551