### PR TITLE
chore: bump greptimedb version v0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "common-base",
  "common-error",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "chrono",
@@ -1167,7 +1167,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arc-swap",
@@ -1455,7 +1455,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1488,7 +1488,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1566,7 +1566,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1599,7 +1599,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chrono",
  "common-error",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "bigdecimal 0.4.2",
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arc-swap",
  "chrono-tz 0.6.3",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-recursion",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "once_cell",
  "rand",
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "chrono",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "build-data",
 ]
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2701,7 +2701,7 @@ dependencies = [
  "sql",
  "storage",
  "store-api",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "tokio",
  "tokio-stream",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arc-swap",
@@ -3334,7 +3334,7 @@ dependencies = [
  "storage",
  "store-api",
  "strfmt",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "tokio",
  "toml 0.7.8",
@@ -4393,7 +4393,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4663,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anymap",
  "api",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anymap",
  "api",
@@ -5294,7 +5294,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5508,7 +5508,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-compat",
@@ -5554,7 +5554,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "storage",
  "store-api",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -5783,7 +5783,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -6112,7 +6112,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "auth",
  "common-base",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "derive_builder 0.12.0",
  "futures",
@@ -6663,7 +6663,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -6721,7 +6721,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "tokio",
  "tokio-stream",
@@ -7940,7 +7940,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arc-swap",
@@ -8211,7 +8211,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aide",
  "api",
@@ -8304,7 +8304,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arc-swap",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "common-base",
@@ -8617,7 +8617,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-trait",
  "clap 4.4.7",
@@ -8823,7 +8823,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "arc-swap",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "aquamarine",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9164,7 +9164,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9270,7 +9270,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "api",
  "async-trait",
@@ -9325,7 +9325,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.4.2",
+ "substrait 0.4.3",
  "table",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Bump greptimedb version v0.4.3


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
