### PR TITLE
feat(mito): Init the write cache in datanode

### DIFF
--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -60,9 +60,9 @@ use tokio::sync::Notify;
 
 use crate::config::{DatanodeOptions, RegionEngineConfig};
 use crate::error::{
-    CreateDirSnafu, GetMetadataSnafu, MissingKvBackendSnafu, MissingNodeIdSnafu, OpenLogStoreSnafu,
-    ParseAddrSnafu, Result, RuntimeResourceSnafu, ShutdownInstanceSnafu, ShutdownServerSnafu,
-    StartServerSnafu,
+    BuildMitoEngineSnafu, CreateDirSnafu, GetMetadataSnafu, MissingKvBackendSnafu,
+    MissingNodeIdSnafu, OpenLogStoreSnafu, ParseAddrSnafu, Result, RuntimeResourceSnafu,
+    ShutdownInstanceSnafu, ShutdownServerSnafu, StartServerSnafu,
 };
 use crate::event_listener::{
     new_region_server_event_channel, NoopRegionServerEventListener, RegionServerEventListenerRef,
@@ -466,12 +466,16 @@ impl DatanodeBuilder {
                 Self::build_raft_engine_log_store(&opts.storage.data_home, raft_engine_config)
                     .await?,
                 object_store_manager,
-            ),
+            )
+            .await
+            .context(BuildMitoEngineSnafu)?,
             WalConfig::Kafka(kafka_config) => MitoEngine::new(
                 config,
                 Self::build_kafka_log_store(kafka_config).await?,
                 object_store_manager,
-            ),
+            )
+            .await
+            .context(BuildMitoEngineSnafu)?,
         };
         Ok(mito_engine)
     }

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -461,9 +461,12 @@ impl DatanodeBuilder {
         mut config: MitoConfig,
     ) -> Result<MitoEngine> {
         // Sets write cache path if it is empty.
-        if config.write_cache_path.is_empty() {
-            config.write_cache_path = join_dir(&opts.storage.data_home, "write_cache");
-            info!("Sets write cache path to {}", config.write_cache_path);
+        if config.experimental_write_cache_path.is_empty() {
+            config.experimental_write_cache_path = join_dir(&opts.storage.data_home, "write_cache");
+            info!(
+                "Sets write cache path to {}",
+                config.experimental_write_cache_path
+            );
         }
 
         let mito_engine = match &opts.wal {

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -282,6 +282,12 @@ pub enum Error {
         source: metric_engine::error::Error,
         location: Location,
     },
+
+    #[snafu(display("Failed to build mito engine"))]
+    BuildMitoEngine {
+        source: mito2::error::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -352,6 +358,7 @@ impl ErrorExt for Error {
             StopRegionEngine { source, .. } => source.status_code(),
 
             FindLogicalRegions { source, .. } => source.status_code(),
+            BuildMitoEngine { source, .. } => source.status_code(),
         }
     }
 

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -27,9 +27,9 @@ use std::{env, path};
 use common_base::readable_size::ReadableSize;
 use common_telemetry::logging::info;
 use object_store::layers::{LoggingLayer, LruCacheLayer, RetryLayer, TracingLayer};
-use object_store::services::Fs as FsBuilder;
-use object_store::util::normalize_dir;
-use object_store::{util, HttpClient, ObjectStore, ObjectStoreBuilder};
+use object_store::services::Fs;
+use object_store::util::{join_dir, normalize_dir};
+use object_store::{HttpClient, ObjectStore, ObjectStoreBuilder};
 use snafu::prelude::*;
 
 use crate::config::{ObjectStoreConfig, DEFAULT_OBJECT_STORE_CACHE_SIZE};
@@ -114,10 +114,9 @@ async fn create_object_store_with_cache(
     };
 
     if let Some(path) = cache_path {
-        let path = util::normalize_dir(path);
-        let atomic_temp_dir = format!("{path}.tmp/");
+        let atomic_temp_dir = join_dir(path, ".tmp/");
         clean_temp_dir(&atomic_temp_dir)?;
-        let cache_store = FsBuilder::default()
+        let cache_store = Fs::default()
             .root(&path)
             .atomic_write_dir(&atomic_temp_dir)
             .build()

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -108,7 +108,7 @@ async fn create_object_store_with_cache(
         let atomic_temp_dir = join_dir(path, ".tmp/");
         clean_temp_dir(&atomic_temp_dir)?;
         let cache_store = Fs::default()
-            .root(&path)
+            .root(path)
             .atomic_write_dir(&atomic_temp_dir)
             .build()
             .context(error::InitBackendSnafu)?;

--- a/src/datanode/src/store/azblob.rs
+++ b/src/datanode/src/store/azblob.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_telemetry::logging::info;
-use object_store::services::Azblob as AzureBuilder;
+use object_store::services::Azblob;
 use object_store::{util, ObjectStore};
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
@@ -30,7 +30,7 @@ pub(crate) async fn new_azblob_object_store(azblob_config: &AzblobConfig) -> Res
         azblob_config.container, &root
     );
 
-    let mut builder = AzureBuilder::default();
+    let mut builder = Azblob::default();
     let _ = builder
         .root(&root)
         .container(&azblob_config.container)

--- a/src/datanode/src/store/fs.rs
+++ b/src/datanode/src/store/fs.rs
@@ -15,7 +15,8 @@
 use std::{fs, path};
 
 use common_telemetry::logging::info;
-use object_store::services::Fs as FsBuilder;
+use object_store::services::Fs;
+use object_store::util::join_dir;
 use object_store::ObjectStore;
 use snafu::prelude::*;
 
@@ -31,10 +32,10 @@ pub(crate) async fn new_fs_object_store(
         .context(error::CreateDirSnafu { dir: data_home })?;
     info!("The file storage home is: {}", data_home);
 
-    let atomic_write_dir = format!("{data_home}.tmp/");
+    let atomic_write_dir = join_dir(data_home, ".tmp/");
     store::clean_temp_dir(&atomic_write_dir)?;
 
-    let mut builder = FsBuilder::default();
+    let mut builder = Fs::default();
     let _ = builder.root(data_home).atomic_write_dir(&atomic_write_dir);
 
     let object_store = ObjectStore::new(builder)

--- a/src/datanode/src/store/gcs.rs
+++ b/src/datanode/src/store/gcs.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_telemetry::logging::info;
-use object_store::services::Gcs as GCSBuilder;
+use object_store::services::Gcs;
 use object_store::{util, ObjectStore};
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
@@ -29,7 +29,7 @@ pub(crate) async fn new_gcs_object_store(gcs_config: &GcsConfig) -> Result<Objec
         gcs_config.bucket, &root
     );
 
-    let mut builder = GCSBuilder::default();
+    let mut builder = Gcs::default();
     builder
         .root(&root)
         .bucket(&gcs_config.bucket)

--- a/src/datanode/src/store/oss.rs
+++ b/src/datanode/src/store/oss.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_telemetry::logging::info;
-use object_store::services::Oss as OSSBuilder;
+use object_store::services::Oss;
 use object_store::{util, ObjectStore};
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
@@ -29,7 +29,7 @@ pub(crate) async fn new_oss_object_store(oss_config: &OssConfig) -> Result<Objec
         oss_config.bucket, &root
     );
 
-    let mut builder = OSSBuilder::default();
+    let mut builder = Oss::default();
     let _ = builder
         .root(&root)
         .bucket(&oss_config.bucket)

--- a/src/datanode/src/store/s3.rs
+++ b/src/datanode/src/store/s3.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use common_telemetry::logging::info;
-use object_store::services::S3 as S3Builder;
+use object_store::services::S3;
 use object_store::{util, ObjectStore};
 use secrecy::ExposeSecret;
 use snafu::prelude::*;
@@ -30,7 +30,7 @@ pub(crate) async fn new_s3_object_store(s3_config: &S3Config) -> Result<ObjectSt
         s3_config.bucket, &root
     );
 
-    let mut builder = S3Builder::default();
+    let mut builder = S3::default();
     let _ = builder
         .root(&root)
         .bucket(&s3_config.bucket)

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -67,9 +67,9 @@ pub struct MitoConfig {
     pub vector_cache_size: ReadableSize,
     /// Cache size for pages of SST row groups (default 512MB). Setting it to 0 to disable the cache.
     pub page_cache_size: ReadableSize,
-    /// Path for write cache.
-    pub write_cache_path: Option<String>,
-    /// Capacity for write cache.
+    /// Path for write cache. Write cache is disabled if the path is empty.
+    pub write_cache_path: String,
+    /// Capacity for write cache. Setting it to 0 to disable the write cache.
     pub write_cache_size: ReadableSize,
 
     // Other configs:
@@ -99,7 +99,7 @@ impl Default for MitoConfig {
             sst_meta_cache_size: ReadableSize::mb(128),
             vector_cache_size: ReadableSize::mb(512),
             page_cache_size: ReadableSize::mb(512),
-            write_cache_path: None,
+            write_cache_path: String::new(),
             write_cache_size: ReadableSize::mb(512),
             sst_write_buffer_size: ReadableSize::mb(8),
             scan_parallelism: divide_num_cpus(4),

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -67,10 +67,11 @@ pub struct MitoConfig {
     pub vector_cache_size: ReadableSize,
     /// Cache size for pages of SST row groups (default 512MB). Setting it to 0 to disable the cache.
     pub page_cache_size: ReadableSize,
+    // TODO(yingwen): Remove `experimental` prefix once write cache is ready.
     /// Path for write cache. Write cache is disabled if the path is empty.
-    pub write_cache_path: String,
+    pub experimental_write_cache_path: String,
     /// Capacity for write cache. Setting it to 0 to disable the write cache.
-    pub write_cache_size: ReadableSize,
+    pub experimental_write_cache_size: ReadableSize,
 
     // Other configs:
     /// Buffer size for SST writing.
@@ -99,8 +100,8 @@ impl Default for MitoConfig {
             sst_meta_cache_size: ReadableSize::mb(128),
             vector_cache_size: ReadableSize::mb(512),
             page_cache_size: ReadableSize::mb(512),
-            write_cache_path: String::new(),
-            write_cache_size: ReadableSize::mb(512),
+            experimental_write_cache_path: String::new(),
+            experimental_write_cache_size: ReadableSize::mb(512),
             sst_write_buffer_size: ReadableSize::mb(8),
             scan_parallelism: divide_num_cpus(4),
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -67,6 +67,10 @@ pub struct MitoConfig {
     pub vector_cache_size: ReadableSize,
     /// Cache size for pages of SST row groups (default 512MB). Setting it to 0 to disable the cache.
     pub page_cache_size: ReadableSize,
+    /// Path for write cache.
+    pub write_cache_path: Option<String>,
+    /// Capacity for write cache.
+    pub write_cache_size: ReadableSize,
 
     // Other configs:
     /// Buffer size for SST writing.
@@ -95,6 +99,8 @@ impl Default for MitoConfig {
             sst_meta_cache_size: ReadableSize::mb(128),
             vector_cache_size: ReadableSize::mb(512),
             page_cache_size: ReadableSize::mb(512),
+            write_cache_path: None,
+            write_cache_size: ReadableSize::mb(512),
             sst_write_buffer_size: ReadableSize::mb(8),
             scan_parallelism: divide_num_cpus(4),
             parallel_scan_channel_size: DEFAULT_SCAN_CHANNEL_SIZE,

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -82,7 +82,7 @@ impl MitoEngine {
         log_store: Arc<S>,
         object_store_manager: ObjectStoreManagerRef,
     ) -> Result<MitoEngine> {
-        config.sanitize();
+        config.sanitize()?;
 
         Ok(MitoEngine {
             inner: Arc::new(EngineInner::new(config, log_store, object_store_manager).await?),
@@ -321,7 +321,7 @@ impl MitoEngine {
         write_buffer_manager: Option<crate::flush::WriteBufferManagerRef>,
         listener: Option<crate::engine::listener::EventListenerRef>,
     ) -> Result<MitoEngine> {
-        config.sanitize();
+        config.sanitize()?;
 
         let config = Arc::new(config);
         Ok(MitoEngine {

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -77,16 +77,16 @@ pub struct MitoEngine {
 
 impl MitoEngine {
     /// Returns a new [MitoEngine] with specific `config`, `log_store` and `object_store`.
-    pub fn new<S: LogStore>(
+    pub async fn new<S: LogStore>(
         mut config: MitoConfig,
         log_store: Arc<S>,
         object_store_manager: ObjectStoreManagerRef,
-    ) -> MitoEngine {
+    ) -> Result<MitoEngine> {
         config.sanitize();
 
-        MitoEngine {
+        Ok(MitoEngine {
             inner: Arc::new(EngineInner::new(config, log_store, object_store_manager)),
-        }
+        })
     }
 
     /// Returns true if the specific region exists.
@@ -314,17 +314,17 @@ impl RegionEngine for MitoEngine {
 #[cfg(any(test, feature = "test"))]
 impl MitoEngine {
     /// Returns a new [MitoEngine] for tests.
-    pub fn new_for_test<S: LogStore>(
+    pub async fn new_for_test<S: LogStore>(
         mut config: MitoConfig,
         log_store: Arc<S>,
         object_store_manager: ObjectStoreManagerRef,
         write_buffer_manager: Option<crate::flush::WriteBufferManagerRef>,
         listener: Option<crate::engine::listener::EventListenerRef>,
-    ) -> MitoEngine {
+    ) -> Result<MitoEngine> {
         config.sanitize();
 
         let config = Arc::new(config);
-        MitoEngine {
+        Ok(MitoEngine {
             inner: Arc::new(EngineInner {
                 workers: WorkerGroup::start_for_test(
                     config.clone(),
@@ -335,6 +335,6 @@ impl MitoEngine {
                 ),
                 config,
             }),
-        }
+        })
     }
 }

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -85,7 +85,7 @@ impl MitoEngine {
         config.sanitize();
 
         Ok(MitoEngine {
-            inner: Arc::new(EngineInner::new(config, log_store, object_store_manager)),
+            inner: Arc::new(EngineInner::new(config, log_store, object_store_manager).await?),
         })
     }
 
@@ -126,16 +126,16 @@ struct EngineInner {
 
 impl EngineInner {
     /// Returns a new [EngineInner] with specific `config`, `log_store` and `object_store`.
-    fn new<S: LogStore>(
+    async fn new<S: LogStore>(
         config: MitoConfig,
         log_store: Arc<S>,
         object_store_manager: ObjectStoreManagerRef,
-    ) -> EngineInner {
+    ) -> Result<EngineInner> {
         let config = Arc::new(config);
-        EngineInner {
-            workers: WorkerGroup::start(config.clone(), log_store, object_store_manager),
+        Ok(EngineInner {
+            workers: WorkerGroup::start(config.clone(), log_store, object_store_manager).await?,
             config,
-        }
+        })
     }
 
     /// Stop the inner engine.
@@ -332,7 +332,8 @@ impl MitoEngine {
                     object_store_manager,
                     write_buffer_manager,
                     listener,
-                ),
+                )
+                .await?,
                 config,
             }),
         })

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -470,6 +470,9 @@ pub enum Error {
         error: std::io::Error,
         location: Location,
     },
+
+    #[snafu(display("Invalid config, {reason}"))]
+    InvalidConfig { reason: String, location: Location },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -559,6 +562,7 @@ impl ErrorExt for Error {
                 source.status_code()
             }
             CleanDir { .. } => StatusCode::Unexpected,
+            InvalidConfig { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -429,35 +429,30 @@ pub enum Error {
 
     #[snafu(display("Failed to build index applier"))]
     BuildIndexApplier {
-        #[snafu(source)]
         source: index::inverted_index::error::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to convert value"))]
     ConvertValue {
-        #[snafu(source)]
         source: datatypes::error::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to apply index"))]
     ApplyIndex {
-        #[snafu(source)]
         source: index::inverted_index::error::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to read puffin metadata"))]
     PuffinReadMetadata {
-        #[snafu(source)]
         source: puffin::error::Error,
         location: Location,
     },
 
     #[snafu(display("Failed to read puffin blob"))]
     PuffinReadBlob {
-        #[snafu(source)]
         source: puffin::error::Error,
         location: Location,
     },
@@ -465,6 +460,14 @@ pub enum Error {
     #[snafu(display("Blob type not found, blob_type: {blob_type}"))]
     PuffinBlobTypeNotFound {
         blob_type: String,
+        location: Location,
+    },
+
+    #[snafu(display("Failed to clean dir {dir}"))]
+    CleanDir {
+        dir: String,
+        #[snafu(source)]
+        error: std::io::Error,
         location: Location,
     },
 }
@@ -555,6 +558,7 @@ impl ErrorExt for Error {
             PuffinReadMetadata { source, .. } | PuffinReadBlob { source, .. } => {
                 source.status_code()
             }
+            CleanDir { .. } => StatusCode::Unexpected,
         }
     }
 

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -743,7 +743,7 @@ mod tests {
             listener: WorkerListener::default(),
             engine_config: Arc::new(MitoConfig::default()),
             row_group_size: None,
-            cache_manager: Arc::new(CacheManager::new(0, 0, 0)),
+            cache_manager: Arc::new(CacheManager::default()),
         };
         task.push_sender(OptionOutputTx::from(output_tx));
         scheduler

--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -342,7 +342,8 @@ mod tests {
         assert_eq!([0, 1, 2, 3, 4], mapper.column_ids());
         assert_eq!([3, 4], mapper.batch_fields());
 
-        let cache = CacheManager::new(0, 1024, 0);
+        // With vector cache.
+        let cache = CacheManager::builder().vector_cache_size(1024).build();
         let batch = new_batch(0, &[1, 2], &[(3, 3), (4, 4)], 3);
         let record_batch = mapper.convert(&batch, Some(&cache)).unwrap();
         let expect = "\

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -170,7 +170,12 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let cache = Some(Arc::new(CacheManager::new(0, 0, 64 * 1024 * 1024)));
+        // Enable page cache.
+        let cache = Some(Arc::new(
+            CacheManager::builder()
+                .page_cache_size(64 * 1024 * 1024)
+                .build(),
+        ));
         let builder = ParquetReaderBuilder::new(FILE_DIR.to_string(), handle.clone(), object_store)
             .cache(cache.clone());
         for _ in 0..3 {

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -239,6 +239,8 @@ impl TestEnv {
             Arc::new(log_store),
             Arc::new(object_store_manager),
         )
+        .await
+        .unwrap()
     }
 
     /// Returns the log store and object store manager.

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -137,6 +137,8 @@ impl TestEnv {
         self.logstore = Some(logstore.clone());
         self.object_store_manager = Some(object_store_manager.clone());
         MitoEngine::new(config, logstore, object_store_manager)
+            .await
+            .unwrap()
     }
 
     /// Creates a new engine with specific config and existing logstore and object store manager.
@@ -145,6 +147,8 @@ impl TestEnv {
         let object_store_manager = self.object_store_manager.as_ref().unwrap().clone();
 
         MitoEngine::new(config, logstore, object_store_manager)
+            .await
+            .unwrap()
     }
 
     /// Creates a new engine with specific config and manager/listener under this env.
@@ -161,6 +165,8 @@ impl TestEnv {
         self.logstore = Some(logstore.clone());
         self.object_store_manager = Some(object_store_manager.clone());
         MitoEngine::new_for_test(config, logstore, object_store_manager, manager, listener)
+            .await
+            .unwrap()
     }
 
     pub async fn create_engine_with_multiple_object_stores(
@@ -190,6 +196,8 @@ impl TestEnv {
         self.logstore = Some(logstore.clone());
         self.object_store_manager = Some(object_store_manager.clone());
         MitoEngine::new_for_test(config, logstore, object_store_manager, manager, listener)
+            .await
+            .unwrap()
     }
 
     /// Reopen the engine.
@@ -201,6 +209,8 @@ impl TestEnv {
             self.logstore.clone().unwrap(),
             self.object_store_manager.clone().unwrap(),
         )
+        .await
+        .unwrap()
     }
 
     /// Open the engine.
@@ -210,6 +220,8 @@ impl TestEnv {
             self.logstore.clone().unwrap(),
             self.object_store_manager.clone().unwrap(),
         )
+        .await
+        .unwrap()
     }
 
     /// Only initializes the object store manager, returns the default object store.

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -66,11 +66,7 @@ impl SchedulerEnv {
     ) -> CompactionScheduler {
         let scheduler = self.get_scheduler();
 
-        CompactionScheduler::new(
-            scheduler,
-            request_sender,
-            Arc::new(CacheManager::new(0, 0, 0)),
-        )
+        CompactionScheduler::new(scheduler, request_sender, Arc::new(CacheManager::default()))
     }
 
     /// Creates a new flush scheduler.

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -264,11 +264,16 @@ async fn write_cache_from_config(
     config: &MitoConfig,
     object_store_manager: ObjectStoreManagerRef,
 ) -> Result<Option<WriteCacheRef>> {
-    let Some(path) = &config.write_cache_path else {
+    if config.write_cache_size.as_bytes() == 0 || config.write_cache_path.is_empty() {
         return Ok(None);
-    };
+    }
 
-    let cache = WriteCache::new_fs(path, object_store_manager, config.write_cache_size).await?;
+    let cache = WriteCache::new_fs(
+        &config.write_cache_path,
+        object_store_manager,
+        config.write_cache_size,
+    )
+    .await?;
     Ok(Some(Arc::new(cache)))
 }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -264,7 +264,9 @@ async fn write_cache_from_config(
     config: &MitoConfig,
     object_store_manager: ObjectStoreManagerRef,
 ) -> Result<Option<WriteCacheRef>> {
-    if config.write_cache_size.as_bytes() == 0 || config.write_cache_path.is_empty() {
+    if config.experimental_write_cache_size.as_bytes() == 0
+        || config.experimental_write_cache_path.is_empty()
+    {
         return Ok(None);
     }
 
@@ -272,9 +274,9 @@ async fn write_cache_from_config(
     warn!("Write cache is an experimental feature");
 
     let cache = WriteCache::new_fs(
-        &config.write_cache_path,
+        &config.experimental_write_cache_path,
         object_store_manager,
-        config.write_cache_size,
+        config.experimental_write_cache_size,
     )
     .await?;
     Ok(Some(Arc::new(cache)))

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -264,9 +264,7 @@ async fn write_cache_from_config(
     config: &MitoConfig,
     object_store_manager: ObjectStoreManagerRef,
 ) -> Result<Option<WriteCacheRef>> {
-    if config.experimental_write_cache_size.as_bytes() == 0
-        || config.experimental_write_cache_path.is_empty()
-    {
+    if !config.enable_experimental_write_cache {
         return Ok(None);
     }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -268,6 +268,9 @@ async fn write_cache_from_config(
         return Ok(None);
     }
 
+    // TODO(yingwen): Remove this and document the config once the write cache is ready.
+    warn!("Write cache is an experimental feature");
+
     let cache = WriteCache::new_fs(
         &config.write_cache_path,
         object_store_manager,

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -120,11 +120,13 @@ impl WorkerGroup {
             config.global_write_buffer_size.as_bytes() as usize,
         ));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = Arc::new(CacheManager::new(
-            config.sst_meta_cache_size.as_bytes(),
-            config.vector_cache_size.as_bytes(),
-            config.page_cache_size.as_bytes(),
-        ));
+        let cache_manager = Arc::new(
+            CacheManager::builder()
+                .sst_meta_cache_size(config.sst_meta_cache_size.as_bytes())
+                .vector_cache_size(config.vector_cache_size.as_bytes())
+                .page_cache_size(config.page_cache_size.as_bytes())
+                .build(),
+        );
 
         let workers = (0..config.num_workers)
             .map(|id| {
@@ -217,11 +219,13 @@ impl WorkerGroup {
             ))
         });
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
-        let cache_manager = Arc::new(CacheManager::new(
-            config.sst_meta_cache_size.as_bytes(),
-            config.vector_cache_size.as_bytes(),
-            config.page_cache_size.as_bytes(),
-        ));
+        let cache_manager = Arc::new(
+            CacheManager::builder()
+                .sst_meta_cache_size(config.sst_meta_cache_size.as_bytes())
+                .vector_cache_size(config.vector_cache_size.as_bytes())
+                .page_cache_size(config.page_cache_size.as_bytes())
+                .build(),
+        );
 
         let workers = (0..config.num_workers)
             .map(|id| {

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 use futures::TryStreamExt;
+use opendal::layers::{LoggingLayer, TracingLayer};
 use opendal::{Entry, Lister};
+
+use crate::layers::PrometheusMetricsLayer;
+use crate::ObjectStore;
 
 /// Collect all entries from the [Lister].
 pub async fn collect(stream: Lister) -> Result<Vec<Entry>, opendal::Error> {
@@ -51,6 +55,20 @@ pub fn join_dir(parent: &str, child: &str) -> String {
 pub fn join_path(parent: &str, child: &str) -> String {
     let output = format!("{parent}/{child}");
     opendal::raw::normalize_path(&output)
+}
+
+/// Attaches instrument layers to the object store.
+pub fn with_instrument_layers(object_store: ObjectStore) -> ObjectStore {
+    object_store
+        .layer(
+            LoggingLayer::default()
+                // Print the expected error only in DEBUG level.
+                // See https://docs.rs/opendal/latest/opendal/layers/struct.LoggingLayer.html#method.with_error_level
+                .with_error_level(Some("debug"))
+                .expect("input error level must be valid"),
+        )
+        .layer(TracingLayer)
+        .layer(PrometheusMetricsLayer)
 }
 
 #[cfg(test)]

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -15,6 +15,7 @@
 use futures::TryStreamExt;
 use opendal::{Entry, Lister};
 
+/// Collect all entries from the [Lister].
 pub async fn collect(stream: Lister) -> Result<Vec<Entry>, opendal::Error> {
     stream.try_collect::<Vec<_>>().await
 }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -804,6 +804,7 @@ global_write_buffer_reject_size = "2GiB"
 sst_meta_cache_size = "128MiB"
 vector_cache_size = "512MiB"
 page_cache_size = "512MiB"
+enable_experimental_write_cache = false
 experimental_write_cache_path = ""
 experimental_write_cache_size = "512MiB"
 sst_write_buffer_size = "8MiB"

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -804,8 +804,8 @@ global_write_buffer_reject_size = "2GiB"
 sst_meta_cache_size = "128MiB"
 vector_cache_size = "512MiB"
 page_cache_size = "512MiB"
-write_cache_path = ""
-write_cache_size = "512MiB"
+experimental_write_cache_path = ""
+experimental_write_cache_size = "512MiB"
 sst_write_buffer_size = "8MiB"
 parallel_scan_channel_size = 32
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -804,6 +804,8 @@ global_write_buffer_reject_size = "2GiB"
 sst_meta_cache_size = "128MiB"
 vector_cache_size = "512MiB"
 page_cache_size = "512MiB"
+write_cache_path = ""
+write_cache_size = "512MiB"
 sst_write_buffer_size = "8MiB"
 parallel_scan_channel_size = 32
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR initializes the `WriteCache` according to the mito config. By default, the write cache is under `DATA_HOME/write_cache` and is disabled.

It addresses an issue that the file cache doesn't use `get()` to access cache entries.

It also refactors some mods to make the integration easier
- Adds a builder for the `CacheManager`
- Recovers the `FileCache` in `WriteCache::new`
- `MitoEngine::new` is an async function now
- Provides a util to attach layers to `ObjectStore`

Now write cache is still an experimental feature so I added prefixes to its config items.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2965