### PR TITLE
chore: do not send message for xlarge PR

### DIFF
--- a/.github/workflows/size-label.yml
+++ b/.github/workflows/size-label.yml
@@ -21,8 +21,5 @@ jobs:
           l_max_size: '1000'
           xl_label: 'Size: XL'
           fail_if_xl: 'false'
-          message_if_xl: >
-            This PR exceeds the recommended size of 1000 lines.
-            Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size.
+          message_if_xl: ""
           files_to_ignore: 'Cargo.lock'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Set the message on xlarge PR to empty string, discussion: https://github.com/CodelyTV/pr-size-labeler/issues/55

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
