### PR TITLE
fix(index): S3 `EntityTooSmall` error

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -135,6 +135,7 @@ impl AccessLayer {
             let indexer = IndexerBuilder {
                 create_inverted_index: request.create_inverted_index,
                 mem_threshold_index_create: request.mem_threshold_index_create,
+                write_buffer_size: request.index_write_buffer_size,
                 file_id,
                 file_path: index_file_path,
                 metadata: &request.metadata,
@@ -183,6 +184,8 @@ pub(crate) struct SstWriteRequest {
     pub(crate) create_inverted_index: bool,
     /// The threshold of memory size to create inverted index.
     pub(crate) mem_threshold_index_create: Option<usize>,
+    /// The size of write buffer for index.
+    pub(crate) index_write_buffer_size: Option<usize>,
 }
 
 /// Creates a fs object store with atomic write dir.

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -110,6 +110,7 @@ impl WriteCache {
         let indexer = IndexerBuilder {
             create_inverted_index: write_request.create_inverted_index,
             mem_threshold_index_create: write_request.mem_threshold_index_create,
+            write_buffer_size: write_request.index_write_buffer_size,
             file_id,
             file_path: self.file_cache.cache_file_path(puffin_key),
             metadata: &write_request.metadata,
@@ -281,6 +282,7 @@ mod tests {
             storage: None,
             create_inverted_index: true,
             mem_threshold_index_create: None,
+            index_write_buffer_size: None,
             cache_manager: Default::default(),
         };
 

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -314,6 +314,12 @@ impl TwcsCompactionTask {
                 .inverted_index
                 .mem_threshold_on_create
                 .map(|m| m.as_bytes() as _);
+            let index_write_buffer_size = Some(
+                self.engine_config
+                    .inverted_index
+                    .write_buffer_size
+                    .as_bytes() as usize,
+            );
 
             let metadata = self.metadata.clone();
             let sst_layer = self.sst_layer.clone();
@@ -334,6 +340,7 @@ impl TwcsCompactionTask {
                             storage,
                             create_inverted_index,
                             mem_threshold_index_create,
+                            index_write_buffer_size,
                         },
                         &write_opts,
                     )

--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -252,6 +252,8 @@ pub struct InvertedIndexConfig {
     pub create_on_compaction: Mode,
     /// Whether to apply the index on query: automatically or never.
     pub apply_on_query: Mode,
+    /// Write buffer size for creating the index.
+    pub write_buffer_size: ReadableSize,
     /// Memory threshold for performing an external sort during index creation.
     /// `None` means all sorting will happen in memory.
     #[serde_as(as = "NoneAsEmptyString")]
@@ -266,6 +268,7 @@ impl Default for InvertedIndexConfig {
             create_on_flush: Mode::Auto,
             create_on_compaction: Mode::Auto,
             apply_on_query: Mode::Auto,
+            write_buffer_size: ReadableSize::mb(8),
             mem_threshold_on_create: Some(ReadableSize::mb(64)),
             intermediate_path: String::new(),
         }

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -321,6 +321,12 @@ impl RegionFlushTask {
                 .inverted_index
                 .mem_threshold_on_create
                 .map(|m| m.as_bytes() as _);
+            let index_write_buffer_size = Some(
+                self.engine_config
+                    .inverted_index
+                    .write_buffer_size
+                    .as_bytes() as usize,
+            );
 
             // Flush to level 0.
             let write_request = SstWriteRequest {
@@ -331,6 +337,7 @@ impl RegionFlushTask {
                 storage: version.options.storage.clone(),
                 create_inverted_index,
                 mem_threshold_index_create,
+                index_write_buffer_size,
             };
             let Some(sst_info) = self
                 .access_layer

--- a/src/mito2/src/sst/index/intermediate.rs
+++ b/src/mito2/src/sst/index/intermediate.rs
@@ -45,6 +45,12 @@ impl IntermediateManager {
         Ok(Self { store })
     }
 
+    /// Set the write buffer size for the store.
+    pub fn with_buffer_size(mut self, write_buffer_size: Option<usize>) -> Self {
+        self.store = self.store.with_write_buffer_size(write_buffer_size);
+        self
+    }
+
     /// Returns the store to access to intermediate files.
     pub(crate) fn store(&self) -> &InstrumentedStore {
         &self.store

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -266,9 +266,21 @@ impl ParquetReaderBuilder {
             if self.file_handle.meta().inverted_index_available() {
                 match index_applier.apply(self.file_handle.file_id()).await {
                     Ok(row_groups) => row_group_ids = row_groups,
-                    Err(err) => warn!(
-                        err; "Failed to apply index, region_id: {}, file_id: {}", 
-                        self.file_handle.region_id(), self.file_handle.file_id()),
+                    Err(err) => {
+                        if cfg!(any(test, feature = "test")) {
+                            panic!(
+                                "Failed to apply index, region_id: {}, file_id: {}, err: {}",
+                                self.file_handle.region_id(),
+                                self.file_handle.file_id(),
+                                err
+                            );
+                        } else {
+                            warn!(
+                                err; "Failed to apply index, region_id: {}, file_id: {}",
+                                self.file_handle.region_id(), self.file_handle.file_id()
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -123,7 +123,9 @@ impl WorkerGroup {
             config.global_write_buffer_size.as_bytes() as usize,
         ));
         let intermediate_manager =
-            IntermediateManager::init_fs(&config.inverted_index.intermediate_path).await?;
+            IntermediateManager::init_fs(&config.inverted_index.intermediate_path)
+                .await?
+                .with_buffer_size(Some(config.inverted_index.write_buffer_size.as_bytes() as _));
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
         let write_cache = write_cache_from_config(
             &config,
@@ -233,7 +235,9 @@ impl WorkerGroup {
         });
         let scheduler = Arc::new(LocalScheduler::new(config.max_background_jobs));
         let intermediate_manager =
-            IntermediateManager::init_fs(&config.inverted_index.intermediate_path).await?;
+            IntermediateManager::init_fs(&config.inverted_index.intermediate_path)
+                .await?
+                .with_buffer_size(Some(config.inverted_index.write_buffer_size.as_bytes() as _));
         let write_cache = write_cache_from_config(
             &config,
             object_store_manager.clone(),

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -777,6 +777,7 @@ allow_stale_entries = false
 create_on_flush = "auto"
 create_on_compaction = "auto"
 apply_on_query = "auto"
+write_buffer_size = "8MiB"
 mem_threshold_on_create = "64.0MiB"
 intermediate_path = ""
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Set the buffer size for the OpenDAL writer to avoid uploading small parts.

Additionally, ensure that index-related exceptions cause panic in test scenarios.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
