### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.6.0
+  NEXT_RELEASE_VERSION: v0.7.0
 
 jobs:
   allocate-runners:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1179,7 +1179,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1452,7 +1452,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1485,7 +1485,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1566,7 +1566,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1599,7 +1599,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1614,7 +1614,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "build-data",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-recursion",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1930,7 +1930,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "backtrace",
  "common-error",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "client",
  "common-query",
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "build-data",
 ]
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2694,7 +2694,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -3300,7 +3300,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -3364,7 +3364,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
  "strfmt",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "tokio",
  "toml 0.8.8",
@@ -4018,7 +4018,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4498,7 +4498,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anymap",
  "api",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anymap",
  "api",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5747,7 +5747,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -5978,7 +5978,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "auth",
  "common-base",
@@ -6555,7 +6555,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.6",
  "async-recursion",
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -6877,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -6935,7 +6935,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -8205,7 +8205,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -8465,7 +8465,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "aide",
  "api",
@@ -8561,7 +8561,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -8825,7 +8825,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "common-base",
@@ -8877,7 +8877,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9084,7 +9084,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -9224,7 +9224,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9372,7 +9372,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -9484,7 +9484,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-integration"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "api",
  "async-trait",
@@ -9540,7 +9540,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.5.1",
+ "substrait 0.6.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Bump version to 0.6.0

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
