### PR TITLE
feat: adds build_info table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "arrow-schema",
  "async-stream",
  "async-trait",
+ "build-data",
  "catalog",
  "chrono",
  "common-catalog",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -13,6 +13,7 @@ arc-swap = "1.0"
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
+build-data = "0.1"
 common-catalog.workspace = true
 common-error.workspace = true
 common-grpc.workspace = true

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -49,7 +49,8 @@ lazy_static! {
     static ref MEMORY_TABLES: &'static [&'static str] = &[
         ENGINES,
         COLUMN_PRIVILEGES,
-        COLUMN_STATISTICS
+        COLUMN_STATISTICS,
+        BUILD_INFO,
     ];
 }
 
@@ -154,6 +155,7 @@ impl InformationSchemaProvider {
             ENGINES => setup_memory_table!(ENGINES),
             COLUMN_PRIVILEGES => setup_memory_table!(COLUMN_PRIVILEGES),
             COLUMN_STATISTICS => setup_memory_table!(COLUMN_STATISTICS),
+            BUILD_INFO => setup_memory_table!(BUILD_INFO),
             _ => None,
         }
     }

--- a/src/catalog/src/information_schema/memory_table/tables.rs
+++ b/src/catalog/src/information_schema/memory_table/tables.rs
@@ -21,6 +21,8 @@ use datatypes::vectors::StringVector;
 
 use crate::information_schema::table_names::*;
 
+const UNKNOWN: &str = "unknown";
+
 /// Find the schema and columns by the table_name, only valid for memory tables.
 /// Safety: the user MUST ensure the table schema exists, panic otherwise.
 pub fn get_schema_columns(table_name: &str) -> (SchemaRef, Vec<VectorRef>) {
@@ -67,6 +69,31 @@ pub fn get_schema_columns(table_name: &str) -> (SchemaRef, Vec<VectorRef>) {
                 Arc::new(StringVector::from(vec!["NO"])),
                 Arc::new(StringVector::from(vec!["NO"])),
                 Arc::new(StringVector::from(vec!["NO"])),
+            ],
+        ),
+
+        BUILD_INFO => (
+            string_columns(&[
+                "GIT_BRANCH",
+                "GIT_COMMIT",
+                "GIT_COMMIT_SHORT",
+                "GIT_DIRTY",
+                "PKG_VERSION",
+            ]),
+            vec![
+                Arc::new(StringVector::from(vec![
+                    build_data::get_git_branch().unwrap_or_else(|_| UNKNOWN.to_string())
+                ])),
+                Arc::new(StringVector::from(vec![
+                    build_data::get_git_commit().unwrap_or_else(|_| UNKNOWN.to_string())
+                ])),
+                Arc::new(StringVector::from(vec![
+                    build_data::get_git_commit_short().unwrap_or_else(|_| UNKNOWN.to_string())
+                ])),
+                Arc::new(StringVector::from(vec![
+                    build_data::get_git_dirty().map_or(UNKNOWN.to_string(), |v| v.to_string())
+                ])),
+                Arc::new(StringVector::from(vec![option_env!("CARGO_PKG_VERSION")])),
             ],
         ),
 

--- a/src/catalog/src/information_schema/table_names.rs
+++ b/src/catalog/src/information_schema/table_names.rs
@@ -19,3 +19,4 @@ pub const COLUMNS: &str = "columns";
 pub const ENGINES: &str = "engines";
 pub const COLUMN_PRIVILEGES: &str = "column_privileges";
 pub const COLUMN_STATISTICS: &str = "column_statistics";
+pub const BUILD_INFO: &str = "build_info";

--- a/src/common/catalog/src/consts.rs
+++ b/src/common/catalog/src/consts.rs
@@ -41,6 +41,8 @@ pub const INFORMATION_SCHEMA_ENGINES_TABLE_ID: u32 = 5;
 pub const INFORMATION_SCHEMA_COLUMN_PRIVILEGES_TABLE_ID: u32 = 6;
 /// id for information_schema.column_statistics
 pub const INFORMATION_SCHEMA_COLUMN_STATISTICS_TABLE_ID: u32 = 7;
+/// id for information_schema.build_info
+pub const INFORMATION_SCHEMA_BUILD_INFO_TABLE_ID: u32 = 8;
 /// ----- End of information_schema tables -----
 
 pub const MITO_ENGINE: &str = "mito";

