### PR TITLE
feat: Script for set up LD_LIBRARY_PATH with pyo3 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ build-by-dev-builder: ## Build greptime by dev-builder.
 	TARGET_DIR=${TARGET_DIR} \
 	TARGET=${TARGET} \
 	RELEASE=${RELEASE} \
-	CARGO_BUILD_EXTRA_OPTS="${CARGO_BUILD_EXTRA_OPTS}"
+	CARGO_BUILD_EXTRA_OPTS="${CARGO_BUILD_EXTRA_OPTS}" && \
+	./scripts/check_pyo3_link_script.sh
 
 .PHONY: build-android-bin
 build-android-bin: ## Build greptime binary for android.

--- a/scripts/check_pyo3_link_script.sh
+++ b/scripts/check_pyo3_link_script.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script is only used in CI to check if the pyo3 backend is linked correctly
+echo $(pwd)
+if [[ $FEATURES == *pyo3_backend* ]]; then
+    cp target/release/greptime scripts
+    if yes | ./scripts/greptime.sh --version &> /dev/null; then
+        exit 0
+    else
+        exit 1
+    fi
+fi

--- a/scripts/greptime.sh
+++ b/scripts/greptime.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# This script configures the environment to run 'greptime' with the required Python version
+
+# This script should be compatible both in Linux and macOS
+OS_TYPE="$(uname)"
+readonly OS_TYPE
+
+check_command_existence() {
+    command -v "$1" &> /dev/null
+}
+
+get_python_version() {
+    case "$OS_TYPE" in
+        Darwin)
+            otool -L greptime | grep -o 'Python.framework/Versions/3.[0-9]+/Python' | grep -o '3.[0-9]+'
+            ;;
+        Linux)
+            ldd greptime | grep -o 'libpython[0-9]\.[0-9]+' | grep -o '[0-9]\.[0-9]+'
+            ;;
+    esac
+}
+
+setup_virtualenv() {
+    local req_py_version="$1"
+    local env_name="GreptimeTmpVenv$req_py_version"
+    virtualenv --python=python"$req_py_version" "$env_name"
+    source "$env_name/bin/activate"
+}
+
+setup_conda_env() {
+    local req_py_version="$1"
+    local conda_base
+    conda_base=$(conda info --base) || { echo "Error obtaining conda base directory"; exit 1; }
+    . "$conda_base/etc/profile.d/conda.sh"
+
+    if ! conda list --name "GreptimeTmpPyO3Env$req_py_version" &> /dev/null; then
+        conda create --yes --name "GreptimeTmpPyO3Env$req_py_version" python="$req_py_version"
+    fi
+
+    conda activate "GreptimeTmpPyO3Env$req_py_version"
+}
+
+# Set library path and pass all arguments to greptime to run it
+execute_greptime() {
+    if [[ "$OS_TYPE" == "Darwin" ]]; then
+        DYLD_LIBRARY_PATH="${CONDA_PREFIX:-$PREFIX}/lib:${LD_LIBRARY_PATH:-}" ./greptime "$@"
+    elif [[ "$OS_TYPE" == "Linux" ]]; then
+        LD_LIBRARY_PATH="${CONDA_PREFIX:-$PREFIX}/lib:${LD_LIBRARY_PATH:-}" ./greptime "$@"
+    fi
+}
+
+main() {
+    local req_py_version
+    req_py_version=$(get_python_version)
+    readonly req_py_version
+
+    if [[ -z "$req_py_version" ]]; then
+        if ./greptime --version &> /dev/null; then
+            ./greptime "$@"
+        else
+            echo "The 'greptime' binary is not valid or encountered an error."
+            exit 1
+        fi
+        return
+    fi
+
+    echo "The required version of Python shared library is $req_py_version"
+
+    echo "Now this script will try to install or find correct Python Version"
+    echo "Do you want to continue? (yes/no): "
+    read -r yn
+    case $yn in
+        [Yy]* ) ;;
+        [Nn]* ) exit;;
+        * ) echo "Please answer yes or no.";;
+    esac
+
+    if check_command_existence "virtualenv"; then
+        setup_virtualenv "$req_py_version"
+    elif check_command_existence "conda"; then
+        setup_conda_env "$req_py_version"
+    else
+        echo "Neither virtualenv nor conda is available."
+        exit 1
+    fi
+
+    execute_greptime "$@"
+}
+
+main "$@"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Added `greptime.sh` script which will try to find or set up proper version of python shared library

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
a script that set up python shared library path and run exectuable, i.e. `./greptim.sh standalone start`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
