### PR TITLE
feat: add  arg to standalone start command

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -101,7 +101,7 @@ struct StartCommand {
     #[clap(long, default_value = "GREPTIMEDB_METASRV")]
     env_prefix: String,
     /// The working home directory of this metasrv instance.
-    #[clap(short('d'), long)]
+    #[clap(long)]
     data_home: Option<String>,
 }
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -100,6 +100,9 @@ struct StartCommand {
     http_timeout: Option<u64>,
     #[clap(long, default_value = "GREPTIMEDB_METASRV")]
     env_prefix: String,
+    /// The working home directory of this metasrv instance.
+    #[clap(short('d'), long)]
+    data_home: Option<String>,
 }
 
 impl StartCommand {
@@ -150,6 +153,10 @@ impl StartCommand {
 
         if let Some(http_timeout) = self.http_timeout {
             opts.http.timeout = Duration::from_secs(http_timeout);
+        }
+
+        if let Some(data_home) = &self.data_home {
+            opts.data_home = data_home.clone();
         }
 
         // Disable dashboard in metasrv.

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -227,6 +227,9 @@ struct StartCommand {
     user_provider: Option<String>,
     #[clap(long, default_value = "GREPTIMEDB_STANDALONE")]
     env_prefix: String,
+    /// The working home directory of this standalone instance.
+    #[clap(short('d'), long)]
+    data_home: Option<String>,
 }
 
 impl StartCommand {
@@ -255,6 +258,10 @@ impl StartCommand {
 
         if let Some(addr) = &self.http_addr {
             opts.http.addr = addr.clone()
+        }
+
+        if let Some(data_home) = &self.data_home {
+            opts.storage.data_home = data_home.clone();
         }
 
         if let Some(addr) = &self.rpc_addr {

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -228,7 +228,7 @@ struct StartCommand {
     #[clap(long, default_value = "GREPTIMEDB_STANDALONE")]
     env_prefix: String,
     /// The working home directory of this standalone instance.
-    #[clap(short('d'), long)]
+    #[clap(long)]
     data_home: Option<String>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Add `--data-home` / `-d` arg to `greptime [standalone|metasrv] start` command. One can change the standalone, datanode and metasrv instance's working directory from command line from now on.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
