### PR TITLE
chore: change admin table api return json format

### DIFF
--- a/src/meta-srv/src/service/admin/meta.rs
+++ b/src/meta-srv/src/service/admin/meta.rs
@@ -155,10 +155,10 @@ impl HttpHandler for TableHandler {
             .await
             .context(TableMetadataManagerSnafu)?
             .into_iter()
-            .map(|(k, v)| (format!("{k}"), format!("{v:?}")))
             .collect::<HashMap<_, _>>();
 
         http::Response::builder()
+            .header("Content-Type", "application/json")
             .status(http::StatusCode::OK)
             // Safety: HashMap<String, String> is definitely "serde-json"-able.
             .body(serde_json::to_string(&table_info_values).unwrap())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

change admin table api response format

```
{"13999":"TableInfoValue { table_info: RawTableInfo { ident: TableIdent { table_id: 13999, version: 0 }, name: \"cpu_metrics\", desc: None, catalog_name: \"q6dj4up5mmriweak_flowers\", schema_name: \"public\", meta: RawTableMeta { schema: RawSchema { column_schemas: [hostname String null, environment String null, usage_user Float64 null, usage_system Float64 null, usage_idle Float64 null, ts Timestamp not null default=Function(\"current_timestamp()\") metadata={\"greptime:time_index\": \"true\"}], timestamp_index: Some(5), version: 0 }, primary_key_indices: [0, 1], value_indices: [], engine: \"mito\", next_column_id: 6, region_numbers: [0], options: TableOptions { write_buffer_size: None, ttl: Some(1800s), extra_options: {} }, created_on: 1970-01-01T00:00:00Z, partition_key_indices: [5] }, table_type: Base }, version: 0 }"}
```

It's hard to deserialize. So we change the format of `TableInfoValue` to json

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
