### PR TITLE
feat: support prometheus format_query endpoint

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -66,7 +66,7 @@ use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb
 use crate::configurator::ConfiguratorRef;
 use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
 use crate::http::prometheus::{
-    instant_query, label_values_query, labels_query, range_query, series_query,
+    format_query, instant_query, label_values_query, labels_query, range_query, series_query,
 };
 use crate::metrics::{
     HTTP_TRACK_METRICS, METRIC_HTTP_REQUESTS_ELAPSED, METRIC_HTTP_REQUESTS_TOTAL,
@@ -623,6 +623,10 @@ impl HttpServer {
 
     fn route_prometheus<S>(&self, prometheus_handler: PrometheusHandlerRef) -> Router<S> {
         Router::new()
+            .route(
+                "/format_query",
+                routing::post(format_query).get(format_query),
+            )
             .route("/query", routing::post(instant_query).get(instant_query))
             .route("/query_range", routing::post(range_query).get(range_query))
             .route("/labels", routing::post(labels_query).get(labels_query))

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -100,6 +100,11 @@ lazy_static! {
         "servers opentsdb line write elapsed"
     )
     .unwrap();
+    pub static ref METRIC_HTTP_PROMQL_FORMAT_QUERY_ELAPSED: Histogram = register_histogram!(
+        "servers_http_promql_format_query_elapsed",
+        "servers http promql format query elapsed"
+    )
+    .unwrap();
     pub static ref METRIC_HTTP_PROMQL_INSTANT_QUERY_ELAPSED: Histogram = register_histogram!(
         "servers_http_promql_instant_query_elapsed",
         "servers http promql instant query elapsed"

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -341,6 +341,17 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     let (app, mut guard) = setup_test_prom_app_with_frontend(store_type, "promql_api").await;
     let client = TestClient::new(app);
 
+    // format_query
+    let res = client
+        .get("/v1/prometheus/api/v1/format_query?query=foo/bar")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        res.text().await.as_str(),
+        r#"{"status":"success","data":"foo / bar"}"#
+    );
+
     // instant query
     let res = client
         .get("/v1/prometheus/api/v1/query?query=up&time=1")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Implement `format_query` endpoint.

```
curl -i 'http://localhost:4000/v1/prometheus/api/v1/format_query?query=foo/bar'
HTTP/1.1 200 OK
content-type: application/json
content-length: 39
date: Fri, 10 Nov 2023 08:56:47 GMT

{"status":"success","data":"foo / bar"}
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

This closes https://github.com/GreptimeTeam/greptimedb/issues/1540.