### PR TITLE
fix: sort condition in HistogramFold

### DIFF
--- a/tests/cases/standalone/common/promql/simple_histogram.result
+++ b/tests/cases/standalone/common/promql/simple_histogram.result
@@ -244,3 +244,44 @@ drop table histogram2_bucket;
 
 Affected Rows: 0
 
+-- not from Prometheus
+-- makesure the sort expr works as expected
+create table histogram3_bucket (
+    ts timestamp time index,
+    le string,
+    s string,
+    val double,
+    primary key (s, le),
+);
+
+Affected Rows: 0
+
+insert into histogram3_bucket values
+    (2900000, "0.1", "a", 0),
+    (2900000, "1", "a", 0),
+    (2900000, "5", "a", 0),
+    (2900000, "+Inf", "a", 0),
+    (3000000, "0.1", "a", 50),
+    (3000000, "1", "a", 70),
+    (3000000, "5", "a", 110),
+    (3000000, "+Inf", "a", 120),
+    (3005000, "0.1", "a", 10),
+    (3005000, "1", "a", 20),
+    (3005000, "5", "a", 20),
+    (3005000, "+Inf", "a", 30);
+
+Affected Rows: 12
+
+tql eval (3000, 3005, '3s') histogram_quantile(0.5, sum by(le, s) (rate(histogram3_bucket[5m])));
+
++---+---------------------+---------------------------------+
+| s | ts                  | SUM(prom_rate(ts_range,val,ts)) |
++---+---------------------+---------------------------------+
+| a | 1970-01-01T00:50:00 | 0.55                            |
+| a | 1970-01-01T00:50:03 | 0.5500000000000002              |
++---+---------------------+---------------------------------+
+
+drop table histogram3_bucket;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/promql/simple_histogram.sql
+++ b/tests/cases/standalone/common/promql/simple_histogram.sql
@@ -132,3 +132,31 @@ tql eval (2820, 2820, '1s') histogram_quantile(0.5, rate(histogram2_bucket[15m])
 tql eval (2820, 2820, '1s') histogram_quantile(0.833, rate(histogram2_bucket[15m]));
 
 drop table histogram2_bucket;
+
+-- not from Prometheus
+-- makesure the sort expr works as expected
+create table histogram3_bucket (
+    ts timestamp time index,
+    le string,
+    s string,
+    val double,
+    primary key (s, le),
+);
+
+insert into histogram3_bucket values
+    (2900000, "0.1", "a", 0),
+    (2900000, "1", "a", 0),
+    (2900000, "5", "a", 0),
+    (2900000, "+Inf", "a", 0),
+    (3000000, "0.1", "a", 50),
+    (3000000, "1", "a", 70),
+    (3000000, "5", "a", 110),
+    (3000000, "+Inf", "a", 120),
+    (3005000, "0.1", "a", 10),
+    (3005000, "1", "a", 20),
+    (3005000, "5", "a", 20),
+    (3005000, "+Inf", "a", 30);
+
+tql eval (3000, 3005, '3s') histogram_quantile(0.5, sum by(le, s) (rate(histogram3_bucket[5m])));
+
+drop table histogram3_bucket;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


to separate time series and le buckets, the input data should be ordered on `<tags>, ts, le` rather than `<tags>, le, ts`

before this change, the result of new sqlness case is 
![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/76f6d203-9795-4f20-8b27-87afec06ac0f)


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
