### PR TITLE
refactor(metrics): add 'greptime_' prefix for every metrics

### DIFF
--- a/src/catalog/src/metrics.rs
+++ b/src/catalog/src/metrics.rs
@@ -19,17 +19,17 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_CATALOG_MANAGER_CATALOG_COUNT: IntGauge =
-        register_int_gauge!("catalog_catalog_count", "catalog catalog count").unwrap();
+        register_int_gauge!("greptimedb_catalog_catalog_count", "catalog catalog count").unwrap();
     pub static ref METRIC_CATALOG_MANAGER_SCHEMA_COUNT: IntGauge =
-        register_int_gauge!("catalog_schema_count", "catalog schema count").unwrap();
+        register_int_gauge!("greptimedb_catalog_schema_count", "catalog schema count").unwrap();
     pub static ref METRIC_CATALOG_MANAGER_TABLE_COUNT: IntGaugeVec = register_int_gauge_vec!(
-        "catalog_table_count",
+        "greptimedb_catalog_table_count",
         "catalog table count",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_CATALOG_KV_REMOTE_GET: Histogram =
-        register_histogram!("catalog_kv_get_remote", "catalog kv get remote").unwrap();
+        register_histogram!("greptimedb_catalog_kv_get_remote", "catalog kv get remote").unwrap();
     pub static ref METRIC_CATALOG_KV_GET: Histogram =
-        register_histogram!("catalog_kv_get", "catalog kv get").unwrap();
+        register_histogram!("greptimedb_catalog_kv_get", "catalog kv get").unwrap();
 }

--- a/src/catalog/src/metrics.rs
+++ b/src/catalog/src/metrics.rs
@@ -19,17 +19,17 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_CATALOG_MANAGER_CATALOG_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_catalog_catalog_count", "catalog catalog count").unwrap();
+        register_int_gauge!("greptime_catalog_catalog_count", "catalog catalog count").unwrap();
     pub static ref METRIC_CATALOG_MANAGER_SCHEMA_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_catalog_schema_count", "catalog schema count").unwrap();
+        register_int_gauge!("greptime_catalog_schema_count", "catalog schema count").unwrap();
     pub static ref METRIC_CATALOG_MANAGER_TABLE_COUNT: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_catalog_table_count",
+        "greptime_catalog_table_count",
         "catalog table count",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_CATALOG_KV_REMOTE_GET: Histogram =
-        register_histogram!("greptimedb_catalog_kv_get_remote", "catalog kv get remote").unwrap();
+        register_histogram!("greptime_catalog_kv_get_remote", "catalog kv get remote").unwrap();
     pub static ref METRIC_CATALOG_KV_GET: Histogram =
-        register_histogram!("greptimedb_catalog_kv_get", "catalog kv get").unwrap();
+        register_histogram!("greptime_catalog_kv_get", "catalog kv get").unwrap();
 }

--- a/src/client/src/metrics.rs
+++ b/src/client/src/metrics.rs
@@ -17,27 +17,30 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_GRPC_CREATE_TABLE: Histogram =
-        register_histogram!("grpc_create_table", "grpc create table").unwrap();
-    pub static ref METRIC_GRPC_PROMQL_RANGE_QUERY: Histogram =
-        register_histogram!("grpc_promql_range_query", "grpc promql range query").unwrap();
+        register_histogram!("greptimedb_grpc_create_table", "grpc create table").unwrap();
+    pub static ref METRIC_GRPC_PROMQL_RANGE_QUERY: Histogram = register_histogram!(
+        "greptimedb_grpc_promql_range_query",
+        "grpc promql range query"
+    )
+    .unwrap();
     pub static ref METRIC_GRPC_INSERT: Histogram =
-        register_histogram!("grpc_insert", "grpc insert").unwrap();
+        register_histogram!("greptimedb_grpc_insert", "grpc insert").unwrap();
     pub static ref METRIC_GRPC_DELETE: Histogram =
-        register_histogram!("grpc_delete", "grpc delete").unwrap();
+        register_histogram!("greptimedb_grpc_delete", "grpc delete").unwrap();
     pub static ref METRIC_GRPC_SQL: Histogram =
-        register_histogram!("grpc_sql", "grpc sql").unwrap();
+        register_histogram!("greptimedb_grpc_sql", "grpc sql").unwrap();
     pub static ref METRIC_GRPC_LOGICAL_PLAN: Histogram =
-        register_histogram!("grpc_logical_plan", "grpc logical plan").unwrap();
+        register_histogram!("greptimedb_grpc_logical_plan", "grpc logical plan").unwrap();
     pub static ref METRIC_GRPC_ALTER: Histogram =
-        register_histogram!("grpc_alter", "grpc alter").unwrap();
+        register_histogram!("greptimedb_grpc_alter", "grpc alter").unwrap();
     pub static ref METRIC_GRPC_DROP_TABLE: Histogram =
-        register_histogram!("grpc_drop_table", "grpc drop table").unwrap();
+        register_histogram!("greptimedb_grpc_drop_table", "grpc drop table").unwrap();
     pub static ref METRIC_GRPC_TRUNCATE_TABLE: Histogram =
-        register_histogram!("grpc_truncate_table", "grpc truncate table").unwrap();
+        register_histogram!("greptimedb_grpc_truncate_table", "grpc truncate table").unwrap();
     pub static ref METRIC_GRPC_DO_GET: Histogram =
-        register_histogram!("grpc_do_get", "grpc do get").unwrap();
+        register_histogram!("greptimedb_grpc_do_get", "grpc do get").unwrap();
     pub static ref METRIC_REGION_REQUEST_GRPC: HistogramVec = register_histogram_vec!(
-        "grpc_region_request",
+        "greptimedb_grpc_region_request",
         "grpc region request",
         &["request_type"]
     )

--- a/src/client/src/metrics.rs
+++ b/src/client/src/metrics.rs
@@ -17,30 +17,30 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_GRPC_CREATE_TABLE: Histogram =
-        register_histogram!("greptimedb_grpc_create_table", "grpc create table").unwrap();
+        register_histogram!("greptime_grpc_create_table", "grpc create table").unwrap();
     pub static ref METRIC_GRPC_PROMQL_RANGE_QUERY: Histogram = register_histogram!(
-        "greptimedb_grpc_promql_range_query",
+        "greptime_grpc_promql_range_query",
         "grpc promql range query"
     )
     .unwrap();
     pub static ref METRIC_GRPC_INSERT: Histogram =
-        register_histogram!("greptimedb_grpc_insert", "grpc insert").unwrap();
+        register_histogram!("greptime_grpc_insert", "grpc insert").unwrap();
     pub static ref METRIC_GRPC_DELETE: Histogram =
-        register_histogram!("greptimedb_grpc_delete", "grpc delete").unwrap();
+        register_histogram!("greptime_grpc_delete", "grpc delete").unwrap();
     pub static ref METRIC_GRPC_SQL: Histogram =
-        register_histogram!("greptimedb_grpc_sql", "grpc sql").unwrap();
+        register_histogram!("greptime_grpc_sql", "grpc sql").unwrap();
     pub static ref METRIC_GRPC_LOGICAL_PLAN: Histogram =
-        register_histogram!("greptimedb_grpc_logical_plan", "grpc logical plan").unwrap();
+        register_histogram!("greptime_grpc_logical_plan", "grpc logical plan").unwrap();
     pub static ref METRIC_GRPC_ALTER: Histogram =
-        register_histogram!("greptimedb_grpc_alter", "grpc alter").unwrap();
+        register_histogram!("greptime_grpc_alter", "grpc alter").unwrap();
     pub static ref METRIC_GRPC_DROP_TABLE: Histogram =
-        register_histogram!("greptimedb_grpc_drop_table", "grpc drop table").unwrap();
+        register_histogram!("greptime_grpc_drop_table", "grpc drop table").unwrap();
     pub static ref METRIC_GRPC_TRUNCATE_TABLE: Histogram =
-        register_histogram!("greptimedb_grpc_truncate_table", "grpc truncate table").unwrap();
+        register_histogram!("greptime_grpc_truncate_table", "grpc truncate table").unwrap();
     pub static ref METRIC_GRPC_DO_GET: Histogram =
-        register_histogram!("greptimedb_grpc_do_get", "grpc do get").unwrap();
+        register_histogram!("greptime_grpc_do_get", "grpc do get").unwrap();
     pub static ref METRIC_REGION_REQUEST_GRPC: HistogramVec = register_histogram_vec!(
-        "greptimedb_grpc_region_request",
+        "greptime_grpc_region_request",
         "grpc region request",
         &["request_type"]
     )

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -28,7 +28,7 @@ pub mod standalone;
 
 lazy_static::lazy_static! {
     static ref APP_VERSION: prometheus::IntGaugeVec =
-        prometheus::register_int_gauge_vec!("greptimedb_app_version", "app version", &["short_version", "version"]).unwrap();
+        prometheus::register_int_gauge_vec!("greptime_app_version", "app version", &["short_version", "version"]).unwrap();
 }
 
 #[async_trait]

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -28,7 +28,7 @@ pub mod standalone;
 
 lazy_static::lazy_static! {
     static ref APP_VERSION: prometheus::IntGaugeVec =
-        prometheus::register_int_gauge_vec!("app_version", "app version", &["short_version", "version"]).unwrap();
+        prometheus::register_int_gauge_vec!("greptimedb_app_version", "app version", &["short_version", "version"]).unwrap();
 }
 
 #[async_trait]

