### PR TITLE
refactor: replace usage of ArrayData by clone

### DIFF
--- a/src/datatypes/src/vectors.rs
+++ b/src/datatypes/src/vectors.rs
@@ -229,17 +229,16 @@ macro_rules! impl_try_from_arrow_array_for_vector {
             ) -> crate::error::Result<$Vector> {
                 use snafu::OptionExt;
 
-                let data = array
+                let arrow_array = array
                     .as_ref()
                     .as_any()
                     .downcast_ref::<$Array>()
                     .with_context(|| crate::error::ConversionSnafu {
                         from: std::format!("{:?}", array.as_ref().data_type()),
                     })?
-                    .to_data();
+                    .clone();
 
-                let concrete_array = $Array::from(data);
-                Ok($Vector::from(concrete_array))
+                Ok($Vector::from(arrow_array))
             }
         }
     };

--- a/src/datatypes/src/vectors/binary.rs
+++ b/src/datatypes/src/vectors/binary.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayBuilder, ArrayData, ArrayIter, ArrayRef};
+use arrow::array::{Array, ArrayBuilder, ArrayIter, ArrayRef};
 use snafu::ResultExt;
 
 use crate::arrow_array::{BinaryArray, MutableBinaryArray};
@@ -35,10 +35,6 @@ pub struct BinaryVector {
 impl BinaryVector {
     pub(crate) fn as_arrow(&self) -> &dyn Array {
         &self.array
-    }
-
-    fn to_array_data(&self) -> ArrayData {
-        self.array.to_data()
     }
 }
 
@@ -74,13 +70,11 @@ impl Vector for BinaryVector {
     }
 
     fn to_arrow_array(&self) -> ArrayRef {
-        let data = self.to_array_data();
-        Arc::new(BinaryArray::from(data))
+        Arc::new(self.array.clone())
     }
 
     fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
-        let data = self.to_array_data();
-        Box::new(BinaryArray::from(data))
+        Box::new(self.array.clone())
     }
 
     fn validity(&self) -> Validity {

--- a/src/datatypes/src/vectors/boolean.rs
+++ b/src/datatypes/src/vectors/boolean.rs
@@ -16,9 +16,7 @@ use std::any::Any;
 use std::borrow::Borrow;
 use std::sync::Arc;
 
-use arrow::array::{
-    Array, ArrayBuilder, ArrayData, ArrayIter, ArrayRef, BooleanArray, BooleanBuilder,
-};
+use arrow::array::{Array, ArrayBuilder, ArrayIter, ArrayRef, BooleanArray, BooleanBuilder};
 use snafu::ResultExt;
 
 use crate::data_type::ConcreteDataType;
@@ -42,16 +40,6 @@ impl BooleanVector {
     /// Get the inner boolean array.
     pub fn as_boolean_array(&self) -> &BooleanArray {
         &self.array
-    }
-
-    fn to_array_data(&self) -> ArrayData {
-        self.array.to_data()
-    }
-
-    fn from_array_data(data: ArrayData) -> BooleanVector {
-        BooleanVector {
-            array: BooleanArray::from(data),
-        }
     }
 
     pub(crate) fn false_count(&self) -> usize {
@@ -107,13 +95,11 @@ impl Vector for BooleanVector {
     }
 
     fn to_arrow_array(&self) -> ArrayRef {
-        let data = self.to_array_data();
-        Arc::new(BooleanArray::from(data))
+        Arc::new(self.array.clone())
     }
 
     fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
-        let data = self.to_array_data();
-        Box::new(BooleanArray::from(data))
+        Box::new(self.array.clone())
     }
 
     fn validity(&self) -> Validity {
@@ -133,8 +119,8 @@ impl Vector for BooleanVector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let data = self.array.to_data().slice(offset, length);
-        Arc::new(Self::from_array_data(data))
+        let data = self.array.slice(offset, length);
+        Arc::new(Self::from(data))
     }
 
     fn get(&self, index: usize) -> Value {

--- a/src/datatypes/src/vectors/boolean.rs
+++ b/src/datatypes/src/vectors/boolean.rs
@@ -119,8 +119,7 @@ impl Vector for BooleanVector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let data = self.array.slice(offset, length);
-        Arc::new(Self::from(data))
+        Arc::new(Self::from(self.array.slice(offset, length)))
     }
 
     fn get(&self, index: usize) -> Value {

--- a/src/datatypes/src/vectors/decimal.rs
+++ b/src/datatypes/src/vectors/decimal.rs
@@ -196,8 +196,7 @@ impl Vector for Decimal128Vector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let array = self.array.slice(offset, length);
-        Arc::new(Self { array })
+        Arc::new(self.get_slice(offset, length))
     }
 
     fn get(&self, index: usize) -> Value {
@@ -380,7 +379,7 @@ vectors::impl_try_from_arrow_array_for_vector!(Decimal128Array, Decimal128Vector
 
 #[cfg(test)]
 pub mod tests {
-    use arrow_array::Decimal128Array;
+    use arrow_array::{Decimal128Array, Int8Array};
     use common_decimal::Decimal128;
 
     use super::*;
@@ -535,23 +534,23 @@ pub mod tests {
         // because 100 is out of Decimal(3, 1) range, so it will be null
         assert!(array.is_null(4));
     }
-}
 
-#[test]
-fn test_decimal28_vector_iter_data() {
-    let vector = Decimal128Vector::from_values(vec![1, 2, 3, 4])
-        .with_precision_and_scale(3, 1)
-        .unwrap();
-    let mut iter = vector.iter_data();
-    assert_eq!(iter.next(), Some(Some(Decimal128::new(1, 3, 1))));
-    assert_eq!(iter.next(), Some(Some(Decimal128::new(2, 3, 1))));
-    assert_eq!(iter.next(), Some(Some(Decimal128::new(3, 3, 1))));
-    assert_eq!(iter.next(), Some(Some(Decimal128::new(4, 3, 1))));
-    assert_eq!(iter.next(), None);
+    #[test]
+    fn test_decimal28_vector_iter_data() {
+        let vector = Decimal128Vector::from_values(vec![1, 2, 3, 4])
+            .with_precision_and_scale(3, 1)
+            .unwrap();
+        let mut iter = vector.iter_data();
+        assert_eq!(iter.next(), Some(Some(Decimal128::new(1, 3, 1))));
+        assert_eq!(iter.next(), Some(Some(Decimal128::new(2, 3, 1))));
+        assert_eq!(iter.next(), Some(Some(Decimal128::new(3, 3, 1))));
+        assert_eq!(iter.next(), Some(Some(Decimal128::new(4, 3, 1))));
+        assert_eq!(iter.next(), None);
 
-    let values = vector
-        .iter_data()
-        .filter_map(|v| v.map(|x| x.val() * 2))
-        .collect::<Vec<_>>();
-    assert_eq!(values, vec![2, 4, 6, 8]);
+        let values = vector
+            .iter_data()
+            .filter_map(|v| v.map(|x| x.val() * 2))
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![2, 4, 6, 8]);
+    }
 }

--- a/src/datatypes/src/vectors/helper.rs
+++ b/src/datatypes/src/vectors/helper.rs
@@ -284,23 +284,21 @@ impl Helper {
             ArrowDataType::Date64 => Arc::new(DateTimeVector::try_from_arrow_array(array)?),
             ArrowDataType::List(_) => Arc::new(ListVector::try_from_arrow_array(array)?),
             ArrowDataType::Timestamp(unit, _) => match unit {
-                TimeUnit::Second => Arc::new(
-                    TimestampSecondVector::try_from_arrow_timestamp_array(array)?,
-                ),
-                TimeUnit::Millisecond => Arc::new(
-                    TimestampMillisecondVector::try_from_arrow_timestamp_array(array)?,
-                ),
-                TimeUnit::Microsecond => Arc::new(
-                    TimestampMicrosecondVector::try_from_arrow_timestamp_array(array)?,
-                ),
-                TimeUnit::Nanosecond => Arc::new(
-                    TimestampNanosecondVector::try_from_arrow_timestamp_array(array)?,
-                ),
+                TimeUnit::Second => Arc::new(TimestampSecondVector::try_from_arrow_array(array)?),
+                TimeUnit::Millisecond => {
+                    Arc::new(TimestampMillisecondVector::try_from_arrow_array(array)?)
+                }
+                TimeUnit::Microsecond => {
+                    Arc::new(TimestampMicrosecondVector::try_from_arrow_array(array)?)
+                }
+                TimeUnit::Nanosecond => {
+                    Arc::new(TimestampNanosecondVector::try_from_arrow_array(array)?)
+                }
             },
             ArrowDataType::Time32(unit) => match unit {
-                TimeUnit::Second => Arc::new(TimeSecondVector::try_from_arrow_time_array(array)?),
+                TimeUnit::Second => Arc::new(TimeSecondVector::try_from_arrow_array(array)?),
                 TimeUnit::Millisecond => {
-                    Arc::new(TimeMillisecondVector::try_from_arrow_time_array(array)?)
+                    Arc::new(TimeMillisecondVector::try_from_arrow_array(array)?)
                 }
                 // Arrow use time32 for second/millisecond.
                 _ => unreachable!(
@@ -310,10 +308,10 @@ impl Helper {
             },
             ArrowDataType::Time64(unit) => match unit {
                 TimeUnit::Microsecond => {
-                    Arc::new(TimeMicrosecondVector::try_from_arrow_time_array(array)?)
+                    Arc::new(TimeMicrosecondVector::try_from_arrow_array(array)?)
                 }
                 TimeUnit::Nanosecond => {
-                    Arc::new(TimeNanosecondVector::try_from_arrow_time_array(array)?)
+                    Arc::new(TimeNanosecondVector::try_from_arrow_array(array)?)
                 }
                 // Arrow use time64 for microsecond/nanosecond.
                 _ => unreachable!(
@@ -322,29 +320,27 @@ impl Helper {
                 ),
             },
             ArrowDataType::Interval(unit) => match unit {
-                IntervalUnit::YearMonth => Arc::new(
-                    IntervalYearMonthVector::try_from_arrow_interval_array(array)?,
-                ),
-                IntervalUnit::DayTime => {
-                    Arc::new(IntervalDayTimeVector::try_from_arrow_interval_array(array)?)
+                IntervalUnit::YearMonth => {
+                    Arc::new(IntervalYearMonthVector::try_from_arrow_array(array)?)
                 }
-                IntervalUnit::MonthDayNano => Arc::new(
-                    IntervalMonthDayNanoVector::try_from_arrow_interval_array(array)?,
-                ),
+                IntervalUnit::DayTime => {
+                    Arc::new(IntervalDayTimeVector::try_from_arrow_array(array)?)
+                }
+                IntervalUnit::MonthDayNano => {
+                    Arc::new(IntervalMonthDayNanoVector::try_from_arrow_array(array)?)
+                }
             },
             ArrowDataType::Duration(unit) => match unit {
-                TimeUnit::Second => {
-                    Arc::new(DurationSecondVector::try_from_arrow_duration_array(array)?)
+                TimeUnit::Second => Arc::new(DurationSecondVector::try_from_arrow_array(array)?),
+                TimeUnit::Millisecond => {
+                    Arc::new(DurationMillisecondVector::try_from_arrow_array(array)?)
                 }
-                TimeUnit::Millisecond => Arc::new(
-                    DurationMillisecondVector::try_from_arrow_duration_array(array)?,
-                ),
-                TimeUnit::Microsecond => Arc::new(
-                    DurationMicrosecondVector::try_from_arrow_duration_array(array)?,
-                ),
-                TimeUnit::Nanosecond => Arc::new(
-                    DurationNanosecondVector::try_from_arrow_duration_array(array)?,
-                ),
+                TimeUnit::Microsecond => {
+                    Arc::new(DurationMicrosecondVector::try_from_arrow_array(array)?)
+                }
+                TimeUnit::Nanosecond => {
+                    Arc::new(DurationNanosecondVector::try_from_arrow_array(array)?)
+                }
             },
             ArrowDataType::Decimal128(_, _) => {
                 Arc::new(Decimal128Vector::try_from_arrow_array(array)?)

--- a/src/datatypes/src/vectors/list.rs
+++ b/src/datatypes/src/vectors/list.rs
@@ -46,17 +46,6 @@ impl ListVector {
             .map(|value_opt| value_opt.map(Helper::try_into_vector).transpose())
     }
 
-    fn to_array_data(&self) -> ArrayData {
-        self.array.to_data()
-    }
-
-    fn from_array_data_and_type(data: ArrayData, item_type: ConcreteDataType) -> Self {
-        Self {
-            array: ListArray::from(data),
-            item_type,
-        }
-    }
-
     pub(crate) fn as_arrow(&self) -> &dyn Array {
         &self.array
     }
@@ -80,13 +69,11 @@ impl Vector for ListVector {
     }
 
     fn to_arrow_array(&self) -> ArrayRef {
-        let data = self.to_array_data();
-        Arc::new(ListArray::from(data))
+        Arc::new(self.array.clone())
     }
 
     fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
-        let data = self.to_array_data();
-        Box::new(ListArray::from(data))
+        Box::new(self.array.clone())
     }
 
     fn validity(&self) -> Validity {
@@ -106,8 +93,10 @@ impl Vector for ListVector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let data = self.array.to_data().slice(offset, length);
-        Arc::new(Self::from_array_data_and_type(data, self.item_type.clone()))
+        Arc::new(Self {
+            array: self.array.slice(offset, length),
+            item_type: self.item_type.clone(),
+        })
     }
 
     fn get(&self, index: usize) -> Value {

--- a/src/datatypes/src/vectors/primitive.rs
+++ b/src/datatypes/src/vectors/primitive.rs
@@ -16,23 +16,12 @@ use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
-use arrow::array::{
-    Array, ArrayBuilder, ArrayData, ArrayIter, ArrayRef, PrimitiveArray, PrimitiveBuilder,
-    Time32MillisecondArray as TimeMillisecondArray, Time32SecondArray as TimeSecondArray,
-    Time64MicrosecondArray as TimeMicrosecondArray, Time64NanosecondArray as TimeNanosecondArray,
-    TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-    TimestampSecondArray,
-};
-use arrow_array::{
-    DurationMicrosecondArray, DurationMillisecondArray, DurationNanosecondArray,
-    DurationSecondArray, IntervalDayTimeArray, IntervalMonthDayNanoArray, IntervalYearMonthArray,
-};
-use arrow_schema::DataType;
+use arrow::array::{Array, ArrayBuilder, ArrayIter, ArrayRef, PrimitiveArray, PrimitiveBuilder};
 use serde_json::Value as JsonValue;
 use snafu::OptionExt;
 
 use crate::data_type::ConcreteDataType;
-use crate::error::{self, CastTypeSnafu, Result};
+use crate::error::{self, Result};
 use crate::scalars::{Scalar, ScalarRef, ScalarVector, ScalarVectorBuilder};
 use crate::serialize::Serializable;
 use crate::types::{
@@ -66,178 +55,15 @@ impl<T: LogicalPrimitiveType> PrimitiveVector<T> {
     }
 
     pub fn try_from_arrow_array(array: impl AsRef<dyn Array>) -> Result<Self> {
-        let data = array
+        let arrow_array = array
             .as_ref()
             .as_any()
             .downcast_ref::<PrimitiveArray<T::ArrowPrimitive>>()
             .with_context(|| error::ConversionSnafu {
                 from: format!("{:?}", array.as_ref().data_type()),
-            })?
-            .to_data();
-        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(data);
-        Ok(Self::new(concrete_array))
-    }
+            })?;
 
-    /// Converts arrow timestamp array to vectors, ignoring time zone info.
-    pub fn try_from_arrow_timestamp_array(array: impl AsRef<dyn Array>) -> Result<Self> {
-        let array = array.as_ref();
-        let array_data = match array.data_type() {
-            DataType::Timestamp(unit, _) => match unit {
-                arrow_schema::TimeUnit::Second => array
-                    .as_any()
-                    .downcast_ref::<TimestampSecondArray>()
-                    .unwrap()
-                    .clone()
-                    .with_timezone_opt(None::<String>)
-                    .to_data(),
-                arrow_schema::TimeUnit::Millisecond => array
-                    .as_any()
-                    .downcast_ref::<TimestampMillisecondArray>()
-                    .unwrap()
-                    .clone()
-                    .with_timezone_opt(None::<String>)
-                    .to_data(),
-                arrow_schema::TimeUnit::Microsecond => array
-                    .as_any()
-                    .downcast_ref::<TimestampMicrosecondArray>()
-                    .unwrap()
-                    .clone()
-                    .with_timezone_opt(None::<String>)
-                    .to_data(),
-                arrow_schema::TimeUnit::Nanosecond => array
-                    .as_any()
-                    .downcast_ref::<TimestampNanosecondArray>()
-                    .unwrap()
-                    .clone()
-                    .with_timezone_opt(None::<String>)
-                    .to_data(),
-            },
-            arrow_type => {
-                return CastTypeSnafu {
-                    msg: format!(
-                        "Failed to cast arrow array {:?} to timestamp vector",
-                        arrow_type,
-                    ),
-                }
-                .fail()?;
-            }
-        };
-        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(array_data);
-        Ok(Self::new(concrete_array))
-    }
-
-    /// Converts arrow time array to vectors
-    pub fn try_from_arrow_time_array(array: impl AsRef<dyn Array>) -> Result<Self> {
-        let array = array.as_ref();
-        let array_data = match array.data_type() {
-            DataType::Time32(unit) => match unit {
-                arrow_schema::TimeUnit::Second => array
-                    .as_any()
-                    .downcast_ref::<TimeSecondArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::TimeUnit::Millisecond => array
-                    .as_any()
-                    .downcast_ref::<TimeMillisecondArray>()
-                    .unwrap()
-                    .to_data(),
-                _ => unreachable!(),
-            },
-            DataType::Time64(unit) => match unit {
-                arrow_schema::TimeUnit::Microsecond => array
-                    .as_any()
-                    .downcast_ref::<TimeMicrosecondArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::TimeUnit::Nanosecond => array
-                    .as_any()
-                    .downcast_ref::<TimeNanosecondArray>()
-                    .unwrap()
-                    .to_data(),
-                _ => unreachable!(),
-            },
-            arrow_type => {
-                return CastTypeSnafu {
-                    msg: format!("Failed to cast arrow array {:?} to time vector", arrow_type,),
-                }
-                .fail()?;
-            }
-        };
-        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(array_data);
-        Ok(Self::new(concrete_array))
-    }
-
-    pub fn try_from_arrow_interval_array(array: impl AsRef<dyn Array>) -> Result<Self> {
-        let array = array.as_ref();
-        let array_data = match array.data_type() {
-            DataType::Interval(unit) => match unit {
-                arrow_schema::IntervalUnit::YearMonth => array
-                    .as_any()
-                    .downcast_ref::<IntervalYearMonthArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::IntervalUnit::DayTime => array
-                    .as_any()
-                    .downcast_ref::<IntervalDayTimeArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::IntervalUnit::MonthDayNano => array
-                    .as_any()
-                    .downcast_ref::<IntervalMonthDayNanoArray>()
-                    .unwrap()
-                    .to_data(),
-            },
-            arrow_type => {
-                return CastTypeSnafu {
-                    msg: format!(
-                        "Failed to cast arrow array {:?} to interval vector",
-                        arrow_type,
-                    ),
-                }
-                .fail()?;
-            }
-        };
-        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(array_data);
-        Ok(Self::new(concrete_array))
-    }
-
-    pub fn try_from_arrow_duration_array(array: impl AsRef<dyn Array>) -> Result<Self> {
-        let array = array.as_ref();
-        let array_data = match array.data_type() {
-            DataType::Duration(unit) => match unit {
-                arrow_schema::TimeUnit::Second => array
-                    .as_any()
-                    .downcast_ref::<DurationSecondArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::TimeUnit::Millisecond => array
-                    .as_any()
-                    .downcast_ref::<DurationMillisecondArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::TimeUnit::Microsecond => array
-                    .as_any()
-                    .downcast_ref::<DurationMicrosecondArray>()
-                    .unwrap()
-                    .to_data(),
-                arrow_schema::TimeUnit::Nanosecond => array
-                    .as_any()
-                    .downcast_ref::<DurationNanosecondArray>()
-                    .unwrap()
-                    .to_data(),
-            },
-            arrow_type => {
-                return CastTypeSnafu {
-                    msg: format!(
-                        "Failed to cast arrow array {:?} to interval vector",
-                        arrow_type,
-                    ),
-                }
-                .fail()?;
-            }
-        };
-        let concrete_array = PrimitiveArray::<T::ArrowPrimitive>::from(array_data);
-        Ok(Self::new(concrete_array))
+        Ok(Self::new(arrow_array.clone()))
     }
 
     pub fn from_slice<P: AsRef<[T::Native]>>(slice: P) -> Self {
@@ -277,24 +103,15 @@ impl<T: LogicalPrimitiveType> PrimitiveVector<T> {
         &self.array
     }
 
-    fn to_array_data(&self) -> ArrayData {
-        self.array.to_data()
-    }
-
-    fn from_array_data(data: ArrayData) -> Self {
-        Self {
-            array: PrimitiveArray::from(data),
-        }
-    }
-
     // To distinguish with `Vector::slice()`.
     /// Slice the vector, returning a new vector.
     ///
     /// # Panics
     /// This function panics if `offset + length > self.len()`.
     pub fn get_slice(&self, offset: usize, length: usize) -> Self {
-        let data = self.array.to_data().slice(offset, length);
-        Self::from_array_data(data)
+        Self {
+            array: self.array.slice(offset, length),
+        }
     }
 }
 
@@ -316,13 +133,11 @@ impl<T: LogicalPrimitiveType> Vector for PrimitiveVector<T> {
     }
 
     fn to_arrow_array(&self) -> ArrayRef {
-        let data = self.to_array_data();
-        Arc::new(PrimitiveArray::<T::ArrowPrimitive>::from(data))
+        Arc::new(self.array.clone())
     }
 
     fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
-        let data = self.to_array_data();
-        Box::new(PrimitiveArray::<T::ArrowPrimitive>::from(data))
+        Box::new(self.array.clone())
     }
 
     fn validity(&self) -> Validity {
@@ -580,7 +395,12 @@ mod tests {
         Time64NanosecondArray,
     };
     use arrow::datatypes::DataType as ArrowDataType;
-    use arrow_array::{DurationSecondArray, IntervalDayTimeArray, IntervalYearMonthArray};
+    use arrow_array::{
+        DurationMicrosecondArray, DurationMillisecondArray, DurationNanosecondArray,
+        DurationSecondArray, IntervalDayTimeArray, IntervalYearMonthArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray,
+    };
     use serde_json;
 
     use super::*;
@@ -704,6 +524,14 @@ mod tests {
     }
 
     #[test]
+    fn test_get_slice() {
+        let v = Int32Vector::from_slice(vec![1, 2, 3, 4, 5]);
+        let slice = v.get_slice(1, 3);
+        assert_eq!(v, Int32Vector::from_slice(vec![1, 2, 3, 4, 5]));
+        assert_eq!(slice, Int32Vector::from_slice(vec![2, 3, 4]));
+    }
+
+    #[test]
     fn test_primitive_vector_builder() {
         let mut builder = Int64Type::default().create_mutable_vector(3);
         builder.push_value_ref(ValueRef::Int64(123));
@@ -748,48 +576,48 @@ mod tests {
     #[test]
     fn test_try_from_arrow_time_array() {
         let array: ArrayRef = Arc::new(Time32SecondArray::from(vec![1i32, 2, 3]));
-        let vector = TimeSecondVector::try_from_arrow_time_array(array).unwrap();
+        let vector = TimeSecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(TimeSecondVector::from_values(vec![1, 2, 3]), vector);
 
         let array: ArrayRef = Arc::new(Time32MillisecondArray::from(vec![1i32, 2, 3]));
-        let vector = TimeMillisecondVector::try_from_arrow_time_array(array).unwrap();
+        let vector = TimeMillisecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(TimeMillisecondVector::from_values(vec![1, 2, 3]), vector);
 
         let array: ArrayRef = Arc::new(Time64MicrosecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimeMicrosecondVector::try_from_arrow_time_array(array).unwrap();
+        let vector = TimeMicrosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(TimeMicrosecondVector::from_values(vec![1, 2, 3]), vector);
 
         let array: ArrayRef = Arc::new(Time64NanosecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimeNanosecondVector::try_from_arrow_time_array(array).unwrap();
+        let vector = TimeNanosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(TimeNanosecondVector::from_values(vec![1, 2, 3]), vector);
 
         // Test convert error
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1i32, 2, 3]));
-        assert!(TimeSecondVector::try_from_arrow_time_array(array).is_err());
+        assert!(TimeSecondVector::try_from_arrow_array(array).is_err());
     }
 
     #[test]
     fn test_try_from_arrow_timestamp_array() {
         let array: ArrayRef = Arc::new(TimestampSecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimestampSecondVector::try_from_arrow_timestamp_array(array).unwrap();
+        let vector = TimestampSecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(TimestampSecondVector::from_values(vec![1, 2, 3]), vector);
 
         let array: ArrayRef = Arc::new(TimestampMillisecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimestampMillisecondVector::try_from_arrow_timestamp_array(array).unwrap();
+        let vector = TimestampMillisecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             TimestampMillisecondVector::from_values(vec![1, 2, 3]),
             vector
         );
 
         let array: ArrayRef = Arc::new(TimestampMicrosecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimestampMicrosecondVector::try_from_arrow_timestamp_array(array).unwrap();
+        let vector = TimestampMicrosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             TimestampMicrosecondVector::from_values(vec![1, 2, 3]),
             vector
         );
 
         let array: ArrayRef = Arc::new(TimestampNanosecondArray::from(vec![1i64, 2, 3]));
-        let vector = TimestampNanosecondVector::try_from_arrow_timestamp_array(array).unwrap();
+        let vector = TimestampNanosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             TimestampNanosecondVector::from_values(vec![1, 2, 3]),
             vector
@@ -797,27 +625,27 @@ mod tests {
 
         // Test convert error
         let array: ArrayRef = Arc::new(Int32Array::from(vec![1i32, 2, 3]));
-        assert!(TimestampSecondVector::try_from_arrow_timestamp_array(array).is_err());
+        assert!(TimestampSecondVector::try_from_arrow_array(array).is_err());
     }
 
     #[test]
     fn test_try_from_arrow_interval_array() {
         let array: ArrayRef = Arc::new(IntervalYearMonthArray::from(vec![1000, 2000, 3000]));
-        let vector = IntervalYearMonthVector::try_from_arrow_interval_array(array).unwrap();
+        let vector = IntervalYearMonthVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             IntervalYearMonthVector::from_values(vec![1000, 2000, 3000]),
             vector
         );
 
         let array: ArrayRef = Arc::new(IntervalDayTimeArray::from(vec![1000, 2000, 3000]));
-        let vector = IntervalDayTimeVector::try_from_arrow_interval_array(array).unwrap();
+        let vector = IntervalDayTimeVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             IntervalDayTimeVector::from_values(vec![1000, 2000, 3000]),
             vector
         );
 
         let array: ArrayRef = Arc::new(IntervalYearMonthArray::from(vec![1000, 2000, 3000]));
-        let vector = IntervalYearMonthVector::try_from_arrow_interval_array(array).unwrap();
+        let vector = IntervalYearMonthVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             IntervalYearMonthVector::from_values(vec![1000, 2000, 3000]),
             vector
@@ -827,28 +655,28 @@ mod tests {
     #[test]
     fn test_try_from_arrow_duration_array() {
         let array: ArrayRef = Arc::new(DurationSecondArray::from(vec![1000, 2000, 3000]));
-        let vector = DurationSecondVector::try_from_arrow_duration_array(array).unwrap();
+        let vector = DurationSecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             DurationSecondVector::from_values(vec![1000, 2000, 3000]),
             vector
         );
 
         let array: ArrayRef = Arc::new(DurationMillisecondArray::from(vec![1000, 2000, 3000]));
-        let vector = DurationMillisecondVector::try_from_arrow_duration_array(array).unwrap();
+        let vector = DurationMillisecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             DurationMillisecondVector::from_values(vec![1000, 2000, 3000]),
             vector
         );
 
         let array: ArrayRef = Arc::new(DurationMicrosecondArray::from(vec![1000, 2000, 3000]));
-        let vector = DurationMicrosecondVector::try_from_arrow_duration_array(array).unwrap();
+        let vector = DurationMicrosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             DurationMicrosecondVector::from_values(vec![1000, 2000, 3000]),
             vector
         );
 
         let array: ArrayRef = Arc::new(DurationNanosecondArray::from(vec![1000, 2000, 3000]));
-        let vector = DurationNanosecondVector::try_from_arrow_duration_array(array).unwrap();
+        let vector = DurationNanosecondVector::try_from_arrow_array(array).unwrap();
         assert_eq!(
             DurationNanosecondVector::from_values(vec![1000, 2000, 3000]),
             vector

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -134,8 +134,7 @@ impl Vector for StringVector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let data = self.array.slice(offset, length);
-        Arc::new(Self::from(data))
+        Arc::new(Self::from(self.array.slice(offset, length)))
     }
 
     fn get(&self, index: usize) -> Value {

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -15,7 +15,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayBuilder, ArrayData, ArrayIter, ArrayRef};
+use arrow::array::{Array, ArrayBuilder, ArrayIter, ArrayRef};
 use snafu::ResultExt;
 
 use crate::arrow_array::{MutableStringArray, StringArray};
@@ -35,16 +35,6 @@ pub struct StringVector {
 impl StringVector {
     pub(crate) fn as_arrow(&self) -> &dyn Array {
         &self.array
-    }
-
-    fn to_array_data(&self) -> ArrayData {
-        self.array.to_data()
-    }
-
-    fn from_array_data(data: ArrayData) -> Self {
-        Self {
-            array: StringArray::from(data),
-        }
     }
 }
 
@@ -120,13 +110,11 @@ impl Vector for StringVector {
     }
 
     fn to_arrow_array(&self) -> ArrayRef {
-        let data = self.to_array_data();
-        Arc::new(StringArray::from(data))
+        Arc::new(self.array.clone())
     }
 
     fn to_boxed_arrow_array(&self) -> Box<dyn Array> {
-        let data = self.to_array_data();
-        Box::new(StringArray::from(data))
+        Box::new(self.array.clone())
     }
 
     fn validity(&self) -> Validity {
@@ -146,8 +134,8 @@ impl Vector for StringVector {
     }
 
     fn slice(&self, offset: usize, length: usize) -> VectorRef {
-        let data = self.array.to_data().slice(offset, length);
-        Arc::new(Self::from_array_data(data))
+        let data = self.array.slice(offset, length);
+        Arc::new(Self::from(data))
     }
 
     fn get(&self, index: usize) -> Value {
@@ -256,6 +244,7 @@ vectors::impl_try_from_arrow_array_for_vector!(StringArray, StringVector);
 
 #[cfg(test)]
 mod tests {
+
     use arrow::datatypes::DataType;
 
     use super::*;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Performance

- use `array.clone()` instead of `ArrayData`.
- refactor `try_from_arrow_array`
- remove `try_from_arrow_timestamp_array`, `try_from_arrow_duration_array`, `try_from_arrow_interval_array`, The 3 functions above can be replaced by `try_from_arrow_array`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
