### PR TITLE
fix: incorrect parsing `broker_endpoints` env variable

### DIFF
--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -128,7 +128,7 @@ impl StartCommand {
         let mut opts: MetaSrvOptions = Options::load_layered_options(
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
-            None,
+            MetaSrvOptions::env_list_keys(),
         )?;
 
         if let Some(dir) = &cli_options.log_dir {

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -118,6 +118,12 @@ pub struct StandaloneOptions {
     pub export_metrics: ExportMetricsOption,
 }
 
+impl StandaloneOptions {
+    pub fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["wal.broker_endpoints"])
+    }
+}
+
 impl Default for StandaloneOptions {
     fn default() -> Self {
         Self {
@@ -267,7 +273,7 @@ impl StartCommand {
         let opts: StandaloneOptions = Options::load_layered_options(
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
-            None,
+            StandaloneOptions::env_list_keys(),
         )?;
 
         self.convert_options(cli_options, opts)

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -276,7 +276,7 @@ impl Default for DatanodeOptions {
 
 impl DatanodeOptions {
     pub fn env_list_keys() -> Option<&'static [&'static str]> {
-        Some(&["meta_client.metasrv_addrs"])
+        Some(&["meta_client.metasrv_addrs", "wal.broker_endpoints"])
     }
 
     pub fn to_toml_string(&self) -> String {

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -79,6 +79,12 @@ pub struct MetaSrvOptions {
     pub store_key_prefix: String,
 }
 
+impl MetaSrvOptions {
+    pub fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["wal.broker_endpoints"])
+    }
+}
+
 impl Default for MetaSrvOptions {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix: incorrect parsing `broker_endpoints` env variable

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