--- a/src/common/meta/src/metrics.rs
+++ b/src/common/meta/src/metrics.rs
@@ -31,11 +31,8 @@ lazy_static! {
     .unwrap();
     pub static ref METRIC_META_CREATE_SCHEMA: Histogram =
         register_histogram!("greptime_meta_create_schema", "meta create schema").unwrap();
-    pub static ref METRIC_META_CREATE_SCHEMA_COUNTER: IntCounter = register_int_counter!(
-        "greptime_meta_create_schema_counter",
-        "meta create schema"
-    )
-    .unwrap();
+    pub static ref METRIC_META_CREATE_SCHEMA_COUNTER: IntCounter =
+        register_int_counter!("greptime_meta_create_schema_counter", "meta create schema").unwrap();
     pub static ref METRIC_META_PROCEDURE_CREATE_TABLE: HistogramVec = register_histogram_vec!(
         "greptime_meta_procedure_create_table",
         "meta procedure create table",

--- a/src/common/meta/src/metrics.rs
+++ b/src/common/meta/src/metrics.rs
@@ -17,45 +17,45 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_META_TXN_REQUEST: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_txn_request",
+        "greptime_meta_txn_request",
         "meta txn request",
         &["target", "op"]
     )
     .unwrap();
     pub static ref METRIC_META_CREATE_CATALOG: Histogram =
-        register_histogram!("greptimedb_meta_create_catalog", "meta create catalog").unwrap();
+        register_histogram!("greptime_meta_create_catalog", "meta create catalog").unwrap();
     pub static ref METRIC_META_CREATE_CATALOG_COUNTER: IntCounter = register_int_counter!(
-        "greptimedb_meta_create_catalog_counter",
+        "greptime_meta_create_catalog_counter",
         "meta create catalog"
     )
     .unwrap();
     pub static ref METRIC_META_CREATE_SCHEMA: Histogram =
-        register_histogram!("greptimedb_meta_create_schema", "meta create schema").unwrap();
+        register_histogram!("greptime_meta_create_schema", "meta create schema").unwrap();
     pub static ref METRIC_META_CREATE_SCHEMA_COUNTER: IntCounter = register_int_counter!(
-        "greptimedb_meta_create_schema_counter",
+        "greptime_meta_create_schema_counter",
         "meta create schema"
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_CREATE_TABLE: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_procedure_create_table",
+        "greptime_meta_procedure_create_table",
         "meta procedure create table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_DROP_TABLE: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_procedure_drop_table",
+        "greptime_meta_procedure_drop_table",
         "meta procedure drop table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_ALTER_TABLE: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_procedure_alter_table",
+        "greptime_meta_procedure_alter_table",
         "meta procedure alter table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_TRUNCATE_TABLE: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_procedure_truncate_table",
+        "greptime_meta_procedure_truncate_table",
         "meta procedure truncate table",
         &["step"]
     )

--- a/src/common/meta/src/metrics.rs
+++ b/src/common/meta/src/metrics.rs
@@ -16,36 +16,46 @@ use lazy_static::lazy_static;
 use prometheus::*;
 
 lazy_static! {
-    pub static ref METRIC_META_TXN_REQUEST: HistogramVec =
-        register_histogram_vec!("meta_txn_request", "meta txn request", &["target", "op"]).unwrap();
+    pub static ref METRIC_META_TXN_REQUEST: HistogramVec = register_histogram_vec!(
+        "greptimedb_meta_txn_request",
+        "meta txn request",
+        &["target", "op"]
+    )
+    .unwrap();
     pub static ref METRIC_META_CREATE_CATALOG: Histogram =
-        register_histogram!("meta_create_catalog", "meta create catalog").unwrap();
-    pub static ref METRIC_META_CREATE_CATALOG_COUNTER: IntCounter =
-        register_int_counter!("meta_create_catalog_counter", "meta create catalog").unwrap();
+        register_histogram!("greptimedb_meta_create_catalog", "meta create catalog").unwrap();
+    pub static ref METRIC_META_CREATE_CATALOG_COUNTER: IntCounter = register_int_counter!(
+        "greptimedb_meta_create_catalog_counter",
+        "meta create catalog"
+    )
+    .unwrap();
     pub static ref METRIC_META_CREATE_SCHEMA: Histogram =
-        register_histogram!("meta_create_schema", "meta create schema").unwrap();
-    pub static ref METRIC_META_CREATE_SCHEMA_COUNTER: IntCounter =
-        register_int_counter!("meta_create_schema_counter", "meta create schema").unwrap();
+        register_histogram!("greptimedb_meta_create_schema", "meta create schema").unwrap();
+    pub static ref METRIC_META_CREATE_SCHEMA_COUNTER: IntCounter = register_int_counter!(
+        "greptimedb_meta_create_schema_counter",
+        "meta create schema"
+    )
+    .unwrap();
     pub static ref METRIC_META_PROCEDURE_CREATE_TABLE: HistogramVec = register_histogram_vec!(
-        "meta_procedure_create_table",
+        "greptimedb_meta_procedure_create_table",
         "meta procedure create table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_DROP_TABLE: HistogramVec = register_histogram_vec!(
-        "meta_procedure_drop_table",
+        "greptimedb_meta_procedure_drop_table",
         "meta procedure drop table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_ALTER_TABLE: HistogramVec = register_histogram_vec!(
-        "meta_procedure_alter_table",
+        "greptimedb_meta_procedure_alter_table",
         "meta procedure alter table",
         &["step"]
     )
     .unwrap();
     pub static ref METRIC_META_PROCEDURE_TRUNCATE_TABLE: HistogramVec = register_histogram_vec!(
-        "meta_procedure_truncate_table",
+        "greptimedb_meta_procedure_truncate_table",
         "meta procedure truncate table",
         &["step"]
     )

--- a/src/common/runtime/src/metrics.rs
+++ b/src/common/runtime/src/metrics.rs
@@ -20,13 +20,13 @@ pub const THREAD_NAME_LABEL: &str = "thread_name";
 
 lazy_static! {
     pub static ref METRIC_RUNTIME_THREADS_ALIVE: IntGaugeVec = register_int_gauge_vec!(
-        "runtime_threads_alive",
+        "greptimedb_runtime_threads_alive",
         "runtime threads alive",
         &[THREAD_NAME_LABEL]
     )
     .unwrap();
     pub static ref METRIC_RUNTIME_THREADS_IDLE: IntGaugeVec = register_int_gauge_vec!(
-        "runtime_threads_idle",
+        "greptimedb_runtime_threads_idle",
         "runtime threads idle",
         &[THREAD_NAME_LABEL]
     )

--- a/src/common/runtime/src/metrics.rs
+++ b/src/common/runtime/src/metrics.rs
@@ -20,13 +20,13 @@ pub const THREAD_NAME_LABEL: &str = "thread_name";
 
 lazy_static! {
     pub static ref METRIC_RUNTIME_THREADS_ALIVE: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_runtime_threads_alive",
+        "greptime_runtime_threads_alive",
         "runtime threads alive",
         &[THREAD_NAME_LABEL]
     )
     .unwrap();
     pub static ref METRIC_RUNTIME_THREADS_IDLE: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_runtime_threads_idle",
+        "greptime_runtime_threads_idle",
         "runtime threads idle",
         &[THREAD_NAME_LABEL]
     )

--- a/src/common/telemetry/src/panic_hook.rs
+++ b/src/common/telemetry/src/panic_hook.rs
@@ -22,7 +22,7 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref PANIC_COUNTER: IntCounter =
-        register_int_counter!("panic_counter", "panic_counter").unwrap();
+        register_int_counter!("greptimedb_panic_counter", "panic_counter").unwrap();
 }
 
 pub fn set_panic_hook() {

--- a/src/common/telemetry/src/panic_hook.rs
+++ b/src/common/telemetry/src/panic_hook.rs
@@ -22,7 +22,7 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref PANIC_COUNTER: IntCounter =
-        register_int_counter!("greptimedb_panic_counter", "panic_counter").unwrap();
+        register_int_counter!("greptime_panic_counter", "panic_counter").unwrap();
 }
 
 pub fn set_panic_hook() {

--- a/src/datanode/src/metrics.rs
+++ b/src/datanode/src/metrics.rs
@@ -24,26 +24,26 @@ pub const REGION_ID: &str = "region_id";
 lazy_static! {
     /// The elapsed time of handling a request in the region_server.
     pub static ref HANDLE_REGION_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-        "datanode_handle_region_request_elapsed",
+        "greptimedb_datanode_handle_region_request_elapsed",
         "datanode handle region request elapsed",
         &[REGION_REQUEST_TYPE]
     )
     .unwrap();
     /// The elapsed time since the last received heartbeat.
     pub static ref LAST_RECEIVED_HEARTBEAT_ELAPSED: IntGauge = register_int_gauge!(
-        "last_received_heartbeat_lease_elapsed",
+        "greptimedb_last_received_heartbeat_lease_elapsed",
         "last received heartbeat lease elapsed",
     )
     .unwrap();
     pub static ref LEASE_EXPIRED_REGION: IntGaugeVec = register_int_gauge_vec!(
-        "lease_expired_region",
+        "greptimedb_lease_expired_region",
         "lease expired region",
         &[REGION_ID]
     )
     .unwrap();
     /// The received region leases via heartbeat.
     pub static ref HEARTBEAT_REGION_LEASES: IntGaugeVec = register_int_gauge_vec!(
-        "heartbeat_region_leases",
+        "greptimedb_heartbeat_region_leases",
         "received region leases via heartbeat",
         &[REGION_ROLE]
     )

--- a/src/datanode/src/metrics.rs
+++ b/src/datanode/src/metrics.rs
@@ -24,26 +24,26 @@ pub const REGION_ID: &str = "region_id";
 lazy_static! {
     /// The elapsed time of handling a request in the region_server.
     pub static ref HANDLE_REGION_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_datanode_handle_region_request_elapsed",
+        "greptime_datanode_handle_region_request_elapsed",
         "datanode handle region request elapsed",
         &[REGION_REQUEST_TYPE]
     )
     .unwrap();
     /// The elapsed time since the last received heartbeat.
     pub static ref LAST_RECEIVED_HEARTBEAT_ELAPSED: IntGauge = register_int_gauge!(
-        "greptimedb_last_received_heartbeat_lease_elapsed",
+        "greptime_last_received_heartbeat_lease_elapsed",
         "last received heartbeat lease elapsed",
     )
     .unwrap();
     pub static ref LEASE_EXPIRED_REGION: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_lease_expired_region",
+        "greptime_lease_expired_region",
         "lease expired region",
         &[REGION_ID]
     )
     .unwrap();
     /// The received region leases via heartbeat.
     pub static ref HEARTBEAT_REGION_LEASES: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_heartbeat_region_leases",
+        "greptime_heartbeat_region_leases",
         "received region leases via heartbeat",
         &[REGION_ROLE]
     )

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -17,34 +17,34 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_HANDLE_SQL_ELAPSED: Histogram =
-        register_histogram!("greptimedb_frontend_handle_sql_elapsed", "frontend handle sql elapsed").unwrap();
+        register_histogram!("greptime_frontend_handle_sql_elapsed", "frontend handle sql elapsed").unwrap();
     pub static ref METRIC_HANDLE_PROMQL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_frontend_handle_promql_elapsed",
