### PR TITLE
feat: support sample ratio in trace

### DIFF
--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -134,7 +134,7 @@ worker_request_batch_size = 64
 # Number of meta action updated to trigger a new checkpoint for the manifest
 manifest_checkpoint_distance = 10
 # Manifest compression type
-manifest_compress_type = "Uncompressed"
+manifest_compress_type = "uncompressed"
 # Max number of running background jobs
 max_background_jobs = 4
 # Interval to auto flush a region if it has not flushed yet.
@@ -162,3 +162,5 @@ sst_write_buffer_size = "8MB"
 # enable_otlp_tracing = false
 # tracing exporter endpoint with format `ip:port`, we use grpc oltp as exporter, default endpoint is `localhost:4317`
 # otlp_endpoint = "localhost:4317"
+# The percentage of tracing will be sampled and exported. Valid range `[0, 1]`, 1 means all traces are sampled, 0 means all traces are not sampled, the default value is 1. ratio > 1 are treated as 1. Fractions < 0 are treated as 0
+# tracing_sample_ratio = 1.0

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -54,6 +54,7 @@ impl PartialEq for LoggingOptions {
             && self.tracing_sample_ratio == other.tracing_sample_ratio
     }
 }
+
 impl Eq for LoggingOptions {}
 
 impl Default for LoggingOptions {
@@ -63,7 +64,7 @@ impl Default for LoggingOptions {
             level: None,
             enable_otlp_tracing: false,
             otlp_endpoint: None,
-            tracing_sample_ratio: Some(1.0),
+            tracing_sample_ratio: None,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

support sample ratio in trace, add config `tracing_sample_ratio`

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- support sample ratio in trace, add config `tracing_sample_ratio`
- fix error config of `manifest_compress_type` in standalone.example.toml

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
