### PR TITLE
fix: Normalize default constrain fn name

### DIFF
--- a/src/datatypes/src/schema.rs
+++ b/src/datatypes/src/schema.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 mod column_schema;
-mod constraint;
+pub mod constraint;
 mod raw;
 
 use std::collections::HashMap;

--- a/src/datatypes/src/schema/constraint.rs
+++ b/src/datatypes/src/schema/constraint.rs
@@ -24,9 +24,9 @@ use crate::value::Value;
 use crate::vectors::operations::VectorOp;
 use crate::vectors::{TimestampMillisecondVector, VectorRef};
 
-const CURRENT_TIMESTAMP: &str = "current_timestamp";
-const CURRENT_TIMESTAMP_FN: &str = "current_timestamp()";
-const NOW_FN: &str = "now()";
+pub const CURRENT_TIMESTAMP: &str = "current_timestamp";
+pub const CURRENT_TIMESTAMP_FN: &str = "current_timestamp()";
+pub const NOW_FN: &str = "now()";
 
 /// Column's default constraint.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -63,6 +63,7 @@ pub enum Error {
     Syntax {
         #[snafu(source)]
         error: ParserError,
+        location: Location,
     },
 
     #[snafu(display("Missing time index constraint"))]

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -273,11 +273,11 @@ fn parse_column_default_constraint(
             ColumnOption::Default(Expr::Function(func)) => {
                 let mut func = format!("{func}").to_lowercase();
                 // normalize CURRENT_TIMESTAMP to CURRENT_TIMESTAMP()
-                if &func == CURRENT_TIMESTAMP {
+                if func == CURRENT_TIMESTAMP {
                     func = CURRENT_TIMESTAMP_FN.to_string();
                 }
                 // Always use lowercase for function expression
-                ColumnDefaultConstraint::Function(format!("{func}").to_lowercase())
+                ColumnDefaultConstraint::Function(func.to_lowercase())
             }
             ColumnOption::Default(expr) => {
                 return UnsupportedDefaultValueSnafu {

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -37,6 +37,7 @@ use common_base::bytes::Bytes;
 use common_query::AddColumnLocation;
 use common_time::Timestamp;
 use datatypes::prelude::ConcreteDataType;
+use datatypes::schema::constraint::{CURRENT_TIMESTAMP, CURRENT_TIMESTAMP_FN};
 use datatypes::schema::{ColumnDefaultConstraint, ColumnSchema, COMMENT_KEY};
 use datatypes::types::cast::CastOption;
 use datatypes::types::{cast, TimestampType};
@@ -270,6 +271,11 @@ fn parse_column_default_constraint(
                 ColumnDefaultConstraint::Value(sql_value_to_value(column_name, data_type, v)?)
             }
             ColumnOption::Default(Expr::Function(func)) => {
+                let mut func = format!("{func}").to_lowercase();
+                // normalize CURRENT_TIMESTAMP to CURRENT_TIMESTAMP()
+                if &func == CURRENT_TIMESTAMP {
+                    func = CURRENT_TIMESTAMP_FN.to_string();
+                }
                 // Always use lowercase for function expression
                 ColumnDefaultConstraint::Function(format!("{func}").to_lowercase())
             }

--- a/tests/cases/standalone/common/create/current_timestamp.result
+++ b/tests/cases/standalone/common/create/current_timestamp.result
@@ -2,13 +2,61 @@ create table t1 (ts timestamp time index default CURRENT_TIMESTAMP);
 
 Affected Rows: 0
 
+show create table t1;
+
++-------+-----------------------------------------------------------+
+| Table | Create Table                                              |
++-------+-----------------------------------------------------------+
+| t1    | CREATE TABLE IF NOT EXISTS "t1" (                         |
+|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|       |   TIME INDEX ("ts")                                       |
+|       | )                                                         |
+|       |                                                           |
+|       | ENGINE=mito                                               |
+|       | WITH(                                                     |
+|       |   regions = 1                                             |
+|       | )                                                         |
++-------+-----------------------------------------------------------+
+
 create table t2 (ts timestamp time index default currEnt_tImEsTamp());
 
 Affected Rows: 0
 
+show create table t2;
+
++-------+-----------------------------------------------------------+
+| Table | Create Table                                              |
++-------+-----------------------------------------------------------+
+| t2    | CREATE TABLE IF NOT EXISTS "t2" (                         |
+|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(), |
+|       |   TIME INDEX ("ts")                                       |
+|       | )                                                         |
+|       |                                                           |
+|       | ENGINE=mito                                               |
+|       | WITH(                                                     |
+|       |   regions = 1                                             |
+|       | )                                                         |
++-------+-----------------------------------------------------------+
+
 create table t3 (ts timestamp time index default now());
 
 Affected Rows: 0
+
+show create table t3;
+
++-------+---------------------------------------------+
+| Table | Create Table                                |
++-------+---------------------------------------------+
+| t3    | CREATE TABLE IF NOT EXISTS "t3" (           |
+|       |   "ts" TIMESTAMP(3) NOT NULL DEFAULT now(), |
+|       |   TIME INDEX ("ts")                         |
+|       | )                                           |
+|       |                                             |
+|       | ENGINE=mito                                 |
+|       | WITH(                                       |
+|       |   regions = 1                               |
+|       | )                                           |
++-------+---------------------------------------------+
 
 create table t4 (ts timestamp time index default now);
 

--- a/tests/cases/standalone/common/create/current_timestamp.sql
+++ b/tests/cases/standalone/common/create/current_timestamp.sql
@@ -1,8 +1,14 @@
 create table t1 (ts timestamp time index default CURRENT_TIMESTAMP);
 
+show create table t1;
+
 create table t2 (ts timestamp time index default currEnt_tImEsTamp());
 
+show create table t2;
+
 create table t3 (ts timestamp time index default now());
+
+show create table t3;
 
 create table t4 (ts timestamp time index default now);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Table created with the following SQL cannot run with `SHOW CREATE`
```sql
CREATE TABLE IF NOT EXISTS cpu_metrics3 (
    hostname STRING,
    environment STRING,
    usage_user DOUBLE,
    usage_system DOUBLE,
    usage_idle DOUBLE,
    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    TIME INDEX(ts),
    PRIMARY KEY(hostname, environment)
);
```

Error:
```
pg:j2qY4ErSyTkM93HyanOBl400@i9ulpzu4mdgf/q6dj4up5mmriweak_flowers-public=> show create table "cpu_metrics3";
error: pq: XX000: sql parser error: Expected (, found: EOF
pg:j2qY4ErSyTkM93HyanOBl400@i9ulpzu4mdgf/q6dj4up5mmriweak_flowers-public=> show create table cpu_metrics3;
error: pq: XX000: sql parser error: Expected (, found: EOF
pg:j2qY4ErSyTkM93HyanOBl400@i9ulpzu4mdgf/q6dj4up5mmriweak_flowers-public=>
```

Server error:
```
2023-11-13T12:59:56.952175Z ERROR frontend::instance: Failed to execute query: show create table cpu_metrics3 trace_id=7129814621363507161 err=0: Table operation error, at src/frontend/src/instance.rs:419:14
1: Failed to execute statement, at /home/wayne/repo/greptimedb/src/operator/src/statement/show.rs:68:14
2: General SQL error, at src/query/src/sql/show_create_table.rs:110:76
3: , at src/sql/src/parser.rs:75:14
4: ParserError("Expected (, found: EOF")
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
