### PR TITLE
fix: return error to client if prepare stmt param not match

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -416,7 +416,7 @@ fn format_duration(duration: Duration) -> String {
 fn replace_params_with_values(
     plan: &LogicalPlan,
     param_types: HashMap<String, Option<ConcreteDataType>>,
-    params: &Vec<ParamValue>,
+    params: &[ParamValue],
 ) -> Result<LogicalPlan> {
     debug_assert_eq!(param_types.len(), params.len());
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

before: (in server)

2023-12-12T11:39:05.369596Z  WARN servers::mysql::server: Internal error occurred during query exec, server actively close the channel to let client try next time err=0: Expected type: Timestamp(Millisecond(TimestampMillisecondType)), actual: MYSQL_TYPE_VAR_STRING, at src/servers/src/mysql/helper.rs:168:14

after: (in client)

com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: err: Expected type: Timestamp(Millisecond(TimestampMillisecondType)), actual: MYSQL_TYPE_VAR_STRING, params: (Value(Bytes([49])), MYSQL_TYPE_VAR_STRING),(Value(Int(1)), MYSQL_TYPE_LONG),(Value(Int(1)), MYSQL_TYPE_LONG),(Value(Int(1)), MYSQL_TYPE_LONG),(Value(Int(1)), MYSQL_TYPE_LONG),(Value(Int(1)), MYSQL_TYPE_LONG),(Value(Int(1)), MYSQL_TYPE_LONG)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
