### PR TITLE
fix(plugin): setup frontend plugin with mut reference

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -316,9 +316,9 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     async fn build(self, opts: MixOptions) -> Result<Instance> {
+        let mut fe_opts = opts.frontend.clone();
         #[allow(clippy::unnecessary_mut_passed)]
-        let fe_opts = opts.frontend.clone();
-        let fe_plugins = plugins::setup_frontend_plugins(&fe_opts)
+        let fe_plugins = plugins::setup_frontend_plugins(&mut fe_opts) // mut ref is MUST, DO NOT change it
             .await
             .context(StartFrontendSnafu)?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`plugins::setup_frontend_plugins` MUST BE supplied with mut reference

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
