### PR TITLE
fix: blocking read timer lack of parameter

### DIFF
--- a/src/object-store/src/layers/prometheus.rs
+++ b/src/object-store/src/layers/prometheus.rs
@@ -319,7 +319,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
             .inc();
 
         let timer = REQUESTS_DURATION_SECONDS
-            .with_label_values(&[&self.scheme])
+            .with_label_values(&[&self.scheme, Operation::BlockingRead.into_static()])
             .start_timer();
         let result = self.inner.blocking_read(path, args).map(|(rp, r)| {
             (


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

When I call opendal blocking read api, it goes wrong.

owing to blocking read function `timer` lack of `Operation::BlockingRead.into_static()`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
