### PR TITLE
feat: simplify log file output by removing bunyan layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,7 +1951,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-appender",
- "tracing-bunyan-formatter",
  "tracing-futures",
  "tracing-log",
  "tracing-opentelemetry",
@@ -9893,24 +9892,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.38",
-]
-
-[[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c266b9ac83dedf0e0385ad78514949e6d89491269e7065bee51d2bb8ec7373"
-dependencies = [
- "ahash 0.8.6",
- "gethostname",
- "log",
- "serde",
- "serde_json",
- "time",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -27,7 +27,6 @@ serde.workspace = true
 tokio.workspace = true
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-bunyan-formatter = "0.3"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 tracing-log = "0.1"
 tracing-opentelemetry = "0.17"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Remove `bunyan` format layer for output docs. JSON formatted logs are hard to use on both loki and log file. Plain text is clearer in both cases.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
