### PR TITLE
fix: update doc label on pr edit

### DIFF
--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -16,5 +16,5 @@ jobs:
       with:
         configuration-path: .github/doc-label-config.yml
         enable-versioned-regex: false
-        repo-token: ${{ github.token }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         sync-labels: 1

--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -17,3 +17,4 @@ jobs:
         configuration-path: .github/doc-label-config.yml
         enable-versioned-regex: false
         repo-token: ${{ github.token }}
+        sync-labels: 1

--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -1,7 +1,7 @@
 name: "PR Doc Labeler"
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, edited, synchronize, ready_for_review, auto_merge_enabled, labeled, unlabeled]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Update the label on editing PR, docs: https://github.com/waynexia/greptimedb/pull/new/sync-doc-label

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
