### PR TITLE
feat(puffin): finish return written bytes

### DIFF
--- a/src/puffin/src/file_format/writer.rs
+++ b/src/puffin/src/file_format/writer.rs
@@ -44,8 +44,8 @@ pub trait PuffinSyncWriter {
     /// Add a blob to the Puffin file
     fn add_blob<R: std::io::Read>(&mut self, blob: Blob<R>) -> Result<()>;
 
-    /// Finish writing the Puffin file
-    fn finish(&mut self) -> Result<()>;
+    /// Finish writing the Puffin file, returns the number of bytes written
+    fn finish(&mut self) -> Result<usize>;
 }
 
 /// The trait for writing Puffin files asynchronously
@@ -57,6 +57,6 @@ pub trait PuffinAsyncWriter {
     /// Add a blob to the Puffin file
     async fn add_blob<R: futures::AsyncRead + Send>(&mut self, blob: Blob<R>) -> Result<()>;
 
-    /// Finish writing the Puffin file
-    async fn finish(&mut self) -> Result<()>;
+    /// Finish writing the Puffin file, returns the number of bytes written
+    async fn finish(&mut self) -> Result<usize>;
 }

--- a/src/puffin/src/tests.rs
+++ b/src/puffin/src/tests.rs
@@ -125,7 +125,8 @@ fn test_writer_reader_with_empty_sync() {
         "Test 1234".to_string(),
     )]));
 
-    writer.finish().unwrap();
+    let written_bytes = writer.finish().unwrap();
+    assert!(written_bytes > 0);
 
     let mut buf = Cursor::new(buf.into_inner());
     let mut reader = PuffinFileReader::new(&mut buf);
@@ -150,7 +151,8 @@ async fn test_writer_reader_empty_async() {
         "Test 1234".to_string(),
     )]));
 
-    writer.finish().await.unwrap();
+    let written_bytes = writer.finish().await.unwrap();
+    assert!(written_bytes > 0);
 
     let mut buf = AsyncCursor::new(buf.into_inner());
     let mut reader = PuffinFileReader::new(&mut buf);
@@ -194,7 +196,8 @@ fn test_writer_reader_sync() {
         "Test 1234".to_string(),
     )]));
 
-    writer.finish().unwrap();
+    let written_bytes = writer.finish().unwrap();
+    assert!(written_bytes > 0);
 
     let mut buf = Cursor::new(buf.into_inner());
     let mut reader = PuffinFileReader::new(&mut buf);
@@ -257,7 +260,8 @@ async fn test_writer_reader_async() {
         "Test 1234".to_string(),
     )]));
 
-    writer.finish().await.unwrap();
+    let written_bytes = writer.finish().await.unwrap();
+    assert!(written_bytes > 0);
 
     let mut buf = AsyncCursor::new(buf.into_inner());
     let mut reader = PuffinFileReader::new(&mut buf);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Puffin writer to return written bytes, to help the upper layer to track it.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
