### PR TITLE
fix: bring back `inactive_region_ids`

### DIFF
--- a/src/meta-srv/src/handler.rs
+++ b/src/meta-srv/src/handler.rs
@@ -28,6 +28,7 @@ use common_telemetry::{debug, info, warn};
 use dashmap::DashMap;
 use futures::future::join_all;
 use snafu::{OptionExt, ResultExt};
+use store_api::storage::RegionId;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{oneshot, Notify, RwLock};
 
@@ -75,7 +76,7 @@ pub struct HeartbeatAccumulator {
     pub header: Option<ResponseHeader>,
     pub instructions: Vec<Instruction>,
     pub stat: Option<Stat>,
-    pub inactive_region_ids: HashSet<u64>,
+    pub inactive_region_ids: HashSet<RegionId>,
     pub region_lease: Option<RegionLease>,
 }
 

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -20,7 +20,6 @@ use api::v1::meta::{HeartbeatRequest, Role};
 use async_trait::async_trait;
 use common_catalog::consts::default_engine;
 use common_meta::RegionIdent;
-use store_api::storage::RegionId;
 
 use crate::error::Result;
 use crate::failure_detector::PhiAccrualFailureDetectorOptions;
@@ -86,7 +85,7 @@ impl HeartbeatHandler for RegionFailureHandler {
                 .region_stats
                 .iter()
                 .map(|x| {
-                    let region_id = RegionId::from(x.id);
+                    let region_id = x.id;
                     RegionIdent {
                         cluster_id: stat.cluster_id,
                         datanode_id: stat.id,
@@ -108,6 +107,7 @@ impl HeartbeatHandler for RegionFailureHandler {
 #[cfg(test)]
 mod tests {
     use store_api::region_engine::RegionRole;
+    use store_api::storage::RegionId;
 
     use super::*;
     use crate::handler::node_stat::{RegionStat, Stat};
@@ -133,7 +133,7 @@ mod tests {
         let acc = &mut HeartbeatAccumulator::default();
         fn new_region_stat(region_id: u64) -> RegionStat {
             RegionStat {
-                id: region_id,
+                id: RegionId::from_u64(region_id),
                 rcus: 0,
                 wcus: 0,
                 approximate_bytes: 0,

--- a/src/meta-srv/src/handler/node_stat.rs
+++ b/src/meta-srv/src/handler/node_stat.rs
@@ -45,7 +45,7 @@ pub struct Stat {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RegionStat {
     /// The region_id.
-    pub id: u64,
+    pub id: RegionId,
     /// The read capacity units during this period
     pub rcus: i64,
     /// The write capacity units during this period
@@ -75,13 +75,10 @@ impl Stat {
 
     /// Returns a tuple array containing [RegionId] and [RegionRole].
     pub fn regions(&self) -> Vec<(RegionId, RegionRole)> {
-        self.region_stats
-            .iter()
-            .map(|s| (RegionId::from(s.id), s.role))
-            .collect()
+        self.region_stats.iter().map(|s| (s.id, s.role)).collect()
     }
 
-    pub fn retain_active_region_stats(&mut self, inactive_region_ids: &HashSet<u64>) {
+    pub fn retain_active_region_stats(&mut self, inactive_region_ids: &HashSet<RegionId>) {
         if inactive_region_ids.is_empty() {
             return;
         }
@@ -140,7 +137,7 @@ impl TryFrom<api::v1::meta::RegionStat> for RegionStat {
 
     fn try_from(value: api::v1::meta::RegionStat) -> Result<Self, Self::Error> {
         Ok(Self {
-            id: value.region_id,
+            id: RegionId::from_u64(value.region_id),
             rcus: value.rcus,
             wcus: value.wcus,
             approximate_bytes: value.approximate_bytes,

--- a/src/meta-srv/src/selector/weight_compute.rs
+++ b/src/meta-srv/src/selector/weight_compute.rs
@@ -94,6 +94,7 @@ mod tests {
 
     use api::v1::meta::Peer;
     use store_api::region_engine::RegionRole;
+    use store_api::storage::RegionId;
 
     use super::{RegionNumsBasedWeightCompute, WeightCompute};
     use crate::handler::node_stat::{RegionStat, Stat};
@@ -189,7 +190,7 @@ mod tests {
             addr: "127.0.0.1:3001".to_string(),
             region_num: 11,
             region_stats: vec![RegionStat {
-                id: 111,
+                id: RegionId::from_u64(111),
                 rcus: 1,
                 wcus: 1,
                 approximate_bytes: 1,
@@ -206,7 +207,7 @@ mod tests {
             addr: "127.0.0.1:3002".to_string(),
             region_num: 12,
             region_stats: vec![RegionStat {
-                id: 112,
+                id: RegionId::from_u64(112),
                 rcus: 1,
                 wcus: 1,
                 approximate_bytes: 1,
@@ -223,7 +224,7 @@ mod tests {
             addr: "127.0.0.1:3003".to_string(),
             region_num: 13,
             region_stats: vec![RegionStat {
-                id: 113,
+                id: RegionId::from_u64(113),
                 rcus: 1,
                 wcus: 1,
                 approximate_bytes: 1,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

bring back `inactive_region_ids`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