+        "greptime_frontend_handle_promql_elapsed",
         "frontend handle promql elapsed"
     )
     .unwrap();
     pub static ref METRIC_EXEC_PLAN_ELAPSED: Histogram =
-        register_histogram!("greptimedb_frontend_exec_plan_elapsed", "frontend exec plan elapsed").unwrap();
+        register_histogram!("greptime_frontend_exec_plan_elapsed", "frontend exec plan elapsed").unwrap();
     pub static ref METRIC_HANDLE_SCRIPTS_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_frontend_handle_scripts_elapsed",
+        "greptime_frontend_handle_scripts_elapsed",
         "frontend handle scripts elapsed"
     )
     .unwrap();
     pub static ref METRIC_RUN_SCRIPT_ELAPSED: Histogram =
-        register_histogram!("greptimedb_frontend_run_script_elapsed", "frontend run script elapsed").unwrap();
+        register_histogram!("greptime_frontend_run_script_elapsed", "frontend run script elapsed").unwrap();
     /// The samples count of Prometheus remote write.
     pub static ref PROM_STORE_REMOTE_WRITE_SAMPLES: IntCounter = register_int_counter!(
-        "greptimedb_frontend_prometheus_remote_write_samples",
+        "greptime_frontend_prometheus_remote_write_samples",
         "frontend prometheus remote write samples"
     )
     .unwrap();
     pub static ref OTLP_METRICS_ROWS: IntCounter = register_int_counter!(
-        "greptimedb_frontend_otlp_metrics_rows",
+        "greptime_frontend_otlp_metrics_rows",
         "frontend otlp metrics rows"
     )
     .unwrap();
     pub static ref OTLP_TRACES_ROWS: IntCounter = register_int_counter!(
-        "greptimedb_frontend_otlp_traces_rows",
+        "greptime_frontend_otlp_traces_rows",
         "frontend otlp traces rows"
     )
     .unwrap();

--- a/src/frontend/src/metrics.rs
+++ b/src/frontend/src/metrics.rs
@@ -17,34 +17,34 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_HANDLE_SQL_ELAPSED: Histogram =
-        register_histogram!("frontend_handle_sql_elapsed", "frontend handle sql elapsed").unwrap();
+        register_histogram!("greptimedb_frontend_handle_sql_elapsed", "frontend handle sql elapsed").unwrap();
     pub static ref METRIC_HANDLE_PROMQL_ELAPSED: Histogram = register_histogram!(
-        "frontend_handle_promql_elapsed",
+        "greptimedb_frontend_handle_promql_elapsed",
         "frontend handle promql elapsed"
     )
     .unwrap();
     pub static ref METRIC_EXEC_PLAN_ELAPSED: Histogram =
-        register_histogram!("frontend_exec_plan_elapsed", "frontend exec plan elapsed").unwrap();
+        register_histogram!("greptimedb_frontend_exec_plan_elapsed", "frontend exec plan elapsed").unwrap();
     pub static ref METRIC_HANDLE_SCRIPTS_ELAPSED: Histogram = register_histogram!(
-        "frontend_handle_scripts_elapsed",
+        "greptimedb_frontend_handle_scripts_elapsed",
         "frontend handle scripts elapsed"
     )
     .unwrap();
     pub static ref METRIC_RUN_SCRIPT_ELAPSED: Histogram =
-        register_histogram!("frontend_run_script_elapsed", "frontend run script elapsed").unwrap();
+        register_histogram!("greptimedb_frontend_run_script_elapsed", "frontend run script elapsed").unwrap();
     /// The samples count of Prometheus remote write.
     pub static ref PROM_STORE_REMOTE_WRITE_SAMPLES: IntCounter = register_int_counter!(
-        "frontend_prometheus_remote_write_samples",
+        "greptimedb_frontend_prometheus_remote_write_samples",
         "frontend prometheus remote write samples"
     )
     .unwrap();
     pub static ref OTLP_METRICS_ROWS: IntCounter = register_int_counter!(
-        "frontend_otlp_metrics_rows",
+        "greptimedb_frontend_otlp_metrics_rows",
         "frontend otlp metrics rows"
     )
     .unwrap();
     pub static ref OTLP_TRACES_ROWS: IntCounter = register_int_counter!(
-        "frontend_otlp_traces_rows",
+        "greptimedb_frontend_otlp_traces_rows",
         "frontend otlp traces rows"
     )
     .unwrap();

--- a/src/meta-srv/src/metrics.rs
+++ b/src/meta-srv/src/metrics.rs
@@ -18,31 +18,31 @@ use prometheus::*;
 lazy_static! {
     /// Elapsed time to responding kv requests.
     pub static ref METRIC_META_KV_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-        "meta_kv_request_elapsed",
+        "greptimedb_meta_kv_request_elapsed",
         "meta kv request",
         &["target", "op", "cluster_id"]
     )
     .unwrap();
     /// The heartbeat connection gauge.
     pub static ref METRIC_META_HEARTBEAT_CONNECTION_NUM: IntGauge = register_int_gauge!(
-        "meta_heartbeat_connection_num",
+        "greptimedb_meta_heartbeat_connection_num",
         "meta heartbeat connection num"
     )
     .unwrap();
     /// Elapsed time to execution of heartbeat handlers.
     pub static ref METRIC_META_HANDLER_EXECUTE: HistogramVec =
-        register_histogram_vec!("meta_handler_execute", "meta handler execute", &["name"]).unwrap();
+        register_histogram_vec!("greptimedb_meta_handler_execute", "meta handler execute", &["name"]).unwrap();
     /// Inactive region gauge.
     pub static ref METRIC_META_INACTIVE_REGIONS: IntGauge =
-        register_int_gauge!("meta_inactive_regions", "meta inactive regions").unwrap();
+        register_int_gauge!("greptimedb_meta_inactive_regions", "meta inactive regions").unwrap();
     /// Elapsed time to leader cache kv.
     pub static ref METRIC_META_LEADER_CACHED_KV_LOAD_ELAPSED: HistogramVec =
-        register_histogram_vec!("meta_leader_cache_kv_load", "meta load cache", &["prefix"])
+        register_histogram_vec!("greptimedb_meta_leader_cache_kv_load", "meta load cache", &["prefix"])
             .unwrap();
     /// Meta kv cache hit counter.
     pub static ref METRIC_META_KV_CACHE_HIT: IntCounterVec =
-        register_int_counter_vec!("meta_kv_cache_hit", "meta kv cache hit", &["op"]).unwrap();
+        register_int_counter_vec!("greptimedb_meta_kv_cache_hit", "meta kv cache hit", &["op"]).unwrap();
     /// Meta kv cache miss counter.
     pub static ref METRIC_META_KV_CACHE_MISS: IntCounterVec =
-        register_int_counter_vec!("meta_kv_cache_miss", "meta kv cache miss", &["op"]).unwrap();
+        register_int_counter_vec!("greptimedb_meta_kv_cache_miss", "meta kv cache miss", &["op"]).unwrap();
 }

--- a/src/meta-srv/src/metrics.rs
+++ b/src/meta-srv/src/metrics.rs
@@ -18,31 +18,31 @@ use prometheus::*;
 lazy_static! {
     /// Elapsed time to responding kv requests.
     pub static ref METRIC_META_KV_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_meta_kv_request_elapsed",
+        "greptime_meta_kv_request_elapsed",
         "meta kv request",
         &["target", "op", "cluster_id"]
     )
     .unwrap();
     /// The heartbeat connection gauge.
     pub static ref METRIC_META_HEARTBEAT_CONNECTION_NUM: IntGauge = register_int_gauge!(
-        "greptimedb_meta_heartbeat_connection_num",
+        "greptime_meta_heartbeat_connection_num",
         "meta heartbeat connection num"
     )
     .unwrap();
     /// Elapsed time to execution of heartbeat handlers.
     pub static ref METRIC_META_HANDLER_EXECUTE: HistogramVec =
-        register_histogram_vec!("greptimedb_meta_handler_execute", "meta handler execute", &["name"]).unwrap();
+        register_histogram_vec!("greptime_meta_handler_execute", "meta handler execute", &["name"]).unwrap();
     /// Inactive region gauge.
     pub static ref METRIC_META_INACTIVE_REGIONS: IntGauge =
-        register_int_gauge!("greptimedb_meta_inactive_regions", "meta inactive regions").unwrap();
+        register_int_gauge!("greptime_meta_inactive_regions", "meta inactive regions").unwrap();
     /// Elapsed time to leader cache kv.
     pub static ref METRIC_META_LEADER_CACHED_KV_LOAD_ELAPSED: HistogramVec =
