### PR TITLE
feat: export runtime metric to promethues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,8 @@ dependencies = [
  "prometheus",
  "snafu",
  "tokio",
+ "tokio-metrics",
+ "tokio-metrics-collector",
  "tokio-test",
  "tokio-util",
 ]
@@ -9700,6 +9702,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "tokio-metrics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "tokio-metrics-collector"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767da47381602cc481653456823b3ebb600e83d5dd4e0293da9b5566c6c00f0"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.12.1",
+ "prometheus",
+ "tokio",
+ "tokio-metrics",
 ]
 
 [[package]]

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -17,5 +17,8 @@ snafu.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true
 
+tokio-metrics = "0.3"
+tokio-metrics-collector = { version = "0.2" }
+
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/common/runtime/Cargo.toml
+++ b/src/common/runtime/Cargo.toml
@@ -14,11 +14,10 @@ once_cell.workspace = true
 paste.workspace = true
 prometheus.workspace = true
 snafu.workspace = true
+tokio-metrics = "0.3"
+tokio-metrics-collector = "0.2"
 tokio-util.workspace = true
 tokio.workspace = true
-
-tokio-metrics = "0.3"
-tokio-metrics-collector = { version = "0.2" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/common/runtime/src/runtime.rs
+++ b/src/common/runtime/src/runtime.rs
@@ -256,9 +256,9 @@ mod tests {
 
         #[cfg(tokio_unstable)]
         {
-            assert!(metric_text.contains("runtime_0_tokio_budget_forced_yield_count"));
-            assert!(metric_text.contains("runtime_0_tokio_injection_queue_depth"));
-            assert!(metric_text.contains("runtime_0_tokio_workers_count"));
+            assert!(metric_text.contains("runtime_0_tokio_budget_forced_yield_count 0"));
+            assert!(metric_text.contains("runtime_0_tokio_injection_queue_depth 0"));
+            assert!(metric_text.contains("runtime_0_tokio_workers_count 5"));
         }
     }
 

--- a/src/common/runtime/src/runtime.rs
+++ b/src/common/runtime/src/runtime.rs
@@ -95,7 +95,7 @@ pub struct Builder {
 impl Default for Builder {
     fn default() -> Self {
         Self {
-            runtime_name: format!("runtime-{}", RUNTIME_ID.fetch_add(1, Ordering::Relaxed)),
+            runtime_name: format!("runtime_{}", RUNTIME_ID.fetch_add(1, Ordering::Relaxed)),
             thread_name: "default-worker".to_string(),
             builder: RuntimeBuilder::new_multi_thread(),
         }
@@ -152,6 +152,7 @@ impl Builder {
             .build()
             .context(BuildRuntimeSnafu)?;
 
+        let name = self.runtime_name.clone();
         let handle = runtime.handle().clone();
         let (send_stop, recv_stop) = oneshot::channel();
         // Block the runtime to shutdown.
@@ -159,14 +160,22 @@ impl Builder {
             .name(format!("{}-blocker", self.thread_name))
             .spawn(move || runtime.block_on(recv_stop));
 
+        register_collector(name.clone(), &handle);
+
         Ok(Runtime {
-            name: self.runtime_name.clone(),
+            name,
             handle,
             _dropper: Arc::new(Dropper {
                 close: Some(send_stop),
             }),
         })
     }
+}
+
+pub fn register_collector(name: String, handle: &Handle) {
+    let monitor = tokio_metrics::RuntimeMonitor::new(handle);
+    let collector = tokio_metrics_collector::RuntimeCollector::new(monitor, name.clone());
+    let _ = prometheus::register(Box::new(collector));
 }
 
 fn on_thread_start(thread_name: String) -> impl Fn() + 'static {
@@ -241,6 +250,9 @@ mod tests {
 
         assert!(metric_text.contains("runtime_threads_idle{thread_name=\"test_runtime_metric\"}"));
         assert!(metric_text.contains("runtime_threads_alive{thread_name=\"test_runtime_metric\"}"));
+        assert!(metric_text.contains("runtime_0_tokio_budget_forced_yield_count"));
+        assert!(metric_text.contains("runtime_0_tokio_injection_queue_depth"));
+        assert!(metric_text.contains("runtime_0_tokio_workers_count"));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

export tokio runtime metrics

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- use tokio-metric to collect runtime metrics
- use tokio-metric-collector to expose to promethues

## Checklist

- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
close https://github.com/GreptimeTeam/greptimedb/issues/1529