### PR TITLE
fix!: remove range calendar as `To` option

### DIFF
--- a/tests/cases/standalone/common/range/to.result
+++ b/tests/cases/standalone/common/range/to.result
@@ -29,17 +29,6 @@ SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' ORDER BY host, ts;
 | 1970-01-03T00:00:00 | host2 | 6                                |
 +---------------------+-------+----------------------------------+
 
-SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' TO CALENDAR ORDER BY host, ts;
-
-+---------------------+-------+----------------------------------+
-| ts                  | host  | MIN(host.val) RANGE 1d FILL NULL |
-+---------------------+-------+----------------------------------+
-| 1970-01-02T00:00:00 | host1 | 0                                |
-| 1970-01-03T00:00:00 | host1 | 2                                |
-| 1970-01-02T00:00:00 | host2 | 4                                |
-| 1970-01-03T00:00:00 | host2 | 6                                |
-+---------------------+-------+----------------------------------+
-
 SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' TO UNKNOWN ORDER BY host, ts;
 
 Error: 3000(PlanQuery), DataFusion error: Error during planning: Illegal `align to` argument `UNKNOWN` in range select query, can't be parse as NOW/CALENDAR/Timestamp, error: Failed to parse a string into Timestamp, raw string: UNKNOWN

--- a/tests/cases/standalone/common/range/to.sql
+++ b/tests/cases/standalone/common/range/to.sql
@@ -16,8 +16,6 @@ INSERT INTO TABLE host VALUES
 
 SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' ORDER BY host, ts;
 
-SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' TO CALENDAR ORDER BY host, ts;
-
 SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' TO UNKNOWN ORDER BY host, ts;
 
 SELECT ts, host, min(val) RANGE '1d' FROM host ALIGN '1d' TO '1900-01-01T00:00:00+01:00' ORDER BY host, ts;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`Calendar` as an `align to` option has the same effect as leave it empty. Such an option is useless and will cause confusion to users, so remove this option in here.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/2894