### PR TITLE
refactor: use string type instead of Option type for '--store-key-prefix'

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -15,6 +15,7 @@ selector = "lease_based"
 use_memory_store = false
 # Whether to enable greptimedb telemetry, true by default.
 enable_telemetry = true
+store_key_prefix = ""
 
 # Log options, see `standalone.example.toml`
 # [logging]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -15,6 +15,7 @@ selector = "lease_based"
 use_memory_store = false
 # Whether to enable greptimedb telemetry, true by default.
 enable_telemetry = true
+# If it's not empty, the metasrv will store all data with this key prefix.
 store_key_prefix = ""
 
 # Log options, see `standalone.example.toml`

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -119,8 +119,8 @@ struct StartCommand {
     data_home: Option<String>,
 
     /// If it's not empty, the metasrv will store all data with this key prefix.
-    #[clap(long)]
-    store_key_prefix: Option<String>,
+    #[clap(long, default_value = "")]
+    store_key_prefix: String,
 }
 
 impl StartCommand {
@@ -177,7 +177,9 @@ impl StartCommand {
             opts.data_home = data_home.clone();
         }
 
-        opts.store_key_prefix = self.store_key_prefix.clone();
+        if !self.store_key_prefix.is_empty() {
+            opts.store_key_prefix = self.store_key_prefix.clone()
+        }
 
         // Disable dashboard in metasrv.
         opts.http.disable_dashboard = true;

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -192,8 +192,11 @@ pub async fn metasrv_builder(
             let etcd_client = create_etcd_client(opts).await?;
             let kv_backend = {
                 let etcd_backend = EtcdStore::with_etcd_client(etcd_client.clone());
-                if let Some(prefix) = opts.store_key_prefix.clone() {
-                    Arc::new(ChrootKvBackend::new(prefix.into_bytes(), etcd_backend))
+                if !opts.store_key_prefix.is_empty() {
+                    Arc::new(ChrootKvBackend::new(
+                        opts.store_key_prefix.clone().into_bytes(),
+                        etcd_backend,
+                    ))
                 } else {
                     etcd_backend
                 }

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -35,14 +35,14 @@ pub struct EtcdElection {
     is_leader: AtomicBool,
     infancy: AtomicBool,
     leader_watcher: broadcast::Sender<LeaderChangeMessage>,
-    store_key_prefix: Option<String>,
+    store_key_prefix: String,
 }
 
 impl EtcdElection {
     pub async fn with_endpoints<E, S>(
         leader_value: E,
         endpoints: S,
-        store_key_prefix: Option<String>,
+        store_key_prefix: String,
     ) -> Result<ElectionRef>
     where
         E: AsRef<str>,
@@ -58,7 +58,7 @@ impl EtcdElection {
     pub async fn with_etcd_client<E>(
         leader_value: E,
         client: Client,
-        store_key_prefix: Option<String>,
+        store_key_prefix: String,
     ) -> Result<ElectionRef>
     where
         E: AsRef<str>,
@@ -105,9 +105,10 @@ impl EtcdElection {
     }
 
     fn election_key(&self) -> String {
-        match &self.store_key_prefix {
-            Some(prefix) => format!("{}{}", prefix, ELECTION_KEY),
-            None => ELECTION_KEY.to_string(),
+        if self.store_key_prefix.is_empty() {
+            ELECTION_KEY.to_string()
+        } else {
+            format!("{}{}", self.store_key_prefix, ELECTION_KEY)
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -75,7 +75,7 @@ pub struct MetaSrvOptions {
     pub data_home: String,
     pub wal: WalConfig,
     pub export_metrics: ExportMetricsOption,
-    pub store_key_prefix: Option<String>,
+    pub store_key_prefix: String,
 }
 
 impl Default for MetaSrvOptions {
@@ -102,7 +102,7 @@ impl Default for MetaSrvOptions {
             data_home: METASRV_HOME.to_string(),
             wal: WalConfig::default(),
             export_metrics: ExportMetricsOption::default(),
-            store_key_prefix: None,
+            store_key_prefix: "".to_string(),
         }
     }
 }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -102,7 +102,7 @@ impl Default for MetaSrvOptions {
             data_home: METASRV_HOME.to_string(),
             wal: WalConfig::default(),
             export_metrics: ExportMetricsOption::default(),
-            store_key_prefix: "".to_string(),
+            store_key_prefix: String::new(),
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

_PLEASE DO NOT LEAVE THIS EMPTY !!!_

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
