### PR TITLE
ci: fix duplicatd doc issue

### DIFF
--- a/.github/workflows/doc-label.yml
+++ b/.github/workflows/doc-label.yml
@@ -20,7 +20,7 @@ jobs:
         sync-labels: 1
     - name: create an issue in doc repo
       uses: dacbd/create-issue-action@main
-      if: ${{ contains(github.event.pull_request.body, '- [ ]  This PR does not require documentation updates.') }}
+      if: ${{ github.event.action == 'opened' && contains(github.event.pull_request.body, '- [ ]  This PR does not require documentation updates.') }}
       with:
         owner: GreptimeTeam
         repo: docs


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Fixes duplicated doc issue created on updating pull request.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
