### PR TITLE
build(cmd): upgrade clap to 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ version = "0.4.3"
 dependencies = [
  "arrow",
  "chrono",
- "clap 4.4.7",
+ "clap 4.4.8",
  "client",
  "futures-util",
  "indicatif",
@@ -1380,50 +1380,32 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
  "textwrap 0.16.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex 0.6.0",
  "strsim 0.10.0",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1525,7 +1507,7 @@ dependencies = [
  "auth",
  "catalog",
  "chrono",
- "clap 3.2.25",
+ "clap 4.4.8",
  "client",
  "common-base",
  "common-catalog",
@@ -8645,7 +8627,7 @@ name = "sqlness-runner"
 version = "0.4.3"
 dependencies = [
  "async-trait",
- "clap 4.4.7",
+ "clap 4.4.8",
  "client",
  "common-base",
  "common-error",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -18,7 +18,7 @@ async-trait.workspace = true
 auth.workspace = true
 catalog.workspace = true
 chrono.workspace = true
-clap = { version = "4.4.8", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 client.workspace = true
 common-base.workspace = true
 common-catalog.workspace = true

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -18,7 +18,7 @@ async-trait.workspace = true
 auth.workspace = true
 catalog.workspace = true
 chrono.workspace = true
-clap = { version = "3.1", features = ["derive"] }
+clap = { version = "4.4.8", features = ["derive"] }
 client.workspace = true
 common-base.workspace = true
 common-catalog.workspace = true

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -89,7 +89,7 @@ struct StartCommand {
     rpc_addr: Option<String>,
     #[clap(long)]
     rpc_hostname: Option<String>,
-    #[clap(long, multiple = true, value_delimiter = ',')]
+    #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addr: Option<Vec<String>>,
     #[clap(short, long)]
     config_file: Option<String>,

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -100,7 +100,7 @@ pub struct StartCommand {
     config_file: Option<String>,
     #[clap(short, long)]
     influxdb_enable: Option<bool>,
-    #[clap(long, multiple = true, value_delimiter = ',')]
+    #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addr: Option<Vec<String>>,
     #[clap(long)]
     tls_mode: Option<TlsMode>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Since the currently used clap version is 3.x, which is already outdated for a long time, it will be updated to the latest 4.4.8.

Because the `multiple` is deprecated,  I use `num_args = 1..` to replace.
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
[#2742](https://github.com/GreptimeTeam/greptimedb/issues/2742) 