### PR TITLE
test: add tests for lease keeper with logical table

### DIFF
--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -91,7 +91,9 @@ impl TableRouteValue {
         Ok(self.physical_table_route().version)
     }
 
-    /// Returns the corresponding [RegionRoute].
+    /// Returns the corresponding [RegionRoute], returns `None` if it's the specific region is not found.
+    ///
+    /// Note: It throws an error if it's a logical table
     pub fn region_route(&self, region_id: RegionId) -> Result<Option<RegionRoute>> {
         ensure!(
             self.is_physical(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add tests for lease keeper handling logical table.
 
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
