### PR TITLE
ci: prevent running nightly FT in forks

### DIFF
--- a/.github/workflows/nightly-funtional-tests.yml
+++ b/.github/workflows/nightly-funtional-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sqlness-test:
     name: Run sqlness test
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Forks cannot reach the secrets in use.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
