### PR TITLE
refactor: reduce the scope of the meta server cache

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -660,9 +660,7 @@ impl TableMetadataManager {
             .table_route_manager()
             .build_update_txn(table_id, &current_table_route_value, &new_table_route_value)?;
 
-        let txn = Txn::merge_all(vec![update_table_route_txn]);
-
-        let r = self.kv_backend.txn(txn).await?;
+        let r = self.kv_backend.txn(update_table_route_txn).await?;
 
         // Checks whether metadata was already updated.
         if !r.succeeded {

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -168,7 +168,6 @@ impl MetaSrvBuilder {
             state.clone(),
             kv_backend.clone(),
         ));
-        let kv_backend = leader_cached_kv_backend.clone() as _;
 
         let meta_peer_client = meta_peer_client
             .unwrap_or_else(|| build_default_meta_peer_client(&election, &in_memory));
@@ -177,7 +176,9 @@ impl MetaSrvBuilder {
         let mailbox = build_mailbox(&kv_backend, &pushers);
         let procedure_manager = build_procedure_manager(&options, &kv_backend);
         let table_id_sequence = Arc::new(Sequence::new(TABLE_ID_SEQ, 1024, 10, kv_backend.clone()));
-        let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
+        let table_metadata_manager = Arc::new(TableMetadataManager::new(
+            leader_cached_kv_backend.clone() as _,
+        ));
         let lock = lock.unwrap_or_else(|| Arc::new(MemLock::default()));
         let selector_ctx = SelectorContext {
             server_addr: options.server_addr.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Reduce the scope of the meta server cache.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
