### PR TITLE
feat(remote_wal): add skeleton for remote wal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,6 +1540,7 @@ dependencies = [
  "servers",
  "session",
  "snafu",
+ "store-api",
  "substrait 0.4.4",
  "table",
  "temp-env",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,7 +3571,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b1d403088f02136bcebde53d604f491c260ca8e2#b1d403088f02136bcebde53d604f491c260ca8e2"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=28725502aa3de91858da16cd4bd23c4066cebc6a#28725502aa3de91858da16cd4bd23c4066cebc6a"
 dependencies = [
  "prost 0.12.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ etcd-client = "0.12"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b1d403088f02136bcebde53d604f491c260ca8e2" }
+# TODO(niebayes): update to the formal revision.
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "28725502aa3de91858da16cd4bd23c4066cebc6a" }
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -31,6 +31,10 @@ tcp_nodelay = true
 
 # WAL options, see `standalone.example.toml`.
 [wal]
+provider = "RaftEngine"
+
+# Raft-engine wal options, .
+[wal.raft_engine]
 # WAL data directory
 # dir = "/tmp/greptimedb/wal"
 file_size = "256MB"
@@ -38,6 +42,9 @@ purge_threshold = "4GB"
 purge_interval = "10m"
 read_batch_size = 128
 sync_write = false
+
+# Kafka wal options.
+[wal.kafka]
 
 # Storage options, see `standalone.example.toml`.
 [storage]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -30,12 +30,11 @@ connect_timeout = "1s"
 tcp_nodelay = true
 
 # WAL options, see `standalone.example.toml`.
+# Uncomments all other wal options except the one you chose.
 [wal]
-provider = "RaftEngine"
+provider = "raft-engine"
 
-# Raft-engine wal options, .
-[wal.raft_engine]
-# WAL data directory
+# Raft-engine wal options.
 # dir = "/tmp/greptimedb/wal"
 file_size = "256MB"
 purge_threshold = "4GB"
@@ -44,7 +43,6 @@ read_batch_size = 128
 sync_write = false
 
 # Kafka wal options.
-[wal.kafka]
 
 # Storage options, see `standalone.example.toml`.
 [storage]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -43,4 +43,4 @@ first_heartbeat_estimate = "1000ms"
 # connect_timeout = "10s"
 # tcp_nodelay = true
 
-# TODO(niebayes): add wal options for meta srv.
+[wal]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -42,3 +42,5 @@ first_heartbeat_estimate = "1000ms"
 # timeout = "10s"
 # connect_timeout = "10s"
 # tcp_nodelay = true
+
+# TODO(niebayes): add wal options for meta srv.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -82,6 +82,13 @@ enable = true
 
 # WAL options.
 [wal]
+# Available wal providers:
+# - "RaftEngine" (default)
+# - "Kafka"
+provider = "RaftEngine"
+
+# Raft-engine wal options.
+[wal.raft_engine]
 # WAL data directory
 # dir = "/tmp/greptimedb/wal"
 # WAL file size in bytes.
@@ -94,6 +101,9 @@ purge_interval = "10m"
 read_batch_size = 128
 # Whether to sync log file after every write.
 sync_write = false
+
+# Kafka wal options.
+[wal.kafka]
 
 # Metadata storage options.
 [metadata_store]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -58,6 +58,7 @@ serde_json.workspace = true
 servers.workspace = true
 session.workspace = true
 snafu.workspace = true
+store-api.workspace = true
 substrait.workspace = true
 table.workspace = true
 tokio.workspace = true

--- a/src/cmd/src/cli/bench.rs
+++ b/src/cmd/src/cli/bench.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,10 +24,12 @@ use common_meta::kv_backend::etcd::EtcdStore;
 use common_meta::peer::Peer;
 use common_meta::rpc::router::{Region, RegionRoute};
 use common_meta::table_name::TableName;
+use common_meta::wal::region_wal_options::RegionWalOptions;
 use common_telemetry::info;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use rand::Rng;
+use store_api::storage::RegionNumber;
 use table::metadata::{RawTableInfo, RawTableMeta, TableId, TableIdent, TableType};
 
 use self::metadata::TableMetadataBencher;
@@ -137,11 +139,11 @@ fn create_table_info(table_id: TableId, table_name: TableName) -> RawTableInfo {
     }
 }
 
