### PR TITLE
chore(ci): auto doc labeler job

### DIFF
--- a/.github/doc-label-config.yml
+++ b/.github/doc-label-config.yml
@@ -1,0 +1,2 @@
+Doc not needed:
+    - '- \[x\]  I have written the necessary rustdoc comments'

--- a/.github/doc-label-config.yml
+++ b/.github/doc-label-config.yml
@@ -1,2 +1,4 @@
 Doc not needed:
-    - '- \[x\]  I have written the necessary rustdoc comments'
+    - '- \[x\]  This PR does not require documentation updates.'
+Doc update required:
+    - '- \[ \]  This PR does not require documentation updates.'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,6 @@ Please explain IN DETAIL what the changes are in this PR and why they are needed
 
 - [ ]  I have written the necessary rustdoc comments.
 - [ ]  I have added the necessary unit tests and integration tests.
+- [ ]  This PR does not require documentation updates.
 
 ## Refer to a related PR or issue link (optional)

--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -1,0 +1,19 @@
+name: "PR Doc Labeler"
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  triage:
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.3
+      with:
+        configuration-path: .github/doc-label-config.yml
+        enable-versioned-regex: false
+        repo-token: ${{ github.token }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add an action job to auto label "Doc not needed" on PR based on the checkbox in "Checklist".

This patch also adds a dedicated checkbox in PR template for "doc not needed"/"doc update required" tuples.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
Closes https://github.com/GreptimeTeam/greptimedb/issues/2997