--- a/tests/cases/standalone/common/show/show_databases_tables.result
+++ b/tests/cases/standalone/common/show/show_databases_tables.result
@@ -19,6 +19,7 @@ show tables;
 +-------------------+
 | Tables            |
 +-------------------+
+| build_info        |
 | column_privileges |
 | column_statistics |
 | columns           |

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -7,6 +7,7 @@ order by table_schema, table_name;
 +---------------+--------------------+-------------------+-----------------+----------+-------------+
 | table_catalog | table_schema       | table_name        | table_type      | table_id | engine      |
 +---------------+--------------------+-------------------+-----------------+----------+-------------+
+| greptime      | information_schema | build_info        | LOCAL TEMPORARY | 8        |             |
 | greptime      | information_schema | column_privileges | LOCAL TEMPORARY | 6        |             |
 | greptime      | information_schema | column_statistics | LOCAL TEMPORARY | 7        |             |
 | greptime      | information_schema | columns           | LOCAL TEMPORARY | 4        |             |
@@ -17,40 +18,45 @@ order by table_schema, table_name;
 
 select * from information_schema.columns order by table_schema, table_name;
 
-+---------------+--------------------+-------------------+----------------+-----------+---------------+
-| table_catalog | table_schema       | table_name        | column_name    | data_type | semantic_type |
-+---------------+--------------------+-------------------+----------------+-----------+---------------+
-| greptime      | information_schema | column_privileges | grantee        | String    | FIELD         |
-| greptime      | information_schema | column_privileges | is_grantable   | String    | FIELD         |
-| greptime      | information_schema | column_privileges | privilege_type | String    | FIELD         |
-| greptime      | information_schema | column_privileges | column_name    | String    | FIELD         |
-| greptime      | information_schema | column_privileges | table_name     | String    | FIELD         |
-| greptime      | information_schema | column_privileges | table_schema   | String    | FIELD         |
-| greptime      | information_schema | column_privileges | table_catalog  | String    | FIELD         |
-| greptime      | information_schema | column_statistics | histogram      | String    | FIELD         |
-| greptime      | information_schema | column_statistics | column_name    | String    | FIELD         |
-| greptime      | information_schema | column_statistics | table_name     | String    | FIELD         |
-| greptime      | information_schema | column_statistics | schema_name    | String    | FIELD         |
-| greptime      | information_schema | columns           | table_catalog  | String    | FIELD         |
-| greptime      | information_schema | columns           | semantic_type  | String    | FIELD         |
-| greptime      | information_schema | columns           | data_type      | String    | FIELD         |
-| greptime      | information_schema | columns           | column_name    | String    | FIELD         |
-| greptime      | information_schema | columns           | table_name     | String    | FIELD         |
-| greptime      | information_schema | columns           | table_schema   | String    | FIELD         |
-| greptime      | information_schema | engines           | engine         | String    | FIELD         |
-| greptime      | information_schema | engines           | support        | String    | FIELD         |
-| greptime      | information_schema | engines           | comment        | String    | FIELD         |
-| greptime      | information_schema | engines           | transactions   | String    | FIELD         |
-| greptime      | information_schema | engines           | xa             | String    | FIELD         |
-| greptime      | information_schema | engines           | savepoints     | String    | FIELD         |
-| greptime      | information_schema | tables            | table_catalog  | String    | FIELD         |
-| greptime      | information_schema | tables            | engine         | String    | FIELD         |
-| greptime      | information_schema | tables            | table_id       | UInt32    | FIELD         |
-| greptime      | information_schema | tables            | table_type     | String    | FIELD         |
-| greptime      | information_schema | tables            | table_name     | String    | FIELD         |
-| greptime      | information_schema | tables            | table_schema   | String    | FIELD         |
-| greptime      | public             | numbers           | number         | UInt32    | TAG           |
-+---------------+--------------------+-------------------+----------------+-----------+---------------+
++---------------+--------------------+-------------------+------------------+-----------+---------------+
+| table_catalog | table_schema       | table_name        | column_name      | data_type | semantic_type |
++---------------+--------------------+-------------------+------------------+-----------+---------------+
+| greptime      | information_schema | build_info        | pkg_version      | String    | FIELD         |
+| greptime      | information_schema | build_info        | git_dirty        | String    | FIELD         |
+| greptime      | information_schema | build_info        | git_commit_short | String    | FIELD         |
+| greptime      | information_schema | build_info        | git_commit       | String    | FIELD         |
+| greptime      | information_schema | build_info        | git_branch       | String    | FIELD         |
+| greptime      | information_schema | column_privileges | grantee          | String    | FIELD         |
+| greptime      | information_schema | column_privileges | is_grantable     | String    | FIELD         |
+| greptime      | information_schema | column_privileges | privilege_type   | String    | FIELD         |
+| greptime      | information_schema | column_privileges | column_name      | String    | FIELD         |
+| greptime      | information_schema | column_privileges | table_name       | String    | FIELD         |
+| greptime      | information_schema | column_privileges | table_schema     | String    | FIELD         |
+| greptime      | information_schema | column_privileges | table_catalog    | String    | FIELD         |
+| greptime      | information_schema | column_statistics | histogram        | String    | FIELD         |
+| greptime      | information_schema | column_statistics | column_name      | String    | FIELD         |
+| greptime      | information_schema | column_statistics | table_name       | String    | FIELD         |
+| greptime      | information_schema | column_statistics | schema_name      | String    | FIELD         |
+| greptime      | information_schema | columns           | table_schema     | String    | FIELD         |
+| greptime      | information_schema | columns           | semantic_type    | String    | FIELD         |
+| greptime      | information_schema | columns           | data_type        | String    | FIELD         |
+| greptime      | information_schema | columns           | column_name      | String    | FIELD         |
+| greptime      | information_schema | columns           | table_name       | String    | FIELD         |
+| greptime      | information_schema | columns           | table_catalog    | String    | FIELD         |
+| greptime      | information_schema | engines           | xa               | String    | FIELD         |
+| greptime      | information_schema | engines           | savepoints       | String    | FIELD         |
+| greptime      | information_schema | engines           | transactions     | String    | FIELD         |
+| greptime      | information_schema | engines           | comment          | String    | FIELD         |
+| greptime      | information_schema | engines           | support          | String    | FIELD         |
+| greptime      | information_schema | engines           | engine           | String    | FIELD         |
+| greptime      | information_schema | tables            | table_catalog    | String    | FIELD         |
+| greptime      | information_schema | tables            | engine           | String    | FIELD         |
+| greptime      | information_schema | tables            | table_id         | UInt32    | FIELD         |
+| greptime      | information_schema | tables            | table_type       | String    | FIELD         |
+| greptime      | information_schema | tables            | table_name       | String    | FIELD         |
+| greptime      | information_schema | tables            | table_schema     | String    | FIELD         |
+| greptime      | public             | numbers           | number           | UInt32    | TAG           |
++---------------+--------------------+-------------------+------------------+-----------+---------------+
 
 create
 database my_db;
