### PR TITLE
feat: set default debug level of release and dev profiles to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,8 +188,11 @@ table = { path = "src/table" }
 git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "abbd357c1e193cd270ea65ee7652334a150b628f"
 
+[profile.dev]
+debug = 1
+
 [profile.release]
-debug = true
+debug = 1
 
 [profile.nightly]
 inherits = "release"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change the default debug level of `release` and `dev` profile to `1`. This change can cut the binary size by half (from 2.1 GB to 1.0 GB)

The panic stack still contains the necessary info under `release` profile
<img width="1186" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/4531d755-4aa7-460e-9680-7ac7b807e65e">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
