### PR TITLE
feat: update our cross schema check to cross catalog

### DIFF
--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -56,7 +56,7 @@ impl DfContextProviderAdapter {
 
         let mut table_provider = DfTableSourceProvider::new(
             engine_state.catalog_manager().clone(),
-            engine_state.disallow_cross_schema_query(),
+            engine_state.disallow_cross_catalog_query(),
             query_ctx.as_ref(),
         );
 

--- a/src/query/src/planner.rs
+++ b/src/query/src/planner.rs
@@ -58,7 +58,7 @@ impl DfLogicalPlanner {
 
         let table_provider = DfTableSourceProvider::new(
             self.engine_state.catalog_manager().clone(),
-            self.engine_state.disallow_cross_schema_query(),
+            self.engine_state.disallow_cross_catalog_query(),
             query_ctx.as_ref(),
         );
 
@@ -91,7 +91,7 @@ impl DfLogicalPlanner {
     async fn plan_pql(&self, stmt: EvalStmt, query_ctx: QueryContextRef) -> Result<LogicalPlan> {
         let table_provider = DfTableSourceProvider::new(
             self.engine_state.catalog_manager().clone(),
-            self.engine_state.disallow_cross_schema_query(),
+            self.engine_state.disallow_cross_catalog_query(),
             query_ctx.as_ref(),
         );
         PromPlanner::stmt_to_plan(table_provider, stmt)

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -163,9 +163,9 @@ impl QueryEngineState {
         self.table_mutation_handler.as_ref()
     }
 
-    pub(crate) fn disallow_cross_schema_query(&self) -> bool {
+    pub(crate) fn disallow_cross_catalog_query(&self) -> bool {
         self.plugins
-            .map::<QueryOptions, _, _>(|x| x.disallow_cross_schema_query)
+            .map::<QueryOptions, _, _>(|x| x.disallow_cross_catalog_query)
             .unwrap_or(false)
     }
 

--- a/src/query/src/tests/query_engine_test.rs
+++ b/src/query/src/tests/query_engine_test.rs
@@ -125,7 +125,7 @@ async fn test_query_validate() -> Result<()> {
     // set plugins
     let plugins = Plugins::new();
     plugins.insert(QueryOptions {
-        disallow_cross_schema_query: true,
+        disallow_cross_catalog_query: true,
     });
 
     let factory = QueryEngineFactory::new_with_plugins(catalog_list, None, None, false, plugins);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

We was restricting cross-schema query because of our cloud permission system. As we are switching to catalog based service, we start to allow those cross-schema access. This patch updates check to valid catalog only. It enables us to utilize internal schema `greptime_private`.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
