### PR TITLE
feat: lazy initialize vector builder on write

### DIFF
--- a/src/datatypes/src/vectors.rs
+++ b/src/datatypes/src/vectors.rs
@@ -211,8 +211,15 @@ pub trait MutableVector: Send + Sync {
         });
     }
 
-    // Push null to this mutable vector.
+    /// Push null to this mutable vector.
     fn push_null(&mut self);
+
+    /// Push nulls to this mutable vector.
+    fn push_nulls(&mut self, num_nulls: usize) {
+        for _ in 0..num_nulls {
+            self.push_null();
+        }
+    }
 
     /// Extend this mutable vector by slice of `vector`.
     ///

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -363,7 +363,6 @@ impl MetricEngineInner {
             .for_each(|metadata| {
                 if metadata.semantic_type == SemanticType::Tag {
                     metadata.semantic_type = SemanticType::Field;
-                    metadata.column_schema.is_nullable();
                 }
             });
 

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -363,6 +363,7 @@ impl MetricEngineInner {
             .for_each(|metadata| {
                 if metadata.semantic_type == SemanticType::Tag {
                     metadata.semantic_type = SemanticType::Field;
+                    metadata.column_schema.is_nullable();
                 }
             });
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -32,7 +32,7 @@ use datatypes::data_type::{ConcreteDataType, DataType};
 use datatypes::prelude::{MutableVector, ScalarVectorBuilder, Vector, VectorRef};
 use datatypes::value::ValueRef;
 use datatypes::vectors::{
-    ConstantVector, Helper, UInt64Vector, UInt64VectorBuilder, UInt8Vector, UInt8VectorBuilder,
+    Helper, UInt64Vector, UInt64VectorBuilder, UInt8Vector, UInt8VectorBuilder,
 };
 use snafu::{ensure, ResultExt};
 use store_api::metadata::RegionMetadataRef;

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -758,9 +758,9 @@ impl From<ValueBuilder> for Values {
                 if let Some(v) = v {
                     v.to_vector()
                 } else {
-                    let mut single_null = value.field_types[i].create_mutable_vector(1);
-                    single_null.push_null();
-                    Arc::new(ConstantVector::new(single_null.to_vector(), num_rows))
+                    let mut single_null = value.field_types[i].create_mutable_vector(num_rows);
+                    single_null.push_nulls(num_rows);
+                    single_null.to_vector()
                 }
             })
             .collect::<Vec<_>>();

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -651,14 +651,8 @@ impl ValueBuilder {
                 self.fields[idx]
                     .get_or_insert_with(|| {
                         // lazy initialize on first non-null value
-                        let mut mutable_vector = self
-                            .region_metadata
-                            .field_columns()
-                            .nth(idx)
-                            .unwrap()
-                            .column_schema
-                            .data_type
-                            .create_mutable_vector(num_rows);
+                        let mut mutable_vector =
+                            self.field_types[idx].create_mutable_vector(num_rows);
                         // fill previous rows with nulls
                         mutable_vector.push_nulls(num_rows - 1);
                         mutable_vector

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -609,7 +609,6 @@ struct ValueBuilder {
     op_type: UInt8VectorBuilder,
     fields: Vec<Option<Box<dyn MutableVector>>>,
     field_types: Vec<ConcreteDataType>,
-    region_metadata: RegionMetadataRef,
 }
 
 impl ValueBuilder {
@@ -634,7 +633,6 @@ impl ValueBuilder {
             op_type,
             fields,
             field_types,
-            region_metadata: region_metadata.clone(),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Lazy create `MutableVector` for `TimeSeries`. This change can save lots of memory when the data's field columns are sparse. In my test scenario where ~90% fields are null, it can cut up to 80% memory consumption:
 
<img width="485" alt="Snipaste_2024-01-21_15-20-39" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/418ca19a-43a0-4e5f-b939-5952712da0c0">

I also run a tsbs-load benchmark to see if this change slow down the normal case. The result shows it doesn't have bad influence:

before this change:
```
loaded 86400000 rows in 141.686sec with 6 workers (mean rate 609798.27 rows/sec)
```
after this change:
```
loaded 86400000 rows in 140.448sec with 6 workers (mean rate 615174.51 rows/sec)
```

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
