### PR TITLE
revert: bring back InactiveRegionManager

### DIFF
--- a/src/meta-srv/src/inactive_region_manager.rs
+++ b/src/meta-srv/src/inactive_region_manager.rs
@@ -1,0 +1,156 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashSet;
+
+use common_meta::kv_backend::ResettableKvBackendRef;
+use common_meta::rpc::store::{BatchGetRequest, DeleteRangeRequest, PutRequest, RangeRequest};
+use common_meta::RegionIdent;
+use snafu::ResultExt;
+
+use crate::error::{self, Result};
+use crate::keys::InactiveRegionKey;
+use crate::metrics::METRIC_META_INACTIVE_REGIONS;
+
+pub struct InactiveRegionManager<'a> {
+    store: &'a ResettableKvBackendRef,
+}
+
+impl<'a> InactiveRegionManager<'a> {
+    pub fn new(store: &'a ResettableKvBackendRef) -> Self {
+        Self { store }
+    }
+
+    pub async fn register_inactive_region(&self, region_ident: &RegionIdent) -> Result<()> {
+        let region_id = region_ident.get_region_id().as_u64();
+        let key = InactiveRegionKey {
+            cluster_id: region_ident.cluster_id,
+            node_id: region_ident.datanode_id,
+            region_id,
+        };
+        let req = PutRequest {
+            key: key.into(),
+            value: vec![],
+            prev_kv: false,
+        };
+        self.store.put(req).await.context(error::KvBackendSnafu)?;
+
+        METRIC_META_INACTIVE_REGIONS.inc();
+
+        Ok(())
+    }
+
+    pub async fn deregister_inactive_region(&self, region_ident: &RegionIdent) -> Result<()> {
+        let region_id = region_ident.get_region_id().as_u64();
+        let key: Vec<u8> = InactiveRegionKey {
+            cluster_id: region_ident.cluster_id,
+            node_id: region_ident.datanode_id,
+            region_id,
+        }
+        .into();
+        self.store
+            .delete(&key, false)
+            .await
+            .context(error::KvBackendSnafu)?;
+
+        METRIC_META_INACTIVE_REGIONS.dec();
+
+        Ok(())
+    }
+
+    /// The input is a list of regions on a specific node. If one or more regions have been
+    /// set to inactive state by metasrv, the corresponding regions will be removed(update the
+    /// `region_ids`), then returns the removed regions.
+    pub async fn retain_active_regions(
+        &self,
+        cluster_id: u64,
+        node_id: u64,
+        region_ids: &mut Vec<u64>,
+    ) -> Result<HashSet<u64>> {
+        let key_region_ids = region_ids
+            .iter()
+            .map(|region_id| {
+                (
+                    InactiveRegionKey {
+                        cluster_id,
+                        node_id,
+                        region_id: *region_id,
+                    }
+                    .into(),
+                    *region_id,
+                )
+            })
+            .collect::<Vec<(Vec<u8>, _)>>();
+        let keys = key_region_ids.iter().map(|(key, _)| key.clone()).collect();
+        let resp = self
+            .store
+            .batch_get(BatchGetRequest { keys })
+            .await
+            .context(error::KvBackendSnafu)?;
+        let kvs = resp.kvs;
+        if kvs.is_empty() {
+            return Ok(HashSet::new());
+        }
+
+        let inactive_keys = kvs.into_iter().map(|kv| kv.key).collect::<HashSet<_>>();
+        let (active_region_ids, inactive_region_ids): (Vec<Option<u64>>, Vec<Option<u64>>) =
+            key_region_ids
+                .into_iter()
+                .map(|(key, region_id)| {
+                    let is_active = !inactive_keys.contains(&key);
+                    if is_active {
+                        (Some(region_id), None)
+                    } else {
+                        (None, Some(region_id))
+                    }
+                })
+                .unzip();
+        *region_ids = active_region_ids.into_iter().flatten().collect();
+
+        Ok(inactive_region_ids.into_iter().flatten().collect())
+    }
+
+    /// Scan all inactive regions in the cluster.
+    ///
+    /// When will these data appear?
+    /// Generally, it is because the corresponding Datanode is disconnected and
+    /// did not respond to the `Failover` scheduling instructions of metasrv.
+    pub async fn scan_all_inactive_regions(
+        &self,
+        cluster_id: u64,
+    ) -> Result<Vec<InactiveRegionKey>> {
+        let prefix = InactiveRegionKey::get_prefix_by_cluster(cluster_id);
+        let request = RangeRequest::new().with_prefix(prefix);
+        let resp = self
+            .store
+            .range(request)
+            .await
+            .context(error::KvBackendSnafu)?;
+        let kvs = resp.kvs;
+        kvs.into_iter()
+            .map(|kv| InactiveRegionKey::try_from(kv.key))
+            .collect::<Result<Vec<_>>>()
+    }
+
+    pub async fn clear_all_inactive_regions(&self, cluster_id: u64) -> Result<()> {
+        let prefix = InactiveRegionKey::get_prefix_by_cluster(cluster_id);
+        let request = DeleteRangeRequest::new().with_prefix(prefix);
+        let _ = self
+            .store
+            .delete_range(request)
+            .await
+            .context(error::KvBackendSnafu)?;
+        Ok(())
+    }
+}

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -40,6 +40,8 @@ pub mod table_meta_alloc;
 
 pub use crate::error::Result;
 
