### PR TITLE
feat: add leader_status for RegionRoute

### DIFF
--- a/src/cmd/src/cli/bench.rs
+++ b/src/cmd/src/cli/bench.rs
@@ -157,6 +157,7 @@ fn create_region_routes() -> Vec<RegionRoute> {
                 addr: String::new(),
             }),
             follower_peers: vec![],
+            leader_status: None,
         });
     }
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -783,6 +783,7 @@ mod tests {
             },
             leader_peer: Some(Peer::new(datanode, "a2")),
             follower_peers: vec![],
+            leader_status: None,
         }
     }
 

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -128,6 +128,7 @@ impl TableMetadataAllocator for StandaloneTableMetadataCreator {
                     region,
                     leader_peer: Some(peer),
                     follower_peers: vec![],
+                    leader_status: None,
                 }
             })
             .collect::<Vec<_>>();

--- a/src/meta-srv/src/table_meta_alloc.rs
+++ b/src/meta-srv/src/table_meta_alloc.rs
@@ -118,6 +118,7 @@ async fn handle_create_region_routes(
                 region,
                 leader_peer: Some(peer.into()),
                 follower_peers: vec![], // follower_peers is not supported at the moment
+                leader_status: None,
             }
         })
         .collect::<Vec<_>>();

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -48,6 +48,7 @@ pub(crate) fn new_region_route(region_id: u64, peers: &[Peer], leader_node: u64)
         region,
         leader_peer,
         follower_peers: vec![],
+        leader_status: None,
     }
 }
 
@@ -133,6 +134,7 @@ pub(crate) async fn prepare_table_region_and_info_value(
             addr: String::new(),
         }),
         follower_peers: vec![],
+        leader_status: None,
     };
 
     // Region distribution:

--- a/src/operator/src/tests/partition_manager.rs
+++ b/src/operator/src/tests/partition_manager.rs
@@ -122,6 +122,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: Some(Peer::new(3, "")),
                     follower_peers: vec![],
+                    leader_status: None,
                 },
                 RegionRoute {
                     region: Region {
@@ -139,6 +140,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: Some(Peer::new(2, "")),
                     follower_peers: vec![],
+                    leader_status: None,
                 },
                 RegionRoute {
                     region: Region {
@@ -156,6 +158,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: Some(Peer::new(1, "")),
                     follower_peers: vec![],
+                    leader_status: None,
                 },
             ],
         )
@@ -185,6 +188,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: None,
                     follower_peers: vec![],
+                    leader_status: None,
                 },
                 RegionRoute {
                     region: Region {
@@ -205,6 +209,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: None,
                     follower_peers: vec![],
+                    leader_status: None,
                 },
                 RegionRoute {
                     region: Region {
@@ -222,6 +227,7 @@ pub(crate) async fn create_partition_rule_manager(
                     },
                     leader_peer: None,
                     follower_peers: vec![],
+                    leader_status: None,
                 },
             ],
         )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

We should downgrade a Region before deactivating it:

- During the Region Failover Procedure.
 - Migrating a Region.

 **Notes:** Meta Server will stop renewing the lease for the downgraded [Region].

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
