### PR TITLE
refactor: make grpc service able to be added dynamically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9487,6 +9487,7 @@ name = "tests-integration"
 version = "0.6.0"
 dependencies = [
  "api",
+ "arrow-flight",
  "async-trait",
  "auth",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ bitflags = "2.4.1"
 bytemuck = "1.12"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4.4", features = ["derive"] }
 dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 arrow.workspace = true
 chrono.workspace = true
-clap = { version = "4.0", features = ["derive"] }
+clap.workspace = true
 client.workspace = true
 futures-util.workspace = true
 indicatif = "0.17.1"

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -18,7 +18,7 @@ async-trait.workspace = true
 auth.workspace = true
 catalog.workspace = true
 chrono.workspace = true
-clap = { version = "4.4", features = ["derive"] }
+clap.workspace = true
 client.workspace = true
 common-base.workspace = true
 common-catalog.workspace = true

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -35,6 +35,11 @@ lazy_static::lazy_static! {
 pub trait App {
     fn name(&self) -> &str;
 
+    /// A hook for implementor to make something happened before actual startup. Defaults to no-op.
+    fn pre_start(&mut self) -> error::Result<()> {
+        Ok(())
+    }
+
     async fn start(&mut self) -> error::Result<()>;
 
     async fn stop(&self) -> error::Result<()>;

--- a/src/datanode/src/lib.rs
+++ b/src/datanode/src/lib.rs
@@ -23,6 +23,7 @@ mod greptimedb_telemetry;
 pub mod heartbeat;
 pub mod metrics;
 pub mod region_server;
+pub mod service;
 mod store;
 #[cfg(any(test, feature = "testing"))]
 pub mod tests;

--- a/src/datanode/src/service.rs
+++ b/src/datanode/src/service.rs
@@ -1,0 +1,107 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use servers::grpc::builder::GrpcServerBuilder;
+use servers::grpc::{GrpcServer, GrpcServerConfig};
+use servers::http::HttpServerBuilder;
+use servers::metrics_handler::MetricsHandler;
+use servers::server::{ServerHandler, ServerHandlers};
+use snafu::ResultExt;
+
+use crate::config::DatanodeOptions;
+use crate::error::{ParseAddrSnafu, Result};
+use crate::region_server::RegionServer;
+
+const DATANODE_GRPC_SERVICE_NAME: &str = "DATANODE_GRPC_SERVICE";
+const DATANODE_HTTP_SERVICE_NAME: &str = "DATANODE_HTTP_SERVICE";
+
+pub struct DatanodeServiceBuilder<'a> {
+    opts: &'a DatanodeOptions,
+    grpc_server: Option<GrpcServer>,
+    enable_http_service: bool,
+}
+
+impl<'a> DatanodeServiceBuilder<'a> {
+    pub fn new(opts: &'a DatanodeOptions) -> Self {
+        Self {
+            opts,
+            grpc_server: None,
+            enable_http_service: false,
+        }
+    }
+
+    pub fn with_grpc_server(self, grpc_server: GrpcServer) -> Self {
+        Self {
+            grpc_server: Some(grpc_server),
+            ..self
+        }
+    }
+
+    pub fn with_default_grpc_server(mut self, region_server: &RegionServer) -> Self {
+        let grpc_server = Self::grpc_server_builder(self.opts, region_server).build();
+        self.grpc_server = Some(grpc_server);
+        self
+    }
+
+    pub fn enable_http_service(self) -> Self {
+        Self {
+            enable_http_service: true,
+            ..self
+        }
+    }
+
+    pub fn build(mut self) -> Result<ServerHandlers> {
+        let mut services = HashMap::new();
+
+        if let Some(grpc_server) = self.grpc_server.take() {
+            let addr: SocketAddr = self.opts.rpc_addr.parse().context(ParseAddrSnafu {
+                addr: &self.opts.rpc_addr,
+            })?;
+            let handler: ServerHandler = (Box::new(grpc_server), addr);
+            services.insert(DATANODE_GRPC_SERVICE_NAME.to_string(), handler);
+        }
+
+        if self.enable_http_service {
+            let http_server = HttpServerBuilder::new(self.opts.http.clone())
+                .with_metrics_handler(MetricsHandler)
+                .with_greptime_config_options(self.opts.to_toml_string())
+                .build();
+            let addr: SocketAddr = self.opts.http.addr.parse().context(ParseAddrSnafu {
+                addr: &self.opts.http.addr,
+            })?;
+            let handler: ServerHandler = (Box::new(http_server), addr);
+            services.insert(DATANODE_HTTP_SERVICE_NAME.to_string(), handler);
+        }
+
+        Ok(services)
+    }
+
+    pub fn grpc_server_builder(
+        opts: &DatanodeOptions,
+        region_server: &RegionServer,
+    ) -> GrpcServerBuilder {
+        let config = GrpcServerConfig {
+            max_recv_message_size: opts.rpc_max_recv_message_size.as_bytes() as usize,
+            max_send_message_size: opts.rpc_max_send_message_size.as_bytes() as usize,
+        };
+
+        GrpcServerBuilder::new(config, region_server.runtime())
+            .flight_handler(Arc::new(region_server.clone()))
+            .region_server_handler(Arc::new(region_server.clone()))
+    }
+}

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -60,7 +60,7 @@ impl Services {
             max_send_message_size: opts.max_send_message_size.as_bytes() as usize,
         };
 
-        Ok(GrpcServerBuilder::new(grpc_runtime).config(grpc_config))
+        Ok(GrpcServerBuilder::new(grpc_config, grpc_runtime))
     }
 
     pub async fn build<T, U>(&self, opts: T, instance: Arc<U>) -> Result<ServerHandlers>
@@ -102,9 +102,8 @@ impl Services {
             );
             let grpc_server = builder
                 .database_handler(greptime_request_handler.clone())
-                .prometheus_handler(instance.clone())
-                .otlp_handler(instance.clone())
-                .user_provider(user_provider.clone())
+                .prometheus_handler(instance.clone(), user_provider.clone())
+                .otlp_handler(instance.clone(), user_provider.clone())
                 .flight_handler(Arc::new(greptime_request_handler))
                 .build();
 

--- a/src/servers/src/grpc/builder.rs
+++ b/src/servers/src/grpc/builder.rs
@@ -14,101 +14,127 @@
 
 use std::sync::Arc;
 
+use api::v1::greptime_database_server::GreptimeDatabaseServer;
+use api::v1::prometheus_gateway_server::PrometheusGatewayServer;
+use api::v1::region::region_server::RegionServer;
+use arrow_flight::flight_service_server::FlightServiceServer;
 use auth::UserProviderRef;
 use common_runtime::Runtime;
+use opentelemetry_proto::tonic::collector::metrics::v1::metrics_service_server::MetricsServiceServer;
+use opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::TraceServiceServer;
 use tokio::sync::Mutex;
+use tonic::transport::server::RoutesBuilder;
+use tower::ServiceBuilder;
 
-use super::flight::FlightCraftRef;
+use super::flight::{FlightCraftRef, FlightCraftWrapper};
 use super::region_server::{RegionServerHandlerRef, RegionServerRequestHandler};
 use super::{GrpcServer, GrpcServerConfig};
+use crate::grpc::authorize::AuthMiddlewareLayer;
+use crate::grpc::database::DatabaseService;
 use crate::grpc::greptime_handler::GreptimeRequestHandler;
+use crate::grpc::otlp::OtlpService;
+use crate::grpc::prom_query_gateway::PrometheusGatewayService;
 use crate::prometheus_handler::PrometheusHandlerRef;
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 
+macro_rules! add_service {
+    ($builder: ident, $service: expr) => {
+        $builder.routes_builder.add_service(
+            $service
+                .max_decoding_message_size($builder.config.max_recv_message_size)
+                .max_encoding_message_size($builder.config.max_send_message_size),
+        )
+    };
+}
+
 pub struct GrpcServerBuilder {
-    config: Option<GrpcServerConfig>,
-    database_handler: Option<GreptimeRequestHandler>,
-    prometheus_handler: Option<PrometheusHandlerRef>,
-    flight_handler: Option<FlightCraftRef>,
-    region_server_handler: Option<RegionServerHandlerRef>,
-    otlp_handler: Option<OpenTelemetryProtocolHandlerRef>,
-    user_provider: Option<UserProviderRef>,
+    config: GrpcServerConfig,
     runtime: Arc<Runtime>,
+    routes_builder: RoutesBuilder,
 }
 
 impl GrpcServerBuilder {
-    pub fn new(runtime: Arc<Runtime>) -> Self {
+    pub fn new(config: GrpcServerConfig, runtime: Arc<Runtime>) -> Self {
         Self {
-            config: None,
-            database_handler: None,
-            prometheus_handler: None,
-            flight_handler: None,
-            region_server_handler: None,
-            otlp_handler: None,
-            user_provider: None,
+            config,
             runtime,
+            routes_builder: RoutesBuilder::default(),
         }
-    }
-
-    pub fn config(mut self, config: GrpcServerConfig) -> Self {
-        self.config = Some(config);
-        self
-    }
-
-    pub fn option_config(mut self, config: Option<GrpcServerConfig>) -> Self {
-        self.config = config;
-        self
     }
 
     pub fn runtime(&self) -> &Arc<Runtime> {
         &self.runtime
     }
 
+    /// Add handler for [DatabaseService] service.
     pub fn database_handler(mut self, database_handler: GreptimeRequestHandler) -> Self {
-        self.database_handler = Some(database_handler);
+        add_service!(
+            self,
+            GreptimeDatabaseServer::new(DatabaseService::new(database_handler))
+        );
         self
     }
 
-    pub fn prometheus_handler(mut self, prometheus_handler: PrometheusHandlerRef) -> Self {
-        self.prometheus_handler = Some(prometheus_handler);
+    /// Add handler for Prometheus-compatible PromQL queries ([PrometheusGateway]).
+    pub fn prometheus_handler(
+        mut self,
+        prometheus_handler: PrometheusHandlerRef,
+        user_provider: Option<UserProviderRef>,
+    ) -> Self {
+        add_service!(
+            self,
+            PrometheusGatewayServer::new(PrometheusGatewayService::new(
+                prometheus_handler,
+                user_provider,
+            ))
+        );
         self
     }
 
+    /// Add handler for [FlightService](arrow_flight::flight_service_server::FlightService).
     pub fn flight_handler(mut self, flight_handler: FlightCraftRef) -> Self {
-        self.flight_handler = Some(flight_handler);
+        add_service!(
+            self,
+            FlightServiceServer::new(FlightCraftWrapper(flight_handler.clone()))
+        );
         self
     }
 
+    /// Add handler for [RegionServer].
     pub fn region_server_handler(mut self, region_server_handler: RegionServerHandlerRef) -> Self {
-        self.region_server_handler = Some(region_server_handler);
+        let handler = RegionServerRequestHandler::new(region_server_handler, self.runtime.clone());
+        add_service!(self, RegionServer::new(handler));
         self
     }
 
-    pub fn otlp_handler(mut self, otlp_handler: OpenTelemetryProtocolHandlerRef) -> Self {
-        self.otlp_handler = Some(otlp_handler);
+    /// Add handler for OpenTelemetry Protocol (OTLP) requests.
+    pub fn otlp_handler(
+        mut self,
+        otlp_handler: OpenTelemetryProtocolHandlerRef,
+        user_provider: Option<UserProviderRef>,
+    ) -> Self {
+        let trace_server = ServiceBuilder::new()
+            .layer(AuthMiddlewareLayer::with(user_provider.clone()))
+            .service(TraceServiceServer::new(OtlpService::new(
+                otlp_handler.clone(),
+            )));
+        self.routes_builder.add_service(trace_server);
+
+        let metrics_server = ServiceBuilder::new()
+            .layer(AuthMiddlewareLayer::with(user_provider))
+            .service(MetricsServiceServer::new(OtlpService::new(otlp_handler)));
+        self.routes_builder.add_service(metrics_server);
+
         self
     }
 
-    pub fn user_provider(mut self, user_provider: Option<UserProviderRef>) -> Self {
-        self.user_provider = user_provider;
-        self
+    pub fn routes_builder_mut(&mut self) -> &mut RoutesBuilder {
+        &mut self.routes_builder
     }
 
     pub fn build(self) -> GrpcServer {
-        let config = self.config.unwrap_or_default();
-        let runtime = self.runtime;
-        let region_server_handler = self
-            .region_server_handler
-            .map(|handler| RegionServerRequestHandler::new(handler, runtime));
-
         GrpcServer {
-            config,
-            prometheus_handler: self.prometheus_handler,
-            flight_handler: self.flight_handler,
-            region_server_handler,
-            database_handler: self.database_handler,
-            otlp_handler: self.otlp_handler,
-            user_provider: self.user_provider,
+            routes: Mutex::new(Some(self.routes_builder.routes())),
             shutdown_tx: Mutex::new(None),
             serve_state: Mutex::new(None),
         }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -9,6 +9,7 @@ dashboard = []
 
 [dependencies]
 api.workspace = true
+arrow-flight.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = "0.6"

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -511,12 +511,10 @@ pub async fn setup_grpc_server_with(
     let flight_handler = Arc::new(greptime_request_handler.clone());
 
     let fe_grpc_server = Arc::new(
-        GrpcServerBuilder::new(runtime)
-            .option_config(grpc_config)
+        GrpcServerBuilder::new(grpc_config.unwrap_or_default(), runtime)
             .database_handler(greptime_request_handler)
             .flight_handler(flight_handler)
-            .prometheus_handler(fe_instance_ref.clone())
-            .user_provider(user_provider)
+            .prometheus_handler(fe_instance_ref.clone(), user_provider)
             .build(),
     );
 

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 
 [dependencies]
 async-trait = "0.1"
-clap = { version = "4.0", features = ["derive"] }
+clap.workspace = true
 client.workspace = true
 common-base.workspace = true
 common-error.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Sometimes in other projects, we need to add another grpc service to tonic server. This PR refactor the grpc codes to enable that.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
