### PR TITLE
feat(remote_wal): support persisting per-region unique metadata

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -45,6 +45,7 @@
 
 pub mod catalog_name;
 pub mod datanode_table;
+pub mod region_meta;
 pub mod schema_name;
 pub mod table_info;
 pub mod table_name;
@@ -82,6 +83,7 @@ use self::schema_name::{SchemaManager, SchemaNameKey, SchemaNameValue};
 use self::table_route::{TableRouteManager, TableRouteValue};
 use crate::ddl::utils::region_storage_path;
 use crate::error::{self, Result, SerdeJsonSnafu};
+use crate::key::region_meta::RegionMetaManager;
 use crate::kv_backend::txn::Txn;
 use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute, RegionStatus};
@@ -93,6 +95,7 @@ const NAME_PATTERN: &str = r"[a-zA-Z_:-][a-zA-Z0-9_:\-\.]*";
 
 const DATANODE_TABLE_KEY_PREFIX: &str = "__dn_table";
 const TABLE_REGION_KEY_PREFIX: &str = "__table_region";
+const REGION_META_KEY_PREFIX: &str = "__region_meta";
 
 pub const TABLE_INFO_KEY_PREFIX: &str = "__table_info";
 pub const TABLE_NAME_KEY_PREFIX: &str = "__table_name";
@@ -154,6 +157,7 @@ pub struct TableMetadataManager {
     catalog_manager: CatalogManager,
     schema_manager: SchemaManager,
     table_route_manager: TableRouteManager,
+    region_meta_manager: RegionMetaManager,
     kv_backend: KvBackendRef,
 }
 
@@ -289,6 +293,7 @@ impl TableMetadataManager {
             catalog_manager: CatalogManager::new(kv_backend.clone()),
             schema_manager: SchemaManager::new(kv_backend.clone()),
             table_route_manager: TableRouteManager::new(kv_backend.clone()),
+            region_meta_manager: RegionMetaManager::new(kv_backend.clone()),
             kv_backend,
         }
     }
@@ -327,6 +332,10 @@ impl TableMetadataManager {
 
     pub fn table_route_manager(&self) -> &TableRouteManager {
         &self.table_route_manager
+    }
+
+    pub fn region_meta_manager(&self) -> &RegionMetaManager {
+        &self.region_meta_manager
     }
 
     #[cfg(feature = "testing")]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -45,6 +45,7 @@
 
 pub mod catalog_name;
 pub mod datanode_table;
+#[allow(dead_code)]
 pub mod region_meta;
 pub mod schema_name;
 pub mod table_info;
@@ -83,7 +84,7 @@ use self::schema_name::{SchemaManager, SchemaNameKey, SchemaNameValue};
 use self::table_route::{TableRouteManager, TableRouteValue};
 use crate::ddl::utils::region_storage_path;
 use crate::error::{self, Result, SerdeJsonSnafu};
-use crate::key::region_meta::RegionMetaManager;
+use crate::key::region_meta::{RegionMetaManager, RegionMetaValue};
 use crate::kv_backend::txn::Txn;
 use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute, RegionStatus};
@@ -740,7 +741,8 @@ impl_table_meta_value! {
     TableNameValue,
     TableInfoValue,
     DatanodeTableValue,
-    TableRouteValue
+    TableRouteValue,
+    RegionMetaValue
 }
 
 impl_optional_meta_value! {

--- a/src/common/meta/src/key/region_meta.rs
+++ b/src/common/meta/src/key/region_meta.rs
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::sync::Arc;
 
 use futures::stream::BoxStream;
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
 use store_api::storage::{RegionId, RegionNumber};
 use table::metadata::TableId;
 
 use crate::error::Result;
 use crate::key::{TableMetaKey, REGION_META_KEY_PREFIX};
-use crate::kv_backend::txn::Txn;
+use crate::kv_backend::txn::{Txn, TxnOp};
 use crate::kv_backend::KvBackendRef;
+use crate::range_stream::{PaginationStream, DEFAULT_PAGE_SIZE};
+use crate::rpc::store::RangeRequest;
+use crate::rpc::KeyValue;
 
 // TODO(niebayes): to be removed when `Kafka Remote Wal` is merged.
 pub type KafkaTopic = String;
@@ -32,6 +37,7 @@ pub struct RegionMeta {
     topic: Option<KafkaTopic>,
 }
 
+// The table id is included to support efficiently scan metadata of all regions of a table.
 pub struct RegionMetaKey {
     table_id: TableId,
     region_number: RegionNumber,
@@ -43,6 +49,10 @@ impl RegionMetaKey {
             table_id,
             region_number,
         }
+    }
+
+    fn range_start_key(table_id: TableId) -> Vec<u8> {
+        format!("{}/{}/", REGION_META_KEY_PREFIX, table_id).into_bytes()
     }
 }
 
