### PR TITLE
fix: wrong link for selector

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -9,7 +9,7 @@ store_addr = "127.0.0.1:2379"
 # Datanode selector type.
 # - "LeaseBased" (default value).
 # - "LoadBased"
-# For details, please see "https://docs.greptime.com/developer-guide/meta/selector".
+# For details, please see "https://docs.greptime.com/developer-guide/metasrv/selector".
 selector = "LeaseBased"
 # Store data in memory, false by default.
 use_memory_store = false


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixed the link for selector type.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
