### PR TITLE
feat: Ignore file not found error temporarily while compacting files

### DIFF
--- a/src/mito2/src/compaction/output.rs
+++ b/src/mito2/src/compaction/output.rs
@@ -79,6 +79,8 @@ async fn build_sst_reader(
 ) -> error::Result<BoxedBatchReader> {
     SeqScan::new(sst_layer, ProjectionMapper::all(&schema)?)
         .with_files(inputs.to_vec())
+        // We ignore file not found error during compaction.
+        .with_ignore_file_not_found(true)
         .build_reader()
         .await
 }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -22,6 +22,7 @@ use common_macro::stack_trace_debug;
 use common_runtime::JoinError;
 use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
+use object_store::ErrorKind;
 use prost::{DecodeError, EncodeError};
 use snafu::{Location, Snafu};
 use store_api::manifest::ManifestVersion;
@@ -410,6 +411,14 @@ impl Error {
     /// Returns true if we need to fill default value for a region.
     pub(crate) fn is_fill_default(&self) -> bool {
         matches!(self, Error::FillDefault { .. })
+    }
+
+    /// Returns true if the file is not found on the object store.
+    pub(crate) fn is_object_not_found(&self) -> bool {
+        match self {
+            Error::OpenDal { error, .. } => error.kind() == ErrorKind::NotFound,
+            _ => false,
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR temporarily ignores files not found during compaction. We use this to workaround the issue caused by #2746

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2746
