### PR TITLE
fix: refactor and fix to_unixtime

### DIFF
--- a/src/common/function/src/scalars/timestamp/to_unixtime.rs
+++ b/src/common/function/src/scalars/timestamp/to_unixtime.rs
@@ -18,14 +18,9 @@ use std::sync::Arc;
 
 use common_query::error::{InvalidFuncArgsSnafu, Result, UnsupportedInputDataTypeSnafu};
 use common_query::prelude::{Signature, Volatility};
-use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
-use datatypes::prelude::ConcreteDataType;
-use datatypes::types::TimestampType;
-use datatypes::vectors::{
-    Int64Vector, StringVector, TimestampMicrosecondVector, TimestampMillisecondVector,
-    TimestampNanosecondVector, TimestampSecondVector, Vector, VectorRef,
-};
+use datatypes::prelude::{ConcreteDataType, ScalarVector};
+use datatypes::vectors::{Int64Vector, StringVector, VectorRef};
 use snafu::ensure;
 
 use crate::scalars::function::{Function, FunctionContext};
@@ -35,19 +30,19 @@ pub struct ToUnixtimeFunction;
 
 const NAME: &str = "to_unixtime";
 
-fn convert_to_seconds(arg: &str) -> Option<i64> {
-    match Timestamp::from_str(arg) {
-        Ok(ts) => {
-            let sec_mul = (TimeUnit::Second.factor() / ts.unit().factor()) as i64;
-            Some(ts.value().div_euclid(sec_mul))
-        }
-        Err(_err) => None,
+fn convert_to_seconds(arg: &Option<&str>) -> Option<i64> {
+    match arg {
+        Some(arg) => match Timestamp::from_str(arg) {
+            Ok(ts) => Some(ts.split().0),
+            Err(_err) => None,
+        },
+        None => None,
     }
 }
 
-fn process_vector(vector: &dyn Vector) -> Vec<Option<i64>> {
+fn convert_timestamps_to_seconds(vector: &VectorRef) -> Vec<Option<i64>> {
     (0..vector.len())
-        .map(|i| paste::expr!((vector.get(i)).as_timestamp().map(|ts| ts.value())))
+        .map(|i| vector.get(i).as_timestamp().map(|ts| ts.split().0))
         .collect::<Vec<Option<i64>>>()
 }
 
@@ -87,51 +82,26 @@ impl Function for ToUnixtimeFunction {
             }
         );
 
+        let vector = &columns[0];
+
         match columns[0].data_type() {
             ConcreteDataType::String(_) => {
-                let array = columns[0].to_arrow_array();
-                let vector = StringVector::try_from_arrow_array(&array).unwrap();
+                let vector = vector.as_any().downcast_ref::<StringVector>().unwrap();
+
                 Ok(Arc::new(Int64Vector::from(
-                    (0..vector.len())
-                        .map(|i| convert_to_seconds(&vector.get(i).to_string()))
+                    vector
+                        .iter_data()
+                        .map(|v| convert_to_seconds(&v))
                         .collect::<Vec<_>>(),
                 )))
             }
             ConcreteDataType::Int64(_) | ConcreteDataType::Int32(_) => {
-                let array = columns[0].to_arrow_array();
-                Ok(Arc::new(Int64Vector::try_from_arrow_array(&array).unwrap()))
+                // Safety: cast always successfully at here
+                Ok(vector.cast(&ConcreteDataType::int64_datatype()).unwrap())
             }
-            ConcreteDataType::Timestamp(ts) => {
-                let array = columns[0].to_arrow_array();
-                let value = match ts {
-                    TimestampType::Second(_) => {
-                        let vector = paste::expr!(TimestampSecondVector::try_from_arrow_array(
-                            array
-                        )
-                        .unwrap());
-                        process_vector(&vector)
-                    }
-                    TimestampType::Millisecond(_) => {
-                        let vector = paste::expr!(
-                            TimestampMillisecondVector::try_from_arrow_array(array).unwrap()
-                        );
-                        process_vector(&vector)
-                    }
-                    TimestampType::Microsecond(_) => {
-                        let vector = paste::expr!(
-                            TimestampMicrosecondVector::try_from_arrow_array(array).unwrap()
-                        );
-                        process_vector(&vector)
-                    }
-                    TimestampType::Nanosecond(_) => {
-                        let vector = paste::expr!(TimestampNanosecondVector::try_from_arrow_array(
-                            array
-                        )
-                        .unwrap());
-                        process_vector(&vector)
-                    }
-                };
-                Ok(Arc::new(Int64Vector::from(value)))
+            ConcreteDataType::Timestamp(_) => {
+                let seconds = convert_timestamps_to_seconds(vector);
+                Ok(Arc::new(Int64Vector::from(seconds)))
             }
             _ => UnsupportedInputDataTypeSnafu {
                 function: NAME,
@@ -151,11 +121,9 @@ impl fmt::Display for ToUnixtimeFunction {
 #[cfg(test)]
 mod tests {
     use common_query::prelude::TypeSignature;
-    use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder};
-    use datatypes::scalars::ScalarVector;
-    use datatypes::timestamp::TimestampSecond;
+    use datatypes::prelude::ConcreteDataType;
     use datatypes::value::Value;
-    use datatypes::vectors::{StringVector, TimestampSecondVector};
+    use datatypes::vectors::{StringVector, TimestampMillisecondVector, TimestampSecondVector};
 
     use super::{ToUnixtimeFunction, *};
     use crate::scalars::Function;
@@ -170,18 +138,18 @@ mod tests {
         );
 
         assert!(matches!(f.signature(),
-        Signature {
-                type_signature: TypeSignature::Uniform(1, valid_types),
-                volatility: Volatility::Immutable
-            } if  valid_types == vec![
-                ConcreteDataType::string_datatype(),
-                ConcreteDataType::int32_datatype(),
-                ConcreteDataType::int64_datatype(),
-                ConcreteDataType::timestamp_second_datatype(),
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                ConcreteDataType::timestamp_microsecond_datatype(),
-                ConcreteDataType::timestamp_nanosecond_datatype(),
-            ]
+                         Signature {
+                             type_signature: TypeSignature::Uniform(1, valid_types),
+                             volatility: Volatility::Immutable
+                         } if  valid_types == vec![
+                             ConcreteDataType::string_datatype(),
+                             ConcreteDataType::int32_datatype(),
+                             ConcreteDataType::int64_datatype(),
+                             ConcreteDataType::timestamp_second_datatype(),
+                             ConcreteDataType::timestamp_millisecond_datatype(),
+                             ConcreteDataType::timestamp_microsecond_datatype(),
+                             ConcreteDataType::timestamp_nanosecond_datatype(),
+                         ]
         ));
 
         let times = vec![
@@ -219,18 +187,18 @@ mod tests {
         );
 
         assert!(matches!(f.signature(),
-        Signature {
-                type_signature: TypeSignature::Uniform(1, valid_types),
-                volatility: Volatility::Immutable
-            } if  valid_types == vec![
-                ConcreteDataType::string_datatype(),
-                ConcreteDataType::int32_datatype(),
-                ConcreteDataType::int64_datatype(),
-                ConcreteDataType::timestamp_second_datatype(),
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                ConcreteDataType::timestamp_microsecond_datatype(),
-                ConcreteDataType::timestamp_nanosecond_datatype(),
-            ]
+                         Signature {
+                             type_signature: TypeSignature::Uniform(1, valid_types),
+                             volatility: Volatility::Immutable
+                         } if  valid_types == vec![
+                             ConcreteDataType::string_datatype(),
+                             ConcreteDataType::int32_datatype(),
+                             ConcreteDataType::int64_datatype(),
+                             ConcreteDataType::timestamp_second_datatype(),
+                             ConcreteDataType::timestamp_millisecond_datatype(),
+                             ConcreteDataType::timestamp_microsecond_datatype(),
+                             ConcreteDataType::timestamp_nanosecond_datatype(),
+                         ]
         ));
 
         let times = vec![Some(3_i64), None, Some(5_i64), None];
@@ -263,28 +231,23 @@ mod tests {
         );
 
         assert!(matches!(f.signature(),
-        Signature {
-                type_signature: TypeSignature::Uniform(1, valid_types),
-                volatility: Volatility::Immutable
-            } if  valid_types == vec![
-                ConcreteDataType::string_datatype(),
-                ConcreteDataType::int32_datatype(),
-                ConcreteDataType::int64_datatype(),
-                ConcreteDataType::timestamp_second_datatype(),
-                ConcreteDataType::timestamp_millisecond_datatype(),
-                ConcreteDataType::timestamp_microsecond_datatype(),
-                ConcreteDataType::timestamp_nanosecond_datatype(),
-            ]
+                         Signature {
+                             type_signature: TypeSignature::Uniform(1, valid_types),
+                             volatility: Volatility::Immutable
+                         } if  valid_types == vec![
+                             ConcreteDataType::string_datatype(),
+                             ConcreteDataType::int32_datatype(),
+                             ConcreteDataType::int64_datatype(),
+                             ConcreteDataType::timestamp_second_datatype(),
+                             ConcreteDataType::timestamp_millisecond_datatype(),
+                             ConcreteDataType::timestamp_microsecond_datatype(),
+                             ConcreteDataType::timestamp_nanosecond_datatype(),
+                         ]
         ));
 
-        let times: Vec<Option<TimestampSecond>> = vec![
-            Some(TimestampSecond::new(123)),
-            None,
-            Some(TimestampSecond::new(42)),
-            None,
-        ];
+        let times = vec![Some(123), None, Some(42), None];
         let results = [Some(123), None, Some(42), None];
-        let ts_vector: TimestampSecondVector = build_vector_from_slice(&times);
+        let ts_vector = TimestampSecondVector::from(times.clone());
         let args: Vec<VectorRef> = vec![Arc::new(ts_vector)];
         let vector = f.eval(FunctionContext::default(), &args).unwrap();
         assert_eq!(4, vector.len());
@@ -301,13 +264,25 @@ mod tests {
                 _ => unreachable!(),
             }
         }
-    }
 
-    fn build_vector_from_slice<T: ScalarVector>(items: &[Option<T::RefItem<'_>>]) -> T {
-        let mut builder = T::Builder::with_capacity(items.len());
-        for item in items {
-            builder.push(*item);
+        let times = vec![Some(123000), None, Some(42000), None];
+        let results = [Some(123), None, Some(42), None];
+        let ts_vector = TimestampMillisecondVector::from(times.clone());
+        let args: Vec<VectorRef> = vec![Arc::new(ts_vector)];
+        let vector = f.eval(FunctionContext::default(), &args).unwrap();
+        assert_eq!(4, vector.len());
+        for (i, _t) in times.iter().enumerate() {
+            let v = vector.get(i);
+            if i == 1 || i == 3 {
+                assert_eq!(Value::Null, v);
+                continue;
+            }
+            match v {
+                Value::Int64(ts) => {
+                    assert_eq!(ts, (*results.get(i).unwrap()).unwrap());
+                }
+                _ => unreachable!(),
+            }
         }
-        builder.finish()
     }
 }

--- a/src/common/time/src/timestamp.rs
+++ b/src/common/time/src/timestamp.rs
@@ -182,7 +182,7 @@ impl Timestamp {
 
     /// Split a [Timestamp] into seconds part and nanoseconds part.
     /// Notice the seconds part of split result is always rounded down to floor.
-    fn split(&self) -> (i64, u32) {
+    pub fn split(&self) -> (i64, u32) {
         let sec_mul = (TimeUnit::Second.factor() / self.unit.factor()) as i64;
         let nsec_mul = (self.unit.factor() / TimeUnit::Nanosecond.factor()) as i64;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Main changes:
* Fixed `to_unixtime` process the `TimestampMillisecondVector` and `TimestampNanosecondVector` not correctly, return the wrong value.
* Refactor `to_unixtime` function to avoid some unnecessary conversions.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
