### PR TITLE
feat: auto config cache size according to memory size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ version = "0.6.0"
 dependencies = [
  "common-base",
  "humantime-serde",
+ "num_cpus",
  "rskafka",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,6 +1633,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sysinfo",
  "toml 0.8.8",
 ]
 
@@ -5010,7 +5011,6 @@ dependencies = [
  "snafu",
  "store-api",
  "strum 0.25.0",
- "sysinfo",
  "table",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,7 +3963,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -4995,7 +4995,6 @@ dependencies = [
  "log-store",
  "memcomparable",
  "moka",
- "num_cpus",
  "object-store",
  "parquet",
  "paste",
@@ -5011,6 +5010,7 @@ dependencies = [
  "snafu",
  "store-api",
  "strum 0.25.0",
+ "sysinfo",
  "table",
  "tokio",
  "tokio-stream",
@@ -5284,6 +5284,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -8023,7 +8032,7 @@ dependencies = [
  "which",
  "widestring",
  "winapi",
- "windows",
+ "windows 0.39.0",
  "winreg 0.10.1",
 ]
 
@@ -9349,6 +9358,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sysinfo"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9518,7 +9542,6 @@ dependencies = [
  "meta-client",
  "meta-srv",
  "mysql_async",
- "num_cpus",
  "object-store",
  "once_cell",
  "opentelemetry-proto 0.3.0",
@@ -10919,12 +10942,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ lazy_static = "1.4"
 meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "abbd357c1e193cd270ea65ee7652334a150b628f" }
 mockall = "0.11.4"
 moka = "0.12"
+num_cpus = "1.16.0"
 once_cell = "1.18"
 opentelemetry-proto = { git = "https://github.com/waynexia/opentelemetry-rust.git", rev = "33841b38dda79b15f2024952be5f32533325ca02", features = [
     "gen-tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.7"
+sysinfo = "0.30.5"
 # on branch v0.38.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "6a93567ae38d42be5c8d08b13c8ff4dde26502ef", features = [
     "visitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ lazy_static = "1.4"
 meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "abbd357c1e193cd270ea65ee7652334a150b628f" }
 mockall = "0.11.4"
 moka = "0.12"
-num_cpus = "1.16.0"
+num_cpus = "1.16"
 once_cell = "1.18"
 opentelemetry-proto = { git = "https://github.com/waynexia/opentelemetry-rust.git", rev = "33841b38dda79b15f2024952be5f32533325ca02", features = [
     "gen-tonic",
@@ -125,7 +125,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.7"
-sysinfo = "0.30.5"
+sysinfo = "0.30"
 # on branch v0.38.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "6a93567ae38d42be5c8d08b13c8ff4dde26502ef", features = [
     "visitor",

--- a/src/common/base/src/readable_size.rs
+++ b/src/common/base/src/readable_size.rs
@@ -33,7 +33,7 @@ pub const GIB: u64 = MIB * BINARY_DATA_MAGNITUDE;
 pub const TIB: u64 = GIB * BINARY_DATA_MAGNITUDE;
 pub const PIB: u64 = TIB * BINARY_DATA_MAGNITUDE;
 
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
 pub struct ReadableSize(pub u64);
 
 impl ReadableSize {

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 common-base.workspace = true
 humantime-serde.workspace = true
+num_cpus.workspace = true
 rskafka.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -11,4 +11,5 @@ rskafka.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_with = "3"
+sysinfo.workspace = true
 toml.workspace = true

--- a/src/common/config/src/lib.rs
+++ b/src/common/config/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod utils;
 pub mod wal;
 
 use common_base::readable_size::ReadableSize;

--- a/src/common/config/src/utils.rs
+++ b/src/common/config/src/utils.rs
@@ -15,7 +15,7 @@
 use common_base::readable_size::ReadableSize;
 use sysinfo::System;
 
-/// Get the cpu cores number of system.
+/// Get the CPU core number of system, aware of cgroups.
 pub fn get_cpus() -> usize {
     // This function will check cgroups
     num_cpus::get()

--- a/src/common/config/src/utils.rs
+++ b/src/common/config/src/utils.rs
@@ -12,6 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_base::readable_size::ReadableSize;
+use sysinfo::System;
+
+/// Get the cpu cores number of system.
 pub fn get_cpus() -> usize {
     let mut sys_info = System::new();
+    sys_info.refresh_cpu();
+    // At least 1 cpu core.
+    sys_info.cpus().len().max(1)
+}
+
+/// Get the total memory of the system.
+pub fn get_sys_total_memory() -> ReadableSize {
+    let mut sys_info = System::new();
+    sys_info.refresh_memory();
+    ReadableSize(sys_info.total_memory())
 }

--- a/src/common/config/src/utils.rs
+++ b/src/common/config/src/utils.rs
@@ -15,17 +15,43 @@
 use common_base::readable_size::ReadableSize;
 use sysinfo::System;
 
+pub struct SystemInfo {
+    pub cpu_cores: usize,
+    pub total_memory: ReadableSize,
+}
+
 /// Get the cpu cores number of system.
 pub fn get_cpus() -> usize {
-    let mut sys_info = System::new();
-    sys_info.refresh_cpu();
-    // At least 1 cpu core.
-    sys_info.cpus().len().max(1)
+    // This function will check cgroups
+    num_cpus::get()
 }
 
 /// Get the total memory of the system.
-pub fn get_sys_total_memory() -> ReadableSize {
-    let mut sys_info = System::new();
-    sys_info.refresh_memory();
-    ReadableSize(sys_info.total_memory())
+pub fn get_sys_total_memory() -> Option<ReadableSize> {
+    if sysinfo::IS_SUPPORTED_SYSTEM {
+        let mut sys_info = System::new();
+        sys_info.refresh_memory();
+        let mut total_memory = sys_info.total_memory();
+        // Compare with cgrous memory limit, use smaller values
+        if let Some(cgrous_limits) = sys_info.cgroup_limits() {
+            total_memory = total_memory.min(cgrous_limits.total_memory)
+        }
+        return Some(ReadableSize(total_memory));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_cpus() {
+        assert!(get_cpus() > 0);
+    }
+
+    #[test]
+    fn test_get_sys_total_memory() {
+        assert!(get_sys_total_memory().unwrap() > ReadableSize::mb(0));
+    }
 }

--- a/src/common/config/src/utils.rs
+++ b/src/common/config/src/utils.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn get_cpus() -> usize {
+    let mut sys_info = System::new();
+}

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -44,7 +44,6 @@ lazy_static = "1.4"
 log-store = { workspace = true, optional = true }
 memcomparable = "0.2"
 moka = { workspace = true, features = ["sync", "future"] }
-num_cpus = "1.13"
 object-store.workspace = true
 parquet = { workspace = true, features = ["async"] }
 paste.workspace = true
@@ -60,6 +59,7 @@ smallvec.workspace = true
 snafu.workspace = true
 store-api.workspace = true
 strum.workspace = true
+sysinfo.workspace = true
 table.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -59,7 +59,6 @@ smallvec.workspace = true
 snafu.workspace = true
 store-api.workspace = true
 strum.workspace = true
-sysinfo.workspace = true
 table.workspace = true
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -18,12 +18,12 @@ use std::cmp;
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
+use common_config::utils::{get_cpus, get_sys_total_memory};
 use common_telemetry::warn;
 use lazy_static::lazy_static;
 use object_store::util::join_dir;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, NoneAsEmptyString};
-use sysinfo::System;
 
 use crate::error::Result;
 use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
@@ -37,19 +37,10 @@ const DEFAULT_SCAN_CHANNEL_SIZE: usize = 32;
 
 lazy_static! {
     /// Number of cpu cores.
-    pub static ref CPU_CORES: usize = {
-        let mut sys_info = System::new();
-        sys_info.refresh_cpu();
-        // At least 1 cpu core.
-        sys_info.cpus().len().max(1)
-    };
+    pub static ref CPU_CORES: usize = get_cpus();
 
     /// Total memory size of the OS.
-    pub static ref SYS_TOTAL_MEMORY: ReadableSize = {
-        let mut sys_info = System::new();
-        sys_info.refresh_memory();
-        ReadableSize(sys_info.total_memory())
-    };
+    pub static ref SYS_TOTAL_MEMORY: ReadableSize = get_sys_total_memory();
 }
 
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -39,8 +39,6 @@ lazy_static! {
     /// Number of cpu cores.
     pub static ref CPU_CORES: usize = get_cpus();
 
-    /// Total memory size of the OS.
-    pub static ref SYS_TOTAL_MEMORY: ReadableSize = get_sys_total_memory();
 }
 
 /// Configuration for [MitoEngine](crate::engine::MitoEngine).
@@ -112,7 +110,7 @@ impl Default for MitoConfig {
         // Use 1/2 of cpu cores' number as workers' number.
         let num_workers = divide_num_cpus(2);
         // OS total memory size.
-        let sys_memory = *SYS_TOTAL_MEMORY;
+        let sys_memory = get_sys_total_memory().unwrap_or(ReadableSize::gb(16));
         // Use 1/64 of OS memory as global write buffer size, it shouldn't be greater than 1G in default mode.
         // For example, if the OS memory size is 16GB, the global write buffer size is 256MB.
         let global_write_buffer_size = cmp::min(sys_memory / 64, ReadableSize::gb(1));

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -200,15 +200,12 @@ impl MitoConfig {
         let sst_meta_cache_size = cmp::min(sys_memory / 256, ReadableSize::mb(128));
         // Use 1/128 of OS memory size as mem cache size, it shouldn't be greater than 512MB in default mode.
         let mem_cache_size = cmp::min(sys_memory / 128, ReadableSize::mb(512));
-        // Use 1/128 of OS memory size as disk cache size, it shouldn't be greater than 512MB in default mode.
-        let disk_cache_size = cmp::min(sys_memory / 128, ReadableSize::mb(512));
 
         self.global_write_buffer_size = global_write_buffer_size;
         self.global_write_buffer_reject_size = global_write_buffer_reject_size;
         self.sst_meta_cache_size = sst_meta_cache_size;
         self.vector_cache_size = mem_cache_size;
         self.page_cache_size = mem_cache_size;
-        self.experimental_write_cache_size = disk_cache_size;
     }
 
     /// Enable experimental write cache.

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -61,17 +61,17 @@ pub struct MitoConfig {
     /// Interval to auto flush a region if it has not flushed yet (default 30 min).
     #[serde(with = "humantime_serde")]
     pub auto_flush_interval: Duration,
-    /// Global write buffer size threshold to trigger flush (default 1G).
+    /// Global write buffer size threshold to trigger flush.
     pub global_write_buffer_size: ReadableSize,
-    /// Global write buffer size threshold to reject write requests (default 2G).
+    /// Global write buffer size threshold to reject write requests.
     pub global_write_buffer_reject_size: ReadableSize,
 
     // Cache configs:
-    /// Cache size for SST metadata (default 128MB). Setting it to 0 to disable the cache.
+    /// Cache size for SST metadata. Setting it to 0 to disable the cache.
     pub sst_meta_cache_size: ReadableSize,
-    /// Cache size for vectors and arrow arrays (default 512MB). Setting it to 0 to disable the cache.
+    /// Cache size for vectors and arrow arrays. Setting it to 0 to disable the cache.
     pub vector_cache_size: ReadableSize,
-    /// Cache size for pages of SST row groups (default 512MB). Setting it to 0 to disable the cache.
+    /// Cache size for pages of SST row groups. Setting it to 0 to disable the cache.
     pub page_cache_size: ReadableSize,
     /// Whether to enable the experimental write cache.
     pub enable_experimental_write_cache: bool,

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -73,7 +73,6 @@ uuid.workspace = true
 datafusion-expr.workspace = true
 datafusion.workspace = true
 itertools.workspace = true
-num_cpus = "1.13"
 opentelemetry-proto.workspace = true
 partition.workspace = true
 paste.workspace = true

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -768,6 +768,7 @@ max_background_jobs = 4
 auto_flush_interval = "30m"
 enable_experimental_write_cache = false
 experimental_write_cache_path = ""
+experimental_write_cache_size = "512MiB"
 sst_write_buffer_size = "8MiB"
 parallel_scan_channel_size = 32
 allow_stale_entries = false
@@ -822,7 +823,6 @@ fn drop_lines_with_inconsistent_results(input: String) -> String {
         "sst_meta_cache_size =",
         "vector_cache_size =",
         "page_cache_size =",
-        "experimental_write_cache_size =",
     ];
 
     input

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
 use std::collections::BTreeMap;
 
 use auth::user_provider_from_option;
 use axum::http::{HeaderName, StatusCode};
 use axum_test_helper::TestClient;
-use common_base::readable_size::ReadableSize;
 use common_error::status_code::StatusCode as ErrorCode;
 use serde_json::json;
 use servers::http::error_result::ErrorResponse;
@@ -650,14 +648,6 @@ pub async fn test_config_api(store_type: StorageType) {
     let res_get = client.get("/config").send().await;
     assert_eq!(res_get.status(), StatusCode::OK);
 
-    // Get system memory size
-    let sys_memory = common_config::utils::get_sys_total_memory().unwrap();
-    let global_write_buffer_size = cmp::min(sys_memory / 64, ReadableSize::gb(1));
-    let global_write_buffer_reject_size = global_write_buffer_size * 2;
-    let sst_meta_cache_size = cmp::min(sys_memory / 256, ReadableSize::mb(128));
-    let mem_cache_size = cmp::min(sys_memory / 128, ReadableSize::mb(512));
-    let disk_cache_size = cmp::min(sys_memory / 128, ReadableSize::mb(512));
-
     let expected_toml_str = format!(
         r#"
 [procedure]
@@ -776,14 +766,8 @@ manifest_checkpoint_distance = 10
 compress_manifest = false
 max_background_jobs = 4
 auto_flush_interval = "30m"
-global_write_buffer_size = "{global_write_buffer_size}"
-global_write_buffer_reject_size = "{global_write_buffer_reject_size}"
-sst_meta_cache_size = "{sst_meta_cache_size}"
-vector_cache_size = "{mem_cache_size}"
-page_cache_size = "{mem_cache_size}"
 enable_experimental_write_cache = false
 experimental_write_cache_path = ""
-experimental_write_cache_size = "{disk_cache_size}"
 sst_write_buffer_size = "8MiB"
 parallel_scan_channel_size = 32
 allow_stale_entries = false
@@ -833,6 +817,12 @@ fn drop_lines_with_inconsistent_results(input: String) -> String {
         "scope =",
         "num_workers =",
         "scan_parallelism =",
+        "global_write_buffer_size =",
+        "global_write_buffer_reject_size =",
+        "sst_meta_cache_size =",
+        "vector_cache_size =",
+        "page_cache_size =",
+        "experimental_write_cache_size =",
     ];
 
     input


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- according to host memory size to decide the mito's buffer or cache size.
- remove `cpu_nums` crate and use `sysinfo`.

For example, my computer has 16G memory and 8 cpu cores
```

Mito(
    MitoConfig {
        num_workers: 4,
        worker_channel_size: 128,
        worker_request_batch_size: 64,
        manifest_checkpoint_distance: 10,
        compress_manifest: false,
        max_background_jobs: 4,
        auto_flush_interval: 1800s,
        global_write_buffer_size: 256.0MiB,
        global_write_buffer_reject_size: 512.0MiB,
        sst_meta_cache_size: 64.0MiB,
        vector_cache_size: 128.0MiB,
        page_cache_size: 128.0MiB,
        enable_experimental_write_cache: false,
        experimental_write_cache_path: "",
        experimental_write_cache_size: 128.0MiB,
        sst_write_buffer_size: 8.0MiB,
        scan_parallelism: 2,
        parallel_scan_channel_size: 32,
        allow_stale_entries: false,
    ...
    ...
    },
),
```

The possible concern here is `sysinfo` couldn't get system info in some unpopular OS.
***
update 2024.1.17 
docker container(ubuntu 24.04), host memory=28G, cpus=16, we limit cpus = 8, memory = 8G, test again.
the result:
```
MitoConfig {
    num_workers: 4,
    worker_channel_size: 128,
    worker_request_batch_size: 64,
    manifest_checkpoint_distance: 10,
    compress_manifest: false,
    max_background_jobs: 4,
    auto_flush_interval: 1800s,
    global_write_buffer_size: 128.0MiB,
    global_write_buffer_reject_size: 256.0MiB,
    sst_meta_cache_size: 32.0MiB,
    vector_cache_size: 64.0MiB,
    page_cache_size: 64.0MiB,
    enable_experimental_write_cache: false,
    experimental_write_cache_path: "",
    experimental_write_cache_size: 64.0MiB,
    sst_write_buffer_size: 8.0MiB,
    scan_parallelism: 2,
    parallel_scan_channel_size: 32,
    allow_stale_entries: false,
    ...
    ...
},

``` 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
