### PR TITLE
test: fix a wronged test script

### DIFF
--- a/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
+++ b/src/script/src/python/ffi_types/pair_tests/sample_testcases.rs
@@ -613,7 +613,7 @@ def answer() -> vector[i64]:
     except ImportError:
         # Python didn't have pyarrow
         print("Warning: no pyarrow in current python")
-        return vector([42, 43, 44])
+        return vector([42])
     a = vector.from_pyarrow(pa.array([42]))
     return a[0:1]
 "#


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
fix a wrong testcase in which in will fail if Python is installed without pyarrow

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
