### PR TITLE
fix: support tailing commas in SQL

### DIFF
--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -16,7 +16,7 @@ use snafu::ResultExt;
 use sqlparser::ast::Ident;
 use sqlparser::dialect::Dialect;
 use sqlparser::keywords::Keyword;
-use sqlparser::parser::{Parser, ParserError};
+use sqlparser::parser::{Parser, ParserError, ParserOptions};
 use sqlparser::tokenizer::{Token, TokenWithLocation};
 
 use crate::ast::{Expr, ObjectName};
@@ -37,6 +37,7 @@ impl<'a> ParserContext<'a> {
         let mut stmts: Vec<Statement> = Vec::new();
 
         let parser = Parser::new(dialect)
+            .with_options(ParserOptions::new().with_trailing_commas(true))
             .try_with_sql(sql)
             .context(SyntaxSnafu)?;
         let mut parser_ctx = ParserContext { sql, parser };
@@ -67,6 +68,7 @@ impl<'a> ParserContext<'a> {
 
     pub fn parse_function(sql: &'a str, dialect: &dyn Dialect) -> Result<Expr> {
         let mut parser = Parser::new(dialect)
+            .with_options(ParserOptions::new().with_trailing_commas(true))
             .try_with_sql(sql)
             .context(SyntaxSnafu)?;
 

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -37,8 +37,20 @@ async fn create_insert_query_assert(
     lookback: Duration,
     expected: &str,
 ) {
-    let _ = instance.do_query(create, QueryContext::arc()).await;
-    let _ = instance.do_query(insert, QueryContext::arc()).await;
+    instance
+        .do_query(create, QueryContext::arc())
+        .await
+        .into_iter()
+        .for_each(|v| {
+            let _ = v.unwrap();
+        });
+    instance
+        .do_query(insert, QueryContext::arc())
+        .await
+        .into_iter()
+        .for_each(|v| {
+            let _ = v.unwrap();
+        });
 
     let query = PromQuery {
         query: promql.to_string(),
@@ -69,8 +81,20 @@ async fn create_insert_tql_assert(
     tql: &str,
     expected: &str,
 ) {
-    let _ = instance.do_query(create, QueryContext::arc()).await;
-    let _ = instance.do_query(insert, QueryContext::arc()).await;
+    instance
+        .do_query(create, QueryContext::arc())
+        .await
+        .into_iter()
+        .for_each(|v| {
+            let _ = v.unwrap();
+        });
+    instance
+        .do_query(insert, QueryContext::arc())
+        .await
+        .into_iter()
+        .for_each(|v| {
+            let _ = v.unwrap();
+        });
 
     let query_output = instance
         .do_query(tql, QueryContext::arc())
@@ -181,7 +205,7 @@ const AGGREGATORS_CREATE_TABLE: &str = r#"create table http_requests (
     "group" string,
     "value" double,
     ts timestamp TIME INDEX,
-    PRIMARY KEY (job, instance, group),
+    PRIMARY KEY (job, instance, "group"),
 );"#;
 
 // load 5m
@@ -193,7 +217,7 @@ const AGGREGATORS_CREATE_TABLE: &str = r#"create table http_requests (
 // http_requests{job="app-server", instance="1", group="production"} 0+60x10
 // http_requests{job="app-server", instance="0", group="canary"}   0+70x10
 // http_requests{job="app-server", instance="1", group="canary"}   0+80x10
-const AGGREGATORS_INSERT_DATA: &str = r#"insert into http_requests(job, instance, group, value, ts) values
+const AGGREGATORS_INSERT_DATA: &str = r#"insert into http_requests(job, instance, "group", value, ts) values
     ('api-server', '0', 'production', 100, 0),
     ('api-server', '1', 'production', 200, 0),
     ('api-server', '0', 'canary', 300, 0),

--- a/tests/cases/standalone/common/select/dummy.result
+++ b/tests/cases/standalone/common/select/dummy.result
@@ -131,6 +131,15 @@ select TO_UNIXTIME(b) from test_unixtime;
 | 27                           |
 +------------------------------+
 
+-- TEST tailing commas support
+select a, b, from test_unixtime;
+
++----+---------------------+
+| a  | b                   |
++----+---------------------+
+| 27 | 1970-01-01T00:00:27 |
++----+---------------------+
+
 DROP TABLE test_unixtime;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/select/dummy.sql
+++ b/tests/cases/standalone/common/select/dummy.sql
@@ -36,4 +36,7 @@ select b from test_unixtime;
 
 select TO_UNIXTIME(b) from test_unixtime;
 
+-- TEST tailing commas support
+select a, b, from test_unixtime;
+
 DROP TABLE test_unixtime;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Because some bug in sqlparser,  sql like `SELECT foo, bar, FROM baz` with tailing commas will be wrongly parse to `SELECT foo, bar, FROM AS baz`

Enable `trailing_commas` in sqlparser to avoid such error.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
