### PR TITLE
feat(remote_wal): refactor LogStore APIs and introduce kafka log store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1603,6 +1603,7 @@ version = "0.4.3"
 dependencies = [
  "common-base",
  "humantime-serde",
+ "rskafka",
  "serde",
 ]
 
@@ -2126,6 +2127,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32c"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "crc32fast"
@@ -4011,6 +4021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "integer-encoding"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
+
+[[package]]
 name = "inventory"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4379,12 +4395,16 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-test-util",
+ "dashmap",
  "futures",
  "futures-util",
  "protobuf",
  "protobuf-build",
  "raft-engine",
  "rand",
+ "rskafka",
+ "serde",
+ "serde_json",
  "snafu",
  "store-api",
  "tokio",
@@ -7258,6 +7278,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rskafka"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132ecfa3cd9c3825208524a80881f115337762904ad3f0174e87975b2d79162c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "flate2",
+ "futures",
+ "integer-encoding 4.0.0",
+ "lz4",
+ "parking_lot 0.12.1",
+ "pin-project-lite",
+ "rand",
+ "snap",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "zstd 0.12.4",
+]
+
+[[package]]
 name = "rstest"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9328,7 +9372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
- "integer-encoding",
+ "integer-encoding 3.0.4",
  "ordered-float 2.10.1",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ base64 = "0.21"
 bigdecimal = "0.4.2"
 bitflags = "2.4.1"
 chrono = { version = "0.4", features = ["serde"] }
+dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
@@ -112,6 +113,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "rustls-tls-native-roots",
     "stream",
 ] }
+rskafka = "0.5.0"
 rust_decimal = "1.33"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -29,8 +29,16 @@ connect_timeout = "1s"
 # `TCP_NODELAY` option for accepted connections, true by default.
 tcp_nodelay = true
 
-# WAL options, see `standalone.example.toml`.
+
+# WAL options.
 [wal]
+# Available wal providers:
+# - "RaftEngine" (default)
+# - "Kafka"
+provider = "Kafka"
+
+# Raft engine wal options, see `standalone.example.toml`.
+[wal.raft_engine_opts]
 # WAL data directory
 # dir = "/tmp/greptimedb/wal"
 file_size = "256MB"
@@ -38,6 +46,31 @@ purge_threshold = "4GB"
 purge_interval = "10m"
 read_batch_size = 128
 sync_write = false
+
+# Kafka wal options.
+[wal.kafka_opts]
+# The broker endpoints of the Kafka cluster. ["127.0.0.1:9090"] by default.
+broker_endpoints = ["127.0.0.1:9090"]
+# Number of topics shall be created beforehand.
+num_topics = 64
+# Topic name prefix.
+topic_name_prefix = "greptime_topic"
+# Number of partitions per topic.
+num_partitions = 1
+# The compression algorithm used to compress log entries.
+# Available compression algorithms:
+# - NoCompression (default)
+# - Gzip
+# - Lz4
+# - Snappy
+# - Zstd
+compression = "Lz4"
+# The maximum log size an rskafka batch producer could buffer.
+max_batch_size = "4MB"
+# The linger duration of an rskafka batch producer.
+linger = "200ms"
+# The maximum amount of time (in milliseconds) to wait for Kafka records to be returned.
+max_wait_time = "100ms"
 
 # Storage options, see `standalone.example.toml`.
 [storage]

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -7,4 +7,5 @@ license.workspace = true
 [dependencies]
 common-base.workspace = true
 humantime-serde.workspace = true
+rskafka.workspace = true
 serde.workspace = true

--- a/src/common/config/src/lib.rs
+++ b/src/common/config/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod wal;
+
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;

