### PR TITLE
chore: tweak status code of promql errors

### DIFF
--- a/src/promql/src/error.rs
+++ b/src/promql/src/error.rs
@@ -147,13 +147,12 @@ impl ErrorExt for Error {
             | Deserialize { .. }
             | FunctionInvalidArgument { .. }
             | UnsupportedVectorMatch { .. }
-            | CombineTableColumnMismatch { .. } => StatusCode::InvalidArguments,
-
-            UnknownTable { .. }
+            | CombineTableColumnMismatch { .. }
             | DataFusionPlanning { .. }
             | UnexpectedPlanExpr { .. }
-            | IllegalRange { .. }
-            | EmptyRange { .. } => StatusCode::Internal,
+            | IllegalRange { .. } => StatusCode::InvalidArguments,
+
+            UnknownTable { .. } | EmptyRange { .. } => StatusCode::Internal,
 
             TableNameNotFound { .. } => StatusCode::TableNotFound,
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change status code of error types that are caused by invalid input. The previous `Internal` code will prevent it from being unwrap to user.

<img width="412" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/74d17d91-e06d-4f94-9553-b73362f416a9">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
