### PR TITLE
feat(inverted_index): get memory usage of appliers

### DIFF
--- a/src/index/src/inverted_index/search/fst_apply.rs
+++ b/src/index/src/inverted_index/search/fst_apply.rs
@@ -30,4 +30,7 @@ pub trait FstApplier: Send + Sync {
     ///
     /// Returns a `Vec<u64>`, with each u64 being a value from the FstMap.
     fn apply(&self, fst: &FstMap) -> Vec<u64>;
+
+    /// Returns the memory usage of the applier.
+    fn memory_usage(&self) -> usize;
 }

--- a/src/index/src/inverted_index/search/index_apply.rs
+++ b/src/index/src/inverted_index/search/index_apply.rs
@@ -33,6 +33,9 @@ pub trait IndexApplier {
         context: SearchContext,
         reader: &mut dyn InvertedIndexReader,
     ) -> Result<Vec<usize>>;
+
+    /// Returns the memory usage of the applier.
+    fn memory_usage(&self) -> usize;
 }
 
 /// A context for searching the inverted index.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add `memory_usage` to traits `FstApplier` and `IndexApplier`.

It helps track the memory usage of the index application process.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