-        register_histogram_vec!("greptimedb_meta_leader_cache_kv_load", "meta load cache", &["prefix"])
+        register_histogram_vec!("greptime_meta_leader_cache_kv_load", "meta load cache", &["prefix"])
             .unwrap();
     /// Meta kv cache hit counter.
     pub static ref METRIC_META_KV_CACHE_HIT: IntCounterVec =
-        register_int_counter_vec!("greptimedb_meta_kv_cache_hit", "meta kv cache hit", &["op"]).unwrap();
+        register_int_counter_vec!("greptime_meta_kv_cache_hit", "meta kv cache hit", &["op"]).unwrap();
     /// Meta kv cache miss counter.
     pub static ref METRIC_META_KV_CACHE_MISS: IntCounterVec =
-        register_int_counter_vec!("greptimedb_meta_kv_cache_miss", "meta kv cache miss", &["op"]).unwrap();
+        register_int_counter_vec!("greptime_meta_kv_cache_miss", "meta kv cache miss", &["op"]).unwrap();
 }

--- a/src/metric-engine/src/metrics.rs
+++ b/src/metric-engine/src/metrics.rs
@@ -20,21 +20,21 @@ use prometheus::*;
 lazy_static! {
     /// Gauge for opened regions
     pub static ref PHYSICAL_REGION_COUNT: IntGauge =
-        register_int_gauge!("metric_engine_physical_region_count", "metric engine physical region count").unwrap();
+        register_int_gauge!("greptimedb_metric_engine_physical_region_count", "metric engine physical region count").unwrap();
 
     /// Gauge of columns across all opened regions
     pub static ref PHYSICAL_COLUMN_COUNT: IntGauge =
-        register_int_gauge!("metric_engine_physical_column_count", "metric engine physical column count").unwrap();
+        register_int_gauge!("greptimedb_metric_engine_physical_column_count", "metric engine physical column count").unwrap();
 
     /// Gauge for opened logical regions
     pub static ref LOGICAL_REGION_COUNT: IntGauge =
-        register_int_gauge!("metric_engine_logical_region_count", "metric engine logical region count").unwrap();
+        register_int_gauge!("greptimedb_metric_engine_logical_region_count", "metric engine logical region count").unwrap();
 
     /// Histogram for opened logical regions
     pub static ref MITO_DDL_DURATION: Histogram =
-        register_histogram!("metric_engine_mito_ddl", "metric engine mito ddl").unwrap();
+        register_histogram!("greptimedb_metric_engine_mito_ddl", "metric engine mito ddl").unwrap();
 
     /// Counter for forbidden operations
     pub static ref FORBIDDEN_OPERATION_COUNT: IntCounter =
-        register_int_counter!("metric_engine_forbidden_request", "metric forbidden request").unwrap();
+        register_int_counter!("greptimedb_metric_engine_forbidden_request", "metric forbidden request").unwrap();
 }

--- a/src/metric-engine/src/metrics.rs
+++ b/src/metric-engine/src/metrics.rs
@@ -20,21 +20,21 @@ use prometheus::*;
 lazy_static! {
     /// Gauge for opened regions
     pub static ref PHYSICAL_REGION_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_metric_engine_physical_region_count", "metric engine physical region count").unwrap();
+        register_int_gauge!("greptime_metric_engine_physical_region_count", "metric engine physical region count").unwrap();
 
     /// Gauge of columns across all opened regions
     pub static ref PHYSICAL_COLUMN_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_metric_engine_physical_column_count", "metric engine physical column count").unwrap();
+        register_int_gauge!("greptime_metric_engine_physical_column_count", "metric engine physical column count").unwrap();
 
     /// Gauge for opened logical regions
     pub static ref LOGICAL_REGION_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_metric_engine_logical_region_count", "metric engine logical region count").unwrap();
+        register_int_gauge!("greptime_metric_engine_logical_region_count", "metric engine logical region count").unwrap();
 
     /// Histogram for opened logical regions
     pub static ref MITO_DDL_DURATION: Histogram =
-        register_histogram!("greptimedb_metric_engine_mito_ddl", "metric engine mito ddl").unwrap();
+        register_histogram!("greptime_metric_engine_mito_ddl", "metric engine mito ddl").unwrap();
 
     /// Counter for forbidden operations
     pub static ref FORBIDDEN_OPERATION_COUNT: IntCounter =
-        register_int_counter!("greptimedb_metric_engine_forbidden_request", "metric forbidden request").unwrap();
+        register_int_counter!("greptime_metric_engine_forbidden_request", "metric forbidden request").unwrap();
 }

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -27,13 +27,13 @@ pub const FILE_TYPE_LABEL: &str = "file_type";
 lazy_static! {
     /// Global write buffer size in bytes.
     pub static ref WRITE_BUFFER_BYTES: IntGauge =
-        register_int_gauge!("greptimedb_mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
+        register_int_gauge!("greptime_mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
     /// Gauge for open regions
     pub static ref REGION_COUNT: IntGauge =
-        register_int_gauge!("greptimedb_mito_region_count", "mito region count").unwrap();
+        register_int_gauge!("greptime_mito_region_count", "mito region count").unwrap();
     /// Elapsed time to handle requests.
     pub static ref HANDLE_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-            "greptimedb_mito_handle_request_elapsed",
+            "greptime_mito_handle_request_elapsed",
             "mito handle request elapsed",
             &[TYPE_LABEL]
         )
@@ -43,44 +43,44 @@ lazy_static! {
     /// Counter of scheduled flush requests.
     /// Note that the flush scheduler may merge some flush requests.
     pub static ref FLUSH_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-            "greptimedb_mito_flush_requests_total",
+            "greptime_mito_flush_requests_total",
             "mito flush requests total",
             &[FLUSH_REASON]
         )
         .unwrap();
     /// Counter of scheduled failed flush jobs.
     pub static ref FLUSH_ERRORS_TOTAL: IntCounter =
-        register_int_counter!("greptimedb_mito_flush_errors_total", "mito flush errors total").unwrap();
+        register_int_counter!("greptime_mito_flush_errors_total", "mito flush errors total").unwrap();
     /// Elapsed time of a flush job.
     pub static ref FLUSH_ELAPSED: HistogramVec = register_histogram_vec!(
-            "greptimedb_mito_flush_elapsed",
+            "greptime_mito_flush_elapsed",
             "mito flush elapsed",
             &[TYPE_LABEL]
         )
         .unwrap();
     /// Histogram of flushed bytes.
     pub static ref FLUSH_BYTES_TOTAL: IntCounter =
-        register_int_counter!("greptimedb_mito_flush_bytes_total", "mito flush bytes total").unwrap();
+        register_int_counter!("greptime_mito_flush_bytes_total", "mito flush bytes total").unwrap();
     // ------ End of flush related metrics
 
 
     // ------ Write related metrics
     /// Counter of stalled write requests.
     pub static ref WRITE_STALL_TOTAL: IntCounter =
-        register_int_counter!("greptimedb_mito_write_stall_total", "mito write stall total").unwrap();
+        register_int_counter!("greptime_mito_write_stall_total", "mito write stall total").unwrap();
     /// Counter of rejected write requests.
     pub static ref WRITE_REJECT_TOTAL: IntCounter =
-        register_int_counter!("greptimedb_mito_write_reject_total", "mito write reject total").unwrap();
+        register_int_counter!("greptime_mito_write_reject_total", "mito write reject total").unwrap();
     /// Elapsed time of each write stage.
     pub static ref WRITE_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-            "greptimedb_mito_write_stage_elapsed",
+            "greptime_mito_write_stage_elapsed",
             "mito write stage elapsed",
             &[STAGE_LABEL]
         )
         .unwrap();
     /// Counter of rows to write.
     pub static ref WRITE_ROWS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_mito_write_rows_total",
+        "greptime_mito_write_rows_total",
         "mito write rows total",
         &[TYPE_LABEL]
     )
@@ -91,56 +91,56 @@ lazy_static! {
     // Compaction metrics
     /// Timer of different stages in compaction.
     pub static ref COMPACTION_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_mito_compaction_stage_elapsed",
+        "greptime_mito_compaction_stage_elapsed",
         "mito compaction stage elapsed",
         &[STAGE_LABEL]
     )
     .unwrap();
     /// Timer of whole compaction task.
     pub static ref COMPACTION_ELAPSED_TOTAL: Histogram =
-        register_histogram!("greptimedb_mito_compaction_total_elapsed", "mito compaction total elapsed").unwrap();
+        register_histogram!("greptime_mito_compaction_total_elapsed", "mito compaction total elapsed").unwrap();
     /// Counter of all requested compaction task.
     pub static ref COMPACTION_REQUEST_COUNT: IntCounter =
-        register_int_counter!("greptimedb_mito_compaction_requests_total", "mito compaction requests total").unwrap();
+        register_int_counter!("greptime_mito_compaction_requests_total", "mito compaction requests total").unwrap();
     /// Counter of failed compaction task.
     pub static ref COMPACTION_FAILURE_COUNT: IntCounter =
-        register_int_counter!("greptimedb_mito_compaction_failure_total", "mito compaction failure total").unwrap();
+        register_int_counter!("greptime_mito_compaction_failure_total", "mito compaction failure total").unwrap();
     // ------- End of compaction metrics.
 
     // Query metrics.
     /// Timer of different stages in query.
     pub static ref READ_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_mito_read_stage_elapsed",
+        "greptime_mito_read_stage_elapsed",
         "mito read stage elapsed",
         &[STAGE_LABEL]
     )
     .unwrap();
     /// Counter of rows read.
     pub static ref READ_ROWS_TOTAL: IntCounterVec =
