### PR TITLE
refactor: DataType name function

### DIFF
--- a/src/catalog/src/information_schema/columns.rs
+++ b/src/catalog/src/information_schema/columns.rs
@@ -202,7 +202,7 @@ impl InformationSchemaColumnsBuilder {
                         &schema_name,
                         &table_name,
                         &column.name,
-                        column.data_type.name(),
+                        &column.data_type.name(),
                         semantic_type,
                     );
                 }

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -833,6 +833,13 @@ mod tests {
             "List<Dictionary<Int32, String>>"
         );
         assert_eq!(
+            ConcreteDataType::list_datatype(ConcreteDataType::list_datatype(
+                ConcreteDataType::list_datatype(ConcreteDataType::int32_datatype())
+            ))
+            .to_string(),
+            "List<List<List<Int32>>>"
+        );
+        assert_eq!(
             ConcreteDataType::dictionary_datatype(
                 ConcreteDataType::int32_datatype(),
                 ConcreteDataType::string_datatype()

--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -85,31 +85,48 @@ pub enum ConcreteDataType {
 impl fmt::Display for ConcreteDataType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConcreteDataType::Null(_) => write!(f, "Null"),
-            ConcreteDataType::Boolean(_) => write!(f, "Boolean"),
-            ConcreteDataType::Int8(_) => write!(f, "Int8"),
-            ConcreteDataType::Int16(_) => write!(f, "Int16"),
-            ConcreteDataType::Int32(_) => write!(f, "Int32"),
-            ConcreteDataType::Int64(_) => write!(f, "Int64"),
-            ConcreteDataType::UInt8(_) => write!(f, "UInt8"),
-            ConcreteDataType::UInt16(_) => write!(f, "UInt16"),
-            ConcreteDataType::UInt32(_) => write!(f, "UInt32"),
-            ConcreteDataType::UInt64(_) => write!(f, "UInt64"),
-            ConcreteDataType::Float32(_) => write!(f, "Float32"),
-            ConcreteDataType::Float64(_) => write!(f, "Float64"),
-            ConcreteDataType::Binary(_) => write!(f, "Binary"),
-            ConcreteDataType::String(_) => write!(f, "String"),
-            ConcreteDataType::Date(_) => write!(f, "Date"),
-            ConcreteDataType::DateTime(_) => write!(f, "DateTime"),
-            ConcreteDataType::Timestamp(_) => write!(f, "Timestamp"),
-            ConcreteDataType::Time(_) => write!(f, "Time"),
-            ConcreteDataType::List(_) => write!(f, "List"),
-            ConcreteDataType::Dictionary(_) => write!(f, "Dictionary"),
-            ConcreteDataType::Interval(_) => write!(f, "Interval"),
-            ConcreteDataType::Duration(_) => write!(f, "Duration"),
-            ConcreteDataType::Decimal128(d) => {
-                write!(f, "Decimal128({},{})", d.precision(), d.scale())
-            }
+            ConcreteDataType::Null(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Boolean(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Int8(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Int16(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Int32(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Int64(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::UInt8(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::UInt16(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::UInt32(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::UInt64(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Float32(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Float64(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Binary(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::String(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Date(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::DateTime(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Timestamp(t) => match t {
+                TimestampType::Second(v) => write!(f, "{}", v.name()),
+                TimestampType::Millisecond(v) => write!(f, "{}", v.name()),
+                TimestampType::Microsecond(v) => write!(f, "{}", v.name()),
+                TimestampType::Nanosecond(v) => write!(f, "{}", v.name()),
+            },
+            ConcreteDataType::Time(t) => match t {
+                TimeType::Second(v) => write!(f, "{}", v.name()),
+                TimeType::Millisecond(v) => write!(f, "{}", v.name()),
+                TimeType::Microsecond(v) => write!(f, "{}", v.name()),
+                TimeType::Nanosecond(v) => write!(f, "{}", v.name()),
+            },
+            ConcreteDataType::Interval(i) => match i {
+                IntervalType::YearMonth(v) => write!(f, "{}", v.name()),
+                IntervalType::DayTime(v) => write!(f, "{}", v.name()),
+                IntervalType::MonthDayNano(v) => write!(f, "{}", v.name()),
+            },
+            ConcreteDataType::Duration(d) => match d {
+                DurationType::Second(v) => write!(f, "{}", v.name()),
+                DurationType::Millisecond(v) => write!(f, "{}", v.name()),
+                DurationType::Microsecond(v) => write!(f, "{}", v.name()),
+                DurationType::Nanosecond(v) => write!(f, "{}", v.name()),
+            },
+            ConcreteDataType::Decimal128(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::List(v) => write!(f, "{}", v.name()),
+            ConcreteDataType::Dictionary(v) => write!(f, "{}", v.name()),
         }
     }
 }
@@ -492,7 +509,7 @@ impl ConcreteDataType {
 #[enum_dispatch::enum_dispatch]
 pub trait DataType: std::fmt::Debug + Send + Sync {
     /// Name of this data type.
-    fn name(&self) -> &str;
+    fn name(&self) -> String;
 
     /// Returns id of the Logical data type.
     fn logical_type_id(&self) -> LogicalTypeId;
@@ -523,7 +540,7 @@ mod tests {
     fn test_concrete_type_as_datatype_trait() {
         let concrete_type = ConcreteDataType::boolean_datatype();
 
-        assert_eq!("Boolean", concrete_type.name());
+        assert_eq!("Boolean", concrete_type.to_string());
         assert_eq!(Value::Boolean(false), concrete_type.default_value());
         assert_eq!(LogicalTypeId::Boolean, concrete_type.logical_type_id());
         assert_eq!(ArrowDataType::Boolean, concrete_type.as_arrow_type());
@@ -767,94 +784,61 @@ mod tests {
 
     #[test]
     fn test_display_concrete_data_type() {
+        assert_eq!(ConcreteDataType::null_datatype().to_string(), "Null");
+        assert_eq!(ConcreteDataType::boolean_datatype().to_string(), "Boolean");
+        assert_eq!(ConcreteDataType::binary_datatype().to_string(), "Binary");
+        assert_eq!(ConcreteDataType::int8_datatype().to_string(), "Int8");
+        assert_eq!(ConcreteDataType::int16_datatype().to_string(), "Int16");
+        assert_eq!(ConcreteDataType::int32_datatype().to_string(), "Int32");
+        assert_eq!(ConcreteDataType::int64_datatype().to_string(), "Int64");
+        assert_eq!(ConcreteDataType::uint8_datatype().to_string(), "UInt8");
+        assert_eq!(ConcreteDataType::uint16_datatype().to_string(), "UInt16");
+        assert_eq!(ConcreteDataType::uint32_datatype().to_string(), "UInt32");
+        assert_eq!(ConcreteDataType::uint64_datatype().to_string(), "UInt64");
+        assert_eq!(ConcreteDataType::float32_datatype().to_string(), "Float32");
+        assert_eq!(ConcreteDataType::float64_datatype().to_string(), "Float64");
+        assert_eq!(ConcreteDataType::string_datatype().to_string(), "String");
+        assert_eq!(ConcreteDataType::date_datatype().to_string(), "Date");
         assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Null).to_string(),
-            "Null"
+            ConcreteDataType::timestamp_millisecond_datatype().to_string(),
+            "TimestampMillisecond"
         );
         assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Boolean).to_string(),
-            "Boolean"
+            ConcreteDataType::time_millisecond_datatype().to_string(),
+            "TimeMillisecond"
         );
         assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Binary).to_string(),
-            "Binary"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::LargeBinary).to_string(),
-            "Binary"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Int8).to_string(),
-            "Int8"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Int16).to_string(),
-            "Int16"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Int32).to_string(),
-            "Int32"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Int64).to_string(),
-            "Int64"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::UInt8).to_string(),
-            "UInt8"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::UInt16).to_string(),
-            "UInt16"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::UInt32).to_string(),
-            "UInt32"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::UInt64).to_string(),
-            "UInt64"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Float32).to_string(),
-            "Float32"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Float64).to_string(),
-            "Float64"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Utf8).to_string(),
-            "String"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::List(Arc::new(Field::new(
-                "item",
-                ArrowDataType::Int32,
-                true,
-            ))))
-            .to_string(),
-            "List"
-        );
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Date32).to_string(),
-            "Date"
-        );
-        assert_eq!(ConcreteDataType::time_second_datatype().to_string(), "Time");
-        assert_eq!(
-            ConcreteDataType::from_arrow_type(&ArrowDataType::Interval(
-                arrow_schema::IntervalUnit::MonthDayNano,
-            ))
-            .to_string(),
-            "Interval"
+            ConcreteDataType::interval_month_day_nano_datatype().to_string(),
+            "IntervalMonthDayNano"
         );
         assert_eq!(
             ConcreteDataType::duration_second_datatype().to_string(),
-            "Duration"
+            "DurationSecond"
         );
         assert_eq!(
             ConcreteDataType::decimal128_datatype(10, 2).to_string(),
-            "Decimal128(10,2)"
+            "Decimal(10, 2)"
+        );
+        // Nested types
+        assert_eq!(
+            ConcreteDataType::list_datatype(ConcreteDataType::int32_datatype()).to_string(),
+            "List<Int32>"
+        );
+        assert_eq!(
+            ConcreteDataType::list_datatype(ConcreteDataType::Dictionary(DictionaryType::new(
+                ConcreteDataType::int32_datatype(),
+                ConcreteDataType::string_datatype()
+            )))
+            .to_string(),
+            "List<Dictionary<Int32, String>>"
+        );
+        assert_eq!(
+            ConcreteDataType::dictionary_datatype(
+                ConcreteDataType::int32_datatype(),
+                ConcreteDataType::string_datatype()
+            )
+            .to_string(),
+            "Dictionary<Int32, String>"
         );
     }
 }

