### PR TITLE
feat: decrease the `page size` if the response size exceeds the limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,6 +1800,7 @@ version = "0.4.2"
 dependencies = [
  "api",
  "arrow-flight",
+ "async-recursion",
  "async-stream",
  "async-trait",
  "base64 0.21.5",
@@ -1830,6 +1831,7 @@ dependencies = [
  "strum 0.25.0",
  "table",
  "tokio",
+ "tonic 0.10.2",
 ]
 
 [[package]]
@@ -3066,16 +3068,16 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b0ea5ef6dc2388a4b1669fa32097249bc03a15417b97cb75e38afb309e4a89"
+checksum = "3d982a3b3088a5f95d19882d298b352a2e0be20703e3080c1e6767731d5dec79"
 dependencies = [
  "http",
- "prost 0.11.9",
+ "prost 0.12.1",
  "tokio",
  "tokio-stream",
- "tonic 0.9.2",
- "tonic-build 0.9.2",
+ "tonic 0.10.2",
+ "tonic-build 0.10.2",
  "tower",
  "tower-service",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ datafusion-physical-expr = { git = "https://github.com/apache/arrow-datafusion.g
 datafusion-sql = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 datafusion-substrait = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 derive_builder = "0.12"
-etcd-client = "0.11"
+etcd-client = "0.12"
 futures = "0.3"
 futures-util = "0.3"
 greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5da72f1cae6b24315e5afc87520aaf7b4d6bb872" }

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -10,6 +10,7 @@ testing = []
 [dependencies]
 api = { workspace = true }
 arrow-flight.workspace = true
+async-recursion = "1.0"
 async-stream.workspace = true
 async-trait.workspace = true
 base64 = "0.21"
@@ -38,6 +39,7 @@ store-api = { workspace = true }
 strum.workspace = true
 table = { workspace = true }
 tokio.workspace = true
+tonic.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -343,4 +343,16 @@ impl Error {
     pub fn is_retry_later(&self) -> bool {
         matches!(self, Error::RetryLater { .. })
     }
+
+    /// Returns true if the response exceeds the size limit.
+    pub fn is_exceeded_size_limit(&self) -> bool {
+        if let Error::EtcdFailed {
+            error: etcd_client::Error::GRpcStatus(status),
+            ..
+        } = self
+        {
+            return status.code() == tonic::Code::OutOfRange;
+        }
+        false
+    }
 }

--- a/src/common/meta/src/lib.rs
+++ b/src/common/meta/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(assert_matches)]
 #![feature(btree_extract_if)]
 #![feature(async_closure)]
 

--- a/src/common/meta/src/range_stream.rs
+++ b/src/common/meta/src/range_stream.rs
@@ -109,6 +109,11 @@ impl PaginationStreamFactory {
                 }
             );
             self.adaptive_page_size = Some(new_adaptive_page_size);
+        } else if self.page_size == 1 {
+            return error::UnexpectedSnafu {
+                err_msg: "Value is larger than response size limit",
+            }
+            .fail();
         } else {
             self.adaptive_page_size = Some(if self.page_size == 0 {
                 DEFAULT_ADAPTIVE_PAGE_SIZE
@@ -321,6 +326,14 @@ mod tests {
         assert_eq!(
             factory.adaptive_page_size.unwrap(),
             DEFAULT_ADAPTIVE_PAGE_SIZE
+        );
+
+        let mut factory =
+            PaginationStreamFactory::new(&kv_backend, vec![], vec![], 1, false, false);
+
+        assert_matches!(
+            factory.try_reduce_adaptive_page_size().unwrap_err(),
+            error::Error::Unexpected { .. }
         );
     }
 

--- a/src/common/meta/src/range_stream.rs
+++ b/src/common/meta/src/range_stream.rs
@@ -151,7 +151,7 @@ impl PaginationStreamFactory {
                 .adaptive_range(RangeRequest {
                     key: self.key.clone(),
                     range_end: self.range_end.clone(),
-                    limit: self.page_size as i64,
+                    limit: self.adaptive_page_size.unwrap_or(self.page_size) as i64,
                     keys_only: self.keys_only,
                 })
                 .await?;
@@ -172,7 +172,7 @@ impl PaginationStreamFactory {
                     page_size: self.page_size,
                     keys_only: self.keys_only,
                     more: resp.more,
-                    adaptive_page_size: None,
+                    adaptive_page_size: self.adaptive_page_size,
                 },
                 Some(resp),
             ))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Decreases the `page size` if the response size exceeds the limit

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#close #2680