### PR TITLE
feat(mito): add `skip_wal_replay` option to OpenRegionRequest

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -371,7 +371,7 @@ impl DatanodeBuilder {
                             engine: engine.clone(),
                             region_dir,
                             options,
-                            skip_replay_wal: false,
+                            skip_wal_replay: false,
                         }),
                     )
                     .await?;

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -371,6 +371,7 @@ impl DatanodeBuilder {
                             engine: engine.clone(),
                             region_dir,
                             options,
+                            skip_replay_wal: false,
                         }),
                     )
                     .await?;

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -64,6 +64,7 @@ impl RegionHeartbeatResponseHandler {
                         engine: region_ident.engine,
                         region_dir: region_dir(&region_storage_path, region_id),
                         options: region_options,
+                        skip_replay_wal: false,
                     });
                     let result = region_server.handle_request(region_id, request).await;
 

--- a/src/datanode/src/heartbeat/handler.rs
+++ b/src/datanode/src/heartbeat/handler.rs
@@ -64,7 +64,7 @@ impl RegionHeartbeatResponseHandler {
                         engine: region_ident.engine,
                         region_dir: region_dir(&region_storage_path, region_id),
                         options: region_options,
-                        skip_replay_wal: false,
+                        skip_wal_replay: false,
                     });
                     let result = region_server.handle_request(region_id, request).await;
 

--- a/src/file-engine/src/region.rs
+++ b/src/file-engine/src/region.rs
@@ -163,6 +163,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
+            skip_replay_wal: false,
         };
 
         let region = FileRegion::open(region_id, request, &object_store)
@@ -211,6 +212,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
+            skip_replay_wal: false,
         };
         let err = FileRegion::open(region_id, request, &object_store)
             .await

--- a/src/file-engine/src/region.rs
+++ b/src/file-engine/src/region.rs
@@ -163,7 +163,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
-            skip_replay_wal: false,
+            skip_wal_replay: false,
         };
 
         let region = FileRegion::open(region_id, request, &object_store)
@@ -212,7 +212,7 @@ mod tests {
             engine: "file".to_string(),
             region_dir,
             options: HashMap::default(),
-            skip_replay_wal: false,
+            skip_wal_replay: false,
         };
         let err = FileRegion::open(region_id, request, &object_store)
             .await

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -119,7 +119,7 @@ async fn test_alter_region() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -202,7 +202,7 @@ async fn test_put_after_alter() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -119,6 +119,7 @@ async fn test_alter_region() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await
@@ -201,6 +202,7 @@ async fn test_put_after_alter() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -117,6 +117,7 @@ async fn test_region_replay() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -117,7 +117,7 @@ async fn test_region_replay() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -43,7 +43,7 @@ async fn test_engine_open_empty() {
                 engine: String::new(),
                 region_dir: "empty".to_string(),
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -75,7 +75,7 @@ async fn test_engine_open_existing() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -164,7 +164,7 @@ async fn test_engine_region_open_with_options() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("ttl".to_string(), "4d".to_string())]),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -209,7 +209,7 @@ async fn test_engine_region_open_with_custom_store() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("storage".to_string(), "Gcs".to_string())]),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -232,7 +232,7 @@ async fn test_engine_region_open_with_custom_store() {
 }
 
 #[tokio::test]
-async fn test_open_region_skip_replay_wal() {
+async fn test_open_region_skip_wal_replay() {
     let mut env = TestEnv::new();
     let engine = env.create_engine(MitoConfig::default()).await;
 
@@ -261,7 +261,7 @@ async fn test_open_region_skip_replay_wal() {
     put_rows(&engine, region_id, rows).await;
 
     let engine = env.reopen_engine(engine, MitoConfig::default()).await;
-    // Skip to replay the WAL.
+    // Skip the WAL replay .
     engine
         .handle_request(
             region_id,
@@ -269,7 +269,7 @@ async fn test_open_region_skip_replay_wal() {
                 engine: String::new(),
                 region_dir: region_dir.to_string(),
                 options: Default::default(),
-                skip_replay_wal: true,
+                skip_wal_replay: true,
             }),
         )
         .await
@@ -298,7 +298,7 @@ async fn test_open_region_skip_replay_wal() {
                 engine: String::new(),
                 region_dir,
                 options: Default::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -42,6 +42,7 @@ async fn test_engine_open_empty() {
                 engine: String::new(),
                 region_dir: "empty".to_string(),
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await
@@ -73,6 +74,7 @@ async fn test_engine_open_existing() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await
@@ -161,6 +163,7 @@ async fn test_engine_region_open_with_options() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("ttl".to_string(), "4d".to_string())]),
+                skip_replay_wal: false,
             }),
         )
         .await
