### PR TITLE
fix: change CI target repo to the origin one

### DIFF
--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -1,6 +1,6 @@
 name: "PR Doc Labeler"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, ready_for_review, auto_merge_enabled, labeled, unlabeled]
 
 permissions:

--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -1,6 +1,6 @@
 name: size-labeler
 
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   labeler:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


According to GitHub Action's doc:

>Runs your workflow when activity on a pull request in the workflow's repository occurs. If no activity types are specified, the workflow runs when a pull request is opened, reopened, or when the head branch of the pull request is updated.
>
>This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