+mod inactive_region_manager;
+
 mod greptimedb_telemetry;
 
 #[cfg(test)]

--- a/src/meta-srv/src/procedure/region_failover/activate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/activate_region.rs
@@ -31,6 +31,7 @@ use crate::error::{
     self, Error, Result, RetryLaterSnafu, SerializeToJsonSnafu, UnexpectedInstructionReplySnafu,
 };
 use crate::handler::HeartbeatMailbox;
+use crate::inactive_region_manager::InactiveRegionManager;
 use crate::procedure::region_failover::OPEN_REGION_MESSAGE_TIMEOUT;
 use crate::service::mailbox::{Channel, MailboxReceiver};
 
@@ -103,6 +104,17 @@ impl ActivateRegion {
             input: instruction.to_string(),
         })?;
 
+        // Ensure that metasrv will renew the lease for this candidate node.
+        //
+        // This operation may not be redundant, imagine the following scenario:
+        // This candidate once had the current region, and because it did not respond to the `close`
+        // command in time, it was considered an inactive node by metasrv, then it replied, and the
+        // current region failed over again, and the node was selected as a candidate, so it needs
+        // to clear its previous state first.
+        InactiveRegionManager::new(&ctx.in_memory)
+            .deregister_inactive_region(&candidate_ident)
+            .await?;
+
         let ch = Channel::Datanode(self.candidate.id);
         ctx.mailbox.send(&ch, msg, timeout).await
     }
@@ -170,6 +182,13 @@ impl State for ActivateRegion {
         ctx: &RegionFailoverContext,
         failed_region: &RegionIdent,
     ) -> Result<Box<dyn State>> {
+        if self.remark_inactive_region {
+            // Remark the fail region as inactive to prevent it from renewing the lease.
+            InactiveRegionManager::new(&ctx.in_memory)
+                .register_inactive_region(failed_region)
+                .await?;
+        }
+
         let mailbox_receiver = self
             .send_open_region_message(ctx, failed_region, OPEN_REGION_MESSAGE_TIMEOUT)
             .await?;

--- a/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/deactivate_region.rs
@@ -30,6 +30,7 @@ use crate::error::{
     self, Error, Result, RetryLaterSnafu, SerializeToJsonSnafu, UnexpectedInstructionReplySnafu,
 };
 use crate::handler::HeartbeatMailbox;
+use crate::inactive_region_manager::InactiveRegionManager;
 use crate::service::mailbox::{Channel, MailboxReceiver};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -90,13 +91,22 @@ impl DeactivateRegion {
         })?;
 
         let ch = Channel::Datanode(failed_region.datanode_id);
