### PR TITLE
feat: add Arrow IPC output format for http rest api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8470,6 +8470,7 @@ dependencies = [
  "aide",
  "api",
  "arrow-flight",
+ "arrow-ipc",
  "async-trait",
  "auth",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8469,8 +8469,10 @@ version = "0.6.0"
 dependencies = [
  "aide",
  "api",
+ "arrow",
  "arrow-flight",
  "arrow-ipc",
+ "arrow-schema",
  "async-trait",
  "auth",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ aquamarine = "0.3"
 arrow = { version = "47.0" }
 arrow-array = "47.0"
 arrow-flight = "47.0"
+arrow-ipc = "47.0"
 arrow-schema = { version = "47.0", features = ["serde"] }
 async-stream = "0.3"
 async-trait = "0.1"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -13,10 +13,10 @@ testing = []
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
 api.workspace = true
-arrow.workspace = true
 arrow-flight.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
+arrow.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = { version = "0.6", features = ["headers"] }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -14,6 +14,7 @@ testing = []
 aide = { version = "0.9", features = ["axum"] }
 api.workspace = true
 arrow-flight.workspace = true
+arrow-ipc.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = { version = "0.6", features = ["headers"] }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -13,8 +13,10 @@ testing = []
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
 api.workspace = true
+arrow.workspace = true
 arrow-flight.workspace = true
 arrow-ipc.workspace = true
+arrow-schema.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = { version = "0.6", features = ["headers"] }

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -35,6 +35,12 @@ use tonic::Code;
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
+    #[snafu(display("Arrow error"))]
+    Arrow {
+        #[snafu(source)]
+        error: arrow_schema::ArrowError,
+    },
+
     #[snafu(display("Internal error: {}", err_msg))]
     Internal { err_msg: String },
 
@@ -450,7 +456,8 @@ impl ErrorExt for Error {
             | TcpIncoming { .. }
             | CatalogError { .. }
             | GrpcReflectionService { .. }
-            | BuildHttpResponse { .. } => StatusCode::Internal,
+            | BuildHttpResponse { .. }
+            | Arrow { .. } => StatusCode::Internal,
 
             UnsupportedDataType { .. } => StatusCode::Unsupported,
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -1020,30 +1020,10 @@ mod test {
                     let mut reader =
                         FileReader::try_new(Cursor::new(output), None).expect("Arrow reader error");
                     let schema = reader.schema();
-                    assert_eq!(
-                        schema.fields.get(0).expect("At least 1 field").name(),
-                        "numbers"
-                    );
-                    assert_eq!(
-                        schema.fields.get(0).expect("At least 1 field").data_type(),
-                        &DataType::UInt32
-                    );
-                    assert_eq!(
-                        schema
-                            .fields
-                            .get(1)
-                            .expect("failed to access field 1")
-                            .name(),
-                        "strings"
-                    );
-                    assert_eq!(
-                        schema
-                            .fields
-                            .get(1)
-                            .expect("failed to access field 2")
-                            .data_type(),
-                        &DataType::Utf8
-                    );
+                    assert_eq!(schema.fields[0].name(), "numbers");
+                    assert_eq!(schema.fields[0].data_type(), &DataType::UInt32);
+                    assert_eq!(schema.fields[1].name(), "strings");
+                    assert_eq!(schema.fields[1].data_type(), &DataType::Utf8);
 
                     let rb = reader.next().unwrap().expect("read record batch failed");
                     assert_eq!(rb.num_columns(), 2);

--- a/src/servers/src/http/arrow_result.rs
+++ b/src/servers/src/http/arrow_result.rs
@@ -1,0 +1,129 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use arrow_ipc::writer::FileWriter;
+use axum::http::{header, HeaderName, HeaderValue};
+use axum::response::{IntoResponse, Response};
+use common_error::status_code::StatusCode;
+use common_query::Output;
+use futures::StreamExt;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::http::error_result::ErrorResponse;
+use crate::http::header::{GREPTIME_DB_HEADER_EXECUTION_TIME, GREPTIME_DB_HEADER_FORMAT};
+use crate::http::{HttpResponse, ResponseFormat};
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+pub struct ArrowResponse {
+    data: Vec<u8>,
+    execution_time_ms: u64,
+}
+
+impl ArrowResponse {
+    pub async fn from_output(mut outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
+        if outputs.len() > 1 {
+            return HttpResponse::Error(ErrorResponse::from_error_message(
+                ResponseFormat::Arrow,
+                StatusCode::InvalidArguments,
+                "Multi-statements are not allowed".to_string(),
+            ));
+        }
+
+        match outputs.remove(0) {
+            Ok(output) => {
+                let payload = match output {
+                    Output::AffectedRows(_rows) => {
+                        vec![]
+                    }
+                    Output::RecordBatches(recordbatches) => {
+                        let schema = recordbatches.schema();
+                        let schema = schema.arrow_schema();
+
+                        // unwrap should be safe here
+                        let mut bytes = Vec::new();
+                        {
+                            let mut writer = FileWriter::try_new(&mut bytes, schema).unwrap();
+
+                            for recordbatch in recordbatches {
+                                writer.write(&recordbatch.into_df_record_batch()).unwrap();
+                            }
+
+                            writer.finish().unwrap();
+                        }
+
+                        bytes
+                    }
+
+                    Output::Stream(mut recordbatches) => {
+                        let schema = recordbatches.schema();
+                        let schema = schema.arrow_schema();
+
+                        let mut bytes = Vec::new();
+                        {
+                            let mut writer = FileWriter::try_new(&mut bytes, schema).unwrap();
+
+                            while let Some(rb) = recordbatches.next().await {
+                                let rb = rb.unwrap();
+                                writer.write(&rb.into_df_record_batch()).unwrap();
+                            }
+
+                            writer.finish().unwrap();
+                        }
+
+                        bytes
+                    }
+                };
+                HttpResponse::Arrow(ArrowResponse {
+                    data: payload,
+                    execution_time_ms: 0,
+                })
+            }
+            Err(e) => HttpResponse::Error(ErrorResponse::from_error(ResponseFormat::Arrow, e)),
+        }
+    }
+
+    pub fn with_execution_time(mut self, execution_time: u64) -> Self {
+        self.execution_time_ms = execution_time;
+        self
+    }
+
+    pub fn execution_time_ms(&self) -> u64 {
+        self.execution_time_ms
+    }
+}
+
+impl IntoResponse for ArrowResponse {
+    fn into_response(self) -> Response {
+        let execution_time = self.execution_time_ms;
+        (
+            [
+                (
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/arrow"),
+                ),
+                (
+                    HeaderName::from_static(GREPTIME_DB_HEADER_FORMAT),
+                    HeaderValue::from_static("ARROW"),
+                ),
+                (
+                    HeaderName::from_static(GREPTIME_DB_HEADER_EXECUTION_TIME),
+                    HeaderValue::from(execution_time),
+                ),
+            ],
+            self.data,
+        )
+            .into_response()
+    }
+}

--- a/src/servers/src/http/arrow_result.rs
+++ b/src/servers/src/http/arrow_result.rs
@@ -61,11 +61,11 @@ async fn write_arrow_bytes(
 
 impl ArrowResponse {
     pub async fn from_output(mut outputs: Vec<crate::error::Result<Output>>) -> HttpResponse {
-        if outputs.len() > 1 {
+        if outputs.len() != 1 {
             return HttpResponse::Error(ErrorResponse::from_error_message(
                 ResponseFormat::Arrow,
                 StatusCode::InvalidArguments,
-                "Multi-statements are not allowed".to_string(),
+                "Multi-statements and empty query are not allowed".to_string(),
             ));
         }
 

--- a/src/servers/src/http/arrow_result.rs
+++ b/src/servers/src/http/arrow_result.rs
@@ -34,8 +34,8 @@ use crate::http::{HttpResponse, ResponseFormat};
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct ArrowResponse {
-    data: Vec<u8>,
-    execution_time_ms: u64,
+    pub(crate) data: Vec<u8>,
+    pub(crate) execution_time_ms: u64,
 }
 
 async fn write_arrow_bytes(

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -29,6 +29,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use session::context::QueryContextRef;
 
+use crate::http::arrow_result::ArrowResponse;
 use crate::http::csv_result::CsvResponse;
 use crate::http::error_result::ErrorResponse;
 use crate::http::greptime_result_v1::GreptimedbV1Response;
@@ -111,6 +112,7 @@ pub async fn sql(
     };
 
     let resp = match format {
+        ResponseFormat::Arrow => ArrowResponse::from_output(outputs).await,
         ResponseFormat::Csv => CsvResponse::from_output(outputs).await,
         ResponseFormat::GreptimedbV1 => GreptimedbV1Response::from_output(outputs).await,
         ResponseFormat::InfluxdbV1 => InfluxdbV1Response::from_output(outputs, epoch).await,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

This patch is initial work to add arrow output format for our http sql api. By using arrow output format it is possible to do zero-copy with arrowjs ecosystem, including visualization library vega (with vega-arrow-loader) and many more.

I will be seeking to add streaming support for output types like csv and arrow in future patch.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
