### PR TITLE
fix: remove incorrect wal comments in config file

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -34,11 +34,7 @@ connect_timeout = "1s"
 tcp_nodelay = true
 
 # WAL options.
-# Currently, users are expected to choose the wal through the provider field. 
-# When a wal provider is chose, the user should comment out all other wal config 
-# except those corresponding to the chosen one.
 [wal]
-# WAL data directory
 provider = "raft_engine"
 
 # Raft-engine wal options, see `standalone.example.toml`.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Remove incorrect comments about wal in config file.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
