### PR TITLE
refactor:  implement version as built-in function and use fixed mysql version

### DIFF
--- a/src/common/function/src/system.rs
+++ b/src/common/function/src/system.rs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 pub mod build;
+pub mod version;
 
 use std::sync::Arc;
 
 use build::BuildFunction;
+use version::VersionFunction;
 
 use crate::function_registry::FunctionRegistry;
 
@@ -25,5 +27,6 @@ pub(crate) struct SystemFunction;
 impl SystemFunction {
     pub fn register(registry: &FunctionRegistry) {
         registry.register(Arc::new(BuildFunction));
+        registry.register(Arc::new(VersionFunction));
     }
 }

--- a/src/common/function/src/system/version.rs
+++ b/src/common/function/src/system/version.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::{env, fmt};
+
+use common_query::error::Result;
+use common_query::prelude::{Signature, Volatility};
+use datatypes::data_type::ConcreteDataType;
+use datatypes::vectors::{StringVector, VectorRef};
+
+use crate::function::{Function, FunctionContext};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct VersionFunction;
+
+impl fmt::Display for VersionFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "VERSION")
+    }
+}
+
+impl Function for VersionFunction {
+    fn name(&self) -> &str {
+        "version"
+    }
+
+    fn return_type(&self, _input_types: &[ConcreteDataType]) -> Result<ConcreteDataType> {
+        Ok(ConcreteDataType::string_datatype())
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::exact(vec![], Volatility::Immutable)
+    }
+
+    fn eval(&self, _func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
+        let result = StringVector::from(vec![format!(
+            "5.7.20-greptimedb-{}",
+            env!("CARGO_PKG_VERSION")
+        )]);
+        Ok(Arc::new(result))
+    }
+}

--- a/tests/cases/standalone/common/function/system.result
+++ b/tests/cases/standalone/common/function/system.result
@@ -8,3 +8,12 @@ SELECT build();
 
 ++|build()|++|branch:BRANCH|commit:COMMIT|commitshort:COMMITSHORT|dirty:DIRTY|version:VERSION++
 
+-- SQLNESS REPLACE greptimedb-[\d\.]+ greptimedb-VERSION
+SELECT version();
+
++-------------------------+
+| version()               |
++-------------------------+
+| 5.7.20-greptimedb-VERSION |
++-------------------------+
+

--- a/tests/cases/standalone/common/function/system.sql
+++ b/tests/cases/standalone/common/function/system.sql
@@ -5,3 +5,6 @@
 -- SQLNESS REPLACE version:\s+.+ version: VERSION
 -- SQLNESS REPLACE [\s\-]+
 SELECT build();
+
+-- SQLNESS REPLACE greptimedb-[\d\.]+ greptimedb-VERSION
+SELECT version();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This patch rewrites implementation of `select version()` as system function so it will be available for both mysql and postgresql.

Also in order to get compatible with some client drivers like python's mysqlclient, we need to return a version number that makes sense for mysql. 

```
  File "/home/sunng/greptime/st-greptimedb-connection/example/.venv/lib/python3.12/site-packages/sqlalchemy/dialects/mysql/base.py", line 2533, in get_isolation_level
    if self._is_mysql and self.server_version_info >= (5, 7, 20):
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>=' not supported between instances of 'NoneType' and 'tuple'
```


In next patch, I'm going to see if we can make `QueryContext` available to function implementation and return version number based on client channel (pg or mysql).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
