### PR TITLE
feat: support current_timestamp and now as default constrains

### DIFF
--- a/tests/cases/standalone/common/create/current_timestamp.result
+++ b/tests/cases/standalone/common/create/current_timestamp.result
@@ -1,0 +1,28 @@
+create table t1 (ts timestamp time index default CURRENT_TIMESTAMP);
+
+Affected Rows: 0
+
+create table t2 (ts timestamp time index default currEnt_tImEsTamp());
+
+Affected Rows: 0
+
+create table t3 (ts timestamp time index default now());
+
+Affected Rows: 0
+
+create table t4 (ts timestamp time index default now);
+
+Error: 1001(Unsupported), Unsupported expr in default constraint: Identifier(Ident { value: "now", quote_style: None }) for column: ts
+
+drop table t1;
+
+Affected Rows: 0
+
+drop table t2;
+
+Affected Rows: 0
+
+drop table t3;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/create/current_timestamp.sql
+++ b/tests/cases/standalone/common/create/current_timestamp.sql
@@ -1,0 +1,11 @@
+create table t1 (ts timestamp time index default CURRENT_TIMESTAMP);
+
+create table t2 (ts timestamp time index default currEnt_tImEsTamp());
+
+create table t3 (ts timestamp time index default now());
+
+create table t4 (ts timestamp time index default now);
+
+drop table t1;
+drop table t2;
+drop table t3;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Support `current_timestamp`, `current_timestamp()` and `now()` as PG does

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
