### PR TITLE
fix: correct memtable cost

### DIFF
--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -410,7 +410,6 @@ impl Iterator for Iter {
             self.metrics.total_series += 1;
 
             let mut series = series.write().unwrap();
-            let start = Instant::now();
             if !self.predicate.is_empty()
                 && !prune_primary_key(
                     &self.codec,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Correct memtable scan cost metrics.

The local variable inside the for loop shadows the start instant outside. I forgot to remove it in the PR introducing iter metrics.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
