### PR TITLE
feat: adds parse options for SQL parser

### DIFF
--- a/src/cmd/src/cli/repl.rs
+++ b/src/cmd/src/cli/repl.rs
@@ -157,10 +157,10 @@ impl Repl {
         let start = Instant::now();
 
         let output = if let Some(query_engine) = &self.query_engine {
-            let stmt = QueryLanguageParser::parse_sql(&sql)
-                .with_context(|_| ParseSqlSnafu { sql: sql.clone() })?;
-
             let query_ctx = QueryContext::with(self.database.catalog(), self.database.schema());
+
+            let stmt = QueryLanguageParser::parse_sql(&sql, &query_ctx)
+                .with_context(|_| ParseSqlSnafu { sql: sql.clone() })?;
 
             let plan = query_engine
                 .planner()

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -615,7 +615,7 @@ impl RegionServerInner {
 
         let table_provider = self
             .table_provider_factory
-            .create(region_id, region_status.into_engine(), &ctx)
+            .create(region_id, region_status.into_engine())
             .await?;
 
         let catalog_list = Arc::new(DummyCatalogList::with_table_provider(table_provider));
@@ -832,7 +832,6 @@ impl TableProviderFactory for DummyTableProviderFactory {
         &self,
         region_id: RegionId,
         engine: RegionEngineRef,
-        query_ctx: &QueryContextRef,
     ) -> Result<Arc<dyn TableProvider>> {
         let metadata =
             engine
@@ -846,10 +845,7 @@ impl TableProviderFactory for DummyTableProviderFactory {
             region_id,
             engine,
             metadata,
-            scan_request: Arc::new(Mutex::new(ScanRequest {
-                timezone: Some(query_ctx.timezone()),
-                ..Default::default()
-            })),
+            scan_request: Default::default(),
         }))
     }
 }
@@ -860,7 +856,6 @@ pub trait TableProviderFactory: Send + Sync {
         &self,
         region_id: RegionId,
         engine: RegionEngineRef,
-        query_ctx: &QueryContextRef,
     ) -> Result<Arc<dyn TableProvider>>;
 }
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -70,7 +70,7 @@ use servers::server::{start_server, ServerHandlers};
 use session::context::QueryContextRef;
 use snafu::prelude::*;
 use sql::dialect::Dialect;
-use sql::parser::ParserContext;
+use sql::parser::{ParseOptions, ParserContext};
 use sql::statements::copy::CopyTable;
 use sql::statements::statement::Statement;
 use sqlparser::ast::ObjectName;
@@ -252,8 +252,17 @@ impl FrontendInstance for Instance {
     }
 }
 