@@ -56,8 +66,15 @@ impl TableMetaKey for RegionMetaKey {
     }
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct RegionMetaValue {
     topic: Option<KafkaTopic>,
+}
+
+impl RegionMetaValue {
+    pub fn new(topic: Option<KafkaTopic>) -> Self {
+        Self { topic }
+    }
 }
 
 pub struct RegionMetaManager {
@@ -71,23 +88,70 @@ impl RegionMetaManager {
 
     /// Gets the region meta value associated with the given region meta key.
     /// Returns None if the key does not exist.
-    pub fn get(&self, key: &RegionMetaKey) -> Result<Option<RegionMetaValue>> {
-        todo!()
+    pub async fn get(&self, key: &RegionMetaKey) -> Result<Option<RegionMetaValue>> {
+        self.kv_backend
+            .get(&key.as_raw_key())
+            .await?
+            .map(|kv| RegionMetaValue::try_from_raw_value(&kv.value))
+            .transpose()
     }
 
     /// Gets metadata of all regions in a table with the given table id.
     /// Returns a stream of region meta values.
     pub fn region_metas(&self, table_id: TableId) -> BoxStream<'static, Result<RegionMetaValue>> {
-        todo!()
+        let start_key = RegionMetaKey::range_start_key(table_id);
+        let range_request = RangeRequest::new().with_prefix(start_key);
+
+        fn region_meta_value_decoder(kv: KeyValue) -> Result<((), RegionMetaValue)> {
+            let value = RegionMetaValue::try_from_raw_value(&kv.value)?;
+            Ok(((), value))
+        }
+
+        let raw_stream = PaginationStream::new(
+            self.kv_backend.clone(),
+            range_request,
+            DEFAULT_PAGE_SIZE,
+            Arc::new(region_meta_value_decoder),
+        );
+        let stream = raw_stream
+            .map(|decode_result| decode_result.map(|(_, region_meta_value)| region_meta_value));
+
+        Box::pin(stream)
     }
 
     /// Builds a txn to create a sequence of region metadata.
     pub(crate) fn build_create_txn(&self, region_metas: Vec<RegionMeta>) -> Result<Txn> {
-        todo!()
+        let txns = region_metas
+            .into_iter()
+            .map(|region_meta| {
+                let table_id = region_meta.region_id.table_id();
+                let region_number = region_meta.region_id.region_number();
+                let topic = region_meta.topic;
+
+                let key = RegionMetaKey::new(table_id, region_number).as_raw_key();
+                let value = RegionMetaValue::new(topic).try_as_raw_value()?;
+
+                Ok(TxnOp::Put(key, value))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Txn::new().and_then(txns))
     }
 
     /// Builds a txn to delete region metadata of the regions identified by the given region ids.
-    pub(crate) fn build_delete_txn(&self, region_ids: Vec<RegionId>) {
-        todo!()
+    pub(crate) fn build_delete_txn(&self, region_ids: Vec<RegionId>) -> Result<Txn> {
+        let txns = region_ids
+            .into_iter()
+            .map(|region_id| {
+                let table_id = region_id.table_id();
+                let region_number = region_id.region_number();
+
+                let key = RegionMetaKey::new(table_id, region_number).as_raw_key();
+
+                TxnOp::Delete(key)
+            })
+            .collect::<Vec<_>>();
+
+        Ok(Txn::new().and_then(txns))
     }
 }

--- a/src/common/meta/src/key/region_meta.rs
+++ b/src/common/meta/src/key/region_meta.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use futures::stream::BoxStream;
+use store_api::storage::{RegionId, RegionNumber};
+use table::metadata::TableId;
+
+use crate::error::Result;
+use crate::key::{TableMetaKey, REGION_META_KEY_PREFIX};
+use crate::kv_backend::txn::Txn;
+use crate::kv_backend::KvBackendRef;
+
+// TODO(niebayes): to be removed when `Kafka Remote Wal` is merged.
+pub type KafkaTopic = String;
+
+/// A region's unique metadata.
+pub struct RegionMeta {
+    region_id: RegionId,
+    topic: Option<KafkaTopic>,
+}
+
+pub struct RegionMetaKey {
+    table_id: TableId,
+    region_number: RegionNumber,
+}
+
+impl RegionMetaKey {
+    pub fn new(table_id: TableId, region_number: RegionNumber) -> Self {
+        Self {
+            table_id,
+            region_number,
+        }
+    }
+}
+
+impl TableMetaKey for RegionMetaKey {
+    fn as_raw_key(&self) -> Vec<u8> {
+        format!(
+            "{}/{}/{}",
+            REGION_META_KEY_PREFIX, self.table_id, self.region_number
+        )
+        .into_bytes()
+    }
+}
+
+pub struct RegionMetaValue {
+    topic: Option<KafkaTopic>,
+}
+
+pub struct RegionMetaManager {
+    kv_backend: KvBackendRef,
+}
+
+impl RegionMetaManager {
+    pub fn new(kv_backend: KvBackendRef) -> Self {
+        Self { kv_backend }
+    }
+
+    /// Gets the region meta value associated with the given region meta key.
+    /// Returns None if the key does not exist.
+    pub fn get(&self, key: &RegionMetaKey) -> Result<Option<RegionMetaValue>> {
+        todo!()
+    }
+
+    /// Gets metadata of all regions in a table with the given table id.
+    /// Returns a stream of region meta values.
+    pub fn region_metas(&self, table_id: TableId) -> BoxStream<'static, Result<RegionMetaValue>> {
+        todo!()
+    }
+
+    /// Builds a txn to create a sequence of region metadata.
+    pub(crate) fn build_create_txn(&self, region_metas: Vec<RegionMeta>) -> Result<Txn> {
+        todo!()
+    }
+
+    /// Builds a txn to delete region metadata of the regions identified by the given region ids.
+    pub(crate) fn build_delete_txn(&self, region_ids: Vec<RegionId>) {
+        todo!()
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Support persisting per-region unique metadata to kv backend through the `RegionMetadataManager` in the `TableMetadataManager`. 
This feature is currently to support persisting the allocated kafka topic for each region. Meta srv now is able to store per-region topics in the kv backend while handling create table requests. Datanode now is able to retrieve the stored per-region topics while re-opening regions for a table during initializing a region server.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
