### PR TITLE
feat: add a default internal schema

### DIFF
--- a/src/catalog/src/memory/manager.rs
+++ b/src/catalog/src/memory/manager.rs
@@ -18,7 +18,9 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock, Weak};
 
 use common_catalog::build_db_string;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME};
+use common_catalog::consts::{
+    DEFAULT_CATALOG_NAME, DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME, INFORMATION_SCHEMA_NAME,
+};
 use snafu::OptionExt;
 use table::TableRef;
 
@@ -133,6 +135,12 @@ impl MemoryCatalogManager {
             .register_schema_sync(RegisterSchemaRequest {
                 catalog: DEFAULT_CATALOG_NAME.to_string(),
                 schema: DEFAULT_SCHEMA_NAME.to_string(),
+            })
+            .unwrap();
+        manager
+            .register_schema_sync(RegisterSchemaRequest {
+                catalog: DEFAULT_CATALOG_NAME.to_string(),
+                schema: DEFAULT_PRIVATE_SCHEMA_NAME.to_string(),
             })
             .unwrap();
 

--- a/src/common/catalog/src/consts.rs
+++ b/src/common/catalog/src/consts.rs
@@ -17,6 +17,7 @@ pub const INFORMATION_SCHEMA_NAME: &str = "information_schema";
 pub const SYSTEM_CATALOG_TABLE_NAME: &str = "system_catalog";
 pub const DEFAULT_CATALOG_NAME: &str = "greptime";
 pub const DEFAULT_SCHEMA_NAME: &str = "public";
+pub const DEFAULT_PRIVATE_SCHEMA_NAME: &str = "greptime_private";
 
 /// Reserves [0,MIN_USER_TABLE_ID) for internal usage.
 /// User defined table id starts from this value.

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -63,7 +63,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use common_catalog::consts::{
+    DEFAULT_CATALOG_NAME, DEFAULT_PRIVATE_SCHEMA_NAME, DEFAULT_SCHEMA_NAME,
+};
 use common_telemetry::warn;
 use datanode_table::{DatanodeTableKey, DatanodeTableManager, DatanodeTableValue};
 use lazy_static::lazy_static;
@@ -295,11 +297,16 @@ impl TableMetadataManager {
 
     pub async fn init(&self) -> Result<()> {
         let catalog_name = CatalogNameKey::new(DEFAULT_CATALOG_NAME);
-        let schema_name = SchemaNameKey::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let public_schema_name = SchemaNameKey::new(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME);
+        let private_schema_name =
+            SchemaNameKey::new(DEFAULT_CATALOG_NAME, DEFAULT_PRIVATE_SCHEMA_NAME);
 
         self.catalog_manager().create(catalog_name, true).await?;
         self.schema_manager()
-            .create(schema_name, None, true)
+            .create(public_schema_name, None, true)
+            .await?;
+        self.schema_manager()
+            .create(private_schema_name, None, true)
             .await?;
 
         Ok(())

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -443,11 +443,12 @@ async fn test_execute_show_databases_tables(instance: Arc<dyn MockInstance>) {
         Output::RecordBatches(databases) => {
             let databases = databases.take();
             assert_eq!(1, databases[0].num_columns());
-            assert_eq!(databases[0].column(0).len(), 2);
+            assert_eq!(databases[0].column(0).len(), 3);
 
             assert_eq!(
                 *databases[0].column(0),
                 Arc::new(StringVector::from(vec![
+                    Some("greptime_private"),
                     Some("information_schema"),
                     Some("public")
                 ])) as VectorRef

--- a/tests/cases/standalone/common/create/create_database.result
+++ b/tests/cases/standalone/common/create/create_database.result
@@ -11,6 +11,7 @@ show databases;
 +--------------------+
 | Schemas            |
 +--------------------+
+| greptime_private   |
 | illegal-database   |
 | information_schema |
 | public             |

--- a/tests/cases/standalone/common/show/show_databases_tables.result
+++ b/tests/cases/standalone/common/show/show_databases_tables.result
@@ -3,6 +3,7 @@ show databases;
 +-----------------------+
 | Schemas               |
 +-----------------------+
+| greptime_private      |
 | illegal-database      |
 | information_schema    |
 | public                |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixes #2964 

This patch introduces a new built-in default schema as namespace of tables created by greptime applications. We have more information discussed in #2964 . In most cases, I think our user won't need to know about this schema.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
