### PR TITLE
fix: don't assert path under windows

### DIFF
--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -117,15 +117,19 @@ mod test {
         let region_id = to_metadata_region_id(env.default_region_id());
         let region_dir = join_dir(&env.data_home(), "test_metric_region");
 
-        // assert metadata region's dir
-        let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
-        let exist = tokio::fs::try_exists(metadata_region_dir).await.unwrap();
-        assert!(exist);
+        // `join_dir` doesn't suit windows path
+        #[cfg(not(target_os = "windows"))]
+        {
+            // assert metadata region's dir
+            let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
+            let exist = tokio::fs::try_exists(metadata_region_dir).await.unwrap();
+            assert!(exist);
 
-        // assert data region's dir
-        let data_region_dir = join_dir(&region_dir, DATA_REGION_SUBDIR);
-        let exist = tokio::fs::try_exists(data_region_dir).await.unwrap();
-        assert!(exist);
+            // assert data region's dir
+            let data_region_dir = join_dir(&region_dir, DATA_REGION_SUBDIR);
+            let exist = tokio::fs::try_exists(data_region_dir).await.unwrap();
+            assert!(exist);
+        }
 
         // check mito engine
         let metadata_region_id = utils::to_metadata_region_id(region_id);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fix this pipeline https://github.com/GreptimeTeam/greptimedb/actions/runs/6764676664/job/18383347651

Which fails with
```
 --- TRY 4 STDERR:        metric-engine engine::test::create_metadata_region ---
thread 'engine::test::create_metadata_region' panicked at src\metric-engine\src\engine.rs:304:61:
called `Result::unwrap()` on an `Err` value: Os { code: 123, kind: InvalidFilename, message: "The filename, directory name, or volume label syntax is incorrect." }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
