### PR TITLE
chore: bump opendal to 0.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,9 +5501,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.40.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddba7299bab261d3ae2f37617fb7f45b19ed872752bb4e22cf93a69d979366c5"
+checksum = "c32736a48ef08a5d2212864e2295c8e54f4d6b352b7f49aa0c29a12fc410ff66"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -5514,15 +5514,15 @@ dependencies = [
  "chrono",
  "flagset",
  "futures",
+ "getrandom",
  "http",
- "hyper",
  "log",
  "md-5",
  "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
  "pin-project",
- "quick-xml 0.29.0",
+ "quick-xml 0.30.0",
  "reqsign",
  "reqwest",
  "serde",
@@ -6938,9 +6938,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
  "serde",

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -87,7 +87,7 @@ impl StateStore for ObjectStateStore {
         let mut lister = self
             .store
             .lister_with(path)
-            .delimiter("")
+            .recursive(true)
             .await
             .map_err(|e| {
                 BoxedError::new(PlainError::new(

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -23,7 +23,7 @@ use futures::{FutureExt, TryStreamExt};
 use moka::future::Cache;
 use moka::notification::RemovalCause;
 use object_store::util::join_path;
-use object_store::{ErrorKind, Metakey, ObjectStore, Reader, Result as ObjectStoreResult};
+use object_store::{ErrorKind, Metakey, ObjectStore, Reader};
 use snafu::ResultExt;
 use store_api::storage::RegionId;
 
@@ -100,7 +100,7 @@ impl FileCache {
         self.memory_index.insert(key, value).await;
     }
 
-    pub(crate) async fn get_reader(&self, file_path: &str) -> ObjectStoreResult<Option<Reader>> {
+    async fn get_reader(&self, file_path: &str) -> object_store::Result<Option<Reader>> {
         if self.local_store.is_exist(file_path).await? {
             Ok(Some(self.local_store.reader(file_path).await?))
         } else {
@@ -126,7 +126,7 @@ impl FileCache {
                     warn!("Failed to get file for key {:?}, err: {}", key, e);
                 }
             }
-            _ => {}
+            Ok(None) => {}
         }
 
         // We removes the file from the index.

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -110,7 +110,7 @@ impl FileCache {
 
     /// Reads a file from the cache.
     pub(crate) async fn reader(&self, key: IndexKey) -> Option<Reader> {
-        if self.memory_index.get(&key).await.is_none() {
+        if !self.memory_index.contains_key(&key) {
             CACHE_MISS.with_label_values(&[FILE_TYPE]).inc();
             return None;
         }

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -15,7 +15,7 @@ futures.workspace = true
 lazy_static.workspace = true
 md5 = "0.7"
 moka = { workspace = true, features = ["future"] }
-opendal = { version = "0.40", features = [
+opendal = { version = "0.44", features = [
     "layers-tracing",
 ] }
 prometheus.workspace = true

--- a/src/object-store/src/layers/lru_cache.rs
+++ b/src/object-store/src/layers/lru_cache.rs
@@ -81,8 +81,8 @@ impl<I: Accessor, C: Accessor + Clone> LayeredAccessor for LruCacheAccessor<I, C
     type BlockingReader = I::BlockingReader;
     type Writer = I::Writer;
     type BlockingWriter = I::BlockingWriter;
-    type Pager = I::Pager;
-    type BlockingPager = I::BlockingPager;
+    type Lister = I::Lister;
+    type BlockingLister = I::BlockingLister;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -112,7 +112,7 @@ impl<I: Accessor, C: Accessor + Clone> LayeredAccessor for LruCacheAccessor<I, C
         result
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.inner.list(path, args).await
     }
 
@@ -130,7 +130,7 @@ impl<I: Accessor, C: Accessor + Clone> LayeredAccessor for LruCacheAccessor<I, C
         result
     }
 
-    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         self.inner.blocking_list(path, args)
     }
 }

--- a/src/object-store/src/layers/lru_cache/read_cache.rs
+++ b/src/object-store/src/layers/lru_cache/read_cache.rs
@@ -251,7 +251,6 @@ impl<C: Accessor + Clone> ReadCache<C> {
     {
         OBJECT_STORE_LRU_CACHE_MISS.inc();
 
-        // The real read will happen after `read_to_end` is invoked.
         let (_, reader) = inner.read(path, args).await?;
         let result = self.try_write_cache::<I>(reader, read_key).await;
 

--- a/src/object-store/src/layers/prometheus.rs
+++ b/src/object-store/src/layers/prometheus.rs
@@ -124,8 +124,8 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     type BlockingReader = PrometheusMetricWrapper<A::BlockingReader>;
     type Writer = PrometheusMetricWrapper<A::Writer>;
     type BlockingWriter = PrometheusMetricWrapper<A::BlockingWriter>;
-    type Pager = A::Pager;
-    type BlockingPager = A::BlockingPager;
+    type Lister = A::Lister;
+    type BlockingLister = A::BlockingLister;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -243,7 +243,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         })
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Pager)> {
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         REQUESTS_TOTAL
             .with_label_values(&[&self.scheme, Operation::List.into_static()])
             .inc();
@@ -388,7 +388,7 @@ impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
         })
     }
 
-    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingPager)> {
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         REQUESTS_TOTAL
             .with_label_values(&[&self.scheme, Operation::BlockingList.into_static()])
             .inc();

--- a/src/object-store/src/lib.rs
+++ b/src/object-store/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use opendal::raw::oio::Pager;
 pub use opendal::raw::{normalize_path as raw_normalize_path, HttpClient};
 pub use opendal::{
     services, Builder as ObjectStoreBuilder, Entry, EntryMode, Error, ErrorKind, Lister, Metakey,

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -248,7 +248,7 @@ async fn test_file_backend_with_lru_cache() -> Result<()> {
     test_object_crud(&store).await?;
     test_object_list(&store).await?;
 
-    assert_eq!(cache_layer.read_cache_stat().await, (4, 0));
+    assert_eq!(cache_layer.read_cache_stat().await, (0, 0));
 
     Ok(())
 }

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -258,11 +258,7 @@ async fn assert_lru_cache<C: Accessor + Clone>(
     file_names: &[&str],
 ) {
     for file_name in file_names {
-        assert!(
-            cache_layer.contains_file(file_name).await,
-            "file: {} is not found",
-            file_name
-        );
+        assert!(cache_layer.contains_file(file_name).await);
     }
 }
 
@@ -307,12 +303,10 @@ async fn test_object_store_cache_policy() -> Result<()> {
 
     // create file cache layer
     let cache_dir = create_temp_dir("test_object_store_cache_policy_cache");
-    let tmp_dir = create_temp_dir("test_object_store_cache_policy_cache_tmp");
-
     let mut builder = Fs::default();
     let _ = builder
         .root(&cache_dir.path().to_string_lossy())
-        .atomic_write_dir(&tmp_dir.path().to_string_lossy());
+        .atomic_write_dir(&cache_dir.path().to_string_lossy());
     let file_cache = Arc::new(builder.build().unwrap());
     let cache_store = OperatorBuilder::new(file_cache.clone()).finish();
 
@@ -340,9 +334,9 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_cache_files(
         &cache_store,
         &[
-            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14",
-            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=7-14",
-            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-14",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=7-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-",
         ],
         &["Hello, object1!", "object2!", "Hello, object2!"],
     )
@@ -350,9 +344,9 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_lru_cache(
         &cache_layer,
         &[
-            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14",
-            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=7-14",
-            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-14",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=7-",
+            "ecfe0dce85de452eb0a325158e7bfb75.cache-bytes=0-",
         ],
     )
     .await;
@@ -363,13 +357,13 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_eq!(cache_layer.read_cache_stat().await, (1, 15));
     assert_cache_files(
         &cache_store,
-        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14"],
+        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-"],
         &["Hello, object1!"],
     )
     .await?;
     assert_lru_cache(
         &cache_layer,
-        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14"],
+        &["6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-"],
     )
     .await;
 
@@ -382,21 +376,13 @@ async fn test_object_store_cache_policy() -> Result<()> {
     let _ = store.read(p3).await.unwrap();
     let _ = store.read_with(p3).range(0..5).await.unwrap();
 
-    // Read the deleted file without a deterministic range size requires an extra `stat.`
-    // Therefore, it won't go into the cache.
-    assert_eq!(cache_layer.read_cache_stat().await, (3, 35));
-
-    // However, The real open file happens after the reader is created.
-    // The reader will throw an error during the reading
-    // instead of returning `NotFound` during the reader creation.
-    assert!(store.read_with(p2).range(0..4).await.is_err());
-    assert_eq!(cache_layer.read_cache_stat().await, (3, 35));
-
+    // The entry count is 4, because we have the p2 `NotFound` cache.
+    assert_eq!(cache_layer.read_cache_stat().await, (4, 35));
     assert_cache_files(
         &cache_store,
         &[
-            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14",
-            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-14",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
             "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
         &["Hello, object1!", "Hello, object3!", "Hello"],
@@ -405,8 +391,8 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert_lru_cache(
         &cache_layer,
         &[
-            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-14",
-            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-14",
+            "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=0-",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
             "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
     )
@@ -418,13 +404,12 @@ async fn test_object_store_cache_policy() -> Result<()> {
     assert!(store.read(p2).await.is_err());
     // Read p1 with range `1..` , the existing p1 with range `0..` must be evicted.
     let _ = store.read_with(p1).range(1..15).await.unwrap();
-    // Again, The entry count should be 3.
-    assert_eq!(cache_layer.read_cache_stat().await, (3, 34));
+    assert_eq!(cache_layer.read_cache_stat().await, (4, 34));
     assert_cache_files(
         &cache_store,
         &[
             "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=1-14",
-            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-14",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
             "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
         &["ello, object1!", "Hello, object3!", "Hello"],
@@ -434,7 +419,7 @@ async fn test_object_store_cache_policy() -> Result<()> {
         &cache_layer,
         &[
             "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=1-14",
-            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-14",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
             "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
     )
@@ -455,7 +440,7 @@ async fn test_object_store_cache_policy() -> Result<()> {
         &cache_layer,
         &[
             "6d29752bdc6e4d5ba5483b96615d6c48.cache-bytes=1-14",
-            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-14",
+            "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-",
             "a8b1dc21e24bb55974e3e68acc77ed52.cache-bytes=0-4",
         ],
     )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Bump opendal to 0.44

The next minor version(0.44.1), a `BufferReader`(https://github.com/apache/incubator-opendal/issues/3735) will be introduced.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
