### PR TITLE
chore: add bound check for raft-engine logstore

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -117,6 +117,8 @@ sst_write_buffer_size = "8MB"
 scan_parallelism = 0
 # Capacity of the channel to send data from parallel scan tasks to the main task (default 32).
 parallel_scan_channel_size = 32
+# Whether to allow stale WAL entries read during replay.
+allow_stale_entries = false
 
 # Log options, see `standalone.example.toml`
 # [logging]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -208,6 +208,8 @@ sst_write_buffer_size = "8MB"
 scan_parallelism = 0
 # Capacity of the channel to send data from parallel scan tasks to the main task (default 32).
 parallel_scan_channel_size = 32
+# Whether to allow stale WAL entries read during replay.
+allow_stale_entries = false
 
 # Log options
 # [logging]

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -20,6 +20,7 @@ use common_macro::stack_trace_debug;
 use common_runtime::error::Error as RuntimeError;
 use serde_json::error::Error as JsonError;
 use snafu::{Location, Snafu};
+use store_api::storage::RegionId;
 
 use crate::kafka::NamespaceImpl as KafkaNamespace;
 
@@ -183,6 +184,18 @@ pub enum Error {
 
     #[snafu(display("The record sequence is not legal, error: {}", error))]
     IllegalSequence { location: Location, error: String },
+
+    #[snafu(display(
+        "Attempt to append discontinuous log entry, region: {}, last index: {}, attempt index: {}",
+        region_id,
+        last_index,
+        attempt_index
+    ))]
+    DiscontinuousLogIndex {
+        region_id: RegionId,
+        last_index: u64,
+        attempt_index: u64,
+    },
 }
 
 impl ErrorExt for Error {

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -196,6 +196,9 @@ pub enum Error {
         last_index: u64,
         attempt_index: u64,
     },
+
+    #[snafu(display("Duplicate log entry, region: {}, attempt index: {}", region_id, index,))]
+    DuplicateLogIndex { region_id: RegionId, index: u64 },
 }
 
 impl ErrorExt for Error {

--- a/src/log-store/src/error.rs
+++ b/src/log-store/src/error.rs
@@ -196,9 +196,6 @@ pub enum Error {
         last_index: u64,
         attempt_index: u64,
     },
-
-    #[snafu(display("Duplicate log entry, region: {}, attempt index: {}", region_id, index,))]
-    DuplicateLogIndex { region_id: RegionId, index: u64 },
 }
 
 impl ErrorExt for Error {

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ use common_runtime::{RepeatedTask, TaskFunction};
 use common_telemetry::{error, info};
 use raft_engine::{Config, Engine, LogBatch, MessageExt, ReadableSize, RecoveryMode};
 use snafu::{ensure, ResultExt};
-use store_api::logstore::entry::{Entry, Id as EntryId};
+use store_api::logstore::entry::Id as EntryId;
 use store_api::logstore::entry_stream::SendableEntryStream;
 use store_api::logstore::namespace::{Id as NamespaceId, Namespace as NamespaceTrait};
 use store_api::logstore::{AppendBatchResponse, AppendResponse, LogStore};

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -148,7 +148,7 @@ impl RaftEngineLogStore {
                     if let Some(first_index) = self.engine.first_index(ns_id) {
                         // ensure the first in batch does not override compacted entry.
                         ensure!(
-                            e.id >= first_index,
+                            e.id > first_index,
                             OverrideCompactedEntrySnafu {
                                 namespace: ns_id,
                                 first_index,
@@ -210,7 +210,7 @@ impl LogStore for RaftEngineLogStore {
 
         if let Some(first_index) = self.engine.first_index(namespace_id) {
             ensure!(
-                entry_id >= first_index,
+                entry_id > first_index,
                 OverrideCompactedEntrySnafu {
                     namespace: namespace_id,
                     first_index,

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -87,6 +87,8 @@ pub struct MitoConfig {
     pub scan_parallelism: usize,
     /// Capacity of the channel to send data from parallel scan tasks to the main task (default 32).
     pub parallel_scan_channel_size: usize,
+    /// Whether to allow stale entries read during replay.
+    pub allow_stale_entries: bool,
 }
 
 impl Default for MitoConfig {
@@ -110,6 +112,7 @@ impl Default for MitoConfig {
             sst_write_buffer_size: ReadableSize::mb(8),
             scan_parallelism: divide_num_cpus(4),
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,
+            allow_stale_entries: false,
         }
     }
 }

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -424,6 +424,18 @@ pub enum Error {
         error: parquet::errors::ParquetError,
     },
 
+    #[snafu(display(
+        "Stale log entry found during replay, region: {}, flushed: {}, replayed: {}",
+        region_id,
+        flushed_entry_id,
+        unexpected_entry_id
+    ))]
+    StaleLogEntry {
+        region_id: RegionId,
+        flushed_entry_id: u64,
+        unexpected_entry_id: u64,
+    },
+
     #[snafu(display("Column not found, column: {column}"))]
     ColumnNotFound { column: String, location: Location },
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -473,6 +473,18 @@ pub enum Error {
 
     #[snafu(display("Invalid config, {reason}"))]
     InvalidConfig { reason: String, location: Location },
+
+    #[snafu(display(
+        "Stale log entry found during replay, region: {}, flushed: {}, replayed: {}",
+        region_id,
+        flushed_entry_id,
+        unexpected_entry_id
+    ))]
+    StaleLogEntry {
+        region_id: RegionId,
+        flushed_entry_id: u64,
+        unexpected_entry_id: u64,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -563,6 +575,7 @@ impl ErrorExt for Error {
             }
             CleanDir { .. } => StatusCode::Unexpected,
             InvalidConfig { .. } => StatusCode::InvalidArguments,
+            StaleLogEntry { .. } => StatusCode::Unexpected,
         }
     }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -424,18 +424,6 @@ pub enum Error {
         error: parquet::errors::ParquetError,
     },
 
-    #[snafu(display(
-        "Stale log entry found during replay, region: {}, flushed: {}, replayed: {}",
-        region_id,
-        flushed_entry_id,
-        unexpected_entry_id
-    ))]
-    StaleLogEntry {
-        region_id: RegionId,
-        flushed_entry_id: u64,
-        unexpected_entry_id: u64,
-    },
-
     #[snafu(display("Column not found, column: {column}"))]
     ColumnNotFound { column: String, location: Location },
 

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -387,10 +387,13 @@ pub(crate) async fn replay_memtable<S: LogStore>(
     let mut region_write_ctx = RegionWriteCtx::new(region_id, version_control, wal_options.clone());
 
     let replay_from_entry_id = flushed_entry_id + 1;
+    let mut stale_entry_found = false;
     let mut wal_stream = wal.scan(region_id, replay_from_entry_id, wal_options)?;
     while let Some(res) = wal_stream.next().await {
         let (entry_id, entry) = res?;
         if entry_id <= flushed_entry_id {
+            stale_entry_found = true;
+            warn!("Stale WAL entries read during replay, region id: {}, flushed entry id: {}, entry id read: {}", region_id, flushed_entry_id, entry_id);
             ensure!(
                 allow_stale_entries,
                 StaleLogEntrySnafu {
@@ -399,7 +402,6 @@ pub(crate) async fn replay_memtable<S: LogStore>(
                     unexpected_entry_id: entry_id,
                 }
             );
-            warn!("Stale WAL entries read during replay, region id: {}, flushed entry id: {}, entry id read: {}", region_id, flushed_entry_id, entry_id);
         }
 
         last_entry_id = last_entry_id.max(entry_id);
@@ -417,7 +419,7 @@ pub(crate) async fn replay_memtable<S: LogStore>(
     region_write_ctx.set_next_entry_id(last_entry_id + 1);
     region_write_ctx.write_memtable();
 
-    if allow_stale_entries {
+    if allow_stale_entries && stale_entry_found {
         wal.obsolete(region_id, flushed_entry_id, wal_options)
             .await?;
         info!("Force obsolete WAL entries, region id: {}, flushed entry id: {}, last entry id read: {}", region_id, flushed_entry_id, last_entry_id);

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -78,6 +78,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             region_id,
             flushed_entry_id,
             &region.version_control,
+            self.config.allow_stale_entries,
         )
         .await?;
         info!(

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -735,6 +735,7 @@ experimental_write_cache_path = ""
 experimental_write_cache_size = "512MiB"
 sst_write_buffer_size = "8MiB"
 parallel_scan_channel_size = 32
+allow_stale_entries = false
 
 [[datanode.region_engine]]
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds bound check to RaftEngine logstore so that it won't panic at "memtable has a hole". This will also helps to diagnose some weird out-of-order sequence in some user cases.

Note: this impose extra constraint to prevent concurrent writes with consecutive entry id to the same region when bound check and actual write overlap. But it won't cause false errors in region worker pattern where only one thread writes to some region.

```
check 1  
   |    check 2  // this bound check will fail with this patch
   |       x 
   v       |
write 1    v 
        write 2
```

## Performance impact

Ran performance regression test in TSBS suite and no noticeable changes observed.
```
// before: 
loaded 1036800000 metrics in 372.554sec with 6 workers (mean rate 2782955.19 metrics/sec)
loaded 103680000 rows in 372.554sec with 6 workers (mean rate 278295.52 rows/sec)

// after:
loaded 1036800000 metrics in 351.834sec with 6 workers (mean rate 2946843.84 metrics/sec)
loaded 103680000 rows in 351.834sec with 6 workers (mean rate 294684.38 rows/sec)

```



## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.
- [X]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

Closes #3042