### PR TITLE
feat: table route for metric engine

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -406,11 +406,18 @@ impl StartCommand {
             opts.wal_meta.clone(),
             kv_backend.clone(),
         ));
-        let table_meta_allocator =
-            TableMetadataAllocator::new(table_id_sequence, wal_options_allocator.clone());
+
+        let table_metadata_manager =
+            Self::create_table_metadata_manager(kv_backend.clone()).await?;
+
+        let table_meta_allocator = TableMetadataAllocator::new(
+            table_id_sequence,
+            wal_options_allocator.clone(),
+            table_metadata_manager.clone(),
+        );
 
         let ddl_task_executor = Self::create_ddl_task_executor(
-            kv_backend.clone(),
+            table_metadata_manager,
             procedure_manager.clone(),
             datanode_manager.clone(),
             table_meta_allocator,
@@ -441,14 +448,11 @@ impl StartCommand {
     }
 
     pub async fn create_ddl_task_executor(
-        kv_backend: KvBackendRef,
+        table_metadata_manager: TableMetadataManagerRef,
         procedure_manager: ProcedureManagerRef,
         datanode_manager: DatanodeManagerRef,
         table_meta_allocator: TableMetadataAllocator,
     ) -> Result<DdlTaskExecutorRef> {
-        let table_metadata_manager =
-            Self::create_table_metadata_manager(kv_backend.clone()).await?;
-
         let ddl_task_executor: DdlTaskExecutorRef = Arc::new(
             DdlManager::try_new(
                 procedure_manager,

--- a/src/common/meta/src/ddl/table_meta.rs
+++ b/src/common/meta/src/ddl/table_meta.rs
@@ -18,12 +18,15 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_catalog::consts::METRIC_ENGINE;
 use common_telemetry::{debug, info};
-use snafu::ensure;
+use snafu::{ensure, OptionExt};
+use store_api::metric_engine_consts::LOGICAL_TABLE_METADATA_KEY;
 use store_api::storage::{RegionId, RegionNumber, TableId};
 
 use crate::ddl::{TableMetadata, TableMetadataAllocatorContext};
-use crate::error::{Result, UnsupportedSnafu};
+use crate::error::{Result, TableNotFoundSnafu, UnsupportedSnafu};
+use crate::key::table_name::TableNameKey;
 use crate::key::table_route::{LogicalTableRouteValue, PhysicalTableRouteValue, TableRouteValue};
+use crate::key::TableMetadataManagerRef;
 use crate::peer::Peer;
 use crate::rpc::ddl::CreateTableTask;
 use crate::rpc::router::{Region, RegionRoute};
@@ -33,6 +36,7 @@ use crate::wal::{allocate_region_wal_options, WalOptionsAllocatorRef};
 pub struct TableMetadataAllocator {
     table_id_sequence: SequenceRef,
     wal_options_allocator: WalOptionsAllocatorRef,
+    table_metadata_manager: TableMetadataManagerRef,
     peer_allocator: PeerAllocatorRef,
 }
 
@@ -40,10 +44,12 @@ impl TableMetadataAllocator {
     pub fn new(
         table_id_sequence: SequenceRef,
         wal_options_allocator: WalOptionsAllocatorRef,
+        table_metadata_manager: TableMetadataManagerRef,
     ) -> Self {
         Self::with_peer_allocator(
             table_id_sequence,
             wal_options_allocator,
+            table_metadata_manager,
             Arc::new(NoopPeerAllocator),
         )
     }
@@ -51,11 +57,13 @@ impl TableMetadataAllocator {
     pub fn with_peer_allocator(
         table_id_sequence: SequenceRef,
         wal_options_allocator: WalOptionsAllocatorRef,
+        table_metadata_manager: TableMetadataManagerRef,
         peer_allocator: PeerAllocatorRef,
     ) -> Self {
         Self {
             table_id_sequence,
             wal_options_allocator,
+            table_metadata_manager,
             peer_allocator,
         }
     }
@@ -115,8 +123,31 @@ impl TableMetadataAllocator {
     ) -> Result<TableRouteValue> {
         let regions = task.partitions.len();
 
-        let table_route = if task.create_table.engine == METRIC_ENGINE {
-            TableRouteValue::Logical(LogicalTableRouteValue {})
+        let table_route = if task.create_table.engine == METRIC_ENGINE
+            && let Some(physical_table_name) = task
+                .create_table
+                .table_options
+                .get(LOGICAL_TABLE_METADATA_KEY)
+        {
+            let physical_table_id = self
+                .table_metadata_manager
+                .table_name_manager()
+                .get(TableNameKey::new(
+                    &task.create_table.catalog_name,
+                    &task.create_table.schema_name,
+                    physical_table_name,
+                ))
+                .await?
+                .context(TableNotFoundSnafu {
+                    table_name: physical_table_name,
+                })?
+                .table_id();
+
+            let region_ids = (0..regions)
+                .map(|i| RegionId::new(table_id, i as RegionNumber))
+                .collect();
+
+            TableRouteValue::Logical(LogicalTableRouteValue::new(physical_table_id, region_ids))
         } else {
             let peers = self.peer_allocator.alloc(ctx, regions).await?;
 

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -495,8 +495,9 @@ mod tests {
             Arc::new(DummyCacheInvalidator),
             table_metadata_manager,
             TableMetadataAllocator::new(
-                Arc::new(SequenceBuilder::new("test", kv_backend).build()),
+                Arc::new(SequenceBuilder::new("test", kv_backend.clone()).build()),
                 Arc::new(WalOptionsAllocator::default()),
+                Arc::new(TableMetadataManager::new(kv_backend)),
             ),
             Arc::new(MemoryRegionKeeper::default()),
         );

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -53,7 +53,8 @@ pub struct PhysicalTableRouteValue {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct LogicalTableRouteValue {
-    // TODO(LFC): Add table route for MetricsEngine table.
+    physical_table_id: TableId,
+    region_ids: Vec<RegionId>,
 }
 
 impl TableRouteValue {
@@ -174,12 +175,19 @@ impl PhysicalTableRouteValue {
 }
 
 impl LogicalTableRouteValue {
-    pub fn physical_table_id(&self) -> TableId {
-        todo!()
+    pub fn new(physical_table_id: TableId, region_ids: Vec<RegionId>) -> Self {
+        Self {
+            physical_table_id,
+            region_ids,
+        }
     }
 
-    pub fn region_ids(&self) -> Vec<RegionId> {
-        todo!()
+    pub fn physical_table_id(&self) -> TableId {
+        self.physical_table_id
+    }
+
+    pub fn region_ids(&self) -> &Vec<RegionId> {
+        &self.region_ids
     }
 }
 

--- a/src/common/meta/src/lib.rs
+++ b/src/common/meta/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(assert_matches)]
 #![feature(btree_extract_if)]
 #![feature(async_closure)]
+#![feature(let_chains)]
 
 pub mod cache_invalidator;
 pub mod datanode_manager;

--- a/src/common/meta/src/rpc/router.rs
+++ b/src/common/meta/src/rpc/router.rs
@@ -123,11 +123,12 @@ pub fn convert_to_region_leader_status_map(
 pub fn find_region_leader(
     region_routes: &[RegionRoute],
     region_number: RegionNumber,
-) -> Option<&Peer> {
+) -> Option<Peer> {
     region_routes
         .iter()
         .find(|x| x.region.id.region_number() == region_number)
         .and_then(|r| r.leader_peer.as_ref())
+        .cloned()
 }
 
 pub fn find_leader_regions(region_routes: &[RegionRoute], datanode: &Peer) -> Vec<RegionNumber> {

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -272,6 +272,16 @@ pub enum Error {
         location: Location,
         source: BoxedError,
     },
+
+    #[snafu(display(
+        "Failed to find logical regions in physical region {}",
+        physical_region_id
+    ))]
+    FindLogicalRegions {
+        physical_region_id: RegionId,
+        source: metric_engine::error::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -340,6 +350,8 @@ impl ErrorExt for Error {
             }
             HandleRegionRequest { source, .. } => source.status_code(),
             StopRegionEngine { source, .. } => source.status_code(),
+
+            FindLogicalRegions { source, .. } => source.status_code(),
         }
     }
 

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -207,4 +207,8 @@ impl RegionEngine for MockRegionEngine {
         }
         Some(RegionRole::Leader)
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -118,6 +119,10 @@ impl RegionEngine for FileRegionEngine {
 
     fn role(&self, region_id: RegionId) -> Option<RegionRole> {
         self.inner.state(region_id)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -225,6 +225,7 @@ impl MetaSrvBuilder {
             TableMetadataAllocator::with_peer_allocator(
                 sequence,
                 wal_options_allocator.clone(),
+                table_metadata_manager.clone(),
                 peer_allocator,
             )
         });

--- a/src/meta-srv/src/procedure/region_migration/manager.rs
+++ b/src/meta-srv/src/procedure/region_migration/manager.rs
@@ -463,7 +463,10 @@ mod test {
         };
 
         let err = manager
-            .verify_table_route(&TableRouteValue::Logical(LogicalTableRouteValue {}), &task)
+            .verify_table_route(
+                &TableRouteValue::Logical(LogicalTableRouteValue::new(0, vec![])),
+                &task,
+            )
             .unwrap_err();
 
         assert_matches!(err, error::Error::Unexpected { .. });

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -21,6 +21,7 @@ mod read;
 mod region_metadata;
 mod state;
 
+use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -38,6 +39,7 @@ use tokio::sync::RwLock;
 
 use self::state::MetricEngineState;
 use crate::data_region::DataRegion;
+use crate::error::Result;
 use crate::metadata_region::MetadataRegion;
 use crate::utils;
 
@@ -193,6 +195,10 @@ impl RegionEngine for MetricEngine {
     fn role(&self, region_id: RegionId) -> Option<RegionRole> {
         todo!()
     }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl MetricEngine {
@@ -207,6 +213,13 @@ impl MetricEngine {
                 state: RwLock::default(),
             }),
         }
+    }
+
+    pub async fn logical_regions(&self, physical_region_id: RegionId) -> Result<Vec<RegionId>> {
+        self.inner
+            .metadata_region
+            .logical_regions(physical_region_id)
+            .await
     }
 }
 

--- a/src/metric-engine/src/lib.rs
+++ b/src/metric-engine/src/lib.rs
@@ -50,6 +50,8 @@
 //!              └─────────────────────┘
 //! ```
 
+#![feature(let_chains)]
+
 mod data_region;
 #[allow(unused)]
 pub mod engine;

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -45,6 +45,7 @@ mod set_readonly_test;
 #[cfg(test)]
 mod truncate_test;
 
+use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -302,6 +303,10 @@ impl RegionEngine for MitoEngine {
 
     fn role(&self, region_id: RegionId) -> Option<RegionRole> {
         self.inner.role(region_id)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/src/partition/src/metrics.rs
+++ b/src/partition/src/metrics.rs
@@ -11,11 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use lazy_static::lazy_static;
-use prometheus::*;
-
-lazy_static! {
-    pub static ref METRIC_TABLE_ROUTE_GET: Histogram =
-        register_histogram!("frontend_table_route_get", "frontend table route get").unwrap();
-}

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -14,6 +14,7 @@
 
 //! Region Engine's definition
 
+use std::any::Any;
 use std::fmt::Display;
 use std::sync::Arc;
 
@@ -165,6 +166,8 @@ pub trait RegionEngine: Send + Sync {
     ///
     /// Returns the `None` if the region is not found.
     fn role(&self, region_id: RegionId) -> Option<RegionRole>;
+
+    fn as_any(&self) -> &dyn Any;
 }
 
 pub type RegionEngineRef = Arc<dyn RegionEngine>;

--- a/tests-integration/src/standalone.rs
+++ b/tests-integration/src/standalone.rs
@@ -149,8 +149,11 @@ impl GreptimeDbStandaloneBuilder {
             wal_meta.clone(),
             kv_backend.clone(),
         ));
-        let table_meta_allocator =
-            TableMetadataAllocator::new(table_id_sequence, wal_options_allocator.clone());
+        let table_meta_allocator = TableMetadataAllocator::new(
+            table_id_sequence,
+            wal_options_allocator.clone(),
+            table_metadata_manager.clone(),
+        );
 
         let ddl_task_executor = Arc::new(
             DdlManager::try_new(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Now metric engine table can be created. Basic insertion is supported:

```text
mysql> create table physical_table(ts timestamp time index) engine = metric with (physical_metric_table = true);
Query OK, 0 rows affected (0.03 sec)

mysql> select * from information_schema.tables where engine = 'metric';
+---------------+--------------+----------------+------------+----------+--------+
| table_catalog | table_schema | table_name     | table_type | table_id | engine |
+---------------+--------------+----------------+------------+----------+--------+
| greptime      | public       | physical_table | BASE TABLE |     1044 | metric |
+---------------+--------------+----------------+------------+----------+--------+
1 row in set (0.48 sec)

mysql> create table l1(ts timestamp time index, i int) engine = metric with (on_physical_table = 'physical_table');
Query OK, 0 rows affected (0.05 sec)

mysql> insert into l1 values (1,1);
Query OK, 1 row affected (0.01 sec)

mysql> select * from l1;
+----------------------------+------+
| ts                         | i    |
+----------------------------+------+
| 1970-01-01 00:00:00.001000 |    1 |
+----------------------------+------+
1 row in set (0.03 sec)

mysql> create table l2(ts timestamp time index, s string) engine = metric with (on_physical_table = 'physical_table');
Query OK, 0 rows affected (0.05 sec)

mysql> insert into l2 values(1,"a");
Query OK, 1 row affected (0.00 sec)
```

Basic query is also supported:

```text
mysql> select * from l2;
+----------------------------+------+
| ts                         | s    |
+----------------------------+------+
| 1970-01-01 00:00:00.001000 | NULL | <-- Not expected line, might be related to some unfinished metric engine works though. Ignore it now.
| 1970-01-01 00:00:00.001000 | a    |
+----------------------------+------+
2 rows in set (0.01 sec)

```

Will add more tests in the next PR.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2864