### PR TITLE
fix: iterator bad implement

### DIFF
--- a/src/datatypes/src/vectors/decimal.rs
+++ b/src/datatypes/src/vectors/decimal.rs
@@ -517,6 +517,7 @@ pub mod tests {
         assert!(array.is_null(4));
     }
 }
+
 #[test]
 fn test_decimal28_vector_iter_data() {
     let vector = Decimal128Vector::from_values(vec![1, 2, 3, 4])


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

my bad implement about iterator trait leads that the `iter_data()` function runs forever.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