-fn create_region_routes() -> Vec<RegionRoute> {
-    let mut regions = Vec::with_capacity(100);
+fn create_region_routes(region_numbers: Vec<RegionNumber>) -> Vec<RegionRoute> {
+    let mut regions = Vec::with_capacity(region_numbers.len());
     let mut rng = rand::thread_rng();
 
-    for region_id in 0..64u64 {
+    for region_id in region_numbers.into_iter().map(u64::from) {
         regions.push(RegionRoute {
             region: Region {
                 id: region_id.into(),
@@ -159,4 +161,10 @@ fn create_region_routes() -> Vec<RegionRoute> {
     }
 
     regions
+}
+
+fn create_region_wal_options(
+    _region_numbers: Vec<RegionNumber>,
+) -> HashMap<RegionNumber, RegionWalOptions> {
+    todo!()
 }

--- a/src/cmd/src/cli/bench/metadata.rs
+++ b/src/cmd/src/cli/bench/metadata.rs
@@ -17,7 +17,9 @@ use std::time::Instant;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::table_name::TableName;
 
-use super::{bench_self_recorded, create_region_routes, create_table_info};
+use super::{
+    bench_self_recorded, create_region_routes, create_region_wal_options, create_table_info,
+};
 
 pub struct TableMetadataBencher {
     table_metadata_manager: TableMetadataManagerRef,
@@ -43,12 +45,15 @@ impl TableMetadataBencher {
                 let table_name = format!("bench_table_name_{}", i);
                 let table_name = TableName::new("bench_catalog", "bench_schema", table_name);
                 let table_info = create_table_info(i, table_name);
-                let region_routes = create_region_routes();
+
+                let regions: Vec<_> = (0..64).collect();
+                let region_routes = create_region_routes(regions.clone());
+                let region_wal_options = create_region_wal_options(regions);
 
                 let start = Instant::now();
 
                 self.table_metadata_manager
-                    .create_table_metadata(table_info, region_routes)
+                    .create_table_metadata(table_info, region_routes, region_wal_options)
                     .await
                     .unwrap();
 

--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -397,7 +397,7 @@ impl MigrateTableMetadata {
             value.regions_id_map.clone().into_iter().collect();
 
         // TODO(niebayes): Properly fetch or construct region wal options.
-        let region_wal_options = HashMap::new();
+        let region_wal_options = HashMap::default();
 
         let datanode_table_kvs = region_distribution
             .into_iter()

--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -395,6 +396,9 @@ impl MigrateTableMetadata {
         let region_distribution: RegionDistribution =
             value.regions_id_map.clone().into_iter().collect();
 
+        // TODO(niebayes): Properly fetch or construct region wal options.
+        let region_wal_options = HashMap::new();
+
         let datanode_table_kvs = region_distribution
             .into_iter()
             .map(|(datanode_id, regions)| {
@@ -410,6 +414,7 @@ impl MigrateTableMetadata {
                             region_storage_path: region_storage_path.clone(),
                             region_options: (&value.table_info.meta.options).into(),
                         },
+                        region_wal_options.clone(),
                     ),
                 )
             })

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -148,6 +148,7 @@ impl Options {
 mod tests {
     use std::io::Write;
 
+    use common_config::WalConfig;
     use common_test_util::temp_dir::create_named_temp_file;
     use datanode::config::{DatanodeOptions, ObjectStoreConfig};
 
@@ -156,6 +157,7 @@ mod tests {
     #[test]
     fn test_load_layered_options() {
         let mut file = create_named_temp_file();
+        // TODO(niebayes): update wal stuff in toml str.
         let toml_str = r#"
             mode = "distributed"
             enable_memory_catalog = false
@@ -254,7 +256,10 @@ mod tests {
                 );
 
                 // Should be the values from config file, not environment variables.
-                assert_eq!(opts.wal.dir.unwrap(), "/tmp/greptimedb/wal");
+                let WalConfig::RaftEngine(raft_engine_config) = opts.wal else {
+                    unreachable!()
+                };
+                assert_eq!(raft_engine_config.dir.unwrap(), "/tmp/greptimedb/wal");
 
                 // Should be default values.
                 assert_eq!(opts.node_id, None);

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -462,6 +462,7 @@ mod tests {
     #[test]
     fn test_read_from_config_file() {
         let mut file = create_named_temp_file();
+        // TODO(niebayes): update wal stuff in toml str.
         let toml_str = r#"
             mode = "distributed"
 
@@ -531,7 +532,10 @@ mod tests {
         assert_eq!(None, fe_opts.mysql.reject_no_database);
         assert!(fe_opts.influxdb.enable);
 
-        assert_eq!("/tmp/greptimedb/test/wal", dn_opts.wal.dir.unwrap());
+        let WalConfig::RaftEngine(raft_engine_config) = dn_opts.wal else {
+            unreachable!()
+        };
+        assert_eq!("/tmp/greptimedb/test/wal", raft_engine_config.dir.unwrap());
 
         assert!(matches!(
             &dn_opts.storage.store,

--- a/src/common/config/src/wal.rs
+++ b/src/common/config/src/wal.rs
@@ -12,32 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod wal;
-
-use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
-pub use wal::WalConfig;
 
-pub fn metadata_store_dir(store_dir: &str) -> String {
-    format!("{store_dir}/metadata")
-}
+use crate::wal::kafka::KafkaOptions;
+use crate::wal::raft_engine::RaftEngineOptions;
 
+pub mod kafka;
+pub mod raft_engine;
+
+// TODO(niebayes): maybe rename all wal-related options to config.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct KvBackendConfig {
-    // Kv file size in bytes
-    pub file_size: ReadableSize,
-    // Kv purge threshold in bytes
-    pub purge_threshold: ReadableSize,
+pub enum WalConfig {
+    RaftEngine(RaftEngineOptions),
+    Kafka(KafkaOptions),
 }
 
-impl Default for KvBackendConfig {
+impl Default for WalConfig {
     fn default() -> Self {
-        Self {
-            // log file size 256MB
-            file_size: ReadableSize::mb(256),
-            // purge threshold 4GB
-            purge_threshold: ReadableSize::gb(4),
-        }
+        WalConfig::RaftEngine(RaftEngineOptions::default())
     }
 }

--- a/src/common/config/src/wal.rs
+++ b/src/common/config/src/wal.rs
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::{Deserialize, Serialize};
-
-use crate::wal::kafka::KafkaOptions;
-use crate::wal::raft_engine::RaftEngineOptions;
-
 pub mod kafka;
 pub mod raft_engine;
 
-// TODO(niebayes): maybe rename all wal-related options to config.
+use serde::{Deserialize, Serialize};
+
+pub use crate::wal::kafka::KafkaConfig;
+pub use crate::wal::raft_engine::RaftEngineConfig;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "provider")]
 pub enum WalConfig {
-    RaftEngine(RaftEngineOptions),
-    Kafka(KafkaOptions),
+    #[serde(rename = "raft-engine")]
+    RaftEngine(RaftEngineConfig),
+    #[serde(rename = "kafka")]
+    Kafka(KafkaConfig),
 }
 
 impl Default for WalConfig {
     fn default() -> Self {
-        WalConfig::RaftEngine(RaftEngineOptions::default())
+        WalConfig::RaftEngine(RaftEngineConfig::default())
     }
 }

--- a/src/common/config/src/wal/kafka.rs
+++ b/src/common/config/src/wal/kafka.rs
@@ -12,32 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod wal;
-
-use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
-pub use wal::WalConfig;
-
-pub fn metadata_store_dir(store_dir: &str) -> String {
-    format!("{store_dir}/metadata")
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct KvBackendConfig {
-    // Kv file size in bytes
-    pub file_size: ReadableSize,
-    // Kv purge threshold in bytes
-    pub purge_threshold: ReadableSize,
-}
-
-impl Default for KvBackendConfig {
-    fn default() -> Self {
-        Self {
-            // log file size 256MB
-            file_size: ReadableSize::mb(256),
-            // purge threshold 4GB
-            purge_threshold: ReadableSize::gb(4),
-        }
-    }
-}
+pub struct KafkaOptions;

--- a/src/common/config/src/wal/kafka.rs
+++ b/src/common/config/src/wal/kafka.rs
@@ -15,4 +15,4 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct KafkaOptions;
+pub struct KafkaConfig;

--- a/src/common/config/src/wal/raft_engine.rs
+++ b/src/common/config/src/wal/raft_engine.rs
@@ -12,32 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod wal;
+use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
-pub use wal::WalConfig;
-
-pub fn metadata_store_dir(store_dir: &str) -> String {
-    format!("{store_dir}/metadata")
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
-pub struct KvBackendConfig {
-    // Kv file size in bytes
+pub struct RaftEngineOptions {
+    // wal directory
+    pub dir: Option<String>,
+    // wal file size in bytes
     pub file_size: ReadableSize,
-    // Kv purge threshold in bytes
+    // wal purge threshold in bytes
     pub purge_threshold: ReadableSize,
+    // purge interval in seconds
+    #[serde(with = "humantime_serde")]
+    pub purge_interval: Duration,
+    // read batch size
+    pub read_batch_size: usize,
+    // whether to sync log file after every write
+    pub sync_write: bool,
 }
 
-impl Default for KvBackendConfig {
+impl Default for RaftEngineOptions {
     fn default() -> Self {
         Self {
-            // log file size 256MB
-            file_size: ReadableSize::mb(256),
-            // purge threshold 4GB
-            purge_threshold: ReadableSize::gb(4),
+            dir: None,
+            file_size: ReadableSize::mb(256), // log file size 256MB
+            purge_threshold: ReadableSize::gb(4), // purge threshold 4GB
+            purge_interval: Duration::from_secs(600),
+            read_batch_size: 128,
+            sync_write: false,
         }
     }
 }

--- a/src/common/config/src/wal/raft_engine.rs
+++ b/src/common/config/src/wal/raft_engine.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
-pub struct RaftEngineOptions {
+pub struct RaftEngineConfig {
     // wal directory
     pub dir: Option<String>,
     // wal file size in bytes
@@ -35,7 +35,7 @@ pub struct RaftEngineOptions {
     pub sync_write: bool,
 }
 
-impl Default for RaftEngineOptions {
+impl Default for RaftEngineConfig {
     fn default() -> Self {
         Self {
             dir: None,

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -96,14 +96,21 @@ pub struct OpenRegion {
     pub region_ident: RegionIdent,
     pub region_storage_path: String,
     pub options: HashMap<String, String>,
+    pub wal_options: HashMap<String, String>,
 }
 
 impl OpenRegion {
-    pub fn new(region_ident: RegionIdent, path: &str, options: HashMap<String, String>) -> Self {
+    pub fn new(
+        region_ident: RegionIdent,
+        path: &str,
+        options: HashMap<String, String>,
+        wal_options: HashMap<String, String>,
+    ) -> Self {
         Self {
             region_ident,
             region_storage_path: path.to_string(),
             options,
+            wal_options,
         }
     }
 }
@@ -217,6 +224,7 @@ mod tests {
                 engine: "mito2".to_string(),
             },
             "test/foo",
+            HashMap::new(),
             HashMap::new(),
         ));
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -388,6 +388,10 @@ impl TableMetadataManager {
             .build_create_txn(&table_name, table_id)?;
 
         let region_options = (&table_info.meta.options).into();
+        let region_wal_options = region_wal_options
+            .into_iter()
+            .map(|(region_number, wal_opts)| (region_number, (&wal_opts).into()))
+            .collect();
 
         // Creates table info.
         let table_info_value = TableInfoValue::new(table_info);

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -223,7 +223,7 @@ impl DatanodeTableManager {
         let mut opts = Vec::new();
 
         // TODO(niebayes): Properly fetch or construct new region wal options.
-        let new_region_wal_options = HashMap::new();
+        let new_region_wal_options = HashMap::default();
 
         // Removes the old datanode table key value pairs
         for current_datanode in current_region_distribution.keys() {

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -31,7 +31,7 @@ use crate::kv_backend::KvBackendRef;
 use crate::range_stream::{PaginationStream, DEFAULT_PAGE_SIZE};
 use crate::rpc::store::RangeRequest;
 use crate::rpc::KeyValue;
-use crate::wal::region_wal_options::RegionWalOptions;
+use crate::wal::region_wal_options::EncodedRegionWalOptions;
 use crate::DatanodeId;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -105,7 +105,7 @@ pub struct DatanodeTableValue {
     #[serde(flatten)]
     pub region_info: RegionInfo,
     #[serde(default)]
-    pub region_wal_options: HashMap<RegionNumber, RegionWalOptions>,
+    pub region_wal_options: HashMap<RegionNumber, EncodedRegionWalOptions>,
     version: u64,
 }
 
@@ -114,14 +114,14 @@ impl DatanodeTableValue {
         table_id: TableId,
         regions: Vec<RegionNumber>,
         region_info: RegionInfo,
-        region_wal_options: HashMap<RegionNumber, RegionWalOptions>,
+        region_wal_options: HashMap<RegionNumber, EncodedRegionWalOptions>,
     ) -> Self {
         Self {
             table_id,
             regions,
             region_info,
-            version: 0,
             region_wal_options,
+            version: 0,
         }
     }
 }
@@ -174,7 +174,7 @@ impl DatanodeTableManager {
         engine: &str,
         region_storage_path: &str,
         region_options: HashMap<String, String>,
-        region_wal_options: HashMap<RegionNumber, RegionWalOptions>,
+        region_wal_options: HashMap<RegionNumber, EncodedRegionWalOptions>,
         distribution: RegionDistribution,
     ) -> Result<Txn> {
         let txns = distribution
@@ -183,10 +183,10 @@ impl DatanodeTableManager {
                 let region_wal_options = regions
                     .iter()
                     .filter_map(|region_number| {
-                        let Some(opts) = region_wal_options.get(region_number).cloned() else {
+                        let Some(wal_opts) = region_wal_options.get(region_number).cloned() else {
                             return None;
                         };
-                        Some((*region_number, opts))
+                        Some((*region_number, wal_opts))
                     })
                     .collect();
 

--- a/src/common/meta/src/wal.rs
+++ b/src/common/meta/src/wal.rs
@@ -12,15 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::default;
+
 use serde::{Deserialize, Serialize};
 
-use crate::wal::kafka::KafkaOptions;
+pub use crate::wal::kafka::KafkaConfig;
 
 pub mod kafka;
 pub mod region_wal_options;
 
-// TODO(niebayes): rename to WalConfig to differ from RegionWalOptions whose abbr is WalOptions.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
-pub struct WalOptions {
-    kafka: Option<KafkaOptions>,
+#[serde(tag = "provider")]
+pub enum WalConfig {
+    #[default]
+    #[serde(rename = "raft-engine")]
+    RaftEngine,
+    #[serde(rename = "kafka")]
+    Kafka(KafkaConfig),
 }

--- a/src/common/meta/src/wal.rs
+++ b/src/common/meta/src/wal.rs
@@ -19,8 +19,6 @@ use crate::wal::kafka::KafkaOptions;
 pub mod kafka;
 pub mod region_wal_options;
 
-pub const WAL_KAFKA_TOPIC: &str = "wal_kafka_topic";
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WalOptions {
     kafka: Option<KafkaOptions>,

--- a/src/common/meta/src/wal.rs
+++ b/src/common/meta/src/wal.rs
@@ -19,6 +19,7 @@ use crate::wal::kafka::KafkaOptions;
 pub mod kafka;
 pub mod region_wal_options;
 
+// TODO(niebayes): rename to WalConfig to differ from RegionWalOptions whose abbr is WalOptions.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct WalOptions {
     kafka: Option<KafkaOptions>,

--- a/src/common/meta/src/wal.rs
+++ b/src/common/meta/src/wal.rs
@@ -12,32 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
-#![feature(btree_extract_if)]
-#![feature(async_closure)]
+use serde::{Deserialize, Serialize};
 
-pub mod cache_invalidator;
-pub mod datanode_manager;
-pub mod ddl;
-pub mod ddl_manager;
-pub mod distributed_time_constants;
-pub mod error;
-pub mod heartbeat;
-pub mod instruction;
-pub mod key;
-pub mod kv_backend;
-pub mod metrics;
-pub mod peer;
-pub mod range_stream;
-pub mod rpc;
-pub mod sequence;
-pub mod state_store;
-pub mod table_name;
-pub mod util;
-#[allow(unused)]
-pub mod wal;
+use crate::wal::kafka::KafkaOptions;
 
-pub type ClusterId = u64;
-pub type DatanodeId = u64;
+pub mod kafka;
+pub mod region_wal_options;
 
-pub use instruction::RegionIdent;
+pub const WAL_KAFKA_TOPIC: &str = "wal_kafka_topic";
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct WalOptions {
+    kafka: Option<KafkaOptions>,
+}

--- a/src/common/meta/src/wal/kafka.rs
+++ b/src/common/meta/src/wal/kafka.rs
@@ -20,4 +20,4 @@ use serde::{Deserialize, Serialize};
 pub type Topic = String;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
-pub struct KafkaOptions;
+pub struct KafkaConfig;

--- a/src/common/meta/src/wal/kafka.rs
+++ b/src/common/meta/src/wal/kafka.rs
@@ -12,32 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
-#![feature(btree_extract_if)]
-#![feature(async_closure)]
+pub mod topic_manager;
+mod topic_selector;
 
-pub mod cache_invalidator;
-pub mod datanode_manager;
-pub mod ddl;
-pub mod ddl_manager;
-pub mod distributed_time_constants;
-pub mod error;
-pub mod heartbeat;
-pub mod instruction;
-pub mod key;
-pub mod kv_backend;
-pub mod metrics;
-pub mod peer;
-pub mod range_stream;
-pub mod rpc;
-pub mod sequence;
-pub mod state_store;
-pub mod table_name;
-pub mod util;
-#[allow(unused)]
-pub mod wal;
+use serde::{Deserialize, Serialize};
 
-pub type ClusterId = u64;
-pub type DatanodeId = u64;
+pub type Topic = String;
 
-pub use instruction::RegionIdent;
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+pub struct KafkaOptions;

--- a/src/common/meta/src/wal/kafka/topic_manager.rs
+++ b/src/common/meta/src/wal/kafka/topic_manager.rs
@@ -12,10 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::error::Result;
+use crate::kv_backend::KvBackendRef;
 use crate::wal::kafka::topic_selector::TopicSelectorRef;
 use crate::wal::kafka::Topic;
+use crate::wal::KafkaOptions;
 
+/// Manages topic initialization and selection.
 pub struct TopicManager {
     topic_pool: Vec<Topic>,
     topic_selector: TopicSelectorRef,
+    kv_backend: KvBackendRef,
+}
+
+impl TopicManager {
+    /// Creates a new topic manager.
+    pub fn new(kafka_opts: &KafkaOptions, kv_backend: KvBackendRef) -> Self {
+        todo!()
+    }
+
+    /// Tries to initialize the topic pool and persist the topics into the kv backend.
+    pub async fn try_init_topic_pool(&mut self) -> Result<()> {
+        todo!()
+    }
+
+    /// Selects one topic from the topic pool through the topic selector.
+    pub fn select(&self) -> Topic {
+        self.topic_selector.select(&self.topic_pool)
+    }
+
+    /// Selects a batch of topics from the topic pool through the topic selector.
+    pub fn select_batch(&self, num_topics: usize) -> Vec<Topic> {
+        todo!()
+    }
 }

--- a/src/common/meta/src/wal/kafka/topic_manager.rs
+++ b/src/common/meta/src/wal/kafka/topic_manager.rs
@@ -12,32 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
-#![feature(btree_extract_if)]
-#![feature(async_closure)]
+use crate::wal::kafka::topic_selector::TopicSelectorRef;
+use crate::wal::kafka::Topic;
 
-pub mod cache_invalidator;
-pub mod datanode_manager;
-pub mod ddl;
-pub mod ddl_manager;
-pub mod distributed_time_constants;
-pub mod error;
-pub mod heartbeat;
-pub mod instruction;
-pub mod key;
-pub mod kv_backend;
-pub mod metrics;
-pub mod peer;
-pub mod range_stream;
-pub mod rpc;
-pub mod sequence;
-pub mod state_store;
-pub mod table_name;
-pub mod util;
-#[allow(unused)]
-pub mod wal;
-
-pub type ClusterId = u64;
-pub type DatanodeId = u64;
-
-pub use instruction::RegionIdent;
+pub struct TopicManager {
+    topic_pool: Vec<Topic>,
+    topic_selector: TopicSelectorRef,
+}

--- a/src/common/meta/src/wal/kafka/topic_manager.rs
+++ b/src/common/meta/src/wal/kafka/topic_manager.rs
@@ -15,8 +15,7 @@
 use crate::error::Result;
 use crate::kv_backend::KvBackendRef;
 use crate::wal::kafka::topic_selector::TopicSelectorRef;
-use crate::wal::kafka::Topic;
-use crate::wal::KafkaOptions;
+use crate::wal::kafka::{KafkaConfig, Topic};
 
 /// Manages topic initialization and selection.
 pub struct TopicManager {
@@ -27,7 +26,7 @@ pub struct TopicManager {
 
 impl TopicManager {
     /// Creates a new topic manager.
-    pub fn new(kafka_opts: &KafkaOptions, kv_backend: KvBackendRef) -> Self {
+    pub fn new(config: &KafkaConfig, kv_backend: KvBackendRef) -> Self {
         todo!()
     }
 

--- a/src/common/meta/src/wal/kafka/topic_selector.rs
+++ b/src/common/meta/src/wal/kafka/topic_selector.rs
@@ -14,6 +14,32 @@
 
 use std::sync::Arc;
 
-pub struct TopicSelector;
+use crate::wal::kafka::Topic;
 
-pub type TopicSelectorRef = Arc<TopicSelector>;
+/// The type of the topic selector, i.e. with which strategy to select a topic.
+pub enum SelectorType {
+    RoundRobin,
+}
+
+/// Controls topic selection.
+pub trait TopicSelector {
+    fn select(&self, topic_pool: &[Topic]) -> Topic;
+}
+
+pub type TopicSelectorRef = Arc<dyn TopicSelector>;
+
+/// A topic selector with the round-robin strategy, i.e. selects topics in a round-robin manner.
+pub struct RoundRobinTopicSelector;
+
+impl RoundRobinTopicSelector {
+    /// Creates a new round-robin topic selector.
+    pub fn new() -> Self {
+        todo!()
+    }
+}
+
+impl TopicSelector for RoundRobinTopicSelector {
+    fn select(&self, topic_pool: &[Topic]) -> Topic {
+        todo!()
+    }
+}

--- a/src/common/meta/src/wal/kafka/topic_selector.rs
+++ b/src/common/meta/src/wal/kafka/topic_selector.rs
@@ -12,32 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(assert_matches)]
-#![feature(btree_extract_if)]
-#![feature(async_closure)]
+use std::sync::Arc;
 
-pub mod cache_invalidator;
-pub mod datanode_manager;
-pub mod ddl;
-pub mod ddl_manager;
-pub mod distributed_time_constants;
-pub mod error;
-pub mod heartbeat;
-pub mod instruction;
-pub mod key;
-pub mod kv_backend;
-pub mod metrics;
-pub mod peer;
-pub mod range_stream;
-pub mod rpc;
-pub mod sequence;
-pub mod state_store;
-pub mod table_name;
-pub mod util;
-#[allow(unused)]
-pub mod wal;
+pub struct TopicSelector;
 
-pub type ClusterId = u64;
-pub type DatanodeId = u64;
-
-pub use instruction::RegionIdent;
+pub type TopicSelectorRef = Arc<TopicSelector>;

--- a/src/common/meta/src/wal/region_wal_options.rs
+++ b/src/common/meta/src/wal/region_wal_options.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::wal::kafka::Topic as KafkaTopic;
-use crate::wal::WalOptions;
+use crate::wal::WalConfig;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct RegionWalOptions;
@@ -52,7 +52,7 @@ pub struct RegionWalOptionsAllocator;
 
 impl RegionWalOptionsAllocator {
     /// Tries to create a RegionWalOptionsAllocator.
-    pub fn try_new(wal_opts: &WalOptions) -> Result<Self> {
+    pub fn try_new(config: &WalConfig) -> Result<Self> {
         todo!()
     }
 

--- a/src/common/meta/src/wal/region_wal_options.rs
+++ b/src/common/meta/src/wal/region_wal_options.rs
@@ -30,16 +30,18 @@ impl RegionWalOptions {
     }
 }
 
-impl From<&RegionWalOptions> for HashMap<String, String> {
+pub type EncodedRegionWalOptions = HashMap<String, String>;
+
+impl From<&RegionWalOptions> for EncodedRegionWalOptions {
     fn from(value: &RegionWalOptions) -> Self {
         todo!()
     }
 }
 
-impl TryFrom<&HashMap<String, String>> for RegionWalOptions {
+impl TryFrom<&EncodedRegionWalOptions> for RegionWalOptions {
     type Error = crate::error::Error;
 
-    fn try_from(value: &HashMap<String, String>) -> Result<Self> {
+    fn try_from(value: &EncodedRegionWalOptions) -> Result<Self> {
         todo!()
     }
 }

--- a/src/common/meta/src/wal/region_wal_options.rs
+++ b/src/common/meta/src/wal/region_wal_options.rs
@@ -1,0 +1,64 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+use crate::wal::kafka::Topic as KafkaTopic;
+use crate::wal::WalOptions;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct RegionWalOptions;
+
+impl RegionWalOptions {
+    /// Tries to get the wal kafka topic from the options.
+    pub fn kafka_topic(&self) -> Option<KafkaTopic> {
+        todo!()
+    }
+}
+
+impl From<&RegionWalOptions> for HashMap<String, String> {
+    fn from(value: &RegionWalOptions) -> Self {
+        todo!()
+    }
+}
+
+impl TryFrom<&HashMap<String, String>> for RegionWalOptions {
+    type Error = crate::error::Error;
+
+    fn try_from(value: &HashMap<String, String>) -> Result<Self> {
+        todo!()
+    }
+}
+
+pub struct RegionWalOptionsAllocator;
+
+impl RegionWalOptionsAllocator {
+    /// Tries to create a RegionWalOptionsAllocator.
+    pub fn try_new(wal_opts: &WalOptions) -> Result<Self> {
+        todo!()
+    }
+
+    /// Allocates wal options for a region.
+    pub fn alloc(&self) -> RegionWalOptions {
+        todo!()
+    }
+
+    /// Allocates a batch of wal options for regions.
+    pub fn alloc_batch(&self, num_regions: usize) -> Vec<RegionWalOptions> {
+        todo!()
+    }
+}

--- a/src/common/meta/src/wal/region_wal_options.rs
+++ b/src/common/meta/src/wal/region_wal_options.rs
@@ -20,7 +20,7 @@ use crate::error::Result;
 use crate::wal::kafka::Topic as KafkaTopic;
 use crate::wal::WalOptions;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct RegionWalOptions;
 
 impl RegionWalOptions {
@@ -34,7 +34,8 @@ pub type EncodedRegionWalOptions = HashMap<String, String>;
 
 impl From<&RegionWalOptions> for EncodedRegionWalOptions {
     fn from(value: &RegionWalOptions) -> Self {
-        todo!()
+        // TODO(niebayes): implement encoding/decoding for region wal options.
+        EncodedRegionWalOptions::default()
     }
 }
 
@@ -46,6 +47,7 @@ impl TryFrom<&EncodedRegionWalOptions> for RegionWalOptions {
     }
 }
 
+#[derive(Default)]
 pub struct RegionWalOptionsAllocator;
 
 impl RegionWalOptionsAllocator {
@@ -61,6 +63,7 @@ impl RegionWalOptionsAllocator {
 
     /// Allocates a batch of wal options for regions.
     pub fn alloc_batch(&self, num_regions: usize) -> Vec<RegionWalOptions> {
-        todo!()
+        // TODO(niebayes): properly allocate a batch of region wal options.
+        vec![RegionWalOptions; num_regions]
     }
 }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -516,14 +516,23 @@ mod tests {
     use common_meta::key::datanode_table::DatanodeTableManager;
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::kv_backend::KvBackendRef;
+    use common_meta::wal::region_wal_options::RegionWalOptions;
     use store_api::region_request::RegionRequest;
-    use store_api::storage::RegionId;
+    use store_api::storage::{RegionId, RegionNumber};
 
     use crate::config::DatanodeOptions;
     use crate::datanode::DatanodeBuilder;
     use crate::tests::{mock_region_server, MockRegionEngine};
 
+    fn new_test_region_wal_options(
+        _regions: Vec<RegionNumber>,
+    ) -> HashMap<RegionNumber, RegionWalOptions> {
+        todo!()
+    }
+
     async fn setup_table_datanode(kv: &KvBackendRef) {
+        let regions = vec![0, 1, 2];
+
         let mgr = DatanodeTableManager::new(kv.clone());
         let txn = mgr
             .build_create_txn(
@@ -531,7 +540,8 @@ mod tests {
                 "mock",
                 "foo/bar/weny",
                 HashMap::from([("foo".to_string(), "bar".to_string())]),
-                BTreeMap::from([(0, vec![0, 1, 2])]),
+                new_test_region_wal_options(regions.clone()),
+                BTreeMap::from([(0, regions)]),
             )
             .unwrap();
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -346,11 +346,18 @@ impl DatanodeBuilder {
         while let Some(table_value) = table_values.next().await {
             let table_value = table_value.context(GetMetadataSnafu)?;
             for region_number in table_value.regions {
+                let region_wal_options = table_value
+                    .region_wal_options
+                    .get(&region_number)
+                    .cloned()
+                    .unwrap_or_default();
+
                 regions.push((
                     RegionId::new(table_value.table_id, region_number),
                     table_value.region_info.engine.clone(),
                     table_value.region_info.region_storage_path.clone(),
                     table_value.region_info.region_options.clone(),
+                    region_wal_options,
                 ));
             }
         }
@@ -358,7 +365,7 @@ impl DatanodeBuilder {
         let semaphore = Arc::new(tokio::sync::Semaphore::new(OPEN_REGION_PARALLELISM));
         let mut tasks = vec![];
 
-        for (region_id, engine, store_path, options) in regions {
+        for (region_id, engine, store_path, options, wal_options) in regions {
             let region_dir = region_dir(&store_path, region_id);
             let semaphore_moved = semaphore.clone();
             tasks.push(async move {
@@ -370,6 +377,7 @@ impl DatanodeBuilder {
                             engine: engine.clone(),
                             region_dir,
                             options,
+                            wal_options,
                         }),
                     )
                     .await?;

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -21,8 +21,7 @@ use std::sync::Arc;
 
 use catalog::memory::MemoryCatalogManager;
 use common_base::Plugins;
-use common_config::wal::kafka::KafkaOptions;
-use common_config::wal::raft_engine::RaftEngineOptions;
+use common_config::wal::{KafkaConfig, RaftEngineConfig};
 use common_config::WalConfig;
 use common_error::ext::BoxedError;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
@@ -494,7 +493,7 @@ impl DatanodeBuilder {
     /// Builds [RaftEngineLogStore].
     async fn build_raft_engine_log_store(
         data_home: &str,
-        config: &RaftEngineOptions,
+        config: &RaftEngineConfig,
     ) -> Result<Arc<RaftEngineLogStore>> {
         let data_home = normalize_dir(data_home);
         let wal_dir = match &config.dir {
@@ -519,8 +518,8 @@ impl DatanodeBuilder {
     }
 
     /// Builds [KafkaLogStore].
-    async fn build_kafka_log_store(kafka_opts: &KafkaOptions) -> Result<Arc<KafkaLogStore>> {
-        let _ = kafka_opts;
+    async fn build_kafka_log_store(config: &KafkaConfig) -> Result<Arc<KafkaLogStore>> {
+        let _ = config;
         todo!()
     }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -516,7 +516,7 @@ mod tests {
     use common_meta::key::datanode_table::DatanodeTableManager;
     use common_meta::kv_backend::memory::MemoryKvBackend;
     use common_meta::kv_backend::KvBackendRef;
-    use common_meta::wal::region_wal_options::RegionWalOptions;
+    use common_meta::wal::region_wal_options::EncodedRegionWalOptions;
     use store_api::region_request::RegionRequest;
     use store_api::storage::{RegionId, RegionNumber};
 
@@ -526,7 +526,7 @@ mod tests {
 
     fn new_test_region_wal_options(
         _regions: Vec<RegionNumber>,
-    ) -> HashMap<RegionNumber, RegionWalOptions> {
+    ) -> HashMap<RegionNumber, EncodedRegionWalOptions> {
         todo!()
     }
 

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -21,6 +21,9 @@ use std::sync::Arc;
 
 use catalog::memory::MemoryCatalogManager;
 use common_base::Plugins;
+use common_config::wal::kafka::KafkaOptions;
+use common_config::wal::raft_engine::RaftEngineOptions;
+use common_config::WalConfig;
 use common_error::ext::BoxedError;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
 use common_meta::key::datanode_table::DatanodeTableManager;
@@ -32,8 +35,10 @@ use file_engine::engine::FileRegionEngine;
 use futures::future;
 use futures_util::future::try_join_all;
 use futures_util::StreamExt;
+use log_store::kafka::log_store::KafkaLogStore;
 use log_store::raft_engine::log_store::RaftEngineLogStore;
 use meta_client::client::MetaClient;
+use mito2::config::MitoConfig;
 use mito2::engine::MitoEngine;
 use object_store::manager::{ObjectStoreManager, ObjectStoreManagerRef};
 use object_store::util::normalize_dir;
@@ -44,7 +49,6 @@ use servers::metrics_handler::MetricsHandler;
 use servers::server::{start_server, ServerHandler, ServerHandlers};
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
-use store_api::logstore::LogStore;
 use store_api::path_utils::{region_dir, WAL_DIR};
 use store_api::region_engine::RegionEngineRef;
 use store_api::region_request::{RegionOpenRequest, RegionRequest};
@@ -220,8 +224,6 @@ impl DatanodeBuilder {
         let kv_backend = self.kv_backend.take().context(MissingKvBackendSnafu)?;
 
         // build and initialize region server
-        let log_store = Self::build_log_store(&self.opts).await?;
-
         let (region_event_listener, region_event_receiver) = if controlled_by_metasrv {
             let (tx, rx) = new_region_server_event_channel();
             (Box::new(tx) as _, Some(rx))
@@ -229,9 +231,7 @@ impl DatanodeBuilder {
             (Box::new(NoopRegionServerEventListener) as _, None)
         };
 
-        let region_server = self
-            .new_region_server(log_store, region_event_listener)
-            .await?;
+        let region_server = self.new_region_server(region_event_listener).await?;
 
         self.initialize_region_server(&region_server, kv_backend, !controlled_by_metasrv)
             .await?;
@@ -400,7 +400,6 @@ impl DatanodeBuilder {
 
     async fn new_region_server(
         &self,
-        log_store: Arc<RaftEngineLogStore>,
         event_listener: RegionServerEventListenerRef,
     ) -> Result<RegionServer> {
         let opts = &self.opts;
@@ -432,7 +431,7 @@ impl DatanodeBuilder {
         );
 
         let object_store_manager = Self::build_object_store_manager(opts).await?;
-        let engines = Self::build_store_engines(opts, log_store, object_store_manager).await?;
+        let engines = Self::build_store_engines(opts, object_store_manager).await?;
         for engine in engines {
             region_server.register_engine(engine);
         }
@@ -442,48 +441,18 @@ impl DatanodeBuilder {
 
     // internal utils
 
-    /// Build [RaftEngineLogStore]
-    async fn build_log_store(opts: &DatanodeOptions) -> Result<Arc<RaftEngineLogStore>> {
-        let data_home = normalize_dir(&opts.storage.data_home);
-        let wal_dir = match &opts.wal.dir {
-            Some(dir) => dir.clone(),
-            None => format!("{}{WAL_DIR}", data_home),
-        };
-        let wal_config = opts.wal.clone();
-
-        // create WAL directory
-        fs::create_dir_all(Path::new(&wal_dir))
-            .await
-            .context(CreateDirSnafu { dir: &wal_dir })?;
-        info!(
-            "Creating logstore with config: {:?} and storage path: {}",
-            wal_config, &wal_dir
-        );
-        let logstore = RaftEngineLogStore::try_new(wal_dir, wal_config)
-            .await
-            .map_err(Box::new)
-            .context(OpenLogStoreSnafu)?;
-        Ok(Arc::new(logstore))
-    }
-
-    /// Build [RegionEngineRef] from `store_engine` section in `opts`
-    async fn build_store_engines<S>(
+    /// Builds [RegionEngineRef] from `store_engine` section in `opts`
+    async fn build_store_engines(
         opts: &DatanodeOptions,
-        log_store: Arc<S>,
         object_store_manager: ObjectStoreManagerRef,
-    ) -> Result<Vec<RegionEngineRef>>
-    where
-        S: LogStore,
-    {
+    ) -> Result<Vec<RegionEngineRef>> {
         let mut engines = vec![];
         for engine in &opts.region_engine {
             match engine {
                 RegionEngineConfig::Mito(config) => {
-                    let engine: MitoEngine = MitoEngine::new(
-                        config.clone(),
-                        log_store.clone(),
-                        object_store_manager.clone(),
-                    );
+                    let engine =
+                        Self::build_mito_engine(opts, object_store_manager.clone(), config.clone())
+                            .await?;
                     engines.push(Arc::new(engine) as _);
                 }
                 RegionEngineConfig::File(config) => {
@@ -496,6 +465,63 @@ impl DatanodeBuilder {
             }
         }
         Ok(engines)
+    }
+
+    /// Builds [MitoEngine] according to options.
+    async fn build_mito_engine(
+        opts: &DatanodeOptions,
+        object_store_manager: ObjectStoreManagerRef,
+        config: MitoConfig,
+    ) -> Result<MitoEngine> {
+        // TODO(niebayes): validate wal config, for e.g. providing a remote wal for standalone mode is not allowed.
+
+        let mito_engine = match &opts.wal {
+            WalConfig::RaftEngine(raft_engine_config) => MitoEngine::new(
+                config,
+                Self::build_raft_engine_log_store(&opts.storage.data_home, raft_engine_config)
+                    .await?,
+                object_store_manager,
+            ),
+            WalConfig::Kafka(kafka_config) => MitoEngine::new(
+                config,
+                Self::build_kafka_log_store(kafka_config).await?,
+                object_store_manager,
+            ),
+        };
+        Ok(mito_engine)
+    }
+
+    /// Builds [RaftEngineLogStore].
+    async fn build_raft_engine_log_store(
+        data_home: &str,
+        config: &RaftEngineOptions,
+    ) -> Result<Arc<RaftEngineLogStore>> {
+        let data_home = normalize_dir(data_home);
+        let wal_dir = match &config.dir {
+            Some(dir) => dir.clone(),
+            None => format!("{}{WAL_DIR}", data_home),
+        };
+
+        // create WAL directory
+        fs::create_dir_all(Path::new(&wal_dir))
+            .await
+            .context(CreateDirSnafu { dir: &wal_dir })?;
+        info!(
+            "Creating raft-engine logstore with config: {:?} and storage path: {}",
+            config, &wal_dir
+        );
+        let logstore = RaftEngineLogStore::try_new(wal_dir, config.clone())
+            .await
+            .map_err(Box::new)
+            .context(OpenLogStoreSnafu)?;
+
+        Ok(Arc::new(logstore))
+    }
+
+    /// Builds [KafkaLogStore].
+    async fn build_kafka_log_store(kafka_opts: &KafkaOptions) -> Result<Arc<KafkaLogStore>> {
+        let _ = kafka_opts;
+        todo!()
     }
 
     /// Builds [ObjectStoreManager]

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -54,6 +54,7 @@ impl RegionHeartbeatResponseHandler {
                 region_ident,
                 region_storage_path,
                 options,
+                wal_options,
             }) => Ok(Box::new(|region_server| {
                 Box::pin(async move {
                     let region_id = Self::region_ident_to_region_id(&region_ident);
@@ -61,6 +62,7 @@ impl RegionHeartbeatResponseHandler {
                         engine: region_ident.engine,
                         region_dir: region_dir(&region_storage_path, region_id),
                         options,
+                        wal_options,
                     });
                     let result = region_server.handle_request(region_id, request).await;
 
@@ -238,6 +240,7 @@ mod tests {
                 engine: MITO_ENGINE_NAME.to_string(),
             },
             path,
+            HashMap::new(),
             HashMap::new(),
         ))
     }

--- a/src/file-engine/src/region.rs
+++ b/src/file-engine/src/region.rs
@@ -102,7 +102,9 @@ mod tests {
 
     use super::*;
     use crate::error::Error;
-    use crate::test_util::{new_test_column_metadata, new_test_object_store, new_test_options};
+    use crate::test_util::{
+        new_test_column_metadata, new_test_object_store, new_test_options, new_test_wal_options,
+    };
 
     #[tokio::test]
     async fn test_create_region() {
@@ -113,6 +115,7 @@ mod tests {
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
             options: new_test_options(),
+            wal_options: new_test_wal_options(),
             region_dir: "create_region_dir/".to_string(),
         };
         let region_id = RegionId::new(1, 0);
@@ -146,11 +149,14 @@ mod tests {
         let (_dir, object_store) = new_test_object_store("test_open_region");
 
         let region_dir = "open_region_dir/".to_string();
+        let region_wal_options = new_test_wal_options();
+
         let request = RegionCreateRequest {
             engine: "file".to_string(),
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
             options: new_test_options(),
+            wal_options: region_wal_options.clone(),
             region_dir: region_dir.clone(),
         };
         let region_id = RegionId::new(1, 0);
@@ -163,6 +169,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
+            wal_options: region_wal_options.clone(),
         };
 
         let region = FileRegion::open(region_id, request, &object_store)
@@ -183,11 +190,14 @@ mod tests {
         let (_dir, object_store) = new_test_object_store("test_drop_region");
 
         let region_dir = "drop_region_dir/".to_string();
+        let region_wal_options = new_test_wal_options();
+
         let request = RegionCreateRequest {
             engine: "file".to_string(),
             column_metadatas: new_test_column_metadata(),
             primary_key: vec![1],
             options: new_test_options(),
+            wal_options: region_wal_options.clone(),
             region_dir: region_dir.clone(),
         };
         let region_id = RegionId::new(1, 0);
@@ -211,6 +221,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
+            wal_options: region_wal_options.clone(),
         };
         let err = FileRegion::open(region_id, request, &object_store)
             .await

--- a/src/file-engine/src/test_util.rs
+++ b/src/file-engine/src/test_util.rs
@@ -65,3 +65,7 @@ pub fn new_test_options() -> HashMap<String, String> {
         ),
     ])
 }
+
+pub fn new_test_wal_options() -> HashMap<String, String> {
+    HashMap::default()
+}

--- a/src/frontend/src/instance/standalone.rs
+++ b/src/frontend/src/instance/standalone.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use api::v1::meta::Partition;
@@ -20,7 +21,7 @@ use async_trait::async_trait;
 use client::region::check_response_header;
 use common_error::ext::BoxedError;
 use common_meta::datanode_manager::{AffectedRows, Datanode, DatanodeManager, DatanodeRef};
-use common_meta::ddl::{TableMetadataAllocator, TableMetadataAllocatorContext};
+use common_meta::ddl::{TableMetadata, TableMetadataAllocator, TableMetadataAllocatorContext};
 use common_meta::error::{self as meta_error, Result as MetaResult};
 use common_meta::kv_backend::KvBackendRef;
 use common_meta::peer::Peer;
@@ -32,7 +33,7 @@ use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use datanode::region_server::RegionServer;
 use servers::grpc::region_server::RegionServerHandler;
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::{RegionId, TableId};
+use store_api::storage::RegionId;
 use table::metadata::RawTableInfo;
 
 use crate::error::{InvalidRegionRequestSnafu, InvokeRegionServerSnafu, Result};
@@ -126,7 +127,7 @@ impl TableMetadataAllocator for StandaloneTableMetadataCreator {
         _ctx: &TableMetadataAllocatorContext,
         raw_table_info: &mut RawTableInfo,
         partitions: &[Partition],
-    ) -> MetaResult<(TableId, Vec<RegionRoute>)> {
+    ) -> MetaResult<TableMetadata> {
         let table_id = self.table_id_sequence.next().await? as u32;
         raw_table_info.ident.table_id = table_id;
         let region_routes = partitions
@@ -149,6 +150,10 @@ impl TableMetadataAllocator for StandaloneTableMetadataCreator {
             })
             .collect::<Vec<_>>();
 
-        Ok((table_id, region_routes))
+        Ok(TableMetadata {
+            table_id,
+            region_routes,
+            region_wal_options: HashMap::new(),
+        })
     }
 }

--- a/src/log-store/src/kafka.rs
+++ b/src/log-store/src/kafka.rs
@@ -1,0 +1,83 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod log_store;
+
+use common_meta::wal::kafka::Topic;
+use store_api::logstore::entry::{Entry, Id as EntryId};
+use store_api::logstore::namespace::Namespace;
+
+use crate::error::Error;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct NamespaceImpl {
+    region_id: u64,
+    topic: Topic,
+}
+
+impl NamespaceImpl {
+    fn new(region_id: u64, topic: Topic) -> Self {
+        Self { region_id, topic }
+    }
+
+    fn region_id(&self) -> u64 {
+        self.region_id
+    }
+
+    fn topic(&self) -> &Topic {
+        &self.topic
+    }
+}
+
+impl Namespace for NamespaceImpl {
+    fn id(&self) -> u64 {
+        self.region_id
+    }
+}
+
+pub struct EntryImpl {
+    /// Entry payload.
+    data: Vec<u8>,
+    /// The logical entry id.
+    id: EntryId,
+    /// The namespace used to identify and isolate log entries from different regions.
+    ns: NamespaceImpl,
+}
+
+impl EntryImpl {
+    fn new(data: Vec<u8>, entry_id: EntryId, ns: NamespaceImpl) -> Self {
+        Self {
+            data,
+            id: entry_id,
+            ns,
+        }
+    }
+}
+
+impl Entry for EntryImpl {
+    type Error = Error;
+    type Namespace = NamespaceImpl;
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn id(&self) -> EntryId {
+        self.id
+    }
+
+    fn namespace(&self) -> Self::Namespace {
+        self.ns.clone()
+    }
+}

--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use common_config::wal::kafka::KafkaOptions;
 use store_api::logstore::entry::Id as EntryId;
 use store_api::logstore::entry_stream::SendableEntryStream;
 use store_api::logstore::namespace::Id as NamespaceId;
@@ -26,7 +27,7 @@ use crate::kafka::{EntryImpl, NamespaceImpl};
 pub struct KafkaLogStore;
 
 impl KafkaLogStore {
-    pub async fn try_new() -> Result<Self> {
+    pub async fn try_new(options: KafkaOptions) -> Result<Self> {
         todo!()
     }
 }

--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use store_api::logstore::entry::Id as EntryId;
+use store_api::logstore::entry_stream::SendableEntryStream;
+use store_api::logstore::namespace::Id as NamespaceId;
+use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore};
+
+use crate::error::{Error, Result};
+use crate::kafka::{EntryImpl, NamespaceImpl};
+
+#[derive(Debug)]
+pub struct KafkaLogStore;
+
+impl KafkaLogStore {
+    pub async fn try_new() -> Result<Self> {
+        todo!()
+    }
+}
+
+#[async_trait::async_trait]
+impl LogStore for KafkaLogStore {
+    type Error = Error;
+    type Entry = EntryImpl;
+    type Namespace = NamespaceImpl;
+
+    /// Create an entry of the associate Entry type.
+    fn entry<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        entry_id: EntryId,
+        ns: Self::Namespace,
+    ) -> Self::Entry {
+        EntryImpl::new(data.as_ref().to_vec(), entry_id, ns)
+    }
+
+    /// Append an `Entry` to WAL with given namespace and return append response containing
+    /// the entry id.
+    async fn append(&self, entry: Self::Entry) -> Result<AppendResponse> {
+        todo!()
+    }
+
+    /// For a batch of log entries belonging to multiple regions, each assigned to a specific topic,
+    /// we need to determine the minimum log offset returned for each region in this batch.
+    /// During replay, we use this offset to fetch log entries for a region from its assigned topic.
+    /// After fetching, we filter the entries to obtain log entries relevant to that specific region.
+    async fn append_batch(&self, entries: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
+        todo!()
+    }
+
+    /// Create a new `EntryStream` to asynchronously generates `Entry` with ids
+    /// starting from `id`. The generated entries will be filtered by the namespace.
+    async fn read(
+        &self,
+        ns: &Self::Namespace,
+        entry_id: EntryId,
+    ) -> Result<SendableEntryStream<Self::Entry, Self::Error>> {
+        todo!()
+    }
+
+    /// Create a namespace of the associate Namespace type
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        wal_options: &HashMap<String, String>,
+    ) -> Result<Self::Namespace> {
+        todo!()
+    }
+
+    /// Create a new `Namespace`.
+    async fn create_namespace(&self, _ns: &Self::Namespace) -> Result<()> {
+        Ok(())
+    }
+
+    /// Delete an existing `Namespace` with given ref.
+    async fn delete_namespace(&self, _ns: &Self::Namespace) -> Result<()> {
+        Ok(())
+    }
+
+    /// List all existing namespaces.
+    async fn list_namespaces(&self) -> Result<Vec<Self::Namespace>> {
+        Ok(vec![])
+    }
+
+    /// Mark all entry ids `<=id` of given `namespace` as obsolete so that logstore can safely delete
+    /// the log files if all entries inside are obsolete. This method may not delete log
+    /// files immediately.
+    async fn obsolete(&self, _ns: Self::Namespace, _entry_id: EntryId) -> Result<()> {
+        Ok(())
+    }
+
+    /// Stop components of logstore.
+    async fn stop(&self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use common_config::wal::kafka::KafkaOptions;
+use common_config::wal::kafka::KafkaConfig;
 use store_api::logstore::entry::Id as EntryId;
 use store_api::logstore::entry_stream::SendableEntryStream;
 use store_api::logstore::namespace::Id as NamespaceId;
@@ -27,7 +27,7 @@ use crate::kafka::{EntryImpl, NamespaceImpl};
 pub struct KafkaLogStore;
 
 impl KafkaLogStore {
-    pub async fn try_new(options: KafkaOptions) -> Result<Self> {
+    pub async fn try_new(config: KafkaConfig) -> Result<Self> {
         todo!()
     }
 }

--- a/src/log-store/src/lib.rs
+++ b/src/log-store/src/lib.rs
@@ -15,6 +15,8 @@
 #![feature(let_chains)]
 
 pub mod error;
+#[allow(unused)]
+pub mod kafka;
 mod noop;
 pub mod raft_engine;
 pub mod test_util;

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use store_api::logstore::entry::{Entry, Id};
+use std::collections::HashMap;
+
+use store_api::logstore::entry::{Entry, Id as EntryId};
 use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
-use store_api::logstore::{AppendResponse, LogStore};
+use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore};
 
 use crate::error::{Error, Result};
 
@@ -42,7 +44,7 @@ impl Entry for EntryImpl {
         &[]
     }
 
-    fn id(&self) -> Id {
+    fn id(&self) -> EntryId {
         0
     }
 
@@ -62,17 +64,22 @@ impl LogStore for NoopLogStore {
     }
 
     async fn append(&self, mut _e: Self::Entry) -> Result<AppendResponse> {
-        Ok(AppendResponse { entry_id: 0 })
+        Ok(AppendResponse {
+            entry_id: 0,
+            offset: None,
+        })
     }
 
-    async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<()> {
-        Ok(())
+    async fn append_batch(&self, _e: Vec<Self::Entry>) -> Result<AppendBatchResponse> {
+        Ok(AppendBatchResponse {
+            offsets: HashMap::new(),
+        })
     }
 
     async fn read(
         &self,
         _ns: &Self::Namespace,
-        _id: Id,
+        _entry_id: EntryId,
     ) -> Result<store_api::logstore::entry_stream::SendableEntryStream<'_, Self::Entry, Self::Error>>
     {
         Ok(Box::pin(futures::stream::once(futures::future::ready(Ok(
@@ -92,25 +99,35 @@ impl LogStore for NoopLogStore {
         Ok(vec![])
     }
 
-    fn entry<D: AsRef<[u8]>>(&self, data: D, id: Id, ns: Self::Namespace) -> Self::Entry {
+    fn entry<D: AsRef<[u8]>>(
+        &self,
+        data: D,
+        entry_id: EntryId,
+        ns: Self::Namespace,
+    ) -> Self::Entry {
         let _ = data;
-        let _ = id;
+        let _ = entry_id;
         let _ = ns;
         EntryImpl
     }
 
-    fn namespace(&self, id: NamespaceId) -> Self::Namespace {
-        let _ = id;
-        NamespaceImpl
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        wal_options: &HashMap<String, String>,
+    ) -> Result<Self::Namespace> {
+        let _ = ns_id;
+        let _ = wal_options;
+        Ok(NamespaceImpl)
     }
 
     async fn obsolete(
         &self,
-        namespace: Self::Namespace,
-        id: Id,
+        ns: Self::Namespace,
+        entry_id: EntryId,
     ) -> std::result::Result<(), Self::Error> {
-        let _ = namespace;
-        let _ = id;
+        let _ = ns;
+        let _ = entry_id;
         Ok(())
     }
 }
@@ -135,7 +152,10 @@ mod tests {
         store.create_namespace(&NamespaceImpl).await.unwrap();
         assert_eq!(0, store.list_namespaces().await.unwrap().len());
         store.delete_namespace(&NamespaceImpl).await.unwrap();
-        assert_eq!(NamespaceImpl, store.namespace(0));
+        assert_eq!(
+            NamespaceImpl,
+            store.namespace(0, &HashMap::default()).unwrap()
+        );
         store.obsolete(NamespaceImpl, 1).await.unwrap();
     }
 }

--- a/src/log-store/src/raft_engine.rs
+++ b/src/log-store/src/raft_engine.rs
@@ -14,8 +14,8 @@
 
 use std::hash::{Hash, Hasher};
 
-use store_api::logstore::entry::{Entry, Id};
-use store_api::logstore::namespace::Namespace;
+use store_api::logstore::entry::{Entry, Id as EntryId};
+use store_api::logstore::namespace::{Id as NamespaceId, Namespace};
 
 use crate::error::Error;
 use crate::raft_engine::protos::logstore::{EntryImpl, NamespaceImpl};
@@ -42,7 +42,7 @@ impl EntryImpl {
 }
 
 impl NamespaceImpl {
-    pub fn with_id(id: Id) -> Self {
+    pub fn with_id(id: NamespaceId) -> Self {
         Self {
             id,
             ..Default::default()
@@ -60,7 +60,7 @@ impl Hash for NamespaceImpl {
 impl Eq for NamespaceImpl {}
 
 impl Namespace for NamespaceImpl {
-    fn id(&self) -> store_api::logstore::namespace::Id {
+    fn id(&self) -> NamespaceId {
         self.id
     }
 }
@@ -73,7 +73,7 @@ impl Entry for EntryImpl {
         self.data.as_slice()
     }
 
-    fn id(&self) -> Id {
+    fn id(&self) -> EntryId {
         self.id
     }
 

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use async_stream::stream;
-use common_config::WalConfig;
+use common_config::wal::raft_engine::RaftEngineOptions;
 use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::{error, info};
 use raft_engine::{Config, Engine, LogBatch, MessageExt, ReadableSize, RecoveryMode};
@@ -38,7 +38,7 @@ use crate::raft_engine::protos::logstore::{EntryImpl, NamespaceImpl as Namespace
 const NAMESPACE_PREFIX: &str = "$sys/";
 
 pub struct RaftEngineLogStore {
-    config: WalConfig,
+    options: RaftEngineOptions,
     engine: Arc<Engine>,
     gc_task: RepeatedTask<Error>,
 }
@@ -73,25 +73,25 @@ impl TaskFunction<Error> for PurgeExpiredFilesFunction {
 }
 
 impl RaftEngineLogStore {
-    pub async fn try_new(dir: String, config: WalConfig) -> Result<Self> {
+    pub async fn try_new(dir: String, options: RaftEngineOptions) -> Result<Self> {
         let raft_engine_config = Config {
             dir,
-            purge_threshold: ReadableSize(config.purge_threshold.0),
+            purge_threshold: ReadableSize(options.purge_threshold.0),
             recovery_mode: RecoveryMode::TolerateTailCorruption,
             batch_compression_threshold: ReadableSize::kb(8),
-            target_file_size: ReadableSize(config.file_size.0),
+            target_file_size: ReadableSize(options.file_size.0),
             ..Default::default()
         };
         let engine = Arc::new(Engine::open(raft_engine_config).context(RaftEngineSnafu)?);
         let gc_task = RepeatedTask::new(
-            config.purge_interval,
+            options.purge_interval,
             Box::new(PurgeExpiredFilesFunction {
                 engine: engine.clone(),
             }),
         );
 
         let log_store = Self {
-            config,
+            options,
             engine,
             gc_task,
         };
@@ -138,7 +138,7 @@ impl RaftEngineLogStore {
 impl Debug for RaftEngineLogStore {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RaftEngineLogsStore")
-            .field("config", &self.config)
+            .field("options", &self.options)
             .field("started", &self.gc_task.started())
             .finish()
     }
@@ -177,7 +177,7 @@ impl LogStore for RaftEngineLogStore {
 
         let _ = self
             .engine
-            .write(&mut batch, self.config.sync_write)
+            .write(&mut batch, self.options.sync_write)
             .context(RaftEngineSnafu)?;
         Ok(AppendResponse {
             entry_id,
@@ -205,7 +205,7 @@ impl LogStore for RaftEngineLogStore {
 
         let _ = self
             .engine
-            .write(&mut batch, self.config.sync_write)
+            .write(&mut batch, self.options.sync_write)
             .context(RaftEngineSnafu)?;
 
         // The user of raft-engine log store does not care about the response.
@@ -231,7 +231,7 @@ impl LogStore for RaftEngineLogStore {
             entry_id,
             self.span(ns)
         );
-        let max_batch_size = self.config.read_batch_size;
+        let max_batch_size = self.options.read_batch_size;
         let (tx, mut rx) = tokio::sync::mpsc::channel(max_batch_size);
         let ns = ns.clone();
         let _handle = common_runtime::spawn_read(async move {
@@ -402,7 +402,7 @@ mod tests {
         let dir = create_temp_dir("raft-engine-logstore-test");
         let logstore = RaftEngineLogStore::try_new(
             dir.path().to_str().unwrap().to_string(),
-            WalConfig::default(),
+            RaftEngineOptions::default(),
         )
         .await
         .unwrap();
@@ -415,7 +415,7 @@ mod tests {
         let dir = create_temp_dir("raft-engine-logstore-test");
         let logstore = RaftEngineLogStore::try_new(
             dir.path().to_str().unwrap().to_string(),
-            WalConfig::default(),
+            RaftEngineOptions::default(),
         )
         .await
         .unwrap();
@@ -441,7 +441,7 @@ mod tests {
         let dir = create_temp_dir("raft-engine-logstore-test");
         let logstore = RaftEngineLogStore::try_new(
             dir.path().to_str().unwrap().to_string(),
-            WalConfig::default(),
+            RaftEngineOptions::default(),
         )
         .await
         .unwrap();
@@ -482,7 +482,7 @@ mod tests {
         {
             let logstore = RaftEngineLogStore::try_new(
                 dir.path().to_str().unwrap().to_string(),
-                WalConfig::default(),
+                RaftEngineOptions::default(),
             )
             .await
             .unwrap();
@@ -502,7 +502,7 @@ mod tests {
 
         let logstore = RaftEngineLogStore::try_new(
             dir.path().to_str().unwrap().to_string(),
-            WalConfig::default(),
+            RaftEngineOptions::default(),
         )
         .await
         .unwrap();
@@ -537,14 +537,14 @@ mod tests {
         let dir = create_temp_dir("raft-engine-logstore-test");
         let path = dir.path().to_str().unwrap().to_string();
 
-        let config = WalConfig {
+        let options = RaftEngineOptions {
             file_size: ReadableSize::mb(2),
             purge_threshold: ReadableSize::mb(4),
             purge_interval: Duration::from_secs(5),
             ..Default::default()
         };
 
-        let logstore = RaftEngineLogStore::try_new(path, config).await.unwrap();
+        let logstore = RaftEngineLogStore::try_new(path, options).await.unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..4096 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());
@@ -569,14 +569,14 @@ mod tests {
         let dir = create_temp_dir("raft-engine-logstore-test");
         let path = dir.path().to_str().unwrap().to_string();
 
-        let config = WalConfig {
+        let options = RaftEngineOptions {
             file_size: ReadableSize::mb(2),
             purge_threshold: ReadableSize::mb(4),
             purge_interval: Duration::from_secs(5),
             ..Default::default()
         };
 
-        let logstore = RaftEngineLogStore::try_new(path, config).await.unwrap();
+        let logstore = RaftEngineLogStore::try_new(path, options).await.unwrap();
         let namespace = Namespace::with_id(42);
         for id in 0..1024 {
             let entry = Entry::create(id, namespace.id(), [b'x'; 4096].to_vec());
@@ -598,14 +598,14 @@ mod tests {
         let dir = create_temp_dir("logstore-append-batch-test");
         let path = dir.path().to_str().unwrap().to_string();
 
-        let config = WalConfig {
+        let options = RaftEngineOptions {
             file_size: ReadableSize::mb(2),
             purge_threshold: ReadableSize::mb(4),
             purge_interval: Duration::from_secs(5),
             ..Default::default()
         };
 
-        let logstore = RaftEngineLogStore::try_new(path, config).await.unwrap();
+        let logstore = RaftEngineLogStore::try_new(path, options).await.unwrap();
 
         let entries = (0..8)
             .flat_map(|ns_id| {
@@ -629,14 +629,14 @@ mod tests {
         let dir = create_temp_dir("logstore-append-batch-test");
 
         let path = dir.path().to_str().unwrap().to_string();
-        let config = WalConfig {
+        let options = RaftEngineOptions {
             file_size: ReadableSize::mb(2),
             purge_threshold: ReadableSize::mb(4),
             purge_interval: Duration::from_secs(5),
             ..Default::default()
         };
 
-        let logstore = RaftEngineLogStore::try_new(path, config).await.unwrap();
+        let logstore = RaftEngineLogStore::try_new(path, options).await.unwrap();
 
         let entries = vec![
             Entry::create(0, 0, [b'0'; 4096].to_vec()),

--- a/src/log-store/src/test_util/log_store_util.rs
+++ b/src/log-store/src/test_util/log_store_util.rs
@@ -15,16 +15,16 @@
 use std::path::Path;
 
 use common_base::readable_size::ReadableSize;
-use common_config::wal::raft_engine::RaftEngineOptions;
+use common_config::wal::raft_engine::RaftEngineConfig;
 
 use crate::raft_engine::log_store::RaftEngineLogStore;
 
 /// Create a write log for the provided path, used for test.
 pub async fn create_tmp_local_file_log_store<P: AsRef<Path>>(path: P) -> RaftEngineLogStore {
     let path = path.as_ref().display().to_string();
-    let options = RaftEngineOptions {
+    let config = RaftEngineConfig {
         file_size: ReadableSize::kb(128),
         ..Default::default()
     };
-    RaftEngineLogStore::try_new(path, options).await.unwrap()
+    RaftEngineLogStore::try_new(path, config).await.unwrap()
 }

--- a/src/log-store/src/test_util/log_store_util.rs
+++ b/src/log-store/src/test_util/log_store_util.rs
@@ -15,16 +15,16 @@
 use std::path::Path;
 
 use common_base::readable_size::ReadableSize;
-use common_config::WalConfig;
+use common_config::wal::raft_engine::RaftEngineOptions;
 
 use crate::raft_engine::log_store::RaftEngineLogStore;
 
 /// Create a write log for the provided path, used for test.
 pub async fn create_tmp_local_file_log_store<P: AsRef<Path>>(path: P) -> RaftEngineLogStore {
     let path = path.as_ref().display().to_string();
-    let cfg = WalConfig {
+    let options = RaftEngineOptions {
         file_size: ReadableSize::kb(128),
         ..Default::default()
     };
-    RaftEngineLogStore::try_new(path, cfg).await.unwrap()
+    RaftEngineLogStore::try_new(path, options).await.unwrap()
 }

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -235,7 +235,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -365,7 +365,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/handler/region_lease_handler.rs
+++ b/src/meta-srv/src/handler/region_lease_handler.rs
@@ -235,7 +235,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -365,7 +365,7 @@ mod test {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -26,7 +26,7 @@ use common_meta::ddl::DdlTaskExecutorRef;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackend, ResettableKvBackendRef};
 use common_meta::sequence::SequenceRef;
-use common_meta::wal::WalOptions;
+use common_meta::wal::WalConfig;
 use common_procedure::options::ProcedureConfig;
 use common_procedure::ProcedureManagerRef;
 use common_telemetry::logging::LoggingOptions;
@@ -72,7 +72,7 @@ pub struct MetaSrvOptions {
     pub datanode: DatanodeOptions,
     pub enable_telemetry: bool,
     pub data_home: String,
-    pub wal: WalOptions,
+    pub wal: WalConfig,
 }
 
 impl Default for MetaSrvOptions {
@@ -97,7 +97,7 @@ impl Default for MetaSrvOptions {
             datanode: DatanodeOptions::default(),
             enable_telemetry: true,
             data_home: METASRV_HOME.to_string(),
-            wal: WalOptions::default(),
+            wal: WalConfig::default(),
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -26,6 +26,7 @@ use common_meta::ddl::DdlTaskExecutorRef;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackend, ResettableKvBackendRef};
 use common_meta::sequence::SequenceRef;
+use common_meta::wal::WalOptions;
 use common_procedure::options::ProcedureConfig;
 use common_procedure::ProcedureManagerRef;
 use common_telemetry::logging::LoggingOptions;
@@ -71,6 +72,7 @@ pub struct MetaSrvOptions {
     pub datanode: DatanodeOptions,
     pub enable_telemetry: bool,
     pub data_home: String,
+    pub wal: WalOptions,
 }
 
 impl Default for MetaSrvOptions {
@@ -95,6 +97,7 @@ impl Default for MetaSrvOptions {
             datanode: DatanodeOptions::default(),
             enable_telemetry: true,
             data_home: METASRV_HOME.to_string(),
+            wal: WalOptions::default(),
         }
     }
 }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -28,6 +28,8 @@ use common_meta::kv_backend::memory::MemoryKvBackend;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
 use common_meta::sequence::Sequence;
 use common_meta::state_store::KvStateStore;
+use common_meta::wal::region_wal_options::RegionWalOptionsAllocator;
+use common_meta::wal::WalOptions;
 use common_procedure::local::{LocalManager, ManagerConfig};
 use common_procedure::ProcedureManagerRef;
 use snafu::ResultExt;
@@ -203,11 +205,13 @@ impl MetaSrvBuilder {
             table_id: None,
         };
 
+        let region_wal_options_allocator = build_region_wal_options_allocator(&options.wal).await?;
         let table_metadata_allocator = table_metadata_allocator.unwrap_or_else(|| {
             Arc::new(MetaSrvTableMetadataAllocator::new(
                 selector_ctx.clone(),
                 selector.clone(),
                 table_id_sequence.clone(),
+                region_wal_options_allocator,
             ))
         });
 
@@ -341,6 +345,12 @@ fn build_procedure_manager(
     };
     let state_store = Arc::new(KvStateStore::new(kv_backend.clone()));
     Arc::new(LocalManager::new(manager_config, state_store))
+}
+
+async fn build_region_wal_options_allocator(
+    _wal_opts: &WalOptions,
+) -> Result<RegionWalOptionsAllocator> {
+    todo!()
 }
 
 fn build_ddl_manager(

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -350,7 +350,8 @@ fn build_procedure_manager(
 async fn build_region_wal_options_allocator(
     _wal_opts: &WalOptions,
 ) -> Result<RegionWalOptionsAllocator> {
-    todo!()
+    // TODO(niebayes): properly construct a region wal options allocator.
+    Ok(RegionWalOptionsAllocator)
 }
 
 fn build_ddl_manager(

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -29,7 +29,7 @@ use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
 use common_meta::sequence::Sequence;
 use common_meta::state_store::KvStateStore;
 use common_meta::wal::region_wal_options::RegionWalOptionsAllocator;
-use common_meta::wal::WalOptions;
+use common_meta::wal::WalConfig;
 use common_procedure::local::{LocalManager, ManagerConfig};
 use common_procedure::ProcedureManagerRef;
 use snafu::ResultExt;
@@ -348,9 +348,10 @@ fn build_procedure_manager(
 }
 
 async fn build_region_wal_options_allocator(
-    _wal_opts: &WalOptions,
+    config: &WalConfig,
 ) -> Result<RegionWalOptionsAllocator> {
-    // TODO(niebayes): properly construct a region wal options allocator.
+    // TODO(niebayes): construct a region wal options allocator.
+    let _ = config;
     Ok(RegionWalOptionsAllocator)
 }
 

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -618,6 +618,7 @@ mod tests {
                             opening_region,
                             &path,
                             HashMap::new(),
+                            HashMap::new(),
                         )))
                         .unwrap(),
                     ))

--- a/src/meta-srv/src/procedure/region_failover/activate_region.rs
+++ b/src/meta-srv/src/procedure/region_failover/activate_region.rs
@@ -43,6 +43,7 @@ pub(super) struct ActivateRegion {
     remark_inactive_region: bool,
     region_storage_path: Option<String>,
     region_options: Option<HashMap<String, String>>,
+    region_wal_options: Option<HashMap<String, String>>,
 }
 
 impl ActivateRegion {
@@ -52,6 +53,7 @@ impl ActivateRegion {
             remark_inactive_region: false,
             region_storage_path: None,
             region_options: None,
+            region_wal_options: None,
         }
     }
 
@@ -80,15 +82,22 @@ impl ActivateRegion {
             ..failed_region.clone()
         };
         info!("Activating region: {candidate_ident:?}");
+
         let region_options: HashMap<String, String> = (&table_info.meta.options).into();
+        // TODO(niebayes): properly fetch or construct region wal options.
+        let region_wal_options = HashMap::default();
+
         let instruction = Instruction::OpenRegion(OpenRegion::new(
             candidate_ident.clone(),
             &region_storage_path,
             region_options.clone(),
+            region_wal_options.clone(),
         ));
 
         self.region_storage_path = Some(region_storage_path);
         self.region_options = Some(region_options);
+        self.region_wal_options = Some(region_wal_options);
+
         let msg = MailboxMessage::json_message(
             "Activate Region",
             &format!("Metasrv@{}", ctx.selector_ctx.server_addr),
@@ -222,6 +231,7 @@ mod tests {
                     },
                     &env.path,
                     HashMap::new(),
+                    HashMap::new(),
                 )))
                 .unwrap(),
             ))
@@ -291,6 +301,7 @@ mod tests {
                         ..failed_region.clone()
                     },
                     &env.path,
+                    HashMap::new(),
                     HashMap::new(),
                 )))
                 .unwrap(),

--- a/src/meta-srv/src/procedure/region_migration/migration_start.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_start.rs
@@ -188,7 +188,7 @@ mod tests {
         };
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, vec![region_route], HashMap::new())
+            .create_table_metadata(table_info, vec![region_route], HashMap::default())
             .await
             .unwrap();
 
@@ -222,7 +222,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -255,7 +255,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -282,7 +282,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/migration_start.rs
+++ b/src/meta-srv/src/procedure/region_migration/migration_start.rs
@@ -137,6 +137,7 @@ impl RegionMigrationStart {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -187,7 +188,7 @@ mod tests {
         };
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, vec![region_route])
+            .create_table_metadata(table_info, vec![region_route], HashMap::new())
             .await
             .unwrap();
 
@@ -221,7 +222,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -254,7 +255,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -281,7 +282,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -418,7 +418,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -77,6 +77,9 @@ impl OpenCandidateRegion {
         let engine = table_info.meta.engine.clone();
         let region_options: HashMap<String, String> = (&table_info.meta.options).into();
 
+        // TODO(niebayes): properly fetch or construct region wal options.
+        let region_wal_options = HashMap::default();
+
         let open_instruction = Instruction::OpenRegion(OpenRegion::new(
             RegionIdent {
                 cluster_id,
@@ -87,6 +90,7 @@ impl OpenCandidateRegion {
             },
             &region_storage_path,
             region_options,
+            region_wal_options,
         ));
 
         Ok(open_instruction)
@@ -212,6 +216,7 @@ mod tests {
             },
             region_storage_path: "/bar/foo/region/".to_string(),
             options: Default::default(),
+            wal_options: Default::default(),
         })
     }
 

--- a/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/open_candidate_region.rs
@@ -418,7 +418,7 @@ mod tests {
         }];
 
         env.table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::assert_matches::assert_matches;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use api::v1::meta::mailbox_message::Payload;
@@ -331,7 +332,7 @@ impl ProcedureMigrationTestSuite {
     ) {
         self.env
             .table_metadata_manager()
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
     }

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -332,7 +332,7 @@ impl ProcedureMigrationTestSuite {
     ) {
         self.env
             .table_metadata_manager()
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
     }

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
@@ -74,6 +74,7 @@ impl UpdateMetadata {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -137,7 +138,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -191,7 +192,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -234,7 +235,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
@@ -138,7 +138,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -192,7 +192,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -235,7 +235,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
@@ -59,6 +59,7 @@ impl UpdateMetadata {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -129,7 +130,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -215,7 +216,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
@@ -130,7 +130,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -216,7 +216,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
@@ -171,6 +171,7 @@ impl UpdateMetadata {
 #[cfg(test)]
 mod tests {
     use std::assert_matches::assert_matches;
+    use std::collections::HashMap;
 
     use common_meta::key::test_utils::new_test_table_info;
     use common_meta::peer::Peer;
@@ -221,7 +222,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -250,7 +251,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -281,7 +282,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -322,7 +323,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -381,7 +382,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -407,7 +408,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -433,7 +434,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -466,7 +467,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
@@ -222,7 +222,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -251,7 +251,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -282,7 +282,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -323,7 +323,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -382,7 +382,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -408,7 +408,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -434,7 +434,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -467,7 +467,7 @@ mod tests {
 
         let table_metadata_manager = env.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -101,7 +101,7 @@ fn test_create_region_request_template() {
         1,
         create_table_task(),
         test_data::new_region_routes(),
-        HashMap::new(),
+        HashMap::default(),
         test_data::new_ddl_context(Arc::new(DatanodeClients::default())),
     );
 
@@ -192,7 +192,7 @@ async fn test_on_datanode_create_regions() {
         1,
         create_table_task(),
         region_routes,
-        HashMap::new(),
+        HashMap::default(),
         test_data::new_ddl_context(datanode_manager),
     );
 
@@ -371,7 +371,11 @@ async fn test_submit_alter_region_requests() {
     let table_info = test_data::new_table_info();
     context
         .table_metadata_manager
-        .create_table_metadata(table_info.clone(), region_routes.clone(), HashMap::new())
+        .create_table_metadata(
+            table_info.clone(),
+            region_routes.clone(),
+            HashMap::default(),
+        )
         .await
         .unwrap();
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -101,6 +101,7 @@ fn test_create_region_request_template() {
         1,
         create_table_task(),
         test_data::new_region_routes(),
+        HashMap::new(),
         test_data::new_ddl_context(Arc::new(DatanodeClients::default())),
     );
 
@@ -191,6 +192,7 @@ async fn test_on_datanode_create_regions() {
         1,
         create_table_task(),
         region_routes,
+        HashMap::new(),
         test_data::new_ddl_context(datanode_manager),
     );
 
@@ -369,7 +371,7 @@ async fn test_submit_alter_region_requests() {
     let table_info = test_data::new_table_info();
     context
         .table_metadata_manager
-        .create_table_metadata(table_info.clone(), region_routes.clone())
+        .create_table_metadata(table_info.clone(), region_routes.clone(), HashMap::new())
         .await
         .unwrap();
 

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -163,6 +163,7 @@ fn test_create_region_request_template() {
         primary_key: vec![2, 1],
         path: String::new(),
         options: HashMap::new(),
+        wal_options: HashMap::new(),
     };
     assert_eq!(template, expected);
 }

--- a/src/meta-srv/src/region/lease_keeper.rs
+++ b/src/meta-srv/src/region/lease_keeper.rs
@@ -328,7 +328,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -388,7 +388,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -438,7 +438,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -475,7 +475,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 
@@ -524,7 +524,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes, HashMap::new())
+            .create_table_metadata(table_info, region_routes, HashMap::default())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/region/lease_keeper.rs
+++ b/src/meta-srv/src/region/lease_keeper.rs
@@ -259,7 +259,7 @@ impl OpeningRegionKeeper {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use common_meta::key::test_utils::new_test_table_info;
@@ -328,7 +328,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -388,7 +388,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -438,7 +438,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -475,7 +475,7 @@ mod tests {
         let table_metadata_manager = keeper.table_metadata_manager();
 
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 
@@ -524,7 +524,7 @@ mod tests {
         let keeper = new_test_keeper();
         let table_metadata_manager = keeper.table_metadata_manager();
         table_metadata_manager
-            .create_table_metadata(table_info, region_routes)
+            .create_table_metadata(table_info, region_routes, HashMap::new())
             .await
             .unwrap();
 

--- a/src/meta-srv/src/table_meta_alloc.rs
+++ b/src/meta-srv/src/table_meta_alloc.rs
@@ -15,10 +15,11 @@
 use api::v1::meta::Partition;
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
-use common_meta::ddl::{TableMetadataAllocator, TableMetadataAllocatorContext};
+use common_meta::ddl::{TableMetadata, TableMetadataAllocator, TableMetadataAllocatorContext};
 use common_meta::error::{self as meta_error, Result as MetaResult};
 use common_meta::rpc::router::{Region, RegionRoute};
 use common_meta::sequence::SequenceRef;
+use common_meta::wal::region_wal_options::RegionWalOptionsAllocator;
 use common_telemetry::warn;
 use snafu::{ensure, ResultExt};
 use store_api::storage::{RegionId, TableId, MAX_REGION_SEQ};
@@ -32,6 +33,7 @@ pub struct MetaSrvTableMetadataAllocator {
     ctx: SelectorContext,
     selector: SelectorRef,
     table_id_sequence: SequenceRef,
+    region_wal_options_allocator: RegionWalOptionsAllocator,
 }
 
 impl MetaSrvTableMetadataAllocator {
@@ -39,11 +41,13 @@ impl MetaSrvTableMetadataAllocator {
         ctx: SelectorContext,
         selector: SelectorRef,
         table_id_sequence: SequenceRef,
+        region_wal_options_allocator: RegionWalOptionsAllocator,
     ) -> Self {
         Self {
             ctx,
             selector,
             table_id_sequence,
+            region_wal_options_allocator,
         }
     }
 }
@@ -55,8 +59,8 @@ impl TableMetadataAllocator for MetaSrvTableMetadataAllocator {
         ctx: &TableMetadataAllocatorContext,
         raw_table_info: &mut RawTableInfo,
         partitions: &[Partition],
-    ) -> MetaResult<(TableId, Vec<RegionRoute>)> {
-        handle_create_region_routes(
+    ) -> MetaResult<TableMetadata> {
+        let (table_id, region_routes) = handle_create_region_routes(
             ctx.cluster_id,
             raw_table_info,
             partitions,
@@ -66,7 +70,21 @@ impl TableMetadataAllocator for MetaSrvTableMetadataAllocator {
         )
         .await
         .map_err(BoxedError::new)
-        .context(meta_error::ExternalSnafu)
+        .context(meta_error::ExternalSnafu)?;
+
+        let region_numbers = region_routes
+            .iter()
+            .map(|route| route.region.id.region_number());
+        let region_wal_options = self
+            .region_wal_options_allocator
+            .alloc_batch(region_numbers.len());
+        let region_wal_options = region_numbers.zip(region_wal_options).collect();
+
+        Ok(TableMetadata {
+            table_id,
+            region_routes,
+            region_wal_options,
+        })
     }
 }
 

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::DateTime;
@@ -143,7 +144,7 @@ pub(crate) async fn prepare_table_region_and_info_value(
         region_route_factory(4, 3),
     ];
     table_metadata_manager
-        .create_table_metadata(table_info, region_routes)
+        .create_table_metadata(table_info, region_routes, HashMap::new())
         .await
         .unwrap();
 }

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -144,7 +144,7 @@ pub(crate) async fn prepare_table_region_and_info_value(
         region_route_factory(4, 3),
     ];
     table_metadata_manager
-        .create_table_metadata(table_info, region_routes, HashMap::new())
+        .create_table_metadata(table_info, region_routes, HashMap::default())
         .await
         .unwrap();
 }

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -345,6 +345,7 @@ impl MetricEngineInner {
             ],
             primary_key: vec![METADATA_SCHEMA_KEY_COLUMN_INDEX as _],
             options: HashMap::new(),
+            wal_options: HashMap::new(),
             region_dir: metadata_region_dir,
         }
     }
@@ -445,6 +446,7 @@ mod test {
             engine: METRIC_ENGINE_NAME.to_string(),
             primary_key: vec![],
             options: HashMap::new(),
+            wal_options: HashMap::new(),
         };
         let result = MetricEngineInner::verify_region_create_request(&request);
         assert!(result.is_err());
@@ -481,6 +483,7 @@ mod test {
             options: [(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new())]
                 .into_iter()
                 .collect(),
+            wal_options: HashMap::new(),
         };
         let result = MetricEngineInner::verify_region_create_request(&request);
         assert!(result.is_ok());
@@ -494,6 +497,7 @@ mod test {
             engine: METRIC_ENGINE_NAME.to_string(),
             primary_key: vec![],
             options: HashMap::new(),
+            wal_options: HashMap::new(),
         };
         let result = MetricEngineInner::verify_region_create_request(&request);
         assert!(result.is_err());
@@ -541,6 +545,7 @@ mod test {
             ],
             primary_key: vec![0],
             options: HashMap::new(),
+            wal_options: HashMap::new(),
             region_dir: "test_dir".to_string(),
         };
 

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -14,6 +14,8 @@
 
 //! Utilities for testing.
 
+use std::collections::HashMap;
+
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, ColumnSchema as PbColumnSchema, Row, SemanticType, Value};
 use datatypes::prelude::ConcreteDataType;
@@ -107,6 +109,7 @@ impl TestEnv {
             options: [(PHYSICAL_TABLE_METADATA_KEY.to_string(), String::new())]
                 .into_iter()
                 .collect(),
+            wal_options: HashMap::new(),
             region_dir: "test_metric_region".to_string(),
         };
 
@@ -221,6 +224,7 @@ pub fn create_logical_region_request(
         )]
         .into_iter()
         .collect(),
+        wal_options: HashMap::new(),
         region_dir: region_dir.to_string(),
     }
 }

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -119,6 +119,7 @@ async fn test_alter_region() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -201,6 +202,7 @@ async fn test_put_after_alter() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -117,6 +117,7 @@ async fn test_region_replay() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/create_test.rs
+++ b/src/mito2/src/engine/create_test.rs
@@ -198,3 +198,5 @@ async fn test_engine_create_with_custom_store() {
         .await
         .unwrap());
 }
+
+// TODO(niebayes): add tests for test_engine_create_with_wal_options.

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -42,6 +42,7 @@ async fn test_engine_open_empty() {
                 engine: String::new(),
                 region_dir: "empty".to_string(),
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -73,6 +74,7 @@ async fn test_engine_open_existing() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -161,6 +163,7 @@ async fn test_engine_region_open_with_options() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("ttl".to_string(), "4d".to_string())]),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -205,6 +208,7 @@ async fn test_engine_region_open_with_custom_store() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("storage".to_string(), "Gcs".to_string())]),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -225,3 +229,5 @@ async fn test_engine_region_open_with_custom_store() {
         .await
         .unwrap());
 }
+
+// TODO(niebayes): add tests for test_engine_open_with_wal_options.

--- a/src/mito2/src/engine/parallel_test.rs
+++ b/src/mito2/src/engine/parallel_test.rs
@@ -50,6 +50,7 @@ async fn scan_in_parallel(
                 engine: String::new(),
                 region_dir: region_dir.to_string(),
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -250,6 +250,7 @@ async fn test_engine_truncate_reopen() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await
@@ -353,6 +354,7 @@ async fn test_engine_truncate_during_flush() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_datasource::compression::CompressionType;
@@ -217,6 +218,17 @@ pub enum Error {
     DeleteWal {
         region_id: RegionId,
         location: Location,
+        source: BoxedError,
+    },
+
+    #[snafu(display(
+        "Failed to build a wal namespace, region_id: {}, wal_options: {:?}",
+        region_id,
+        wal_options
+    ))]
+    BuildWalNamespace {
+        region_id: RegionId,
+        wal_options: HashMap<String, String>,
         source: BoxedError,
     },
 
@@ -427,7 +439,8 @@ impl ErrorExt for Error {
             | ReadParquet { .. }
             | WriteWal { .. }
             | ReadWal { .. }
-            | DeleteWal { .. } => StatusCode::StorageUnavailable,
+            | DeleteWal { .. }
+            | BuildWalNamespace { .. } => StatusCode::StorageUnavailable,
             CompressObject { .. }
             | DecompressObject { .. }
             | SerdeJson { .. }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -74,6 +74,8 @@ pub(crate) struct MitoRegion {
     pub(crate) manifest_manager: RegionManifestManager,
     /// SST file purger.
     pub(crate) file_purger: FilePurgerRef,
+    /// Wal options of this region.
+    pub(crate) wal_options: HashMap<String, String>,
     /// Last flush time in millis.
     last_flush_millis: AtomicI64,
     /// Whether the region is writable.

--- a/src/mito2/src/region_write_ctx.rs
+++ b/src/mito2/src/region_write_ctx.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 
@@ -86,6 +87,8 @@ pub(crate) struct RegionWriteCtx {
     /// We keep [WalEntry] instead of mutations to avoid taking mutations
     /// out of the context to construct the wal entry when we write to the wal.
     wal_entry: WalEntry,
+    /// Wal options.
+    wal_options: HashMap<String, String>,
     /// Notifiers to send write results to waiters.
     ///
     /// The i-th notify is for i-th mutation.
@@ -102,7 +105,11 @@ pub(crate) struct RegionWriteCtx {
 
 impl RegionWriteCtx {
     /// Returns an empty context.
-    pub(crate) fn new(region_id: RegionId, version_control: &VersionControlRef) -> RegionWriteCtx {
+    pub(crate) fn new(
+        region_id: RegionId,
+        version_control: &VersionControlRef,
+        wal_options: HashMap<String, String>,
+    ) -> RegionWriteCtx {
         let VersionControlData {
             version,
             committed_sequence,
@@ -117,6 +124,7 @@ impl RegionWriteCtx {
             next_sequence: committed_sequence + 1,
             next_entry_id: last_entry_id + 1,
             wal_entry: WalEntry::default(),
+            wal_options,
             notifiers: Vec::new(),
             failed: false,
             put_num: 0,
@@ -153,7 +161,12 @@ impl RegionWriteCtx {
         &mut self,
         wal_writer: &mut WalWriter<S>,
     ) -> Result<()> {
-        wal_writer.add_entry(self.region_id, self.next_entry_id, &self.wal_entry)?;
+        wal_writer.add_entry(
+            self.region_id,
+            self.next_entry_id,
+            &self.wal_entry,
+            &self.wal_options,
+        )?;
         // We only call this method one time, but we still bump next entry id for consistency.
         self.next_entry_id += 1;
         Ok(())

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -289,6 +289,7 @@ pub struct CreateRequestBuilder {
     tag_num: usize,
     field_num: usize,
     options: HashMap<String, String>,
+    wal_options: HashMap<String, String>,
     primary_key: Option<Vec<ColumnId>>,
     all_not_null: bool,
     engine: String,
@@ -301,6 +302,7 @@ impl Default for CreateRequestBuilder {
             tag_num: 1,
             field_num: 1,
             options: HashMap::new(),
+            wal_options: HashMap::new(),
             primary_key: None,
             all_not_null: false,
             engine: MITO_ENGINE_NAME.to_string(),
@@ -341,6 +343,12 @@ impl CreateRequestBuilder {
     #[must_use]
     pub fn insert_option(mut self, key: &str, value: &str) -> Self {
         self.options.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    #[must_use]
+    pub fn insert_wal_option(mut self, key: &str, value: &str) -> Self {
+        self.wal_options.insert(key.to_string(), value.to_string());
         self
     }
 
@@ -397,6 +405,7 @@ impl CreateRequestBuilder {
             column_metadatas,
             primary_key: self.primary_key.clone().unwrap_or(primary_key),
             options: self.options.clone(),
+            wal_options: self.wal_options.clone(),
             region_dir: self.region_dir.clone(),
         }
     }
@@ -698,6 +707,7 @@ pub async fn reopen_region(
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                wal_options: HashMap::default(),
             }),
         )
         .await

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -64,6 +64,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         )
         .metadata(metadata)
         .options(request.options)
+        .wal_options(request.wal_options)
         .cache(Some(self.cache_manager.clone()))
         .create_or_open(&self.config, &self.wal)
         .await?;

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -14,6 +14,7 @@
 
 //! Handling flush related requests.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_telemetry::{error, info, warn};
@@ -201,7 +202,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             "Region {} flush finished, tries to bump wal to {}",
             region_id, request.flushed_entry_id
         );
-        if let Err(e) = self.wal.obsolete(region_id, request.flushed_entry_id).await {
+        // TODO(niebayes): Properly fetch wal options.
+        if let Err(e) = self
+            .wal
+            .obsolete(region_id, request.flushed_entry_id, &HashMap::default())
+            .await
+        {
             error!(e; "Failed to write wal, region: {}", region_id);
             request.on_failure(e);
             return;

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -70,6 +70,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             self.scheduler.clone(),
         )
         .options(request.options)
+        .wal_options(request.wal_options)
         .cache(Some(self.cache_manager.clone()))
         .open(&self.config, &self.wal)
         .await?;

--- a/src/mito2/src/worker/handle_truncate.rs
+++ b/src/mito2/src/worker/handle_truncate.rs
@@ -14,6 +14,8 @@
 
 //! Handling truncate related requests.
 
+use std::collections::HashMap;
+
 use common_telemetry::info;
 use store_api::logstore::LogStore;
 use store_api::region_request::AffectedRows;
@@ -59,7 +61,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         );
 
         // Make all data obsolete.
-        self.wal.obsolete(region_id, truncated_entry_id).await?;
+        // TODO(niebayes): Properly fetch wal options.
+        self.wal
+            .obsolete(region_id, truncated_entry_id, &HashMap::default())
+            .await?;
         info!(
             "Complete truncating region: {}, entry id: {} and sequence: {}.",
             region_id, truncated_entry_id, truncated_sequence

--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -133,7 +133,11 @@ impl<S> RegionWorkerLoop<S> {
                     continue;
                 };
 
-                let region_ctx = RegionWriteCtx::new(region.region_id, &region.version_control);
+                let region_ctx = RegionWriteCtx::new(
+                    region.region_id,
+                    &region.version_control,
+                    region.wal_options.clone(),
+                );
 
                 e.insert(region_ctx);
             }

--- a/src/operator/src/tests/partition_manager.rs
+++ b/src/operator/src/tests/partition_manager.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -22,6 +22,7 @@ use common_meta::kv_backend::memory::MemoryKvBackend;
 use common_meta::kv_backend::KvBackendRef;
 use common_meta::peer::Peer;
 use common_meta::rpc::router::{Region, RegionRoute};
+use common_meta::wal::region_wal_options::RegionWalOptions;
 use common_query::prelude::Expr;
 use datafusion_expr::expr_fn::{and, binary_expr, col, or};
 use datafusion_expr::{lit, Operator};
@@ -80,6 +81,12 @@ pub fn new_test_table_info(
         .unwrap()
 }
 
+fn new_test_region_wal_options(
+    _regions: Vec<RegionNumber>,
+) -> HashMap<RegionNumber, RegionWalOptions> {
+    todo!()
+}
+
 /// Create a partition rule manager with two tables, one is partitioned by single column, and
 /// the other one is two. The tables are under default catalog and schema.
 ///
@@ -102,9 +109,10 @@ pub(crate) async fn create_partition_rule_manager(
     let table_metadata_manager = TableMetadataManager::new(kv_backend.clone());
     let partition_manager = Arc::new(PartitionRuleManager::new(kv_backend));
 
+    let regions = vec![1u32, 2, 3];
     table_metadata_manager
         .create_table_metadata(
-            new_test_table_info(1, "table_1", vec![0u32, 1, 2].into_iter()).into(),
+            new_test_table_info(1, "table_1", regions.clone().into_iter()).into(),
             vec![
                 RegionRoute {
                     region: Region {
@@ -161,13 +169,15 @@ pub(crate) async fn create_partition_rule_manager(
                     leader_status: None,
                 },
             ],
+            new_test_region_wal_options(regions),
         )
         .await
         .unwrap();
 
+    let regions = vec![1u32, 2, 3];
     table_metadata_manager
         .create_table_metadata(
-            new_test_table_info(2, "table_2", vec![0u32, 1, 2].into_iter()).into(),
+            new_test_table_info(2, "table_2", regions.clone().into_iter()).into(),
             vec![
                 RegionRoute {
                     region: Region {
@@ -230,6 +240,7 @@ pub(crate) async fn create_partition_rule_manager(
                     leader_status: None,
                 },
             ],
+            new_test_region_wal_options(regions),
         )
         .await
         .unwrap();

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -14,11 +14,13 @@
 
 //! LogStore APIs.
 
+use std::collections::HashMap;
+
 use common_error::ext::ErrorExt;
 
-use crate::logstore::entry::{Entry, Id};
+use crate::logstore::entry::{Entry, Id as EntryId, Offset as EntryOffset};
 use crate::logstore::entry_stream::SendableEntryStream;
-use crate::logstore::namespace::Namespace;
+use crate::logstore::namespace::{Id as NamespaceId, Namespace};
 
 pub mod entry;
 pub mod entry_stream;
@@ -36,17 +38,21 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
 
     /// Append an `Entry` to WAL with given namespace and return append response containing
     /// the entry id.
-    async fn append(&self, e: Self::Entry) -> Result<AppendResponse, Self::Error>;
+    async fn append(&self, entry: Self::Entry) -> Result<AppendResponse, Self::Error>;
 
-    /// Append a batch of entries atomically and return the offset of first entry.
-    async fn append_batch(&self, e: Vec<Self::Entry>) -> Result<(), Self::Error>;
+    /// Append a batch of entries and return an append batch response containing the start entry ids of
+    /// log entries written to each region.
+    async fn append_batch(
+        &self,
+        entries: Vec<Self::Entry>,
+    ) -> Result<AppendBatchResponse, Self::Error>;
 
     /// Create a new `EntryStream` to asynchronously generates `Entry` with ids
     /// starting from `id`.
     async fn read(
         &self,
         ns: &Self::Namespace,
-        id: Id,
+        id: EntryId,
     ) -> Result<SendableEntryStream<Self::Entry, Self::Error>, Self::Error>;
 
     /// Create a new `Namespace`.
@@ -59,19 +65,37 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     async fn list_namespaces(&self) -> Result<Vec<Self::Namespace>, Self::Error>;
 
     /// Create an entry of the associate Entry type
-    fn entry<D: AsRef<[u8]>>(&self, data: D, id: Id, ns: Self::Namespace) -> Self::Entry;
+    fn entry<D: AsRef<[u8]>>(&self, data: D, entry_id: EntryId, ns: Self::Namespace)
+        -> Self::Entry;
 
     /// Create a namespace of the associate Namespace type
     // TODO(sunng87): confusion with `create_namespace`
-    fn namespace(&self, id: namespace::Id) -> Self::Namespace;
+    fn namespace(
+        &self,
+        ns_id: NamespaceId,
+        wal_options: &HashMap<String, String>,
+    ) -> Result<Self::Namespace, Self::Error>;
 
     /// Mark all entry ids `<=id` of given `namespace` as obsolete so that logstore can safely delete
     /// the log files if all entries inside are obsolete. This method may not delete log
     /// files immediately.
-    async fn obsolete(&self, namespace: Self::Namespace, id: Id) -> Result<(), Self::Error>;
+    async fn obsolete(&self, ns: Self::Namespace, entry_id: EntryId) -> Result<(), Self::Error>;
 }
 
+/// The response of an `append` operation.
 #[derive(Debug)]
 pub struct AppendResponse {
-    pub entry_id: Id,
+    /// The entry id of the appended log entry.
+    pub entry_id: EntryId,
+    /// The start entry offset of the appended log entry.
+    /// Depends on the `LogStore` implementation, the entry offset may be missing.
+    pub offset: Option<EntryOffset>,
+}
+
+/// The response of an `append_batch` operation.
+#[derive(Debug, Default)]
+pub struct AppendBatchResponse {
+    /// Key: region id (as u64). Value: the known minimum start offset of appended log entries belonging to the region.
+    /// Depends on the `LogStore` implementation, the entry offsets may be missing.
+    pub offsets: HashMap<u64, EntryOffset>,
 }

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -17,6 +17,7 @@ use common_error::ext::ErrorExt;
 use crate::logstore::namespace::Namespace;
 
 pub type Offset = usize;
+// TODO(niebayes): Consider removing `Epoch`.
 pub type Epoch = u64;
 pub type Id = u64;
 

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -99,6 +99,7 @@ impl RegionRequest {
                         column_metadatas,
                         primary_key: create.primary_key,
                         options: create.options,
+                        wal_options: create.wal_options,
                         region_dir,
                     }),
                 )])
@@ -116,6 +117,7 @@ impl RegionRequest {
                         engine: open.engine,
                         region_dir,
                         options: open.options,
+                        wal_options: HashMap::default(),
                     }),
                 )])
             }
@@ -181,6 +183,8 @@ pub struct RegionCreateRequest {
     pub primary_key: Vec<ColumnId>,
     /// Options of the created region.
     pub options: HashMap<String, String>,
+    /// Wal Options of the created region.
+    pub wal_options: HashMap<String, String>,
     /// Directory for region's data home. Usually is composed by catalog and table id
     pub region_dir: String,
 }
@@ -197,6 +201,8 @@ pub struct RegionOpenRequest {
     pub region_dir: String,
     /// Options of the opened region.
     pub options: HashMap<String, String>,
+    /// Wal options of the opened region.
+    pub wal_options: HashMap<String, String>,
 }
 
 /// Close region request.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

I've observed that reviewers are finding it challenging to grasp the overall scope of the remote wal project. This PR is proposed to try to speed up the review process.

The added skeleton codes consist of: 
- Build a `RegionWalOptionsAllocator` upon starting meta srv. The `RegionWalOptionsAllocator` is managed by `MetaSrvTableMetadataAllocator`. 
- The `RegionWalOptionsAllocator` is responsible for allocating per-region wal options when the `MetaSrvTableMetadataAllocator` is handling create table requests.
- The `RegionOpenRequest` and `RegionCreateRequest` are augmented with an extra `wal_options` field which is of type `HashMap<String, String>`, aka `EncodedRegionWalOptions`. Such a wal options is the encoded per-region `RegionWalOptions`. 
- The procedure manager is responsible for encoding `RegionWalOptions` and store it into `RegionCreateRequest`s. With these wal options, datanodes are able to create regions with specific wal options.
- The `DatanodeTableValue` is augmented with an extra `region_wal_options` field which is of type `HashMap<RegionNumber, EncodedRegionWalOptions>`. With this augmentation, the procedure manager is able to persist the `RegionWalOptions` for regions of a table.
- A datanode is now able to retrieve persisted `RegionWalOptions` through `DatanodeTableValue`. The restored wal options will be stored in `RegionOpenRequest`s. With these options, datanodes are able to open regions with specific wal options.
- The `MitoRegion` is augmented with a `wal_options` field which is of type `EncodedRegionWalOptions`. With these wal options, region workers are able to retrieve per-region wal options and utilize it to complete region write operations. 
- The `LogStore` is refactored to be able to support Kafka log store. 
- The initialization of a datanode is refactored so that a datanode is able to build a log store according to wal config.
 
Required: https://github.com/GreptimeTeam/greptime-proto/pull/127

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
