### PR TITLE
fix: compiler errors under non-default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4626,6 +4626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a5a03cefb0d953ec0be133036f14e109412fa594edc2f77227249db66cc3ed"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,9 +6177,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -6181,9 +6190,9 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "parking_lot 0.12.1",
- "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-derive 0.11.9",
+ "prost 0.12.1",
+ "prost-build 0.12.1",
+ "prost-derive 0.12.1",
  "protobuf",
  "sha2",
  "smallvec",
@@ -7642,7 +7651,7 @@ dependencies = [
  "mac_address",
  "md-5",
  "memchr",
- "memmap2",
+ "memmap2 0.5.10",
  "mt19937",
  "nix 0.26.4",
  "num-bigint",
@@ -9062,21 +9071,21 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "symbolic-common"
-version = "10.2.1"
+version = "12.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+checksum = "405af7bd5edd866cef462e22ef73f11cf9bf506c9d62824fef8364eb69d4d4ad"
 dependencies = [
  "debugid",
- "memmap2",
+ "memmap2 0.8.0",
  "stable_deref_trait",
  "uuid",
 ]
 
 [[package]]
 name = "symbolic-demangle"
-version = "10.2.1"
+version = "12.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+checksum = "2bcd041ccfb77d9c70639efcd5b804b508ac7a273e9224d227379e225625daf9"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",

--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,11 @@ sqlness-test: ## Run sqlness test.
 
 .PHONY: check
 check: ## Cargo check all the targets.
-	cargo check --workspace --all-targets
+	cargo check --workspace --all-targets --all-features
 
 .PHONY: clippy
 clippy: ## Check clippy rules.
-	cargo clippy --workspace --all-targets -F pyo3_backend -- -D warnings
+	cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 .PHONY: fmt-check
 fmt-check: ## Check code format.

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -189,7 +189,6 @@ pub fn init_global_logging(
 
         Registry::default()
             .with(tokio_console_layer)
-            .with(JsonStorageLayer)
             .with(stdout_logging_layer)
             .with(file_logging_layer)
             .with(err_file_logging_layer.with_filter(filter::LevelFilter::ERROR))

--- a/src/file-engine/Cargo.toml
+++ b/src/file-engine/Cargo.toml
@@ -9,6 +9,7 @@ default = []
 test = ["common-test-util"]
 
 [dependencies]
+api = { workspace = true, optional = true }
 async-trait = "0.1"
 common-catalog.workspace = true
 common-datasource.workspace = true

--- a/src/file-engine/src/lib.rs
+++ b/src/file-engine/src/lib.rs
@@ -23,7 +23,7 @@ pub(crate) mod query;
 pub(crate) mod region;
 
 #[cfg(any(test, feature = "test"))]
-pub(crate) mod test_util;
+pub mod test_util;
 
 use datatypes::schema::ColumnSchema;
 use serde::{Deserialize, Serialize};

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -60,7 +60,7 @@ parking_lot = "0.12"
 pgwire = "0.16"
 pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }
-pprof = { version = "0.11", features = [
+pprof = { version = "0.13", features = [
     "flamegraph",
     "prost-codec",
     "protobuf",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes compiler errors under non-default features.

It also enables `--all-features` in CI checks.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
