### PR TITLE
feat: add parquet metadata to cache

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -324,23 +324,12 @@ impl TwcsCompactionTask {
                         &write_opts,
                     )
                     .await?
-                    .map(|sst_info| {
-                        // Add parquet metadata to cache
-                        if let Some(metadata) = sst_info.file_metadata {
-                            cache_manager.put_parquet_meta_data(
-                                region_id,
-                                file_id,
-                                Arc::new(metadata),
-                            );
-                        }
-
-                        FileMeta {
-                            region_id,
-                            file_id,
-                            time_range: sst_info.time_range,
-                            level: output.output_level,
-                            file_size: sst_info.file_size,
-                        }
+                    .map(|sst_info| FileMeta {
+                        region_id,
+                        file_id,
+                        time_range: sst_info.time_range,
+                        level: output.output_level,
+                        file_size: sst_info.file_size,
                     });
                 Ok(file_meta_opt)
             });

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -326,13 +326,13 @@ impl TwcsCompactionTask {
                     .await?
                     .map(|sst_info| {
                         // Add parquet metadata to cache
-                        sst_info.file_metadata.map(|metadata| {
+                        if let Some(metadata) = sst_info.file_metadata {
                             cache_manager.put_parquet_meta_data(
                                 region_id,
                                 file_id,
                                 Arc::new(metadata),
                             );
-                        });
+                        }
 
                         FileMeta {
                             region_id,

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -318,7 +318,7 @@ impl TwcsCompactionTask {
                             file_id,
                             metadata,
                             source: Source::Reader(reader),
-                            cache_manager: cache_manager.clone(),
+                            cache_manager,
                             storage,
                         },
                         &write_opts,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -331,14 +331,7 @@ impl RegionFlushTask {
                 // No data written.
                 continue;
             };
-            // Add parquet file metadata to cache
-            if let Some(metadata) = sst_info.file_metadata {
-                self.cache_manager.put_parquet_meta_data(
-                    self.region_id,
-                    file_id,
-                    Arc::new(metadata),
-                );
-            }
+
             flushed_bytes += sst_info.file_size;
             let file_meta = FileMeta {
                 region_id: self.region_id,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -331,6 +331,14 @@ impl RegionFlushTask {
                 // No data written.
                 continue;
             };
+            // Add parquet file metadata to cache
+            if let Some(metadata) = sst_info.file_metadata {
+                self.cache_manager.put_parquet_meta_data(
+                    self.region_id,
+                    file_id,
+                    Arc::new(metadata),
+                );
+            }
             flushed_bytes += sst_info.file_size;
             let file_meta = FileMeta {
                 region_id: self.region_id,

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -22,6 +22,8 @@ pub mod row_group;
 mod stats;
 pub mod writer;
 
+use std::sync::Arc;
+
 use common_base::readable_size::ReadableSize;
 use parquet::file::metadata::ParquetMetaData;
 
@@ -62,7 +64,7 @@ pub struct SstInfo {
     /// Number of rows.
     pub num_rows: usize,
     /// File Meta Data
-    pub file_metadata: Option<ParquetMetaData>,
+    pub file_metadata: Option<Arc<ParquetMetaData>>,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -14,6 +14,8 @@
 
 //! Parquet writer.
 
+use std::sync::Arc;
+
 use common_datasource::file_format::parquet::BufferedWriter;
 use common_telemetry::debug;
 use common_time::Timestamp;
@@ -121,7 +123,7 @@ impl ParquetWriter {
             time_range,
             file_size,
             num_rows: stats.num_rows,
-            file_metadata: Some(parquet_metadata),
+            file_metadata: Some(Arc::new(parquet_metadata)),
         }))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

add parquet metadata to `SstMetaCache` after flush or compact.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
Closes #2963 