+        // Mark the region as inactive
+        InactiveRegionManager::new(&ctx.in_memory)
+            .register_inactive_region(failed_region)
+            .await?;
+        // We first marked the region as inactive, which means that the failed region cannot
+        // be successfully renewed from now on, so after the lease time is exceeded, the region
+        // will be automatically closed.
+        // If the deadline is exceeded, we can proceed to the next step with confidence,
+        // as the expiration means that the region has been closed.
         let timeout = Duration::from_secs(ctx.region_lease_secs);
         ctx.mailbox.send(&ch, msg, timeout).await
     }
 
     async fn handle_response(
         &self,
-        _ctx: &RegionFailoverContext,
+        ctx: &RegionFailoverContext,
         mailbox_receiver: MailboxReceiver,
         failed_region: &RegionIdent,
     ) -> Result<Box<dyn State>> {
@@ -113,6 +123,10 @@ impl DeactivateRegion {
                     .fail();
                 };
                 if result {
+                    InactiveRegionManager::new(&ctx.in_memory)
+                        .deregister_inactive_region(failed_region)
+                        .await?;
+
                     Ok(Box::new(ActivateRegion::new(self.candidate.clone())))
                 } else {
                     // Under rare circumstances would a Datanode fail to close a Region.

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -14,6 +14,7 @@
 
 mod health;
 mod heartbeat;
+mod inactive_regions;
 mod leader;
 mod meta;
 mod node_lease;
@@ -89,6 +90,20 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
     let router = router
         .route("/route", handler.clone())
         .route("/route/help", handler);
+
+    let router = router.route(
+        "/inactive-regions/view",
+        inactive_regions::ViewInactiveRegionsHandler {
+            store: meta_srv.in_memory().clone(),
+        },
+    );
+
+    let router = router.route(
+        "/inactive-regions/clear",
+        inactive_regions::ClearInactiveRegionsHandler {
+            store: meta_srv.in_memory().clone(),
+        },
+    );
 
     let router = Router::nest("/admin", router);
 

--- a/src/meta-srv/src/service/admin/inactive_regions.rs
+++ b/src/meta-srv/src/service/admin/inactive_regions.rs
@@ -1,0 +1,92 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use common_meta::kv_backend::ResettableKvBackendRef;
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+use tonic::codegen::http;
+
+use crate::error::{self, Result};
+use crate::inactive_region_manager::InactiveRegionManager;
+use crate::keys::InactiveRegionKey;
+use crate::service::admin::{util, HttpHandler};
+
+pub struct ViewInactiveRegionsHandler {
+    pub store: ResettableKvBackendRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for ViewInactiveRegionsHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let cluster_id = util::extract_cluster_id(params)?;
+
+        let inactive_region_manager = InactiveRegionManager::new(&self.store);
+        let inactive_regions = inactive_region_manager
+            .scan_all_inactive_regions(cluster_id)
+            .await?;
+        let result = InactiveRegions { inactive_regions }.try_into()?;
+
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(result)
+            .context(error::InvalidHttpBodySnafu)
+    }
+}
+
+pub struct ClearInactiveRegionsHandler {
+    pub store: ResettableKvBackendRef,
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for ClearInactiveRegionsHandler {
+    async fn handle(
+        &self,
+        _: &str,
+        params: &HashMap<String, String>,
+    ) -> Result<http::Response<String>> {
+        let cluster_id = util::extract_cluster_id(params)?;
+
+        let inactive_region_manager = InactiveRegionManager::new(&self.store);
+        inactive_region_manager
+            .clear_all_inactive_regions(cluster_id)
+            .await?;
+
+        Ok(http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body("Success\n".to_owned())
+            .unwrap())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+struct InactiveRegions {
+    inactive_regions: Vec<InactiveRegionKey>,
+}
+
+impl TryFrom<InactiveRegions> for String {
+    type Error = error::Error;
+
+    fn try_from(value: InactiveRegions) -> Result<Self> {
+        serde_json::to_string(&value).context(error::SerializeToJsonSnafu {
+            input: format!("{value:?}"),
+        })
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Revert "refactor: remove InactiveRegionManager"(This reverts commit https://github.com/GreptimeTeam/greptimedb/commit/8ee768242df00800399c0e9ab239390dbd1f7882.)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
