### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.5.0
+  NEXT_RELEASE_VERSION: v0.6.0
 
 jobs:
   allocate-runners:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1179,7 +1179,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1450,7 +1450,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1483,7 +1483,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1562,7 +1562,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1595,7 +1595,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "build-data",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1794,7 +1794,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-recursion",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "once_cell",
  "rand",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "build-data",
 ]
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2683,7 +2683,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3158,7 +3158,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -3289,7 +3289,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -3353,7 +3353,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
  "strfmt",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "tokio",
  "toml 0.7.8",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4471,7 +4471,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anymap",
  "api",
@@ -4853,7 +4853,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anymap",
  "api",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5661,7 +5661,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5705,7 +5705,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6244,7 +6244,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "auth",
  "common-base",
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -6881,7 +6881,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -8141,7 +8141,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "aide",
  "api",
@@ -8497,7 +8497,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "common-base",
@@ -8810,7 +8810,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9016,7 +9016,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -9156,7 +9156,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9304,7 +9304,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9416,7 +9416,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-integration"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "api",
  "async-trait",
@@ -9472,7 +9472,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.4.4",
+ "substrait 0.5.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -191,8 +191,6 @@ table = { path = "src/table" }
 [workspace.dependencies.meter-macros]
 git = "https://github.com/GreptimeTeam/greptime-meter.git"
 rev = "abbd357c1e193cd270ea65ee7652334a150b628f"
-
-[profile.dev]
 
 [profile.release]
 debug = 1


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump version to `0.5.0`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.

## Refer to a related PR or issue link (optional)