-        register_int_counter_vec!("greptimedb_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();
+        register_int_counter_vec!("greptime_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();
     /// Counter of filtered rows during merge.
     pub static ref MERGE_FILTER_ROWS_TOTAL: IntCounterVec =
-        register_int_counter_vec!("greptimedb_mito_merge_filter_rows_total", "mito merge filter rows total", &[TYPE_LABEL]).unwrap();
+        register_int_counter_vec!("greptime_mito_merge_filter_rows_total", "mito merge filter rows total", &[TYPE_LABEL]).unwrap();
     // ------- End of query metrics.
 
     // Cache related metrics.
     /// Cache hit counter.
     pub static ref CACHE_HIT: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_mito_cache_hit",
+        "greptime_mito_cache_hit",
         "mito cache hit",
         &[TYPE_LABEL]
     )
     .unwrap();
     /// Cache miss counter.
     pub static ref CACHE_MISS: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_mito_cache_miss",
+        "greptime_mito_cache_miss",
         "mito cache miss",
         &[TYPE_LABEL]
     )
     .unwrap();
     /// Cache size in bytes.
     pub static ref CACHE_BYTES: IntGaugeVec = register_int_gauge_vec!(
-        "greptimedb_mito_cache_bytes",
+        "greptime_mito_cache_bytes",
         "mito cache bytes",
         &[TYPE_LABEL]
     )

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -27,13 +27,13 @@ pub const FILE_TYPE_LABEL: &str = "file_type";
 lazy_static! {
     /// Global write buffer size in bytes.
     pub static ref WRITE_BUFFER_BYTES: IntGauge =
-        register_int_gauge!("mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
+        register_int_gauge!("greptimedb_mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
     /// Gauge for open regions
     pub static ref REGION_COUNT: IntGauge =
-        register_int_gauge!("mito_region_count", "mito region count").unwrap();
+        register_int_gauge!("greptimedb_mito_region_count", "mito region count").unwrap();
     /// Elapsed time to handle requests.
     pub static ref HANDLE_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
-            "mito_handle_request_elapsed",
+            "greptimedb_mito_handle_request_elapsed",
             "mito handle request elapsed",
             &[TYPE_LABEL]
         )
@@ -43,44 +43,44 @@ lazy_static! {
     /// Counter of scheduled flush requests.
     /// Note that the flush scheduler may merge some flush requests.
     pub static ref FLUSH_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-            "mito_flush_requests_total",
+            "greptimedb_mito_flush_requests_total",
             "mito flush requests total",
             &[FLUSH_REASON]
         )
         .unwrap();
     /// Counter of scheduled failed flush jobs.
     pub static ref FLUSH_ERRORS_TOTAL: IntCounter =
-        register_int_counter!("mito_flush_errors_total", "mito flush errors total").unwrap();
+        register_int_counter!("greptimedb_mito_flush_errors_total", "mito flush errors total").unwrap();
     /// Elapsed time of a flush job.
     pub static ref FLUSH_ELAPSED: HistogramVec = register_histogram_vec!(
-            "mito_flush_elapsed",
+            "greptimedb_mito_flush_elapsed",
             "mito flush elapsed",
             &[TYPE_LABEL]
         )
         .unwrap();
     /// Histogram of flushed bytes.
     pub static ref FLUSH_BYTES_TOTAL: IntCounter =
-        register_int_counter!("mito_flush_bytes_total", "mito flush bytes total").unwrap();
+        register_int_counter!("greptimedb_mito_flush_bytes_total", "mito flush bytes total").unwrap();
     // ------ End of flush related metrics
 
 
     // ------ Write related metrics
     /// Counter of stalled write requests.
     pub static ref WRITE_STALL_TOTAL: IntCounter =
-        register_int_counter!("mito_write_stall_total", "mito write stall total").unwrap();
+        register_int_counter!("greptimedb_mito_write_stall_total", "mito write stall total").unwrap();
     /// Counter of rejected write requests.
     pub static ref WRITE_REJECT_TOTAL: IntCounter =
-        register_int_counter!("mito_write_reject_total", "mito write reject total").unwrap();
+        register_int_counter!("greptimedb_mito_write_reject_total", "mito write reject total").unwrap();
     /// Elapsed time of each write stage.
     pub static ref WRITE_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-            "mito_write_stage_elapsed",
+            "greptimedb_mito_write_stage_elapsed",
             "mito write stage elapsed",
             &[STAGE_LABEL]
         )
         .unwrap();
     /// Counter of rows to write.
     pub static ref WRITE_ROWS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "mito_write_rows_total",
+        "greptimedb_mito_write_rows_total",
         "mito write rows total",
         &[TYPE_LABEL]
     )
@@ -91,56 +91,56 @@ lazy_static! {
     // Compaction metrics
     /// Timer of different stages in compaction.
     pub static ref COMPACTION_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "mito_compaction_stage_elapsed",
+        "greptimedb_mito_compaction_stage_elapsed",
         "mito compaction stage elapsed",
         &[STAGE_LABEL]
     )
     .unwrap();
     /// Timer of whole compaction task.
     pub static ref COMPACTION_ELAPSED_TOTAL: Histogram =
-        register_histogram!("mito_compaction_total_elapsed", "mito compaction total elapsed").unwrap();
+        register_histogram!("greptimedb_mito_compaction_total_elapsed", "mito compaction total elapsed").unwrap();
     /// Counter of all requested compaction task.
     pub static ref COMPACTION_REQUEST_COUNT: IntCounter =
-        register_int_counter!("mito_compaction_requests_total", "mito compaction requests total").unwrap();
+        register_int_counter!("greptimedb_mito_compaction_requests_total", "mito compaction requests total").unwrap();
     /// Counter of failed compaction task.
     pub static ref COMPACTION_FAILURE_COUNT: IntCounter =
-        register_int_counter!("mito_compaction_failure_total", "mito compaction failure total").unwrap();
+        register_int_counter!("greptimedb_mito_compaction_failure_total", "mito compaction failure total").unwrap();
     // ------- End of compaction metrics.
 
     // Query metrics.
     /// Timer of different stages in query.
     pub static ref READ_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "mito_read_stage_elapsed",
+        "greptimedb_mito_read_stage_elapsed",
         "mito read stage elapsed",
         &[STAGE_LABEL]
     )
     .unwrap();
     /// Counter of rows read.
     pub static ref READ_ROWS_TOTAL: IntCounterVec =
