### PR TITLE
fix(mito): do not check nullability of fields in delete requests

### DIFF
--- a/tests/cases/standalone/common/delete/delete_non_null.result
+++ b/tests/cases/standalone/common/delete/delete_non_null.result
@@ -1,0 +1,38 @@
+CREATE TABLE monitor (host STRING NOT NULL, ts TIMESTAMP NOT NULL, cpu DOUBLE NOT NULL, memory DOUBLE NOT NULL, TIME INDEX (ts), PRIMARY KEY(host));
+
+Affected Rows: 0
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+(1655276557000, 'host1', 10.0, 1024),
+(1655276557000, 'host2', 20.0, 1024),
+(1655276557000, 'host3', 30.0, 1024);
+
+Affected Rows: 3
+
+SELECT ts, host, cpu, memory FROM monitor ORDER BY ts, host;
+
++---------------------+-------+------+--------+
+| ts                  | host  | cpu  | memory |
++---------------------+-------+------+--------+
+| 2022-06-15T07:02:37 | host1 | 10.0 | 1024.0 |
+| 2022-06-15T07:02:37 | host2 | 20.0 | 1024.0 |
+| 2022-06-15T07:02:37 | host3 | 30.0 | 1024.0 |
++---------------------+-------+------+--------+
+
+DELETE FROM monitor WHERE host = 'host2';
+
+Affected Rows: 1
+
+SELECT ts, host, cpu, memory FROM monitor ORDER BY ts, host;
+
++---------------------+-------+------+--------+
+| ts                  | host  | cpu  | memory |
++---------------------+-------+------+--------+
+| 2022-06-15T07:02:37 | host1 | 10.0 | 1024.0 |
+| 2022-06-15T07:02:37 | host3 | 30.0 | 1024.0 |
++---------------------+-------+------+--------+
+
+DROP TABLE monitor;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/delete/delete_non_null.sql
+++ b/tests/cases/standalone/common/delete/delete_non_null.sql
@@ -1,0 +1,14 @@
+CREATE TABLE monitor (host STRING NOT NULL, ts TIMESTAMP NOT NULL, cpu DOUBLE NOT NULL, memory DOUBLE NOT NULL, TIME INDEX (ts), PRIMARY KEY(host));
+
+INSERT INTO monitor(ts, host, cpu, memory) VALUES
+(1655276557000, 'host1', 10.0, 1024),
+(1655276557000, 'host2', 20.0, 1024),
+(1655276557000, 'host3', 30.0, 1024);
+
+SELECT ts, host, cpu, memory FROM monitor ORDER BY ts, host;
+
+DELETE FROM monitor WHERE host = 'host2';
+
+SELECT ts, host, cpu, memory FROM monitor ORDER BY ts, host;
+
+DROP TABLE monitor;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Allow missing fields in delete requests. Before this PR, the engine always checks whether a field column has a suitable default value.

This PR also adds some tests for this case.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2813
