### PR TITLE
test: add more tests for region migration procedure

### DIFF
--- a/src/meta-srv/src/procedure/region_migration/migration_start.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_start.rs
@@ -201,7 +201,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_next_downgrade_leader_region_state() {
+    async fn test_next_update_metadata_downgrade_state() {
         let mut state = Box::new(RegionMigrationStart);
         // from_peer: 1
         // to_peer: 2

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -35,6 +35,7 @@ use store_api::storage::RegionId;
 use table::metadata::RawTableInfo;
 use tokio::sync::mpsc::{Receiver, Sender};
 
+use super::migration_abort::RegionMigrationAbort;
 use super::upgrade_candidate_region::UpgradeCandidateRegion;
 use super::{Context, ContextFactory, ContextFactoryImpl, State, VolatileContext};
 use crate::error::{Error, Result};
@@ -478,9 +479,23 @@ pub(crate) fn assert_update_metadata_upgrade(next: &dyn State) {
     assert_matches!(state, UpdateMetadata::Upgrade);
 }
 
+/// Asserts the [State] should be [UpdateMetadata::Rollback].
+pub(crate) fn assert_update_metadata_rollback(next: &dyn State) {
+    let state = next.as_any().downcast_ref::<UpdateMetadata>().unwrap();
+    assert_matches!(state, UpdateMetadata::Rollback);
+}
+
 /// Asserts the [State] should be [RegionMigrationEnd].
 pub(crate) fn assert_region_migration_end(next: &dyn State) {
     let _ = next.as_any().downcast_ref::<RegionMigrationEnd>().unwrap();
+}
+
+/// Asserts the [State] should be [RegionMigrationAbort].
+pub(crate) fn assert_region_migration_abort(next: &dyn State) {
+    let _ = next
+        .as_any()
+        .downcast_ref::<RegionMigrationAbort>()
+        .unwrap();
 }
 
 /// Asserts the [State] should be [DowngradeLeaderRegion].


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Add flow test for open candidate region with retryable error
2. Add flow test for upgrade candidate retry failed
3. Add flow test for upgrade candidate with retry

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2700