### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1179,7 +1179,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1451,7 +1451,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1484,7 +1484,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1565,7 +1565,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1598,7 +1598,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1690,7 +1690,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arc-swap",
  "build-data",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-recursion",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1889,7 +1889,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "once_cell",
  "rand",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "build-data",
 ]
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2690,7 +2690,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -3296,7 +3296,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -3360,7 +3360,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
  "strfmt",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "tokio",
  "toml 0.8.8",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4494,7 +4494,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -4801,7 +4801,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anymap",
  "api",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anymap",
  "api",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5740,7 +5740,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -5971,7 +5971,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -6290,7 +6290,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "auth",
  "common-base",
@@ -6548,7 +6548,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash 0.8.6",
  "async-recursion",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -6927,7 +6927,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -8197,7 +8197,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -8457,7 +8457,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aide",
  "api",
@@ -8553,7 +8553,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -8814,7 +8814,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "common-base",
@@ -8866,7 +8866,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9073,7 +9073,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9213,7 +9213,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9473,7 +9473,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-integration"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "api",
  "async-trait",
@@ -9529,7 +9529,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.5.0",
+ "substrait 0.5.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump version to 0.5.1

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