--- a/src/datatypes/src/types/binary_type.rs
+++ b/src/datatypes/src/types/binary_type.rs
@@ -34,8 +34,8 @@ impl BinaryType {
 }
 
 impl DataType for BinaryType {
-    fn name(&self) -> &str {
-        "Binary"
+    fn name(&self) -> String {
+        "Binary".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/boolean_type.rs
+++ b/src/datatypes/src/types/boolean_type.rs
@@ -34,8 +34,8 @@ impl BooleanType {
 }
 
 impl DataType for BooleanType {
-    fn name(&self) -> &str {
-        "Boolean"
+    fn name(&self) -> String {
+        "Boolean".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/cast.rs
+++ b/src/datatypes/src/types/cast.rs
@@ -248,7 +248,7 @@ mod tests {
         assert!(res.is_err());
         assert_eq!(
             res.unwrap_err().to_string(),
-            "Type Timestamp with value 1970-01-01 08:00:10+0800 can't be cast to the destination type Int8"
+            "Type TimestampSecond with value 1970-01-01 08:00:10+0800 can't be cast to the destination type Int8"
         );
     }
 

--- a/src/datatypes/src/types/date_type.rs
+++ b/src/datatypes/src/types/date_type.rs
@@ -32,8 +32,8 @@ use crate::vectors::{DateVector, DateVectorBuilder, MutableVector, Vector};
 pub struct DateType;
 
 impl DataType for DateType {
-    fn name(&self) -> &str {
-        "Date"
+    fn name(&self) -> String {
+        "Date".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/datetime_type.rs
+++ b/src/datatypes/src/types/datetime_type.rs
@@ -30,8 +30,8 @@ use crate::vectors::{DateTimeVector, DateTimeVectorBuilder, PrimitiveVector};
 pub struct DateTimeType;
 
 impl DataType for DateTimeType {
-    fn name(&self) -> &str {
-        "DateTime"
+    fn name(&self) -> String {
+        "DateTime".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/decimal_type.rs
+++ b/src/datatypes/src/types/decimal_type.rs
@@ -56,9 +56,8 @@ impl Decimal128Type {
 }
 
 impl DataType for Decimal128Type {
-    fn name(&self) -> &str {
-        // TODO(QuenKar): support precision and scale information in name
-        "decimal"
+    fn name(&self) -> String {
+        format!("Decimal({}, {})", self.precision, self.scale)
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/dictionary_type.rs
+++ b/src/datatypes/src/types/dictionary_type.rs
@@ -62,8 +62,12 @@ impl DictionaryType {
 }
 
 impl DataType for DictionaryType {
-    fn name(&self) -> &str {
-        "Dictionary"
+    fn name(&self) -> String {
+        format!(
+            "Dictionary<{}, {}>",
+            self.key_type.name(),
+            self.value_type.name()
+        )
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/duration_type.rs
+++ b/src/datatypes/src/types/duration_type.rs
@@ -78,8 +78,8 @@ macro_rules! impl_data_type_for_duration {
             pub struct [<Duration $unit Type>];
 
             impl DataType for [<Duration $unit Type>] {
-                fn name(&self) -> &str {
-                    stringify!([<Duration $unit>])
+                fn name(&self) -> String {
+                    stringify!([<Duration $unit>]).to_string()
                 }
 
                 fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/interval_type.rs
+++ b/src/datatypes/src/types/interval_type.rs
@@ -66,8 +66,8 @@ macro_rules! impl_data_type_for_interval {
             pub struct [<Interval $unit Type>];
 
             impl DataType for [<Interval $unit Type>] {
-                fn name(&self) -> &str {
-                    stringify!([<Interval $unit>])
+                fn name(&self) -> String {
+                    stringify!([<Interval $unit>]).to_string()
                 }
 
                 fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/list_type.rs
+++ b/src/datatypes/src/types/list_type.rs
@@ -52,8 +52,8 @@ impl ListType {
 }
 
 impl DataType for ListType {
-    fn name(&self) -> &str {
-        "List"
+    fn name(&self) -> String {
+        format!("List<{}>", self.item_type.name())
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn test_list_type() {
         let t = ListType::new(ConcreteDataType::boolean_datatype());
-        assert_eq!("List", t.name());
+        assert_eq!("List<Boolean>", t.name());
         assert_eq!(LogicalTypeId::List, t.logical_type_id());
         assert_eq!(
             Value::List(ListValue::new(None, ConcreteDataType::boolean_datatype())),

--- a/src/datatypes/src/types/null_type.rs
+++ b/src/datatypes/src/types/null_type.rs
@@ -32,8 +32,8 @@ impl NullType {
 }
 
 impl DataType for NullType {
-    fn name(&self) -> &str {
-        "Null"
+    fn name(&self) -> String {
+        "Null".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/primitive_type.rs
+++ b/src/datatypes/src/types/primitive_type.rs
@@ -251,8 +251,8 @@ macro_rules! define_non_timestamp_primitive {
         define_logical_primitive_type!($Native, $TypeId, $DataType, $Largest);
 
         impl DataType for $DataType {
-            fn name(&self) -> &str {
-                stringify!($TypeId)
+            fn name(&self) -> String {
+                stringify!($TypeId).to_string()
             }
 
             fn logical_type_id(&self) -> LogicalTypeId {
@@ -350,8 +350,8 @@ define_logical_primitive_type!(i64, Int64, Int64Type, Int64Type);
 define_logical_primitive_type!(i32, Int32, Int32Type, Int64Type);
 
 impl DataType for Int64Type {
-    fn name(&self) -> &str {
-        "Int64"
+    fn name(&self) -> String {
+        "Int64".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {
@@ -397,8 +397,8 @@ impl DataType for Int64Type {
 }
 
 impl DataType for Int32Type {
-    fn name(&self) -> &str {
-        "Int32"
+    fn name(&self) -> String {
+        "Int32".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/string_type.rs
+++ b/src/datatypes/src/types/string_type.rs
@@ -34,8 +34,8 @@ impl StringType {
 }
 
 impl DataType for StringType {
-    fn name(&self) -> &str {
-        "String"
+    fn name(&self) -> String {
+        "String".to_string()
     }
 
     fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/time_type.rs
+++ b/src/datatypes/src/types/time_type.rs
@@ -92,8 +92,8 @@ macro_rules! impl_data_type_for_time {
             pub struct [<Time $unit Type>];
 
             impl DataType for [<Time $unit Type>] {
-                fn name(&self) -> &str {
-                    stringify!([<Time $unit>])
+                fn name(&self) -> String {
+                    stringify!([<Time $unit>]).to_string()
                 }
 
                 fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/datatypes/src/types/timestamp_type.rs
+++ b/src/datatypes/src/types/timestamp_type.rs
@@ -109,8 +109,8 @@ macro_rules! impl_data_type_for_timestamp {
             pub struct [<Timestamp $unit Type>];
 
             impl DataType for [<Timestamp $unit Type>] {
-                fn name(&self) -> &str {
-                    stringify!([<Timestamp $unit>])
+                fn name(&self) -> String {
+                    stringify!([<Timestamp $unit>]).to_string()
                 }
 
                 fn logical_type_id(&self) -> LogicalTypeId {

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -286,8 +286,11 @@ fn describe_column_names(columns_schemas: &[ColumnSchema]) -> VectorRef {
 }
 
 fn describe_column_types(columns_schemas: &[ColumnSchema]) -> VectorRef {
-    Arc::new(StringVector::from_iterator(
-        columns_schemas.iter().map(|cs| cs.data_type.name()),
+    Arc::new(StringVector::from(
+        columns_schemas
+            .iter()
+            .map(|cs| cs.data_type.name())
+            .collect::<Vec<_>>(),
     ))
 }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -207,7 +207,7 @@ impl TryFrom<Vec<RecordBatch>> for HttpRecordsOutput {
                     .iter()
                     .map(|cs| ColumnSchema {
                         name: cs.name.clone(),
-                        data_type: cs.data_type.name().to_owned(),
+                        data_type: cs.data_type.name(),
                     })
                     .collect(),
             };

--- a/src/store-api/src/metadata.rs
+++ b/src/store-api/src/metadata.rs
@@ -1141,6 +1141,6 @@ mod test {
     fn test_debug_for_column_metadata() {
         let region_metadata = build_test_region_metadata();
         let formatted = format!("{:?}", region_metadata);
-        assert_eq!(formatted, "RegionMetadata { column_metadatas: [[a Int64 not null Tag 1], [b Float64 not null Field 2], [c Timestamp not null Timestamp 3]], time_index: 3, primary_key: [1], region_id: 5299989648942(1234, 5678), schema_version: 0 }");
+        assert_eq!(formatted, "RegionMetadata { column_metadatas: [[a Int64 not null Tag 1], [b Float64 not null Field 2], [c TimestampMillisecond not null Timestamp 3]], time_index: 3, primary_key: [1], region_id: 5299989648942(1234, 5678), schema_version: 0 }");
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

refactor the `name` function return type from `&str` to `String`, 
and we can print `decimal(10, 6)` or some nested type info such as `List<Int64>`, `List<Dictionary<Int32, String>>` etc.

```sql
create table test(
    val decimal(10,6),
    ts timestamp time index,
);

describe table test;
+--------+----------------------+------+------+---------+---------------+
| Column | Type                 | Key  | Null | Default | Semantic Type |
+--------+----------------------+------+------+---------+---------------+
| val    | Decimal(10, 6)       |      | YES  |         | FIELD         |
| ts     | TimestampMillisecond | PRI  | NO   |         | TIMESTAMP     |
+--------+----------------------+------+------+---------+---------------+
```


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
