### PR TITLE
fix: correctly decode mysql timestamp binary value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5459,8 +5459,7 @@ dependencies = [
 [[package]]
 name = "opensrv-mysql"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b6a785aafb26a97c26078b9457e96cb238b386781583783a3a3d3de47fa841"
+source = "git+https://github.com/MichaelScofield/opensrv.git?rev=1676c1d#1676c1d166cf33e7745e1b5db54b3fe2b7defec9"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -54,7 +54,8 @@ lazy_static.workspace = true
 mime_guess = "2.0"
 once_cell.workspace = true
 openmetrics-parser = "0.4"
-opensrv-mysql = "0.6"
+# TODO(LFC): Wait for https://github.com/datafuselabs/opensrv/pull/60
+opensrv-mysql = { git = "https://github.com/MichaelScofield/opensrv.git", rev = "1676c1d" }
 opentelemetry-proto.workspace = true
 parking_lot = "0.12"
 pgwire = "0.17"

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -401,6 +401,9 @@ pub enum Error {
         error: FromUtf8Error,
         location: Location,
     },
+
+    #[snafu(display("Failed to convert Mysql value, error: {}", err_msg))]
+    MysqlValueConversion { err_msg: String, location: Location },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -452,7 +455,8 @@ impl ErrorExt for Error {
             | PreparedStmtTypeMismatch { .. }
             | TimePrecision { .. }
             | UrlDecode { .. }
-            | IncompatibleSchema { .. } => StatusCode::InvalidArguments,
+            | IncompatibleSchema { .. }
+            | MysqlValueConversion { .. } => StatusCode::InvalidArguments,
 
             InfluxdbLinesWrite { source, .. }
             | PromSeriesWrite { source, .. }

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -24,7 +24,7 @@ use chrono::{NaiveDate, NaiveDateTime};
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::ErrorExt;
 use common_query::Output;
-use common_telemetry::{error, logging, tracing, warn};
+use common_telemetry::{debug, error, logging, tracing, warn};
 use datatypes::prelude::ConcreteDataType;
 use itertools::Itertools;
 use opensrv_mysql::{
@@ -418,6 +418,15 @@ fn replace_params_with_values(
     params: &[ParamValue],
 ) -> Result<LogicalPlan> {
     debug_assert_eq!(param_types.len(), params.len());
+
+    debug!(
+        "replace_params_with_values(param_types: {:#?}, params: {:#?})",
+        param_types,
+        params
+            .iter()
+            .map(|x| format!("({:?}, {:?})", x.value, x.coltype))
+            .join(", ")
+    );
 
     let mut values = Vec::with_capacity(params.len());
 

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -291,17 +291,16 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
                 let plan = match replace_params_with_values(&plan, param_types, &params) {
                     Ok(plan) => plan,
                     Err(e) => {
+                        if e.status_code().should_log_error() {
+                            error!(e; "params: {}", params
+                                .iter()
+                                .map(|x| format!("({:?}, {:?})", x.value, x.coltype))
+                                .join(", "));
+                        }
+
                         w.error(
                             ErrorKind::ER_TRUNCATED_WRONG_VALUE,
-                            format!(
-                                "err: {}, params: {}",
-                                e.output_msg(),
-                                params
-                                    .iter()
-                                    .map(|x| format!("({:?}, {:?})", x.value, x.coltype))
-                                    .join(", ")
-                            )
-                            .as_bytes(),
+                            e.output_msg().as_bytes(),
                         )
                         .await?;
                         return Ok(());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

as title

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
