### PR TITLE
fix: unify all sst_write_buffer_size usage

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -105,6 +105,9 @@ global_write_buffer_reject_size = "2GB"
 sst_meta_cache_size = "128MB"
 # Cache size for vectors and arrow arrays (default 512MB). Setting it to 0 to disable the cache.
 vector_cache_size = "512MB"
+# Buffer size for SST writing.
+sst_write_buffer_size = "8MB"
+
 
 # Log options
 # [logging]

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -191,7 +191,6 @@ mod tests {
     use std::io::Write;
     use std::time::Duration;
 
-    use common_base::readable_size::ReadableSize;
     use common_test_util::temp_dir::create_named_temp_file;
     use datanode::config::{CompactionConfig, FileConfig, ObjectStoreConfig, RegionManifestConfig};
     use servers::heartbeat_options::HeartbeatOptions;
@@ -300,7 +299,6 @@ mod tests {
                 max_inflight_tasks: 3,
                 max_files_in_level0: 7,
                 max_purge_tasks: 32,
-                sst_write_buffer_size: ReadableSize::mb(8),
             },
             options.storage.compaction,
         );

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -250,8 +250,6 @@ pub struct CompactionConfig {
     pub max_files_in_level0: usize,
     /// Max task number for SST purge task after compaction.
     pub max_purge_tasks: usize,
-    /// Buffer threshold while writing SST files
-    pub sst_write_buffer_size: ReadableSize,
 }
 
 impl Default for CompactionConfig {
@@ -260,7 +258,6 @@ impl Default for CompactionConfig {
             max_inflight_tasks: 4,
             max_files_in_level0: 8,
             max_purge_tasks: 32,
-            sst_write_buffer_size: ReadableSize::mb(8),
         }
     }
 }
