### PR TITLE
feat: enable empty range by

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,7 +1881,7 @@ dependencies = [
  "datatypes",
  "serde",
  "snafu",
- "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c)",
+ "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "sqlparser_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "statrs",
  "tokio",
@@ -3320,7 +3320,7 @@ dependencies = [
  "session",
  "snafu",
  "sql",
- "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c)",
+ "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "storage",
  "store-api",
  "strfmt",
@@ -5527,7 +5527,7 @@ dependencies = [
  "session",
  "snafu",
  "sql",
- "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c)",
+ "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "storage",
  "store-api",
  "substrait 0.4.2",
@@ -8549,7 +8549,7 @@ dependencies = [
  "once_cell",
  "regex",
  "snafu",
- "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c)",
+ "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "sqlparser_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "table",
 ]
@@ -8612,13 +8612,13 @@ dependencies = [
 [[package]]
 name = "sqlparser"
 version = "0.38.0"
-source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c#602d7878c9949e48512251c7f18695a50936e51c"
+source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd#0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd"
 dependencies = [
  "lazy_static",
  "log",
  "regex",
  "sqlparser 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sqlparser_derive 0.1.1 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c)",
+ "sqlparser_derive 0.1.1 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
 ]
 
 [[package]]
@@ -8635,7 +8635,7 @@ dependencies = [
 [[package]]
 name = "sqlparser_derive"
 version = "0.1.1"
-source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=602d7878c9949e48512251c7f18695a50936e51c#602d7878c9949e48512251c7f18695a50936e51c"
+source = "git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd#0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ serde_json = "1.0"
 smallvec = "1"
 snafu = { version = "0.7", features = ["backtraces"] }
 # on branch v0.38.x
-sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "602d7878c9949e48512251c7f18695a50936e51c", features = [
+sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd", features = [
     "visitor",
 ] }
 strum = { version = "0.25", features = ["derive"] }

--- a/tests/cases/standalone/common/range/by.result
+++ b/tests/cases/standalone/common/range/by.result
@@ -39,6 +39,17 @@ SELECT ts, max(val) RANGE '5s' FROM host ALIGN '20s' BY (2) ORDER BY ts;
 | 1970-01-01T00:00:20 | 5                                |
 +---------------------+----------------------------------+
 
+-- The user explicitly specifies that the aggregation key is empty. In this case, there is no aggregation key. All data will be aggregated into a group.
+-- Implement by rewrite `BY()` to `BY(1)` automatically through sqlparser. They are semantically equivalent.
+SELECT ts, max(val) RANGE '5s' FROM host ALIGN '20s' BY () ORDER BY ts;
+
++---------------------+----------------------------------+
+| ts                  | MAX(host.val) RANGE 5s FILL NULL |
++---------------------+----------------------------------+
+| 1970-01-01T00:00:00 | 3                                |
+| 1970-01-01T00:00:20 | 5                                |
++---------------------+----------------------------------+
+
 SELECT ts, CAST(length(host) as INT64) + 2, max(val) RANGE '5s' FROM host ALIGN '20s' BY (CAST(length(host) as INT64) + 2) ORDER BY ts;
 
 +---------------------+----------------------------------------+----------------------------------+
@@ -47,6 +58,12 @@ SELECT ts, CAST(length(host) as INT64) + 2, max(val) RANGE '5s' FROM host ALIGN 
 | 1970-01-01T00:00:00 | 7                                      | 3                                |
 | 1970-01-01T00:00:20 | 7                                      | 5                                |
 +---------------------+----------------------------------------+----------------------------------+
+
+-- Test error
+-- project non-aggregation key
+SELECT ts, host, max(val) RANGE '5s' FROM host ALIGN '20s' BY () ORDER BY ts;
+
+Error: 3001(EngineExecuteQuery), No field named host.host. Valid fields are "MAX(host.val) RANGE 5s FILL NULL", host.ts, "Int64(1)".
 
 DROP TABLE host;
 

--- a/tests/cases/standalone/common/range/by.sql
+++ b/tests/cases/standalone/common/range/by.sql
@@ -22,6 +22,15 @@ SELECT ts, length(host), max(val) RANGE '5s' FROM host ALIGN '20s' BY (length(ho
 
 SELECT ts, max(val) RANGE '5s' FROM host ALIGN '20s' BY (2) ORDER BY ts;
 
+-- The user explicitly specifies that the aggregation key is empty. In this case, there is no aggregation key. All data will be aggregated into a group.
+-- Implement by rewrite `BY()` to `BY(1)` automatically through sqlparser. They are semantically equivalent.
+SELECT ts, max(val) RANGE '5s' FROM host ALIGN '20s' BY () ORDER BY ts;
+
 SELECT ts, CAST(length(host) as INT64) + 2, max(val) RANGE '5s' FROM host ALIGN '20s' BY (CAST(length(host) as INT64) + 2) ORDER BY ts;
+
+-- Test error
+
+-- project non-aggregation key
+SELECT ts, host, max(val) RANGE '5s' FROM host ALIGN '20s' BY () ORDER BY ts;
 
 DROP TABLE host;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Enable case `BY ()` like 

```sql
SELECT 
    sum(metrics) RANGE '10m' FILL MAX
FROM t ALIGN '1h' by () FILL NULL;
```

The user explicitly specifies that the aggregation key is empty. In this case, there is no aggregation key.  All data will be aggregated into a group, which is equivalent to using a random constant as the aggregation key. Therefore, in this case, the constant 1 is used directly as the aggregation key. The sql is rewrite by sqlparser to:

```sql
SELECT 
    sum(metrics) RANGE '10m' FILL MAX
FROM t ALIGN '1h' by (1) FILL NULL;
```

The work is mainly done by sqlparser. Here we just simply replace the version of sqlparser and add test cases.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/sqlparser-rs/pull/8