### PR TITLE
fix: save code in `debug_assert!`

### DIFF
--- a/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/downgrade_leader_region.rs
@@ -60,13 +60,13 @@ impl UpdateMetadata {
             .await
             .context(error::TableMetadataManagerSnafu)
         {
-            debug_assert!(ctx.remove_table_route_value());
+            ctx.remove_table_route_value();
             return error::RetryLaterSnafu {
                 reason: format!("Failed to update the table route during the downgrading leader region, error: {err}")
             }.fail();
         }
 
-        debug_assert!(ctx.remove_table_route_value());
+        ctx.remove_table_route_value();
 
         Ok(())
     }

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/rollback_downgraded_region.rs
@@ -44,13 +44,13 @@ impl UpdateMetadata {
             .await
             .context(error::TableMetadataManagerSnafu)
         {
-            debug_assert!(ctx.remove_table_route_value());
+            ctx.remove_table_route_value();
             return error::RetryLaterSnafu {
                 reason: format!("Failed to update the table route during the rollback downgraded leader region, error: {err}")
             }.fail();
         }
 
-        debug_assert!(ctx.remove_table_route_value());
+        ctx.remove_table_route_value();
 
         Ok(())
     }

--- a/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/update_metadata/upgrade_candidate_region.rs
@@ -167,13 +167,13 @@ impl UpdateMetadata {
             .await
             .context(error::TableMetadataManagerSnafu)
         {
-            debug_assert!(ctx.remove_table_route_value());
+            ctx.remove_table_route_value();
             return error::RetryLaterSnafu {
                     reason: format!("Failed to update the table route during the upgrading candidate region, error: {err}")
                 }.fail();
         };
 
-        debug_assert!(ctx.remove_table_route_value());
+        ctx.remove_table_route_value();
         // Consumes the guard.
         ctx.volatile_ctx.opening_region_guard.take();
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

save code in `debug_assert!`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
#2700