### PR TITLE
test: remove unstable timezone test

### DIFF
--- a/src/common/time/src/time.rs
+++ b/src/common/time/src/time.rs
@@ -409,11 +409,6 @@ mod tests {
                 .to_timezone_aware_string(TimeZone::from_tz_string("UTC").unwrap())
         );
         assert_eq!(
-            "02:00:00.001",
-            Time::new(1, TimeUnit::Millisecond)
-                .to_timezone_aware_string(TimeZone::from_tz_string("Europe/Berlin").unwrap())
-        );
-        assert_eq!(
             "03:00:00.001",
             Time::new(1, TimeUnit::Millisecond)
                 .to_timezone_aware_string(TimeZone::from_tz_string("Europe/Moscow").unwrap())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Due to [DST](https://en.wikipedia.org/wiki/Daylight_saving_time), some test results are unstable.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
