### PR TITLE
fix: add new column as primary key can't work

### DIFF
--- a/tests/cases/standalone/common/alter/add_col.result
+++ b/tests/cases/standalone/common/alter/add_col.result
@@ -59,7 +59,7 @@ DESC TABLE test;
 | i      | Int32                |     | YES  |         | FIELD         |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | k      | Int32                |     | YES  |         | FIELD         |
-| host   | String               |     | YES  |         | FIELD         |
+| host   | String               | PRI | YES  |         | TAG           |
 +--------+----------------------+-----+------+---------+---------------+
 
 ALTER TABLE test ADD COLUMN idc STRING default 'idc' PRIMARY KEY;
@@ -83,8 +83,8 @@ DESC TABLE test;
 | i      | Int32                |     | YES  |         | FIELD         |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | k      | Int32                |     | YES  |         | FIELD         |
-| host   | String               |     | YES  |         | FIELD         |
-| idc    | String               |     | YES  | idc     | FIELD         |
+| host   | String               | PRI | YES  |         | TAG           |
+| idc    | String               | PRI | YES  | idc     | TAG           |
 +--------+----------------------+-----+------+---------+---------------+
 
 ALTER TABLE test ADD COLUMN "IdC" STRING default 'idc' PRIMARY KEY;
@@ -99,9 +99,9 @@ DESC TABLE test;
 | i      | Int32                |     | YES  |         | FIELD         |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | k      | Int32                |     | YES  |         | FIELD         |
-| host   | String               |     | YES  |         | FIELD         |
-| idc    | String               |     | YES  | idc     | FIELD         |
-| IdC    | String               |     | YES  | idc     | FIELD         |
+| host   | String               | PRI | YES  |         | TAG           |
+| idc    | String               | PRI | YES  | idc     | TAG           |
+| IdC    | String               | PRI | YES  | idc     | TAG           |
 +--------+----------------------+-----+------+---------+---------------+
 
 DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixed `alter table [table] add column [new_column] [type] PRIMARY KEY` can't work as expected. The new column is not added as `tag` semantic type.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
