### PR TITLE
feat: upgrade pgwire to 0.18 for corrected statement caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6093,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7f181d085a224ff2b2ea46bd2066b487b87e83dabbcdfe60bf3f027f5d0593"
+checksum = "3b277432819ee6b76bf56de5e91eae578d6b332bd6f05f963ee81fc788bc886f"
 dependencies = [
  "async-trait",
  "base64 0.21.5",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -58,7 +58,7 @@ openmetrics-parser = "0.4"
 opensrv-mysql = { git = "https://github.com/MichaelScofield/opensrv.git", rev = "1676c1d" }
 opentelemetry-proto.workspace = true
 parking_lot = "0.12"
-pgwire = "0.17"
+pgwire = "0.18"
 pin-project = "1.0"
 postgres-types = { version = "0.2", features = ["with-chrono-0_4"] }
 pprof = { version = "0.13", features = [

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -31,7 +31,6 @@ use std::sync::Arc;
 use ::auth::UserProviderRef;
 use derive_builder::Builder;
 use pgwire::api::auth::ServerParameterProvider;
-use pgwire::api::store::MemPortalStore;
 use pgwire::api::ClientInfo;
 pub use server::PostgresServer;
 use session::context::Channel;
@@ -40,7 +39,6 @@ use session::Session;
 use self::auth_handler::PgLoginVerifier;
 use self::handler::DefaultQueryParser;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
-use crate::SqlPlan;
 
 pub(crate) struct GreptimeDBStartupParameters {
     version: &'static str,
@@ -76,7 +74,6 @@ pub struct PostgresServerHandler {
     param_provider: Arc<GreptimeDBStartupParameters>,
 
     session: Arc<Session>,
-    portal_store: Arc<MemPortalStore<SqlPlan>>,
     query_parser: Arc<DefaultQueryParser>,
 }
 
@@ -99,7 +96,6 @@ impl MakePostgresServerHandler {
             param_provider: self.param_provider.clone(),
 
             session: session.clone(),
-            portal_store: Arc::new(MemPortalStore::new()),
             query_parser: Arc::new(DefaultQueryParser::new(self.query_handler.clone(), session)),
         }
     }

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -25,7 +25,6 @@ use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler, StatementOrPortal};
 use pgwire::api::results::{DataRowEncoder, DescribeResponse, QueryResponse, Response, Tag};
 use pgwire::api::stmt::QueryParser;
-use pgwire::api::store::MemPortalStore;
 use pgwire::api::{ClientInfo, Type};
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use query::query_engine::DescribeResult;
@@ -192,11 +191,6 @@ impl QueryParser for DefaultQueryParser {
 impl ExtendedQueryHandler for PostgresServerHandler {
     type Statement = SqlPlan;
     type QueryParser = DefaultQueryParser;
-    type PortalStore = MemPortalStore<Self::Statement>;
-
-    fn portal_store(&self) -> Arc<Self::PortalStore> {
-        self.portal_store.clone()
-    }
 
     fn query_parser(&self) -> Arc<Self::QueryParser> {
         self.query_parser.clone()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch upgrades pgwire to 0.18 which corrected implementation of prepared statement caching https://github.com/sunng87/pgwire/pull/140. The statements are now cached with client and dropped when client disconnected.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
