### PR TITLE
feat(tests-fuzz): add CreateTableExprGenerator & AlterTableExprGenerator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9512,6 +9512,7 @@ dependencies = [
  "lazy_static",
  "partition",
  "rand",
+ "serde",
  "snafu",
  "sql",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9505,6 +9505,7 @@ dependencies = [
  "async-trait",
  "common-error",
  "common-macro",
+ "common-query",
  "datatypes",
  "derive_builder 0.12.0",
  "faker_rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2857,6 +2857,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3132,17 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
+ "rand",
+]
+
+[[package]]
+name = "faker_rand"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d2ddbf2245b5b5e723995e0961033121b4fc2be9045fb661af82bd739ffb6"
+dependencies = [
+ "deunicode",
+ "lazy_static",
  "rand",
 ]
 
@@ -9486,6 +9503,16 @@ name = "tests-fuzz"
 version = "0.6.0"
 dependencies = [
  "async-trait",
+ "common-error",
+ "common-macro",
+ "datatypes",
+ "derive_builder 0.12.0",
+ "faker_rand",
+ "lazy_static",
+ "partition",
+ "rand",
+ "snafu",
+ "sql",
 ]
 
 [[package]]

--- a/src/partition/src/partition.rs
+++ b/src/partition/src/partition.rs
@@ -50,7 +50,7 @@ pub enum PartitionBound {
     MaxValue,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PartitionDef {
     partition_columns: Vec<String>,
     partition_bounds: Vec<PartitionBound>,

--- a/src/partition/src/partition.rs
+++ b/src/partition/src/partition.rs
@@ -50,7 +50,7 @@ pub enum PartitionBound {
     MaxValue,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartitionDef {
     partition_columns: Vec<String>,
     partition_bounds: Vec<PartitionBound>,

--- a/tests-fuzz/Cargo.toml
+++ b/tests-fuzz/Cargo.toml
@@ -6,3 +6,13 @@ license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+common-error = { workspace = true }
+common-macro = { workspace = true }
+datatypes = { workspace = true }
+derive_builder = { workspace = true }
+faker_rand = "0.1"
+lazy_static = { workspace = true }
+partition = { workspace = true }
+rand = { workspace = true }
+snafu = { workspace = true }
+sql = { workspace = true }

--- a/tests-fuzz/Cargo.toml
+++ b/tests-fuzz/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 async-trait = { workspace = true }
 common-error = { workspace = true }
 common-macro = { workspace = true }
+common-query = { workspace = true }
 datatypes = { workspace = true }
 derive_builder = { workspace = true }
 faker_rand = "0.1"

--- a/tests-fuzz/Cargo.toml
+++ b/tests-fuzz/Cargo.toml
@@ -15,5 +15,6 @@ faker_rand = "0.1"
 lazy_static = { workspace = true }
 partition = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 snafu = { workspace = true }
 sql = { workspace = true }

--- a/tests-fuzz/src/context.rs
+++ b/tests-fuzz/src/context.rs
@@ -11,3 +11,40 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use std::sync::Arc;
+
+use partition::partition::PartitionDef;
+
+use crate::ir::{Column, CreateTableExpr};
+
+pub type TableContextRef = Arc<TableContext>;
+
+/// TableContext stores table info.
+pub struct TableContext {
+    pub name: String,
+    pub columns: Vec<Column>,
+
+    // GreptimeDB specific options
+    pub partitions: Vec<PartitionDef>,
+    pub primary_keys: Vec<usize>,
+}
+
+impl From<&CreateTableExpr> for TableContext {
+    fn from(
+        CreateTableExpr {
+            name,
+            columns,
+            partitions,
+            primary_keys,
+            ..
+        }: &CreateTableExpr,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            columns: columns.clone(),
+            partitions: partitions.clone(),
+            primary_keys: primary_keys.clone(),
+        }
+    }
+}

--- a/tests-fuzz/src/error.rs
+++ b/tests-fuzz/src/error.rs
@@ -35,4 +35,7 @@ pub enum Error {
         error: CreateTableExprBuilderError,
         location: Location,
     },
+
+    #[snafu(display("No droppable columns"))]
+    DroppableColumns { location: Location },
 }

--- a/tests-fuzz/src/error.rs
+++ b/tests-fuzz/src/error.rs
@@ -12,14 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(extract_if)]
+use common_macro::stack_trace_debug;
+use snafu::{Location, Snafu};
 
-pub(crate) mod context;
-pub(crate) mod error;
-pub(crate) mod executor;
-// TODO(weny): removes it.
-#[allow(unused)]
-pub(crate) mod generator;
-pub(crate) mod ir;
-pub(crate) mod table_creator;
-pub(crate) mod translator;
+use crate::ir::create_expr::CreateTableExprBuilderError;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Snafu)]
+#[snafu(visibility(pub))]
+#[stack_trace_debug]
+pub enum Error {
+    #[snafu(display("Unexpected, violated: {violated}"))]
+    Unexpected {
+        violated: String,
+        location: Location,
+    },
+
+    #[snafu(display("Failed to build create table expr"))]
+    BuildCreateTableExpr {
+        #[snafu(source)]
+        error: CreateTableExprBuilderError,
+        location: Location,
+    },
+}

