### PR TITLE
fix: unstable time record test

### DIFF
--- a/src/mito2/src/sst/index/creator/statistics.rs
+++ b/src/mito2/src/sst/index/creator/statistics.rs
@@ -144,12 +144,25 @@ mod tests {
             let mut guard = stats.record_update();
             guard.inc_byte_count(100);
             guard.inc_row_count(10);
+
+            let now = Instant::now();
+            while now.elapsed().is_zero() {
+                // busy loop
+            }
         }
         {
             let _guard = stats.record_finish();
+            let now = Instant::now();
+            while now.elapsed().is_zero() {
+                // busy loop
+            }
         }
         {
             let _guard = stats.record_cleanup();
+            let now = Instant::now();
+            while now.elapsed().is_zero() {
+                // busy loop
+            }
         }
         assert_eq!(stats.row_count(), 10);
         assert_eq!(stats.byte_count(), 100);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use a busy loop to ensure the monotonic timer has been advanced.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