-        register_int_counter_vec!("mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();
+        register_int_counter_vec!("greptimedb_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();
     /// Counter of filtered rows during merge.
     pub static ref MERGE_FILTER_ROWS_TOTAL: IntCounterVec =
-        register_int_counter_vec!("mito_merge_filter_rows_total", "mito merge filter rows total", &[TYPE_LABEL]).unwrap();
+        register_int_counter_vec!("greptimedb_mito_merge_filter_rows_total", "mito merge filter rows total", &[TYPE_LABEL]).unwrap();
     // ------- End of query metrics.
 
     // Cache related metrics.
     /// Cache hit counter.
     pub static ref CACHE_HIT: IntCounterVec = register_int_counter_vec!(
-        "mito_cache_hit",
+        "greptimedb_mito_cache_hit",
         "mito cache hit",
         &[TYPE_LABEL]
     )
     .unwrap();
     /// Cache miss counter.
     pub static ref CACHE_MISS: IntCounterVec = register_int_counter_vec!(
-        "mito_cache_miss",
+        "greptimedb_mito_cache_miss",
         "mito cache miss",
         &[TYPE_LABEL]
     )
     .unwrap();
     /// Cache size in bytes.
     pub static ref CACHE_BYTES: IntGaugeVec = register_int_gauge_vec!(
-        "mito_cache_bytes",
+        "greptimedb_mito_cache_bytes",
         "mito cache bytes",
         &[TYPE_LABEL]
     )

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -156,13 +156,13 @@ lazy_static! {
     .unwrap();
     /// Gauge of index apply memory usage.
     pub static ref INDEX_APPLY_MEMORY_USAGE: IntGauge = register_int_gauge!(
-        "index_apply_memory_usage",
+        "greptime_index_apply_memory_usage",
         "index apply memory usage",
     )
     .unwrap();
     /// Counter of r/w bytes on index related IO operations.
     pub static ref INDEX_IO_BYTES_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "index_io_bytes_total",
+        "greptime_index_io_bytes_total",
         "index io bytes total",
         &[TYPE_LABEL, FILE_TYPE_LABEL]
     )
@@ -173,7 +173,7 @@ lazy_static! {
 
     /// Counter of r/w operations on index related IO operations, e.g. read, write, seek and flush.
     pub static ref INDEX_IO_OP_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "index_io_op_total",
+        "greptime_index_io_op_total",
         "index io op total",
         &[TYPE_LABEL, FILE_TYPE_LABEL]
     )

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -21,18 +21,18 @@ use prometheus::*;
 lazy_static! {
     /// Cache hit counter, no matter what the cache result is.
     pub static ref OBJECT_STORE_LRU_CACHE_HIT: IntCounterVec = register_int_counter_vec!(
-        "object_store_lru_cache_hit",
+        "greptimedb_object_store_lru_cache_hit",
         "object store lru cache hit",
         &["result"]
     )
     .unwrap();
     /// Cache miss counter
     pub static ref OBJECT_STORE_LRU_CACHE_MISS: IntCounter =
-        register_int_counter!("object_store_lru_cache_miss", "object store lru cache miss")
+        register_int_counter!("greptimedb_object_store_lru_cache_miss", "object store lru cache miss")
             .unwrap();
     /// Object store read error counter
     pub static ref OBJECT_STORE_READ_ERROR: IntCounterVec = register_int_counter_vec!(
-        "object_store_read_errors",
+        "greptimedb_object_store_read_errors",
         "object store read errors",
         &["kind"]
     )
@@ -40,11 +40,11 @@ lazy_static! {
 
     /// Cache entry number
     pub static ref OBJECT_STORE_LRU_CACHE_ENTRIES: IntGauge =
-        register_int_gauge!("object_store_lru_cache_entries", "object store lru cache entries")
+        register_int_gauge!("greptimedb_object_store_lru_cache_entries", "object store lru cache entries")
             .unwrap();
 
     /// Cache size in bytes
     pub static ref OBJECT_STORE_LRU_CACHE_BYTES: IntGauge =
-        register_int_gauge!("object_store_lru_cache_bytes",  "object store lru cache bytes")
+        register_int_gauge!("greptimedb_object_store_lru_cache_bytes",  "object store lru cache bytes")
             .unwrap();
 }

--- a/src/object-store/src/metrics.rs
+++ b/src/object-store/src/metrics.rs
@@ -21,18 +21,18 @@ use prometheus::*;
 lazy_static! {
     /// Cache hit counter, no matter what the cache result is.
     pub static ref OBJECT_STORE_LRU_CACHE_HIT: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_object_store_lru_cache_hit",
+        "greptime_object_store_lru_cache_hit",
         "object store lru cache hit",
         &["result"]
     )
     .unwrap();
     /// Cache miss counter
     pub static ref OBJECT_STORE_LRU_CACHE_MISS: IntCounter =
-        register_int_counter!("greptimedb_object_store_lru_cache_miss", "object store lru cache miss")
+        register_int_counter!("greptime_object_store_lru_cache_miss", "object store lru cache miss")
             .unwrap();
     /// Object store read error counter
     pub static ref OBJECT_STORE_READ_ERROR: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_object_store_read_errors",
+        "greptime_object_store_read_errors",
         "object store read errors",
         &["kind"]
     )
@@ -40,11 +40,11 @@ lazy_static! {
 
     /// Cache entry number
     pub static ref OBJECT_STORE_LRU_CACHE_ENTRIES: IntGauge =
-        register_int_gauge!("greptimedb_object_store_lru_cache_entries", "object store lru cache entries")
+        register_int_gauge!("greptime_object_store_lru_cache_entries", "object store lru cache entries")
             .unwrap();
 
     /// Cache size in bytes
     pub static ref OBJECT_STORE_LRU_CACHE_BYTES: IntGauge =
-        register_int_gauge!("greptimedb_object_store_lru_cache_bytes",  "object store lru cache bytes")
+        register_int_gauge!("greptime_object_store_lru_cache_bytes",  "object store lru cache bytes")
             .unwrap();
 }

--- a/src/operator/src/metrics.rs
+++ b/src/operator/src/metrics.rs
@@ -17,9 +17,9 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref DIST_CREATE_TABLE: Histogram =
-        register_histogram!("greptimedb_table_operator_create_table", "table operator create table").unwrap();
+        register_histogram!("greptime_table_operator_create_table", "table operator create table").unwrap();
     pub static ref DIST_INGEST_ROW_COUNT: IntCounter =
-        register_int_counter!("greptimedb_table_operator_ingest_rows", "table operator ingest rows").unwrap();
+        register_int_counter!("greptime_table_operator_ingest_rows", "table operator ingest rows").unwrap();
     pub static ref DIST_DELETE_ROW_COUNT: IntCounter =
-        register_int_counter!("greptimedb_table_operator_delete_rows", "table operator delete rows").unwrap();
+        register_int_counter!("greptime_table_operator_delete_rows", "table operator delete rows").unwrap();
 }

--- a/src/operator/src/metrics.rs
+++ b/src/operator/src/metrics.rs
@@ -16,10 +16,19 @@ use lazy_static::lazy_static;
 use prometheus::*;
 
 lazy_static! {
-    pub static ref DIST_CREATE_TABLE: Histogram =
-        register_histogram!("greptime_table_operator_create_table", "table operator create table").unwrap();
-    pub static ref DIST_INGEST_ROW_COUNT: IntCounter =
-        register_int_counter!("greptime_table_operator_ingest_rows", "table operator ingest rows").unwrap();
-    pub static ref DIST_DELETE_ROW_COUNT: IntCounter =
-        register_int_counter!("greptime_table_operator_delete_rows", "table operator delete rows").unwrap();
+    pub static ref DIST_CREATE_TABLE: Histogram = register_histogram!(
+        "greptime_table_operator_create_table",
+        "table operator create table"
+    )
+    .unwrap();
+    pub static ref DIST_INGEST_ROW_COUNT: IntCounter = register_int_counter!(
+        "greptime_table_operator_ingest_rows",
+        "table operator ingest rows"
+    )
+    .unwrap();
+    pub static ref DIST_DELETE_ROW_COUNT: IntCounter = register_int_counter!(
+        "greptime_table_operator_delete_rows",
+        "table operator delete rows"
+    )
+    .unwrap();
 }

--- a/src/operator/src/metrics.rs
+++ b/src/operator/src/metrics.rs
@@ -17,9 +17,9 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref DIST_CREATE_TABLE: Histogram =
-        register_histogram!("table_operator_create_table", "table operator create table").unwrap();
+        register_histogram!("greptimedb_table_operator_create_table", "table operator create table").unwrap();
     pub static ref DIST_INGEST_ROW_COUNT: IntCounter =
-        register_int_counter!("table_operator_ingest_rows", "table operator ingest rows").unwrap();
+        register_int_counter!("greptimedb_table_operator_ingest_rows", "table operator ingest rows").unwrap();
     pub static ref DIST_DELETE_ROW_COUNT: IntCounter =
-        register_int_counter!("table_operator_delete_rows", "table operator delete rows").unwrap();
+        register_int_counter!("greptimedb_table_operator_delete_rows", "table operator delete rows").unwrap();
 }

--- a/src/partition/src/metrics.rs
+++ b/src/partition/src/metrics.rs
@@ -17,7 +17,7 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_TABLE_ROUTE_GET: Histogram = register_histogram!(
-        "greptimedb_frontend_table_route_get",
+        "greptime_frontend_table_route_get",
         "frontend table route get"
     )
     .unwrap();

--- a/src/partition/src/metrics.rs
+++ b/src/partition/src/metrics.rs
@@ -11,3 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use lazy_static::lazy_static;
+use prometheus::*;
+
+lazy_static! {
+    pub static ref METRIC_TABLE_ROUTE_GET: Histogram = register_histogram!(
+        "greptimedb_frontend_table_route_get",
+        "frontend table route get"
+    )
+    .unwrap();
+}

--- a/src/partition/src/metrics.rs
+++ b/src/partition/src/metrics.rs
@@ -11,14 +11,3 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-use lazy_static::lazy_static;
-use prometheus::*;
-
-lazy_static! {
-    pub static ref METRIC_TABLE_ROUTE_GET: Histogram = register_histogram!(
-        "greptime_frontend_table_route_get",
-        "frontend table route get"
-    )
-    .unwrap();
-}

--- a/src/promql/src/metrics.rs
+++ b/src/promql/src/metrics.rs
@@ -18,5 +18,5 @@ use prometheus::*;
 lazy_static! {
     /// Counter for the number of series processed per query.
     pub static ref PROMQL_SERIES_COUNT: Histogram =
-        register_histogram!("promql_series_count", "promql series count").unwrap();
+        register_histogram!("greptimedb_promql_series_count", "promql series count").unwrap();
 }

--- a/src/promql/src/metrics.rs
+++ b/src/promql/src/metrics.rs
@@ -18,5 +18,5 @@ use prometheus::*;
 lazy_static! {
     /// Counter for the number of series processed per query.
     pub static ref PROMQL_SERIES_COUNT: Histogram =
-        register_histogram!("greptimedb_promql_series_count", "promql series count").unwrap();
+        register_histogram!("greptime_promql_series_count", "promql series count").unwrap();
 }

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -16,36 +16,48 @@ use lazy_static::lazy_static;
 use prometheus::*;
 
 lazy_static! {
-    pub static ref METRIC_PARSE_SQL_ELAPSED: Histogram =
-        register_histogram!("query_parse_sql_elapsed", "query parse sql elapsed").unwrap();
-    pub static ref METRIC_PARSE_PROMQL_ELAPSED: Histogram =
-        register_histogram!("query_parse_promql_elapsed", "query parse promql elapsed").unwrap();
+    pub static ref METRIC_PARSE_SQL_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_query_parse_sql_elapsed",
+        "query parse sql elapsed"
+    )
+    .unwrap();
+    pub static ref METRIC_PARSE_PROMQL_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_query_parse_promql_elapsed",
+        "query parse promql elapsed"
+    )
+    .unwrap();
     pub static ref METRIC_OPTIMIZE_LOGICAL_ELAPSED: Histogram = register_histogram!(
-        "query_optimize_logicalplan_elapsed",
+        "greptimedb_query_optimize_logicalplan_elapsed",
         "query optimize logicalplan elapsed"
     )
     .unwrap();
     pub static ref METRIC_OPTIMIZE_PHYSICAL_ELAPSED: Histogram = register_histogram!(
-        "query_optimize_physicalplan_elapsed",
+        "greptimedb_query_optimize_physicalplan_elapsed",
         "query optimize physicalplan elapsed"
     )
     .unwrap();
     pub static ref METRIC_CREATE_PHYSICAL_ELAPSED: Histogram = register_histogram!(
-        "query_create_physicalplan_elapsed",
+        "greptimedb_query_create_physicalplan_elapsed",
         "query create physicalplan elapsed"
     )
     .unwrap();
-    pub static ref METRIC_EXEC_PLAN_ELAPSED: Histogram =
-        register_histogram!("query_execute_plan_elapsed", "query execute plan elapsed").unwrap();
+    pub static ref METRIC_EXEC_PLAN_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_query_execute_plan_elapsed",
+        "query execute plan elapsed"
+    )
+    .unwrap();
     pub static ref METRIC_MERGE_SCAN_POLL_ELAPSED: Histogram = register_histogram!(
-        "query_merge_scan_poll_elapsed",
+        "greptimedb_query_merge_scan_poll_elapsed",
         "query merge scan poll elapsed"
     )
     .unwrap();
