### PR TITLE
feat: add options to enable log recycle and periodical fsync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,6 +4509,8 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-test-util",
+ "common-time",
+ "dashmap",
  "futures",
  "futures-util",
  "itertools 0.10.5",

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -138,6 +138,12 @@ purge_interval = "10m"
 read_batch_size = 128
 # Whether to sync log file after every write.
 sync_write = false
+# Whether to reuse logically truncated log files.
+enable_log_recycle = true
+# Whether to pre-create log files on start up
+prefill_log_files = false
+# Duration for fsyncing log files.
+sync_period = "1000ms"
 
 # Metadata storage options.
 [metadata_store]

--- a/src/common/config/src/wal/raft_engine.rs
+++ b/src/common/config/src/wal/raft_engine.rs
@@ -34,6 +34,13 @@ pub struct RaftEngineConfig {
     pub read_batch_size: usize,
     // whether to sync log file after every write
     pub sync_write: bool,
+    // whether to reuse logically truncated log files.
+    pub enable_log_recycle: bool,
+    // whether to pre-create log files on start up
+    pub prefill_log_files: bool,
+    // duration for fsyncing log files.
+    #[serde(with = "humantime_serde")]
+    pub sync_period: Option<Duration>,
 }
 
 impl Default for RaftEngineConfig {
@@ -45,6 +52,9 @@ impl Default for RaftEngineConfig {
             purge_interval: Duration::from_secs(600),
             read_batch_size: 128,
             sync_write: false,
+            enable_log_recycle: true,
+            prefill_log_files: false,
+            sync_period: None,
         }
     }
 }

--- a/src/log-store/Cargo.toml
+++ b/src/log-store/Cargo.toml
@@ -22,6 +22,8 @@ common-macro.workspace = true
 common-meta.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true
+common-time.workspace = true
+dashmap.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 protobuf = { version = "2", features = ["bytes"] }

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -217,7 +217,7 @@ impl LogStore for RaftEngineLogStore {
 
         let mut sync = self.config.sync_write;
 
-        if let Some(sync_period) = self.config.sync_period.as_ref() {
+        if let Some(sync_period) = &self.config.sync_period {
             let now = common_time::util::current_time_millis();
             if now - self.last_sync_time.load(Ordering::Relaxed) >= sync_period.as_millis() as i64 {
                 self.last_sync_time.store(now, Ordering::Relaxed);

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -14,7 +14,9 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_stream::stream;
 use common_config::wal::{RaftEngineConfig, WalOptions};
@@ -41,6 +43,7 @@ pub struct RaftEngineLogStore {
     config: RaftEngineConfig,
     engine: Arc<Engine>,
     gc_task: RepeatedTask<Error>,
+    last_sync_time: AtomicI64,
 }
 
 pub struct PurgeExpiredFilesFunction {
@@ -80,6 +83,8 @@ impl RaftEngineLogStore {
             recovery_mode: RecoveryMode::TolerateTailCorruption,
             batch_compression_threshold: ReadableSize::kb(8),
             target_file_size: ReadableSize(config.file_size.0),
+            enable_log_recycle: config.enable_log_recycle,
+            prefill_for_recycle: config.prefill_log_files,
             ..Default::default()
         };
         let engine = Arc::new(Engine::open(raft_engine_config).context(RaftEngineSnafu)?);
@@ -94,6 +99,7 @@ impl RaftEngineLogStore {
             config,
             engine,
             gc_task,
+            last_sync_time: AtomicI64::new(0),
         };
         log_store.start()?;
         Ok(log_store)
@@ -210,9 +216,22 @@ impl LogStore for RaftEngineLogStore {
                 .context(AddEntryLogBatchSnafu)?;
         }
 
+        let mut sync = self.config.sync_write;
+        if let Some(sync_period) = self.config.sync_period.as_ref()
+            && let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH)
+        {
+            let now_millis = now.as_millis() as i64;
+            if now_millis - self.last_sync_time.load(Ordering::Relaxed)
+                >= sync_period.as_millis() as i64
+            {
+                self.last_sync_time.store(now_millis, Ordering::Relaxed);
+                sync = true;
+            }
+        }
+
         let _ = self
             .engine
-            .write(&mut batch, self.config.sync_write)
+            .write(&mut batch, sync)
             .context(RaftEngineSnafu)?;
 
         Ok(AppendBatchResponse { last_entry_ids })

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -711,6 +711,8 @@ purge_threshold = "4GiB"
 purge_interval = "10m"
 read_batch_size = 128
 sync_write = false
+enable_log_recycle = true
+prefill_log_files = false
 
 [datanode.storage]
 type = "{}"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds config to enable log recycle/prefill and periodical log fsync to smooth IO utilization. This change helps both local fs and S3 mode.

### Rows written per second change

- `enable_log_recycle`: true
- `prefill_log_files`: false
- `sync_period`: 1000ms

#### Local FS mode

Before:
![image](https://github.com/GreptimeTeam/greptimedb/assets/6406592/88e3a0a2-f988-4b85-ad78-cd340a78fcdd)
After:
![image](https://github.com/GreptimeTeam/greptimedb/assets/6406592/d707bdec-cc58-4e3a-bbf2-208ab2463a89)

#### S3 mode (tested on MinIO)
Before: 
![image](https://github.com/GreptimeTeam/greptimedb/assets/6406592/01d99a30-17ec-4c70-899f-053ca06bfc9d)
After:
![image](https://github.com/GreptimeTeam/greptimedb/assets/6406592/0e40bf5e-2076-4570-8405-32a7cf33bf07)





## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
Fixes #3085 