@@ -205,6 +208,7 @@ async fn test_engine_region_open_with_custom_store() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::from([("storage".to_string(), "Gcs".to_string())]),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/parallel_test.rs
+++ b/src/mito2/src/engine/parallel_test.rs
@@ -50,7 +50,7 @@ async fn scan_in_parallel(
                 engine: String::new(),
                 region_dir: region_dir.to_string(),
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/parallel_test.rs
+++ b/src/mito2/src/engine/parallel_test.rs
@@ -50,6 +50,7 @@ async fn scan_in_parallel(
                 engine: String::new(),
                 region_dir: region_dir.to_string(),
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -250,7 +250,7 @@ async fn test_engine_truncate_reopen() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await
@@ -354,7 +354,7 @@ async fn test_engine_truncate_during_flush() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -250,6 +250,7 @@ async fn test_engine_truncate_reopen() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await
@@ -353,6 +354,7 @@ async fn test_engine_truncate_during_flush() {
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -54,7 +54,7 @@ pub(crate) struct RegionOpener {
     scheduler: SchedulerRef,
     options: HashMap<String, String>,
     cache_manager: Option<CacheManagerRef>,
-    skip_replay_wal: bool,
+    skip_wal_replay: bool,
 }
 
 impl RegionOpener {
@@ -75,7 +75,7 @@ impl RegionOpener {
             scheduler,
             options: HashMap::new(),
             cache_manager: None,
-            skip_replay_wal: false,
+            skip_wal_replay: false,
         }
     }
 
@@ -97,8 +97,9 @@ impl RegionOpener {
         self
     }
 
-    pub(crate) fn skip_replay_wal(mut self, skip: bool) -> Self {
-        self.skip_replay_wal = skip;
+    /// Sets the `skip_wal_replay`.
+    pub(crate) fn skip_wal_replay(mut self, skip: bool) -> Self {
+        self.skip_wal_replay = skip;
         self
     }
 
@@ -242,10 +243,10 @@ impl RegionOpener {
             .build();
         let flushed_entry_id = version.flushed_entry_id;
         let version_control = Arc::new(VersionControl::new(version));
-        if !self.skip_replay_wal {
+        if !self.skip_wal_replay {
             replay_memtable(wal, region_id, flushed_entry_id, &version_control).await?;
         } else {
-            info!("Skip to replay the WAL for region: {}", region_id);
+            info!("Skip the WAL replay for region: {}", region_id);
         }
 
         let region = MitoRegion {

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -30,7 +30,6 @@ use api::helper::ColumnDataTypeWrapper;
 use api::v1::value::ValueData;
 use api::v1::{OpType, Row, Rows, SemanticType};
 use common_datasource::compression::CompressionType;
-use common_query::Output;
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use datatypes::arrow::array::{TimestampMillisecondArray, UInt64Array, UInt8Array};
 use datatypes::prelude::ConcreteDataType;

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -696,7 +696,7 @@ pub async fn reopen_region(
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
-                skip_replay_wal: false,
+                skip_wal_replay: false,
             }),
         )
         .await

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -697,6 +697,7 @@ pub async fn reopen_region(
                 engine: String::new(),
                 region_dir,
                 options: HashMap::default(),
+                skip_replay_wal: false,
             }),
         )
         .await

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -70,6 +70,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             self.scheduler.clone(),
         )
         .options(request.options)
+        .skip_replay_wal(request.skip_replay_wal)
         .cache(Some(self.cache_manager.clone()))
         .open(&self.config, &self.wal)
         .await?;

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -70,7 +70,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             self.scheduler.clone(),
         )
         .options(request.options)
-        .skip_replay_wal(request.skip_replay_wal)
+        .skip_wal_replay(request.skip_wal_replay)
         .cache(Some(self.cache_manager.clone()))
         .open(&self.config, &self.wal)
         .await?;

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -116,7 +116,7 @@ impl RegionRequest {
                         engine: open.engine,
                         region_dir,
                         options: open.options,
-                        skip_replay_wal: false,
+                        skip_wal_replay: false,
                     }),
                 )])
             }
@@ -199,7 +199,7 @@ pub struct RegionOpenRequest {
     /// Options of the opened region.
     pub options: HashMap<String, String>,
     /// To skip replaying the WAL.
-    pub skip_replay_wal: bool,
+    pub skip_wal_replay: bool,
 }
 
 /// Close region request.

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -116,6 +116,7 @@ impl RegionRequest {
                         engine: open.engine,
                         region_dir,
                         options: open.options,
+                        skip_replay_wal: false,
                     }),
                 )])
             }
@@ -197,6 +198,8 @@ pub struct RegionOpenRequest {
     pub region_dir: String,
     /// Options of the opened region.
     pub options: HashMap<String, String>,
+    /// To skip replaying the WAL.
+    pub skip_replay_wal: bool,
 }
 
 /// Close region request.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The region migration will open the candidate region first(the engine opens the region without replaying the WAL, for now), then upgrade the candidate region to the leader region(catching up on the latest manifest and replaying the WAL).

BTW, the follower region does not automatically synchronize with the changes made to the leader region. The duration of the write-stop window during region migration will be reduced once this feature is implemented.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2700
