### PR TITLE
refactor: reduce number of parquet metadata reads and enable reader buffer

### DIFF
--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -351,8 +351,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Failed to read parquet file"))]
-    ReadParquet {
+    #[snafu(display("Failed to read parquet file metadata"))]
+    ReadParquetMetadata {
         #[snafu(source)]
         error: parquet::errors::ParquetError,
         location: Location,
@@ -587,9 +587,9 @@ impl ErrorExt for Error {
 
             Error::UnrecognizedTableOption { .. } => StatusCode::InvalidArguments,
 
-            Error::ReadObject { .. } | Error::ReadParquet { .. } | Error::ReadOrc { .. } => {
-                StatusCode::StorageUnavailable
-            }
+            Error::ReadObject { .. }
+            | Error::ReadParquetMetadata { .. }
+            | Error::ReadOrc { .. } => StatusCode::StorageUnavailable,
 
             Error::ListObjects { source, .. }
             | Error::ParseUrl { source, .. }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. Reduce the number of parquet metadata reads
2. Enable the reader buffer

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
