### PR TITLE
fix: windows build and check ci check for windows

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -42,7 +42,10 @@ jobs:
   check:
     name: Check
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest-8-cores, ubuntu-20.04 ]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -339,6 +339,7 @@ pub enum Error {
         source: crate::http::pprof::nix::Error,
     },
 
+    #[cfg(not(windows))]
     #[snafu(display("Failed to update jemalloc metrics"))]
     UpdateJemallocMetrics {
         #[snafu(source)]
@@ -412,8 +413,10 @@ impl ErrorExt for Error {
             | TcpIncoming { .. }
             | CatalogError { .. }
             | GrpcReflectionService { .. }
-            | BuildHttpResponse { .. }
-            | UpdateJemallocMetrics { .. } => StatusCode::Internal,
+            | BuildHttpResponse { .. } => StatusCode::Internal,
+
+            #[cfg(not(windows))]
+            UpdateJemallocMetrics { .. } => StatusCode::Internal,
 
             CollectRecordbatch { .. } => StatusCode::EngineExecuteQuery,
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Resolves build issue introduced in #2791 and attempt to add `cargo check` for windows platform.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