@@ -125,6 +131,26 @@ select * from engines;
 +--------+---------+-------------------------------------+--------------+----+------------+
 | mito   | DEFAULT | Storage engine for time-series data | NO           | NO | NO         |
 +--------+---------+-------------------------------------+--------------+----+------------+
+
+desc table build_info;
+
++------------------+--------+-----+------+---------+---------------+
+| Column           | Type   | Key | Null | Default | Semantic Type |
++------------------+--------+-----+------+---------+---------------+
+| git_branch       | String |     | NO   |         | FIELD         |
+| git_commit       | String |     | NO   |         | FIELD         |
+| git_commit_short | String |     | NO   |         | FIELD         |
+| git_dirty        | String |     | NO   |         | FIELD         |
+| pkg_version      | String |     | NO   |         | FIELD         |
++------------------+--------+-----+------+---------+---------------+
+
+select count(*) from build_info;
+
++----------+
+| COUNT(*) |
++----------+
+| 1        |
++----------+
 
 -- tables not implemented
 desc table COLUMN_PRIVILEGES;

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -44,6 +44,10 @@ use information_schema;
 -- test engines
 select * from engines;
 
+desc table build_info;
+
+select count(*) from build_info;
+
 -- tables not implemented
 desc table COLUMN_PRIVILEGES;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Adds a new table `information_schema.build_info`:

```sql
> select * from information_schema.build_info;
+--------------------+------------------------------------------+------------------+-----------+-------------+
| git_branch         | git_commit                               | git_commit_short | git_dirty | pkg_version |
+--------------------+------------------------------------------+------------------+-----------+-------------+
| feature/build-info | 6e33e9921a89d8577d09f180cbe90b166e87628d | 6e33e99          | true      | 0.4.4       |
+--------------------+------------------------------------------+------------------+-----------+-------------+
1 row in set (0.09 sec)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)

#2931 