### PR TITLE
Format sql

### DIFF
--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -362,6 +362,7 @@ impl GreptimedbV1Response {
 /// Currently, `greptimedb_v1` and `influxdb_v1` are supported.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseFormat {
+    Csv,
     GreptimedbV1,
     InfluxdbV1,
 }
@@ -369,6 +370,7 @@ pub enum ResponseFormat {
 impl ResponseFormat {
     pub fn parse(s: &str) -> Option<Self> {
         match s {
+            "csv" => Some(ResponseFormat::Csv),
             "greptimedb_v1" => Some(ResponseFormat::GreptimedbV1),
             "influxdb_v1" => Some(ResponseFormat::InfluxdbV1),
             _ => None,

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -35,7 +35,7 @@ use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 pub struct SqlQuery {
     pub db: Option<String>,
     pub sql: Option<String>,
-    // (Optional) result format: [`gerptimedb_v1`, `influxdb_v1`],
+    // (Optional) result format: [`greptimedb_v1`, `influxdb_v1`],
     // the default value is `greptimedb_v1`
     pub format: Option<String>,
     // Returns epoch timestamps with the specified precision.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This closes #577.

It's still a draft to demonstrate what we will implement. I don't fix test but you can preview the manner with:

```
$ cargo run -- standalone start
$ curl -i -X POST \
-H 'Content-Type: application/x-www-form-urlencoded' \
-d 'sql=SELECT 1, 42&format=csv' \
http://localhost:4000/v1/sql\?db\=public
HTTP/1.1 200 OK
content-type: text/csv; charset=utf-8
content-length: 5
date: Mon, 01 Jan 2024 01:39:16 GMT

1,42
$ curl -i -X POST \
-H 'Content-Type: application/x-www-form-urlencoded' \
-d 'sql=show tables&format=csv' \ 
http://localhost:4000/v1/sql\?db\=public
HTTP/1.1 200 OK
content-type: text/csv; charset=utf-8
content-length: 10
date: Mon, 01 Jan 2024 01:38:59 GMT

"numbers"
```

I'll comment some code ideas inline.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
