### PR TITLE
fix: correct the previously unsuccessful decimal_ops sort result fix

### DIFF
--- a/tests/cases/standalone/common/types/decimal/decimal_ops.result
+++ b/tests/cases/standalone/common/types/decimal/decimal_ops.result
@@ -7,7 +7,7 @@ INSERT INTO decimals VALUES ('0.1',1000), ('0.2',2000);
 
 Affected Rows: 2
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM decimals;
 
 +------+---------------------+
@@ -37,7 +37,7 @@ SELECT * FROM decimals WHERE d = '0.1'::DECIMAL(3,2);
 +------+---------------------+
 
 -- greater than equals
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM decimals WHERE d >= '0.1'::DECIMAL(3,2);
 
 +------+---------------------+
@@ -409,7 +409,7 @@ INSERT INTO tmp_table VALUES (1, 1000), (2, 2000), (3, 3000);
 
 Affected Rows: 3
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM tmp_table;
 
 +---+---------------------+
@@ -420,7 +420,7 @@ SELECT * FROM tmp_table;
 | 3 | 1970-01-01T00:00:03 |
 +---+---------------------+
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM tmp_table JOIN decimals ON decimals.ts = tmp_table.ts;
 
 +---+---------------------+------+---------------------+

--- a/tests/cases/standalone/common/types/decimal/decimal_ops.sql
+++ b/tests/cases/standalone/common/types/decimal/decimal_ops.sql
@@ -4,7 +4,7 @@ CREATE TABLE decimals(d DECIMAL(3, 2), ts timestamp time index);
 
 INSERT INTO decimals VALUES ('0.1',1000), ('0.2',2000);
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM decimals;
 
 -- ORDER BY
@@ -17,7 +17,7 @@ SELECT * FROM decimals WHERE d = '0.1'::DECIMAL(3,2);
 
 -- greater than equals
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM decimals WHERE d >= '0.1'::DECIMAL(3,2);
 
 -- what about if we use different decimal scales?
@@ -196,10 +196,10 @@ CREATE TABLE tmp_table(i INTEGER, ts timestamp time index);
 
 INSERT INTO tmp_table VALUES (1, 1000), (2, 2000), (3, 3000);
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM tmp_table;
 
--- SQLNESS SORT 3 1
+-- SQLNESS SORT_RESULT 3 1
 SELECT * FROM tmp_table JOIN decimals ON decimals.ts = tmp_table.ts;
 
 DROP TABLE decimals;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

correct https://github.com/GreptimeTeam/greptimedb/pull/2867 


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
