### PR TITLE
feat: add 'sqlness-cli' to run sqlness in blackbox mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ linker = "aarch64-linux-gnu-gcc"
 
 [alias]
 sqlness = "run --bin sqlness-runner --"
-
+sqlness-cli = "run --bin sqlness-cli --"
 
 [build]
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8558,21 +8558,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlness-cli"
+version = "0.4.2"
+dependencies = [
+ "async-trait",
+ "clap 4.4.7",
+ "client",
+ "sqlness",
+ "sqlness-util",
+ "tokio",
+]
+
+[[package]]
 name = "sqlness-runner"
 version = "0.4.2"
 dependencies = [
  "async-trait",
  "clap 4.4.7",
  "client",
- "common-base",
- "common-error",
- "common-grpc",
- "common-query",
- "common-recordbatch",
  "common-time",
  "serde",
  "sqlness",
+ "sqlness-util",
  "tinytemplate",
+ "tokio",
+]
+
+[[package]]
+name = "sqlness-util"
+version = "0.4.2"
+dependencies = [
+ "client",
+ "common-error",
+ "common-query",
+ "common-recordbatch",
+ "sqlness",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "src/table",
     "tests-integration",
     "tests/runner",
+    "tests/cli",
+    "tests/util",
 ]
 resolver = "2"
 
@@ -165,6 +167,7 @@ script = { path = "src/script" }
 servers = { path = "src/servers" }
 session = { path = "src/session" }
 sql = { path = "src/sql" }
+sqlness-util = { path = "tests/util" }
 storage = { path = "src/storage" }
 store-api = { path = "src/store-api" }
 substrait = { path = "src/common/substrait" }

--- a/tests/cli/Cargo.toml
+++ b/tests/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sqlness-runner"
+name = "sqlness-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -8,9 +8,6 @@ license.workspace = true
 async-trait = "0.1"
 clap = { version = "4.0", features = ["derive"] }
 client = { workspace = true }
-common-time = { workspace = true }
-serde.workspace = true
 sqlness = { version = "0.5" }
 sqlness-util = { workspace = true }
-tinytemplate = "1.2"
 tokio.workspace = true

--- a/tests/cli/src/main.rs
+++ b/tests/cli/src/main.rs
@@ -1,0 +1,89 @@
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
+use std::process::exit;
+
+use async_trait::async_trait;
+use clap::Parser;
+use client::{Client, Database as DB, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use sqlness::{ConfigBuilder, Database, EnvController, QueryContext, Runner};
+use tokio::sync::Mutex as TokioMutex;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+/// A cli to run sqlness tests.
+struct Args {
+    /// Directory of test cases
+    #[clap(short, long)]
+    case_dir: Option<PathBuf>,
+
+    /// Fail this run as soon as one case fails if true
+    #[arg(short, long, default_value = "false")]
+    fail_fast: bool,
+
+    /// Name of test cases to run. Accept as a regexp.
+    #[clap(short, long, default_value = ".*")]
+    test_filter: String,
+
+    /// Address of the server
+    #[clap(short, long, default_value = "127.0.0.1:4001")]
+    server_addr: String,
+}
+
+pub struct GreptimeDB {
+    client: TokioMutex<DB>,
+}
+
+#[async_trait]
+impl Database for GreptimeDB {
+    async fn query(&self, ctx: QueryContext, query: String) -> Box<dyn Display> {
+        sqlness_util::do_query(ctx, self.client.lock().await, query).await
+    }
+}
+
+pub struct CliController {
+    server_addr: String,
+}
+
+impl CliController {
+    pub fn new(server_addr: String) -> Self {
+        Self { server_addr }
+    }
+
+    async fn connect(&self) -> GreptimeDB {
+        let client = Client::with_urls(vec![self.server_addr.clone()]);
+        let db = DB::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
+
+        GreptimeDB {
+            client: TokioMutex::new(db),
+        }
+    }
+}
+
+#[async_trait]
+impl EnvController for CliController {
+    type DB = GreptimeDB;
+
+    async fn start(&self, mode: &str, _config: Option<&Path>) -> Self::DB {
+        match mode {
+            "standalone" => self.connect().await,
+            "distributed" => self.connect().await,
+            _ => panic!("Unexpected mode: {mode}"),
+        }
+    }
+
+    async fn stop(&self, _mode: &str, _database: Self::DB) {}
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    let config = ConfigBuilder::default()
+        .case_dir(sqlness_util::get_case_dir(args.case_dir))
+        .fail_fast(args.fail_fast)
+        .test_filter(args.test_filter)
+        .follow_links(true)
+        .build()
+        .unwrap();
+    let runner = Runner::new(config, CliController::new(args.server_addr));
+    runner.run().await.unwrap();
+}

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -19,7 +19,6 @@ use env::Env;
 use sqlness::{ConfigBuilder, Runner};
 
 mod env;
-mod util;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -52,7 +51,7 @@ async fn main() {
     let data_home = std::path::PathBuf::from("/tmp");
 
     let config = ConfigBuilder::default()
-        .case_dir(util::get_case_dir(args.case_dir))
+        .case_dir(sqlness_util::get_case_dir(args.case_dir))
         .fail_fast(args.fail_fast)
         .test_filter(args.test_filter)
         .follow_links(true)

--- a/tests/util/Cargo.toml
+++ b/tests/util/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sqlness-util"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+client = { workspace = true }
+common-error = { workspace = true }
+common-query = { workspace = true }
+common-recordbatch = { workspace = true }
+sqlness = { version = "0.5" }
+tokio.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

For the regression functional tests, we need to run sqlness tests in black box mode, for example:

```console
cargo sqlness-cli --server-addr 127.0.0.1:14001
```

In this PR, I add the new runner `sqlness-cli`(I don't know whether it's a good name) and the new crate `sqlness-util` to put the common logic between `sqlness-runner` and `sqlness-cli`.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
