### PR TITLE
refactor: refactor region lease keeper

### DIFF
--- a/src/meta-srv/src/region/lease_keeper.rs
+++ b/src/meta-srv/src/region/lease_keeper.rs
@@ -39,7 +39,7 @@ impl RegionLeaseKeeper {
 }
 
 impl RegionLeaseKeeper {
-    fn collect_table(&self, datanode_regions: &[RegionId]) -> HashMap<TableId, Vec<RegionId>> {
+    fn collect_tables(&self, datanode_regions: &[RegionId]) -> HashMap<TableId, Vec<RegionId>> {
         let mut tables = HashMap::<TableId, Vec<RegionId>>::new();
 
         // Group by `table_id`.
@@ -51,7 +51,7 @@ impl RegionLeaseKeeper {
         tables
     }
 
-    async fn collect_table_metadata(
+    async fn collect_tables_metadata(
         &self,
         table_ids: &[TableId],
     ) -> Result<HashMap<TableId, TableRouteValue>> {
@@ -83,9 +83,9 @@ impl RegionLeaseKeeper {
         datanode_id: u64,
         datanode_regions: &[RegionId],
     ) -> Result<(HashSet<RegionId>, HashSet<RegionId>)> {
-        let tables = self.collect_table(datanode_regions);
+        let tables = self.collect_tables(datanode_regions);
         let table_ids = tables.keys().copied().collect::<Vec<_>>();
-        let metadata_subset = self.collect_table_metadata(&table_ids).await?;
+        let metadata_subset = self.collect_tables_metadata(&table_ids).await?;
 
         let mut closable_set = HashSet::new();
         let mut downgradable_set = HashSet::new();
@@ -122,9 +122,9 @@ impl RegionLeaseKeeper {
         datanode_id: u64,
         datanode_regions: &[RegionId],
     ) -> Result<(HashSet<RegionId>, HashSet<RegionId>)> {
-        let tables = self.collect_table(datanode_regions);
+        let tables = self.collect_tables(datanode_regions);
         let table_ids = tables.keys().copied().collect::<Vec<_>>();
-        let metadata_subset = self.collect_table_metadata(&table_ids).await?;
+        let metadata_subset = self.collect_tables_metadata(&table_ids).await?;
 
         let mut upgradable_set = HashSet::new();
         let mut closable_set = HashSet::new();

--- a/src/meta-srv/src/region/lease_keeper/utils.rs
+++ b/src/meta-srv/src/region/lease_keeper/utils.rs
@@ -12,22 +12,125 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use common_meta::peer::Peer;
-use store_api::storage::RegionId;
+use common_meta::rpc::router::{
+    convert_to_region_leader_map, convert_to_region_leader_status_map, convert_to_region_peer_map,
+    RegionRoute, RegionStatus,
+};
+use store_api::storage::{RegionId, RegionNumber};
 
-/// Returns Some(region_id) if it's a inactive leader region.
+/// Returns Some(region_id) if it's not a leader region in `region_route`.
 ///
-/// It removes a leader region if the `node_id` isn't the corresponding leader peer in `region_routes`.
-pub fn staled_leader_regions(
+/// It removes a leader region if its peer(`node_id`) isn't the corresponding leader peer in `region_routes`.
+pub fn closable_leader_region(
     node_id: u64,
     region_id: RegionId,
-    region_leader_map: &HashMap<u32, &Peer>,
+    region_leader_map: &HashMap<RegionNumber, &Peer>,
 ) -> Option<RegionId> {
-    if let Some(peer) = region_leader_map.get(&region_id.region_number()) {
-        // TODO(weny): treats the leader peer as inactive if it's readonly or downgraded.
+    let region_number = region_id.region_number();
+    if let Some(peer) = region_leader_map.get(&region_number) {
         if peer.id == node_id {
+            None
+        } else {
+            Some(region_id)
+        }
+    } else {
+        Some(region_id)
+    }
+}
+
+/// Returns Some(region_id) if its peer(`node_id`) a downgrade leader region peer in `region_route`.
+pub fn downgradable_leader_regions(
+    node_id: u64,
+    region_id: RegionId,
+    region_leader_map: &HashMap<RegionNumber, &Peer>,
+    region_leader_status: &HashMap<RegionNumber, RegionStatus>,
+) -> Option<RegionId> {
+    let region_number = region_id.region_number();
+    let leader_status = region_leader_status.get(&region_number);
+    let downgraded = matches!(leader_status, Some(RegionStatus::Downgraded));
+
+    if let Some(peer) = region_leader_map.get(&region_number) {
+        if peer.id == node_id && downgraded {
+            Some(region_id)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Returns upgradable regions, and closable regions.
+///
+/// Upgradable regions:
+/// - Region's peer(`datanode_id`) is the corresponding leader peer in `region_routes`.
+///
+/// Closable regions:
+/// - Region's peer(`datanode_id`) isn't the corresponding leader/follower peer in `region_routes`.
+pub fn find_staled_follower_regions(
+    datanode_id: u64,
+    datanode_regions: &[RegionId],
+    region_routes: &[RegionRoute],
+) -> (HashSet<RegionId>, HashSet<RegionId>) {
+    let region_leader_map = convert_to_region_leader_map(region_routes);
+    let region_leader_status_map = convert_to_region_leader_status_map(region_routes);
+    let region_peer_map = convert_to_region_peer_map(region_routes);
+
+    let (upgradable, closable): (HashSet<Option<RegionId>>, HashSet<Option<RegionId>>) =
+        datanode_regions
+            .iter()
+            .map(|region_id| {
+                (
+                    upgradable_follower_region(
+                        datanode_id,
+                        *region_id,
+                        &region_leader_map,
+                        &region_leader_status_map,
+                    ),
+                    closable_region(datanode_id, *region_id, &region_peer_map),
+                )
+            })
+            .unzip();
+
+    let upgradable = upgradable.into_iter().flatten().collect();
+    let closable = closable.into_iter().flatten().collect();
+
+    (upgradable, closable)
+}
+
+/// Returns Some(region) if its peer(`node_id`) a leader region peer in `region_routes`.
+pub fn upgradable_follower_region(
+    node_id: u64,
+    region_id: RegionId,
+    region_leader_map: &HashMap<RegionNumber, &Peer>,
+    region_leader_status: &HashMap<RegionNumber, RegionStatus>,
+) -> Option<RegionId> {
+    let region_number = region_id.region_number();
+    let leader_status = region_leader_status.get(&region_number);
+    let downgraded = matches!(leader_status, Some(RegionStatus::Downgraded));
+
+    if let Some(peer) = region_leader_map.get(&region_number) {
+        if peer.id == node_id && !downgraded {
+            Some(region_id)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Returns Some(region) if its peer(`node_id) is't a leader or follower region peer in `region_routes`.
+pub fn closable_region(
+    node_id: u64,
+    region_id: RegionId,
+    region_peer_map: &HashMap<RegionNumber, HashSet<u64>>,
+) -> Option<RegionId> {
+    if let Some(set) = region_peer_map.get(&region_id.region_number()) {
+        if set.get(&node_id).is_some() {
             None
         } else {
             Some(region_id)
@@ -46,7 +149,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_inactive_leader_regions() {
+    fn test_closable_leader_region() {
         let datanode_id = 1u64;
         let region_number = 1u32;
         let region_id = RegionId::from_u64(region_number as u64);
@@ -54,16 +157,22 @@ mod tests {
 
         let region_leader_map = [(region_number, &peer)].into();
 
-        // Should be None, `region_id` is a active region of `peer`.
+        // Should be None, `region_id` is an active region of `peer`.
         assert_eq!(
             None,
-            staled_leader_regions(datanode_id, region_id, &region_leader_map)
+            closable_leader_region(datanode_id, region_id, &region_leader_map,)
+        );
+
+        // Should be Some(`region_id`), incorrect datanode_id.
+        assert_eq!(
+            Some(region_id),
+            closable_leader_region(datanode_id + 1, region_id, &region_leader_map,)
         );
 
         // Should be Some(`region_id`), the inactive_leader_regions is empty.
         assert_eq!(
             Some(region_id),
-            staled_leader_regions(datanode_id, region_id, &Default::default())
+            closable_leader_region(datanode_id, region_id, &Default::default(),)
         );
 
         let another_peer = Peer::empty(datanode_id + 1);
@@ -72,7 +181,160 @@ mod tests {
         // Should be Some(`region_id`), `region_id` is active region of `another_peer`.
         assert_eq!(
             Some(region_id),
-            staled_leader_regions(datanode_id, region_id, &region_leader_map)
+            closable_leader_region(datanode_id, region_id, &region_leader_map,)
+        );
+    }
+
+    #[test]
+    fn test_downgradable_region() {
+        let datanode_id = 1u64;
+        let region_number = 1u32;
+        let region_id = RegionId::from_u64(region_number as u64);
+        let peer = Peer::empty(datanode_id);
+
+        let region_leader_map = [(region_number, &peer)].into();
+        let region_leader_status_map = [(region_number, RegionStatus::Downgraded)].into();
+
+        // Should be Some(region_id), `region_id` is a downgraded leader region.
+        assert_eq!(
+            Some(region_id),
+            downgradable_leader_regions(
+                datanode_id,
+                region_id,
+                &region_leader_map,
+                &region_leader_status_map
+            )
+        );
+
+        // Should be None, `region_id` is a leader region.
+        assert_eq!(
+            None,
+            downgradable_leader_regions(
+                datanode_id,
+                region_id,
+                &region_leader_map,
+                &Default::default(),
+            )
+        );
+
+        // Should be None, incorrect datanode_id.
+        assert_eq!(
+            None,
+            downgradable_leader_regions(
+                datanode_id + 1,
+                region_id,
+                &region_leader_map,
+                &region_leader_status_map
+            )
+        );
+
+        // Should be None, incorrect datanode_id.
+        assert_eq!(
+            None,
+            downgradable_leader_regions(
+                datanode_id + 1,
+                region_id,
+                &region_leader_map,
+                &Default::default(),
+            )
+        );
+    }
+
+    #[test]
+    fn test_closable_follower_region() {
+        let region_number = 1u32;
+        let region_id = RegionId::from_u64(region_number as u64);
+        let another_region_id = RegionId::from_u64(region_number as u64 + 1);
+        let region_peer_map = [(region_number, HashSet::from([1, 2, 3]))].into();
+
+        // Should be None.
+        assert_eq!(None, closable_region(1, region_id, &region_peer_map));
+
+        // Should be Some(`region_id`), incorrect `datanode_id`.
+        assert_eq!(
+            Some(region_id),
+            closable_region(4, region_id, &region_peer_map)
+        );
+
+        // Should be Some(`another_region_id`), `another_region_id` doesn't exist.
+        assert_eq!(
+            Some(another_region_id),
+            closable_region(1, another_region_id, &region_peer_map)
+        );
+
+        // Should be Some(`another_region_id`), `another_region_id` doesn't exist, incorrect `datanode_id`.
+        assert_eq!(
+            Some(another_region_id),
+            closable_region(4, another_region_id, &region_peer_map)
+        );
+    }
+
+    #[test]
+    fn test_upgradable_follower_region() {
+        let datanode_id = 1u64;
+        let region_number = 1u32;
+        let region_id = RegionId::from_u64(region_number as u64);
+        let another_region_id = RegionId::from_u64(region_number as u64 + 1);
+        let peer = Peer::empty(datanode_id);
+
+        let region_leader_map = [(region_number, &peer)].into();
+        let region_leader_status = HashMap::new();
+
+        // Should be Some(region_id), `region_id` is a leader region.
+        assert_eq!(
+            Some(region_id),
+            upgradable_follower_region(
+                datanode_id,
+                region_id,
+                &region_leader_map,
+                &region_leader_status
+            )
+        );
+
+        let downgraded_leader = [(region_number, RegionStatus::Downgraded)].into();
+
+        // Should be None, `region_id` is a downgraded leader region.
+        assert_eq!(
+            None,
+            upgradable_follower_region(
+                datanode_id,
+                region_id,
+                &region_leader_map,
+                &downgraded_leader
+            )
+        );
+
+        // Should be None, incorrect `datanode_id`.
+        assert_eq!(
+            None,
+            upgradable_follower_region(
+                datanode_id + 1,
+                region_id,
+                &region_leader_map,
+                &region_leader_status
+            )
+        );
+
+        // Should be None, incorrect `datanode_id`, `another_region_id` doesn't exist.
+        assert_eq!(
+            None,
+            upgradable_follower_region(
+                datanode_id,
+                another_region_id,
+                &region_leader_map,
+                &region_leader_status
+            )
+        );
+
+        // Should be None, incorrect `datanode_id`, `another_region_id` doesn't exist, incorrect `datanode_id`.
+        assert_eq!(
+            None,
+            upgradable_follower_region(
+                datanode_id + 1,
+                another_region_id,
+                &region_leader_map,
+                &region_leader_status
+            )
         );
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

I realized we can't simply retain active leader regions and also need to find out the downgraded leader regions.

1. Refactor `find_staled_leader_regions`; now, it can find out the downgraded leader regions.
2. Add `find_staled_follower_regions`, returning upgradable and closable regions.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2700