### PR TITLE
feat(remote_wal): introduce region meta and integrate it into creating table metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
+ "store-api",
  "substrait 0.4.3",
  "table",
  "temp-env",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -58,6 +58,7 @@ serde_json.workspace = true
 servers.workspace = true
 session.workspace = true
 snafu.workspace = true
+store-api.workspace = true
 substrait.workspace = true
 table.workspace = true
 tokio.workspace = true

--- a/src/cmd/src/cli/bench/metadata.rs
+++ b/src/cmd/src/cli/bench/metadata.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::table_name::TableName;
 
-use super::{bench_self_recorded, create_region_routes, create_table_info};
+use super::{bench_self_recorded, create_region_meta_map, create_region_routes, create_table_info};
 
 pub struct TableMetadataBencher {
     table_metadata_manager: TableMetadataManagerRef,
@@ -44,11 +44,12 @@ impl TableMetadataBencher {
                 let table_name = TableName::new("bench_catalog", "bench_schema", table_name);
                 let table_info = create_table_info(i, table_name);
                 let region_routes = create_region_routes();
+                let region_meta_map = create_region_meta_map(i);
 
                 let start = Instant::now();
 
                 self.table_metadata_manager
-                    .create_table_metadata(table_info, region_routes)
+                    .create_table_metadata(table_info, region_routes, region_meta_map)
                     .await
                     .unwrap();
 

--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -394,6 +394,8 @@ impl MigrateTableMetadata {
         );
         let region_distribution: RegionDistribution =
             value.regions_id_map.clone().into_iter().collect();
+        // TODO(niebayes): Requires properly construct a region_meta_map.
+        let region_metas = Vec::new();
 
         let datanode_table_kvs = region_distribution
             .into_iter()
@@ -405,6 +407,7 @@ impl MigrateTableMetadata {
                     DatanodeTableValue::new(
                         table_id,
                         regions,
+                        region_metas.clone(),
                         RegionInfo {
                             engine: engine.to_string(),
                             region_storage_path: region_storage_path.clone(),

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -266,6 +266,12 @@ pub enum Error {
 
     #[snafu(display("Retry later"))]
     RetryLater { source: BoxedError },
+
+    #[snafu(display("The length of region metas is not identical with that of regions, num_region_metas: {}, num_regions: {}", num_region_metas, num_regions))]
+    RegionMetaLengthMismatched {
+        num_region_metas: usize,
+        num_regions: usize,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -323,6 +329,8 @@ impl ErrorExt for Error {
             RetryLater { source, .. } => source.status_code(),
             InvalidCatalogValue { source, .. } => source.status_code(),
             ConvertAlterTableRequest { source, .. } => source.status_code(),
+
+            RegionMetaLengthMismatched { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/common/meta/src/region_meta.rs
+++ b/src/common/meta/src/region_meta.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::region_meta::wal_meta::RegionWalMeta;
 
 /// Stores a region's unique metadata. Any common metadata or options among regions shall not be stored in the struct.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
 pub struct RegionMeta {
     /// The region's unique wal metadata.
     pub wal_meta: RegionWalMeta,

--- a/src/common/meta/src/region_meta.rs
+++ b/src/common/meta/src/region_meta.rs
@@ -12,31 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
-#![feature(btree_extract_if)]
-#![feature(async_closure)]
+pub mod wal_meta;
 
-pub mod cache_invalidator;
-pub mod datanode_manager;
-pub mod ddl;
-pub mod ddl_manager;
-pub mod distributed_time_constants;
-pub mod error;
-pub mod heartbeat;
-pub mod instruction;
-pub mod key;
-pub mod kv_backend;
-pub mod metrics;
-pub mod peer;
-pub mod range_stream;
-pub mod region_meta;
-pub mod rpc;
-pub mod sequence;
-pub mod state_store;
-pub mod table_name;
-pub mod util;
+use serde::{Deserialize, Serialize};
 
-pub type ClusterId = u64;
-pub type DatanodeId = u64;
+use crate::region_meta::wal_meta::RegionWalMeta;
 
-pub use instruction::RegionIdent;
+/// Stores a region's unique metadata. Any common metadata or options among regions shall not be stored in the struct.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct RegionMeta {
+    /// The region's unique wal metadata.
+    pub wal_meta: RegionWalMeta,
+}

--- a/src/common/meta/src/region_meta/wal_meta.rs
+++ b/src/common/meta/src/region_meta/wal_meta.rs
@@ -1,0 +1,77 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+use store_api::storage::{RegionNumber, TableId};
+
+/// The name of a wal meta key.
+#[derive(Debug)]
+pub enum KeyName {
+    /// Kafka topic.
+    KafkaTopic,
+}
+
+impl Display for KeyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name_str = match self {
+            KeyName::KafkaTopic => "kafka_topic",
+        };
+        f.write_str(name_str)
+    }
+}
+
+/// The key to identify a wal meta.
+pub struct WalMetaKey {
+    table_id: TableId,
+    region_number: RegionNumber,
+    name: KeyName,
+}
+
+impl WalMetaKey {
+    /// Construct a wal meta key with the given table id, region number, and key name.
+    pub fn new(table_id: TableId, region_number: RegionNumber, name: KeyName) -> Self {
+        Self {
+            table_id,
+            region_number,
+            name,
+        }
+    }
+}
+
+impl ToString for WalMetaKey {
+    fn to_string(&self) -> String {
+        format!("{}/{}/{}", self.table_id, self.region_number, self.name)
+    }
+}
+
+/// A region's unique wal metadata.
+// FIXME(niebayes): Shall String or WalMetaKey be used as the key type?
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct RegionWalMeta(HashMap<String, String>);
+
+impl RegionWalMeta {
+    /// Gets the value associated with the given wal meta key.
+    pub fn get(&self, key: &WalMetaKey) -> Option<String> {
+        self.0.get(&key.to_string())
+    }
+
+    /// Inserts a key-value pair with the key represented as a wal meta key while the value a string.
+    /// This insertion always succeeds since the given key-value pair will override the existing one.
+    pub fn insert(&self, key: WalMetaKey, value: String) {
+        self.0.insert(key, value);
+    }
+}

--- a/src/common/meta/src/region_meta/wal_meta.rs
+++ b/src/common/meta/src/region_meta/wal_meta.rs
@@ -35,13 +35,13 @@ impl Display for KeyName {
 }
 
 /// The key to identify a wal meta.
-pub struct WalMetaKey {
+pub struct RegionWalMetaKey {
     table_id: TableId,
     region_number: RegionNumber,
     name: KeyName,
 }
 
-impl WalMetaKey {
+impl RegionWalMetaKey {
     /// Construct a wal meta key with the given table id, region number, and key name.
     pub fn new(table_id: TableId, region_number: RegionNumber, name: KeyName) -> Self {
         Self {
@@ -52,26 +52,33 @@ impl WalMetaKey {
     }
 }
 
-impl ToString for WalMetaKey {
+impl ToString for RegionWalMetaKey {
     fn to_string(&self) -> String {
         format!("{}/{}/{}", self.table_id, self.region_number, self.name)
     }
 }
 
 /// A region's unique wal metadata.
-// FIXME(niebayes): Shall String or WalMetaKey be used as the key type?
-#[derive(Default, Debug, Serialize, Deserialize)]
+// FIXME(niebayes): Shall String or RegionWalMetaKey be used as the key type?
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct RegionWalMeta(HashMap<String, String>);
 
 impl RegionWalMeta {
+    pub fn with_metas<T>(metas: T) -> Self
+    where
+        T: IntoIterator<Item = (String, String)>,
+    {
+        Self(HashMap::from_iter(metas))
+    }
+
     /// Gets the value associated with the given wal meta key.
-    pub fn get(&self, key: &WalMetaKey) -> Option<String> {
+    pub fn get(&self, key: &RegionWalMetaKey) -> Option<&String> {
         self.0.get(&key.to_string())
     }
 
     /// Inserts a key-value pair with the key represented as a wal meta key while the value a string.
     /// This insertion always succeeds since the given key-value pair will override the existing one.
-    pub fn insert(&self, key: WalMetaKey, value: String) {
-        self.0.insert(key, value);
+    pub fn insert(&mut self, key: RegionWalMetaKey, value: String) {
+        self.0.insert(key.to_string(), value);
     }
 }

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -221,7 +221,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -351,7 +351,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/migration_start.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_start.rs
@@ -129,6 +129,7 @@ impl RegionMigrationStart {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -183,7 +184,7 @@ mod tests {
         };
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, vec![region_route])
+            .create_table_metadata(table_info, vec![region_route], HashMap::new())
             .await
             .unwrap();
 
@@ -217,7 +218,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -251,7 +252,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -278,7 +279,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -463,7 +463,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata.rs
@@ -95,6 +95,7 @@ impl UpdateMetadata {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -162,7 +163,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -215,7 +216,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -368,7 +368,7 @@ async fn test_submit_alter_region_requests() {
     let table_info = test_data::new_table_info();
     context
         .table_metadata_manager
-        .create_table_metadata(table_info.clone(), region_routes.clone())
+        .create_table_metadata(table_info.clone(), region_routes.clone(), HashMap::new())
         .await
         .unwrap();
 

--- a/src/meta-srv/src/region/lease_keeper.rs
+++ b/src/meta-srv/src/region/lease_keeper.rs
@@ -241,7 +241,7 @@ impl OpeningRegionKeeper {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use common_meta::key::test_utils::new_test_table_info;
@@ -310,7 +310,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -370,7 +370,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -420,7 +420,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -457,7 +457,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -506,7 +506,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::DateTime;
@@ -143,7 +144,7 @@ pub(crate) async fn prepare_table_region_and_info_value(
         region_route_factory(4, 3),
     ];
     table_metadata_manager
-        .create_table_metadata(table_info, region_routes)
+        .create_table_metadata(table_info, region_routes, HashMap::new())
         .await
         .unwrap();
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Define a `RegionMeta` to store per-region unique metadata. Currently, it stores per-region unique wal metadata which is stored in `RegionWalMeta`.
- Add `RegionMeta` in `DatanodeTableValue` and integrate persisting region metas into creating table metadata.
- Update tests accordingly.

This PR is part of the Kafka Remote Wal project. With this feature, the `TableMetadataAllocator` is able to allocate per-region unique metadata while handling create table requests. The allocated metadata will be persisted during creating table metadata by the procedure manager. On the other hand, a datanode is able to fetch regions' unique metadata during initializing region servers, so that regions can be opened properly.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/2753
https://github.com/GreptimeTeam/greptimedb/pull/2816
