### PR TITLE
feat: add '--server-addr' in sqlness runner

### DIFF
--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -45,7 +45,6 @@ const DEFAULT_LOG_LEVEL: &str = "--log-level=debug,hyper=warn,tower=warn,datafus
 pub struct Env {
     data_home: PathBuf,
     server_addr: Option<String>,
-    specified_mode: String,
 }
 
 #[allow(clippy::print_stdout)]
@@ -56,53 +55,43 @@ impl EnvController for Env {
     async fn start(&self, mode: &str, _config: Option<&Path>) -> Self::DB {
         match mode {
             "standalone" => {
-                if self.specified_mode == "all" || self.specified_mode == "standalone" {
-                    if let Some(server_addr) = self.server_addr.clone() {
-                        let client = Client::with_urls(vec![server_addr.clone()]);
-                        let db = DB::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
-                        GreptimeDB {
-                            client: TokioMutex::new(db),
-                            server_processes: None,
-                            metasrv_process: None,
-                            frontend_process: None,
-                            ctx: GreptimeDBContext {
-                                time: 0,
-                                datanode_id: Default::default(),
-                            },
-                            is_standalone: false,
-                            env: self.clone(),
-                        }
-                    } else {
-                        self.start_standalone().await
+                if let Some(server_addr) = self.server_addr.clone() {
+                    let client = Client::with_urls(vec![server_addr.clone()]);
+                    let db = DB::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
+                    GreptimeDB {
+                        client: TokioMutex::new(db),
+                        server_processes: None,
+                        metasrv_process: None,
+                        frontend_process: None,
+                        ctx: GreptimeDBContext {
+                            time: 0,
+                            datanode_id: Default::default(),
+                        },
+                        is_standalone: false,
+                        env: self.clone(),
                     }
                 } else {
-                    // Exit and do nothing.
-                    std::process::exit(0);
+                    self.start_standalone().await
                 }
             }
             "distributed" => {
-                if self.specified_mode == "all" || self.specified_mode == "distributed" {
-                    if let Some(server_addr) = self.server_addr.clone() {
-                        let client = Client::with_urls(vec![server_addr.clone()]);
-                        let db = DB::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
-                        GreptimeDB {
-                            client: TokioMutex::new(db),
-                            server_processes: None,
-                            metasrv_process: None,
-                            frontend_process: None,
-                            ctx: GreptimeDBContext {
-                                time: 0,
-                                datanode_id: Default::default(),
-                            },
-                            is_standalone: false,
-                            env: self.clone(),
-                        }
-                    } else {
-                        self.start_distributed().await
+                if let Some(server_addr) = self.server_addr.clone() {
+                    let client = Client::with_urls(vec![server_addr.clone()]);
+                    let db = DB::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, client);
+                    GreptimeDB {
+                        client: TokioMutex::new(db),
+                        server_processes: None,
+                        metasrv_process: None,
+                        frontend_process: None,
+                        ctx: GreptimeDBContext {
+                            time: 0,
+                            datanode_id: Default::default(),
+                        },
+                        is_standalone: false,
+                        env: self.clone(),
                     }
                 } else {
-                    // Exit and do nothing.
-                    std::process::exit(0);
+                    self.start_distributed().await
                 }
             }
             _ => panic!("Unexpected mode: {mode}"),
@@ -117,11 +106,10 @@ impl EnvController for Env {
 
 #[allow(clippy::print_stdout)]
 impl Env {
-    pub fn new(data_home: PathBuf, server_addr: Option<String>, specified_mode: String) -> Self {
+    pub fn new(data_home: PathBuf, server_addr: Option<String>) -> Self {
         Self {
             data_home,
             server_addr,
-            specified_mode,
         }
     }
 

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -44,10 +44,6 @@ struct Args {
     /// Address of the server
     #[clap(short, long)]
     server_addr: Option<String>,
-
-    /// Test mode, can be 'all', 'standalone' and 'distributed'.
-    #[clap(short, long, default_value = "all")]
-    mode: String,
 }
 
 #[tokio::main]
@@ -67,6 +63,6 @@ async fn main() {
         .env_config_file(args.env_config_file)
         .build()
         .unwrap();
-    let runner = Runner::new(config, Env::new(data_home, args.server_addr, args.mode));
+    let runner = Runner::new(config, Env::new(data_home, args.server_addr));
     runner.run().await.unwrap();
 }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -40,6 +40,14 @@ struct Args {
     /// Name of test cases to run. Accept as a regexp.
     #[clap(short, long, default_value = ".*")]
     test_filter: String,
+
+    /// Address of the server
+    #[clap(short, long)]
+    server_addr: Option<String>,
+
+    /// Test mode, can be 'all', 'standalone' and 'distributed'.
+    #[clap(short, long, default_value = "all")]
+    mode: String,
 }
 
 #[tokio::main]
@@ -59,6 +67,6 @@ async fn main() {
         .env_config_file(args.env_config_file)
         .build()
         .unwrap();
-    let runner = Runner::new(config, Env::new(data_home));
+    let runner = Runner::new(config, Env::new(data_home, args.server_addr, args.mode));
     runner.run().await.unwrap();
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `--server-addr` in sqlness runner, we can run the tests like:

```console
cargo sqlness --server-addr 127.0.0.1:14001 --test-filter standalone

cargo sqlness --server-addr 127.0.0.1:24001 --test-filter distributed
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
closes https://github.com/GreptimeTeam/greptimedb/issues/2635