### PR TITLE
fix: use linear interpolation to implement range LINEAR fill strategy

### DIFF
--- a/src/query/src/range_select/plan.rs
+++ b/src/query/src/range_select/plan.rs
@@ -1420,10 +1420,6 @@ mod test {
         ];
         Fill::Linear.apply_fill_strategy(&ts, &mut test1).unwrap();
         assert_eq!(test, test1);
-    }
-
-    #[test]
-    fn test_fill_linear1() {
         let ts = vec![1, 2, 3, 4, 5, 6, 7, 8];
         let mut test = vec![
             ScalarValue::Float32(Some(1.0)),
@@ -1441,12 +1437,28 @@ mod test {
             ScalarValue::Float32(None),
             ScalarValue::Float32(Some(3.0)),
             ScalarValue::Float32(None),
-            ScalarValue::Float32(Some(5.0)),
             ScalarValue::Float32(None),
             ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(7.0)),
             ScalarValue::Float32(None),
         ];
         Fill::Linear.apply_fill_strategy(&ts, &mut test1).unwrap();
         assert_eq!(test, test1);
+    }
+
+    #[test]
+    fn test_fill_linear1() {
+        let ts = vec![1, 3, 11];
+        let mut test = vec![
+            ScalarValue::Float32(Some(1.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(3.0)),
+        ];
+        Fill::Linear.apply_fill_strategy(&ts, &mut test).unwrap();
+        assert_eq!(ScalarValue::Float32(Some(1.4)), test[1]);
+        let ts = vec![1];
+        let mut test = vec![ScalarValue::Float32(None)];
+        Fill::Linear.apply_fill_strategy(&ts, &mut test).unwrap();
+        assert_eq!(ScalarValue::Float32(None), test[0]);
     }
 }

