### PR TITLE
fix: expose unsupported datatype error on mysql protocol

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -38,6 +38,12 @@ pub enum Error {
     #[snafu(display("Internal error: {}", err_msg))]
     Internal { err_msg: String },
 
+    #[snafu(display("Unsupported data type: {}, reason: {}", data_type, reason))]
+    UnsupportedDataType {
+        data_type: ConcreteDataType,
+        reason: String,
+    },
+
     #[snafu(display("Internal IO error"))]
     InternalIo {
         #[snafu(source)]
@@ -445,6 +451,8 @@ impl ErrorExt for Error {
             | CatalogError { .. }
             | GrpcReflectionService { .. }
             | BuildHttpResponse { .. } => StatusCode::Internal,
+
+            UnsupportedDataType { .. } => StatusCode::Unsupported,
 
             #[cfg(not(windows))]
             UpdateJemallocMetrics { .. } => StatusCode::Internal,

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -265,8 +265,9 @@ pub(crate) fn create_mysql_column(
         ConcreteDataType::Interval(_) => Ok(ColumnType::MYSQL_TYPE_VARCHAR),
         ConcreteDataType::Duration(_) => Ok(ColumnType::MYSQL_TYPE_TIME),
         ConcreteDataType::Decimal128(_) => Ok(ColumnType::MYSQL_TYPE_DECIMAL),
-        _ => error::InternalSnafu {
-            err_msg: format!("not implemented for column datatype {:?}", data_type),
+        _ => error::UnsupportedDataTypeSnafu {
+            data_type,
+            reason: "not implemented",
         }
         .fail(),
     };

--- a/src/servers/src/postgres/types.rs
+++ b/src/servers/src/postgres/types.rs
@@ -135,8 +135,9 @@ pub(super) fn type_gt_to_pg(origin: &ConcreteDataType) -> Result<Type> {
         &ConcreteDataType::Decimal128(_) => Ok(Type::NUMERIC),
         &ConcreteDataType::Duration(_)
         | &ConcreteDataType::List(_)
-        | &ConcreteDataType::Dictionary(_) => error::InternalSnafu {
-            err_msg: format!("not implemented for column datatype {origin:?}"),
+        | &ConcreteDataType::Dictionary(_) => error::UnsupportedDataTypeSnafu {
+            data_type: origin,
+            reason: "not implemented",
         }
         .fail(),
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Change the error type on encountering unsupported datatype when writing to MySQL protocol. Makes it easier to understand what's happening

Before:
```sql
ERROR 1815 (HY000): Internal error: 1003
```

After:
```sql
ERROR 1815 (HY000): Unsupported data type: List<String>
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
