### PR TITLE
feat: write and upload sst

### DIFF
--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -210,6 +210,16 @@ pub(crate) struct IndexValue {
     file_size: u32,
 }
 
+impl IndexValue {
+    pub fn new(file_size: u32) -> IndexValue {
+        IndexValue { file_size }
+    }
+
+    pub fn file_size(&self) -> u32 {
+        self.file_size
+    }
+}
+
 /// Generates the path to the cached file.
 ///
 /// The file name format is `{region_id}.{file_id}`

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -90,6 +90,10 @@ impl FileCache {
         }
     }
 
+    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
+        self.memory_index.contains_key(key)
+    }
+
     /// Puts a file into the cache index.
     ///
     /// The `WriteCache` should ensure the file is in the correct path.

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -213,7 +213,7 @@ pub(crate) type IndexKey = (RegionId, FileId);
 #[derive(Debug, Clone)]
 pub(crate) struct IndexValue {
     /// Size of the file in bytes.
-    pub file_size: u32,
+    pub(crate) file_size: u32,
 }
 
 /// Generates the path to the cached file.

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -90,10 +90,6 @@ impl FileCache {
         }
     }
 
-    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
-        self.memory_index.contains_key(key)
-    }
-
     /// Puts a file into the cache index.
     ///
     /// The `WriteCache` should ensure the file is in the correct path.
@@ -200,6 +196,12 @@ impl FileCache {
             Ok(None)
         }
     }
+
+    /// Checks if the key is in the file cache.
+    #[cfg(test)]
+    pub(crate) fn contains_key(&self, key: &IndexKey) -> bool {
+        self.memory_index.contains_key(key)
+    }
 }
 
 /// Key of file cache index.
@@ -211,17 +213,7 @@ pub(crate) type IndexKey = (RegionId, FileId);
 #[derive(Debug, Clone)]
 pub(crate) struct IndexValue {
     /// Size of the file in bytes.
-    file_size: u32,
-}
-
-impl IndexValue {
-    pub fn new(file_size: u32) -> IndexValue {
-        IndexValue { file_size }
-    }
-
-    pub fn file_size(&self) -> u32 {
-        self.file_size
-    }
+    pub file_size: u32,
 }
 
 /// Generates the path to the cached file.

--- a/src/mito2/src/cache/test_util.rs
+++ b/src/mito2/src/cache/test_util.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 use bytes::Bytes;
 use datatypes::arrow::array::{ArrayRef, Int64Array};
 use datatypes::arrow::record_batch::RecordBatch;
+use object_store::services::Fs;
+use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::file::metadata::ParquetMetaData;
@@ -41,4 +43,10 @@ fn parquet_file_data() -> Vec<u8> {
     writer.close().unwrap();
 
     buffer
+}
+
+pub(crate) fn new_fs_store(path: &str) -> ObjectStore {
+    let mut builder = Fs::default();
+    builder.root(path);
+    ObjectStore::new(builder).unwrap().finish()
 }

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -128,7 +128,7 @@ impl WriteCache {
         writer.close().await.context(error::OpenDalSnafu)?;
 
         debug!(
-            "Sucessfully upload file to remote, region: {}, file: {}, upload_path: {}, cost: {:?}s",
+            "Successfully upload file to remote, region: {}, file: {}, upload_path: {}, cost: {:?}s",
             region_id,
             file_id,
             upload_path,

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -101,10 +101,10 @@ impl WriteCache {
         timer.stop_and_record();
 
         // Upload sst file to remote object store.
-        if sst_info.is_none() {
+        let Some(sst_info) = sst_info else {
             // No data need to upload.
             return Ok(None);
-        }
+        };
 
         let timer = FLUSH_ELAPSED
             .with_label_values(&["upload_sst"])
@@ -143,14 +143,12 @@ impl WriteCache {
         );
 
         // Register to file cache
-        if let Some(sst_info) = &sst_info {
-            let file_size = sst_info.file_size as u32;
-            self.file_cache
-                .put((region_id, file_id), IndexValue { file_size })
-                .await;
-        }
+        let file_size = sst_info.file_size as u32;
+        self.file_cache
+            .put((region_id, file_id), IndexValue { file_size })
+            .await;
 
-        Ok(sst_info)
+        Ok(Some(sst_info))
     }
 }
 

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -82,7 +82,7 @@ impl WriteCache {
         write_opts: &WriteOptions,
     ) -> Result<Option<SstInfo>> {
         let timer = FLUSH_ELAPSED
-            .with_label_values(&["write_parquet"])
+            .with_label_values(&["write_sst"])
             .start_timer();
 
         let region_id = request.metadata.region_id;
@@ -106,7 +106,7 @@ impl WriteCache {
             return Ok(None);
         }
 
-        let timer = FLUSH_ELAPSED.with_label_values(&["upload"]).start_timer();
+        let timer = FLUSH_ELAPSED.with_label_values(&["upload_sst"]).start_timer();
 
         let reader = self
             .file_cache

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -106,7 +106,9 @@ impl WriteCache {
             return Ok(None);
         }
 
-        let timer = FLUSH_ELAPSED.with_label_values(&["upload_sst"]).start_timer();
+        let timer = FLUSH_ELAPSED
+            .with_label_values(&["upload_sst"])
+            .start_timer();
 
         let reader = self
             .file_cache

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -201,7 +201,9 @@ mod tests {
             local_store.clone(),
             object_store_manager,
             ReadableSize::mb(10),
-        );
+        )
+        .await
+        .unwrap();
 
         // Create Source
         let metadata = Arc::new(sst_region_metadata());

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -512,6 +512,19 @@ pub enum Error {
         flushed_entry_id: u64,
         unexpected_entry_id: u64,
     },
+
+    #[snafu(display(
+        "Failed to upload sst file, region_id: {}, file_id: {}",
+        region_id,
+        file_id
+    ))]
+    UploadSst {
+        region_id: RegionId,
+        file_id: FileId,
+        #[snafu(source)]
+        error: std::io::Error,
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -608,6 +621,7 @@ impl ErrorExt for Error {
             CleanDir { .. } => StatusCode::Unexpected,
             InvalidConfig { .. } => StatusCode::InvalidArguments,
             StaleLogEntry { .. } => StatusCode::Unexpected,
+            UploadSst { .. } => StatusCode::StorageUnavailable,
         }
     }
 

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -145,6 +145,18 @@ lazy_static! {
         &[TYPE_LABEL]
     )
     .unwrap();
