### PR TITLE
feat(mito): filters memtables by their time ranges

### DIFF
--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -258,7 +258,7 @@ impl Memtable for TimeSeriesMemtable {
         let min_timestamp = ts_type.create_timestamp(self.min_timestamp.load(Ordering::Relaxed));
         MemtableStats {
             estimated_bytes,
-            time_range: Some((max_timestamp, min_timestamp)),
+            time_range: Some((min_timestamp, max_timestamp)),
         }
     }
 }
@@ -1047,6 +1047,16 @@ mod tests {
             .map(|v| v.unwrap().0.value())
             .collect::<HashSet<_>>();
         assert_eq!(expected_ts, read);
+
+        let stats = memtable.stats();
+        assert!(stats.bytes_allocated() > 0);
+        assert_eq!(
+            Some((
+                Timestamp::new_millisecond(0),
+                Timestamp::new_millisecond(99)
+            )),
+            stats.time_range()
+        );
     }
 
     #[test]

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -157,10 +157,22 @@ impl ScanRegion {
         }
 
         let memtables = self.version.memtables.list_memtables();
-        // Skip empty memtables.
+        // Skip empty memtables and memtables out of time range.
         let memtables: Vec<_> = memtables
             .into_iter()
-            .filter(|mem| !mem.is_empty())
+            .filter(|mem| {
+                if mem.is_empty() {
+                    return false;
+                }
+                let stats = mem.stats();
+                let Some((start, end)) = stats.time_range() else {
+                    return true;
+                };
+
+                // The time range of the memtable is inclusive.
+                let memtable_range = TimestampRange::new_inclusive(Some(start), Some(end));
+                memtable_range.intersects(&time_range)
+            })
             .collect();
 
         debug!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR filters memtables by their time ranges while building the scanner. So we don't need to scan a memtable if doesn't contain the data we need.

It also fixes an issue that `TimeSeriesMemtable` returns incorrect time range in its `stats`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
