### PR TITLE
fix: check env before running kafka test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,6 +4522,7 @@ dependencies = [
  "store-api",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -40,3 +40,4 @@ tokio.workspace = true
 common-meta = { workspace = true, features = ["testing"] }
 common-test-util.workspace = true
 rand.workspace = true
+uuid.workspace = true

--- a/src/log-store/src/kafka/util/record.rs
+++ b/src/log-store/src/kafka/util/record.rs
@@ -300,6 +300,7 @@ mod tests {
     use super::*;
     use crate::kafka::client_manager::ClientManager;
     use crate::kafka::util::test_util::run_test_with_kafka_wal;
+
     // Implements some utility methods for testing.
     impl Default for Record {
         fn default() -> Self {

--- a/src/log-store/src/kafka/util/record.rs
+++ b/src/log-store/src/kafka/util/record.rs
@@ -295,11 +295,11 @@ mod tests {
 
     use common_base::readable_size::ReadableSize;
     use common_config::wal::KafkaConfig;
-    use rand::Rng;
+    use uuid::Uuid;
 
     use super::*;
     use crate::kafka::client_manager::ClientManager;
-
+    use crate::kafka::util::test_util::run_test_with_kafka_wal;
     // Implements some utility methods for testing.
     impl Default for Record {
         fn default() -> Self {
@@ -544,21 +544,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_produce_large_entry() {
-        let topic = format!("greptimedb_wal_topic_{}", rand::thread_rng().gen::<usize>());
-        let ns = NamespaceImpl {
-            region_id: 1,
-            topic,
-        };
-        let entry = new_test_entry([b'1'; 2000000], 0, ns.clone());
-        let producer = RecordProducer::new(ns.clone()).with_entries(vec![entry]);
-
-        // TODO(niebayes): get broker endpoints from env vars.
-        let config = KafkaConfig {
-            broker_endpoints: vec!["localhost:9092".to_string()],
-            max_batch_size: ReadableSize::mb(1),
-            ..Default::default()
-        };
-        let manager = Arc::new(ClientManager::try_new(&config).await.unwrap());
-        producer.produce(&manager).await.unwrap();
+        run_test_with_kafka_wal(|broker_endpoints| {
+            Box::pin(async {
+                let topic = format!("greptimedb_wal_topic_{}", Uuid::new_v4());
+                let ns = NamespaceImpl {
+                    region_id: 1,
+                    topic,
+                };
+                let entry = new_test_entry([b'1'; 2000000], 0, ns.clone());
+                let producer = RecordProducer::new(ns.clone()).with_entries(vec![entry]);
+                let config = KafkaConfig {
+                    broker_endpoints,
+                    max_batch_size: ReadableSize::mb(1),
+                    ..Default::default()
+                };
+                let manager = Arc::new(ClientManager::try_new(&config).await.unwrap());
+                producer.produce(&manager).await.unwrap();
+            })
+        })
+        .await
     }
 }

--- a/src/log-store/src/kafka/util/test_util.rs
+++ b/src/log-store/src/kafka/util/test_util.rs
@@ -21,11 +21,10 @@ pub async fn run_test_with_kafka_wal<F>(test: F)
 where
     F: FnOnce(Vec<String>) -> BoxFuture<'static, ()>,
 {
-    let endpoints = env::var("GT_KAFKA_ENDPOINTS").unwrap_or_default();
-    if endpoints.is_empty() {
+    let Ok(endpoints) = env::var("GT_KAFKA_ENDPOINTS") else {
         warn!("The endpoints is empty, skipping the test");
         return;
-    }
+    };
 
     let endpoints = endpoints
         .split(',')

--- a/src/log-store/src/kafka/util/test_util.rs
+++ b/src/log-store/src/kafka/util/test_util.rs
@@ -12,7 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod offset;
-pub mod record;
-#[cfg(test)]
-mod test_util;
+use std::env;
+
+use common_telemetry::warn;
+use futures_util::future::BoxFuture;
+
+pub async fn run_test_with_kafka_wal<F>(test: F)
+where
+    F: FnOnce(Vec<String>) -> BoxFuture<'static, ()>,
+{
+    let endpoints = env::var("GT_KAFKA_ENDPOINTS").unwrap_or_default();
+    if endpoints.is_empty() {
+        warn!("The endpoints is empty, skipping the test");
+        return;
+    }
+
+    let endpoints = endpoints
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect::<Vec<_>>();
+
+    test(endpoints).await
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

check env before running kafka test

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