+    /// Upload bytes counter.
+    pub static ref UPLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
+        "mito_upload_bytes_total",
+        "mito upload bytes total",
+    )
+    .unwrap();
+    /// Timer of upload.
+    pub static ref WRITE_AND_UPLOAD_ELAPSED_TOTAL: Histogram = register_histogram!(
+        "mito_write_and_upload_elapsed_total",
+        "mito write and upload elapsed total",
+    )
+    .unwrap();
     // ------- End of cache metrics.
 
     // Index metrics.

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -151,12 +151,6 @@ lazy_static! {
         "mito upload bytes total",
     )
     .unwrap();
-    /// Timer of upload.
-    pub static ref WRITE_AND_UPLOAD_ELAPSED_TOTAL: Histogram = register_histogram!(
-        "mito_write_and_upload_elapsed_total",
-        "mito write and upload elapsed total",
-    )
-    .unwrap();
     // ------- End of cache metrics.
 
     // Index metrics.

--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -23,5 +23,5 @@ pub mod location;
 pub mod parquet;
 pub(crate) mod version;
 
-/// Default write buffer size.
+/// Default write buffer size, it should be greater than the default minimum upload part of S3 (5mb).
 pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);

--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -14,9 +14,14 @@
 
 //! Sorted strings tables.
 
+use common_base::readable_size::ReadableSize;
+
 pub mod file;
 pub mod file_purger;
 pub mod index;
 pub mod location;
 pub mod parquet;
 pub(crate) mod version;
+
+/// Default write buffer size.
+pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -27,11 +27,12 @@ use std::sync::Arc;
 use common_base::readable_size::ReadableSize;
 use parquet::file::metadata::ParquetMetaData;
 
+use super::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::sst::file::FileTimeRange;
 
 /// Key of metadata in parquet SST.
 pub const PARQUET_METADATA_KEY: &str = "greptime:metadata";
-pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
+
 /// Default batch size to read parquet files.
 pub(crate) const DEFAULT_READ_BATCH_SIZE: usize = 1024;
 /// Default row group size for parquet files.
@@ -71,32 +72,18 @@ pub struct SstInfo {
 mod tests {
     use std::sync::Arc;
 
-    use api::v1::OpType;
     use common_time::Timestamp;
 
     use super::*;
     use crate::cache::{CacheManager, PageKey};
-    use crate::read::Batch;
     use crate::sst::parquet::reader::ParquetReaderBuilder;
     use crate::sst::parquet::writer::ParquetWriter;
     use crate::test_util::sst_util::{
-        new_primary_key, new_source, sst_file_handle, sst_region_metadata,
+        new_batch_by_range, new_source, sst_file_handle, sst_region_metadata,
     };
-    use crate::test_util::{check_reader_result, new_batch_builder, TestEnv};
+    use crate::test_util::{check_reader_result, TestEnv};
 
     const FILE_DIR: &str = "/";
-
-    fn new_batch_by_range(tags: &[&str], start: usize, end: usize) -> Batch {
-        assert!(end > start);
-        let pk = new_primary_key(tags);
-        let timestamps: Vec<_> = (start..end).map(|v| v as i64).collect();
-        let sequences = vec![1000; end - start];
-        let op_types = vec![OpType::Put; end - start];
-        let field: Vec<_> = (start..end).map(|v| v as u64).collect();
-        new_batch_builder(&pk, &timestamps, &sequences, &op_types, 2, &field)
-            .build()
-            .unwrap()
-    }
 
     #[tokio::test]
     async fn test_write_read() {

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -31,7 +31,7 @@ use crate::sst::file::FileTimeRange;
 
 /// Key of metadata in parquet SST.
 pub const PARQUET_METADATA_KEY: &str = "greptime:metadata";
-const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
+pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
 /// Default batch size to read parquet files.
 pub(crate) const DEFAULT_READ_BATCH_SIZE: usize = 1024;
 /// Default row group size for parquet files.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
part of #2965
write sst file to cache and upload it to remote object store

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
#2965 