--- a/src/query/src/range_select/plan.rs
+++ b/src/query/src/range_select/plan.rs
@@ -106,8 +106,11 @@ impl Fill {
 
     /// The input `data` contains data on a complete time series.
     /// If the filling strategy is `PREV` or `LINEAR`, caller must be ensured that the incoming `data` is ascending time order.
-    pub fn apply_fill_strategy(&self, data: &mut [ScalarValue]) -> DfResult<()> {
+    pub fn apply_fill_strategy(&self, ts: &[i64], data: &mut [ScalarValue]) -> DfResult<()> {
         let len = data.len();
+        if *self == Fill::Linear {
+            return Self::fill_linear(ts, data);
+        }
         for i in 0..len {
             if data[i].is_null() {
                 match self {
@@ -117,32 +120,88 @@ impl Fill {
                             data[i] = data[i - 1].clone()
                         }
                     }
-                    Fill::Linear => {
-                        if 0 < i && i < len - 1 {
-                            match (&data[i - 1], &data[i + 1]) {
-                                (ScalarValue::Float64(Some(a)), ScalarValue::Float64(Some(b))) => {
-                                    data[i] = ScalarValue::Float64(Some((a + b) / 2.0));
-                                }
-                                (ScalarValue::Float32(Some(a)), ScalarValue::Float32(Some(b))) => {
-                                    data[i] = ScalarValue::Float32(Some((a + b) / 2.0));
-                                }
-                                (a, b) => {
-                                    if !a.is_null() && !b.is_null() {
-                                        return Err(DataFusionError::Execution(
-                                            "RangePlan: Apply Fill LINEAR strategy on Non-floating type".to_string()));
-                                    } else {
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    Fill::Linear => {}
                     Fill::Const(v) => data[i] = v.clone(),
                 }
             }
         }
         Ok(())
     }
+
+    fn fill_linear(ts: &[i64], data: &mut [ScalarValue]) -> DfResult<()> {
+        let not_null_num = data
+            .iter()
+            .fold(0, |acc, x| if x.is_null() { acc } else { acc + 1 });
+        // We need at least two non-empty data points to perform linear interpolation
+        if not_null_num < 2 {
+            return Ok(());
+        }
+        let mut index = 0;
+        while index < data.len() {
+            // find null interval [start, end)
+            let start = data[index..]
+                .iter()
+                .position(ScalarValue::is_null)
+                .unwrap_or(data.len() - index)
+                + index;
+            if start == data.len() {
+                break;
+            }
+            let end = data[start..]
+                .iter()
+                .position(|r| !r.is_null())
+                .unwrap_or(data.len() - start)
+                + start;
+            index = end + 1;
+            // head or tail null dispose later
+            if start != 0 && end != data.len() {
+                linear_interpolation(ts, data, start - 1, end, start, end)?;
+            }
+        }
+        // dispose head null interval
+        if data[0].is_null() {
+            let start = data.iter().position(|r| !r.is_null()).unwrap();
+            linear_interpolation(ts, data, start, start + 1, 0, start)?;
+        }
+        // dispose tail null interval
+        if data[data.len() - 1].is_null() {
+            let start = data.len() - 1 - data.iter().rev().position(|r| !r.is_null()).unwrap();
+            linear_interpolation(ts, data, start, start - 1, start + 1, data.len())?;
+        }
+        Ok(())
+    }
+}
+
+/// use `(ts[i1], data[i1])`, `(ts[i2], data[i2])` as endpoint, linearly interpolates element over the interval `[start, end)`
+fn linear_interpolation(
+    ts: &[i64],
+    data: &mut [ScalarValue],
+    i1: usize,
+    i2: usize,
+    start: usize,
+    end: usize,
+) -> DfResult<()> {
+    let (x0, x1) = (ts[i1] as f64, ts[i2] as f64);
+    let (y0, y1, is_float32) = match (&data[i1], &data[i2]) {
+        (ScalarValue::Float64(Some(y0)), ScalarValue::Float64(Some(y1))) => (*y0, *y1, false),
+        (ScalarValue::Float32(Some(y0)), ScalarValue::Float32(Some(y1))) => {
+            (*y0 as f64, *y1 as f64, true)
+        }
+        _ => {
+            return Err(DataFusionError::Execution(
+                "RangePlan: Apply Fill LINEAR strategy on Non-floating type".to_string(),
+            ));
+        }
+    };
+    for i in start..end {
+        let val = y0 + (y1 - y0) / (x1 - x0) * (ts[i] as f64 - x0);
+        data[i] = if is_float32 {
+            ScalarValue::Float32(Some(val as f32))
+        } else {
+            ScalarValue::Float64(Some(val))
+        }
+    }
+    Ok(())
 }
 
 #[derive(Eq, Clone, Debug)]
@@ -859,25 +918,16 @@ impl RangeSelectStream {
         } in self.series_map.values()
         {
             // collect data on time series
-            if !need_sort_output {
-                for (ts, accumulators) in align_ts_accumulator {
-                    for (i, accumulator) in accumulators.iter().enumerate() {
-                        all_scalar[i].push(accumulator.evaluate()?);
-                    }
-                    ts_builder.append_value(*ts);
-                }
-            } else {
-                let mut keys = align_ts_accumulator.keys().copied().collect::<Vec<_>>();
-                keys.sort();
-                for key in &keys {
-                    for (i, accumulator) in
-                        align_ts_accumulator.get(key).unwrap().iter().enumerate()
-                    {
-                        all_scalar[i].push(accumulator.evaluate()?);
-                    }
-                }
-                ts_builder.append_slice(&keys);
+            let mut align_ts = align_ts_accumulator.keys().copied().collect::<Vec<_>>();
+            if need_sort_output {
+                align_ts.sort();
             }
+            for ts in &align_ts {
+                for (i, accumulator) in align_ts_accumulator.get(ts).unwrap().iter().enumerate() {
+                    all_scalar[i].push(accumulator.evaluate()?);
+                }
+            }
+            ts_builder.append_slice(&align_ts);
             // apply fill strategy on time series
             for (
                 i,
@@ -891,7 +941,7 @@ impl RangeSelectStream {
                 if let Some(data_type) = need_cast {
                     cast_scalar_values(time_series_data, data_type)?;
                 }
-                fill.apply_fill_strategy(time_series_data)?;
+                fill.apply_fill_strategy(&align_ts, time_series_data)?;
             }
             by_rows.resize(by_rows.len() + align_ts_accumulator.len(), row.row());
             start_index += align_ts_accumulator.len();
@@ -1220,13 +1270,13 @@ mod test {
             \n| 1.0        | 1.0        | 1970-01-01T00:00:10 | host1 |\
             \n| 1.0        | 1.5        | 1970-01-01T00:00:15 | host1 |\
             \n| 2.0        | 2.0        | 1970-01-01T00:00:20 | host1 |\
-            \n| 2.0        |            | 1970-01-01T00:00:25 | host1 |\
+            \n| 2.0        | 2.5        | 1970-01-01T00:00:25 | host1 |\
             \n| 3.0        | 3.0        | 1970-01-01T00:00:00 | host2 |\
             \n| 3.0        | 3.5        | 1970-01-01T00:00:05 | host2 |\
             \n| 4.0        | 4.0        | 1970-01-01T00:00:10 | host2 |\
             \n| 4.0        | 4.5        | 1970-01-01T00:00:15 | host2 |\
             \n| 5.0        | 5.0        | 1970-01-01T00:00:20 | host2 |\
-            \n| 5.0        |            | 1970-01-01T00:00:25 | host2 |\
+            \n| 5.0        | 5.5        | 1970-01-01T00:00:25 | host2 |\
             \n+------------+------------+---------------------+-------+",
         );
         do_range_select_test(10_000, 5_000, 5_000, Fill::Linear, true, expected).await;
@@ -1266,13 +1316,13 @@ mod test {
             \n| 1.0        | 1.0        | 1970-01-01T00:00:10 | host1 |\
             \n| 1.0        | 1.5        | 1970-01-01T00:00:15 | host1 |\
             \n| 2.0        | 2.0        | 1970-01-01T00:00:20 | host1 |\
-            \n| 2.0        |            | 1970-01-01T00:00:25 | host1 |\
+            \n| 2.0        | 2.5        | 1970-01-01T00:00:25 | host1 |\
             \n| 3.0        | 3.0        | 1970-01-01T00:00:00 | host2 |\
             \n| 3.0        | 3.5        | 1970-01-01T00:00:05 | host2 |\
             \n| 4.0        | 4.0        | 1970-01-01T00:00:10 | host2 |\
             \n| 4.0        | 4.5        | 1970-01-01T00:00:15 | host2 |\
             \n| 5.0        | 5.0        | 1970-01-01T00:00:20 | host2 |\
-            \n| 5.0        |            | 1970-01-01T00:00:25 | host2 |\
+            \n| 5.0        | 5.5        | 1970-01-01T00:00:25 | host2 |\
             \n+------------+------------+---------------------+-------+",
         );
         do_range_select_test(10_000, 5_000, 5_000, Fill::Linear, false, expected).await;
@@ -1339,29 +1389,64 @@ mod test {
             ScalarValue::UInt8(None),
             ScalarValue::UInt8(Some(9)),
         ];
-        Fill::Null.apply_fill_strategy(&mut test1).unwrap();
+        Fill::Null.apply_fill_strategy(&[], &mut test1).unwrap();
         assert_eq!(test1[1], ScalarValue::UInt8(None));
-        Fill::Prev.apply_fill_strategy(&mut test1).unwrap();
+        Fill::Prev.apply_fill_strategy(&[], &mut test1).unwrap();
         assert_eq!(test1[1], ScalarValue::UInt8(Some(8)));
         test1[1] = ScalarValue::UInt8(None);
         Fill::Const(ScalarValue::UInt8(Some(10)))
-            .apply_fill_strategy(&mut test1)
+            .apply_fill_strategy(&[], &mut test1)
             .unwrap();
         assert_eq!(test1[1], ScalarValue::UInt8(Some(10)));
-        test1[1] = ScalarValue::UInt8(None);
-        assert_eq!(
-            Fill::Linear
-                .apply_fill_strategy(&mut test1)
-                .unwrap_err()
-                .to_string(),
-            "Execution error: RangePlan: Apply Fill LINEAR strategy on Non-floating type"
-        );
-        let mut test2 = vec![
-            ScalarValue::Float32(Some(8.0)),
+    }
+
+    #[test]
+    fn test_fill_linear() {
+        let ts = vec![1, 2, 3, 4, 5];
+        let mut test = vec![
+            ScalarValue::Float32(Some(1.0)),
             ScalarValue::Float32(None),
-            ScalarValue::Float32(Some(9.0)),
+            ScalarValue::Float32(Some(3.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(5.0)),
         ];
-        Fill::Linear.apply_fill_strategy(&mut test2).unwrap();
-        assert_eq!(test2[1], ScalarValue::Float32(Some(8.5)));
+        Fill::Linear.apply_fill_strategy(&ts, &mut test).unwrap();
+        let mut test1 = vec![
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(2.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(4.0)),
+            ScalarValue::Float32(None),
+        ];
+        Fill::Linear.apply_fill_strategy(&ts, &mut test1).unwrap();
+        assert_eq!(test, test1);
+    }
+
+    #[test]
+    fn test_fill_linear1() {
+        let ts = vec![1, 2, 3, 4, 5, 6, 7, 8];
+        let mut test = vec![
+            ScalarValue::Float32(Some(1.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(3.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(5.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(None),
+        ];
+        Fill::Linear.apply_fill_strategy(&ts, &mut test).unwrap();
+        let mut test1 = vec![
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(3.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(Some(5.0)),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(None),
+            ScalarValue::Float32(None),
+        ];
+        Fill::Linear.apply_fill_strategy(&ts, &mut test1).unwrap();
+        assert_eq!(test, test1);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use linear interpolation to implement range `LINEAR` fill strategy

The previous `LINEAR` strategy of range fill was implemented using the average value. Only the data before and after an null data point are non-empty, and the value of this point will be filled with the average of the two numbers. Now the implementation is changed to linear interpolation. As long as there are more than two non-empty data points in the entire time series, all null data points can be filled in using linear interpolation.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