--- a/tests-fuzz/src/generator.rs
+++ b/tests-fuzz/src/generator.rs
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod create_expr;
 use std::fmt;
+
+use crate::error::Error;
+use crate::ir::CreateTableExpr;
+
+pub type CreateTableExprGenerator =
+    Box<dyn Generator<CreateTableExpr, Error = Error> + Sync + Send>;
 
 #[async_trait::async_trait]
 pub(crate) trait Generator<T> {

--- a/tests-fuzz/src/generator/alter_expr.rs
+++ b/tests-fuzz/src/generator/alter_expr.rs
@@ -1,0 +1,142 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::f64::consts::E;
+use std::sync::Arc;
+
+use common_query::AddColumnLocation;
+use faker_rand::lorem::Word;
+use rand::{random, Rng};
+use snafu::ensure;
+
+use crate::error::{self, Result};
+use crate::ir::alter_expr::{AlterTableExpr, AlterTableOperation};
+use crate::ir::{droppable_columns, Column};
+
+pub struct AlterTableExprGenerator {
+    name: String,
+    columns: Arc<Vec<Column>>,
+    ignore_no_droppable_column: bool,
+}
+
+impl AlterTableExprGenerator {
+    pub fn new(name: String, columns: Arc<Vec<Column>>) -> Self {
+        Self {
+            name,
+            columns,
+            ignore_no_droppable_column: false,
+        }
+    }
+
+    /// If the `ignore_no_droppable_column` is true, it retries if there is no droppable column.
+    pub fn ignore_no_droppable_column(mut self, v: bool) -> Self {
+        self.ignore_no_droppable_column = v;
+        self
+    }
+
+    fn generate_inner(&self) -> Result<AlterTableExpr> {
+        let mut rng = rand::thread_rng();
+        let idx = rng.gen_range(0..3);
+        // 0 -> AddColumn
+        // 1 -> DropColumn(invariant: We can't non-primary key columns, non-ts columns)
+        // 2 -> RenameTable
+        let alter_expr = match idx {
+            0 => {
+                let with_location = rng.gen::<bool>();
+                let location = if with_location {
+                    let use_first = rng.gen::<bool>();
+                    let location = if use_first {
+                        AddColumnLocation::First
+                    } else {
+                        AddColumnLocation::After {
+                            column_name: self.columns[rng.gen_range(0..self.columns.len())]
+                                .name
+                                .to_string(),
+                        }
+                    };
+                    Some(location)
+                } else {
+                    None
+                };
+                let column = rng.gen::<Column>();
+                AlterTableExpr {
+                    name: self.name.to_string(),
+                    alter_options: AlterTableOperation::AddColumn { column, location },
+                }
+            }
+            1 => {
+                let droppable = droppable_columns(&self.columns);
+                ensure!(!droppable.is_empty(), error::DroppableColumnsSnafu);
+                let name = droppable[rng.gen_range(0..droppable.len())]
+                    .name
+                    .to_string();
+                AlterTableExpr {
+                    name: self.name.to_string(),
+                    alter_options: AlterTableOperation::DropColumn { name },
+                }
+            }
+            2 => {
+                let mut new_table_name = rng.gen::<Word>().to_string();
+                if new_table_name == self.name {
+                    new_table_name = format!("{}-{}", self.name, rng.gen::<u64>());
+                }
+                AlterTableExpr {
+                    name: self.name.to_string(),
+                    alter_options: AlterTableOperation::RenameTable { new_table_name },
+                }
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(alter_expr)
+    }
+
+    /// Generates the [AlterTableExpr].
+    pub fn generate(&self) -> Result<AlterTableExpr> {
+        match self.generate_inner() {
+            Ok(expr) => Ok(expr),
+            Err(err) => {
+                if matches!(err, error::Error::DroppableColumns { .. }) {
+                    return self.generate();
+                }
+                Err(err)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::AlterTableExprGenerator;
+    use crate::generator::create_expr::CreateTableExprGenerator;
+    use crate::generator::Generator;
+
+    #[test]
+    fn test_alter_table_expr_generator() {
+        let create_expr = CreateTableExprGenerator::default()
+            .columns(10)
+            .generate()
+            .unwrap();
+
+        let alter_expr = AlterTableExprGenerator::new(
+            create_expr.name.to_string(),
+            Arc::new(create_expr.columns),
+        )
+        .ignore_no_droppable_column(true)
+        .generate()
+        .unwrap();
+    }
+}

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -20,11 +20,11 @@ use snafu::{ensure, ResultExt};
 
 use super::Generator;
 use crate::error::{self, Error, Result};
-use crate::ir::create_expr::{
-    generate_random_value, Column, ColumnOption, CreateTableExprBuilder, PartibleColumn, TsColumn,
+use crate::ir::create_expr::{ColumnOption, CreateTableExprBuilder};
+use crate::ir::{
+    self, generate_random_value, Column, CreateTableExpr, PartibleColumn, TsColumn,
     PARTIBLE_DATA_TYPES,
 };
-use crate::ir::{self, CreateTableExpr};
 
 pub struct CreateTableExprGenerator {
     columns: usize,

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -1,0 +1,192 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use faker_rand::lorem::Word;
+use partition::partition::{PartitionBound, PartitionDef};
+use rand::seq::SliceRandom;
+use rand::Rng;
+use snafu::{ensure, ResultExt};
+
+use super::Generator;
+use crate::error::{self, Error, Result};
+use crate::ir::create_expr::{
+    generate_random_value, Column, ColumnOption, CreateTableExprBuilder, PartibleColumn, TsColumn,
+    PARTIBLE_DATA_TYPES,
+};
+use crate::ir::{self, CreateTableExpr};
+
+pub struct CreateTableExprGenerator {
+    columns: usize,
+    engine: String,
+    partition: usize,
+    if_not_exists: bool,
+}
+
+const DEFAULT_ENGINE: &str = "mito";
+
+impl Default for CreateTableExprGenerator {
+    fn default() -> Self {
+        Self {
+            columns: 0,
+            engine: DEFAULT_ENGINE.to_string(),
+            if_not_exists: false,
+            partition: 0,
+        }
+    }
+}
+
+impl CreateTableExprGenerator {
+    /// Sets column num.
+    pub fn columns(mut self, columns: usize) -> Self {
+        self.columns = columns;
+        self
+    }
+
+    /// Sets the `if_not_exists`.
+    pub fn create_is_not_exists(mut self, v: bool) -> Self {
+        self.if_not_exists = v;
+        self
+    }
+
+    /// Sets the `engine`.
+    pub fn engine(mut self, engine: &str) -> Self {
+        self.engine = engine.to_string();
+        self
+    }
+
+    /// Sets the partition num.
+    /// If there is no primary key column,
+    /// it appends a primary key atomically.
+    pub fn partitions(mut self, partition: usize) -> Self {
+        self.partition = partition;
+        self
+    }
+
+    /// Generates the [CreateTableExpr].
+    fn generate_inner(&self) -> Result<CreateTableExpr> {
+        ensure!(
+            self.columns != 0,
+            error::UnexpectedSnafu {
+                violated: "The columns must larger than zero"
+            }
+        );
+
+        let mut builder = CreateTableExprBuilder::default();
+        let mut columns = Vec::with_capacity(self.columns + 1);
+        let mut primary_keys = vec![];
+        let mut rng = rand::thread_rng();
+
+        // Generates columns.
+        for i in 0..self.columns {
+            let mut column = rng.gen::<Column>();
+            // Removes the primary key option.
+            let options = column
+                .options
+                .extract_if(|option| option == &ColumnOption::PrimaryKey)
+                .collect::<Vec<_>>();
+            if !options.is_empty() {
+                primary_keys.push(i);
+            }
+            columns.push(column);
+        }
+
+        // Shuffles the primary keys.
+        primary_keys.shuffle(&mut rng);
+        let partitions = if self.partition > 1 {
+            // Finds a partible primary keys.
+            let partible_primary_keys = primary_keys
+                .iter()
+                .flat_map(|i| {
+                    if PARTIBLE_DATA_TYPES.contains(&columns[*i].column_type) {
+                        Some(*i)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            // Generates the partitions.
+            if partible_primary_keys.is_empty() {
+                columns.push(rng.gen::<PartibleColumn>().0);
+                primary_keys.push(columns.len() - 1);
+            }
+            let primary_key_idx = primary_keys[rng.gen_range(0..primary_keys.len())];
+            let primary_column = &columns[primary_key_idx];
+
+            // Generates partition bounds.
+            let mut partition_bounds = Vec::with_capacity(self.partition);
+            for _ in 0..self.partition - 1 {
+                partition_bounds.push(PartitionBound::Value(generate_random_value(
+                    &primary_column.column_type,
+                )));
+                partition_bounds.sort();
+            }
+            partition_bounds.push(PartitionBound::MaxValue);
+
+            vec![PartitionDef::new(
+                vec![primary_column.name.to_string()],
+                partition_bounds,
+            )]
+        } else {
+            vec![]
+        };
+        // Generates ts column.
+        columns.push(rng.gen::<TsColumn>().0);
+
+        builder.columns(columns);
+        builder.primary_keys(primary_keys);
+        builder.engine(self.engine.to_string());
+        builder.if_not_exists(self.if_not_exists);
+        builder.name(rng.gen::<Word>().to_string());
+        builder.partitions(partitions);
+        builder.build().context(error::BuildCreateTableExprSnafu)
+    }
+}
+
+#[async_trait::async_trait]
+impl Generator<CreateTableExpr> for CreateTableExprGenerator {
+    type Error = Error;
+
+    async fn generate(&self) -> Result<CreateTableExpr> {
+        self.generate_inner()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_table_expr_generator() {
+        let expr = CreateTableExprGenerator::default()
+            .columns(10)
+            .partitions(3)
+            .create_is_not_exists(true)
+            .engine("mito2")
+            .generate_inner()
+            .unwrap();
+        assert_eq!(expr.engine, "mito2");
+        assert!(expr.if_not_exists);
+        assert!(expr.columns.len() >= 11);
+        assert_eq!(expr.partitions[0].partition_bounds().len(), 3);
+
+        let expr = CreateTableExprGenerator::default()
+            .columns(10)
+            .partitions(1)
+            .generate_inner()
+            .unwrap();
+        assert_eq!(expr.columns.len(), 11);
+        assert_eq!(expr.partitions.len(), 0);
+    }
+}

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -12,14 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(extract_if)]
+//! The intermediate representation
 
-pub(crate) mod context;
-pub(crate) mod error;
-pub(crate) mod executor;
-// TODO(weny): removes it.
-#[allow(unused)]
-pub(crate) mod generator;
-pub(crate) mod ir;
-pub(crate) mod table_creator;
-pub(crate) mod translator;
+pub(crate) mod create_expr;
+
+pub use create_expr::CreateTableExpr;

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -17,3 +17,120 @@
 pub(crate) mod create_expr;
 
 pub use create_expr::CreateTableExpr;
+use datatypes::data_type::ConcreteDataType;
+use datatypes::value::Value;
+use derive_builder::Builder;
+use faker_rand::lorem::Word;
+use lazy_static::lazy_static;
+use rand::distributions::{Distribution, Standard};
+
+use crate::ir::create_expr::ColumnOption;
+
+lazy_static! {
+    static ref DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::boolean_datatype(),
+        ConcreteDataType::int16_datatype(),
+        ConcreteDataType::int32_datatype(),
+        ConcreteDataType::int64_datatype(),
+        ConcreteDataType::float32_datatype(),
+        ConcreteDataType::float64_datatype(),
+    ];
+    static ref TS_DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::timestamp_nanosecond_datatype(),
+        ConcreteDataType::timestamp_microsecond_datatype(),
+        ConcreteDataType::timestamp_millisecond_datatype(),
+        ConcreteDataType::timestamp_second_datatype(),
+    ];
+    pub static ref PARTIBLE_DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::int16_datatype(),
+        ConcreteDataType::int32_datatype(),
+        ConcreteDataType::int64_datatype(),
+        ConcreteDataType::float32_datatype(),
+        ConcreteDataType::float64_datatype(),
+        ConcreteDataType::string_datatype(),
+        ConcreteDataType::date_datatype(),
+        ConcreteDataType::datetime_datatype(),
+    ];
+}
+
+/// Generates a random [Value].
+pub fn generate_random_value(datatype: &ConcreteDataType) -> Value {
+    match datatype {
+        &ConcreteDataType::Boolean(_) => Value::from(rand::random::<bool>()),
+        ConcreteDataType::Int16(_) => Value::from(rand::random::<i16>()),
+        ConcreteDataType::Int32(_) => Value::from(rand::random::<i32>()),
+        ConcreteDataType::Int64(_) => Value::from(rand::random::<i64>()),
+        ConcreteDataType::Float32(_) => Value::from(rand::random::<f32>()),
+        ConcreteDataType::Float64(_) => Value::from(rand::random::<f64>()),
+        ConcreteDataType::String(_) => Value::from(rand::random::<char>().to_string()),
+        ConcreteDataType::Date(_) => Value::from(rand::random::<i32>()),
+        ConcreteDataType::DateTime(_) => Value::from(rand::random::<i64>()),
+
+        _ => unimplemented!("unsupported type: {datatype}"),
+    }
+}
+
+/// The IR column.
+#[derive(Debug, Builder, Clone)]
+pub struct Column {
+    #[builder(setter(into))]
+    pub name: String,
+    pub column_type: ConcreteDataType,
+    #[builder(default, setter(into))]
+    pub options: Vec<ColumnOption>,
+}
+
+impl Distribution<Column> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> Column {
+        let column_type = DATA_TYPES[rng.gen_range(0..DATA_TYPES.len())].clone();
+        // 0 -> NULL
+        // 1 -> NOT NULL
+        // 2 -> DEFAULT VALUE
+        // 3 -> PRIMARY KEY
+        // 4 -> EMPTY
+        let option_idx = rng.gen_range(0..5);
+        let options = match option_idx {
+            0 => vec![ColumnOption::Null],
+            1 => vec![ColumnOption::NotNull],
+            2 => vec![ColumnOption::DefaultValue(generate_random_value(
+                &column_type,
+            ))],
+            3 => vec![ColumnOption::PrimaryKey],
+            _ => vec![],
+        };
+
+        Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options,
+        }
+    }
+}
+
+/// The IR ts column.
+pub struct TsColumn(pub Column);
+
+impl Distribution<TsColumn> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> TsColumn {
+        let column_type = TS_DATA_TYPES[rng.gen_range(0..TS_DATA_TYPES.len())].clone();
+        TsColumn(Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options: vec![],
+        })
+    }
+}
+
+/// The IR partible column.
+pub struct PartibleColumn(pub Column);
+
+impl Distribution<PartibleColumn> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> PartibleColumn {
+        let column_type = PARTIBLE_DATA_TYPES[rng.gen_range(0..PARTIBLE_DATA_TYPES.len())].clone();
+        PartibleColumn(Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options: vec![],
+        })
+    }
+}

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -25,6 +25,7 @@ use derive_builder::Builder;
 use faker_rand::lorem::Word;
 use lazy_static::lazy_static;
 use rand::distributions::{Distribution, Standard};
+use serde::{Deserialize, Serialize};
 
 use crate::ir::create_expr::ColumnOption;
 
@@ -73,7 +74,7 @@ pub fn generate_random_value(datatype: &ConcreteDataType) -> Value {
 }
 
 /// The IR column.
-#[derive(Debug, Builder, Clone)]
+#[derive(Debug, Builder, Clone, Serialize, Deserialize)]
 pub struct Column {
     #[builder(setter(into))]
     pub name: String,

--- a/tests-fuzz/src/ir/alter_expr.rs
+++ b/tests-fuzz/src/ir/alter_expr.rs
@@ -14,6 +14,7 @@
 
 use common_query::AddColumnLocation;
 use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
 
 use crate::ir::Column;
 
@@ -23,7 +24,7 @@ pub struct AlterTableExpr {
     pub alter_options: AlterTableOperation,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AlterTableOperation {
     /// `ADD [ COLUMN ] <column_def> [location]`
     AddColumn {

--- a/tests-fuzz/src/ir/alter_expr.rs
+++ b/tests-fuzz/src/ir/alter_expr.rs
@@ -12,21 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod alter_expr;
-pub mod create_expr;
+use common_query::AddColumnLocation;
+use derive_builder::Builder;
 
-use std::fmt;
+use crate::ir::Column;
 
-use crate::error::Error;
-use crate::ir::{AlterTableExpr, CreateTableExpr};
+#[derive(Debug, Builder, Clone)]
+pub struct AlterTableExpr {
+    pub name: String,
+    pub alter_options: AlterTableOperation,
+}
 
-pub type CreateTableExprGenerator =
-    Box<dyn Generator<CreateTableExpr, Error = Error> + Sync + Send>;
-
-pub type AlterTableExprGenerator = Box<dyn Generator<AlterTableExpr, Error = Error> + Sync + Send>;
-
-pub(crate) trait Generator<T> {
-    type Error: Sync + Send + fmt::Debug;
-
-    fn generate(&self) -> Result<T, Self::Error>;
+#[derive(Debug, Clone)]
+pub enum AlterTableOperation {
+    /// `ADD [ COLUMN ] <column_def> [location]`
+    AddColumn {
+        column: Column,
+        location: Option<AddColumnLocation>,
+    },
+    /// `DROP COLUMN <name>`
+    DropColumn { name: String },
+    /// `RENAME <new_table_name>`
+    RenameTable { new_table_name: String },
 }

--- a/tests-fuzz/src/ir/create_expr.rs
+++ b/tests-fuzz/src/ir/create_expr.rs
@@ -15,13 +15,11 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use datatypes::data_type::ConcreteDataType;
 use datatypes::value::Value;
 use derive_builder::Builder;
-use faker_rand::lorem::Word;
-use lazy_static::lazy_static;
 use partition::partition::PartitionDef;
-use rand::distributions::{Distribution, Standard};
+
+use crate::ir::Column;
 
 // The column options
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,115 +42,6 @@ impl Display for ColumnOption {
             ColumnOption::TimeIndex => write!(f, "TIME INDEX"),
             ColumnOption::PrimaryKey => write!(f, "PRIMARY KEY"),
         }
-    }
-}
-
-lazy_static! {
-    static ref DATA_TYPES: Vec<ConcreteDataType> = vec![
-        ConcreteDataType::boolean_datatype(),
-        ConcreteDataType::int16_datatype(),
-        ConcreteDataType::int32_datatype(),
-        ConcreteDataType::int64_datatype(),
-        ConcreteDataType::float32_datatype(),
-        ConcreteDataType::float64_datatype(),
-    ];
-    static ref TS_DATA_TYPES: Vec<ConcreteDataType> = vec![
-        ConcreteDataType::timestamp_nanosecond_datatype(),
-        ConcreteDataType::timestamp_microsecond_datatype(),
-        ConcreteDataType::timestamp_millisecond_datatype(),
-        ConcreteDataType::timestamp_second_datatype(),
-    ];
-    pub static ref PARTIBLE_DATA_TYPES: Vec<ConcreteDataType> = vec![
-        ConcreteDataType::int16_datatype(),
-        ConcreteDataType::int32_datatype(),
-        ConcreteDataType::int64_datatype(),
-        ConcreteDataType::float32_datatype(),
-        ConcreteDataType::float64_datatype(),
-        ConcreteDataType::string_datatype(),
-        ConcreteDataType::date_datatype(),
-        ConcreteDataType::datetime_datatype(),
-    ];
-}
-
-/// Generates a random [Value].
-pub fn generate_random_value(datatype: &ConcreteDataType) -> Value {
-    match datatype {
-        &ConcreteDataType::Boolean(_) => Value::from(rand::random::<bool>()),
-        ConcreteDataType::Int16(_) => Value::from(rand::random::<i16>()),
-        ConcreteDataType::Int32(_) => Value::from(rand::random::<i32>()),
-        ConcreteDataType::Int64(_) => Value::from(rand::random::<i64>()),
-        ConcreteDataType::Float32(_) => Value::from(rand::random::<f32>()),
-        ConcreteDataType::Float64(_) => Value::from(rand::random::<f64>()),
-        ConcreteDataType::String(_) => Value::from(rand::random::<char>().to_string()),
-        ConcreteDataType::Date(_) => Value::from(rand::random::<i32>()),
-        ConcreteDataType::DateTime(_) => Value::from(rand::random::<i64>()),
-
-        _ => unimplemented!("unsupported type: {datatype}"),
-    }
-}
-
-/// The IR column.
-#[derive(Debug, Builder, Clone)]
-pub struct Column {
-    #[builder(setter(into))]
-    pub name: String,
-    pub column_type: ConcreteDataType,
-    #[builder(default, setter(into))]
-    pub options: Vec<ColumnOption>,
-}
-
-impl Distribution<Column> for Standard {
-    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> Column {
-        let column_type = DATA_TYPES[rng.gen_range(0..DATA_TYPES.len())].clone();
-        // 0 -> NULL
-        // 1 -> NOT NULL
-        // 2 -> DEFAULT VALUE
-        // 3 -> PRIMARY KEY
-        // 4 -> EMPTY
-        let option_idx = rng.gen_range(0..5);
-        let options = match option_idx {
-            0 => vec![ColumnOption::Null],
-            1 => vec![ColumnOption::NotNull],
-            2 => vec![ColumnOption::DefaultValue(generate_random_value(
-                &column_type,
-            ))],
-            3 => vec![ColumnOption::PrimaryKey],
-            _ => vec![],
-        };
-
-        Column {
-            name: rng.gen::<Word>().to_string(),
-            column_type,
-            options,
-        }
-    }
-}
-
-/// The IR ts column.
-pub struct TsColumn(pub Column);
-
-impl Distribution<TsColumn> for Standard {
-    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> TsColumn {
-        let column_type = TS_DATA_TYPES[rng.gen_range(0..TS_DATA_TYPES.len())].clone();
-        TsColumn(Column {
-            name: rng.gen::<Word>().to_string(),
-            column_type,
-            options: vec![],
-        })
-    }
-}
-
-/// The IR partible column.
-pub struct PartibleColumn(pub Column);
-
-impl Distribution<PartibleColumn> for Standard {
-    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> PartibleColumn {
-        let column_type = PARTIBLE_DATA_TYPES[rng.gen_range(0..PARTIBLE_DATA_TYPES.len())].clone();
-        PartibleColumn(Column {
-            name: rng.gen::<Word>().to_string(),
-            column_type,
-            options: vec![],
-        })
     }
 }
 

--- a/tests-fuzz/src/ir/create_expr.rs
+++ b/tests-fuzz/src/ir/create_expr.rs
@@ -18,11 +18,12 @@ use std::fmt::Display;
 use datatypes::value::Value;
 use derive_builder::Builder;
 use partition::partition::PartitionDef;
+use serde::{Deserialize, Serialize};
 
 use crate::ir::Column;
 
 // The column options
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ColumnOption {
     Null,
     NotNull,
@@ -46,7 +47,7 @@ impl Display for ColumnOption {
 }
 
 /// A naive create table expr builder.
-#[derive(Debug, Builder, Clone)]
+#[derive(Debug, Builder, Clone, Serialize, Deserialize)]
 pub struct CreateTableExpr {
     pub name: String,
     pub columns: Vec<Column>,

--- a/tests-fuzz/src/ir/create_expr.rs
+++ b/tests-fuzz/src/ir/create_expr.rs
@@ -1,0 +1,174 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::fmt::Display;
+
+use datatypes::data_type::ConcreteDataType;
+use datatypes::value::Value;
+use derive_builder::Builder;
+use faker_rand::lorem::Word;
+use lazy_static::lazy_static;
+use partition::partition::PartitionDef;
+use rand::distributions::{Distribution, Standard};
+
+// The column options
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColumnOption {
+    Null,
+    NotNull,
+    DefaultValue(Value),
+    DefaultFn(String),
+    TimeIndex,
+    PrimaryKey,
+}
+
+impl Display for ColumnOption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnOption::Null => write!(f, "NULL"),
+            ColumnOption::NotNull => write!(f, "NOT NULL"),
+            ColumnOption::DefaultFn(s) => write!(f, "DEFAULT {}", s),
+            ColumnOption::DefaultValue(s) => write!(f, "DEFAULT {}", s),
+            ColumnOption::TimeIndex => write!(f, "TIME INDEX"),
+            ColumnOption::PrimaryKey => write!(f, "PRIMARY KEY"),
+        }
+    }
+}
+
+lazy_static! {
+    static ref DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::boolean_datatype(),
+        ConcreteDataType::int16_datatype(),
+        ConcreteDataType::int32_datatype(),
+        ConcreteDataType::int64_datatype(),
+        ConcreteDataType::float32_datatype(),
+        ConcreteDataType::float64_datatype(),
+    ];
+    static ref TS_DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::timestamp_nanosecond_datatype(),
+        ConcreteDataType::timestamp_microsecond_datatype(),
+        ConcreteDataType::timestamp_millisecond_datatype(),
+        ConcreteDataType::timestamp_second_datatype(),
+    ];
+    pub static ref PARTIBLE_DATA_TYPES: Vec<ConcreteDataType> = vec![
+        ConcreteDataType::int16_datatype(),
+        ConcreteDataType::int32_datatype(),
+        ConcreteDataType::int64_datatype(),
+        ConcreteDataType::float32_datatype(),
+        ConcreteDataType::float64_datatype(),
+        ConcreteDataType::string_datatype(),
+        ConcreteDataType::date_datatype(),
+        ConcreteDataType::datetime_datatype(),
+    ];
+}
+
+/// Generates a random [Value].
+pub fn generate_random_value(datatype: &ConcreteDataType) -> Value {
+    match datatype {
+        &ConcreteDataType::Boolean(_) => Value::from(rand::random::<bool>()),
+        ConcreteDataType::Int16(_) => Value::from(rand::random::<i16>()),
+        ConcreteDataType::Int32(_) => Value::from(rand::random::<i32>()),
+        ConcreteDataType::Int64(_) => Value::from(rand::random::<i64>()),
+        ConcreteDataType::Float32(_) => Value::from(rand::random::<f32>()),
+        ConcreteDataType::Float64(_) => Value::from(rand::random::<f64>()),
+        ConcreteDataType::String(_) => Value::from(rand::random::<char>().to_string()),
+        ConcreteDataType::Date(_) => Value::from(rand::random::<i32>()),
+        ConcreteDataType::DateTime(_) => Value::from(rand::random::<i64>()),
+
+        _ => unimplemented!("unsupported type: {datatype}"),
+    }
+}
+
+/// The IR column.
+#[derive(Debug, Builder, Clone)]
+pub struct Column {
+    #[builder(setter(into))]
+    pub name: String,
+    pub column_type: ConcreteDataType,
+    #[builder(default, setter(into))]
+    pub options: Vec<ColumnOption>,
+}
+
+impl Distribution<Column> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> Column {
+        let column_type = DATA_TYPES[rng.gen_range(0..DATA_TYPES.len())].clone();
+        // 0 -> NULL
+        // 1 -> NOT NULL
+        // 2 -> DEFAULT VALUE
+        // 3 -> PRIMARY KEY
+        // 4 -> EMPTY
+        let option_idx = rng.gen_range(0..5);
+        let options = match option_idx {
+            0 => vec![ColumnOption::Null],
+            1 => vec![ColumnOption::NotNull],
+            2 => vec![ColumnOption::DefaultValue(generate_random_value(
+                &column_type,
+            ))],
+            3 => vec![ColumnOption::PrimaryKey],
+            _ => vec![],
+        };
+
+        Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options,
+        }
+    }
+}
+
+/// The IR ts column.
+pub struct TsColumn(pub Column);
+
+impl Distribution<TsColumn> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> TsColumn {
+        let column_type = TS_DATA_TYPES[rng.gen_range(0..TS_DATA_TYPES.len())].clone();
+        TsColumn(Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options: vec![],
+        })
+    }
+}
+
+/// The IR partible column.
+pub struct PartibleColumn(pub Column);
+
+impl Distribution<PartibleColumn> for Standard {
+    fn sample<R: rand::prelude::Rng + ?Sized>(&self, rng: &mut R) -> PartibleColumn {
+        let column_type = PARTIBLE_DATA_TYPES[rng.gen_range(0..PARTIBLE_DATA_TYPES.len())].clone();
+        PartibleColumn(Column {
+            name: rng.gen::<Word>().to_string(),
+            column_type,
+            options: vec![],
+        })
+    }
+}
+
+/// A naive create table expr builder.
+#[derive(Debug, Builder, Clone)]
+pub struct CreateTableExpr {
+    pub name: String,
+    pub columns: Vec<Column>,
+    #[builder(default)]
+    pub if_not_exists: bool,
+
+    // GreptimeDB specific options
+    #[builder(default, setter(into))]
+    pub partitions: Vec<PartitionDef>,
+    pub engine: String,
+    #[builder(default, setter(into))]
+    pub options: HashMap<String, Value>,
+    pub primary_keys: Vec<usize>,
+}

--- a/tests-fuzz/src/lib.rs
+++ b/tests-fuzz/src/lib.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(extract_if)]
-
 pub(crate) mod context;
 pub(crate) mod error;
 pub(crate) mod executor;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. add CreateTableExprGenerator
2. add AlterTableExprGenerator

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
#3174