### PR TITLE
feat: add migration start step

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -551,6 +551,13 @@ pub enum Error {
     },
 }
 
+impl Error {
+    /// Returns `true` if the error is retryable.
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Error::RetryLater { .. })
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 define_into_tonic_status!(Error);

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -14,29 +14,24 @@
 
 use std::any::Any;
 
-use common_procedure::Status;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegionMigrationEnd;
+pub struct DowngradeLeaderRegion;
 
 #[async_trait::async_trait]
 #[typetag::serde]
-impl State for RegionMigrationEnd {
+impl State for DowngradeLeaderRegion {
     async fn next(
         &mut self,
-        _: &Context,
-        _: &mut PersistentContext,
-        _: &mut VolatileContext,
+        _ctx: &Context,
+        _pc: &mut PersistentContext,
+        _vc: &mut VolatileContext,
     ) -> Result<Box<dyn State>> {
-        Ok(Box::new(RegionMigrationEnd))
-    }
-
-    fn status(&self) -> Status {
-        Status::Done
+        todo!()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
-use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
+use crate::procedure::region_migration::{Context, State};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DowngradeLeaderRegion;
@@ -25,12 +25,7 @@ pub struct DowngradeLeaderRegion;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for DowngradeLeaderRegion {
-    async fn next(
-        &mut self,
-        _ctx: &Context,
-        _pc: &mut PersistentContext,
-        _vc: &mut VolatileContext,
-    ) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _ctx: &Context) -> Result<Box<dyn State>> {
         todo!()
     }
 

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -25,7 +25,7 @@ pub struct DowngradeLeaderRegion;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for DowngradeLeaderRegion {
-    async fn next(&mut self, _ctx: &Context) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _ctx: &mut Context) -> Result<Box<dyn State>> {
         todo!()
     }
 

--- a/src/meta-srv/src/procedure/region_migration/migration_end.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_end.rs
@@ -18,7 +18,7 @@ use common_procedure::Status;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
-use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
+use crate::procedure::region_migration::{Context, State};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RegionMigrationEnd;
@@ -26,12 +26,7 @@ pub struct RegionMigrationEnd;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for RegionMigrationEnd {
-    async fn next(
-        &mut self,
-        _: &Context,
-        _: &mut PersistentContext,
-        _: &mut VolatileContext,
-    ) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _: &Context) -> Result<Box<dyn State>> {
         Ok(Box::new(RegionMigrationEnd))
     }
 

--- a/src/meta-srv/src/procedure/region_migration/migration_end.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_end.rs
@@ -26,7 +26,7 @@ pub struct RegionMigrationEnd;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for RegionMigrationEnd {
-    async fn next(&mut self, _: &Context) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _: &mut Context) -> Result<Box<dyn State>> {
         Ok(Box::new(RegionMigrationEnd))
     }
 

--- a/src/meta-srv/src/procedure/region_migration/migration_start.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_start.rs
@@ -12,24 +12,293 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Serialize};
+use std::any::Any;
 
-use crate::error::Result;
+use common_meta::peer::Peer;
+use common_meta::rpc::router::RegionRoute;
+use serde::{Deserialize, Serialize};
+use snafu::{location, Location, OptionExt, ResultExt};
+use store_api::storage::RegionId;
+
+use super::downgrade_leader_region::DowngradeLeaderRegion;
+use super::migration_end::RegionMigrationEnd;
+use super::open_candidate_region::OpenCandidateRegion;
+use crate::error::{self, Result};
 use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegionMigrationStart {}
+pub struct RegionMigrationStart;
 
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for RegionMigrationStart {
+    /// Yields next [State].
+    ///
+    /// If the expected leader region has been opened on `to_peer`, go to the MigrationEnd state.
+    ///
+    /// If the candidate region has been opened on `to_peer`, go to the DowngradeLeader state.
+    ///
+    /// Otherwise go to the OpenCandidateRegion state.
     async fn next(
         &mut self,
-        _ctx: &Context,
-        _pc: &mut PersistentContext,
+        ctx: &Context,
+        pc: &mut PersistentContext,
         _vc: &mut VolatileContext,
     ) -> Result<Box<dyn State>> {
-        // TODO(weny): It will be added in the following PRs.
-        todo!()
+        let region_id = pc.region_id;
+        let to_peer = &pc.to_peer;
+        let region_route = self.retrieve_regions_route(ctx, region_id).await?;
+
+        if self.check_leader_region_on_peer(&region_route, to_peer)? {
+            Ok(Box::new(RegionMigrationEnd))
+        } else if self.check_candidate_region_on_peer(&region_route, to_peer) {
+            Ok(Box::new(DowngradeLeaderRegion))
+        } else {
+            Ok(Box::new(OpenCandidateRegion))
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+impl RegionMigrationStart {
+    /// Retrieves region route.
+    ///
+    /// Abort(non-retry):
+    /// - TableRoute is not found.
+    /// - RegionRoute is not found.
+    ///
+    /// Retry:
+    /// - Failed to retrieve the metadata of table.
+    async fn retrieve_regions_route(
+        &self,
+        ctx: &Context,
+        region_id: RegionId,
+    ) -> Result<RegionRoute> {
+        let table_id = region_id.table_id();
+        let table_route = ctx
+            .table_metadata_manager
+            .table_route_manager()
+            .get(table_id)
+            .await
+            .context(error::TableMetadataManagerSnafu)
+            .map_err(|e| error::Error::RetryLater {
+                reason: e.to_string(),
+                location: location!(),
+            })?
+            .context(error::TableRouteNotFoundSnafu { table_id })?;
+
+        let region_route = table_route
+            .region_routes
+            .iter()
+            .find(|route| route.region.id == region_id)
+            .cloned()
+            .context(error::UnexpectedSnafu {
+                violated: format!(
+                    "RegionRoute({}) is not found in TableRoute({})",
+                    region_id, table_id
+                ),
+            })?;
+
+        Ok(region_route)
+    }
+
+    /// Checks whether the candidate region on region has been opened.
+    /// Returns true if it's been opened.
+    fn check_candidate_region_on_peer(&self, region_route: &RegionRoute, to_peer: &Peer) -> bool {
+        let region_opened = region_route
+            .follower_peers
+            .iter()
+            .any(|peer| peer.id == to_peer.id);
+
+        region_opened
+    }
+
+    /// Checks whether the leader region on region has been opened.
+    /// Returns true if it's been opened.
+    ///     
+    /// Abort(non-retry):
+    /// - Leader peer of RegionRoute is not found.
+    fn check_leader_region_on_peer(
+        &self,
+        region_route: &RegionRoute,
+        to_peer: &Peer,
+    ) -> Result<bool> {
+        let region_id = region_route.region.id;
+
+        let region_opened = region_route
+            .leader_peer
+            .as_ref()
+            .context(error::UnexpectedSnafu {
+                violated: format!("Leader peer is not found in TableRoute({})", region_id),
+            })?
+            .id
+            == to_peer.id;
+
+        Ok(region_opened)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+
+    use common_meta::key::test_utils::new_test_table_info;
+    use common_meta::peer::Peer;
+    use common_meta::rpc::router::{Region, RegionRoute};
+    use store_api::storage::RegionId;
+
+    use super::*;
+    use crate::error::Error;
+    use crate::procedure::region_migration::test_util::TestingEnv;
+
+    fn new_persistent_context() -> PersistentContext {
+        PersistentContext {
+            from_peer: Peer::empty(1),
+            to_peer: Peer::empty(2),
+            region_id: RegionId::new(1024, 1),
+            cluster_id: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_table_route_is_not_found_error() {
+        let state = RegionMigrationStart;
+        let env = TestingEnv::new();
+        let ctx = env.context();
+
+        let err = state
+            .retrieve_regions_route(&ctx, RegionId::new(1024, 1))
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, Error::TableRouteNotFound { .. });
+
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn test_region_route_is_not_found_error() {
+        let state = RegionMigrationStart;
+        let persistent_context = new_persistent_context();
+        let env = TestingEnv::new();
+        let ctx = env.context();
+
+        let table_info = new_test_table_info(1024, vec![1]).into();
+        let region_route = RegionRoute {
+            region: Region::new_test(RegionId::new(1024, 1)),
+            leader_peer: Some(persistent_context.from_peer.clone()),
+            ..Default::default()
+        };
+
+        env.table_metadata_manager()
+            .create_table_metadata(table_info, vec![region_route])
+            .await
+            .unwrap();
+
+        let err = state
+            .retrieve_regions_route(&ctx, RegionId::new(1024, 3))
+            .await
+            .unwrap_err();
+
+        assert_matches!(err, Error::Unexpected { .. });
+        assert!(!err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn test_next_downgrade_leader_region_state() {
+        let mut state = Box::new(RegionMigrationStart);
+        // from_peer: 1
+        // to_peer: 2
+        let mut persistent_context = new_persistent_context();
+        let mut volatile_context = VolatileContext::default();
+        let env = TestingEnv::new();
+        let ctx = env.context();
+
+        let table_info = new_test_table_info(1024, vec![1]).into();
+        let region_routes = vec![RegionRoute {
+            region: Region::new_test(persistent_context.region_id),
+            leader_peer: Some(Peer::empty(3)),
+            follower_peers: vec![persistent_context.to_peer.clone()],
+            ..Default::default()
+        }];
+
+        env.table_metadata_manager()
+            .create_table_metadata(table_info, region_routes)
+            .await
+            .unwrap();
+
+        let next = state
+            .next(&ctx, &mut persistent_context, &mut volatile_context)
+            .await
+            .unwrap();
+
+        let _ = next
+            .as_any()
+            .downcast_ref::<DowngradeLeaderRegion>()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_next_migration_end_state() {
+        let mut state = Box::new(RegionMigrationStart);
+        // from_peer: 1
+        // to_peer: 2
+        let mut persistent_context = new_persistent_context();
+        let mut volatile_context = VolatileContext::default();
+        let env = TestingEnv::new();
+        let ctx = env.context();
+
+        let table_info = new_test_table_info(1024, vec![1]).into();
+        let region_routes = vec![RegionRoute {
+            region: Region::new_test(persistent_context.region_id),
+            leader_peer: Some(persistent_context.to_peer.clone()),
+            follower_peers: vec![persistent_context.from_peer.clone()],
+            ..Default::default()
+        }];
+
+        env.table_metadata_manager()
+            .create_table_metadata(table_info, region_routes)
+            .await
+            .unwrap();
+
+        let next = state
+            .next(&ctx, &mut persistent_context, &mut volatile_context)
+            .await
+            .unwrap();
+
+        let _ = next.as_any().downcast_ref::<RegionMigrationEnd>().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_next_open_candidate_region_state() {
+        let mut state = Box::new(RegionMigrationStart);
+        // from_peer: 1
+        // to_peer: 2
+        let mut persistent_context = new_persistent_context();
+        let mut volatile_context = VolatileContext::default();
+        let env = TestingEnv::new();
+        let ctx = env.context();
+
+        let table_info = new_test_table_info(1024, vec![1]).into();
+        let region_routes = vec![RegionRoute {
+            region: Region::new_test(persistent_context.region_id),
+            leader_peer: Some(Peer::empty(3)),
+            ..Default::default()
+        }];
+
+        env.table_metadata_manager()
+            .create_table_metadata(table_info, region_routes)
+            .await
+            .unwrap();
+
+        let next = state
+            .next(&ctx, &mut persistent_context, &mut volatile_context)
+            .await
+            .unwrap();
+
+        let _ = next.as_any().downcast_ref::<OpenCandidateRegion>().unwrap();
     }
 }

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -25,7 +25,7 @@ pub struct OpenCandidateRegion;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for OpenCandidateRegion {
-    async fn next(&mut self, _ctx: &Context) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _ctx: &mut Context) -> Result<Box<dyn State>> {
         todo!()
     }
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -17,7 +17,7 @@ use std::any::Any;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
-use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
+use crate::procedure::region_migration::{Context, State};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OpenCandidateRegion;
@@ -25,12 +25,7 @@ pub struct OpenCandidateRegion;
 #[async_trait::async_trait]
 #[typetag::serde]
 impl State for OpenCandidateRegion {
-    async fn next(
-        &mut self,
-        _ctx: &Context,
-        _pc: &mut PersistentContext,
-        _vc: &mut VolatileContext,
-    ) -> Result<Box<dyn State>> {
+    async fn next(&mut self, _ctx: &Context) -> Result<Box<dyn State>> {
         todo!()
     }
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -14,29 +14,24 @@
 
 use std::any::Any;
 
-use common_procedure::Status;
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::procedure::region_migration::{Context, PersistentContext, State, VolatileContext};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct RegionMigrationEnd;
+pub struct OpenCandidateRegion;
 
 #[async_trait::async_trait]
 #[typetag::serde]
-impl State for RegionMigrationEnd {
+impl State for OpenCandidateRegion {
     async fn next(
         &mut self,
-        _: &Context,
-        _: &mut PersistentContext,
-        _: &mut VolatileContext,
+        _ctx: &Context,
+        _pc: &mut PersistentContext,
+        _vc: &mut VolatileContext,
     ) -> Result<Box<dyn State>> {
-        Ok(Box::new(RegionMigrationEnd))
-    }
-
-    fn status(&self) -> Status {
-        Status::Done
+        todo!()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -19,7 +19,7 @@ use common_meta::kv_backend::memory::MemoryKvBackend;
 use common_procedure::{Context as ProcedureContext, ProcedureId};
 use common_procedure_test::MockContextProvider;
 
-use crate::procedure::region_migration::Context;
+use super::ContextFactoryImpl;
 
 /// `TestingEnv` provides components during the tests.
 pub struct TestingEnv {
@@ -38,9 +38,10 @@ impl TestingEnv {
     }
 
     /// Returns a context of region migration procedure.
-    pub fn context(&self) -> Context {
-        Context {
+    pub fn context_factory(&self) -> ContextFactoryImpl {
+        ContextFactoryImpl {
             table_metadata_manager: self.table_metadata_manager.clone(),
+            volatile_ctx: Default::default(),
         }
     }
 

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_meta::key::{TableMetadataManager, TableMetadataManagerRef};
+use common_meta::kv_backend::memory::MemoryKvBackend;
+use common_procedure::{Context as ProcedureContext, ProcedureId};
+use common_procedure_test::MockContextProvider;
+
+use crate::procedure::region_migration::Context;
+
+/// `TestingEnv` provides components during the tests.
+pub struct TestingEnv {
+    table_metadata_manager: TableMetadataManagerRef,
+}
+
+impl TestingEnv {
+    /// Returns an empty [TestingEnv].
+    pub fn new() -> Self {
+        let kv_backend = Arc::new(MemoryKvBackend::new());
+        let table_metadata_manager = Arc::new(TableMetadataManager::new(kv_backend.clone()));
+
+        Self {
+            table_metadata_manager,
+        }
+    }
+
+    /// Returns a context of region migration procedure.
+    pub fn context(&self) -> Context {
+        Context {
+            table_metadata_manager: self.table_metadata_manager.clone(),
+        }
+    }
+
+    pub fn table_metadata_manager(&self) -> &TableMetadataManagerRef {
+        &self.table_metadata_manager
+    }
+
+    /// Returns a [ProcedureContext] with a random [ProcedureId] and a [MockContextProvider].
+    pub fn procedure_context() -> ProcedureContext {
+        ProcedureContext {
+            procedure_id: ProcedureId::random(),
+            provider: Arc::new(MockContextProvider::default()),
+        }
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add migration start step
- If the expected leader region has been opened on `to_peer`, go to the `MigrationEnd` state.
- If the candidate region has been opened on `to_peer`, go to the `DowngradeLeader` state.
- Else go to the `OpenCandidateRegion` state.

**Behaviors:**

 Abort(non-retry):
 - TableRoute is not found.
 - RegionRoute is not found.
 - Leader peer of RegionRoute is not found.

 Retry:
 - Failed to retrieve the metadata of table.
## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2700