### PR TITLE
chore: pub some mods and methods

### DIFF
--- a/src/common/base/src/bytes.rs
+++ b/src/common/base/src/bytes.rs
@@ -167,6 +167,8 @@ impl<'de> Deserialize<'de> for StringBytes {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     fn check_bytes_deref(expect: &[u8], given: &[u8]) {
@@ -178,6 +180,14 @@ mod tests {
         let hello = b"hello";
         let bytes = Bytes::from(hello.to_vec());
         check_bytes_deref(hello, &bytes);
+    }
+
+    #[test]
+    fn test_bytes_borrow() {
+        let hello = b"hello";
+        let bytes = Bytes::from(hello.to_vec());
+        let set: HashSet<Bytes> = HashSet::from([bytes]);
+        assert!(set.get(hello.as_slice()).is_some());
     }
 
     #[test]

--- a/src/common/base/src/bytes.rs
+++ b/src/common/base/src/bytes.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Borrow;
 use std::ops::Deref;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -73,6 +74,12 @@ impl PartialEq<[u8]> for Bytes {
 impl PartialEq<Bytes> for [u8] {
     fn eq(&self, other: &Bytes) -> bool {
         self == other.0
+    }
+}
+
+impl Borrow<[u8]> for Bytes {
+    fn borrow(&self) -> &[u8] {
+        &self.0
     }
 }
 

--- a/src/storage/src/memtable.rs
+++ b/src/storage/src/memtable.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod btree;
+pub mod btree;
 mod inserter;
 #[cfg(test)]
 pub mod tests;

--- a/src/storage/src/read.rs
+++ b/src/storage/src/read.rs
@@ -85,7 +85,7 @@ impl Batch {
     ///
     /// # Panics
     /// Panics if `offset + length > self.num_rows()`.
-    fn slice(&self, offset: usize, length: usize) -> Batch {
+    pub fn slice(&self, offset: usize, length: usize) -> Batch {
         let columns = self
             .columns
             .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR pub some mods and methods.

It also implements `Borrow<[u8]>` for `Bytes` so we can use it as map keys.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