-    pub static ref METRIC_MERGE_SCAN_REGIONS: Histogram =
-        register_histogram!("query_merge_scan_regions", "query merge scan regions").unwrap();
+    pub static ref METRIC_MERGE_SCAN_REGIONS: Histogram = register_histogram!(
+        "greptimedb_query_merge_scan_regions",
+        "query merge scan regions"
+    )
+    .unwrap();
     pub static ref METRIC_MERGE_SCAN_ERRORS_TOTAL: IntCounter = register_int_counter!(
-        "query_merge_scan_errors_total",
+        "greptimedb_query_merge_scan_errors_total",
         "query merge scan errors total"
     )
     .unwrap();

--- a/src/query/src/metrics.rs
+++ b/src/query/src/metrics.rs
@@ -17,47 +17,47 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_PARSE_SQL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_parse_sql_elapsed",
+        "greptime_query_parse_sql_elapsed",
         "query parse sql elapsed"
     )
     .unwrap();
     pub static ref METRIC_PARSE_PROMQL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_parse_promql_elapsed",
+        "greptime_query_parse_promql_elapsed",
         "query parse promql elapsed"
     )
     .unwrap();
     pub static ref METRIC_OPTIMIZE_LOGICAL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_optimize_logicalplan_elapsed",
+        "greptime_query_optimize_logicalplan_elapsed",
         "query optimize logicalplan elapsed"
     )
     .unwrap();
     pub static ref METRIC_OPTIMIZE_PHYSICAL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_optimize_physicalplan_elapsed",
+        "greptime_query_optimize_physicalplan_elapsed",
         "query optimize physicalplan elapsed"
     )
     .unwrap();
     pub static ref METRIC_CREATE_PHYSICAL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_create_physicalplan_elapsed",
+        "greptime_query_create_physicalplan_elapsed",
         "query create physicalplan elapsed"
     )
     .unwrap();
     pub static ref METRIC_EXEC_PLAN_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_execute_plan_elapsed",
+        "greptime_query_execute_plan_elapsed",
         "query execute plan elapsed"
     )
     .unwrap();
     pub static ref METRIC_MERGE_SCAN_POLL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_query_merge_scan_poll_elapsed",
+        "greptime_query_merge_scan_poll_elapsed",
         "query merge scan poll elapsed"
     )
     .unwrap();
     pub static ref METRIC_MERGE_SCAN_REGIONS: Histogram = register_histogram!(
-        "greptimedb_query_merge_scan_regions",
+        "greptime_query_merge_scan_regions",
         "query merge scan regions"
     )
     .unwrap();
     pub static ref METRIC_MERGE_SCAN_ERRORS_TOTAL: IntCounter = register_int_counter!(
-        "greptimedb_query_merge_scan_errors_total",
+        "greptime_query_merge_scan_errors_total",
         "query merge scan errors total"
     )
     .unwrap();

--- a/src/script/src/python/metric.rs
+++ b/src/script/src/python/metric.rs
@@ -17,17 +17,17 @@ use prometheus::*;
 
 lazy_static! {
     pub static ref METRIC_RSPY_INIT_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_rspy_init_elapsed",
+        "greptime_script_rspy_init_elapsed",
         "script rspy init elapsed"
     )
     .unwrap();
     pub static ref METRIC_RSPY_EXEC_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_rspy_exec_elapsed",
+        "greptime_script_rspy_exec_elapsed",
         "script rspy exec elapsed"
     )
     .unwrap();
     pub static ref METRIC_RSPY_EXEC_TOTAL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_rspy_exec_total_elapsed",
+        "greptime_script_rspy_exec_total_elapsed",
         "script rspy exec total elapsed"
     )
     .unwrap();
@@ -36,17 +36,17 @@ lazy_static! {
 #[cfg(feature = "pyo3_backend")]
 lazy_static! {
     pub static ref METRIC_PYO3_EXEC_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_pyo3_exec_elapsed",
+        "greptime_script_pyo3_exec_elapsed",
         "script pyo3 exec elapsed"
     )
     .unwrap();
     pub static ref METRIC_PYO3_INIT_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_pyo3_init_elapsed",
+        "greptime_script_pyo3_init_elapsed",
         "script pyo3 init elapsed"
     )
     .unwrap();
     pub static ref METRIC_PYO3_EXEC_TOTAL_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_script_pyo3_exec_total_elapsed",
+        "greptime_script_pyo3_exec_total_elapsed",
         "script pyo3 exec total elapsed"
     )
     .unwrap();

--- a/src/script/src/python/metric.rs
+++ b/src/script/src/python/metric.rs
@@ -16,12 +16,18 @@ use lazy_static::lazy_static;
 use prometheus::*;
 
 lazy_static! {
-    pub static ref METRIC_RSPY_INIT_ELAPSED: Histogram =
-        register_histogram!("script_rspy_init_elapsed", "script rspy init elapsed").unwrap();
-    pub static ref METRIC_RSPY_EXEC_ELAPSED: Histogram =
-        register_histogram!("script_rspy_exec_elapsed", "script rspy exec elapsed").unwrap();
+    pub static ref METRIC_RSPY_INIT_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_script_rspy_init_elapsed",
+        "script rspy init elapsed"
+    )
+    .unwrap();
+    pub static ref METRIC_RSPY_EXEC_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_script_rspy_exec_elapsed",
+        "script rspy exec elapsed"
+    )
+    .unwrap();
     pub static ref METRIC_RSPY_EXEC_TOTAL_ELAPSED: Histogram = register_histogram!(
-        "script_rspy_exec_total_elapsed",
+        "greptimedb_script_rspy_exec_total_elapsed",
         "script rspy exec total elapsed"
     )
     .unwrap();
