### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -1160,7 +1160,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arc-swap",
@@ -1429,7 +1429,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1462,7 +1462,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1540,7 +1540,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1573,7 +1573,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "chrono",
  "common-error",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1639,7 +1639,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arc-swap",
  "chrono-tz 0.6.3",
@@ -1684,7 +1684,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -1752,7 +1752,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-recursion",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "once_cell",
  "rand",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "build-data",
 ]
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2640,7 +2640,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "tokio",
  "tokio-stream",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arc-swap",
@@ -3272,7 +3272,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "store-api",
  "strfmt",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "tokio",
  "toml 0.7.8",
@@ -3910,7 +3910,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "common-base",
@@ -4365,7 +4365,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4635,7 +4635,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -4665,7 +4665,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anymap",
  "api",
@@ -4743,7 +4743,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anymap",
  "api",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5519,7 +5519,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-compat",
@@ -5564,7 +5564,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=0fbae07d0c46dc18e3381c406d8b9b8abef6b1fd)",
  "store-api",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "auth",
  "common-base",
@@ -6349,7 +6349,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -6727,7 +6727,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "tokio",
  "tokio-stream",
@@ -7928,7 +7928,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arc-swap",
@@ -8188,7 +8188,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "aide",
  "api",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "arc-swap",
@@ -8543,7 +8543,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "common-base",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-trait",
  "clap 4.4.8",
@@ -8801,7 +8801,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "aquamarine",
@@ -8940,7 +8940,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9088,7 +9088,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9194,7 +9194,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "api",
  "async-trait",
@@ -9250,7 +9250,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.4.3",
+ "substrait 0.4.4",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump version to 0.4.4

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
