### PR TITLE
refactor: greptimedb cluster sqlness test scripts

### DIFF
--- a/.github/scripts/deploy-greptimedb.sh
+++ b/.github/scripts/deploy-greptimedb.sh
@@ -107,12 +107,9 @@ function deploy_greptimedb_cluster_with_s3_storage() {
     --set storage.s3.bucket="$AWS_CI_TEST_BUCKET" \
     --set storage.s3.region="$AWS_REGION" \
     --set storage.s3.root="$DATA_ROOT" \
-    --set storage.s3.secretName=s3-credentials \
     --set storage.credentials.secretName=s3-credentials \
-    --set storage.credentials.secretCreation.enabled=true \
-    --set storage.credentials.secretCreation.enableEncryption=false \
-    --set storage.credentials.secretCreation.data.access-key-id="$AWS_ACCESS_KEY_ID" \
-    --set storage.credentials.secretCreation.data.secret-access-key="$AWS_SECRET_ACCESS_KEY"
+    --set storage.credentials.accessKeyId="$AWS_ACCESS_KEY_ID" \
+    --set storage.credentials.secretAccessKey="$AWS_SECRET_ACCESS_KEY"
 
   # Wait for greptimedb cluster to be ready.
   while true; do


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
When after [this pr](https://github.com/GreptimeTeam/helm-charts/pull/90) merge, not require so many parameters to helm install greptimedb cluster. `accessKeyId` and `secretAccessKey` located in `storage.credentials.accessKeyId`, `storage.credentials.secretAccessKey`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
