### PR TITLE
chore: stop exposing num_partitions

### DIFF
--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -64,8 +64,6 @@ provider = "raft_engine"
 # selector_type = "round_robin"
 # A Kafka topic is constructed by concatenating `topic_name_prefix` and `topic_id`.
 # topic_name_prefix = "greptimedb_wal_topic"
-# Number of partitions per topic.
-# num_partitions = 1
 # Expected number of replicas of each partition.
 # replication_factor = 1
 # Above which a topic creation operation will be cancelled.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -102,9 +102,8 @@ provider = "raft_engine"
 # selector_type = "round_robin"
 # The prefix of topic name.
 # topic_name_prefix = "greptimedb_wal_topic"
-# Number of partitions per topic.
-# num_partitions = 1
 # The number of replicas of each partition.
+# Warning: the replication factor must be positive and must not be greater than the number of broker endpoints.
 # replication_factor = 1
 
 # The max size of a single producer batch.

--- a/src/common/meta/src/wal.rs
+++ b/src/common/meta/src/wal.rs
@@ -97,7 +97,6 @@ mod tests {
             num_topics = 32
             selector_type = "round_robin"
             topic_name_prefix = "greptimedb_wal_topic"
-            num_partitions = 1
             replication_factor = 1
             create_topic_timeout = "30s"
             backoff_init = "500ms"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Since we only utilize the partition 0 (the first partition) of each Kafka topic, there's no need to expose the `num_partitions` to users through config file. If it's exposed, some users may set it to be greater than 1 and expect that there're multiple partitions per topic which we cannot provide.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
