### PR TITLE
fix: handle if num_cpus / 2 == 0

### DIFF
--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -92,7 +92,7 @@ impl MitoConfig {
         // Sanitize worker num.
         let num_workers_before = self.num_workers;
         if self.num_workers == 0 {
-            self.num_workers = num_cpus::get() / 2;
+            self.num_workers = (num_cpus::get() / 2).max(1);
         }
         if num_workers_before != self.num_workers {
             warn!(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


This sanitizer cannot help when `num_cpus / 2` == 0. Add an additional `.max()` to avoid this.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
