### PR TITLE
chore: remove debug = 1 of dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,6 @@ git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "abbd357c1e193cd270ea65ee7652334a150b628f"
 
 [profile.dev]
-debug = 1
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove `debug = 1` of dev profile

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
