### PR TITLE
perf: disable dictionary of ts columns

### DIFF
--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -502,9 +502,9 @@ async fn test_region_usage() {
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_usage().await;
-    assert!(region_stat.wal_usage == 0);
-    assert_eq!(region_stat.sst_usage, 2827);
+    assert_eq!(region_stat.wal_usage, 0);
+    assert_eq!(region_stat.sst_usage, 2742);
 
     // region total usage
-    assert_eq!(region_stat.disk_usage(), 3833);
+    assert_eq!(region_stat.disk_usage(), 3748);
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR disables the dictionary page for timestamp columns since timestamp values seldom repeat and dictionary encoding does nothing but increases SST file size. In some cases, the dictionary page size of timestamp columns will be larger than data page size.

## Checklist

- [X]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
