### PR TITLE
chore: unify workspace dependencies and remove some unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4416,7 +4416,6 @@ version = "0.4.2"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64 0.13.1",
  "byteorder",
  "bytes",
  "common-base",
@@ -8217,7 +8216,7 @@ dependencies = [
  "axum",
  "axum-macros",
  "axum-test-helper",
- "base64 0.13.1",
+ "base64 0.21.5",
  "build-data",
  "bytes",
  "catalog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,8 +1634,6 @@ dependencies = [
  "chrono",
  "common-error",
  "common-macro",
- "serde",
- "serde_json",
  "snafu",
  "tokio",
 ]
@@ -1782,9 +1780,7 @@ name = "common-macro"
 version = "0.4.2"
 dependencies = [
  "arc-swap",
- "backtrace",
  "common-query",
- "common-telemetry",
  "datatypes",
  "proc-macro2",
  "quote",
@@ -1812,7 +1808,6 @@ name = "common-meta"
 version = "0.4.2"
 dependencies = [
  "api",
- "arrow-flight",
  "async-recursion",
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8468,7 +8468,6 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4de37ad025c587a29e8f3f5605c00f70b98715ef90b9061a815b9e59e9042d6"
 dependencies = [
- "backtrace",
  "doc-comment",
  "snafu-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ rust_decimal = "1.32.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1"
-snafu = { version = "0.7" }
+snafu = "0.7"
 # on branch v0.38.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd", features = [
     "visitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ rust_decimal = "1.32.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = "1"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu = { version = "0.7" }
 # on branch v0.38.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd", features = [
     "visitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ arrow-flight = "47.0"
 arrow-schema = { version = "47.0", features = ["serde"] }
 async-stream = "0.3"
 async-trait = "0.1"
+base64 = "0.21"
 bigdecimal = "0.4.2"
 chrono = { version = "0.4", features = ["serde"] }
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
@@ -122,6 +123,7 @@ tokio-util = { version = "0.7", features = ["io-util", "compat"] }
 toml = "0.7"
 tonic = { version = "0.10", features = ["tls"] }
 uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
+
 ## workspaces members
 api = { path = "src/api" }
 auth = { path = "src/auth" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 arrow.workspace = true
 chrono.workspace = true
 clap = { version = "4.0", features = ["derive"] }
-client = { workspace = true }
+client.workspace = true
 futures-util.workspace = true
 indicatif = "0.17.1"
 itertools.workspace = true

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -12,7 +12,7 @@ common-time = { workspace = true }
 datatypes = { workspace = true }
 greptime-proto.workspace = true
 prost.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tonic.workspace = true
 
 [build-dependencies]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -5,11 +5,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-base = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-time = { workspace = true }
-datatypes = { workspace = true }
+common-base.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-time.workspace = true
+datatypes.workspace = true
 greptime-proto.workspace = true
 prost.workspace = true
 snafu.workspace = true

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -8,28 +8,28 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 arc-swap = "1.0"
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-grpc = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-catalog.workspace = true
+common-error.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 dashmap = "5.4"
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures = "0.3"
 futures-util.workspace = true
 lazy_static.workspace = true
-meta-client = { workspace = true }
+meta-client.workspace = true
 moka = { workspace = true, features = ["future"] }
 parking_lot = "0.12"
 partition.workspace = true
@@ -37,17 +37,17 @@ prometheus.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
-table = { workspace = true }
+store-api.workspace = true
+table.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
 catalog = { workspace = true, features = ["testing"] }
 chrono.workspace = true
-common-test-util = { workspace = true }
-log-store = { workspace = true }
-object-store = { workspace = true }
-storage = { workspace = true }
+common-test-util.workspace = true
+log-store.workspace = true
+object-store.workspace = true
+storage.workspace = true
 tokio.workspace = true

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -38,7 +38,7 @@ regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 session = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 store-api = { workspace = true }
 table = { workspace = true }
 tokio.workspace = true

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 arrow-flight.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-grpc = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 derive_builder.workspace = true
 enum_dispatch = "0.3"
 futures-util.workspace = true
@@ -33,17 +33,17 @@ parking_lot = "0.12"
 prometheus.workspace = true
 prost.workspace = true
 rand.workspace = true
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-common-grpc-expr = { workspace = true }
-datanode = { workspace = true }
+common-grpc-expr.workspace = true
+datanode.workspace = true
 derive-new = "0.5"
-substrait = { workspace = true }
+substrait.workspace = true
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -16,50 +16,50 @@ tokio-console = ["common-telemetry/tokio-console"]
 anymap = "1.0.0-beta.2"
 async-trait.workspace = true
 auth.workspace = true
-catalog = { workspace = true }
+catalog.workspace = true
 chrono.workspace = true
 clap = { version = "3.1", features = ["derive"] }
-client = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-config = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
+client.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-config.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
 common-telemetry = { workspace = true, features = [
     "deadlock_detection",
 ] }
 config = "0.13"
-datanode = { workspace = true }
-datatypes = { workspace = true }
+datanode.workspace = true
+datatypes.workspace = true
 either = "1.8"
 etcd-client.workspace = true
-file-engine = { workspace = true }
-frontend = { workspace = true }
+file-engine.workspace = true
+frontend.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
-meta-client = { workspace = true }
-meta-srv = { workspace = true }
-mito2 = { workspace = true }
+meta-client.workspace = true
+meta-srv.workspace = true
+mito2.workspace = true
 nu-ansi-term = "0.46"
-partition = { workspace = true }
+partition.workspace = true
 plugins.workspace = true
 prometheus.workspace = true
 prost.workspace = true
-query = { workspace = true }
+query.workspace = true
 rand.workspace = true
 regex.workspace = true
 rustyline = "10.1"
 serde.workspace = true
 serde_json.workspace = true
-servers = { workspace = true }
-session = { workspace = true }
+servers.workspace = true
+session.workspace = true
 snafu.workspace = true
-substrait = { workspace = true }
-table = { workspace = true }
+substrait.workspace = true
+table.workspace = true
 tokio.workspace = true
 toml.workspace = true
 
@@ -67,7 +67,7 @@ toml.workspace = true
 tikv-jemallocator = "0.5"
 
 [dev-dependencies]
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 serde.workspace = true
 temp-env = "0.3"
 
@@ -75,4 +75,4 @@ temp-env = "0.3"
 rexpect = "0.5"
 
 [build-dependencies]
-common-version = { workspace = true }
+common-version.workspace = true

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 anymap = "1.0.0-beta.2"
 bitvec = "1.0"
 bytes = { version = "1.1", features = ["serde"] }
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
 paste = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 snafu.workspace = true

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 common-error = { workspace = true }
 common-macro = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
 snafu.workspace = true
 
 [dev-dependencies]

--- a/src/common/catalog/Cargo.toml
+++ b/src/common/catalog/Cargo.toml
@@ -7,8 +7,6 @@ license.workspace = true
 [dependencies]
 common-error = { workspace = true }
 common-macro = { workspace = true }
-serde.workspace = true
-serde_json = "1.0"
 snafu = { version = "0.7", features = ["backtraces"] }
 
 [dev-dependencies]

--- a/src/common/datasource/Cargo.toml
+++ b/src/common/datasource/Cargo.toml
@@ -17,14 +17,14 @@ async-compression = { version = "0.3", features = [
 ] }
 async-trait.workspace = true
 bytes = "1.1"
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-runtime = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
+common-runtime.workspace = true
 datafusion.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
-object-store = { workspace = true }
+object-store.workspace = true
 orc-rust = "0.2"
 paste = "1.0"
 regex = "1.7"
@@ -36,4 +36,4 @@ tokio.workspace = true
 url = "2.3"
 
 [dev-dependencies]
-common-test-util = { workspace = true }
+common-test-util.workspace = true

--- a/src/common/decimal/Cargo.toml
+++ b/src/common/decimal/Cargo.toml
@@ -6,10 +6,10 @@ license.workspace = true
 
 [dependencies]
 arrow.workspace = true
-bigdecimal = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-rust_decimal = { workspace = true }
+bigdecimal.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+rust_decimal.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -5,5 +5,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 strum.workspace = true

--- a/src/common/function/Cargo.toml
+++ b/src/common/function/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 [dependencies]
 arc-swap = "1.0"
 chrono-tz = "0.6"
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-time = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-time.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 libc = "0.2"
 num = "0.4"
 num-traits = "0.2"

--- a/src/common/greptimedb-telemetry/Cargo.toml
+++ b/src/common/greptimedb-telemetry/Cargo.toml
@@ -6,19 +6,19 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-error = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-reqwest = { workspace = true }
+common-error.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 hyper = { version = "0.14", features = ["full"] }
 tempfile.workspace = true
 
 [build-dependencies]
-common-version = { workspace = true }
+common-version.workspace = true

--- a/src/common/grpc-expr/Cargo.toml
+++ b/src/common/grpc-expr/Cargo.toml
@@ -15,7 +15,7 @@ common-query = { workspace = true }
 common-telemetry = { workspace = true }
 common-time = { workspace = true }
 datatypes = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 table = { workspace = true }
 
 [dev-dependencies]

--- a/src/common/grpc-expr/Cargo.toml
+++ b/src/common/grpc-expr/Cargo.toml
@@ -5,18 +5,18 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-trait.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
-datatypes = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
+datatypes.workspace = true
 snafu.workspace = true
-table = { workspace = true }
+table.workspace = true
 
 [dev-dependencies]
 paste = "1.0"

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -23,7 +23,7 @@ flatbuffers = "23.1"
 futures = "0.3"
 lazy_static.workspace = true
 prost.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 tower = "0.4"

--- a/src/common/grpc/Cargo.toml
+++ b/src/common/grpc/Cargo.toml
@@ -5,20 +5,20 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 arrow-flight.workspace = true
 async-trait = "0.1"
 backtrace = "0.3"
-common-base = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-base.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 dashmap = "5.4"
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 flatbuffers = "23.1"
 futures = "0.3"
 lazy_static.workspace = true

--- a/src/common/macro/Cargo.toml
+++ b/src/common/macro/Cargo.toml
@@ -8,8 +8,6 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-backtrace = "0.3"
-common-telemetry = { workspace = true }
 proc-macro2 = "1.0.66"
 quote = "1.0"
 syn = "1.0"

--- a/src/common/macro/Cargo.toml
+++ b/src/common/macro/Cargo.toml
@@ -23,7 +23,7 @@ syn2 = { version = "2.0", package = "syn", features = [
 
 [dev-dependencies]
 arc-swap = "1.0"
-common-query = { workspace = true }
-datatypes = { workspace = true }
+common-query.workspace = true
+datatypes.workspace = true
 snafu.workspace = true
 static_assertions = "1.1.0"

--- a/src/common/mem-prof/Cargo.toml
+++ b/src/common/mem-prof/Cargo.toml
@@ -5,8 +5,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
 snafu.workspace = true
 tempfile = "3.4"
 tokio.workspace = true

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -9,7 +9,6 @@ testing = []
 
 [dependencies]
 api = { workspace = true }
-arrow-flight.workspace = true
 async-recursion = "1.0"
 async-stream.workspace = true
 async-trait.workspace = true

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -8,22 +8,22 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-recursion = "1.0"
 async-stream.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bytes = "1.4"
-common-catalog = { workspace = true }
-common-error = { workspace = true }
+common-catalog.workspace = true
+common-error.workspace = true
 common-grpc-expr.workspace = true
-common-macro = { workspace = true }
-common-procedure = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
-datatypes = { workspace = true }
+common-macro.workspace = true
+common-procedure.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
+datatypes.workspace = true
 etcd-client.workspace = true
 futures.workspace = true
 humantime-serde.workspace = true
@@ -34,13 +34,13 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
+store-api.workspace = true
 strum.workspace = true
-table = { workspace = true }
+table.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
 chrono.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 hyper = { version = "0.14", features = ["full"] }

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -13,7 +13,7 @@ arrow-flight.workspace = true
 async-recursion = "1.0"
 async-stream.workspace = true
 async-trait.workspace = true
-base64 = "0.21"
+base64.workspace = true
 bytes = "1.4"
 common-catalog = { workspace = true }
 common-error = { workspace = true }

--- a/src/common/procedure-test/Cargo.toml
+++ b/src/common/procedure-test/Cargo.toml
@@ -6,4 +6,4 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-procedure = { workspace = true }
+common-procedure.workspace = true

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -8,13 +8,13 @@ license.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 backon = "0.4"
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
 futures.workspace = true
 humantime-serde.workspace = true
-object-store = { workspace = true }
+object-store.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 smallvec.workspace = true
@@ -23,5 +23,5 @@ tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 futures-util.workspace = true

--- a/src/common/query/Cargo.toml
+++ b/src/common/query/Cargo.toml
@@ -5,16 +5,16 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-trait.workspace = true
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-recordbatch = { workspace = true }
-common-time = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
+common-recordbatch.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 serde.workspace = true
 snafu.workspace = true
 sqlparser.workspace = true
@@ -22,5 +22,5 @@ sqlparser_derive = "0.1"
 statrs = "0.16"
 
 [dev-dependencies]
-common-base = { workspace = true }
+common-base.workspace = true
 tokio.workspace = true

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -13,7 +13,7 @@ datatypes = { workspace = true }
 futures.workspace = true
 paste = "1.0"
 serde.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/common/recordbatch/Cargo.toml
+++ b/src/common/recordbatch/Cargo.toml
@@ -5,11 +5,11 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
 datafusion-common.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures.workspace = true
 paste = "1.0"
 serde.workspace = true

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-telemetry = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
+common-telemetry.workspace = true
 lazy_static.workspace = true
 once_cell.workspace = true
 paste.workspace = true

--- a/src/common/substrait/Cargo.toml
+++ b/src/common/substrait/Cargo.toml
@@ -8,28 +8,28 @@ license.workspace = true
 async-recursion = "1.0"
 async-trait.workspace = true
 bytes = "1.1"
-catalog = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-telemetry = { workspace = true }
+catalog.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-telemetry.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-substrait.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures = "0.3"
-promql = { workspace = true }
+promql.workspace = true
 prost.workspace = true
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
-table = { workspace = true }
+table.workspace = true
 
 [dependencies.substrait_proto]
 package = "substrait"
 version = "0.17"
 
 [dev-dependencies]
-datatypes = { workspace = true }
-table = { workspace = true }
+datatypes.workspace = true
+table.workspace = true
 tokio.workspace = true

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -10,7 +10,7 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 
 [dependencies]
 backtrace = "0.3"
-common-error = { workspace = true }
+common-error.workspace = true
 console-subscriber = { version = "0.1", optional = true }
 lazy_static.workspace = true
 once_cell.workspace = true

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -8,8 +8,8 @@ license.workspace = true
 arrow.workspace = true
 chrono-tz = "0.8"
 chrono.workspace = true
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-error.workspace = true
+common-macro.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu.workspace = true

--- a/src/common/time/Cargo.toml
+++ b/src/common/time/Cargo.toml
@@ -12,7 +12,7 @@ common-error = { workspace = true }
 common-macro = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 arrow-flight.workspace = true
 async-compat = "0.2"
 async-stream.workspace = true
@@ -16,55 +16,55 @@ async-trait.workspace = true
 axum = "0.6"
 axum-macros = "0.3"
 bytes = "1.1"
-catalog = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-config = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-function = { workspace = true }
-common-greptimedb-telemetry = { workspace = true }
-common-grpc = { workspace = true }
-common-grpc-expr = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+catalog.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-config.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-function.workspace = true
+common-greptimedb-telemetry.workspace = true
+common-grpc-expr.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 dashmap = "5.4"
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
-file-engine = { workspace = true }
+datatypes.workspace = true
+file-engine.workspace = true
 futures = "0.3"
 futures-util.workspace = true
 humantime-serde.workspace = true
 hyper = { version = "0.14", features = ["full"] }
 lazy_static.workspace = true
-log-store = { workspace = true }
-meta-client = { workspace = true }
-mito2 = { workspace = true }
-object-store = { workspace = true }
+log-store.workspace = true
+meta-client.workspace = true
+mito2.workspace = true
+object-store.workspace = true
 pin-project = "1.0"
 prometheus.workspace = true
 prost.workspace = true
-query = { workspace = true }
-reqwest = { workspace = true }
+query.workspace = true
+reqwest.workspace = true
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde.workspace = true
 serde_json = "1.0"
-servers = { workspace = true }
-session = { workspace = true }
+servers.workspace = true
+session.workspace = true
 snafu.workspace = true
-sql = { workspace = true }
-storage = { workspace = true }
-store-api = { workspace = true }
-substrait = { workspace = true }
-table = { workspace = true }
+sql.workspace = true
+storage.workspace = true
+store-api.workspace = true
+substrait.workspace = true
+table.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 toml.workspace = true
@@ -76,8 +76,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-client = { workspace = true }
-common-query = { workspace = true }
-common-test-util = { workspace = true }
+client.workspace = true
+common-query.workspace = true
+common-test-util.workspace = true
 datafusion-common.workspace = true
-session = { workspace = true }
+session.workspace = true

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -59,7 +59,7 @@ serde.workspace = true
 serde_json = "1.0"
 servers = { workspace = true }
 session = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sql = { workspace = true }
 storage = { workspace = true }
 store-api = { workspace = true }

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -12,11 +12,11 @@ test = []
 arrow-array.workspace = true
 arrow-schema.workspace = true
 arrow.workspace = true
-common-base = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-base.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 enum_dispatch = "0.3"
 num = "0.4"

--- a/src/datatypes/Cargo.toml
+++ b/src/datatypes/Cargo.toml
@@ -25,4 +25,4 @@ ordered-float = { version = "3.0", features = ["serde"] }
 paste = "1.0"
 serde.workspace = true
 serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true

--- a/src/file-engine/Cargo.toml
+++ b/src/file-engine/Cargo.toml
@@ -10,28 +10,28 @@ test = ["common-test-util"]
 
 [dependencies]
 async-trait = "0.1"
-common-catalog = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-telemetry = { workspace = true }
+common-catalog.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-telemetry.workspace = true
 common-test-util = { workspace = true, optional = true }
-common-time = { workspace = true }
+common-time.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures.workspace = true
-object-store = { workspace = true }
+object-store.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snafu.workspace = true
-store-api = { workspace = true }
-table = { workspace = true }
+store-api.workspace = true
+table.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-api = { workspace = true }
-common-procedure-test = { workspace = true }
-common-test-util = { workspace = true }
+api.workspace = true
+common-procedure-test.workspace = true
+common-test-util.workspace = true

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -10,76 +10,76 @@ python = ["dep:script"]
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 arc-swap = "1.0"
 arrow-flight.workspace = true
 async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
 auth.workspace = true
-catalog = { workspace = true }
+catalog.workspace = true
 chrono.workspace = true
-client = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-config = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-function = { workspace = true }
-common-grpc = { workspace = true }
-common-grpc-expr = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+client.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-config.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-function.workspace = true
+common-grpc-expr.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datanode = { workspace = true }
-datatypes = { workspace = true }
-file-engine = { workspace = true }
+datanode.workspace = true
+datatypes.workspace = true
+file-engine.workspace = true
 futures = "0.3"
 futures-util.workspace = true
 humantime-serde.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
-log-store = { workspace = true }
-meta-client = { workspace = true }
+log-store.workspace = true
+meta-client.workspace = true
 moka = { workspace = true, features = ["future"] }
-object-store = { workspace = true }
+object-store.workspace = true
 openmetrics-parser = "0.4"
 opentelemetry-proto.workspace = true
 operator.workspace = true
-partition = { workspace = true }
+partition.workspace = true
 prometheus.workspace = true
 prost.workspace = true
-query = { workspace = true }
-raft-engine = { workspace = true }
+query.workspace = true
+raft-engine.workspace = true
 regex.workspace = true
 script = { workspace = true, features = ["python"], optional = true }
 serde.workspace = true
 serde_json = "1.0"
-servers = { workspace = true }
-session = { workspace = true }
+servers.workspace = true
+session.workspace = true
 snafu.workspace = true
-sql = { workspace = true }
-sqlparser = { workspace = true }
-storage = { workspace = true }
-store-api = { workspace = true }
-substrait = { workspace = true }
-table = { workspace = true }
+sql.workspace = true
+sqlparser.workspace = true
+storage.workspace = true
+store-api.workspace = true
+substrait.workspace = true
+table.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-catalog = { workspace = true }
-common-test-util = { workspace = true }
-datanode = { workspace = true }
+catalog.workspace = true
+common-test-util.workspace = true
+datanode.workspace = true
 futures = "0.3"
 meta-srv = { workspace = true, features = ["mock"] }
 strfmt = "0.2"

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -19,18 +19,19 @@ common-base = { workspace = true }
 common-config = { workspace = true }
 common-error = { workspace = true }
 common-macro = { workspace = true }
-common-meta = { workspace = true, features = ["testing"] }
+common-meta.workspace = true
 common-runtime = { workspace = true }
 common-telemetry = { workspace = true }
 futures-util.workspace = true
 futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }
 raft-engine = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 store-api = { workspace = true }
 tokio-util.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
+common-meta = { workspace = true, features = ["testing"] }
 common-test-util = { workspace = true }
 rand.workspace = true

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -12,7 +12,6 @@ protobuf-build = { version = "0.15", default-features = false, features = [
 [dependencies]
 async-stream.workspace = true
 async-trait.workspace = true
-base64 = "0.13"
 byteorder = "1.4"
 bytes = "1.1"
 common-base = { workspace = true }

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -14,23 +14,23 @@ async-stream.workspace = true
 async-trait.workspace = true
 byteorder = "1.4"
 bytes = "1.1"
-common-base = { workspace = true }
-common-config = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
+common-base.workspace = true
+common-config.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
 common-meta.workspace = true
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
+common-runtime.workspace = true
+common-telemetry.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }
-raft-engine = { workspace = true }
+raft-engine.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
+store-api.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
 common-meta = { workspace = true, features = ["testing"] }
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 rand.workspace = true

--- a/src/meta-client/Cargo.toml
+++ b/src/meta-client/Cargo.toml
@@ -5,27 +5,27 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-trait = "0.1"
 chrono.workspace = true
-common-error = { workspace = true }
-common-grpc = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-telemetry = { workspace = true }
+common-error.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-telemetry.workspace = true
 etcd-client.workspace = true
 humantime-serde.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
-table = { workspace = true }
+table.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 tonic.workspace = true
 
 [dev-dependencies]
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures = "0.3"
 meta-srv = { workspace = true, features = ["mock"] }
 tower = "0.4"

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -9,25 +9,25 @@ mock = []
 
 [dependencies]
 anymap = "1.0.0-beta.2"
-api = { workspace = true }
+api.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
-catalog = { workspace = true }
-client = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-greptimedb-telemetry = { workspace = true }
-common-grpc = { workspace = true }
-common-grpc-expr = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-procedure = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+catalog.workspace = true
+client.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-greptimedb-telemetry.workspace = true
+common-grpc-expr.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-procedure.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 dashmap = "5.4"
-datatypes = { workspace = true }
+datatypes.workspace = true
 derive_builder.workspace = true
 etcd-client.workspace = true
 futures.workspace = true
@@ -42,11 +42,11 @@ rand.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
-servers = { workspace = true }
+servers.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
+store-api.workspace = true
 strum.workspace = true
-table = { workspace = true }
+table.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
 toml.workspace = true
@@ -60,7 +60,7 @@ uuid.workspace = true
 chrono.workspace = true
 client = { workspace = true, features = ["testing"] }
 common-meta = { workspace = true, features = ["testing"] }
-common-procedure-test = { workspace = true }
-session = { workspace = true }
+common-procedure-test.workspace = true
+session.workspace = true
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/metric-engine/Cargo.toml
+++ b/src/metric-engine/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 api.workspace = true
 async-trait.workspace = true
-base64 = "0.21"
+base64.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
 common-query.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -19,30 +19,30 @@ async-stream.workspace = true
 async-trait = "0.1"
 bytes = "1.4"
 chrono.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
 common-test-util = { workspace = true, optional = true }
-common-time = { workspace = true }
+common-time.workspace = true
 dashmap = "5.4"
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures.workspace = true
-humantime-serde = { workspace = true }
+humantime-serde.workspace = true
 lazy_static = "1.4"
 log-store = { workspace = true, optional = true }
 memcomparable = "0.2"
 moka = { workspace = true, features = ["sync"] }
-object-store = { workspace = true }
+object-store.workspace = true
 parquet = { workspace = true, features = ["async"] }
 paste.workspace = true
 prometheus.workspace = true
@@ -53,14 +53,14 @@ serde_json.workspace = true
 serde_with = "3"
 smallvec.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
+store-api.workspace = true
 strum.workspace = true
-table = { workspace = true }
+table.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-common-procedure-test = { workspace = true }
-common-test-util = { workspace = true }
-log-store = { workspace = true }
+common-procedure-test.workspace = true
+common-test-util.workspace = true
+log-store.workspace = true

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -25,6 +25,6 @@ uuid.workspace = true
 
 [dev-dependencies]
 anyhow = "1.0"
-common-telemetry = { workspace = true }
-common-test-util = { workspace = true }
+common-telemetry.workspace = true
+common-test-util.workspace = true
 tokio.workspace = true

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -8,51 +8,51 @@ license.workspace = true
 testing = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-compat = "0.2"
 async-trait = "0.1"
 auth.workspace = true
-catalog = { workspace = true }
+catalog.workspace = true
 chrono.workspace = true
-client = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-grpc-expr = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+client.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-grpc-expr.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
-file-engine = { workspace = true }
+datatypes.workspace = true
+file-engine.workspace = true
 futures = "0.3"
 futures-util.workspace = true
 lazy_static.workspace = true
-meta-client = { workspace = true }
+meta-client.workspace = true
 meter-core.workspace = true
 meter-macros.workspace = true
-object-store = { workspace = true }
-partition = { workspace = true }
+object-store.workspace = true
+partition.workspace = true
 prometheus.workspace = true
-query = { workspace = true }
+query.workspace = true
 regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
-servers = { workspace = true }
-session = { workspace = true }
+servers.workspace = true
+session.workspace = true
 snafu.workspace = true
-sql = { workspace = true }
-sqlparser = { workspace = true }
-storage = { workspace = true }
-store-api = { workspace = true }
-substrait = { workspace = true }
-table = { workspace = true }
+sql.workspace = true
+sqlparser.workspace = true
+storage.workspace = true
+store-api.workspace = true
+substrait.workspace = true
+table.workspace = true
 tokio.workspace = true
 tonic.workspace = true

--- a/src/partition/Cargo.toml
+++ b/src/partition/Cargo.toml
@@ -5,24 +5,24 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-trait = "0.1"
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-meta = { workspace = true }
-common-query = { workspace = true }
-common-telemetry = { workspace = true }
+common-catalog.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-meta.workspace = true
+common-query.workspace = true
+common-telemetry.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 lazy_static.workspace = true
-meta-client = { workspace = true }
+meta-client.workspace = true
 moka = { workspace = true, features = ["future"] }
 prometheus.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true
-store-api = { workspace = true }
-table = { workspace = true }
+store-api.workspace = true
+table.workspace = true

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -8,25 +8,25 @@ license.workspace = true
 async-recursion = "1.0"
 async-trait.workspace = true
 bytemuck = "1.12"
-catalog = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-recordbatch = { workspace = true }
-common-telemetry = { workspace = true }
+catalog.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-recordbatch.workspace = true
+common-telemetry.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures = "0.3"
 greptime-proto.workspace = true
 lazy_static.workspace = true
 prometheus.workspace = true
 promql-parser = "0.1.1"
 prost.workspace = true
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
-table = { workspace = true }
+table.workspace = true
 
 [dev-dependencies]
-query = { workspace = true }
+query.workspace = true
 session = { workspace = true, features = ["testing"] }
 tokio.workspace = true

--- a/src/promql/Cargo.toml
+++ b/src/promql/Cargo.toml
@@ -23,7 +23,7 @@ prometheus.workspace = true
 promql-parser = "0.1.1"
 prost.workspace = true
 session = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 table = { workspace = true }
 
 [dev-dependencies]

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -49,7 +49,7 @@ regex.workspace = true
 serde.workspace = true
 serde_json = "1.0"
 session.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sql.workspace = true
 store-api.workspace = true
 substrait.workspace = true

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -28,30 +28,30 @@ api.workspace = true
 arc-swap = "1.0"
 arrow.workspace = true
 async-trait.workspace = true
-catalog = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-function = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+catalog.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-function.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 console = "0.15"
 crossbeam-utils = "0.8.14"
 datafusion = { workspace = true, optional = true }
 datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }
 datafusion-physical-expr = { workspace = true, optional = true }
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
 once_cell.workspace = true
 paste = { workspace = true, optional = true }
 prometheus.workspace = true
-query = { workspace = true }
+query.workspace = true
 # TODO(discord9): This is a forked and tweaked version of RustPython, please update it to newest original RustPython After RustPython support GC
 pyo3 = { version = "0.19", optional = true, features = ["abi3", "abi3-py37"] }
 rustpython-ast = { git = "https://github.com/discord9/RustPython", optional = true, rev = "9ed5137412" }
@@ -68,24 +68,24 @@ rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = tru
     "codegen",
 ] }
 servers.workspace = true
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
-sql = { workspace = true }
-store-api = { workspace = true }
-table = { workspace = true }
+sql.workspace = true
+store-api.workspace = true
+table.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
 catalog = { workspace = true, features = ["testing"] }
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 criterion = { version = "0.4", features = ["html_reports", "async_tokio"] }
-log-store = { workspace = true }
+log-store.workspace = true
 operator.workspace = true
 rayon = "1.0"
 ron = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 session = { workspace = true, features = ["testing"] }
-storage = { workspace = true }
+storage.workspace = true
 tokio-test = "0.4"
 
 [[bench]]

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -69,7 +69,7 @@ rustpython-vm = { git = "https://github.com/discord9/RustPython", optional = tru
 ] }
 servers.workspace = true
 session = { workspace = true }
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sql = { workspace = true }
 store-api = { workspace = true }
 table = { workspace = true }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 auth.workspace = true
 axum = { version = "0.6", features = ["headers"] }
 axum-macros = "0.3.8"
-base64 = "0.13"
+base64.workspace = true
 bytes = "1.2"
 catalog = { workspace = true }
 chrono.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -12,7 +12,7 @@ testing = []
 
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
-api = { workspace = true }
+api.workspace = true
 arrow-flight.workspace = true
 async-trait = "0.1"
 auth.workspace = true
@@ -20,25 +20,25 @@ axum = { version = "0.6", features = ["headers"] }
 axum-macros = "0.3.8"
 base64.workspace = true
 bytes = "1.2"
-catalog = { workspace = true }
+catalog.workspace = true
 chrono.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-grpc = { workspace = true }
-common-grpc-expr = { workspace = true }
-common-macro = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-grpc-expr.workspace = true
+common-grpc.workspace = true
+common-macro.workspace = true
 common-mem-prof = { workspace = true, optional = true }
-common-meta = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-meta.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 derive_builder.workspace = true
 digest = "0.10"
 futures = "0.3"
@@ -69,7 +69,7 @@ pprof = { version = "0.11", features = [
 prometheus.workspace = true
 promql-parser = "0.1.1"
 prost.workspace = true
-query = { workspace = true }
+query.workspace = true
 rand.workspace = true
 regex.workspace = true
 rust-embed = { version = "6.6", features = ["debug-embed"] }
@@ -79,13 +79,13 @@ schemars = "0.8"
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde.workspace = true
 serde_json = "1.0"
-session = { workspace = true }
+session.workspace = true
 sha1 = "0.10"
 snafu.workspace = true
 snap = "1"
-sql = { workspace = true }
+sql.workspace = true
 strum.workspace = true
-table = { workspace = true }
+table.workspace = true
 tokio-rustls = "0.24"
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio.workspace = true
@@ -101,9 +101,9 @@ tikv-jemalloc-ctl = { version = "0.5", features = ["use_std"] }
 auth = { workspace = true, features = ["testing"] }
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
 catalog = { workspace = true, features = ["testing"] }
-client = { workspace = true }
-common-base = { workspace = true }
-common-test-util = { workspace = true }
+client.workspace = true
+common-base.workspace = true
+common-test-util.workspace = true
 mysql_async = { git = "https://github.com/blackbeam/mysql_async.git", rev = "32c6f2a986789f97108502c2d0c755a089411b66", default-features = false, features = [
     "default-rustls",
 ] }
@@ -112,7 +112,7 @@ rustls = { version = "0.21", features = ["dangerous_configuration"] }
 script = { workspace = true, features = ["python"] }
 serde_json = "1.0"
 session = { workspace = true, features = ["testing"] }
-table = { workspace = true }
+table.workspace = true
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.10"
 tokio-test = "0.4"

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -17,6 +17,8 @@ use std::marker::PhantomData;
 use ::auth::UserProviderRef;
 use axum::http::{self, Request, StatusCode};
 use axum::response::Response;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
@@ -244,7 +246,9 @@ fn auth_header<B>(req: &Request<B>) -> Result<AuthScheme> {
 }
 
 fn decode_basic(credential: Credential) -> Result<(Username, Password)> {
-    let decoded = base64::decode(credential).context(error::InvalidBase64ValueSnafu)?;
+    let decoded = BASE64_STANDARD
+        .decode(credential)
+        .context(error::InvalidBase64ValueSnafu)?;
     let as_utf8 = String::from_utf8(decoded).context(error::InvalidUtf8ValueSnafu)?;
 
     if let Some((user_id, password)) = as_utf8.split_once(':') {

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -11,8 +11,8 @@ testing = []
 api.workspace = true
 arc-swap = "1.5"
 auth.workspace = true
-common-catalog = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-catalog.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 derive_builder.workspace = true
-sql = { workspace = true }
+sql.workspace = true

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -19,7 +19,7 @@ itertools.workspace = true
 lazy_static.workspace = true
 once_cell.workspace = true
 regex.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 sqlparser.workspace = true
 sqlparser_derive = "0.1"
 table = { workspace = true }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -5,15 +5,15 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-time = { workspace = true }
+api.workspace = true
+common-base.workspace = true
+common-catalog.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-time.workspace = true
 datafusion-sql.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 hex = "0.4"
 itertools.workspace = true
 lazy_static.workspace = true
@@ -22,7 +22,7 @@ regex.workspace = true
 snafu.workspace = true
 sqlparser.workspace = true
 sqlparser_derive = "0.1"
-table = { workspace = true }
+table.workspace = true
 
 [dev-dependencies]
-common-datasource = { workspace = true }
+common-datasource.workspace = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -39,7 +39,7 @@ prost.workspace = true
 regex = "1.5"
 serde.workspace = true
 serde_json = "1.0"
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 store-api = { workspace = true }
 table = { workspace = true }
 tokio-util.workspace = true

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -13,25 +13,25 @@ async-compat = "0.2"
 async-stream.workspace = true
 async-trait = "0.1"
 bytes = "1.1"
-common-base = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-base.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
-object-store = { workspace = true }
+object-store.workspace = true
 parquet = { workspace = true, features = ["async"] }
 paste.workspace = true
 prometheus.workspace = true
@@ -40,8 +40,8 @@ regex = "1.5"
 serde.workspace = true
 serde_json = "1.0"
 snafu.workspace = true
-store-api = { workspace = true }
-table = { workspace = true }
+store-api.workspace = true
+table.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -49,11 +49,11 @@ uuid.workspace = true
 
 [dev-dependencies]
 atomic_float = "0.1"
-common-config = { workspace = true }
-common-test-util = { workspace = true }
+common-config.workspace = true
+common-test-util.workspace = true
 criterion = "0.3"
 datatypes = { workspace = true, features = ["test"] }
-log-store = { workspace = true }
+log-store.workspace = true
 rand.workspace = true
 
 [build-dependencies]

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -5,17 +5,17 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 aquamarine.workspace = true
 async-trait.workspace = true
 bytes = "1.1"
-common-base = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-time = { workspace = true }
-datatypes = { workspace = true }
+common-base.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-time.workspace = true
+datatypes.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 serde.workspace = true

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -11,21 +11,21 @@ testing = []
 anymap = "1.0.0-beta.2"
 async-trait = "0.1"
 chrono.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-datasource = { workspace = true }
-common-error = { workspace = true }
-common-macro = { workspace = true }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-telemetry = { workspace = true }
-common-time = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-datasource.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion.workspace = true
-datatypes = { workspace = true }
+datatypes.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 humantime = "2.1"
@@ -33,11 +33,11 @@ humantime-serde.workspace = true
 paste = "1.0"
 serde.workspace = true
 snafu.workspace = true
-store-api = { workspace = true }
+store-api.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]
-common-test-util = { workspace = true }
+common-test-util.workspace = true
 parquet = { workspace = true, features = ["async"] }
 serde_json.workspace = true
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -32,7 +32,7 @@ humantime = "2.1"
 humantime-serde.workspace = true
 paste = "1.0"
 serde.workspace = true
-snafu = { version = "0.7", features = ["backtraces"] }
+snafu.workspace = true
 store-api = { workspace = true }
 tokio.workspace = true
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -8,38 +8,38 @@ license.workspace = true
 dashboard = []
 
 [dependencies]
-api = { workspace = true }
+api.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = "0.6"
 axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
-catalog = { workspace = true }
+catalog.workspace = true
 chrono.workspace = true
 client = { workspace = true, features = ["testing"] }
 cmd.workspace = true
-common-base = { workspace = true }
-common-catalog = { workspace = true }
-common-config = { workspace = true }
-common-error = { workspace = true }
-common-grpc = { workspace = true }
+common-base.workspace = true
+common-catalog.workspace = true
+common-config.workspace = true
+common-error.workspace = true
+common-grpc.workspace = true
 common-meta = { workspace = true, features = ["testing"] }
-common-procedure = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-runtime = { workspace = true }
-common-telemetry = { workspace = true }
-common-test-util = { workspace = true }
+common-procedure.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-test-util.workspace = true
 datanode = { workspace = true, features = ["testing"] }
-datatypes = { workspace = true }
+datatypes.workspace = true
 dotenv = "0.15"
 frontend = { workspace = true, features = ["testing"] }
 futures.workspace = true
-meta-client = { workspace = true }
+meta-client.workspace = true
 meta-srv = { workspace = true, features = ["mock"] }
-object-store = { workspace = true }
+object-store.workspace = true
 once_cell.workspace = true
-operator = { workspace = true }
-query = { workspace = true }
+operator.workspace = true
+query.workspace = true
 rand.workspace = true
 rstest = "0.17"
 rstest_reuse = "0.5"
@@ -47,17 +47,17 @@ secrecy = "0.8"
 serde.workspace = true
 serde_json = "1.0"
 servers = { workspace = true, features = ["testing"] }
-session = { workspace = true }
+session.workspace = true
 snafu.workspace = true
-sql = { workspace = true }
+sql.workspace = true
 sqlx = { version = "0.6", features = [
     "runtime-tokio-rustls",
     "mysql",
     "postgres",
     "chrono",
 ] }
-substrait = { workspace = true }
-table = { workspace = true }
+substrait.workspace = true
+table.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -69,10 +69,10 @@ datafusion-expr.workspace = true
 datafusion.workspace = true
 itertools.workspace = true
 opentelemetry-proto.workspace = true
-partition = { workspace = true }
+partition.workspace = true
 paste.workspace = true
 prost.workspace = true
-script = { workspace = true }
+script.workspace = true
 session = { workspace = true, features = ["testing"] }
-store-api = { workspace = true }
+store-api.workspace = true
 tokio-postgres = "0.7"

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -7,13 +7,13 @@ license.workspace = true
 [dependencies]
 async-trait = "0.1"
 clap = { version = "4.0", features = ["derive"] }
-client = { workspace = true }
-common-base = { workspace = true }
-common-error = { workspace = true }
-common-grpc = { workspace = true }
-common-query = { workspace = true }
-common-recordbatch = { workspace = true }
-common-time = { workspace = true }
+client.workspace = true
+common-base.workspace = true
+common-error.workspace = true
+common-grpc.workspace = true
+common-query.workspace = true
+common-recordbatch.workspace = true
+common-time.workspace = true
 serde.workspace = true
 sqlness = { version = "0.5" }
 tinytemplate = "1.2"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Change `snafu`, `log-store` and `base64` to the workspace level dep.

This patch also changes all `xxx = { workspace = true }` to `xxx.workspace = true`. Make it simpler like `xxx = "1.0.0"` instead of `xxx = { version = "1.0.0" }`


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
