### PR TITLE
chore: Update CI badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
     <a href="https://codecov.io/gh/GrepTimeTeam/greptimedb"><img src="https://codecov.io/gh/GrepTimeTeam/greptimedb/branch/main/graph/badge.svg?token=FITFDI3J3C"></img></a>
     &nbsp;
-    <a href="https://github.com/GreptimeTeam/greptimedb/actions/workflows/main.yml"><img src="https://github.com/GreptimeTeam/greptimedb/actions/workflows/main.yml/badge.svg" alt="CI"></img></a>
+    <a href="https://github.com/GreptimeTeam/greptimedb/actions/workflows/develop.yml"><img src="https://github.com/GreptimeTeam/greptimedb/actions/workflows/develop.yml/badge.svg" alt="CI"></img></a>
     &nbsp;
     <a href="https://github.com/greptimeTeam/greptimedb/blob/main/LICENSE"><img src="https://img.shields.io/github/license/greptimeTeam/greptimedb"></a>
 </p>


### PR DESCRIPTION
Fix CI badge

I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Fixes broken CI badge
<img width="614" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/7058520/8f8c9b69-6e08-4b91-993d-1001e908bf04">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #3025
- #3026