### PR TITLE
ci: add user-doc label checker

### DIFF
--- a/.github/workflows/user-doc-label-checker.yml
+++ b/.github/workflows/user-doc-label-checker.yml
@@ -1,0 +1,19 @@
+name: Check user doc labels
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+
+  check_labels:
+    name: Check doc labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          one_of: Doc update required,Doc not needed
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

In order to catching the imapaction of the PRs to [user documentation](https://github.com/GreptimeTeam/docs/), label `Doc update required` or `Doc not needed` should be added before merging.

If the label `Doc update required` is added, the `doc-issue.yml` workflow will add a issue to docs repo.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
