### PR TITLE
feat: convert `FileMetaData` to `ParquetMetaData`

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -399,6 +399,13 @@ pub enum Error {
         error: ArrowError,
         location: Location,
     },
+
+    #[snafu(display("Invalid file metadata"))]
+    ConvertMetaData {
+        location: Location,
+        #[snafu(source)]
+        error: parquet::errors::ParquetError,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -459,6 +466,7 @@ impl ErrorExt for Error {
             InvalidBatch { .. } => StatusCode::InvalidArguments,
             InvalidRecordBatch { .. } => StatusCode::InvalidArguments,
             ConvertVector { source, .. } => source.status_code(),
+            ConvertMetaData { .. } => StatusCode::Internal,
             ComputeArrow { .. } => StatusCode::Internal,
             ComputeVector { .. } => StatusCode::Internal,
             PrimaryKeyLengthMismatch { .. } => StatusCode::InvalidArguments,

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -234,32 +234,33 @@ mod tests {
         let reader = builder.build().await.unwrap();
         let reader_metadata = reader.parquet_metadata();
 
-        // Due to ParquetMetaData not implementing PartialEq
-        // we check the fields manually
-        assert_eq!(
-            writer_metadata.file_metadata().version(),
-            reader_metadata.file_metadata().version()
+        // Because ParquetMetaData doesn't implement PartialEq,
+        // check all fields manually
+        macro_rules! assert_metadata {
+            ( $writer:expr, $reader:expr, $($method:ident,)+ ) => {
+                $(
+                    assert_eq!($writer.$method(), $reader.$method());
+                )+
+            }
+        }
+
+        assert_metadata!(
+            writer_metadata.file_metadata(),
+            reader_metadata.file_metadata(),
+            version,
+            num_rows,
+            created_by,
+            key_value_metadata,
+            schema_descr,
+            column_orders,
         );
-        assert_eq!(
-            writer_metadata.file_metadata().schema_descr(),
-            reader_metadata.file_metadata().schema_descr()
+
+        assert_metadata!(
+            writer_metadata,
+            reader_metadata,
+            row_groups,
+            column_index,
+            offset_index,
         );
-        assert_eq!(
-            writer_metadata.file_metadata().num_rows(),
-            reader_metadata.file_metadata().num_rows()
-        );
-        assert_eq!(
-            writer_metadata.file_metadata().created_by(),
-            reader_metadata.file_metadata().created_by()
-        );
-        assert_eq!(
-            writer_metadata.file_metadata().key_value_metadata(),
-            reader_metadata.file_metadata().key_value_metadata()
-        );
-        assert_eq!(
-            writer_metadata.file_metadata().column_orders(),
-            reader_metadata.file_metadata().column_orders()
-        );
-        assert_eq!(writer_metadata.row_groups(), reader_metadata.row_groups());
     }
 }

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -22,6 +22,7 @@ mod stats;
 pub mod writer;
 
 use common_base::readable_size::ReadableSize;
+use parquet::file::metadata::ParquetMetaData;
 
 use crate::sst::file::FileTimeRange;
 
@@ -59,6 +60,8 @@ pub struct SstInfo {
     pub file_size: u64,
     /// Number of rows.
     pub num_rows: usize,
+    /// File Meta Data
+    pub file_metadata: Option<ParquetMetaData>,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/sst/parquet/helper.rs
+++ b/src/mito2/src/sst/parquet/helper.rs
@@ -1,0 +1,86 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use parquet::basic::ColumnOrder;
+use parquet::file::metadata::{FileMetaData, ParquetMetaData, RowGroupMetaData};
+use parquet::format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
+use parquet::schema::types::{from_thrift, SchemaDescriptor};
+use snafu::ResultExt;
+
+use crate::error;
+use crate::error::Result;
+
+// refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L74-L90
+/// Convert [TFileMetaData] to [ParquetMetaData]
+pub fn to_parquet_metadata(t_file_metadata: TFileMetaData) -> Result<ParquetMetaData> {
+    let schema = from_thrift(&t_file_metadata.schema).context(error::ConvertMetaDataSnafu)?;
+    let schema_desc_ptr = Arc::new(SchemaDescriptor::new(schema));
+
+    let mut row_groups = Vec::new();
+    for rg in t_file_metadata.row_groups {
+        row_groups.push(
+            RowGroupMetaData::from_thrift(schema_desc_ptr.clone(), rg)
+                .context(error::ConvertMetaDataSnafu)?,
+        );
+    }
+    let column_orders = parse_column_orders(t_file_metadata.column_orders, &schema_desc_ptr);
+
+    let file_metadata = FileMetaData::new(
+        t_file_metadata.version,
+        t_file_metadata.num_rows,
+        t_file_metadata.created_by,
+        t_file_metadata.key_value_metadata,
+        schema_desc_ptr,
+        column_orders,
+    );
+    // There may be a problem owing to lacking of column_index and offset_index,
+    // if we open page index in the future.
+    Ok(ParquetMetaData::new(file_metadata, row_groups))
+}
+
+// Port from https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L106-L137
+/// Parses column orders from Thrift definition.
+/// If no column orders are defined, returns `None`.
+fn parse_column_orders(
+    t_column_orders: Option<Vec<TColumnOrder>>,
+    schema_descr: &SchemaDescriptor,
+) -> Option<Vec<ColumnOrder>> {
+    match t_column_orders {
+        Some(orders) => {
+            // Should always be the case
+            assert_eq!(
+                orders.len(),
+                schema_descr.num_columns(),
+                "Column order length mismatch"
+            );
+            let mut res = Vec::new();
+            for (i, column) in schema_descr.columns().iter().enumerate() {
+                match orders[i] {
+                    TColumnOrder::TYPEORDER(_) => {
+                        let sort_order = ColumnOrder::get_sort_order(
+                            column.logical_type(),
+                            column.converted_type(),
+                            column.physical_type(),
+                        );
+                        res.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
+                    }
+                }
+            }
+            Some(res)
+        }
+        None => None,
+    }
+}

--- a/src/mito2/src/sst/parquet/helper.rs
+++ b/src/mito2/src/sst/parquet/helper.rs
@@ -25,11 +25,11 @@ use crate::error::Result;
 
 // Refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L74-L90
 /// Convert [format::FileMetaData] to [ParquetMetaData]
-pub fn to_parquet_metadata(t_file_metadata: format::FileMetaData) -> Result<ParquetMetaData> {
+pub fn parse_parquet_metadata(t_file_metadata: format::FileMetaData) -> Result<ParquetMetaData> {
     let schema = from_thrift(&t_file_metadata.schema).context(error::ConvertMetaDataSnafu)?;
     let schema_desc_ptr = Arc::new(SchemaDescriptor::new(schema));
 
-    let mut row_groups = Vec::new();
+    let mut row_groups = Vec::with_capacity(t_file_metadata.row_groups.len());
     for rg in t_file_metadata.row_groups {
         row_groups.push(
             RowGroupMetaData::from_thrift(schema_desc_ptr.clone(), rg)
@@ -66,7 +66,7 @@ fn parse_column_orders(
                 schema_descr.num_columns(),
                 "Column order length mismatch"
             );
-            let mut res = Vec::new();
+            let mut res = Vec::with_capacity(schema_descr.num_columns());
             for (i, column) in schema_descr.columns().iter().enumerate() {
                 match orders[i] {
                     format::ColumnOrder::TYPEORDER(_) => {

--- a/src/mito2/src/sst/parquet/helper.rs
+++ b/src/mito2/src/sst/parquet/helper.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use parquet::basic::ColumnOrder;
 use parquet::file::metadata::{FileMetaData, ParquetMetaData, RowGroupMetaData};
-use parquet::format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
+use parquet::format;
 use parquet::schema::types::{from_thrift, SchemaDescriptor};
 use snafu::ResultExt;
 
@@ -24,8 +24,8 @@ use crate::error;
 use crate::error::Result;
 
 // Refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L74-L90
-/// Convert [TFileMetaData] to [ParquetMetaData]
-pub fn to_parquet_metadata(t_file_metadata: TFileMetaData) -> Result<ParquetMetaData> {
+/// Convert [format::FileMetaData] to [ParquetMetaData]
+pub fn to_parquet_metadata(t_file_metadata: format::FileMetaData) -> Result<ParquetMetaData> {
     let schema = from_thrift(&t_file_metadata.schema).context(error::ConvertMetaDataSnafu)?;
     let schema_desc_ptr = Arc::new(SchemaDescriptor::new(schema));
 
@@ -55,7 +55,7 @@ pub fn to_parquet_metadata(t_file_metadata: TFileMetaData) -> Result<ParquetMeta
 /// Parses column orders from Thrift definition.
 /// If no column orders are defined, returns `None`.
 fn parse_column_orders(
-    t_column_orders: Option<Vec<TColumnOrder>>,
+    t_column_orders: Option<Vec<format::ColumnOrder>>,
     schema_descr: &SchemaDescriptor,
 ) -> Option<Vec<ColumnOrder>> {
     match t_column_orders {
@@ -69,7 +69,7 @@ fn parse_column_orders(
             let mut res = Vec::new();
             for (i, column) in schema_descr.columns().iter().enumerate() {
                 match orders[i] {
-                    TColumnOrder::TYPEORDER(_) => {
+                    format::ColumnOrder::TYPEORDER(_) => {
                         let sort_order = ColumnOrder::get_sort_order(
                             column.logical_type(),
                             column.converted_type(),

--- a/src/mito2/src/sst/parquet/helper.rs
+++ b/src/mito2/src/sst/parquet/helper.rs
@@ -23,7 +23,7 @@ use snafu::ResultExt;
 use crate::error;
 use crate::error::Result;
 
-// refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L74-L90
+// Refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L74-L90
 /// Convert [TFileMetaData] to [ParquetMetaData]
 pub fn to_parquet_metadata(t_file_metadata: TFileMetaData) -> Result<ParquetMetaData> {
     let schema = from_thrift(&t_file_metadata.schema).context(error::ConvertMetaDataSnafu)?;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -450,4 +450,9 @@ impl ParquetReader {
 
         Ok(None)
     }
+
+    #[cfg(test)]
+    pub fn parquet_metadata(&self) -> Arc<ParquetMetaData> {
+        self.reader_builder.parquet_meta.clone()
+    }
 }

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -26,7 +26,7 @@ use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::SEQUENCE_COLUMN_NAME;
 
-use super::helper::to_parquet_metadata;
+use super::helper::parse_parquet_metadata;
 use crate::error::{InvalidMetadataSnafu, Result, WriteBufferSnafu};
 use crate::read::{Batch, Source};
 use crate::sst::parquet::format::WriteFormat;
@@ -114,7 +114,7 @@ impl ParquetWriter {
         let time_range = stats.time_range.unwrap();
 
         // convert FileMetaData to ParquetMetaData
-        let parquet_metadata = to_parquet_metadata(file_meta)?;
+        let parquet_metadata = parse_parquet_metadata(file_meta)?;
 
         // object_store.write will make sure all bytes are written or an error is raised.
         Ok(Some(SstInfo {

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -114,14 +114,14 @@ impl ParquetWriter {
         let time_range = stats.time_range.unwrap();
 
         // convert FileMetaData to ParquetMetaData
-        let parquet_metadata = to_parquet_metadata(file_meta).ok();
+        let parquet_metadata = to_parquet_metadata(file_meta)?;
 
         // object_store.write will make sure all bytes are written or an error is raised.
         Ok(Some(SstInfo {
             time_range,
             file_size,
             num_rows: stats.num_rows,
-            file_metadata: parquet_metadata,
+            file_metadata: Some(parquet_metadata),
         }))
     }
 

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -14,14 +14,18 @@
 
 //! Parquet writer.
 
+use std::sync::Arc;
+
 use common_datasource::file_format::parquet::BufferedWriter;
 use common_telemetry::debug;
 use common_time::Timestamp;
 use object_store::ObjectStore;
-use parquet::basic::{Compression, Encoding, ZstdLevel};
-use parquet::file::metadata::KeyValue;
+use parquet::basic::{ColumnOrder, Compression, Encoding, ZstdLevel};
+use parquet::file::metadata::{FileMetaData, KeyValue, ParquetMetaData, RowGroupMetaData};
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
-use parquet::schema::types::ColumnPath;
+use parquet::format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
+use parquet::schema::types;
+use parquet::schema::types::{from_thrift, ColumnPath, SchemaDescPtr, SchemaDescriptor};
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::SEQUENCE_COLUMN_NAME;
@@ -107,15 +111,20 @@ impl ParquetWriter {
             return Ok(None);
         }
 
-        let (_file_meta, file_size) = buffered_writer.close().await.context(WriteBufferSnafu)?;
+        let (file_meta, file_size) = buffered_writer.close().await.context(WriteBufferSnafu)?;
+
         // Safety: num rows > 0 so we must have min/max.
         let time_range = stats.time_range.unwrap();
+
+        // convert file_meta to ParquetMetaData
+        let parquet_metadata = convert_t_file_meta_to_parquet_meta_data(file_meta);
 
         // object_store.write will make sure all bytes are written or an error is raised.
         Ok(Some(SstInfo {
             time_range,
             file_size,
             num_rows: stats.num_rows,
+            file_metadata: parquet_metadata.ok(),
         }))
     }
 
@@ -165,5 +174,66 @@ impl SourceStats {
         } else {
             self.time_range = Some((min_in_batch, max_in_batch));
         }
+    }
+}
+
+// refer to https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L72-L90
+/// Convert [TFileMetaData] to [ParquetMetaData]
+fn convert_t_file_meta_to_parquet_meta_data(
+    t_file_metadata: TFileMetaData,
+) -> Result<ParquetMetaData> {
+    let schema = from_thrift(&t_file_metadata.schema)?;
+    let schema_desc_ptr = Arc::new(SchemaDescriptor::new(schema));
+    let row_groups: Vec<_> = t_file_metadata
+        .row_groups
+        .into_iter()
+        .map(|rg| RowGroupMetaData::from_thrift(schema_desc_ptr.clone(), rg)?)
+        .collect();
+
+    let column_orders = parse_column_orders(t_file_metadata.column_orders, &schema_desc_ptr);
+
+    let file_metadata = FileMetaData::new(
+        t_file_metadata.version,
+        t_file_metadata.num_rows,
+        t_file_metadata.created_by,
+        t_file_metadata.key_value_metadata,
+        schema_desc_ptr,
+        column_orders,
+    );
+
+    Ok(ParquetMetaData::new(file_metadata, row_groups))
+}
+
+// Port from https://github.com/apache/arrow-rs/blob/7e134f4d277c0b62c27529fc15a4739de3ad0afd/parquet/src/file/footer.rs#L106-L137
+/// Parses column orders from Thrift definition.
+/// If no column orders are defined, returns `None`.
+fn parse_column_orders(
+    t_column_orders: Option<Vec<TColumnOrder>>,
+    schema_descr: &SchemaDescriptor,
+) -> Option<Vec<ColumnOrder>> {
+    match t_column_orders {
+        Some(orders) => {
+            // Should always be the case
+            assert_eq!(
+                orders.len(),
+                schema_descr.num_columns(),
+                "Column order length mismatch"
+            );
+            let mut res = Vec::new();
+            for (i, column) in schema_descr.columns().iter().enumerate() {
+                match orders[i] {
+                    TColumnOrder::TYPEORDER(_) => {
+                        let sort_order = ColumnOrder::get_sort_order(
+                            column.logical_type(),
+                            column.converted_type(),
+                            column.physical_type(),
+                        );
+                        res.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
+                    }
+                }
+            }
+            Some(res)
+        }
+        None => None,
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
part of #2963 , this pr is pre-work.
support to convert from `FileMetaData` to `ParquetMetaData`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
#2963 