### PR TITLE
fix: fix exits typos

### DIFF
--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -101,7 +101,7 @@ impl CreateTable {
     }
 
     #[inline]
-    fn format_if_not_exits(&self) -> &str {
+    fn format_if_not_exists(&self) -> &str {
         if self.if_not_exists {
             "IF NOT EXISTS"
         } else {
@@ -174,7 +174,7 @@ impl Display for Partitions {
 
 impl Display for CreateTable {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let if_not_exists = self.format_if_not_exits();
+        let if_not_exists = self.format_if_not_exists();
         let name = &self.name;
         let columns = format_list_indent!(self.columns);
         let constraints = self.format_constraints();

--- a/tests/cases/standalone/common/truncate/truncate.result
+++ b/tests/cases/standalone/common/truncate/truncate.result
@@ -1,6 +1,6 @@
-TRUNCATE TABLE not_exits_table;
+TRUNCATE TABLE not_exists_table;
 
-Error: 4001(TableNotFound), Table not found: greptime.public.not_exits_table
+Error: 4001(TableNotFound), Table not found: greptime.public.not_exists_table
 
 CREATE TABLE monitor (host STRING, ts TIMESTAMP, cpu DOUBLE DEFAULT 0, memory DOUBLE, TIME INDEX (ts), PRIMARY KEY(host));
 

--- a/tests/cases/standalone/common/truncate/truncate.sql
+++ b/tests/cases/standalone/common/truncate/truncate.sql
@@ -1,4 +1,4 @@
-TRUNCATE TABLE not_exits_table;
+TRUNCATE TABLE not_exists_table;
 
 CREATE TABLE monitor (host STRING, ts TIMESTAMP, cpu DOUBLE DEFAULT 0, memory DOUBLE, TIME INDEX (ts), PRIMARY KEY(host));
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Rename exits to exists

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
