### PR TITLE
fix(remote_wal): some known issues

### DIFF
--- a/src/log-store/src/kafka/client_manager.rs
+++ b/src/log-store/src/kafka/client_manager.rs
@@ -23,7 +23,7 @@ use rskafka::client::producer::{BatchProducer, BatchProducerBuilder};
 use rskafka::client::{Client as RsKafkaClient, ClientBuilder};
 use rskafka::BackoffConfig;
 use snafu::ResultExt;
-use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::Mutex;
 
 use crate::error::{BuildClientSnafu, BuildPartitionClientSnafu, Result};
 
@@ -68,7 +68,7 @@ pub(crate) struct ClientManager {
     client_factory: RsKafkaClient,
     /// A pool maintaining a collection of clients.
     /// Key: a topic. Value: the associated client of the topic.
-    client_pool: TokioMutex<HashMap<Topic, Client>>,
+    client_pool: Mutex<HashMap<Topic, Client>>,
 }
 
 impl ClientManager {
@@ -92,7 +92,7 @@ impl ClientManager {
         Ok(Self {
             config: config.clone(),
             client_factory: client,
-            client_pool: TokioMutex::new(HashMap::new()),
+            client_pool: Mutex::new(HashMap::new()),
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Rewrite the iteration in `append_batch` to ensure the `region_ids` and `last_entry_ids` coincide.
- Temporarily replace the `DashMap` with `tokio::sync::Mutex` to resolve a known deadlock issue.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