-fn parse_stmt(sql: &str, dialect: &(dyn Dialect + Send + Sync)) -> Result<Vec<Statement>> {
-    ParserContext::create_with_dialect(sql, dialect).context(ParseSqlSnafu)
+fn parse_stmt(
+    sql: &str,
+    dialect: &(dyn Dialect + Send + Sync),
+    query_ctx: &QueryContextRef,
+) -> Result<Vec<Statement>> {
+    ParserContext::create_with_dialect(
+        sql,
+        dialect,
+        ParseOptions::with_timezone(query_ctx.timezone().as_ref()),
+    )
+    .context(ParseSqlSnafu)
 }
 
 impl Instance {
@@ -284,7 +293,7 @@ impl SqlQueryHandler for Instance {
         let checker_ref = self.plugins.get::<PermissionCheckerRef>();
         let checker = checker_ref.as_ref();
 
-        match parse_stmt(query.as_ref(), query_ctx.sql_dialect())
+        match parse_stmt(query.as_ref(), query_ctx.sql_dialect(), &query_ctx)
             .and_then(|stmts| query_interceptor.post_parsing(stmts, query_ctx.clone()))
         {
             Ok(stmts) => {
@@ -414,8 +423,10 @@ impl PrometheusHandler for Instance {
             .check_permission(query_ctx.current_user(), PermissionReq::PromQuery)
             .context(AuthSnafu)?;
 
-        let stmt = QueryLanguageParser::parse_promql(query).with_context(|_| ParsePromQLSnafu {
-            query: query.clone(),
+        let stmt = QueryLanguageParser::parse_promql(query, &query_ctx).with_context(|_| {
+            ParsePromQLSnafu {
+                query: query.clone(),
+            }
         })?;
 
         let output = self
@@ -531,7 +542,7 @@ mod tests {
         CREATE DATABASE test_database;
         SHOW DATABASES;
         "#;
-        let stmts = parse_stmt(sql, &GreptimeDbDialect {}).unwrap();
+        let stmts = parse_stmt(sql, &GreptimeDbDialect {}, &query_ctx).unwrap();
         assert_eq!(stmts.len(), 4);
         for stmt in stmts {
             let re = check_permission(plugins.clone(), &stmt, &query_ctx);
@@ -542,7 +553,7 @@ mod tests {
         SHOW CREATE TABLE demo;
         ALTER TABLE demo ADD COLUMN new_col INT;
         "#;
-        let stmts = parse_stmt(sql, &GreptimeDbDialect {}).unwrap();
+        let stmts = parse_stmt(sql, &GreptimeDbDialect {}, &query_ctx).unwrap();
         assert_eq!(stmts.len(), 2);
         for stmt in stmts {
             let re = check_permission(plugins.clone(), &stmt, &query_ctx);
@@ -576,7 +587,7 @@ mod tests {
         }
 
         fn do_test(sql: &str, plugins: Plugins, query_ctx: &QueryContextRef, is_ok: bool) {
-            let stmt = &parse_stmt(sql, &GreptimeDbDialect {}).unwrap()[0];
+            let stmt = &parse_stmt(sql, &GreptimeDbDialect {}, query_ctx).unwrap()[0];
             let re = check_permission(plugins, stmt, query_ctx);
             if is_ok {
                 re.unwrap();
@@ -604,11 +615,11 @@ mod tests {
 
         // test show tables
         let sql = "SHOW TABLES FROM public";
-        let stmt = parse_stmt(sql, &GreptimeDbDialect {}).unwrap();
+        let stmt = parse_stmt(sql, &GreptimeDbDialect {}, &query_ctx).unwrap();
         check_permission(plugins.clone(), &stmt[0], &query_ctx).unwrap();
 
         let sql = "SHOW TABLES FROM private";
-        let stmt = parse_stmt(sql, &GreptimeDbDialect {}).unwrap();
+        let stmt = parse_stmt(sql, &GreptimeDbDialect {}, &query_ctx).unwrap();
         let re = check_permission(plugins.clone(), &stmt[0], &query_ctx);
         assert!(re.is_ok());
 

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -351,7 +351,6 @@ impl MetadataRegion {
             filters: vec![],
             output_ordering: None,
             limit: None,
-            timezone: None,
         };
         let record_batch_stream = self
             .mito
@@ -409,7 +408,6 @@ impl MetadataRegion {
             filters: vec![filter_expr.into()],
             output_ordering: None,
             limit: None,
-            timezone: None,
         }
     }
 
@@ -570,7 +568,6 @@ mod test {
             filters: vec![expected_filter_expr.into()],
             output_ordering: None,
             limit: None,
-            timezone: None,
         };
         let actual_scan_request = MetadataRegion::build_read_request(key);
         assert_eq!(actual_scan_request, expected_scan_request);

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -351,6 +351,7 @@ impl MetadataRegion {
             filters: vec![],
             output_ordering: None,
             limit: None,
+            timezone: None,
         };
         let record_batch_stream = self
             .mito
@@ -408,6 +409,7 @@ impl MetadataRegion {
             filters: vec![filter_expr.into()],
             output_ordering: None,
             limit: None,
+            timezone: None,
         }
     }
 
@@ -568,6 +570,7 @@ mod test {
             filters: vec![expected_filter_expr.into()],
             output_ordering: None,
             limit: None,
+            timezone: None,
         };
         let actual_scan_request = MetadataRegion::build_read_request(key);
         assert_eq!(actual_scan_request, expected_scan_request);

--- a/src/mito2/src/engine/projection_test.rs
+++ b/src/mito2/src/engine/projection_test.rs
@@ -78,7 +78,6 @@ async fn test_scan_projection() {
         filters: Vec::new(),
         output_ordering: None,
         limit: None,
-        timezone: None,
     };
     let stream = engine.handle_query(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/mito2/src/engine/projection_test.rs
+++ b/src/mito2/src/engine/projection_test.rs
@@ -78,6 +78,7 @@ async fn test_scan_projection() {
         filters: Vec::new(),
         output_ordering: None,
         limit: None,
+        timezone: None,
     };
     let stream = engine.handle_query(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -411,7 +411,7 @@ pub(crate) fn to_alter_expr(
 mod tests {
     use session::context::QueryContext;
     use sql::dialect::GreptimeDbDialect;
-    use sql::parser::ParserContext;
+    use sql::parser::{ParseOptions, ParserContext};
     use sql::statements::statement::Statement;
 
     use super::*;
@@ -419,10 +419,11 @@ mod tests {
     #[test]
     fn test_create_to_expr() {
         let sql = "CREATE TABLE monitor (host STRING,ts TIMESTAMP,TIME INDEX (ts),PRIMARY KEY(host)) ENGINE=mito WITH(regions=1, ttl='3days', write_buffer_size='1024KB');";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .pop()
-            .unwrap();
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .pop()
+                .unwrap();
 
         let Statement::CreateTable(create_table) = stmt else {
             unreachable!()

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -632,7 +632,7 @@ fn merge_options(mut table_opts: TableOptions, schema_opts: SchemaNameValue) -> 
 mod test {
     use session::context::QueryContext;
     use sql::dialect::GreptimeDbDialect;
-    use sql::parser::ParserContext;
+    use sql::parser::{ParseOptions, ParserContext};
     use sql::statements::statement::Statement;
 
     use super::*;
@@ -698,7 +698,12 @@ ENGINE=mito",
             ),
         ];
         for (sql, expected) in cases {
-            let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+            let result = ParserContext::create_with_dialect(
+                sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default(),
+            )
+            .unwrap();
             match &result[0] {
                 Statement::CreateTable(c) => {
                     let expr = expr_factory::create_to_expr(c, QueryContext::arc()).unwrap();

--- a/src/operator/src/statement/tql.rs
+++ b/src/operator/src/statement/tql.rs
@@ -35,7 +35,7 @@ impl StatementExecutor {
                     step: eval.step,
                     query: eval.query,
                 };
-                QueryLanguageParser::parse_promql(&promql).context(ParseQuerySnafu)?
+                QueryLanguageParser::parse_promql(&promql, &query_ctx).context(ParseQuerySnafu)?
             }
             Tql::Explain(explain) => {
                 let promql = PromQuery {
@@ -43,7 +43,7 @@ impl StatementExecutor {
                     ..PromQuery::default()
                 };
                 let params = HashMap::from([("name".to_string(), EXPLAIN_NODE_NAME.to_string())]);
-                QueryLanguageParser::parse_promql(&promql)
+                QueryLanguageParser::parse_promql(&promql, &query_ctx)
                     .context(ParseQuerySnafu)?
                     .post_process(params)
                     .unwrap()
@@ -56,7 +56,7 @@ impl StatementExecutor {
                     query: tql_analyze.query,
                 };
                 let params = HashMap::from([("name".to_string(), ANALYZE_NODE_NAME.to_string())]);
-                QueryLanguageParser::parse_promql(&promql)
+                QueryLanguageParser::parse_promql(&promql, &query_ctx)
                     .context(ParseQuerySnafu)?
                     .post_process(params)
                     .unwrap()

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -519,7 +519,7 @@ mod tests {
     use datatypes::vectors::{Helper, StringVectorBuilder, UInt32Vector, UInt64Vector, VectorRef};
     use session::context::QueryContext;
     use sql::dialect::GreptimeDbDialect;
-    use sql::parser::ParserContext;
+    use sql::parser::{ParseOptions, ParserContext};
     use sql::statements::show::{ShowKind, ShowTables};
     use sql::statements::statement::Statement;
     use table::table::numbers::{NumbersTable, NUMBERS_TABLE_NAME};
@@ -547,7 +547,7 @@ mod tests {
         let engine = create_test_engine().await;
         let sql = "select sum(number) from numbers limit 20";
 
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(sql, &QueryContext::arc()).unwrap();
         let plan = engine
             .planner()
             .plan(stmt, QueryContext::arc())
@@ -569,7 +569,7 @@ mod tests {
         let engine = create_test_engine().await;
         let sql = "select sum(number) from numbers limit 20";
 
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(sql, &QueryContext::arc()).unwrap();
         let plan = engine
             .planner()
             .plan(stmt, QueryContext::arc())
@@ -643,7 +643,7 @@ mod tests {
         let engine = create_test_engine().await;
         let sql = "select sum(number) from numbers limit 20";
 
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(sql, &QueryContext::arc()).unwrap();
 
         let plan = engine
             .planner()
@@ -709,6 +709,7 @@ mod tests {
         let statement = ParserContext::create_with_dialect(
             "SHOW TABLES WHERE \"Tables\"='monitor'",
             &GreptimeDbDialect {},
+            ParseOptions::default(),
         )
         .unwrap()[0]
             .clone();

--- a/src/query/src/parser.rs
+++ b/src/query/src/parser.rs
@@ -112,9 +112,7 @@ impl QueryLanguageParser {
         let mut statement =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
                 .map_err(BoxedError::new)
-                .context(QueryParseSnafu {
-                    query: sql,
-                })?;
+                .context(QueryParseSnafu { query: sql })?;
         if statement.len() != 1 {
             MultipleStatementsSnafu {
                 query: sql.to_string(),

--- a/src/query/src/parser.rs
+++ b/src/query/src/parser.rs
@@ -107,17 +107,14 @@ pub struct QueryLanguageParser {}
 
 impl QueryLanguageParser {
     /// Try to parse SQL with GreptimeDB dialect, return the statement when success.
-    pub fn parse_sql(sql: &str, query_ctx: &QueryContextRef) -> Result<QueryStatement> {
+    pub fn parse_sql(sql: &str, _query_ctx: &QueryContextRef) -> Result<QueryStatement> {
         let _timer = METRIC_PARSE_SQL_ELAPSED.start_timer();
-        let mut statement = ParserContext::create_with_dialect(
-            sql,
-            &GreptimeDbDialect {},
-            ParseOptions::with_timezone(query_ctx.timezone().as_ref()),
-        )
-        .map_err(BoxedError::new)
-        .context(QueryParseSnafu {
-            query: sql.to_string(),
-        })?;
+        let mut statement =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .map_err(BoxedError::new)
+                .context(QueryParseSnafu {
+                    query: sql.to_string(),
+                })?;
         if statement.len() != 1 {
             MultipleStatementsSnafu {
                 query: sql.to_string(),

--- a/src/query/src/parser.rs
+++ b/src/query/src/parser.rs
@@ -23,9 +23,10 @@ use common_error::status_code::StatusCode;
 use promql_parser::parser::ast::{Extension as NodeExtension, ExtensionExpr};
 use promql_parser::parser::Expr::Extension;
 use promql_parser::parser::{EvalStmt, Expr, ValueType};
+use session::context::QueryContextRef;
 use snafu::{OptionExt, ResultExt};
 use sql::dialect::GreptimeDbDialect;
-use sql::parser::ParserContext;
+use sql::parser::{ParseOptions, ParserContext};
 use sql::statements::statement::Statement;
 
 use crate::error::{
@@ -101,16 +102,22 @@ impl Default for PromQuery {
     }
 }
 
+/// Query language parser, supports parsing SQL and PromQL
 pub struct QueryLanguageParser {}
 
 impl QueryLanguageParser {
-    pub fn parse_sql(sql: &str) -> Result<QueryStatement> {
+    /// Try to parse SQL with GreptimeDB dialect, return the statement when success.
+    pub fn parse_sql(sql: &str, query_ctx: &QueryContextRef) -> Result<QueryStatement> {
         let _timer = METRIC_PARSE_SQL_ELAPSED.start_timer();
-        let mut statement = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .map_err(BoxedError::new)
-            .context(QueryParseSnafu {
-                query: sql.to_string(),
-            })?;
+        let mut statement = ParserContext::create_with_dialect(
+            sql,
+            &GreptimeDbDialect {},
+            ParseOptions::with_timezone(query_ctx.timezone().as_ref()),
+        )
+        .map_err(BoxedError::new)
+        .context(QueryParseSnafu {
+            query: sql.to_string(),
+        })?;
         if statement.len() != 1 {
             MultipleStatementsSnafu {
                 query: sql.to_string(),
@@ -121,7 +128,8 @@ impl QueryLanguageParser {
         }
     }
 
-    pub fn parse_promql(query: &PromQuery) -> Result<QueryStatement> {
+    /// Try to parse PromQL, return the statement when success.
+    pub fn parse_promql(query: &PromQuery, _query_ctx: &QueryContextRef) -> Result<QueryStatement> {
         let _timer = METRIC_PARSE_PROMQL_ELAPSED.start_timer();
 
         let expr = promql_parser::parser::parse(&query.query)
@@ -165,6 +173,7 @@ impl QueryLanguageParser {
     }
 
     fn parse_promql_timestamp(timestamp: &str) -> Result<SystemTime> {
+        // FIXME(dennis): aware of timezone
         // try rfc3339 format
         let rfc3339_result = DateTime::parse_from_rfc3339(timestamp)
             .context(ParseTimestampSnafu { raw: timestamp })
@@ -236,13 +245,15 @@ define_node_ast_extension!(Explain, ExplainExpr, Expr, EXPLAIN_NODE_NAME);
 
 #[cfg(test)]
 mod test {
+    use session::context::QueryContext;
+
     use super::*;
 
     // Detailed logic tests are covered in the parser crate.
     #[test]
     fn parse_sql_simple() {
         let sql = "select * from t1";
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(sql, &QueryContext::arc()).unwrap();
         let expected = String::from("Sql(Query(Query { \
             inner: Query { \
                 with: None, body: Select(Select { \
@@ -360,7 +371,7 @@ mod test {
             })",
         );
 
-        let result = QueryLanguageParser::parse_promql(&promql).unwrap();
+        let result = QueryLanguageParser::parse_promql(&promql, &QueryContext::arc()).unwrap();
         assert_eq!(format!("{result:?}"), expected);
     }
 }

--- a/src/query/src/parser.rs
+++ b/src/query/src/parser.rs
@@ -113,7 +113,7 @@ impl QueryLanguageParser {
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
                 .map_err(BoxedError::new)
                 .context(QueryParseSnafu {
-                    query: sql.to_string(),
+                    query: sql,
                 })?;
         if statement.len() != 1 {
             MultipleStatementsSnafu {

--- a/src/query/src/range_select/plan_rewrite.rs
+++ b/src/query/src/range_select/plan_rewrite.rs
@@ -526,7 +526,7 @@ mod test {
     }
 
     async fn do_query(sql: &str) -> Result<crate::plan::LogicalPlan> {
-        let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(sql, &QueryContext::arc()).unwrap();
         let engine = create_test_engine().await;
         engine.planner().plan(stmt, QueryContext::arc()).await
     }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -657,7 +657,7 @@ mod test {
             variable: ObjectName(vec![Ident::new(variable)]),
         };
         let ctx = QueryContextBuilder::default()
-            .timezone(Timezone::from_tz_string(tz).unwrap())
+            .timezone(Arc::new(Timezone::from_tz_string(tz).unwrap()))
             .build();
         match show_variable(stmt, ctx) {
             Ok(Output::RecordBatches(record)) => {

--- a/src/query/src/tests.rs
+++ b/src/query/src/tests.rs
@@ -36,13 +36,14 @@ mod function;
 mod pow;
 
 async fn exec_selection(engine: QueryEngineRef, sql: &str) -> Vec<RecordBatch> {
-    let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+    let query_ctx = QueryContext::arc();
+    let stmt = QueryLanguageParser::parse_sql(sql, &query_ctx).unwrap();
     let plan = engine
         .planner()
         .plan(stmt, QueryContext::arc())
         .await
         .unwrap();
-    let Output::Stream(stream) = engine.execute(plan, QueryContext::arc()).await.unwrap() else {
+    let Output::Stream(stream) = engine.execute(plan, query_ctx).await.unwrap() else {
         unreachable!()
     };
     util::collect(stream).await.unwrap()

--- a/src/query/src/tests/query_engine_test.rs
+++ b/src/query/src/tests/query_engine_test.rs
@@ -131,14 +131,20 @@ async fn test_query_validate() -> Result<()> {
     let factory = QueryEngineFactory::new_with_plugins(catalog_list, None, None, false, plugins);
     let engine = factory.query_engine();
 
-    let stmt = QueryLanguageParser::parse_sql("select number from public.numbers").unwrap();
+    let stmt =
+        QueryLanguageParser::parse_sql("select number from public.numbers", &QueryContext::arc())
+            .unwrap();
     assert!(engine
         .planner()
         .plan(stmt, QueryContext::arc())
         .await
         .is_ok());
 
-    let stmt = QueryLanguageParser::parse_sql("select number from wrongschema.numbers").unwrap();
+    let stmt = QueryLanguageParser::parse_sql(
+        "select number from wrongschema.numbers",
+        &QueryContext::arc(),
+    )
+    .unwrap();
     assert!(engine
         .planner()
         .plan(stmt, QueryContext::arc())

--- a/src/script/src/engine.rs
+++ b/src/script/src/engine.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use common_error::ext::ErrorExt;
 use common_query::Output;
+use session::context::{QueryContext, QueryContextRef};
 
 #[async_trait]
 pub trait Script {
@@ -57,8 +58,18 @@ pub trait ScriptEngine {
 }
 
 /// Evaluate script context
-#[derive(Debug, Default)]
-pub struct EvalContext {}
+#[derive(Debug)]
+pub struct EvalContext {
+    pub query_ctx: QueryContextRef,
+}
+
+impl Default for EvalContext {
+    fn default() -> Self {
+        Self {
+            query_ctx: QueryContext::arc(),
+        }
+    }
+}
 
 /// Compile script context
 #[derive(Debug, Default)]

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -36,7 +36,6 @@ use datatypes::vectors::VectorRef;
 use futures::Stream;
 use query::parser::{QueryLanguageParser, QueryStatement};
 use query::QueryEngineRef;
-use session::context::QueryContextBuilder;
 use snafu::{ensure, ResultExt};
 use sql::statements::statement::Statement;
 
@@ -158,12 +157,16 @@ impl Function for PyUDF {
         let schema = self.fake_schema(columns);
         let columns = columns.to_vec();
         let rb = Some(RecordBatch::new(schema, columns).context(UdfTempRecordBatchSnafu)?);
-        let res = exec_parsed(&self.copr, &rb, &HashMap::new()).map_err(|err| {
-            PyUdfSnafu {
-                msg: format!("{err:#?}"),
-            }
-            .build()
-        })?;
+
+        // FIXME(dennis): Create EvalContext from FunctionContext.
+        let res = exec_parsed(&self.copr, &rb, &HashMap::new(), &EvalContext::default()).map_err(
+            |err| {
+                PyUdfSnafu {
+                    msg: format!("{err:#?}"),
+                }
+                .build()
+            },
+        )?;
         let len = res.columns().len();
         if len == 0 {
             return PyUdfSnafu {
@@ -206,6 +209,7 @@ pub struct CoprStream {
     copr: CoprocessorRef,
     ret_schema: SchemaRef,
     params: HashMap<String, String>,
+    eval_ctx: EvalContext,
 }
 
 impl CoprStream {
@@ -213,6 +217,7 @@ impl CoprStream {
         stream: SendableRecordBatchStream,
         copr: CoprocessorRef,
         params: HashMap<String, String>,
+        eval_ctx: EvalContext,
     ) -> Result<Self> {
         let mut schema = vec![];
         for (ty, name) in copr.return_types.iter().zip(&copr.deco_args.ret_names) {
@@ -238,6 +243,7 @@ impl CoprStream {
             copr,
             ret_schema,
             params,
+            eval_ctx,
         })
     }
 }
@@ -256,9 +262,10 @@ impl Stream for CoprStream {
         match Pin::new(&mut self.stream).poll_next(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Some(Ok(recordbatch))) => {
-                let batch = exec_parsed(&self.copr, &Some(recordbatch), &self.params)
-                    .map_err(BoxedError::new)
-                    .context(ExternalSnafu)?;
+                let batch =
+                    exec_parsed(&self.copr, &Some(recordbatch), &self.params, &self.eval_ctx)
+                        .map_err(BoxedError::new)
+                        .context(ExternalSnafu)?;
                 Poll::Ready(Some(Ok(batch)))
             }
             Poll::Ready(other) => Poll::Ready(other),
@@ -283,36 +290,35 @@ impl Script for PyScript {
         self
     }
 
-    async fn execute(&self, params: HashMap<String, String>, _ctx: EvalContext) -> Result<Output> {
+    async fn execute(&self, params: HashMap<String, String>, ctx: EvalContext) -> Result<Output> {
         if let Some(sql) = &self.copr.deco_args.sql {
-            let stmt = QueryLanguageParser::parse_sql(sql).unwrap();
+            let stmt = QueryLanguageParser::parse_sql(sql, &ctx.query_ctx).unwrap();
             ensure!(
                 matches!(stmt, QueryStatement::Sql(Statement::Query { .. })),
                 error::UnsupportedSqlSnafu { sql }
             );
-            let ctx = QueryContextBuilder::default().build();
             let plan = self
                 .query_engine
                 .planner()
-                .plan(stmt, ctx.clone())
+                .plan(stmt, ctx.query_ctx.clone())
                 .await
                 .context(DatabaseQuerySnafu)?;
             let res = self
                 .query_engine
-                .execute(plan, ctx)
+                .execute(plan, ctx.query_ctx.clone())
                 .await
                 .context(DatabaseQuerySnafu)?;
             let copr = self.copr.clone();
             match res {
                 Output::Stream(stream) => Ok(Output::Stream(Box::pin(CoprStream::try_new(
-                    stream, copr, params,
+                    stream, copr, params, ctx,
                 )?))),
                 _ => unreachable!(),
             }
         } else {
             let copr = self.copr.clone();
             let params = params.clone();
-            let batch = spawn_blocking_script(move || exec_parsed(&copr, &None, &params))
+            let batch = spawn_blocking_script(move || exec_parsed(&copr, &None, &params, &ctx))
                 .await
                 .context(TokioJoinSnafu)??;
             let batches = RecordBatches::try_new(batch.schema.clone(), vec![batch]).unwrap();

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -34,12 +34,13 @@ use rustpython_compiler_core::CodeObject;
 use rustpython_vm as vm;
 #[cfg(test)]
 use serde::Deserialize;
-use session::context::QueryContextBuilder;
+use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
 use vm::convert::ToPyObject;
 use vm::{pyclass as rspyclass, PyObjectRef, PyPayload, PyResult, VirtualMachine};
 
 use super::py_recordbatch::PyRecordBatch;
+use crate::engine::EvalContext;
 use crate::python::error::{ensure, ArrowSnafu, OtherSnafu, Result, TypeCastSnafu};
 use crate::python::ffi_types::PyVector;
 #[cfg(feature = "pyo3_backend")]
@@ -325,12 +326,16 @@ pub(crate) fn check_args_anno_real_type(
 /// You can return constant in python code like `return 1, 1.0, True`
 /// which create a constant array(with same value)(currently support int, float and bool) as column on return
 #[cfg(test)]
-pub fn exec_coprocessor(script: &str, rb: &Option<RecordBatch>) -> Result<RecordBatch> {
+pub fn exec_coprocessor(
+    script: &str,
+    rb: &Option<RecordBatch>,
+    eval_ctx: &EvalContext,
+) -> Result<RecordBatch> {
     // 1. parse the script and check if it's only a function with `@coprocessor` decorator, and get `args` and `returns`,
     // 2. also check for exist of `args` in `rb`, if not found, return error
     // cache the result of parse_copr
     let copr = parse::parse_and_compile_copr(script, None)?;
-    exec_parsed(&copr, rb, &HashMap::new())
+    exec_parsed(&copr, rb, &HashMap::new(), eval_ctx)
 }
 
 #[cfg_attr(feature = "pyo3_backend", pyo3class(name = "query_engine"))]
@@ -338,6 +343,7 @@ pub fn exec_coprocessor(script: &str, rb: &Option<RecordBatch>) -> Result<Record
 #[derive(Debug, PyPayload, Clone)]
 pub struct PyQueryEngine {
     inner: QueryEngineWeakRef,
+    query_ctx: QueryContextRef,
 }
 pub(crate) enum Either {
     Rb(RecordBatches),
@@ -365,14 +371,16 @@ impl PyQueryEngine {
 
 #[rspyclass]
 impl PyQueryEngine {
-    pub(crate) fn from_weakref(inner: QueryEngineWeakRef) -> Self {
-        Self { inner }
+    pub(crate) fn from_weakref(inner: QueryEngineWeakRef, query_ctx: QueryContextRef) -> Self {
+        Self { inner, query_ctx }
     }
     pub(crate) fn query_with_new_thread(&self, s: String) -> StdResult<Either, String> {
         let query = self.inner.0.upgrade();
+        let query_ctx = self.query_ctx.clone();
         let thread_handle = std::thread::spawn(move || -> std::result::Result<_, String> {
             if let Some(engine) = query {
-                let stmt = QueryLanguageParser::parse_sql(&s).map_err(|e| e.to_string())?;
+                let stmt =
+                    QueryLanguageParser::parse_sql(&s, &query_ctx).map_err(|e| e.to_string())?;
 
                 // To prevent the error of nested creating Runtime, if is nested, use the parent runtime instead
 
@@ -445,13 +453,14 @@ pub fn exec_parsed(
     copr: &Coprocessor,
     rb: &Option<RecordBatch>,
     params: &HashMap<String, String>,
+    eval_ctx: &EvalContext,
 ) -> Result<RecordBatch> {
     match copr.backend {
-        BackendType::RustPython => rspy_exec_parsed(copr, rb, params),
+        BackendType::RustPython => rspy_exec_parsed(copr, rb, params, eval_ctx),
         BackendType::CPython => {
             #[cfg(feature = "pyo3_backend")]
             {
-                pyo3_exec_parsed(copr, rb, params)
+                pyo3_exec_parsed(copr, rb, params, eval_ctx)
             }
             #[cfg(not(feature = "pyo3_backend"))]
             {
@@ -477,8 +486,9 @@ pub fn exec_copr_print(
     rb: &Option<RecordBatch>,
     ln_offset: usize,
     filename: &str,
+    eval_ctx: &EvalContext,
 ) -> StdResult<RecordBatch, String> {
-    let res = exec_coprocessor(script, rb);
+    let res = exec_coprocessor(script, rb, eval_ctx);
     res.map_err(|e| {
         crate::python::error::pretty_print_error_in_src(script, &e, ln_offset, filename)
     })

--- a/src/script/src/python/rspython/test.rs
+++ b/src/script/src/python/rspython/test.rs
@@ -28,6 +28,7 @@ use ron::from_str as from_ron_string;
 use rustpython_parser::{parse, Mode};
 use serde::{Deserialize, Serialize};
 
+use crate::engine::EvalContext;
 use crate::python::error::{get_error_reason_loc, pretty_print_error_in_src, visualize_loc, Error};
 use crate::python::ffi_types::copr::parse::parse_and_compile_copr;
 use crate::python::ffi_types::copr::{exec_coprocessor, AnnotationInfo};
@@ -124,7 +125,8 @@ fn run_ron_testcases() {
             }
             Predicate::ExecIsOk { fields, columns } => {
                 let rb = create_sample_recordbatch();
-                let res = exec_coprocessor(&testcase.code, &Some(rb)).unwrap();
+                let res =
+                    exec_coprocessor(&testcase.code, &Some(rb), &EvalContext::default()).unwrap();
                 fields
                     .iter()
                     .zip(res.schema.column_schemas())
@@ -150,7 +152,7 @@ fn run_ron_testcases() {
                 reason: part_reason,
             } => {
                 let rb = create_sample_recordbatch();
-                let res = exec_coprocessor(&testcase.code, &Some(rb));
+                let res = exec_coprocessor(&testcase.code, &Some(rb), &EvalContext::default());
                 assert!(res.is_err(), "{res:#?}\nExpect Err(...), actual Ok(...)");
                 if let Err(res) = res {
                     error!(
@@ -252,7 +254,7 @@ def calc_rvs(open_time, close):
         ],
     )
     .unwrap();
-    let ret = exec_coprocessor(python_source, &Some(rb));
+    let ret = exec_coprocessor(python_source, &Some(rb), &EvalContext::default());
     if let Err(Error::PyParse { location: _, error }) = ret {
         let res = visualize_loc(
             python_source,
@@ -298,7 +300,7 @@ def a(cpu, mem):
         ],
     )
     .unwrap();
-    let ret = exec_coprocessor(python_source, &Some(rb));
+    let ret = exec_coprocessor(python_source, &Some(rb), &EvalContext::default());
     if let Err(Error::PyParse { location: _, error }) = ret {
         let res = visualize_loc(
             python_source,

--- a/src/servers/src/grpc/greptime_handler.rs
+++ b/src/servers/src/grpc/greptime_handler.rs
@@ -166,7 +166,7 @@ pub(crate) fn create_query_context(header: Option<&RequestHeader>) -> QueryConte
     QueryContextBuilder::default()
         .current_catalog(catalog.to_string())
         .current_schema(schema.to_string())
-        .timezone(timezone)
+        .timezone(Arc::new(timezone))
         .build()
 }
 

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use ::auth::UserProviderRef;
 use axum::extract::State;
 use axum::http::{self, Request, StatusCode};
@@ -62,7 +64,7 @@ pub async fn inner_auth<B>(
     let query_ctx = QueryContextBuilder::default()
         .current_catalog(catalog.to_string())
         .current_schema(schema.to_string())
-        .timezone(timezone)
+        .timezone(Arc::new(timezone))
         .build();
     let need_auth = need_auth(&req);
     let is_influxdb = req.uri().path().contains("influxdb");

--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -208,7 +208,7 @@ impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShi
         let query_ctx = self.session.new_query_context();
         let (query, param_num) = replace_placeholders(raw_query);
 
-        let statement = validate_query(raw_query, &query_ctx).await?;
+        let statement = validate_query(raw_query).await?;
 
         // We have to transform the placeholder, because DataFusion only parses placeholders
         // in the form of "$i", it can't process "?" right now.
@@ -444,12 +444,9 @@ fn replace_params_with_values(
         .context(error::ReplacePreparedStmtParamsSnafu)
 }
 
-async fn validate_query(query: &str, query_ctx: &QueryContextRef) -> Result<Statement> {
-    let statement = ParserContext::create_with_dialect(
-        query,
-        &MySqlDialect {},
-        ParseOptions::with_timezone(query_ctx.timezone().as_ref()),
-    );
+async fn validate_query(query: &str) -> Result<Statement> {
+    let statement =
+        ParserContext::create_with_dialect(query, &MySqlDialect {}, ParseOptions::default());
     let mut statement = statement.map_err(|e| {
         InvalidPrepareStatementSnafu {
             err_msg: e.output_msg(),

--- a/src/servers/src/mysql/helper.rs
+++ b/src/servers/src/mysql/helper.rs
@@ -203,7 +203,7 @@ pub fn convert_value(param: &ParamValue, t: &ConcreteDataType) -> Result<ScalarV
 #[cfg(test)]
 mod tests {
     use sql::dialect::MySqlDialect;
-    use sql::parser::ParserContext;
+    use sql::parser::{ParseOptions, ParserContext};
 
     use super::*;
 
@@ -232,7 +232,9 @@ mod tests {
     }
 
     fn parse_sql(sql: &str) -> Statement {
-        let mut stmts = ParserContext::create_with_dialect(sql, &MySqlDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &MySqlDialect {}, ParseOptions::default())
+                .unwrap();
         stmts.remove(0)
     }
 

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -30,7 +30,7 @@ use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use query::query_engine::DescribeResult;
 use session::Session;
 use sql::dialect::PostgreSqlDialect;
-use sql::parser::ParserContext;
+use sql::parser::{ParseOptions, ParserContext};
 
 use super::types::*;
 use super::PostgresServerHandler;
@@ -150,8 +150,12 @@ impl QueryParser for DefaultQueryParser {
     async fn parse_sql(&self, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> {
         crate::metrics::METRIC_POSTGRES_PREPARED_COUNT.inc();
         let query_ctx = self.session.new_query_context();
-        let mut stmts = ParserContext::create_with_dialect(sql, &PostgreSqlDialect {})
-            .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        let mut stmts = ParserContext::create_with_dialect(
+            sql,
+            &PostgreSqlDialect {},
+            ParseOptions::with_timezone(self.session.timezone().as_ref()),
+        )
+        .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
         if stmts.len() != 1 {
             Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -150,12 +150,9 @@ impl QueryParser for DefaultQueryParser {
     async fn parse_sql(&self, sql: &str, _types: &[Type]) -> PgWireResult<Self::Statement> {
         crate::metrics::METRIC_POSTGRES_PREPARED_COUNT.inc();
         let query_ctx = self.session.new_query_context();
-        let mut stmts = ParserContext::create_with_dialect(
-            sql,
-            &PostgreSqlDialect {},
-            ParseOptions::with_timezone(self.session.timezone().as_ref()),
-        )
-        .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &PostgreSqlDialect {}, ParseOptions::default())
+                .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
         if stmts.len() != 1 {
             Err(PgWireError::UserError(Box::new(ErrorInfo::new(
                 "ERROR".to_owned(),

--- a/src/servers/tests/mod.rs
+++ b/src/servers/tests/mod.rs
@@ -67,7 +67,7 @@ impl SqlQueryHandler for DummyInstance {
     type Error = Error;
 
     async fn do_query(&self, query: &str, query_ctx: QueryContextRef) -> Vec<Result<Output>> {
-        let stmt = QueryLanguageParser::parse_sql(query).unwrap();
+        let stmt = QueryLanguageParser::parse_sql(query, &query_ctx).unwrap();
         let plan = self
             .query_engine
             .planner()

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -44,8 +44,8 @@ pub struct QueryContext {
 }
 
 impl QueryContextBuilder {
-    pub fn timezone(mut self, tz: Timezone) -> Self {
-        self.timezone = Some(ArcSwap::new(Arc::new(tz)));
+    pub fn timezone(mut self, tz: Arc<Timezone>) -> Self {
+        self.timezone = Some(ArcSwap::new(tz));
         self
     }
 }
@@ -143,7 +143,7 @@ impl QueryContext {
     /// We need persist these change in `Session`.
     pub fn update_session(&self, session: &SessionRef) {
         let tz = self.timezone();
-        if session.timezone() != *tz {
+        if *session.timezone() != *tz {
             session.set_timezone(tz.as_ref().clone())
         }
     }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -74,8 +74,8 @@ impl Session {
     }
 
     #[inline]
-    pub fn timezone(&self) -> Timezone {
-        self.timezone.load().as_ref().clone()
+    pub fn timezone(&self) -> Arc<Timezone> {
+        self.timezone.load().clone()
     }
 
     #[inline]

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_time::Timezone;
 use snafu::ResultExt;
 use sqlparser::ast::Ident;
 use sqlparser::dialect::Dialect;
@@ -28,16 +27,7 @@ use crate::statements::transform_statements;
 
 /// SQL Parser options, such as session timezone etc.
 #[derive(Clone, Debug, Default)]
-pub struct ParseOptions<'a> {
-    pub timezone: Option<&'a Timezone>,
-}
-
-impl<'a> ParseOptions<'a> {
-    /// Create a [`ParseOptions`] with timezone.
-    pub fn with_timezone(tz: &'a Timezone) -> Self {
-        Self { timezone: Some(tz) }
-    }
-}
+pub struct ParseOptions {}
 
 /// GrepTime SQL parser context, a simple wrapper for Datafusion SQL parser.
 pub struct ParserContext<'a> {

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -25,7 +25,7 @@ use crate::parsers::tql_parser;
 use crate::statements::statement::Statement;
 use crate::statements::transform_statements;
 
-/// SQL Parser options, such as session timezone etc.
+/// SQL Parser options.
 #[derive(Clone, Debug, Default)]
 pub struct ParseOptions {}
 

--- a/src/sql/src/parsers/alter_parser.rs
+++ b/src/sql/src/parsers/alter_parser.rs
@@ -104,11 +104,14 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     fn test_parse_alter_add_column() {
         let sql = "ALTER TABLE my_metric_1 ADD tagk_i STRING Null;";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -142,7 +145,9 @@ mod tests {
     #[test]
     fn test_parse_alter_add_column_with_first() {
         let sql = "ALTER TABLE my_metric_1 ADD tagk_i STRING Null FIRST;";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -176,7 +181,9 @@ mod tests {
     #[test]
     fn test_parse_alter_add_column_with_after() {
         let sql = "ALTER TABLE my_metric_1 ADD tagk_i STRING Null AFTER ts;";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -215,12 +222,16 @@ mod tests {
     #[test]
     fn test_parse_alter_drop_column() {
         let sql = "ALTER TABLE my_metric_1 DROP a";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap_err();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap_err();
         let err = result.output_msg();
         assert!(err.contains("expect keyword COLUMN after ALTER TABLE DROP"));
 
         let sql = "ALTER TABLE my_metric_1 DROP COLUMN a";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -245,12 +256,16 @@ mod tests {
     #[test]
     fn test_parse_alter_rename_table() {
         let sql = "ALTER TABLE test_table table_t";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap_err();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap_err();
         let err = result.output_msg();
         assert!(err.contains("expect keyword ADD or DROP or RENAME after ALTER TABLE"));
 
         let sql = "ALTER TABLE test_table RENAME table_t";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -185,14 +185,25 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
     use crate::statements::statement::Statement::Copy;
 
     #[test]
     fn test_parse_copy_table() {
         let sql0 = "COPY catalog0.schema0.tbl TO 'tbl_file.parquet'";
         let sql1 = "COPY catalog0.schema0.tbl TO 'tbl_file.parquet' WITH (FORMAT = 'parquet')";
-        let result0 = ParserContext::create_with_dialect(sql0, &GreptimeDbDialect {}).unwrap();
-        let result1 = ParserContext::create_with_dialect(sql1, &GreptimeDbDialect {}).unwrap();
+        let result0 = ParserContext::create_with_dialect(
+            sql0,
+            &GreptimeDbDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap();
+        let result1 = ParserContext::create_with_dialect(
+            sql1,
+            &GreptimeDbDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap();
 
         for mut result in [result0, result1] {
             assert_eq!(1, result.len());
@@ -238,7 +249,10 @@ mod tests {
             "COPY catalog0.schema0.tbl FROM 'tbl_file.parquet' WITH (FORMAT = 'parquet')",
         ]
         .iter()
-        .map(|sql| ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap())
+        .map(|sql| {
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+        })
         .collect::<Vec<_>>();
 
         for mut result in results {
@@ -298,8 +312,12 @@ mod tests {
         ];
 
         for test in tests {
-            let mut result =
-                ParserContext::create_with_dialect(test.sql, &GreptimeDbDialect {}).unwrap();
+            let mut result = ParserContext::create_with_dialect(
+                test.sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default(),
+            )
+            .unwrap();
             assert_eq!(1, result.len());
 
             let statement = result.remove(0);
@@ -344,8 +362,12 @@ mod tests {
         ];
 
         for test in tests {
-            let mut result =
-                ParserContext::create_with_dialect(test.sql, &GreptimeDbDialect {}).unwrap();
+            let mut result = ParserContext::create_with_dialect(
+                test.sql,
+                &GreptimeDbDialect {},
+                ParseOptions::default(),
+            )
+            .unwrap();
             assert_eq!(1, result.len());
 
             let statement = result.remove(0);
@@ -367,10 +389,11 @@ mod tests {
     #[test]
     fn test_copy_database_to() {
         let sql = "COPY DATABASE catalog0.schema0 TO 'tbl_file.parquet' WITH (FORMAT = 'parquet') CONNECTION (FOO='Bar', ONE='two')";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .pop()
-            .unwrap();
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .pop()
+                .unwrap();
 
         let Copy(crate::statements::copy::Copy::CopyDatabase(stmt)) = stmt else {
             unreachable!()

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -775,7 +775,10 @@ fn ensure_value_lists_strictly_increased<'a>(
                         match (is_string_value(x), is_string_value(y)) {
                             (true, false) | (false, true) => {
                                 return error::InvalidSqlSnafu {
-                                    msg: format!("Can't compare {:?} with {:?}", x, y),
+                                    msg: format!(
+                                        "Can't compare {:?} with {:?} in partition rules",
+                                        x, y
+                                    ),
                                 }
                                 .fail();
                             }

--- a/src/sql/src/parsers/delete_parser.rs
+++ b/src/sql/src/parsers/delete_parser.rs
@@ -45,11 +45,14 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_parse_insert() {
         let sql = r"delete from my_table where k1 = xxx and k2 = xxx and timestamp = xxx;";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
         assert_matches!(result[0], Statement::Delete { .. })
     }
@@ -57,7 +60,8 @@ mod tests {
     #[test]
     pub fn test_parse_invalid_insert() {
         let sql = r"delete my_table where "; // intentionally a bad sql
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(result.is_err(), "result is: {result:?}");
     }
 }

--- a/src/sql/src/parsers/describe_parser.rs
+++ b/src/sql/src/parsers/describe_parser.rs
@@ -55,6 +55,7 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     fn test_parse_function() {
@@ -64,10 +65,11 @@ mod tests {
     }
 
     fn assert_describe_table(sql: &str) {
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .pop()
-            .unwrap();
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .pop()
+                .unwrap();
         assert!(matches!(stmt, Statement::DescribeTable(_)))
     }
 

--- a/src/sql/src/parsers/drop_parser.rs
+++ b/src/sql/src/parsers/drop_parser.rs
@@ -56,11 +56,13 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_drop_table() {
         let sql = "DROP TABLE foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
@@ -68,7 +70,8 @@ mod tests {
         );
 
         let sql = "DROP TABLE IF EXISTS foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
@@ -76,7 +79,8 @@ mod tests {
         );
 
         let sql = "DROP TABLE my_schema.foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
@@ -87,7 +91,8 @@ mod tests {
         );
 
         let sql = "DROP TABLE my_catalog.my_schema.foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),

--- a/src/sql/src/parsers/explain_parser.rs
+++ b/src/sql/src/parsers/explain_parser.rs
@@ -43,11 +43,13 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_explain() {
         let sql = "EXPLAIN select * from foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 

--- a/src/sql/src/parsers/insert_parser.rs
+++ b/src/sql/src/parsers/insert_parser.rs
@@ -45,6 +45,7 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_parse_insert() {
@@ -52,7 +53,9 @@ mod tests {
             'test1',1,'true',
             'test2',2,'false')
          ";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
         assert_matches!(result[0], Statement::Insert { .. })
     }
@@ -60,7 +63,8 @@ mod tests {
     #[test]
     pub fn test_parse_invalid_insert() {
         let sql = r"INSERT INTO table_1 VALUES ("; // intentionally a bad sql
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(result.is_err(), "result is: {result:?}");
     }
 }

--- a/src/sql/src/parsers/query_parser.rs
+++ b/src/sql/src/parsers/query_parser.rs
@@ -33,7 +33,7 @@ mod tests {
     use common_error::ext::ErrorExt;
 
     use crate::dialect::GreptimeDbDialect;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
 
     #[test]
     pub fn test_parse_query() {
@@ -42,13 +42,16 @@ mod tests {
            WHERE a > b AND b < 100 \
            ORDER BY a DESC, b";
 
-        let _ = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let _ =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
     }
 
     #[test]
     pub fn test_parse_invalid_query() {
         let sql = "SELECT * FROM table_1 WHERE";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/src/sql/src/parsers/set_var_parser.rs
+++ b/src/sql/src/parsers/set_var_parser.rs
@@ -49,12 +49,14 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_set_timezone() {
         // mysql style
         let sql = "SET time_zone = 'UTC'";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
@@ -65,7 +67,8 @@ mod tests {
         );
         // postgresql style
         let sql = "SET TIMEZONE TO 'UTC'";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),

--- a/src/sql/src/parsers/show_parser.rs
+++ b/src/sql/src/parsers/show_parser.rs
@@ -194,12 +194,14 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
     use crate::statements::show::ShowDatabases;
 
     #[test]
     pub fn test_show_database_all() {
         let sql = "SHOW DATABASES";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -214,7 +216,8 @@ mod tests {
     #[test]
     pub fn test_show_database_like() {
         let sql = "SHOW DATABASES LIKE test_database";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -232,7 +235,8 @@ mod tests {
     #[test]
     pub fn test_show_database_where() {
         let sql = "SHOW DATABASES WHERE Database LIKE '%whatever1%' OR Database LIKE '%whatever2%'";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -251,7 +255,8 @@ mod tests {
     #[test]
     pub fn test_show_tables_all() {
         let sql = "SHOW TABLES";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -268,7 +273,8 @@ mod tests {
     #[test]
     pub fn test_show_tables_like() {
         let sql = "SHOW TABLES LIKE test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -285,7 +291,8 @@ mod tests {
         );
 
         let sql = "SHOW TABLES in test_db LIKE test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -305,7 +312,8 @@ mod tests {
     #[test]
     pub fn test_show_tables_where() {
         let sql = "SHOW TABLES where name like test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -319,7 +327,8 @@ mod tests {
         );
 
         let sql = "SHOW TABLES in test_db where name LIKE test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -336,7 +345,9 @@ mod tests {
     #[test]
     pub fn test_show_full_tables() {
         let sql = "SHOW FULL TABLES";
-        let stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::ShowTables { .. });
         match &stmts[0] {
@@ -352,7 +363,9 @@ mod tests {
     #[test]
     pub fn test_show_full_tables_where() {
         let sql = "SHOW FULL TABLES IN test_db WHERE Tables LIKE test_table";
-        let stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
 
         assert_matches!(
@@ -368,7 +381,8 @@ mod tests {
     #[test]
     pub fn test_show_full_tables_like() {
         let sql = "SHOW FULL TABLES LIKE test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -385,7 +399,8 @@ mod tests {
         );
 
         let sql = "SHOW FULL TABLES in test_db LIKE test_table";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
 
@@ -405,7 +420,8 @@ mod tests {
     #[test]
     pub fn test_show_variables() {
         let sql = "SHOW VARIABLES system_time_zone";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let stmts = result.unwrap();
         assert_eq!(1, stmts.len());
         assert_eq!(

--- a/src/sql/src/parsers/tql_parser.rs
+++ b/src/sql/src/parsers/tql_parser.rs
@@ -168,11 +168,14 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
     #[test]
     fn test_parse_tql_eval() {
         let sql = "TQL EVAL (1676887657, 1676887659, '1m') http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -188,7 +191,9 @@ mod tests {
 
         let sql = "TQL EVAL (1676887657.1, 1676887659.5, 30.3) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -204,7 +209,9 @@ mod tests {
 
         let sql = "TQL EVALUATE (1676887657.1, 1676887659.5, 30.3) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement2 = result.remove(0);
@@ -212,7 +219,9 @@ mod tests {
 
         let sql = "tql eval ('2015-07-01T20:10:30.781Z', '2015-07-01T20:11:00.781Z', '30s') http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -231,7 +240,9 @@ mod tests {
     fn test_parse_tql_explain() {
         let sql = "TQL EXPLAIN http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -247,7 +258,9 @@ mod tests {
 
         let sql = "TQL EXPLAIN (20,100,10) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
 
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         let statement = result.remove(0);
@@ -265,7 +278,9 @@ mod tests {
     #[test]
     fn test_parse_tql_analyze() {
         let sql = "TQL ANALYZE (1676887657.1, 1676887659.5, 30.3) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
-        let mut result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
         let statement = result.remove(0);
         match statement {
@@ -283,12 +298,16 @@ mod tests {
     fn test_parse_tql_error() {
         // Invalid duration
         let sql = "TQL EVAL (1676887657, 1676887659, 1m) http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap_err();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap_err();
         assert!(result.output_msg().contains("Expected ), found: m"));
 
         // missing end
         let sql = "TQL EVAL (1676887657, '1m') http_requests_total{environment=~'staging|testing|development',method!='GET'} @ 1609746000 offset 5m";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap_err();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap_err();
         assert!(result.output_msg().contains("Expected ,, found: )"));
     }
 }

--- a/src/sql/src/parsers/truncate_parser.rs
+++ b/src/sql/src/parsers/truncate_parser.rs
@@ -53,25 +53,32 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
+    use crate::parser::ParseOptions;
 
     #[test]
     pub fn test_parse_truncate() {
         let sql = "TRUNCATE foo";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![Ident::new("foo")])))
         );
 
         let sql = "TRUNCATE TABLE foo";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![Ident::new("foo")])))
         );
 
         let sql = "TRUNCATE TABLE my_schema.foo";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![
@@ -81,7 +88,9 @@ mod tests {
         );
 
         let sql = "TRUNCATE my_schema.foo";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![
@@ -91,7 +100,9 @@ mod tests {
         );
 
         let sql = "TRUNCATE TABLE my_catalog.my_schema.foo";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![
@@ -102,14 +113,18 @@ mod tests {
         );
 
         let sql = "TRUNCATE drop";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![Ident::new("drop")])))
         );
 
         let sql = "TRUNCATE `drop`";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![Ident::with_quote(
@@ -118,7 +133,9 @@ mod tests {
         );
 
         let sql = "TRUNCATE \"drop\"";
-        let mut stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::TruncateTable(TruncateTable::new(ObjectName(vec![Ident::with_quote(
@@ -130,11 +147,13 @@ mod tests {
     #[test]
     pub fn test_parse_invalid_truncate() {
         let sql = "TRUNCATE SCHEMA foo";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(result.is_err(), "result is: {result:?}");
 
         let sql = "TRUNCATE";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(result.is_err(), "result is: {result:?}");
     }
 }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -222,7 +222,7 @@ pub struct CreateExternalTable {
 mod tests {
     use crate::dialect::GreptimeDbDialect;
     use crate::error::Error::InvalidTableOption;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
     #[test]
@@ -243,7 +243,9 @@ mod tests {
                        engine=mito
                        with(regions=1, ttl='7d', storage='File');
          ";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         match &result[0] {
@@ -273,8 +275,12 @@ WITH(
                     &new_sql
                 );
 
-                let new_result =
-                    ParserContext::create_with_dialect(&new_sql, &GreptimeDbDialect {}).unwrap();
+                let new_result = ParserContext::create_with_dialect(
+                    &new_sql,
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap();
                 assert_eq!(result, new_result);
             }
             _ => unreachable!(),
@@ -292,7 +298,9 @@ WITH(
             PRIMARY KEY(ts, host)
             );
         ";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, result.len());
 
         match &result[0] {
@@ -313,8 +321,12 @@ ENGINE=mito
                     &new_sql
                 );
 
-                let new_result =
-                    ParserContext::create_with_dialect(&new_sql, &GreptimeDbDialect {}).unwrap();
+                let new_result = ParserContext::create_with_dialect(
+                    &new_sql,
+                    &GreptimeDbDialect {},
+                    ParseOptions::default(),
+                )
+                .unwrap();
                 assert_eq!(result, new_result);
             }
             _ => unreachable!(),
@@ -339,7 +351,8 @@ ENGINE=mito
       engine=mito
       with(regions=1, ttl='7d', hello='world');
 ";
-        let result = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {});
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         assert!(matches!(result, Err(InvalidTableOption { .. })))
     }
 }

--- a/src/sql/src/statements/describe.rs
+++ b/src/sql/src/statements/describe.rs
@@ -37,7 +37,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     use crate::dialect::GreptimeDbDialect;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
     use crate::util::format_raw_object_name;
 
@@ -45,7 +45,8 @@ mod tests {
     pub fn test_describe_table() {
         let sql = "DESCRIBE TABLE test";
         let stmts: Vec<Statement> =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::DescribeTable { .. });
         match &stmts[0] {
@@ -62,7 +63,8 @@ mod tests {
     pub fn test_describe_schema_table() {
         let sql = "DESCRIBE TABLE test_schema.test";
         let stmts: Vec<Statement> =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::DescribeTable { .. });
         match &stmts[0] {
@@ -79,7 +81,8 @@ mod tests {
     pub fn test_describe_catalog_schema_table() {
         let sql = "DESCRIBE TABLE test_catalog.test_schema.test";
         let stmts: Vec<Statement> =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::DescribeTable { .. });
         match &stmts[0] {
@@ -98,6 +101,11 @@ mod tests {
     #[test]
     pub fn test_describe_missing_table_name() {
         let sql = "DESCRIBE TABLE";
-        assert!(ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).is_err());
+        assert!(ParserContext::create_with_dialect(
+            sql,
+            &GreptimeDbDialect {},
+            ParseOptions::default()
+        )
+        .is_err());
     }
 }

--- a/src/sql/src/statements/insert.rs
+++ b/src/sql/src/statements/insert.rs
@@ -171,16 +171,17 @@ impl TryFrom<Statement> for Insert {
 mod tests {
     use super::*;
     use crate::dialect::GreptimeDbDialect;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
     #[test]
     fn test_insert_value_with_unary_op() {
         // insert "-1"
         let sql = "INSERT INTO my_table VALUES(-1)";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -191,9 +192,10 @@ mod tests {
 
         // insert "+1"
         let sql = "INSERT INTO my_table VALUES(+1)";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -207,9 +209,10 @@ mod tests {
     fn test_insert_value_with_default() {
         // insert "default"
         let sql = "INSERT INTO my_table VALUES(default)";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -223,9 +226,10 @@ mod tests {
     fn test_insert_value_with_default_uppercase() {
         // insert "DEFAULT"
         let sql = "INSERT INTO my_table VALUES(DEFAULT)";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -239,9 +243,10 @@ mod tests {
     fn test_insert_value_with_quoted_string() {
         // insert 'default'
         let sql = "INSERT INTO my_table VALUES('default')";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -255,9 +260,10 @@ mod tests {
 
         // insert "default". Treating double-quoted identifiers as strings.
         let sql = "INSERT INTO my_table VALUES(\"default\")";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let values = insert.values_body().unwrap();
@@ -270,9 +276,10 @@ mod tests {
         }
 
         let sql = "INSERT INTO my_table VALUES(`default`)";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 assert!(insert.values_body().is_err());
@@ -284,9 +291,10 @@ mod tests {
     #[test]
     fn test_insert_select() {
         let sql = "INSERT INTO my_table select * from other_table";
-        let stmt = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0);
+        let stmt =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap()
+                .remove(0);
         match stmt {
             Statement::Insert(insert) => {
                 let q = insert.query_body().unwrap().unwrap();

--- a/src/sql/src/statements/query.rs
+++ b/src/sql/src/statements/query.rs
@@ -54,13 +54,17 @@ mod test {
 
     use super::Query;
     use crate::dialect::GreptimeDbDialect;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
     fn create_query(sql: &str) -> Option<Box<Query>> {
-        match ParserContext::create_with_dialect(sql, &GreptimeDbDialect {})
-            .unwrap()
-            .remove(0)
+        match ParserContext::create_with_dialect(
+            sql,
+            &GreptimeDbDialect {},
+            ParseOptions::default(),
+        )
+        .unwrap()
+        .remove(0)
         {
             Statement::Query(query) => Some(query),
             _ => None,

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -77,7 +77,7 @@ mod tests {
 
     use super::*;
     use crate::dialect::GreptimeDbDialect;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
     #[test]
@@ -111,7 +111,9 @@ mod tests {
     #[test]
     pub fn test_show_database() {
         let sql = "SHOW DATABASES";
-        let stmts = ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+        let stmts =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::ShowDatabases { .. });
         match &stmts[0] {
@@ -128,7 +130,8 @@ mod tests {
     pub fn test_show_create_table() {
         let sql = "SHOW CREATE TABLE test";
         let stmts: Vec<Statement> =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).unwrap();
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
         assert_eq!(1, stmts.len());
         assert_matches!(&stmts[0], Statement::ShowCreateTable { .. });
         match &stmts[0] {
@@ -144,6 +147,11 @@ mod tests {
     #[test]
     pub fn test_show_create_missing_table_name() {
         let sql = "SHOW CREATE TABLE";
-        assert!(ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}).is_err());
+        assert!(ParserContext::create_with_dialect(
+            sql,
+            &GreptimeDbDialect {},
+            ParseOptions::default()
+        )
+        .is_err());
     }
 }

--- a/src/sql/src/statements/transform/type_alias.rs
+++ b/src/sql/src/statements/transform/type_alias.rs
@@ -167,7 +167,7 @@ mod tests {
     use sqlparser::dialect::GenericDialect;
 
     use super::*;
-    use crate::parser::ParserContext;
+    use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::transform_statements;
 
     #[test]
@@ -265,7 +265,9 @@ mod tests {
 
     fn test_timestamp_alias(alias: &str, expected: &str) {
         let sql = format!("SELECT TIMESTAMP '2020-01-01 01:23:45.12345678'::{alias}");
-        let mut stmts = ParserContext::create_with_dialect(&sql, &GenericDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(&sql, &GenericDialect {}, ParseOptions::default())
+                .unwrap();
         transform_statements(&mut stmts).unwrap();
 
         match &stmts[0] {
@@ -318,7 +320,9 @@ CREATE TABLE data_types (
   ts9 TimestampNanosecond DEFAULT CURRENT_TIMESTAMP TIME INDEX,
   PRIMARY KEY(s));"#;
 
-        let mut stmts = ParserContext::create_with_dialect(sql, &GenericDialect {}).unwrap();
+        let mut stmts =
+            ParserContext::create_with_dialect(sql, &GenericDialect {}, ParseOptions::default())
+                .unwrap();
         transform_statements(&mut stmts).unwrap();
 
         match &stmts[0] {

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use common_query::logical_plan::Expr;
 use common_recordbatch::OrderOption;
+use common_time::Timezone;
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct ScanRequest {
@@ -29,4 +32,6 @@ pub struct ScanRequest {
     /// If set, it contains the amount of rows needed by the caller,
     /// The data source should return *at least* this number of rows if available.
     pub limit: Option<usize>,
+    /// The session timezone
+    pub timezone: Option<Arc<Timezone>>,
 }

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use common_query::logical_plan::Expr;
 use common_recordbatch::OrderOption;
-use common_time::Timezone;
 
 #[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct ScanRequest {
@@ -32,6 +29,4 @@ pub struct ScanRequest {
     /// If set, it contains the amount of rows needed by the caller,
     /// The data source should return *at least* this number of rows if available.
     pub limit: Option<usize>,
-    /// The session timezone
-    pub timezone: Option<Arc<Timezone>>,
 }

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -531,9 +531,10 @@ CREATE TABLE {table_name} (
         .collect::<HashMap<u32, u64>>();
         assert!(region_to_dn_map.len() <= instance.datanodes().len());
 
-        let stmt = QueryLanguageParser::parse_sql(&format!(
-            "SELECT ts, a, b FROM {table_name} ORDER BY ts"
-        ))
+        let stmt = QueryLanguageParser::parse_sql(
+            &format!("SELECT ts, a, b FROM {table_name} ORDER BY ts"),
+            &QueryContext::arc(),
+        )
         .unwrap();
         let LogicalPlan::DfPlan(plan) = instance
             .frontend()

--- a/tests-integration/src/instance.rs
+++ b/tests-integration/src/instance.rs
@@ -226,7 +226,11 @@ mod tests {
         .collect::<HashMap<u32, u64>>();
         assert!(region_to_dn_map.len() <= instance.datanodes().len());
 
-        let stmt = QueryLanguageParser::parse_sql("SELECT ts, host FROM demo ORDER BY ts").unwrap();
+        let stmt = QueryLanguageParser::parse_sql(
+            "SELECT ts, host FROM demo ORDER BY ts",
+            &QueryContext::arc(),
+        )
+        .unwrap();
         let LogicalPlan::DfPlan(plan) = instance
             .frontend()
             .statement_executor()

--- a/tests-integration/src/tests/promql_test.rs
+++ b/tests-integration/src/tests/promql_test.rs
@@ -58,7 +58,8 @@ async fn create_insert_query_assert(
         query: promql.to_string(),
         ..PromQuery::default()
     };
-    let QueryStatement::Promql(mut eval_stmt) = QueryLanguageParser::parse_promql(&query).unwrap()
+    let QueryStatement::Promql(mut eval_stmt) =
+        QueryLanguageParser::parse_promql(&query, &QueryContext::arc()).unwrap()
     else {
         unreachable!()
     };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Prepare for the following PRs and #3175, main changes:

* Added `ParseOptions` to SQL `ParserContext`. 
* Let all the parsing sql places be aware of `ParseOptions`.
* Improve `ensure_value_lists_strictly_increased` in creating table parser, checking column types to avoid timezone errors.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/2907