### PR TITLE
fix: `date` - `interval` sqlness

### DIFF
--- a/tests/cases/standalone/common/types/interval/interval.result
+++ b/tests/cases/standalone/common/types/interval/interval.result
@@ -202,8 +202,26 @@ SELECT DATE '2000-10-30' + interval_value from intervals;
 +-----------------------------------------------+
 
 -- DATE - INTERVAL
--- Run failed in distributed mode, but passed in standalone mode:
--- SELECT DATE '2000-10-30' - interval_value from intervals;
+SELECT DATE '2000-10-30' - interval_value from intervals;
+
++-----------------------------------------------+
+| Utf8("2000-10-30") - intervals.interval_value |
++-----------------------------------------------+
+| 1999-10-30                                    |
+| 1999-10-30                                    |
+| 1998-08-30                                    |
+| 1997-10-30                                    |
+| 1996-10-30                                    |
+| 1995-10-30                                    |
+| 1994-10-30                                    |
+| 1993-10-30                                    |
+| 1992-10-30                                    |
+| 1991-10-21                                    |
+| 1990-10-30                                    |
+| 1989-10-19                                    |
+| 1988-10-18                                    |
++-----------------------------------------------+
+
 -- INTERVAL + TIMESTAMP CONSTANT
 SELECT TIMESTAMP '1992-09-20 11:30:00.123456' + interval_value as new_value from intervals;
 

--- a/tests/cases/standalone/common/types/interval/interval.sql
+++ b/tests/cases/standalone/common/types/interval/interval.sql
@@ -58,8 +58,7 @@ SELECT ts - interval_value as new_value from intervals;
 SELECT DATE '2000-10-30' + interval_value from intervals;
 
 -- DATE - INTERVAL
--- Run failed in distributed mode, but passed in standalone mode:
--- SELECT DATE '2000-10-30' - interval_value from intervals;
+SELECT DATE '2000-10-30' - interval_value from intervals;
 
 -- INTERVAL + TIMESTAMP CONSTANT
 SELECT TIMESTAMP '1992-09-20 11:30:00.123456' + interval_value as new_value from intervals;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

open `date` - `interval` test case which can work now.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes #2319 .