### PR TITLE
fix: re-enable ignored case test_query_prepared

### DIFF
--- a/src/servers/tests/mysql/mysql_server_test.rs
+++ b/src/servers/tests/mysql/mysql_server_test.rs
@@ -451,7 +451,6 @@ async fn test_query_concurrently() -> Result<()> {
     Ok(())
 }
 
-#[ignore = "https://github.com/GreptimeTeam/greptimedb/issues/1385"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_query_prepared() -> Result<()> {
     common_telemetry::init_default_ut_logging();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

As @tisonkun mention #1385 is not reproducible in current HEAD. I bisects the history and find it's already fixed in https://github.com/GreptimeTeam/greptimedb/pull/1677. This PR re-enables the ignored case `test_query_prepared` due to that bug.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
- Closes #1385