--- a/src/common/config/src/wal.rs
+++ b/src/common/config/src/wal.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod kafka;
+pub mod raft_engine;
+
+use serde::{Deserialize, Serialize};
+
+use crate::wal::kafka::KafkaOptions;
+use crate::wal::raft_engine::RaftEngineOptions;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum WalProvider {
+    RaftEngine,
+    Kafka,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct WalOptions {
+    pub provider: WalProvider,
+    pub raft_engine_opts: Option<RaftEngineOptions>,
+    pub kafka_opts: Option<KafkaOptions>,
+}
+
+impl Default for WalOptions {
+    fn default() -> Self {
+        Self {
+            provider: WalProvider::RaftEngine,
+            raft_engine_opts: Some(RaftEngineOptions::default()),
+            kafka_opts: None,
+        }
+    }
+}

--- a/src/common/config/src/wal/kafka.rs
+++ b/src/common/config/src/wal/kafka.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use common_base::readable_size::ReadableSize;
+use rskafka::client::partition::Compression as RsKafkaCompression;
+use serde::{Deserialize, Serialize};
+
+pub type KafkaTopic = String;
+pub const TOPIC_NAME_PREFIX: &str = "greptime_topic";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Compression {
+    NoCompression,
+    Gzip,
+    Lz4,
+    Snappy,
+    Zstd,
+}
+
+impl From<Compression> for RsKafkaCompression {
+    fn from(compression: Compression) -> Self {
+        match compression {
+            Compression::NoCompression => RsKafkaCompression::NoCompression,
+            Compression::Gzip => RsKafkaCompression::Gzip,
+            Compression::Lz4 => RsKafkaCompression::Lz4,
+            Compression::Snappy => RsKafkaCompression::Snappy,
+            Compression::Zstd => RsKafkaCompression::Zstd,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct KafkaOptions {
+    /// The broker endpoints of the Kafka cluster.
+    pub broker_endpoints: Vec<String>,
+    /// Number of topics shall be created beforehand.
+    pub num_topics: usize,
+    /// Topic name prefix.
+    pub topic_name_prefix: String,
+    /// Number of partitions per topic.
+    pub num_partitions: i32,
+    /// The compression algorithm used to compress log entries.
+    pub compression: Compression,
+    /// The maximum log size an rskakfa batch producer could buffer.
+    pub max_batch_size: ReadableSize,
+    /// The linger duration of an rskafka batch producer.
+    #[serde(with = "humantime_serde")]
+    pub linger: Duration,
+    /// The maximum amount of time (in milliseconds) to wait for Kafka records to be returned.
+    #[serde(with = "humantime_serde")]
+    pub max_wait_time: Duration,
+}
+
+impl Default for KafkaOptions {
+    fn default() -> Self {
+        Self {
+            broker_endpoints: vec!["127.0.0.1:9090".to_string()],
+            num_topics: 64,
+            topic_name_prefix: TOPIC_NAME_PREFIX.to_string(),
+            num_partitions: 1,
+            compression: Compression::NoCompression,
+            max_batch_size: ReadableSize::mb(4),       // 4MB.
+            linger: Duration::from_millis(200),        // 200ms.
+            max_wait_time: Duration::from_millis(100), // 100ms.
+        }
+    }
+}
+
+// TODO(niebayes): Add tests on serializing and deserializing kafka options.

--- a/src/common/config/src/wal/kafka.rs
+++ b/src/common/config/src/wal/kafka.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 
 pub type KafkaTopic = String;
 pub const TOPIC_NAME_PREFIX: &str = "greptime_topic";
+pub const TOPIC_KEY: &str = "kafka_topic";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Compression {

--- a/src/common/config/src/wal/raft_engine.rs
+++ b/src/common/config/src/wal/raft_engine.rs
@@ -1,0 +1,19 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use serde::{Deserialize, Serialize};
+
+// TODO(niebayes): Migrate `WalConfig` to `RaftEngineOptions`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct RaftEngineOptions {}

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -21,10 +21,14 @@ common-macro.workspace = true
 common-meta.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true
+dashmap.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }
 raft-engine.workspace = true
+rskafka.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 snafu.workspace = true
 store-api.workspace = true
 tokio-util.workspace = true

--- a/src/log-store/src/kafka.rs
+++ b/src/log-store/src/kafka.rs
@@ -1,0 +1,153 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod log_store;
+mod topic_client_manager;
+use std::collections::BTreeMap;
+
+use common_config::wal::kafka::KafkaTopic as Topic;
+use rskafka::record::Record;
+use serde::{Deserialize, Serialize};
+use snafu::{OptionExt, ResultExt};
+use store_api::logstore::entry::{Entry, Id as EntryId};
+use store_api::logstore::namespace::Namespace;
+
+use crate::error::{
+    DeserEntryMetaSnafu, Error, MissingEntryMetaSnafu, MissingRecordValueSnafu, Result,
+    SerEntryMetaSnafu,
+};
+
+const ENTRY_META_KEY: &str = "entry_meta";
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct NamespaceImpl {
+    region_id: u64,
+    topic: Topic,
+}
+
+impl NamespaceImpl {
+    fn new(region_id: u64, topic: Topic) -> Self {
+        Self { region_id, topic }
+    }
+
+    fn region_id(&self) -> u64 {
+        self.region_id
+    }
+
+    fn topic(&self) -> &Topic {
+        &self.topic
+    }
+}
+
+impl Namespace for NamespaceImpl {
+    fn id(&self) -> u64 {
+        self.region_id
+    }
+}
+
+pub struct EntryImpl {
+    /// Entry payload.
+    data: Vec<u8>,
+    /// The logical entry id.
+    id: EntryId,
+    /// The namespace used to identify and isolate log entries from different regions.
+    ns: NamespaceImpl,
+}
+
+impl EntryImpl {
+    fn new(data: Vec<u8>, entry_id: EntryId, ns: NamespaceImpl) -> Self {
+        Self {
+            data,
+            id: entry_id,
+            ns,
+        }
+    }
+}
+
+impl Entry for EntryImpl {
+    type Error = Error;
+    type Namespace = NamespaceImpl;
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn id(&self) -> EntryId {
+        self.id
+    }
+
+    fn namespace(&self) -> Self::Namespace {
+        self.ns.clone()
+    }
+}
+
+/// The `EntryMeta` is used to group entry metadata during serialization and deserialization.
+#[derive(Serialize, Deserialize)]
+struct EntryMeta {
+    entry_id: EntryId,
+    region_id: u64,
+    topic: String,
+}
+
+impl TryInto<Record> for EntryImpl {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Record> {
+        let entry_meta = EntryMeta {
+            entry_id: self.id,
+            region_id: self.ns.region_id(),
+            topic: self.ns.topic,
+        };
+        let raw_entry_meta = serde_json::to_vec(&entry_meta).context(SerEntryMetaSnafu)?;
+
+        Ok(Record {
+            key: None,
+            value: Some(self.data),
+            headers: BTreeMap::from([(ENTRY_META_KEY.to_string(), raw_entry_meta)]),
+            timestamp: rskafka::chrono::Utc::now(),
+        })
+    }
+}
+
+impl TryFrom<Record> for EntryImpl {
+    type Error = Error;
+
+    fn try_from(record: Record) -> Result<Self> {
+        let value = record.value.as_ref().context(MissingRecordValueSnafu {
+            record: record.clone(),
+        })?;
+
+        let raw_entry_meta = record
+            .headers
+            .get(ENTRY_META_KEY)
+            .context(MissingEntryMetaSnafu {
+                record: record.clone(),
+            })?;
+        let entry_meta = serde_json::from_slice(raw_entry_meta).context(DeserEntryMetaSnafu {
+            record: record.clone(),
+        })?;
+
+        let EntryMeta {
+            entry_id,
+            region_id,
+            topic,
+        } = entry_meta;
+
+        Ok(Self {
+            data: value.clone(),
+            id: entry_id,
+            ns: NamespaceImpl::new(region_id, topic),
+        })
+    }
+}

--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -1,0 +1,300 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_config::wal::kafka::{KafkaOptions, KafkaTopic as Topic, TOPIC_KEY};
+use futures_util::StreamExt;
+use rskafka::client::consumer::{StartOffset, StreamConsumerBuilder};
+use rskafka::client::error::Error as RsKafkaError;
+use rskafka::record::{Record, RecordAndOffset};
+use snafu::{OptionExt, ResultExt};
+use store_api::logstore::entry::{Id as EntryId, Offset as EntryOffset};
+use store_api::logstore::entry_stream::SendableEntryStream;
+use store_api::logstore::namespace::Id as NamespaceId;
+use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore, RegionWalOptions};
+
+use crate::error::{
+    ConvertEntryIdToOffsetSnafu, ConvertRsKafkaOffsetToEntryOffsetSnafu, EmptyKafkaOffsetsSnafu,
+    Error, GetKafkaTopicClientSnafu, MissingEntryOffsetSnafu, MissingKafkaTopicSnafu,
+    ReadRecordFromKafkaSnafu, Result, WriteEntriesToKafkaSnafu,
+};
+use crate::kafka::topic_client_manager::{TopicClientManager, TopicClientManagerRef};
+use crate::kafka::{EntryImpl, NamespaceImpl};
+
+#[derive(Debug)]
+pub struct KafkaLogStore {
+    opts: KafkaOptions,
+    topic_client_manager: TopicClientManagerRef,
+}
+
+impl KafkaLogStore {
+    pub async fn try_new(kafka_opts: &KafkaOptions) -> Result<Self> {
+        Ok(Self {
+            opts: kafka_opts.clone(),
+            topic_client_manager: Arc::new(TopicClientManager::try_new(kafka_opts).await?),
+        })
+    }
+
+    /// Appends a batch of entries to the topic and returns the minimum start offsets of those entries grouped by region ids.
+    async fn append_batch_to_topic(
+        &self,
+        entries: Vec<EntryImpl>,
+        topic: Topic,
+    ) -> Result<AppendBatchResponse> {
+        // Safety: the caller ensures the input entries is not empty.
+        assert!(!entries.is_empty());
+
+        let region_ids = entries
+            .iter()
+            .map(|entry| entry.ns.region_id)
+            .collect::<Vec<_>>();
+
+        let topic_client = self
+            .topic_client_manager
+            .get_or_insert(&topic)
+            .await
+            .map_err(|_| GetKafkaTopicClientSnafu { topic: &topic }.build())?;
+        let producer = &topic_client.producer;
+
+        let produce_tasks = try_into_records(entries)?
+            .into_iter()
+            .map(|record| producer.produce(record))
+            .collect::<Vec<_>>();
+        let offsets = futures::future::try_join_all(produce_tasks)
+            .await
+            .context(WriteEntriesToKafkaSnafu { topic })?;
+
+        let min_offset = offsets.into_iter().min().context(EmptyKafkaOffsetsSnafu)?;
+        let min_offset: EntryOffset =
+            min_offset
+                .try_into()
+                .context(ConvertRsKafkaOffsetToEntryOffsetSnafu {
+                    rskafka_offset: min_offset,
+                })?;
+
+        // All regions belonging to a topic share the same entry offset
+        // since that offset is the known minimum start offset for those regions.
+        let num_region_ids = region_ids.len();
+        let region_offset_map = region_ids
+            .into_iter()
+            .zip(vec![min_offset; num_region_ids])
+            .collect();
+
+        Ok(AppendBatchResponse {
+            offsets: region_offset_map,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl LogStore for KafkaLogStore {
+    type Error = Error;
+    type Entry = EntryImpl;
+    type Namespace = NamespaceImpl;
+
+    /// Create an entry of the associate Entry type.
+    fn entry<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        entry_id: EntryId,
+        ns: Self::Namespace,
+    ) -> Self::Entry {
+        EntryImpl::new(data.as_ref().to_vec(), entry_id, ns)
+    }
+
+    /// Append an `Entry` to WAL with given namespace and return append response containing
+    /// the entry id.
+    async fn append(&self, entry: Self::Entry) -> Result<AppendResponse> {
+        let entry_id = entry.id;
+        let region_id = entry.ns.region_id();
+        let topic = entry.ns.topic.clone();
+
+        let response = self
+            .append_batch_to_topic(vec![entry], topic.clone())
+            .await?;
+        let offset = response
+            .offsets
+            .get(&region_id)
+            .context(MissingEntryOffsetSnafu {
+                entry_id,
+                region_id,
+                topic,
+            })?;
+
+        Ok(AppendResponse {
+            entry_id,
+            offset: Some(*offset),
+        })
+    }
+
+    /// For a batch of log entries belonging to multiple regions, each assigned to a specific topic,
+    /// we need to determine the minimum log offset returned for each region in this batch.
+    /// During replay, we use this offset to fetch log entries for a region from its assigned topic.
+    /// After fetching, we filter the entries to obtain log entries relevant to that specific region.
+    async fn append_batch(&self, entries: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
+        if entries.is_empty() {
+            return Ok(AppendBatchResponse::default());
+        }
+
+        // Groups entries by topic.
+        let mut topic_entries: HashMap<String, Vec<_>> = HashMap::new();
+        for entry in entries {
+            topic_entries
+                .entry(entry.ns.topic().clone())
+                .or_default()
+                .push(entry)
+        }
+
+        // Appends each group of entries to the corresponding topic.
+        let append_tasks = topic_entries
+            .into_iter()
+            .map(|(topic, entries)| self.append_batch_to_topic(entries, topic))
+            .collect::<Vec<_>>();
+        let responses = futures::future::try_join_all(append_tasks).await?;
+
+        // Each append task appends a batch of entries to a specific topic. Since each region is assigned only a single topic,
+        // the returned `response.offsets` of different tasks are guaranteed to not have any overlapping. Therefore, a simple `extend` operation
+        // is enough to find the known minimum start offset of the appended entries for each region.
+        let mut region_offset_map = HashMap::new();
+        for response in responses {
+            region_offset_map.extend(response.offsets);
+        }
+
+        Ok(AppendBatchResponse {
+            offsets: region_offset_map,
+        })
+    }
+
+    /// Create a new `EntryStream` to asynchronously generates `Entry` with ids
+    /// starting from `id`. The generated entries will be filtered by the namespace.
+    async fn read(
+        &self,
+        ns: &Self::Namespace,
+        entry_id: EntryId,
+    ) -> Result<SendableEntryStream<Self::Entry, Self::Error>> {
+        let topic = ns.topic().clone();
+        let region_id = ns.region_id();
+        let offset = try_into_offset(entry_id)?;
+
+        let raw_client = self
+            .topic_client_manager
+            .get_or_insert(&topic)
+            .await?
+            .raw_client
+            .clone();
+        let mut stream_consumer = StreamConsumerBuilder::new(raw_client, StartOffset::At(offset))
+            .with_max_batch_size(self.opts.max_batch_size.as_bytes() as i32)
+            .with_max_wait_ms(self.opts.max_wait_time.as_millis() as i32)
+            .build();
+
+        // TODO(niebayes): May also need a buffering mechanism on fetching entries since the mapping between
+        // entries and records is one-one currently.
+        let stream = async_stream::stream!({
+            while let Some(fetch_result) = stream_consumer.next().await {
+                yield handle_fetch_result(fetch_result, &topic, region_id, offset);
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+
+    /// Create a namespace of the associate Namespace type
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        region_wal_options: &RegionWalOptions,
+    ) -> Result<Self::Namespace> {
+        let region_id = ns_id;
+        let topic = region_wal_options
+            .get(TOPIC_KEY)
+            .context(MissingKafkaTopicSnafu {
+                ns_id,
+                region_wal_options: region_wal_options.clone(),
+            })?;
+        Ok(NamespaceImpl::new(region_id, topic.clone()))
+    }
+
+    /// Create a new `Namespace`.
+    async fn create_namespace(&self, _ns: &Self::Namespace) -> Result<()> {
+        Ok(())
+    }
+
+    /// Delete an existing `Namespace` with given ref.
+    async fn delete_namespace(&self, _ns: &Self::Namespace) -> Result<()> {
+        Ok(())
+    }
+
+    /// List all existing namespaces.
+    async fn list_namespaces(&self) -> Result<Vec<Self::Namespace>> {
+        Ok(vec![])
+    }
+
+    /// Mark all entry ids `<=id` of given `namespace` as obsolete so that logstore can safely delete
+    /// the log files if all entries inside are obsolete. This method may not delete log
+    /// files immediately.
+    async fn obsolete(&self, _ns: Self::Namespace, _entry_id: EntryId) -> Result<()> {
+        Ok(())
+    }
+
+    /// Stop components of logstore.
+    async fn stop(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// The mapping between entries and records is one-one currently.
+// TODO(niebayes): Shall limit a record to be within the max batch size and group entries into several records if necessary.
+fn try_into_records(entries: Vec<EntryImpl>) -> Result<Vec<Record>> {
+    entries
+        .into_iter()
+        .map(|entry| entry.try_into())
+        .collect::<Result<Vec<_>>>()
+}
+
+/// Try to convert the given entry id into an offset used by Kafka.
+fn try_into_offset(entry_id: EntryId) -> Result<i64> {
+    entry_id
+        .try_into()
+        .map_err(|_| ConvertEntryIdToOffsetSnafu { entry_id }.build())
+}
+
+fn try_from_record(record: Record) -> Result<Vec<EntryImpl>> {
+    let entry = record.try_into()?;
+    Ok(vec![entry])
+}
+
+fn handle_fetch_result(
+    fetch_result: std::result::Result<(RecordAndOffset, i64), RsKafkaError>,
+    topic: &Topic,
+    region_id: u64,
+    start_offset: i64,
+) -> Result<Vec<EntryImpl>> {
+    match fetch_result {
+        Ok((record_and_offset, _)) => {
+            let entries = try_from_record(record_and_offset.record)?
+                .into_iter()
+                .filter(|entry| entry.ns.region_id() == region_id)
+                .collect();
+            Ok(entries)
+        }
+        Err(e) => Err(e).context(ReadRecordFromKafkaSnafu {
+            start_offset,
+            topic,
+            region_id,
+        }),
+    }
+}
+
+// TODO(niebayes): Add necessary unit tests.

--- a/src/log-store/src/kafka/topic_client_manager.rs
+++ b/src/log-store/src/kafka/topic_client_manager.rs
@@ -114,3 +114,5 @@ impl TopicClientManager {
         Ok(Arc::new(topic_client))
     }
 }
+
+// TODO(niebayes): Add necessary unit tests.

--- a/src/log-store/src/kafka/topic_client_manager.rs
+++ b/src/log-store/src/kafka/topic_client_manager.rs
@@ -1,0 +1,116 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_config::wal::kafka::{KafkaOptions, KafkaTopic as Topic};
+use dashmap::mapref::entry::Entry as DashMapEntry;
+use dashmap::DashMap;
+use rskafka::client::partition::{PartitionClient, UnknownTopicHandling};
+use rskafka::client::producer::aggregator::RecordAggregator;
+use rskafka::client::producer::{BatchProducer, BatchProducerBuilder};
+use rskafka::client::{Client, ClientBuilder};
+use rskafka::BackoffConfig;
+use snafu::ResultExt;
+
+use crate::error::{BuildKafkaClientSnafu, BuildKafkaPartitionClientSnafu, Result};
+
+// There's only one partition for each topic currently.
+const DEFAULT_PARTITION: i32 = 0;
+
+pub type TopicClientRef = Arc<TopicClient>;
+pub type TopicClientManagerRef = Arc<TopicClientManager>;
+
+#[derive(Debug)]
+pub struct TopicClient {
+    /// The raw client used to construct a batch producer and/or a stream consumer for a specific topic.
+    pub raw_client: Arc<PartitionClient>,
+    /// A producer used to buffer log entries for a specific topic.
+    pub producer: Arc<BatchProducer<RecordAggregator>>,
+}
+
+impl TopicClient {
+    pub fn new(raw_client: Arc<PartitionClient>, kafka_opts: &KafkaOptions) -> Self {
+        let record_aggregator =
+            RecordAggregator::new(kafka_opts.max_batch_size.as_bytes() as usize);
+        let batch_producer = BatchProducerBuilder::new(raw_client.clone())
+            .with_compression(kafka_opts.compression.clone().into())
+            .with_linger(kafka_opts.linger)
+            .build(record_aggregator);
+
+        Self {
+            raw_client,
+            producer: Arc::new(batch_producer),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TopicClientManager {
+    opts: KafkaOptions,
+    client_factory: Client,
+    topic_client_pool: DashMap<Topic, TopicClientRef>,
+}
+
+impl TopicClientManager {
+    pub async fn try_new(kafka_opts: &KafkaOptions) -> Result<Self> {
+        // Sets backoff config for rskafka clients.
+        let backoff_config = BackoffConfig {
+            init_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(8),
+            base: 2.,
+            deadline: Some(Duration::from_secs(30)),
+        };
+
+        let kafka_client = ClientBuilder::new(kafka_opts.broker_endpoints.clone())
+            .backoff_config(backoff_config)
+            .build()
+            .await
+            .context(BuildKafkaClientSnafu {
+                broker_endpoints: kafka_opts.broker_endpoints.clone(),
+            })?;
+
+        Ok(Self {
+            opts: kafka_opts.clone(),
+            client_factory: kafka_client,
+            topic_client_pool: DashMap::with_capacity(kafka_opts.num_topics),
+        })
+    }
+
+    pub async fn get_or_insert(&self, topic: &Topic) -> Result<TopicClientRef> {
+        match self.topic_client_pool.entry(topic.to_string()) {
+            DashMapEntry::Occupied(entry) => Ok(entry.get().clone()),
+            DashMapEntry::Vacant(entry) => {
+                let topic_client = self.try_create_topic_client(topic).await?;
+                Ok(entry.insert(topic_client).clone())
+            }
+        }
+    }
+
+    async fn try_create_topic_client(&self, topic: &Topic) -> Result<TopicClientRef> {
+        let raw_client = self
+            .client_factory
+            .partition_client(topic, DEFAULT_PARTITION, UnknownTopicHandling::Retry)
+            .await
+            .context(BuildKafkaPartitionClientSnafu {
+                topic,
+                partition: DEFAULT_PARTITION,
+            })
+            .map(Arc::new)?;
+
+        let topic_client = TopicClient::new(raw_client, &self.opts);
+        Ok(Arc::new(topic_client))
+    }
+}

--- a/src/log-store/src/lib.rs
+++ b/src/log-store/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(let_chains)]
 
 pub mod error;
+pub mod kafka;
 mod noop;
 pub mod raft_engine;
 pub mod test_util;

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -64,12 +64,15 @@ impl LogStore for NoopLogStore {
     }
 
     async fn append(&self, mut _e: Self::Entry) -> Result<AppendResponse> {
-        Ok(AppendResponse { entry_id: 0 })
+        Ok(AppendResponse {
+            entry_id: 0,
+            offset: None,
+        })
     }
 
     async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
         Ok(AppendBatchResponse {
-            region_min_entry_id: HashMap::new(),
+            offsets: HashMap::new(),
         })
     }
 

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use store_api::logstore::entry::{Entry, Id};
+use std::collections::HashMap;
+
+use store_api::logstore::entry::{Entry, Id as EntryId};
 use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
-use store_api::logstore::{AppendResponse, LogStore};
+use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore, RegionWalOptions};
 
 use crate::error::{Error, Result};
 
@@ -42,7 +44,7 @@ impl Entry for EntryImpl {
         &[]
     }
 
-    fn id(&self) -> Id {
+    fn id(&self) -> EntryId {
         0
     }
 
@@ -65,14 +67,16 @@ impl LogStore for NoopLogStore {
         Ok(AppendResponse { entry_id: 0 })
     }
 
-    async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<()> {
-        Ok(())
+    async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
+        Ok(AppendBatchResponse {
+            region_min_entry_id: HashMap::new(),
+        })
     }
 
     async fn read(
         &self,
         _ns: &Self::Namespace,
-        _id: Id,
+        _entry_id: EntryId,
     ) -> Result<store_api::logstore::entry_stream::SendableEntryStream<'_, Self::Entry, Self::Error>>
     {
         Ok(Box::pin(futures::stream::once(futures::future::ready(Ok(
@@ -92,25 +96,35 @@ impl LogStore for NoopLogStore {
         Ok(vec![])
     }
 
-    fn entry<D: AsRef<[u8]>>(&self, data: D, id: Id, ns: Self::Namespace) -> Self::Entry {
+    fn entry<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        entry_id: EntryId,
+        ns: Self::Namespace,
+    ) -> Self::Entry {
         let _ = data;
-        let _ = id;
+        let _ = entry_id;
         let _ = ns;
         EntryImpl
     }
 
-    fn namespace(&self, id: NamespaceId) -> Self::Namespace {
-        let _ = id;
-        NamespaceImpl
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        region_wal_options: &RegionWalOptions,
+    ) -> Result<Self::Namespace> {
+        let _ = ns_id;
+        let _ = region_wal_options;
+        Ok(NamespaceImpl)
     }
 
     async fn obsolete(
         &self,
-        namespace: Self::Namespace,
-        id: Id,
+        ns: Self::Namespace,
+        entry_id: EntryId,
     ) -> std::result::Result<(), Self::Error> {
-        let _ = namespace;
-        let _ = id;
+        let _ = ns;
+        let _ = entry_id;
         Ok(())
     }
 }
@@ -135,7 +149,10 @@ mod tests {
         store.create_namespace(&NamespaceImpl).await.unwrap();
         assert_eq!(0, store.list_namespaces().await.unwrap().len());
         store.delete_namespace(&NamespaceImpl).await.unwrap();
-        assert_eq!(NamespaceImpl, store.namespace(0));
+        assert_eq!(
+            NamespaceImpl,
+            store.namespace(0, &RegionWalOptions::default()).unwrap()
+        );
         store.obsolete(NamespaceImpl, 1).await.unwrap();
     }
 }

--- a/src/log-store/src/raft_engine.rs
+++ b/src/log-store/src/raft_engine.rs
@@ -14,8 +14,8 @@
 
 use std::hash::{Hash, Hasher};
 
-use store_api::logstore::entry::{Entry, Id};
-use store_api::logstore::namespace::Namespace;
+use store_api::logstore::entry::{Entry, Id as EntryId};
+use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
 
 use crate::error::Error;
 use crate::raft_engine::protos::logstore::{EntryImpl, NamespaceImpl};
@@ -42,7 +42,7 @@ impl EntryImpl {
 }
 
 impl NamespaceImpl {
-    pub fn with_id(id: Id) -> Self {
+    pub fn with_id(id: NamespaceId) -> Self {
         Self {
             id,
             ..Default::default()
@@ -60,7 +60,7 @@ impl Hash for NamespaceImpl {
 impl Eq for NamespaceImpl {}
 
 impl Namespace for NamespaceImpl {
-    fn id(&self) -> store_api::logstore::namespace::Id {
+    fn id(&self) -> NamespaceId {
         self.id
     }
 }
@@ -73,7 +73,7 @@ impl Entry for EntryImpl {
         self.data.as_slice()
     }
 
-    fn id(&self) -> Id {
+    fn id(&self) -> EntryId {
         self.id
     }
 

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -178,7 +178,10 @@ impl LogStore for RaftEngineLogStore {
             .engine
             .write(&mut batch, self.config.sync_write)
             .context(RaftEngineSnafu)?;
-        Ok(AppendResponse { entry_id })
+        Ok(AppendResponse {
+            entry_id,
+            offset: None,
+        })
     }
 
     /// Append a batch of entries to logstore. `RaftEngineLogStore` assures the atomicity of
@@ -186,8 +189,7 @@ impl LogStore for RaftEngineLogStore {
     async fn append_batch(&self, entries: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
         ensure!(self.started(), IllegalStateSnafu);
         if entries.is_empty() {
-            // TODO(niebayes): Returns an `AppendBatchResponse`.
-            todo!()
+            return Ok(AppendBatchResponse::default());
         }
 
         let mut batch = LogBatch::with_capacity(entries.len());
@@ -205,8 +207,8 @@ impl LogStore for RaftEngineLogStore {
             .write(&mut batch, self.config.sync_write)
             .context(RaftEngineSnafu)?;
 
-        // TODO(niebayes): Returns an `AppendBatchResponse`.
-        todo!()
+        // The user of raft-engine log store does not care about the response.
+        Ok(AppendBatchResponse::default())
     }
 
     /// Create a stream of entries from logstore in the given namespace. The end of stream is

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -21,10 +21,10 @@ use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::{error, info};
 use raft_engine::{Config, Engine, LogBatch, MessageExt, ReadableSize, RecoveryMode};
 use snafu::{ensure, ResultExt};
-use store_api::logstore::entry::{Entry, Id};
+use store_api::logstore::entry::{Entry, Id as EntryId};
 use store_api::logstore::entry_stream::SendableEntryStream;
-use store_api::logstore::namespace::Namespace as NamespaceTrait;
-use store_api::logstore::{AppendResponse, LogStore};
+use store_api::logstore::namespace::{Id as NamespaceId, Namespace as NamespaceTrait};
+use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore, RegionWalOptions};
 
 use crate::error;
 use crate::error::{
@@ -183,10 +183,11 @@ impl LogStore for RaftEngineLogStore {
 
     /// Append a batch of entries to logstore. `RaftEngineLogStore` assures the atomicity of
     /// batch append.
-    async fn append_batch(&self, entries: Vec<Self::Entry>) -> Result<()> {
+    async fn append_batch(&self, entries: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
         ensure!(self.started(), IllegalStateSnafu);
         if entries.is_empty() {
-            return Ok(());
+            // TODO(niebayes): Returns an `AppendBatchResponse`.
+            todo!()
         }
 
         let mut batch = LogBatch::with_capacity(entries.len());
@@ -203,7 +204,9 @@ impl LogStore for RaftEngineLogStore {
             .engine
             .write(&mut batch, self.config.sync_write)
             .context(RaftEngineSnafu)?;
-        Ok(())
+
+        // TODO(niebayes): Returns an `AppendBatchResponse`.
+        todo!()
     }
 
     /// Create a stream of entries from logstore in the given namespace. The end of stream is
@@ -211,18 +214,18 @@ impl LogStore for RaftEngineLogStore {
     async fn read(
         &self,
         ns: &Self::Namespace,
-        id: Id,
+        entry_id: EntryId,
     ) -> Result<SendableEntryStream<'_, Self::Entry, Self::Error>> {
         ensure!(self.started(), IllegalStateSnafu);
         let engine = self.engine.clone();
 
-        let last_index = engine.last_index(ns.id).unwrap_or(0);
-        let mut start_index = id.max(engine.first_index(ns.id).unwrap_or(last_index + 1));
+        let last_index = engine.last_index(ns.id()).unwrap_or(0);
+        let mut start_index = entry_id.max(engine.first_index(ns.id()).unwrap_or(last_index + 1));
 
         info!(
             "Read logstore, namespace: {}, start: {}, span: {:?}",
             ns.id(),
-            id,
+            entry_id,
             self.span(ns)
         );
         let max_batch_size = self.config.read_batch_size;
@@ -322,31 +325,40 @@ impl LogStore for RaftEngineLogStore {
         Ok(namespaces)
     }
 
-    fn entry<D: AsRef<[u8]>>(&self, data: D, id: Id, ns: Self::Namespace) -> Self::Entry {
+    fn entry<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        entry_id: EntryId,
+        ns: Self::Namespace,
+    ) -> Self::Entry {
         EntryImpl {
-            id,
+            id: entry_id,
             data: data.as_ref().to_vec(),
             namespace_id: ns.id(),
             ..Default::default()
         }
     }
 
-    fn namespace(&self, id: store_api::logstore::namespace::Id) -> Self::Namespace {
-        Namespace {
-            id,
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        _region_wal_options: &RegionWalOptions,
+    ) -> Result<Self::Namespace> {
+        Ok(Namespace {
+            id: ns_id,
             ..Default::default()
-        }
+        })
     }
 
-    async fn obsolete(&self, namespace: Self::Namespace, id: Id) -> Result<()> {
+    async fn obsolete(&self, ns: Self::Namespace, entry_id: EntryId) -> Result<()> {
         ensure!(self.started(), IllegalStateSnafu);
-        let obsoleted = self.engine.compact_to(namespace.id(), id + 1);
+        let obsoleted = self.engine.compact_to(ns.id(), entry_id + 1);
         info!(
             "Namespace {} obsoleted {} entries, compacted index: {}, span: {:?}",
-            namespace.id(),
+            ns.id(),
             obsoleted,
-            id,
-            self.span(&namespace)
+            entry_id,
+            self.span(&ns)
         );
         Ok(())
     }

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -155,6 +155,7 @@ impl RegionWriteCtx {
         &mut self,
         wal_writer: &mut WalWriter<S>,
     ) -> Result<()> {
+        // TODO(niebayes): An entry id may be mapped to an entry offset. We need to maintain the mapping at somewhere.
         wal_writer.add_entry(self.region_id, self.next_entry_id, &self.wal_entry)?;
         // We only call this method one time, but we still bump next entry id for consistency.
         self.next_entry_id += 1;

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -172,7 +172,7 @@ impl<S: LogStore> WalWriter<S> {
     pub async fn write_to_wal(&mut self) -> Result<()> {
         // TODO(yingwen): metrics.
 
-        // TODO(niebayes): Returns an `AppendBatchResponse`.
+        // TODO(niebayes): Returns an `AppendBatchResponse` or the inner region_offset_map.
         let entries = mem::take(&mut self.entries);
         self.store
             .append_batch(entries)

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -18,10 +18,9 @@ use std::collections::HashMap;
 
 use common_error::ext::ErrorExt;
 
-use crate::logstore::entry::{Entry, Id as EntryId};
+use crate::logstore::entry::{Entry, Id as EntryId, Offset as EntryOffset};
 use crate::logstore::entry_stream::SendableEntryStream;
 use crate::logstore::namespace::{Id as NamespaceId, Namespace};
-use crate::storage::RegionId;
 
 pub mod entry;
 pub mod entry_stream;
@@ -87,12 +86,20 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     async fn obsolete(&self, ns: Self::Namespace, entry_id: EntryId) -> Result<(), Self::Error>;
 }
 
+/// The response of an `append` operation.
 #[derive(Debug)]
 pub struct AppendResponse {
+    /// The entry id of the appended log entry.
     pub entry_id: EntryId,
+    /// The start entry offset of the appended log entry.
+    /// Depends on the `LogStore` implementation, the entry offset may be missing.
+    pub offset: Option<EntryOffset>,
 }
 
-#[derive(Debug)]
+/// The response of an `append_batch` operation.
+#[derive(Debug, Default)]
 pub struct AppendBatchResponse {
-    pub region_min_entry_id: HashMap<RegionId, EntryId>,
+    /// Key: region id (as u64). Value: the known minimum start offset of appended log entries belonging to the region.
+    /// Depends on the `LogStore` implementation, the entry offsets may be missing.
+    pub offsets: HashMap<u64, EntryOffset>,
 }

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -16,8 +16,8 @@ use common_error::ext::ErrorExt;
 
 use crate::logstore::namespace::Namespace;
 
-// TODO(niebayes): Consider removing `Epoch` and `Offset`.
 pub type Offset = usize;
+// TODO(niebayes): Consider removing `Epoch`.
 pub type Epoch = u64;
 pub type Id = u64;
 

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -16,6 +16,7 @@ use common_error::ext::ErrorExt;
 
 use crate::logstore::namespace::Namespace;
 
+// TODO(niebayes): Consider removing `Epoch` and `Offset`.
 pub type Offset = usize;
 pub type Epoch = u64;
 pub type Id = u64;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Refactored `LogStore` API and introduced `KafkaLogStore`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
