### PR TITLE
chore: change the default doc checkbox to no need

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@ Please explain IN DETAIL what the changes are in this PR and why they are needed
 
 - [ ]  I have written the necessary rustdoc comments.
 - [ ]  I have added the necessary unit tests and integration tests.
-- [ ]  This PR does not require documentation updates.
+- [x]  This PR does not require documentation updates.
 
 ## Refer to a related PR or issue link (optional)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Change the default "require document update" checkbox to not required. Thus an opt-in workflow (it's sometimes annoying, like https://github.com/GreptimeTeam/greptimedb/pull/3114)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
