### PR TITLE
feat: improve http error message

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -382,6 +382,13 @@ pub enum Error {
         actual: i32,
         location: Location,
     },
+
+    #[snafu(display("Failed to convert to json"))]
+    ToJson {
+        #[snafu(source)]
+        error: serde_json::error::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -475,6 +482,8 @@ impl ErrorExt for Error {
             Metrics { source } => source.status_code(),
 
             ConvertScalarValue { source, .. } => source.status_code(),
+
+            ToJson { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -61,10 +61,10 @@ use tower::ServiceBuilder;
 use tower_http::auth::AsyncRequireAuthorizationLayer;
 use tower_http::trace::TraceLayer;
 
-use self::authorize::HttpAuth;
-use self::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb_write_v2};
 use crate::configurator::ConfiguratorRef;
-use crate::error::{AlreadyStartedSnafu, Result, StartHttpSnafu};
+use crate::error::{AlreadyStartedSnafu, Error, Result, StartHttpSnafu, ToJsonSnafu};
+use crate::http::authorize::HttpAuth;
+use crate::http::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb_write_v2};
 use crate::http::prometheus::{
     format_query, instant_query, label_values_query, labels_query, range_query, series_query,
 };
@@ -185,7 +185,7 @@ impl HttpRecordsOutput {
 }
 
 impl TryFrom<Vec<RecordBatch>> for HttpRecordsOutput {
-    type Error = String;
+    type Error = Error;
 
     // TODO(sunng87): use schema from recordstreams when #366 fixed
     fn try_from(
@@ -218,8 +218,9 @@ impl TryFrom<Vec<RecordBatch>> for HttpRecordsOutput {
                 for row in recordbatch.rows() {
                     let value_row = row
                         .into_iter()
-                        .map(|f| Value::try_from(f).map_err(|err| err.to_string()))
-                        .collect::<std::result::Result<Vec<Value>, _>>()?;
+                        .map(|f| Value::try_from(f))
+                        .collect::<std::result::Result<Vec<Value>, _>>()
+                        .context(ToJsonSnafu)?;
 
                     rows.push(value_row);
                 }
@@ -252,9 +253,20 @@ pub struct JsonResponse {
 }
 
 impl JsonResponse {
-    pub fn with_error(error: String, error_code: StatusCode) -> Self {
+    pub fn with_error(error: impl ErrorExt) -> Self {
+        // todo(yingwen): log error.
+
         JsonResponse {
-            error: Some(error),
+            error: Some(error.output_msg()),
+            code: error.status_code() as u32,
+            output: None,
+            execution_time_ms: None,
+        }
+    }
+
+    fn with_error_message(err_msg: String, error_code: StatusCode) -> Self {
+        JsonResponse {
+            error: Some(err_msg),
             code: error_code as u32,
             output: None,
             execution_time_ms: None,
@@ -293,12 +305,12 @@ impl JsonResponse {
                                 results.push(JsonOutput::Records(rows));
                             }
                             Err(err) => {
-                                return Self::with_error(err, StatusCode::Internal);
+                                return Self::with_error(err);
                             }
                         },
 
                         Err(e) => {
-                            return Self::with_error(e.output_msg(), e.status_code());
+                            return Self::with_error(e);
                         }
                     }
                 }
@@ -307,11 +319,11 @@ impl JsonResponse {
                         results.push(JsonOutput::Records(rows));
                     }
                     Err(err) => {
-                        return Self::with_error(err, StatusCode::Internal);
+                        return Self::with_error(err);
                     }
                 },
                 Err(e) => {
-                    return Self::with_error(e.output_msg(), e.status_code());
+                    return Self::with_error(e);
                 }
             }
         }
@@ -756,7 +768,7 @@ impl Server for HttpServer {
 async fn handle_error(err: BoxError) -> Json<JsonResponse> {
     logging::error!("Unhandled internal error: {}", err);
 
-    Json(JsonResponse::with_error(
+    Json(JsonResponse::with_error_message(
         format!("Unhandled internal error: {err}"),
         StatusCode::Unexpected,
     ))

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -219,7 +219,7 @@ impl TryFrom<Vec<RecordBatch>> for HttpRecordsOutput {
                 for row in recordbatch.rows() {
                     let value_row = row
                         .into_iter()
-                        .map(|f| Value::try_from(f))
+                        .map(Value::try_from)
                         .collect::<std::result::Result<Vec<Value>, _>>()
                         .context(ToJsonSnafu)?;
 

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -182,7 +182,7 @@ async fn insert_script(
     )
     .await;
     assert!(!json.success(), "{json:?}");
-    assert_eq!(json.error().unwrap(), "Invalid argument: invalid schema");
+    assert_eq!(json.error().unwrap(), "invalid schema");
 
     let body = RawBody(Body::from(script.clone()));
     let exec = create_script_query();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Use `output_msg` instead of `Display` to show error messages in HTTP API.

Also, logs the error if `should_log_error` returns true.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
