### PR TITLE
refactor: remove sequence number from ScanRequest

### DIFF
--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -262,7 +262,6 @@ impl MetadataRegion {
         let filter_expr = col(METADATA_SCHEMA_KEY_COLUMN_NAME).eq(lit(key));
 
         ScanRequest {
-            sequence: None,
             projection: Some(vec![METADATA_SCHEMA_VALUE_COLUMN_INDEX]),
             filters: vec![filter_expr.into()],
             output_ordering: None,
@@ -390,7 +389,6 @@ mod test {
         let key = "test_key";
         let expected_filter_expr = col(METADATA_SCHEMA_KEY_COLUMN_NAME).eq(lit(key));
         let expected_scan_request = ScanRequest {
-            sequence: None,
             projection: Some(vec![METADATA_SCHEMA_VALUE_COLUMN_INDEX]),
             filters: vec![expected_filter_expr.into()],
             output_ordering: None,

--- a/src/mito2/src/engine/projection_test.rs
+++ b/src/mito2/src/engine/projection_test.rs
@@ -74,7 +74,6 @@ async fn test_scan_projection() {
 
     // Scans tag_1, field_1, ts
     let request = ScanRequest {
-        sequence: None,
         projection: Some(vec![1, 3, 4]),
         filters: Vec::new(),
         output_ordering: None,

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -26,7 +26,7 @@ use snafu::{OptionExt, ResultExt};
 use crate::error::{
     BuildColumnDescriptorSnafu, Error, InvalidDefaultConstraintSnafu, InvalidRawRegionRequestSnafu,
 };
-use crate::storage::{ColumnDescriptor, ColumnDescriptorBuilder, RegionDescriptor, SequenceNumber};
+use crate::storage::{ColumnDescriptor, ColumnDescriptorBuilder, RegionDescriptor};
 
 /// Write request holds a collection of updates to apply to a region.
 ///
@@ -48,11 +48,6 @@ pub trait WriteRequest: Send {
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct ScanRequest {
-    /// Max sequence number to read, None for latest sequence.
-    ///
-    /// Default is None. Only returns data whose sequence number is less than or
-    /// equal to the `sequence`.
-    pub sequence: Option<SequenceNumber>,
     /// Indices of columns to read, `None` to read all columns.
     pub projection: Option<Vec<usize>>,
     /// Filters pushed down


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove yet another overdesign. 

Remove the sequence number from `ScanRequest`. We won't be using it in the near future. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