@@ -312,7 +309,6 @@ impl From<&DatanodeOptions> for StorageEngineConfig {
             manifest_gc_duration: value.storage.manifest.gc_duration,
             max_files_in_l0: value.storage.compaction.max_files_in_level0,
             max_purge_tasks: value.storage.compaction.max_purge_tasks,
-            sst_write_buffer_size: value.storage.compaction.sst_write_buffer_size,
             max_flush_tasks: value.storage.flush.max_flush_tasks,
             region_write_buffer_size: value.storage.flush.region_write_buffer_size,
             picker_schedule_interval: value.storage.flush.picker_schedule_interval,

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -356,7 +356,7 @@ impl CompactionTask for TwcsCompactionTask {
             Ok((added, deleted)) => {
                 info!(
                     "Compacted SST files, input: {:?}, output: {:?}, window: {:?}",
-                    added, deleted, self.compaction_time_window
+                    deleted, added, self.compaction_time_window
                 );
 
                 BackgroundNotify::CompactionFinished(CompactionFinished {

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -120,6 +120,7 @@ impl Picker for TwcsPicker {
             waiters,
             file_purger,
             start_time,
+            sst_write_buffer_size,
         } = req;
 
         let region_metadata = current_version.metadata.clone();
@@ -167,7 +168,7 @@ impl Picker for TwcsPicker {
             sst_layer: access_layer,
             outputs,
             expired_ssts,
-            sst_write_buffer_size: ReadableSize::mb(4),
+            sst_write_buffer_size,
             compaction_time_window: Some(time_window_size),
             request_sender,
             waiters,

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -63,6 +63,8 @@ pub struct MitoConfig {
     pub sst_meta_cache_size: ReadableSize,
     /// Cache size for vectors and arrow arrays (default 512MB). Setting it to 0 to disable the cache.
     pub vector_cache_size: ReadableSize,
+    /// Buffer size for SST writing.
+    pub sst_write_buffer_size: ReadableSize,
 }
 
 impl Default for MitoConfig {
@@ -79,6 +81,7 @@ impl Default for MitoConfig {
             global_write_buffer_reject_size: ReadableSize::gb(2),
             sst_meta_cache_size: ReadableSize::mb(128),
             vector_cache_size: ReadableSize::mb(512),
+            sst_write_buffer_size: ReadableSize::mb(8),
         }
     }
 }
@@ -115,6 +118,14 @@ impl MitoConfig {
             warn!(
                 "Sanitize global write buffer reject size to {}",
                 self.global_write_buffer_reject_size
+            );
+        }
+
+        if self.sst_write_buffer_size < ReadableSize::mb(5) {
+            self.sst_write_buffer_size = ReadableSize::mb(5);
+            warn!(
+                "Sanitize sst write buffer reject size to {}",
+                self.sst_write_buffer_size
             );
         }
     }

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -26,6 +26,8 @@ const DEFAULT_NUM_WORKERS: usize = 1;
 /// Default max running background job.
 const DEFAULT_MAX_BG_JOB: usize = 4;
 
+const MULTIPART_UPLOAD_MINIMUM_SIZE: ReadableSize = ReadableSize::mb(5);
+
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
@@ -121,10 +123,10 @@ impl MitoConfig {
             );
         }
 
-        if self.sst_write_buffer_size < ReadableSize::mb(5) {
-            self.sst_write_buffer_size = ReadableSize::mb(5);
+        if self.sst_write_buffer_size < MULTIPART_UPLOAD_MINIMUM_SIZE {
+            self.sst_write_buffer_size = MULTIPART_UPLOAD_MINIMUM_SIZE;
             warn!(
-                "Sanitize sst write buffer reject size to {}",
+                "Sanitize sst write buffer size to {}",
                 self.sst_write_buffer_size
             );
         }

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -291,7 +291,6 @@ impl RegionFlushTask {
             .with_label_values(&["flush_memtables"])
             .start_timer();
 
-        // TODO(yingwen): Make it configurable.
         let mut write_opts = WriteOptions {
             write_buffer_size: self.engine_config.sst_write_buffer_size,
             ..Default::default()

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -80,7 +80,7 @@ impl<S> RegionWorkerLoop<S> {
             info!("Flush region: {} before alteration", region_id);
 
             // Try to submit a flush task.
-            let task = self.new_flush_task(&region, FlushReason::Alter, None);
+            let task = self.new_flush_task(&region, FlushReason::Alter, None, self.config.clone());
             if let Err(e) =
                 self.flush_scheduler
                     .schedule_flush(region.region_id, &region.version_control, task)

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -38,6 +38,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             &region.access_layer,
             &region.file_purger,
             sender,
+            self.config.clone(),
         ) {
             error!(e; "Failed to schedule compaction task for region: {}", region_id);
         } else {
@@ -86,8 +87,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         }
         // compaction finished.
         request.on_success();
+
         // Schedule next compaction if necessary.
-        self.compaction_scheduler.on_compaction_finished(region_id);
+        self.compaction_scheduler
+            .on_compaction_finished(region_id, self.config.clone());
     }
 
     /// When compaction fails, we simply log the error.

--- a/src/storage/src/config.rs
+++ b/src/storage/src/config.rs
@@ -34,7 +34,6 @@ pub struct EngineConfig {
     pub manifest_gc_duration: Option<Duration>,
     pub max_files_in_l0: usize,
     pub max_purge_tasks: usize,
-    pub sst_write_buffer_size: ReadableSize,
     /// Max inflight flush tasks.
     pub max_flush_tasks: usize,
     /// Default write buffer size for a region.
@@ -59,7 +58,6 @@ impl Default for EngineConfig {
             manifest_gc_duration: Some(Duration::from_secs(30)),
             max_files_in_l0: 8,
             max_purge_tasks: 32,
-            sst_write_buffer_size: ReadableSize::mb(8),
             max_flush_tasks: DEFAULT_MAX_FLUSH_TASKS,
             region_write_buffer_size: DEFAULT_REGION_WRITE_BUFFER_SIZE,
             picker_schedule_interval: Duration::from_millis(

--- a/src/storage/src/flush.rs
+++ b/src/storage/src/flush.rs
@@ -18,6 +18,7 @@ mod scheduler;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use common_base::readable_size::ReadableSize;
 use common_telemetry::logging;
 pub use picker::{FlushPicker, PickerConfig};
 pub use scheduler::{
@@ -269,7 +270,7 @@ impl<S: LogStore> FlushJob<S> {
             let iter = m.iter(iter_ctx.clone())?;
             let sst_layer = self.sst_layer.clone();
             let write_options = WriteOptions {
-                sst_write_buffer_size: self.engine_config.sst_write_buffer_size,
+                sst_write_buffer_size: ReadableSize::mb(8), // deprecated usage
             };
             futures.push(async move {
                 Ok(sst_layer

--- a/src/storage/src/flush/scheduler.rs
+++ b/src/storage/src/flush/scheduler.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use common_base::readable_size::ReadableSize;
 use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::logging;
 use snafu::{ensure, ResultExt};
@@ -147,7 +148,7 @@ impl<S: LogStore> From<&FlushRegionRequest<S>> for CompactionRequestImpl<S> {
             compaction_time_window: req.compaction_time_window,
             sender: None,
             picker: req.compaction_picker.clone(),
-            sst_write_buffer_size: req.engine_config.sst_write_buffer_size,
+            sst_write_buffer_size: ReadableSize::mb(8), // deprecated usage
             // compaction triggered by flush always reschedules
             reschedule_on_finish: true,
         }

--- a/src/storage/src/region/writer.rs
+++ b/src/storage/src/region/writer.rs
@@ -374,7 +374,7 @@ where
         let mut inner = self.inner.lock().await;
 
         ensure!(!inner.is_closed(), error::ClosedRegionSnafu);
-        let sst_write_buffer_size = inner.engine_config.sst_write_buffer_size;
+        let sst_write_buffer_size = ReadableSize::mb(8); // deprecated usage
 
         inner
             .manual_compact(

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -706,7 +706,6 @@ type = "{}"
 max_inflight_tasks = 4
 max_files_in_level0 = 8
 max_purge_tasks = 32
-sst_write_buffer_size = "8MiB"
 
 [datanode.storage.manifest]
 checkpoint_margin = 10
@@ -733,6 +732,7 @@ global_write_buffer_size = "1GiB"
 global_write_buffer_reject_size = "2GiB"
 sst_meta_cache_size = "128MiB"
 vector_cache_size = "512MiB"
+sst_write_buffer_size = "8MiB"
 
 [[datanode.region_engine]]
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR enforces all config values for SST writer buffer size to the value in `MitoConfig`. The hard coded config may result `EntityTooSmall` error raised by S3.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
fixes #2662