### PR TITLE
fix: add back mut ref

### DIFF
--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -188,6 +188,7 @@ impl StartCommand {
     }
 
     async fn build(self, mut opts: FrontendOptions) -> Result<Instance> {
+        #[allow(clippy::unnecessary_mut_passed)]
         let plugins = plugins::setup_frontend_plugins(&mut opts)
             .await
             .context(StartFrontendSnafu)?;
@@ -312,6 +313,7 @@ mod tests {
             ..Default::default()
         };
 
+        #[allow(clippy::unnecessary_mut_passed)]
         let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -187,8 +187,8 @@ impl StartCommand {
         Ok(Options::Frontend(Box::new(opts)))
     }
 
-    async fn build(self, opts: FrontendOptions) -> Result<Instance> {
-        let plugins = plugins::setup_frontend_plugins(&opts)
+    async fn build(self, mut opts: FrontendOptions) -> Result<Instance> {
+        let plugins = plugins::setup_frontend_plugins(&mut opts)
             .await
             .context(StartFrontendSnafu)?;
 
@@ -303,7 +303,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_from_start_command_to_anymap() {
-        let fe_opts = FrontendOptions {
+        let mut fe_opts = FrontendOptions {
             http: HttpOptions {
                 disable_dashboard: false,
                 ..Default::default()
@@ -312,7 +312,7 @@ mod tests {
             ..Default::default()
         };
 
-        let plugins = plugins::setup_frontend_plugins(&fe_opts).await.unwrap();
+        let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();
         let result = provider

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -317,6 +317,7 @@ impl StartCommand {
     #[allow(clippy::diverging_sub_expression)]
     async fn build(self, opts: MixOptions) -> Result<Instance> {
         let mut fe_opts = opts.frontend;
+        #[allow(clippy::unnecessary_mut_passed)]
         let fe_plugins = plugins::setup_frontend_plugins(&mut fe_opts)
             .await
             .context(StartFrontendSnafu)?;
@@ -426,6 +427,7 @@ mod tests {
             ..Default::default()
         };
 
+        #[allow(clippy::unnecessary_mut_passed)]
         let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -316,8 +316,8 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     async fn build(self, opts: MixOptions) -> Result<Instance> {
-        let fe_opts = opts.frontend;
-        let fe_plugins = plugins::setup_frontend_plugins(&fe_opts)
+        let mut fe_opts = opts.frontend;
+        let fe_plugins = plugins::setup_frontend_plugins(&mut fe_opts)
             .await
             .context(StartFrontendSnafu)?;
 
@@ -421,12 +421,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_from_start_command_to_anymap() {
-        let fe_opts = FrontendOptions {
+        let mut fe_opts = FrontendOptions {
             user_provider: Some("static_user_provider:cmd:test=test".to_string()),
             ..Default::default()
         };
 
-        let plugins = plugins::setup_frontend_plugins(&fe_opts).await.unwrap();
+        let plugins = plugins::setup_frontend_plugins(&mut fe_opts).await.unwrap();
 
         let provider = plugins.get::<UserProviderRef>().unwrap();
         let result = provider


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The mut ref is used for modifying contents of the options in function from other distros. Adding `#[allow(clippy::unnecessary_mut_passed)]` to pass clippy check.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
