### PR TITLE
fix: mysql writer does not print error message in some cases

### DIFF
--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -85,7 +85,7 @@ impl GreptimeRequestHandler {
                     logging::error!(e; "Failed to handle request");
                 } else {
                     // Currently, we still print a debug log.
-                    logging::debug!("Failed to handle request, err: {}", e);
+                    logging::debug!("Failed to handle request, err: {:?}", e);
                 }
                 e
             })

--- a/src/servers/src/grpc/region_server.rs
+++ b/src/servers/src/grpc/region_server.rs
@@ -70,7 +70,7 @@ impl RegionServerRequestHandler {
                     error!(e; "Failed to handle request");
                 } else {
                     // Currently, we still print a debug log.
-                    debug!("Failed to handle request, err: {}", e);
+                    debug!("Failed to handle request, err: {:?}", e);
                 }
                 e
             })

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -298,10 +298,7 @@ impl JsonResponse {
                         },
 
                         Err(e) => {
-                            return Self::with_error(
-                                format!("Recordbatch error: {e}"),
-                                e.status_code(),
-                            );
+                            return Self::with_error(e.output_msg(), e.status_code());
                         }
                     }
                 }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -355,7 +355,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                 return w
                     .error(
                         ErrorKind::ER_DBACCESS_DENIED_ERROR,
-                        e.to_string().as_bytes(),
+                        e.output_msg().as_bytes(),
                     )
                     .await
                     .map_err(|e| e.into());
@@ -421,7 +421,7 @@ async fn validate_query(query: &str) -> Result<Statement> {
     let statement = ParserContext::create_with_dialect(query, &MySqlDialect {});
     let mut statement = statement.map_err(|e| {
         InvalidPrepareStatementSnafu {
-            err_msg: e.to_string(),
+            err_msg: e.output_msg(),
         }
         .build()
     })?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR fixes the issue that our MySQL handler may not print the error message to users.

It outputs OK but the query actually fails if the error is an internal error.
```
Query OK (0.02 sec)
```

Now users can see the internal error message.
```
ERROR 1815 (HY000): Internal error: 1003
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
