### PR TITLE
feat: add open candidate region step

### DIFF
--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -36,7 +36,7 @@ pub enum Error {
         region_id,
         peer_id
     ))]
-    RegionOpening {
+    RegionOpeningRace {
         location: Location,
         peer_id: DatanodeId,
         region_id: RegionId,
@@ -639,7 +639,7 @@ impl ErrorExt for Error {
             | Error::Unexpected { .. }
             | Error::Txn { .. }
             | Error::TableIdChanged { .. }
-            | Error::RegionOpening { .. } => StatusCode::Unexpected,
+            | Error::RegionOpeningRace { .. } => StatusCode::Unexpected,
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidateTableCache { source, .. } => source.status_code(),
             Error::RequestDatanode { source, .. } => source.status_code(),

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -16,9 +16,11 @@ use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_meta::peer::Peer;
+use common_meta::DatanodeId;
 use common_runtime::JoinError;
 use servers::define_into_tonic_status;
 use snafu::{Location, Snafu};
+use store_api::storage::RegionId;
 use table::metadata::TableId;
 use tokio::sync::mpsc::error::SendError;
 use tonic::codegen::http;
@@ -29,6 +31,17 @@ use crate::pubsub::Message;
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
+    #[snafu(display(
+        "Another procedure is opening the region: {} on peer: {}",
+        region_id,
+        peer_id
+    ))]
+    RegionOpening {
+        location: Location,
+        peer_id: DatanodeId,
+        region_id: RegionId,
+    },
+
     #[snafu(display("Failed to create default catalog and schema"))]
     InitMetadata {
         location: Location,
@@ -625,7 +638,8 @@ impl ErrorExt for Error {
             | Error::UnexpectedInstructionReply { .. }
             | Error::Unexpected { .. }
             | Error::Txn { .. }
-            | Error::TableIdChanged { .. } => StatusCode::Unexpected,
+            | Error::TableIdChanged { .. }
+            | Error::RegionOpening { .. } => StatusCode::Unexpected,
             Error::TableNotFound { .. } => StatusCode::TableNotFound,
             Error::InvalidateTableCache { source, .. } => source.status_code(),
             Error::RequestDatanode { source, .. } => source.status_code(),

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -36,6 +36,7 @@ use store_api::storage::RegionId;
 use self::migration_start::RegionMigrationStart;
 use crate::error::{Error, Result};
 use crate::procedure::utils::region_lock_key;
+use crate::service::mailbox::MailboxRef;
 
 /// It's shared in each step and available even after recovering.
 ///
@@ -77,6 +78,8 @@ pub trait ContextFactory {
 pub struct ContextFactoryImpl {
     volatile_ctx: VolatileContext,
     table_metadata_manager: TableMetadataManagerRef,
+    mailbox: MailboxRef,
+    server_addr: String,
 }
 
 impl ContextFactory for ContextFactoryImpl {
@@ -85,6 +88,8 @@ impl ContextFactory for ContextFactoryImpl {
             persistent_ctx,
             volatile_ctx: self.volatile_ctx,
             table_metadata_manager: self.table_metadata_manager,
+            mailbox: self.mailbox,
+            server_addr: self.server_addr,
         }
     }
 }
@@ -96,12 +101,14 @@ pub struct Context {
     persistent_ctx: PersistentContext,
     volatile_ctx: VolatileContext,
     table_metadata_manager: TableMetadataManagerRef,
+    mailbox: MailboxRef,
+    server_addr: String,
 }
 
 impl Context {
     /// Returns address of meta server.
     pub fn server_addr(&self) -> &str {
-        todo!()
+        &self.server_addr
     }
 }
 

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -36,6 +36,7 @@ use store_api::storage::RegionId;
 use self::migration_start::RegionMigrationStart;
 use crate::error::{Error, Result};
 use crate::procedure::utils::region_lock_key;
+use crate::region::lease_keeper::{OpeningRegionGuard, OpeningRegionKeeperRef};
 use crate::service::mailbox::MailboxRef;
 
 /// It's shared in each step and available even after recovering.
@@ -67,7 +68,15 @@ impl PersistentContext {
 ///
 /// The additional remote fetches are only required in the worst cases.
 #[derive(Debug, Clone, Default)]
-pub struct VolatileContext {}
+pub struct VolatileContext {
+    /// `opening_region_guard` will be set after the
+    /// [OpenCandidateRegion](crate::procedure::region_migration::open_candidate_region::OpenCandidateRegion) step.
+    ///
+    /// `opening_region_guard` should be consumed after
+    /// the corresponding [RegionRoute](common_meta::rpc::router::RegionRoute) of the opening region
+    /// was written into [TableRouteValue](common_meta::key::table_route::TableRouteValue) .
+    opening_region_guard: Option<OpeningRegionGuard>,
+}
 
 /// Used to generate new [Context].
 pub trait ContextFactory {
@@ -78,6 +87,7 @@ pub trait ContextFactory {
 pub struct ContextFactoryImpl {
     volatile_ctx: VolatileContext,
     table_metadata_manager: TableMetadataManagerRef,
+    opening_region_keeper: OpeningRegionKeeperRef,
     mailbox: MailboxRef,
     server_addr: String,
 }
@@ -88,6 +98,7 @@ impl ContextFactory for ContextFactoryImpl {
             persistent_ctx,
             volatile_ctx: self.volatile_ctx,
             table_metadata_manager: self.table_metadata_manager,
+            opening_region_keeper: self.opening_region_keeper,
             mailbox: self.mailbox,
             server_addr: self.server_addr,
         }
@@ -101,6 +112,7 @@ pub struct Context {
     persistent_ctx: PersistentContext,
     volatile_ctx: VolatileContext,
     table_metadata_manager: TableMetadataManagerRef,
+    opening_region_keeper: OpeningRegionKeeperRef,
     mailbox: MailboxRef,
     server_addr: String,
 }

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -121,7 +121,7 @@ impl OpenCandidateRegion {
         let guard = ctx
             .opening_region_keeper
             .register(candidate.id, region_id)
-            .context(error::RegionOpeningSnafu {
+            .context(error::RegionOpeningRaceSnafu {
                 peer_id: candidate.id,
                 region_id,
             })?;
@@ -310,7 +310,7 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert_matches!(err, Error::RegionOpening { .. });
+        assert_matches!(err, Error::RegionOpeningRace { .. });
         assert!(!err.is_retryable());
     }
 

--- a/src/meta-srv/src/region/lease_keeper.rs
+++ b/src/meta-srv/src/region/lease_keeper.rs
@@ -171,6 +171,13 @@ impl Drop for OpeningRegionGuard {
     }
 }
 
+impl OpeningRegionGuard {
+    /// Returns opening region info.
+    pub fn info(&self) -> (DatanodeId, RegionId) {
+        (self.datanode_id, self.region_id)
+    }
+}
+
 pub type OpeningRegionKeeperRef = Arc<OpeningRegionKeeper>;
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This step opens the candidate region on `to_peer`.

**Behaviors:**

Abort(non-retry):
- Table Info is not found.
- The Datanode is unreachable(e.g., Candidate pusher is not found).
- Unexpected instruction reply.
- Another procedure is opening the candidate region.

Retry:
- Exceeded deadline of open instruction.
- Datanode failed to open the candidate region.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2700 
Waits for #2756