@@ -29,12 +35,18 @@ lazy_static! {
 
 #[cfg(feature = "pyo3_backend")]
 lazy_static! {
-    pub static ref METRIC_PYO3_EXEC_ELAPSED: Histogram =
-        register_histogram!("script_pyo3_exec_elapsed", "script pyo3 exec elapsed").unwrap();
-    pub static ref METRIC_PYO3_INIT_ELAPSED: Histogram =
-        register_histogram!("script_pyo3_init_elapsed", "script pyo3 init elapsed").unwrap();
+    pub static ref METRIC_PYO3_EXEC_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_script_pyo3_exec_elapsed",
+        "script pyo3 exec elapsed"
+    )
+    .unwrap();
+    pub static ref METRIC_PYO3_INIT_ELAPSED: Histogram = register_histogram!(
+        "greptimedb_script_pyo3_init_elapsed",
+        "script pyo3 init elapsed"
+    )
+    .unwrap();
     pub static ref METRIC_PYO3_EXEC_TOTAL_ELAPSED: Histogram = register_histogram!(
-        "script_pyo3_exec_total_elapsed",
+        "greptimedb_script_pyo3_exec_total_elapsed",
         "script pyo3 exec total elapsed"
     )
     .unwrap();

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -42,165 +42,172 @@ pub(crate) const METRIC_METHOD_LABEL: &str = "method";
 pub(crate) const METRIC_PATH_LABEL: &str = "path";
 
 lazy_static! {
-    pub static ref METRIC_ERROR_COUNTER: IntCounterVec =
-        register_int_counter_vec!("servers_error", "servers error", &[METRIC_PROTOCOL_LABEL])
-            .unwrap();
+    pub static ref METRIC_ERROR_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "greptimedb_servers_error",
+        "servers error",
+        &[METRIC_PROTOCOL_LABEL]
+    )
+    .unwrap();
     pub static ref METRIC_HTTP_SQL_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_sql_elapsed",
+        "greptimedb_servers_http_sql_elapsed",
         "servers http sql elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_promql_elapsed",
+        "greptimedb_servers_http_promql_elapsed",
         "servers http promql elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_AUTH_FAILURE: IntCounterVec = register_int_counter_vec!(
-        "servers_auth_failure_count",
+        "greptimedb_servers_auth_failure_count",
         "servers auth failure count",
         &[METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_INFLUXDB_WRITE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_influxdb_write_elapsed",
+        "greptimedb_servers_http_influxdb_write_elapsed",
         "servers http influxdb write elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROM_STORE_WRITE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_prometheus_write_elapsed",
+        "greptimedb_servers_http_prometheus_write_elapsed",
         "servers http prometheus write elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROM_STORE_READ_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_prometheus_read_elapsed",
+        "greptimedb_servers_http_prometheus_read_elapsed",
         "servers http prometheus read elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_OPENTELEMETRY_METRICS_ELAPSED: HistogramVec =
         register_histogram_vec!(
-            "servers_http_otlp_metrics_elapsed",
+            "greptimedb_servers_http_otlp_metrics_elapsed",
             "servers_http_otlp_metrics_elapsed",
             &[METRIC_DB_LABEL]
         )
         .unwrap();
     pub static ref METRIC_HTTP_OPENTELEMETRY_TRACES_ELAPSED: HistogramVec =
         register_histogram_vec!(
-            "servers_http_otlp_traces_elapsed",
+            "greptimedb_servers_http_otlp_traces_elapsed",
             "servers http otlp traces elapsed",
             &[METRIC_DB_LABEL]
         )
         .unwrap();
     pub static ref METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED: Histogram = register_histogram!(
-        "servers_opentsdb_line_write_elapsed",
+        "greptimedb_servers_opentsdb_line_write_elapsed",
         "servers opentsdb line write elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_FORMAT_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_format_query_elapsed",
+        "greptimedb_servers_http_promql_format_query_elapsed",
         "servers http promql format query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_INSTANT_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_instant_query_elapsed",
+        "greptimedb_servers_http_promql_instant_query_elapsed",
         "servers http promql instant query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_RANGE_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_range_query_elapsed",
+        "greptimedb_servers_http_promql_range_query_elapsed",
         "servers http promql range query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_LABEL_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_label_query_elapsed",
+        "greptimedb_servers_http_promql_label_query_elapsed",
         "servers http promql label query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_SERIES_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_series_query_elapsed",
+        "greptimedb_servers_http_promql_series_query_elapsed",
         "servers http promql series query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_LABEL_VALUE_QUERY_ELAPSED: Histogram = register_histogram!(
-        "servers_http_promql_label_value_query_elapsed",
+        "greptimedb_servers_http_promql_label_value_query_elapsed",
         "servers http promql label value query elapsed"
     )
     .unwrap();
     pub static ref METRIC_MYSQL_CONNECTIONS: IntGauge = register_int_gauge!(
-        "servers_mysql_connection_count",
+        "greptimedb_servers_mysql_connection_count",
         "servers mysql connection count"
     )
     .unwrap();
     pub static ref METRIC_MYSQL_QUERY_TIMER: HistogramVec = register_histogram_vec!(
-        "servers_mysql_query_elapsed",
+        "greptimedb_servers_mysql_query_elapsed",
         "servers mysql query elapsed",
         &[METRIC_MYSQL_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_MYSQL_PREPARED_COUNT: IntCounterVec = register_int_counter_vec!(
-        "servers_mysql_prepared_count",
+        "greptimedb_servers_mysql_prepared_count",
         "servers mysql prepared count",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_CONNECTIONS: IntGauge = register_int_gauge!(
-        "servers_postgres_connection_count",
+        "greptimedb_servers_postgres_connection_count",
         "servers postgres connection count"
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_QUERY_TIMER: HistogramVec = register_histogram_vec!(
-        "servers_postgres_query_elapsed",
+        "greptimedb_servers_postgres_query_elapsed",
         "servers postgres query elapsed",
         &[METRIC_POSTGRES_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_PREPARED_COUNT: IntCounter = register_int_counter!(
-        "servers_postgres_prepared_count",
+        "greptimedb_servers_postgres_prepared_count",
         "servers postgres prepared count"
     )
     .unwrap();
     pub static ref METRIC_SERVER_GRPC_DB_REQUEST_TIMER: HistogramVec = register_histogram_vec!(
-        "servers_grpc_db_request_elapsed",
+        "greptimedb_servers_grpc_db_request_elapsed",
         "servers grpc db request elapsed",
         &[METRIC_DB_LABEL, METRIC_TYPE_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: HistogramVec = register_histogram_vec!(
-        "servers_grpc_prom_request_elapsed",
+        "greptimedb_servers_grpc_prom_request_elapsed",
         "servers grpc prom request elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "servers_http_requests_total",
+        "greptimedb_servers_http_requests_total",
         "servers http requests total",
         &[METRIC_METHOD_LABEL, METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_REQUESTS_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_http_requests_elapsed",
+        "greptimedb_servers_http_requests_elapsed",
         "servers http requests elapsed",
         &[METRIC_METHOD_LABEL, METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_GRPC_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "servers_grpc_requests_total",
+        "greptimedb_servers_grpc_requests_total",
         "servers grpc requests total",
         &[METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_GRPC_REQUESTS_ELAPSED: HistogramVec = register_histogram_vec!(
-        "servers_grpc_requests_elapsed",
+        "greptimedb_servers_grpc_requests_elapsed",
         "servers grpc requests elapsed",
         &[METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
-    pub static ref HTTP_TRACK_METRICS: HistogramVec =
-        register_histogram_vec!("http_track_metrics", "http track metrics", &["tag"]).unwrap();
+    pub static ref HTTP_TRACK_METRICS: HistogramVec = register_histogram_vec!(
+        "greptimedb_http_track_metrics",
+        "http track metrics",
+        &["tag"]
+    )
+    .unwrap();
 }
 
 // Based on https://github.com/hyperium/tonic/blob/master/examples/src/tower/server.rs

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -43,167 +43,167 @@ pub(crate) const METRIC_PATH_LABEL: &str = "path";
 
 lazy_static! {
     pub static ref METRIC_ERROR_COUNTER: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_servers_error",
+        "greptime_servers_error",
         "servers error",
         &[METRIC_PROTOCOL_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_SQL_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_sql_elapsed",
+        "greptime_servers_http_sql_elapsed",
         "servers http sql elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_promql_elapsed",
+        "greptime_servers_http_promql_elapsed",
         "servers http promql elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_AUTH_FAILURE: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_servers_auth_failure_count",
+        "greptime_servers_auth_failure_count",
         "servers auth failure count",
         &[METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_INFLUXDB_WRITE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_influxdb_write_elapsed",
+        "greptime_servers_http_influxdb_write_elapsed",
         "servers http influxdb write elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROM_STORE_WRITE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_prometheus_write_elapsed",
+        "greptime_servers_http_prometheus_write_elapsed",
         "servers http prometheus write elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROM_STORE_READ_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_prometheus_read_elapsed",
+        "greptime_servers_http_prometheus_read_elapsed",
         "servers http prometheus read elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_OPENTELEMETRY_METRICS_ELAPSED: HistogramVec =
         register_histogram_vec!(
-            "greptimedb_servers_http_otlp_metrics_elapsed",
+            "greptime_servers_http_otlp_metrics_elapsed",
             "servers_http_otlp_metrics_elapsed",
             &[METRIC_DB_LABEL]
         )
         .unwrap();
     pub static ref METRIC_HTTP_OPENTELEMETRY_TRACES_ELAPSED: HistogramVec =
         register_histogram_vec!(
-            "greptimedb_servers_http_otlp_traces_elapsed",
+            "greptime_servers_http_otlp_traces_elapsed",
             "servers http otlp traces elapsed",
             &[METRIC_DB_LABEL]
         )
         .unwrap();
     pub static ref METRIC_TCP_OPENTSDB_LINE_WRITE_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_opentsdb_line_write_elapsed",
+        "greptime_servers_opentsdb_line_write_elapsed",
         "servers opentsdb line write elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_FORMAT_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_format_query_elapsed",
+        "greptime_servers_http_promql_format_query_elapsed",
         "servers http promql format query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_INSTANT_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_instant_query_elapsed",
+        "greptime_servers_http_promql_instant_query_elapsed",
         "servers http promql instant query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_RANGE_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_range_query_elapsed",
+        "greptime_servers_http_promql_range_query_elapsed",
         "servers http promql range query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_LABEL_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_label_query_elapsed",
+        "greptime_servers_http_promql_label_query_elapsed",
         "servers http promql label query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_SERIES_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_series_query_elapsed",
+        "greptime_servers_http_promql_series_query_elapsed",
         "servers http promql series query elapsed"
     )
     .unwrap();
     pub static ref METRIC_HTTP_PROMQL_LABEL_VALUE_QUERY_ELAPSED: Histogram = register_histogram!(
-        "greptimedb_servers_http_promql_label_value_query_elapsed",
+        "greptime_servers_http_promql_label_value_query_elapsed",
         "servers http promql label value query elapsed"
     )
     .unwrap();
     pub static ref METRIC_MYSQL_CONNECTIONS: IntGauge = register_int_gauge!(
-        "greptimedb_servers_mysql_connection_count",
+        "greptime_servers_mysql_connection_count",
         "servers mysql connection count"
     )
     .unwrap();
     pub static ref METRIC_MYSQL_QUERY_TIMER: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_mysql_query_elapsed",
+        "greptime_servers_mysql_query_elapsed",
         "servers mysql query elapsed",
         &[METRIC_MYSQL_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_MYSQL_PREPARED_COUNT: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_servers_mysql_prepared_count",
+        "greptime_servers_mysql_prepared_count",
         "servers mysql prepared count",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_CONNECTIONS: IntGauge = register_int_gauge!(
-        "greptimedb_servers_postgres_connection_count",
+        "greptime_servers_postgres_connection_count",
         "servers postgres connection count"
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_QUERY_TIMER: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_postgres_query_elapsed",
+        "greptime_servers_postgres_query_elapsed",
         "servers postgres query elapsed",
         &[METRIC_POSTGRES_SUBPROTOCOL_LABEL, METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_POSTGRES_PREPARED_COUNT: IntCounter = register_int_counter!(
-        "greptimedb_servers_postgres_prepared_count",
+        "greptime_servers_postgres_prepared_count",
         "servers postgres prepared count"
     )
     .unwrap();
     pub static ref METRIC_SERVER_GRPC_DB_REQUEST_TIMER: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_grpc_db_request_elapsed",
+        "greptime_servers_grpc_db_request_elapsed",
         "servers grpc db request elapsed",
         &[METRIC_DB_LABEL, METRIC_TYPE_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_SERVER_GRPC_PROM_REQUEST_TIMER: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_grpc_prom_request_elapsed",
+        "greptime_servers_grpc_prom_request_elapsed",
         "servers grpc prom request elapsed",
         &[METRIC_DB_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_servers_http_requests_total",
+        "greptime_servers_http_requests_total",
         "servers http requests total",
         &[METRIC_METHOD_LABEL, METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_HTTP_REQUESTS_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_http_requests_elapsed",
+        "greptime_servers_http_requests_elapsed",
         "servers http requests elapsed",
         &[METRIC_METHOD_LABEL, METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_GRPC_REQUESTS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptimedb_servers_grpc_requests_total",
+        "greptime_servers_grpc_requests_total",
         "servers grpc requests total",
         &[METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref METRIC_GRPC_REQUESTS_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptimedb_servers_grpc_requests_elapsed",
+        "greptime_servers_grpc_requests_elapsed",
         "servers grpc requests elapsed",
         &[METRIC_PATH_LABEL, METRIC_CODE_LABEL]
     )
     .unwrap();
     pub static ref HTTP_TRACK_METRICS: HistogramVec = register_histogram_vec!(
-        "greptimedb_http_track_metrics",
+        "greptime_http_track_metrics",
         "http track metrics",
         &["tag"]
     )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add `greptime_` prefix for every metrics

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
