### PR TITLE
feat: builder to vector without resetting

### DIFF
--- a/src/datatypes/src/scalars.rs
+++ b/src/datatypes/src/scalars.rs
@@ -139,10 +139,10 @@ pub trait ScalarVectorBuilder: MutableVector {
     /// Push a value into the builder.
     fn push(&mut self, value: Option<<Self::VectorType as ScalarVector>::RefItem<'_>>);
 
-    /// Finish build a new vector and reset `self`.
+    /// Build a new vector and reset `self`.
     fn finish(&mut self) -> Self::VectorType;
 
-    /// Finish build a new vector without resetting `self`.
+    /// Build a new vector without resetting `self`.
     fn finish_cloned(&self) -> Self::VectorType;
 }
 

--- a/src/datatypes/src/scalars.rs
+++ b/src/datatypes/src/scalars.rs
@@ -139,8 +139,11 @@ pub trait ScalarVectorBuilder: MutableVector {
     /// Push a value into the builder.
     fn push(&mut self, value: Option<<Self::VectorType as ScalarVector>::RefItem<'_>>);
 
-    /// Finish build and return a new vector.
+    /// Finish build a new vector and reset `self`.
     fn finish(&mut self) -> Self::VectorType;
+
+    /// Finish build a new vector without resetting `self`.
+    fn finish_cloned(&self) -> Self::VectorType;
 }
 
 macro_rules! impl_scalar_for_native {

--- a/src/datatypes/src/vectors.rs
+++ b/src/datatypes/src/vectors.rs
@@ -428,30 +428,14 @@ pub mod tests {
     }
 
     #[test]
-    fn test_mutable_vector_finish_cloned() {
-        // create a primitive type mutable vector
-        let mut builder = Int32VectorBuilder::with_capacity(1024);
-        builder.push(Some(1));
-        builder.push(Some(2));
-        builder.push(Some(3));
-        // use finish_cloned won't reset builder
-        let vector = builder.finish_cloned();
-        assert_eq!(vector.len(), 3);
-        assert_eq!(builder.len(), 3);
-
-        builder.push(Some(4));
-        assert_eq!(builder.len(), 4);
-
-        // use finish will reset builder
-        let vector = builder.finish();
-        assert_eq!(vector.len(), 4);
-        assert_eq!(builder.len(), 0);
+    fn test_mutable_vector_to_vector_cloned() {
+        // create a string vector builder
+        let mut builder = ConcreteDataType::string_datatype().create_mutable_vector(1024);
+        builder.push_value_ref(ValueRef::String("hello"));
+        builder.push_value_ref(ValueRef::String("world"));
+        builder.push_value_ref(ValueRef::String("!"));
 
         // use MutableVector trait to_vector_cloned won't reset builder
-        let mut builder = StringVectorBuilder::with_capacity(1024);
-        builder.push(Some("1"));
-        builder.push(Some("2"));
-        builder.push(Some("3"));
         let vector = builder.to_vector_cloned();
         assert_eq!(vector.len(), 3);
         assert_eq!(builder.len(), 3);

--- a/src/datatypes/src/vectors/binary.rs
+++ b/src/datatypes/src/vectors/binary.rs
@@ -159,6 +159,10 @@ impl MutableVector for BinaryVectorBuilder {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         match value.as_binary()? {
             Some(v) => self.mutable_array.append_value(v),
@@ -195,6 +199,12 @@ impl ScalarVectorBuilder for BinaryVectorBuilder {
     fn finish(&mut self) -> Self::VectorType {
         BinaryVector {
             array: self.mutable_array.finish(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        BinaryVector {
+            array: self.mutable_array.finish_cloned(),
         }
     }
 }

--- a/src/datatypes/src/vectors/binary.rs
+++ b/src/datatypes/src/vectors/binary.rs
@@ -358,4 +358,21 @@ mod tests {
         let expect: VectorRef = Arc::new(BinaryVector::from_slice(&[b"hello", b"one", b"two"]));
         assert_eq!(expect, vector);
     }
+
+    #[test]
+    fn test_binary_vector_builder_finish_cloned() {
+        let mut builder = BinaryVectorBuilder::with_capacity(1024);
+        builder.push(Some(b"one"));
+        builder.push(Some(b"two"));
+        builder.push(Some(b"three"));
+        let vector = builder.finish_cloned();
+        assert_eq!(b"one", vector.get_data(0).unwrap());
+        assert_eq!(vector.len(), 3);
+        assert_eq!(builder.len(), 3);
+
+        builder.push(Some(b"four"));
+        let vector = builder.finish_cloned();
+        assert_eq!(b"four", vector.get_data(3).unwrap());
+        assert_eq!(builder.len(), 4);
+    }
 }

--- a/src/datatypes/src/vectors/boolean.rs
+++ b/src/datatypes/src/vectors/boolean.rs
@@ -175,6 +175,10 @@ impl MutableVector for BooleanVectorBuilder {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         match value.as_boolean()? {
             Some(v) => self.mutable_array.append_value(v),
@@ -211,6 +215,12 @@ impl ScalarVectorBuilder for BooleanVectorBuilder {
     fn finish(&mut self) -> Self::VectorType {
         BooleanVector {
             array: self.mutable_array.finish(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        BooleanVector {
+            array: self.mutable_array.finish_cloned(),
         }
     }
 }

--- a/src/datatypes/src/vectors/boolean.rs
+++ b/src/datatypes/src/vectors/boolean.rs
@@ -368,4 +368,21 @@ mod tests {
         let expect: VectorRef = Arc::new(BooleanVector::from_slice(&[true, false, true]));
         assert_eq!(expect, vector);
     }
+
+    #[test]
+    fn test_boolean_vector_builder_finish_cloned() {
+        let mut builder = BooleanVectorBuilder::with_capacity(1024);
+        builder.push(Some(true));
+        builder.push(Some(false));
+        builder.push(Some(true));
+        let vector = builder.finish_cloned();
+        assert!(vector.get_data(0).unwrap());
+        assert_eq!(vector.len(), 3);
+        assert_eq!(builder.len(), 3);
+
+        builder.push(Some(false));
+        let vector = builder.finish_cloned();
+        assert!(!vector.get_data(3).unwrap());
+        assert_eq!(builder.len(), 4);
+    }
 }

--- a/src/datatypes/src/vectors/decimal.rs
+++ b/src/datatypes/src/vectors/decimal.rs
@@ -563,4 +563,16 @@ pub mod tests {
             .collect::<Vec<_>>();
         assert_eq!(values, vec![2, 4, 6, 8]);
     }
+
+    #[test]
+    fn test_decimal128_vector_builder_finish_cloned() {
+        let mut builder = Decimal128VectorBuilder::with_capacity(1024);
+        builder.push(Some(Decimal128::new(1, 3, 1)));
+        builder.push(Some(Decimal128::new(1, 3, 1)));
+        builder.push(Some(Decimal128::new(1, 3, 1)));
+        builder.push(Some(Decimal128::new(1, 3, 1)));
+        let vector = builder.finish_cloned();
+        assert_eq!(vector.len(), 4);
+        assert_eq!(builder.len(), 4);
+    }
 }

--- a/src/datatypes/src/vectors/decimal.rs
+++ b/src/datatypes/src/vectors/decimal.rs
@@ -310,6 +310,10 @@ impl MutableVector for Decimal128VectorBuilder {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         let decimal_val = value.as_decimal128()?.map(|v| v.val());
         self.mutable_array.append_option(decimal_val);
@@ -356,6 +360,12 @@ impl ScalarVectorBuilder for Decimal128VectorBuilder {
     fn finish(&mut self) -> Self::VectorType {
         Decimal128Vector {
             array: self.mutable_array.finish(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        Decimal128Vector {
+            array: self.mutable_array.finish_cloned(),
         }
     }
 }

--- a/src/datatypes/src/vectors/list.rs
+++ b/src/datatypes/src/vectors/list.rs
@@ -763,4 +763,24 @@ pub mod tests {
             iter.nth(1).unwrap().unwrap()
         );
     }
+
+    #[test]
+    fn test_list_vector_builder_finish_cloned() {
+        let mut builder =
+            ListVectorBuilder::with_type_capacity(ConcreteDataType::int32_datatype(), 2);
+        builder.push(None);
+        builder.push(Some(ListValueRef::Ref {
+            val: &ListValue::new(
+                Some(Box::new(vec![
+                    Value::Int32(4),
+                    Value::Null,
+                    Value::Int32(6),
+                ])),
+                ConcreteDataType::int32_datatype(),
+            ),
+        }));
+        let vector = builder.finish_cloned();
+        assert_eq!(vector.len(), 2);
+        assert_eq!(builder.len(), 2);
+    }
 }

--- a/src/datatypes/src/vectors/list.rs
+++ b/src/datatypes/src/vectors/list.rs
@@ -360,6 +360,7 @@ impl ScalarVectorBuilder for ListVectorBuilder {
         }
     }
 
+    // Port from https://github.com/apache/arrow-rs/blob/ef6932f31e243d8545e097569653c8d3f1365b4d/arrow-array/src/builder/generic_list_builder.rs#L302-L325
     fn finish_cloned(&self) -> Self::VectorType {
         let len = self.len();
         let values_vector = self.values_builder.to_vector_cloned();

--- a/src/datatypes/src/vectors/list.rs
+++ b/src/datatypes/src/vectors/list.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use arrow::array::{
     Array, ArrayData, ArrayRef, BooleanBufferBuilder, Int32BufferBuilder, ListArray,
 };
-use arrow::buffer::Buffer;
+use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::DataType as ArrowDataType;
 use serde_json::Value as JsonValue;
 
@@ -281,6 +281,10 @@ impl MutableVector for ListVectorBuilder {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         if let Some(list_ref) = value.as_list()? {
             match list_ref {
@@ -346,6 +350,31 @@ impl ScalarVectorBuilder for ListVectorBuilder {
             .add_buffer(offset_buffer)
             .add_child_data(values_data)
             .null_bit_buffer(null_bit_buffer);
+
+        let array_data = unsafe { array_data_builder.build_unchecked() };
+        let array = ListArray::from(array_data);
+
+        ListVector {
+            array,
+            item_type: self.item_type.clone(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        let len = self.len();
+        let values_vector = self.values_builder.to_vector_cloned();
+        let values_arr = values_vector.to_arrow_array();
+        let values_data = values_arr.to_data();
+
+        let offset_buffer = Buffer::from_slice_ref(self.offsets_builder.as_slice());
+        let nulls = self.null_buffer_builder.finish_cloned();
+
+        let data_type = ConcreteDataType::list_datatype(self.item_type.clone()).as_arrow_type();
+        let array_data_builder = ArrayData::builder(data_type)
+            .len(len)
+            .add_buffer(offset_buffer)
+            .add_child_data(values_data)
+            .nulls(nulls);
 
         let array_data = unsafe { array_data_builder.build_unchecked() };
         let array = ListArray::from(array_data);
@@ -425,6 +454,12 @@ impl NullBufferBuilder {
         let buf = self.bitmap_builder.take().map(Into::into);
         self.len = 0;
         buf
+    }
+
+    /// Builds the [NullBuffer] without resetting the builder.
+    fn finish_cloned(&self) -> Option<NullBuffer> {
+        let buffer = self.bitmap_builder.as_ref()?.finish_cloned();
+        Some(NullBuffer::new(buffer))
     }
 
     #[inline]

--- a/src/datatypes/src/vectors/null.rs
+++ b/src/datatypes/src/vectors/null.rs
@@ -156,6 +156,10 @@ impl MutableVector for NullVectorBuilder {
         vector
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(NullVector::new(self.length))
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         ensure!(
             value.is_null(),

--- a/src/datatypes/src/vectors/null.rs
+++ b/src/datatypes/src/vectors/null.rs
@@ -279,4 +279,14 @@ mod tests {
         let expect: VectorRef = Arc::new(input);
         assert_eq!(expect, vector);
     }
+
+    #[test]
+    fn test_null_vector_builder_finish_cloned() {
+        let mut builder = NullType.create_mutable_vector(3);
+        builder.push_null();
+        builder.push_null();
+        let vector = builder.to_vector_cloned();
+        assert_eq!(vector.len(), 2);
+        assert_eq!(vector.null_count(), 2);
+    }
 }

--- a/src/datatypes/src/vectors/primitive.rs
+++ b/src/datatypes/src/vectors/primitive.rs
@@ -303,6 +303,10 @@ impl<T: LogicalPrimitiveType> MutableVector for PrimitiveVectorBuilder<T> {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         let primitive = T::cast_value_ref(value)?;
         match primitive {
@@ -350,6 +354,12 @@ where
     fn finish(&mut self) -> Self::VectorType {
         PrimitiveVector {
             array: self.mutable_array.finish(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        PrimitiveVector {
+            array: self.mutable_array.finish_cloned(),
         }
     }
 }

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -254,6 +254,8 @@ vectors::impl_try_from_arrow_array_for_vector!(StringArray, StringVector);
 #[cfg(test)]
 mod tests {
 
+    use std::vec;
+
     use arrow::datatypes::DataType;
 
     use super::*;
@@ -368,5 +370,20 @@ mod tests {
         let vector = StringVector::from(corpus);
         let serialized = serde_json::to_string(&vector.serialize_to_json().unwrap()).unwrap();
         assert_eq!(r#"["🀀🀀🀀","🀁🀁🀁","🀂🀂🀂","🀃🀃🀃","🀆🀆"]"#, serialized);
+    }
+
+    #[test]
+    fn test_string_vector_builder_finish_cloned() {
+        let mut builder = StringVectorBuilder::with_capacity(1024);
+        builder.push(Some("1"));
+        builder.push(Some("2"));
+        builder.push(Some("3"));
+        let vector = builder.finish_cloned();
+        assert_eq!(vector.len(), 3);
+        assert_eq!(
+            r#"["1","2","3"]"#,
+            serde_json::to_string(&vector.serialize_to_json().unwrap()).unwrap(),
+        );
+        assert_eq!(builder.len(), 3);
     }
 }

--- a/src/datatypes/src/vectors/string.rs
+++ b/src/datatypes/src/vectors/string.rs
@@ -190,6 +190,10 @@ impl MutableVector for StringVectorBuilder {
         Arc::new(self.finish())
     }
 
+    fn to_vector_cloned(&self) -> VectorRef {
+        Arc::new(self.finish_cloned())
+    }
+
     fn try_push_value_ref(&mut self, value: ValueRef) -> Result<()> {
         match value.as_string()? {
             Some(v) => self.mutable_array.append_value(v),
@@ -226,6 +230,12 @@ impl ScalarVectorBuilder for StringVectorBuilder {
     fn finish(&mut self) -> Self::VectorType {
         StringVector {
             array: self.mutable_array.finish(),
+        }
+    }
+
+    fn finish_cloned(&self) -> Self::VectorType {
+        StringVector {
+            array: self.mutable_array.finish_cloned(),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

main changes:
- add new method named `finish_cloned` in `ScalarVectorBuilder` trait
- add new method named `to_vector_cloned` in `MutableVector` trait.
- some unit tests

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
