### PR TITLE
feat: pushdown filters for some information_schema tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ version = "0.5.0"
 dependencies = [
  "api",
  "arc-swap",
+ "arrow",
  "arrow-schema",
  "async-stream",
  "async-trait",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -10,6 +10,7 @@ testing = []
 [dependencies]
 api.workspace = true
 arc-swap = "1.0"
+arrow.workspace = true
 arrow-schema.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -10,8 +10,8 @@ testing = []
 [dependencies]
 api.workspace = true
 arc-swap = "1.0"
-arrow.workspace = true
 arrow-schema.workspace = true
+arrow.workspace = true
 async-stream.workspace = true
 async-trait = "0.1"
 build-data = "0.1"

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -238,7 +238,7 @@ trait InformationTable {
 
     fn schema(&self) -> SchemaRef;
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream>;
+    fn to_stream(&self, requst: ScanRequest) -> Result<SendableRecordBatchStream>;
 
     fn table_type(&self) -> TableType {
         TableType::Temporary
@@ -272,7 +272,7 @@ impl DataSource for InformationTableDataSource {
         &self,
         request: ScanRequest,
     ) -> std::result::Result<SendableRecordBatchStream, BoxedError> {
-        let projection = request.projection;
+        let projection = request.projection.clone();
         let projected_schema = match &projection {
             Some(projection) => self.try_project(projection)?,
             None => self.table.schema(),
@@ -280,7 +280,7 @@ impl DataSource for InformationTableDataSource {
 
         let stream = self
             .table
-            .to_stream()
+            .to_stream(request)
             .map_err(BoxedError::new)
             .context(TablesRecordBatchSnafu)
             .map_err(BoxedError::new)?

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -15,6 +15,7 @@
 mod columns;
 mod key_column_usage;
 mod memory_table;
+pub(crate) mod predicate;
 mod schemata;
 mod table_names;
 mod tables;
@@ -29,6 +30,7 @@ use datatypes::schema::SchemaRef;
 use futures_util::StreamExt;
 use lazy_static::lazy_static;
 use paste::paste;
+pub(crate) use predicate::Predicates;
 use snafu::ResultExt;
 use store_api::data_source::DataSource;
 use store_api::storage::{ScanRequest, TableId};
@@ -159,7 +161,7 @@ impl InformationSchemaProvider {
     fn build_table(&self, name: &str) -> Option<TableRef> {
         self.information_table(name).map(|table| {
             let table_info = Self::table_info(self.catalog_name.clone(), &table);
-            let filter_pushdown = FilterPushDownType::Unsupported;
+            let filter_pushdown = FilterPushDownType::Inexact;
             let thin_table = ThinTable::new(table_info, filter_pushdown);
 
             let data_source = Arc::new(InformationTableDataSource::new(table));

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -15,7 +15,7 @@
 mod columns;
 mod key_column_usage;
 mod memory_table;
-pub(crate) mod predicate;
+mod predicate;
 mod schemata;
 mod table_names;
 mod tables;

--- a/src/catalog/src/information_schema.rs
+++ b/src/catalog/src/information_schema.rs
@@ -240,7 +240,7 @@ trait InformationTable {
 
     fn schema(&self) -> SchemaRef;
 
-    fn to_stream(&self, requst: ScanRequest) -> Result<SendableRecordBatchStream>;
+    fn to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream>;
 
     fn table_type(&self) -> TableType {
         TableType::Temporary

--- a/src/catalog/src/information_schema/columns.rs
+++ b/src/catalog/src/information_schema/columns.rs
@@ -31,7 +31,7 @@ use datatypes::scalars::ScalarVectorBuilder;
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{StringVectorBuilder, VectorRef};
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::TableId;
+use store_api::storage::{ScanRequest, TableId};
 
 use super::{InformationTable, COLUMNS};
 use crate::error::{
@@ -102,7 +102,7 @@ impl InformationTable for InformationSchemaColumns {
         self.schema.clone()
     }
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/columns.rs
+++ b/src/catalog/src/information_schema/columns.rs
@@ -233,11 +233,12 @@ impl InformationSchemaColumnsBuilder {
         let data_type = &column_schema.data_type.name();
 
         let row = [
-            ("catalog_name", &Value::from(catalog_name)),
-            ("schema_name", &Value::from(schema_name)),
-            ("table_name", &Value::from(table_name)),
-            ("semantic_type", &Value::from(semantic_type)),
-            ("data_type", &Value::from(data_type.as_str())),
+            (TABLE_CATALOG, &Value::from(catalog_name)),
+            (TABLE_SCHEMA, &Value::from(schema_name)),
+            (TABLE_NAME, &Value::from(table_name)),
+            (COLUMN_NAME, &Value::from(column_schema.name.as_str())),
+            (DATA_TYPE, &Value::from(data_type.as_str())),
+            (SEMANTIC_TYPE, &Value::from(semantic_type)),
         ];
 
         if !predicates.eval(&row) {

--- a/src/catalog/src/information_schema/key_column_usage.rs
+++ b/src/catalog/src/information_schema/key_column_usage.rs
@@ -37,6 +37,13 @@ use crate::error::{
 use crate::information_schema::{InformationTable, Predicates};
 use crate::CatalogManager;
 
+const CONSTRAINT_SCHEMA: &str = "constraint_schema";
+const CONSTRAINT_NAME: &str = "constraint_name";
+const TABLE_SCHEMA: &str = "table_schema";
+const TABLE_NAME: &str = "table_name";
+const COLUMN_NAME: &str = "column_name";
+const ORDINAL_POSITION: &str = "ordinal_position";
+
 /// The virtual table implementation for `information_schema.KEY_COLUMN_USAGE`.
 pub(super) struct InformationSchemaKeyColumnUsage {
     schema: SchemaRef,
@@ -61,24 +68,16 @@ impl InformationSchemaKeyColumnUsage {
                 false,
             ),
             ColumnSchema::new(
-                "constraint_schema",
+                CONSTRAINT_SCHEMA,
                 ConcreteDataType::string_datatype(),
                 false,
             ),
-            ColumnSchema::new(
-                "constraint_name",
-                ConcreteDataType::string_datatype(),
-                false,
-            ),
+            ColumnSchema::new(CONSTRAINT_NAME, ConcreteDataType::string_datatype(), false),
             ColumnSchema::new("table_catalog", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_schema", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_name", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("column_name", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new(
-                "ordinal_position",
-                ConcreteDataType::uint32_datatype(),
-                false,
-            ),
+            ColumnSchema::new(TABLE_SCHEMA, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_NAME, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(COLUMN_NAME, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(ORDINAL_POSITION, ConcreteDataType::uint32_datatype(), false),
             ColumnSchema::new(
                 "position_in_unique_constraint",
                 ConcreteDataType::uint32_datatype(),
@@ -280,12 +279,12 @@ impl InformationSchemaKeyColumnUsageBuilder {
         ordinal_position: u32,
     ) {
         let row = [
-            ("constraint_schema", &Value::from(constraint_schema)),
-            ("constraint_name", &Value::from(constraint_name)),
-            ("table_schema", &Value::from(table_schema)),
-            ("table_name", &Value::from(table_name)),
-            ("column_name", &Value::from(column_name)),
-            ("ordinal_position", &Value::from(ordinal_position)),
+            (CONSTRAINT_SCHEMA, &Value::from(constraint_schema)),
+            (CONSTRAINT_NAME, &Value::from(constraint_name)),
+            (TABLE_SCHEMA, &Value::from(table_schema)),
+            (TABLE_NAME, &Value::from(table_name)),
+            (COLUMN_NAME, &Value::from(column_name)),
+            (ORDINAL_POSITION, &Value::from(ordinal_position)),
         ];
 
         if !predicates.eval(&row) {

--- a/src/catalog/src/information_schema/key_column_usage.rs
+++ b/src/catalog/src/information_schema/key_column_usage.rs
@@ -39,6 +39,7 @@ use crate::CatalogManager;
 
 const CONSTRAINT_SCHEMA: &str = "constraint_schema";
 const CONSTRAINT_NAME: &str = "constraint_name";
+const TABLE_CATALOG: &str = "table_catalog";
 const TABLE_SCHEMA: &str = "table_schema";
 const TABLE_NAME: &str = "table_name";
 const COLUMN_NAME: &str = "column_name";
@@ -73,7 +74,7 @@ impl InformationSchemaKeyColumnUsage {
                 false,
             ),
             ColumnSchema::new(CONSTRAINT_NAME, ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_catalog", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_CATALOG, ConcreteDataType::string_datatype(), false),
             ColumnSchema::new(TABLE_SCHEMA, ConcreteDataType::string_datatype(), false),
             ColumnSchema::new(TABLE_NAME, ConcreteDataType::string_datatype(), false),
             ColumnSchema::new(COLUMN_NAME, ConcreteDataType::string_datatype(), false),

--- a/src/catalog/src/information_schema/key_column_usage.rs
+++ b/src/catalog/src/information_schema/key_column_usage.rs
@@ -27,7 +27,7 @@ use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{StringVectorBuilder, UInt32VectorBuilder};
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::TableId;
+use store_api::storage::{ScanRequest, TableId};
 
 use super::KEY_COLUMN_USAGE;
 use crate::error::{
@@ -123,7 +123,7 @@ impl InformationTable for InformationSchemaKeyColumnUsage {
         self.schema.clone()
     }
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _requets: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/memory_table.rs
+++ b/src/catalog/src/information_schema/memory_table.rs
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!("test", table.table_name());
         assert_eq!(schema, InformationTable::schema(&table));
 
-        let stream = table.to_stream().unwrap();
+        let stream = table.to_stream(ScanRequest::default()).unwrap();
 
         let batches = RecordBatches::try_collect(stream).await.unwrap();
 
@@ -198,7 +198,7 @@ mod tests {
         assert_eq!("test", table.table_name());
         assert_eq!(schema, InformationTable::schema(&table));
 
-        let stream = table.to_stream().unwrap();
+        let stream = table.to_stream(ScanRequest::default()).unwrap();
 
         let batches = RecordBatches::try_collect(stream).await.unwrap();
 

--- a/src/catalog/src/information_schema/memory_table.rs
+++ b/src/catalog/src/information_schema/memory_table.rs
@@ -26,7 +26,7 @@ use datafusion::physical_plan::SendableRecordBatchStream as DfSendableRecordBatc
 use datatypes::schema::SchemaRef;
 use datatypes::vectors::VectorRef;
 use snafu::ResultExt;
-use store_api::storage::TableId;
+use store_api::storage::{ScanRequest, TableId};
 pub use tables::get_schema_columns;
 
 use crate::error::{CreateRecordBatchSnafu, InternalSnafu, Result};
@@ -74,7 +74,7 @@ impl InformationTable for MemoryTable {
         self.schema.clone()
     }
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _requets: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/memory_table.rs
+++ b/src/catalog/src/information_schema/memory_table.rs
@@ -74,7 +74,7 @@ impl InformationTable for MemoryTable {
         self.schema.clone()
     }
 
-    fn to_stream(&self, _requets: ScanRequest) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -18,7 +18,7 @@ use datatypes::value::Value;
 use store_api::storage::ScanRequest;
 
 type ColumnName = String;
-/// Predicate to filter information_schema tables stream,
+/// Predicate to filter `information_schema` tables stream,
 /// we only support these simple predicates currently.
 /// TODO(dennis): supports more predicate types.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -33,9 +33,9 @@ enum Predicate {
 
 impl Predicate {
     /// Evaluate the predicate with the row, returns:
-    /// - None when the predicate can't evaluate with the row.
-    /// - Some(true) when the predicate is satisfied,
-    /// - Some(false) when the predicate is not satisfied,
+    /// - `None` when the predicate can't evaluate with the row.
+    /// - `Some(true)` when the predicate is satisfied,
+    /// - `Some(false)` when the predicate is not satisfied,
     fn eval(&self, row: &[(&str, &Value)]) -> Option<bool> {
         match self {
             Predicate::Eq(c, v) => {
@@ -91,7 +91,7 @@ impl Predicate {
         None
     }
 
-    /// Try to create a predicate from datafusion `Expr`, return None if fails.
+    /// Try to create a predicate from datafusion [`Expr`], return None if fails.
     fn from_expr(expr: DfExpr) -> Option<Predicate> {
         match expr {
             // NOT expr
@@ -189,7 +189,7 @@ pub struct Predicates {
 }
 
 impl Predicates {
-    /// Try its best to create predicates from `ScanRequest`.
+    /// Try its best to create predicates from [`ScanRequest`].
     pub fn from_scan_request(request: &Option<ScanRequest>) -> Predicates {
         if let Some(request) = request {
             let mut predicates = Vec::with_capacity(request.filters.len());
@@ -236,7 +236,7 @@ impl Predicates {
     }
 }
 
-/// Returns true when the values are all `ScalarValue`.
+/// Returns true when the values are all [`DfExpr::Literal`].
 fn is_all_scalars(list: &[DfExpr]) -> bool {
     list.iter().all(|v| matches!(v, DfExpr::Literal(_)))
 }

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -51,7 +51,7 @@ impl Predicate {
                     return Some(v == *value);
                 }
             }
-            Predicate::Like(c, pattern, case_insenstive) => {
+            Predicate::Like(c, pattern, case_insensitive) => {
                 for (column, value) in row {
                     if c != column {
                         continue;
@@ -61,7 +61,7 @@ impl Predicate {
                         continue;
                     };
 
-                    return like_utf8(bs.as_utf8(), pattern, case_insenstive);
+                    return like_utf8(bs.as_utf8(), pattern, case_insensitive);
                 }
             }
             Predicate::NotEq(c, v) => {
@@ -240,12 +240,12 @@ impl Predicate {
 /// Perform SQL left LIKE right, return `None` if fail to evaluate.
 /// - `s` the target string
 /// - `pattern` the pattern just like '%abc'
-/// - `case_insenstive` whether to perform case-insensitive like or not.
-fn like_utf8(s: &str, pattern: &str, case_insenstive: &bool) -> Option<bool> {
+/// - `case_insensitive` whether to perform case-insensitive like or not.
+fn like_utf8(s: &str, pattern: &str, case_insensitive: &bool) -> Option<bool> {
     let array = StringArray::from(vec![s]);
     let patterns = StringArray::new_scalar(pattern);
 
-    let Ok(booleans) = (if *case_insenstive {
+    let Ok(booleans) = (if *case_insensitive {
         comparison::ilike(&array, &patterns)
     } else {
         comparison::like(&array, &patterns)
@@ -253,7 +253,7 @@ fn like_utf8(s: &str, pattern: &str, case_insenstive: &bool) -> Option<bool> {
         return None;
     };
 
-    // Safty: at least one value in result
+    // Safety: at least one value in result
     Some(booleans.value(0))
 }
 
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_predicate_like() {
-        // case insenstive
+        // case insensitive
         let expr = DfExpr::Like(Like {
             negated: false,
             expr: Box::new(column("a")),
@@ -435,7 +435,7 @@ mod tests {
         assert!(!p.eval(&unmatch_row).unwrap());
         assert!(p.eval(&[]).is_none());
 
-        // case senstive
+        // case sensitive
         let expr = DfExpr::Like(Like {
             negated: false,
             expr: Box::new(column("a")),

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -1,0 +1,253 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_query::logical_plan::DfExpr;
+use datafusion::logical_expr::Operator;
+use datatypes::value::Value;
+use store_api::storage::ScanRequest;
+
+type ColumnName = String;
+/// Predicate to filter information_schema tables stream,
+/// we only support these simple predicates currently.
+/// TODO(dennis): supports more predicate types.
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum Predicate {
+    Eq(ColumnName, Value),
+    NotEq(ColumnName, Value),
+    InList(ColumnName, Vec<Value>),
+    And(Box<Predicate>, Box<Predicate>),
+    Or(Box<Predicate>, Box<Predicate>),
+    Not(Box<Predicate>),
+}
+
+impl Predicate {
+    /// Evaluate the predicate with value, returns:
+    /// - `None` when the predicate can't run on value,
+    /// - `Some(true)`  when the predicate is satisfied,.
+    /// - `Some(false)` when the predicate is not satisfied.
+    fn eval(&self, column: &str, value: &Value) -> Option<bool> {
+        match self {
+            Predicate::Eq(c, v) => {
+                if c != column {
+                    return None;
+                }
+                Some(v == value)
+            }
+            Predicate::NotEq(c, v) => {
+                if c != column {
+                    return None;
+                }
+                Some(v != value)
+            }
+            Predicate::InList(c, values) => {
+                if c != column {
+                    return None;
+                }
+                Some(values.iter().any(|v| v == value))
+            }
+            Predicate::And(left, right) => {
+                let Some(left) = left.eval(column, value) else {
+                    return None;
+                };
+                let Some(right) = right.eval(column, value) else {
+                    return None;
+                };
+
+                Some(left && right)
+            }
+            Predicate::Or(left, right) => {
+                let Some(left) = left.eval(column, value) else {
+                    return None;
+                };
+                let Some(right) = right.eval(column, value) else {
+                    return None;
+                };
+
+                Some(left || right)
+            }
+            Predicate::Not(p) => {
+                let Some(p) = p.eval(column, value) else {
+                    return None;
+                };
+
+                Some(!p)
+            }
+        }
+    }
+
+    // Try to create a predicate from datafusion `Expr`, return None if fails.
+    fn from_expr(expr: DfExpr) -> Option<Predicate> {
+        match expr {
+            // NOT expr
+            DfExpr::Not(expr) => {
+                let Some(p) = Self::from_expr(*expr) else {
+                    return None;
+                };
+
+                Some(Predicate::Not(Box::new(p)))
+            }
+            // left OP right
+            DfExpr::BinaryExpr(bin) => match (*bin.left, bin.op, *bin.right) {
+                // left == right
+                (DfExpr::Literal(scalar), Operator::Eq, DfExpr::Column(c))
+                | (DfExpr::Column(c), Operator::Eq, DfExpr::Literal(scalar)) => {
+                    let Ok(v) = Value::try_from(scalar) else {
+                        return None;
+                    };
+
+                    Some(Predicate::Eq(c.name, v))
+                }
+                // left != right
+                (DfExpr::Literal(scalar), Operator::NotEq, DfExpr::Column(c))
+                | (DfExpr::Column(c), Operator::NotEq, DfExpr::Literal(scalar)) => {
+                    let Ok(v) = Value::try_from(scalar) else {
+                        return None;
+                    };
+
+                    Some(Predicate::NotEq(c.name, v))
+                }
+                // left AND right
+                (left, Operator::And, right) => {
+                    let Some(left) = Self::from_expr(left) else {
+                        return None;
+                    };
+
+                    let Some(right) = Self::from_expr(right) else {
+                        return None;
+                    };
+
+                    Some(Predicate::And(Box::new(left), Box::new(right)))
+                }
+                // left OR right
+                (left, Operator::Or, right) => {
+                    let Some(left) = Self::from_expr(left) else {
+                        return None;
+                    };
+
+                    let Some(right) = Self::from_expr(right) else {
+                        return None;
+                    };
+
+                    Some(Predicate::Or(Box::new(left), Box::new(right)))
+                }
+                _ => None,
+            },
+            // [NOT] IN (LIST)
+            DfExpr::InList(list) => {
+                match (*list.expr, list.list, list.negated) {
+                    // column [NOT] IN (v1, v2, v3, ...)
+                    (DfExpr::Column(c), list, negated) if is_all_scalars(&list) => {
+                        let mut values = Vec::with_capacity(list.len());
+                        for scalar in list {
+                            // Safety: checked by `is_all_scalars`
+                            let DfExpr::Literal(scalar) = scalar else {
+                                unreachable!();
+                            };
+
+                            let Ok(value) = Value::try_from(scalar) else {
+                                return None;
+                            };
+
+                            values.push(value);
+                        }
+
+                        let predicate = Predicate::InList(c.name, values);
+
+                        if negated {
+                            Some(Predicate::Not(Box::new(predicate)))
+                        } else {
+                            Some(predicate)
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+/// A list of predicate
+pub struct Predicates {
+    predicates: Vec<Predicate>,
+}
+
+impl Predicates {
+    /// Try its best to create predicates from `ScanRequest`.
+    pub fn from_scan_request(request: &Option<ScanRequest>) -> Predicates {
+        if let Some(request) = request {
+            let mut predicates = Vec::with_capacity(request.filters.len());
+
+            for filter in &request.filters {
+                if let Some(predicate) = Predicate::from_expr(filter.df_expr().clone()) {
+                    predicates.push(predicate);
+                }
+            }
+
+            Self { predicates }
+        } else {
+            Self {
+                predicates: Vec::new(),
+            }
+        }
+    }
+
+    /// Evaluate the predicates with the column value,
+    /// returns true when all the predicates are satisfied or can't be evaluated.
+    fn eval_column(&self, column: &str, value: &Value) -> bool {
+        let mut result = true;
+        for predicate in &self.predicates {
+            match predicate.eval(column, value) {
+                Some(b) => {
+                    result = result && b;
+                }
+                None => {
+                    // Can't eval this predicate, continue
+                    continue;
+                }
+            }
+
+            if !result {
+                break;
+            }
+        }
+
+        result
+    }
+
+    /// Evaluate the predicates with the columns and values,
+    /// returns true when all the predicates are satisfied or can't be evaluated.
+    pub fn eval(&self, row: &[(&str, &Value)]) -> bool {
+        // fast path
+        if self.predicates.is_empty() {
+            return true;
+        }
+
+        let mut result = true;
+        for (column, value) in row {
+            result = result && self.eval_column(column, value);
+
+            if !result {
+                break;
+            }
+        }
+
+        result
+    }
+}
+
+/// Returns true when the values are all `ScalarValue`.
+fn is_all_scalars(list: &[DfExpr]) -> bool {
+    list.iter().all(|v| matches!(v, DfExpr::Literal(_)))
+}

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -91,7 +91,7 @@ impl Predicate {
         None
     }
 
-    // Try to create a predicate from datafusion `Expr`, return None if fails.
+    /// Try to create a predicate from datafusion `Expr`, return None if fails.
     fn from_expr(expr: DfExpr) -> Option<Predicate> {
         match expr {
             // NOT expr

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -298,23 +298,10 @@ impl Predicates {
             return true;
         }
 
-        let mut result = true;
-
-        for predicate in &self.predicates {
-            match predicate.eval(row) {
-                Some(b) => {
-                    result = result && b;
-                }
-                // The predicate can't evaluate with the row, continue
-                None => continue,
-            }
-
-            if !result {
-                break;
-            }
-        }
-
-        result
+        self.predicates
+            .iter()
+            .filter_map(|p| p.eval(row))
+            .all(|b| b)
     }
 }
 

--- a/src/catalog/src/information_schema/predicate.rs
+++ b/src/catalog/src/information_schema/predicate.rs
@@ -87,7 +87,7 @@ impl Predicate {
             }
         }
 
-        // Can't evaluate predicate on the row
+        // Can't evaluate predicate with the row
         None
     }
 
@@ -208,7 +208,7 @@ impl Predicates {
         }
     }
 
-    /// Evaluate the predicates with the columns and values,
+    /// Evaluate the predicates with the row.
     /// returns true when all the predicates are satisfied or can't be evaluated.
     pub fn eval(&self, row: &[(&str, &Value)]) -> bool {
         // fast path
@@ -223,7 +223,7 @@ impl Predicates {
                 Some(b) => {
                     result = result && b;
                 }
-                // The predicate can't evalute on the row, continue
+                // The predicate can't evaluate with the row, continue
                 None => continue,
             }
 

--- a/src/catalog/src/information_schema/schemata.rs
+++ b/src/catalog/src/information_schema/schemata.rs
@@ -37,6 +37,11 @@ use crate::error::{
 use crate::information_schema::{InformationTable, Predicates};
 use crate::CatalogManager;
 
+const CATALOG_NAME: &str = "catalog_name";
+const SCHEMA_NAME: &str = "schema_name";
+const DEFAULT_CHARACTER_SET_NAME: &str = "default_character_set_name";
+const DEFAULT_COLLATION_NAME: &str = "default_collation_name";
+
 /// The `information_schema.schemata` table implementation.
 pub(super) struct InformationSchemaSchemata {
     schema: SchemaRef,
@@ -55,15 +60,15 @@ impl InformationSchemaSchemata {
 
     pub(crate) fn schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
-            ColumnSchema::new("catalog_name", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("schema_name", ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(CATALOG_NAME, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(SCHEMA_NAME, ConcreteDataType::string_datatype(), false),
             ColumnSchema::new(
-                "default_character_set_name",
+                DEFAULT_CHARACTER_SET_NAME,
                 ConcreteDataType::string_datatype(),
                 false,
             ),
             ColumnSchema::new(
-                "default_collation_name",
+                DEFAULT_COLLATION_NAME,
                 ConcreteDataType::string_datatype(),
                 false,
             ),
@@ -172,10 +177,10 @@ impl InformationSchemaSchemataBuilder {
 
     fn add_schema(&mut self, predicates: &Predicates, catalog_name: &str, schema_name: &str) {
         let row = [
-            ("catalog_name", &Value::from(catalog_name)),
-            ("schema_name", &Value::from(schema_name)),
-            ("default_character_set_name", &Value::from("utf8")),
-            ("default_collation_name", &Value::from("utf8_bin")),
+            (CATALOG_NAME, &Value::from(catalog_name)),
+            (SCHEMA_NAME, &Value::from(schema_name)),
+            (DEFAULT_CHARACTER_SET_NAME, &Value::from("utf8")),
+            (DEFAULT_COLLATION_NAME, &Value::from("utf8_bin")),
         ];
 
         if !predicates.eval(&row) {

--- a/src/catalog/src/information_schema/schemata.rs
+++ b/src/catalog/src/information_schema/schemata.rs
@@ -25,6 +25,7 @@ use datafusion::physical_plan::streaming::PartitionStream as DfPartitionStream;
 use datafusion::physical_plan::SendableRecordBatchStream as DfSendableRecordBatchStream;
 use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
+use datatypes::value::Value;
 use datatypes::vectors::StringVectorBuilder;
 use snafu::{OptionExt, ResultExt};
 use store_api::storage::{ScanRequest, TableId};
@@ -33,7 +34,7 @@ use super::SCHEMATA;
 use crate::error::{
     CreateRecordBatchSnafu, InternalSnafu, Result, UpgradeWeakCatalogManagerRefSnafu,
 };
-use crate::information_schema::InformationTable;
+use crate::information_schema::{InformationTable, Predicates};
 use crate::CatalogManager;
 
 /// The `information_schema.schemata` table implementation.
@@ -92,14 +93,14 @@ impl InformationTable for InformationSchemaSchemata {
         self.schema.clone()
     }
 
-    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(
             schema,
             futures::stream::once(async move {
                 builder
-                    .make_schemata()
+                    .make_schemata(Some(request))
                     .await
                     .map(|x| x.into_df_record_batch())
                     .map_err(Into::into)
@@ -147,12 +148,13 @@ impl InformationSchemaSchemataBuilder {
     }
 
     /// Construct the `information_schema.schemata` virtual table
-    async fn make_schemata(&mut self) -> Result<RecordBatch> {
+    async fn make_schemata(&mut self, request: Option<ScanRequest>) -> Result<RecordBatch> {
         let catalog_name = self.catalog_name.clone();
         let catalog_manager = self
             .catalog_manager
             .upgrade()
             .context(UpgradeWeakCatalogManagerRefSnafu)?;
+        let predicates = Predicates::from_scan_request(&request);
 
         for schema_name in catalog_manager.schema_names(&catalog_name).await? {
             if !catalog_manager
@@ -162,13 +164,24 @@ impl InformationSchemaSchemataBuilder {
                 continue;
             }
 
-            self.add_schema(&catalog_name, &schema_name);
+            self.add_schema(&predicates, &catalog_name, &schema_name);
         }
 
         self.finish()
     }
 
-    fn add_schema(&mut self, catalog_name: &str, schema_name: &str) {
+    fn add_schema(&mut self, predicates: &Predicates, catalog_name: &str, schema_name: &str) {
+        let row = [
+            ("catalog_name", &Value::from(catalog_name)),
+            ("schema_name", &Value::from(schema_name)),
+            ("charset_name", &Value::from("utf8")),
+            ("collation_name", &Value::from("utf8_bin")),
+        ];
+
+        if !predicates.eval(&row) {
+            return;
+        }
+
         self.catalog_names.push(Some(catalog_name));
         self.schema_names.push(Some(schema_name));
         self.charset_names.push(Some("utf8"));
@@ -200,7 +213,7 @@ impl DfPartitionStream for InformationSchemaSchemata {
             schema,
             futures::stream::once(async move {
                 builder
-                    .make_schemata()
+                    .make_schemata(None)
                     .await
                     .map(|x| x.into_df_record_batch())
                     .map_err(Into::into)

--- a/src/catalog/src/information_schema/schemata.rs
+++ b/src/catalog/src/information_schema/schemata.rs
@@ -27,7 +27,7 @@ use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::StringVectorBuilder;
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::TableId;
+use store_api::storage::{ScanRequest, TableId};
 
 use super::SCHEMATA;
 use crate::error::{
@@ -92,7 +92,7 @@ impl InformationTable for InformationSchemaSchemata {
         self.schema.clone()
     }
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/schemata.rs
+++ b/src/catalog/src/information_schema/schemata.rs
@@ -174,8 +174,8 @@ impl InformationSchemaSchemataBuilder {
         let row = [
             ("catalog_name", &Value::from(catalog_name)),
             ("schema_name", &Value::from(schema_name)),
-            ("charset_name", &Value::from("utf8")),
-            ("collation_name", &Value::from("utf8_bin")),
+            ("default_character_set_name", &Value::from("utf8")),
+            ("default_collation_name", &Value::from("utf8_bin")),
         ];
 
         if !predicates.eval(&row) {

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -27,7 +27,7 @@ use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{StringVectorBuilder, UInt32VectorBuilder};
 use snafu::{OptionExt, ResultExt};
-use store_api::storage::TableId;
+use store_api::storage::{ScanRequest, TableId};
 use table::metadata::TableType;
 
 use super::TABLES;
@@ -85,7 +85,7 @@ impl InformationTable for InformationSchemaTables {
         self.schema.clone()
     }
 
-    fn to_stream(&self) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -38,6 +38,13 @@ use crate::error::{
 use crate::information_schema::{InformationTable, Predicates};
 use crate::CatalogManager;
 
+const TABLE_CATALOG: &str = "table_catalog";
+const TABLE_SCHEMA: &str = "table_schema";
+const TABLE_NAME: &str = "table_name";
+const TABLE_TYPE: &str = "table_type";
+const TABLE_ID: &str = "table_id";
+const ENGINE: &str = "engine";
+
 pub(super) struct InformationSchemaTables {
     schema: SchemaRef,
     catalog_name: String,
@@ -55,12 +62,12 @@ impl InformationSchemaTables {
 
     pub(crate) fn schema() -> SchemaRef {
         Arc::new(Schema::new(vec![
-            ColumnSchema::new("table_catalog", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_schema", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_name", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_type", ConcreteDataType::string_datatype(), false),
-            ColumnSchema::new("table_id", ConcreteDataType::uint32_datatype(), true),
-            ColumnSchema::new("engine", ConcreteDataType::string_datatype(), true),
+            ColumnSchema::new(TABLE_CATALOG, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_SCHEMA, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_NAME, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_TYPE, ConcreteDataType::string_datatype(), false),
+            ColumnSchema::new(TABLE_ID, ConcreteDataType::uint32_datatype(), true),
+            ColumnSchema::new(ENGINE, ConcreteDataType::string_datatype(), true),
         ]))
     }
 
@@ -204,10 +211,10 @@ impl InformationSchemaTablesBuilder {
         };
 
         let row = [
-            ("table_catalog", &Value::from(catalog_name)),
-            ("table_schema", &Value::from(schema_name)),
-            ("table_name", &Value::from(table_name)),
-            ("table_type", &Value::from(table_type)),
+            (TABLE_CATALOG, &Value::from(catalog_name)),
+            (TABLE_SCHEMA, &Value::from(schema_name)),
+            (TABLE_NAME, &Value::from(table_name)),
+            (TABLE_TYPE, &Value::from(table_type)),
         ];
 
         if !predicates.eval(&row) {

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -204,8 +204,8 @@ impl InformationSchemaTablesBuilder {
         };
 
         let row = [
-            ("catalog_name", &Value::from(catalog_name)),
-            ("schema_name", &Value::from(schema_name)),
+            ("table_catalog", &Value::from(catalog_name)),
+            ("table_schema", &Value::from(schema_name)),
             ("table_name", &Value::from(table_name)),
             ("table_type", &Value::from(table_type)),
         ];

--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -25,6 +25,7 @@ use datafusion::physical_plan::streaming::PartitionStream as DfPartitionStream;
 use datafusion::physical_plan::SendableRecordBatchStream as DfSendableRecordBatchStream;
 use datatypes::prelude::{ConcreteDataType, ScalarVectorBuilder, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
+use datatypes::value::Value;
 use datatypes::vectors::{StringVectorBuilder, UInt32VectorBuilder};
 use snafu::{OptionExt, ResultExt};
 use store_api::storage::{ScanRequest, TableId};
@@ -34,7 +35,7 @@ use super::TABLES;
 use crate::error::{
     CreateRecordBatchSnafu, InternalSnafu, Result, UpgradeWeakCatalogManagerRefSnafu,
 };
-use crate::information_schema::InformationTable;
+use crate::information_schema::{InformationTable, Predicates};
 use crate::CatalogManager;
 
 pub(super) struct InformationSchemaTables {
@@ -85,14 +86,14 @@ impl InformationTable for InformationSchemaTables {
         self.schema.clone()
     }
 
-    fn to_stream(&self, _request: ScanRequest) -> Result<SendableRecordBatchStream> {
+    fn to_stream(&self, request: ScanRequest) -> Result<SendableRecordBatchStream> {
         let schema = self.schema.arrow_schema().clone();
         let mut builder = self.builder();
         let stream = Box::pin(DfRecordBatchStreamAdapter::new(
             schema,
             futures::stream::once(async move {
                 builder
-                    .make_tables()
+                    .make_tables(Some(request))
                     .await
                     .map(|x| x.into_df_record_batch())
                     .map_err(Into::into)
@@ -142,12 +143,13 @@ impl InformationSchemaTablesBuilder {
     }
 
     /// Construct the `information_schema.tables` virtual table
-    async fn make_tables(&mut self) -> Result<RecordBatch> {
+    async fn make_tables(&mut self, request: Option<ScanRequest>) -> Result<RecordBatch> {
         let catalog_name = self.catalog_name.clone();
         let catalog_manager = self
             .catalog_manager
             .upgrade()
             .context(UpgradeWeakCatalogManagerRefSnafu)?;
+        let predicates = Predicates::from_scan_request(&request);
 
         for schema_name in catalog_manager.schema_names(&catalog_name).await? {
             if !catalog_manager
@@ -167,6 +169,7 @@ impl InformationSchemaTablesBuilder {
                 {
                     let table_info = table.table_info();
                     self.add_table(
+                        &predicates,
                         &catalog_name,
                         &schema_name,
                         &table_name,
@@ -183,8 +186,10 @@ impl InformationSchemaTablesBuilder {
         self.finish()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_table(
         &mut self,
+        predicates: &Predicates,
         catalog_name: &str,
         schema_name: &str,
         table_name: &str,
@@ -192,14 +197,27 @@ impl InformationSchemaTablesBuilder {
         table_id: Option<u32>,
         engine: Option<&str>,
     ) {
-        self.catalog_names.push(Some(catalog_name));
-        self.schema_names.push(Some(schema_name));
-        self.table_names.push(Some(table_name));
-        self.table_types.push(Some(match table_type {
+        let table_type = match table_type {
             TableType::Base => "BASE TABLE",
             TableType::View => "VIEW",
             TableType::Temporary => "LOCAL TEMPORARY",
-        }));
+        };
+
+        let row = [
+            ("catalog_name", &Value::from(catalog_name)),
+            ("schema_name", &Value::from(schema_name)),
+            ("table_name", &Value::from(table_name)),
+            ("table_type", &Value::from(table_type)),
+        ];
+
+        if !predicates.eval(&row) {
+            return;
+        }
+
+        self.catalog_names.push(Some(catalog_name));
+        self.schema_names.push(Some(schema_name));
+        self.table_names.push(Some(table_name));
+        self.table_types.push(Some(table_type));
         self.table_ids.push(table_id);
         self.engines.push(engine);
     }
@@ -229,7 +247,7 @@ impl DfPartitionStream for InformationSchemaTables {
             schema,
             futures::stream::once(async move {
                 builder
-                    .make_tables()
+                    .make_tables(None)
                     .await
                     .map(|x| x.into_df_record_batch())
                     .map_err(Into::into)

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -324,6 +324,29 @@ order by table_name;
 | foo        |
 +------------+
 
+select table_name
+from information_schema.tables
+where table_schema in ('my_db', 'public')
+order by table_name;
+
++------------+
+| table_name |
++------------+
+| foo        |
+| numbers    |
++------------+
+
+select table_name
+from information_schema.tables
+where table_schema not in ('my_db', 'information_schema')
+order by table_name;
+
++------------+
+| table_name |
++------------+
+| numbers    |
++------------+
+
 select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
@@ -350,6 +373,22 @@ order by table_schema, table_name, column_name;
 | greptime      | my_db        | foo        | ts          | TimestampMillisecond | TIMESTAMP     |
 +---------------+--------------+------------+-------------+----------------------+---------------+
 
+-- test query filter for columns --
+select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
+from information_schema.columns
+where table_catalog = 'greptime'
+  and (table_schema in ('public')
+      or
+      table_schema == 'my_db')
+order by table_schema, table_name, column_name;
+
++---------------+--------------+------------+-------------+----------------------+---------------+
+| table_catalog | table_schema | table_name | column_name | data_type            | semantic_type |
++---------------+--------------+------------+-------------+----------------------+---------------+
+| greptime      | my_db        | foo        | ts          | TimestampMillisecond | TIMESTAMP     |
+| greptime      | public       | numbers    | number      | UInt32               | TAG           |
++---------------+--------------+------------+-------------+----------------------+---------------+
+
 use public;
 
 Affected Rows: 0
@@ -361,6 +400,28 @@ Error: 1001(Unsupported), SQL statement is not supported: drop schema my_db;, ke
 use information_schema;
 
 Affected Rows: 0
+
+-- test query filter for key_column_usage --
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME = 'TIME INDEX';
+
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| constraint_catalog | constraint_schema | constraint_name | table_catalog | table_schema | table_name | column_name | ordinal_position | position_in_unique_constraint | referenced_table_schema | referenced_table_name | referenced_column_name |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| def                | my_db             | TIME INDEX      | def           | my_db        | foo        | ts          | 1                |                               |                         |                       |                        |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME != 'TIME INDEX';
+
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| constraint_catalog | constraint_schema | constraint_name | table_catalog | table_schema | table_name | column_name | ordinal_position | position_in_unique_constraint | referenced_table_schema | referenced_table_name | referenced_column_name |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| def                | public            | PRIMARY         | def           | public       | numbers    | number      | 1                |                               |                         |                       |                        |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME == 'TIME INDEX' AND CONSTRAINT_SCHEMA != 'my_db';
+
+++
+++
 
 -- schemata --
 desc table schemata;

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -338,6 +338,17 @@ order by table_name;
 
 select table_name
 from information_schema.tables
+where table_schema like 'my%'
+order by table_name;
+
++------------+
+| table_name |
++------------+
+| foo        |
++------------+
+
+select table_name
+from information_schema.tables
 where table_schema not in ('my_db', 'information_schema')
 order by table_name;
 
@@ -411,6 +422,22 @@ select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME = 'TIME INDEX';
 +--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
 
 select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME != 'TIME INDEX';
+
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| constraint_catalog | constraint_schema | constraint_name | table_catalog | table_schema | table_name | column_name | ordinal_position | position_in_unique_constraint | referenced_table_schema | referenced_table_name | referenced_column_name |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| def                | public            | PRIMARY         | def           | public       | numbers    | number      | 1                |                               |                         |                       |                        |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME LIKE '%INDEX';
+
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| constraint_catalog | constraint_schema | constraint_name | table_catalog | table_schema | table_name | column_name | ordinal_position | position_in_unique_constraint | referenced_table_schema | referenced_table_name | referenced_column_name |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+| def                | my_db             | TIME INDEX      | def           | my_db        | foo        | ts          | 1                |                               |                         |                       |                        |
++--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME NOT LIKE '%INDEX';
 
 +--------------------+-------------------+-----------------+---------------+--------------+------------+-------------+------------------+-------------------------------+-------------------------+-----------------------+------------------------+
 | constraint_catalog | constraint_schema | constraint_name | table_catalog | table_schema | table_name | column_name | ordinal_position | position_in_unique_constraint | referenced_table_schema | referenced_table_name | referenced_column_name |

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -31,6 +31,11 @@ order by table_name;
 
 select table_name
 from information_schema.tables
+where table_schema like 'my%'
+order by table_name;
+
+select table_name
+from information_schema.tables
 where table_schema not in ('my_db', 'information_schema')
 order by table_name;
 
@@ -67,6 +72,10 @@ use information_schema;
 select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME = 'TIME INDEX';
 
 select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME != 'TIME INDEX';
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME LIKE '%INDEX';
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME NOT LIKE '%INDEX';
 
 select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME == 'TIME INDEX' AND CONSTRAINT_SCHEMA != 'my_db';
 

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -24,6 +24,16 @@ from information_schema.tables
 where table_schema = 'my_db'
 order by table_name;
 
+select table_name
+from information_schema.tables
+where table_schema in ('my_db', 'public')
+order by table_name;
+
+select table_name
+from information_schema.tables
+where table_schema not in ('my_db', 'information_schema')
+order by table_name;
+
 select table_catalog, table_schema, table_name, table_type, engine
 from information_schema.tables
 where table_catalog = 'greptime'
@@ -38,11 +48,27 @@ where table_catalog = 'greptime'
   and table_schema != 'information_schema'
 order by table_schema, table_name, column_name;
 
+-- test query filter for columns --
+select table_catalog, table_schema, table_name, column_name, data_type, semantic_type
+from information_schema.columns
+where table_catalog = 'greptime'
+  and (table_schema in ('public')
+      or
+      table_schema == 'my_db')
+order by table_schema, table_name, column_name;
+
 use public;
 
 drop schema my_db;
 
 use information_schema;
+
+-- test query filter for key_column_usage --
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME = 'TIME INDEX';
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME != 'TIME INDEX';
+
+select * from KEY_COLUMN_USAGE where CONSTRAINT_NAME == 'TIME INDEX' AND CONSTRAINT_SCHEMA != 'my_db';
 
 -- schemata --
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Some tables in `information_schema` will be large in the production when there are many created tables, such as `columns` and `tables` etc.
This PR supports pushing down query filters for some information_schema tables, it would reduce the memory consumption while constructing the result stream and speed up the query.

Currently it supports following filters:

* `Eq`
* `NotEq`
* `InList`
* `expr AND expr`
* `expr OR expr`
* `NOT expr`
* `expr LIKE pattern`

We can support more types in the future. Looks like datafusion doesn't push down `like` expression currently. @waynexia 

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/2931