### PR TITLE
chore: SelectorType use snake_case

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -7,10 +7,10 @@ server_addr = "127.0.0.1:3002"
 # Etcd server address, "127.0.0.1:2379" by default.
 store_addr = "127.0.0.1:2379"
 # Datanode selector type.
-# - "LeaseBased" (default value).
-# - "LoadBased"
+# - "lease_based" (default value).
+# - "load_based"
 # For details, please see "https://docs.greptime.com/developer-guide/metasrv/selector".
-selector = "LeaseBased"
+selector = "lease_based"
 # Store data in memory, false by default.
 use_memory_store = false
 # Whether to enable greptimedb telemetry, true by default.

--- a/src/meta-srv/src/selector.rs
+++ b/src/meta-srv/src/selector.rs
@@ -67,8 +67,8 @@ impl TryFrom<&str> for SelectorType {
 
     fn try_from(value: &str) -> Result<Self> {
         match value {
-            "LoadBased" => Ok(SelectorType::LoadBased),
-            "LeaseBased" => Ok(SelectorType::LeaseBased),
+            "load_based" | "LoadBased" => Ok(SelectorType::LoadBased),
+            "lease_based" | "LeaseBased" => Ok(SelectorType::LeaseBased),
             other => error::UnsupportedSelectorTypeSnafu {
                 selector_type: other,
             }
@@ -89,12 +89,18 @@ mod tests {
 
     #[test]
     fn test_convert_str_to_selector_type() {
-        let leasebased = "LeaseBased";
-        let selector_type = leasebased.try_into().unwrap();
+        let lease_based = "lease_based";
+        let selector_type = lease_based.try_into().unwrap();
+        assert_eq!(SelectorType::LeaseBased, selector_type);
+        let lease_based = "LeaseBased";
+        let selector_type = lease_based.try_into().unwrap();
         assert_eq!(SelectorType::LeaseBased, selector_type);
 
-        let loadbased = "LoadBased";
-        let selector_type = loadbased.try_into().unwrap();
+        let load_based = "load_based";
+        let selector_type = load_based.try_into().unwrap();
+        assert_eq!(SelectorType::LoadBased, selector_type);
+        let load_based = "LoadBased";
+        let selector_type = load_based.try_into().unwrap();
         assert_eq!(SelectorType::LoadBased, selector_type);
 
         let unknown = "unknown";


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

As the title said

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
