### PR TITLE
fix: remove __name__ matcher from processed matcher list

### DIFF
--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -557,6 +557,7 @@ impl PromPlanner {
         name: &Option<String>,
     ) -> Result<Matchers> {
         self.ctx.reset();
+
         let metric_name;
         if let Some(name) = name.clone() {
             metric_name = Some(name);
@@ -581,7 +582,7 @@ impl PromPlanner {
                     .field_column_matcher
                     .get_or_insert_default()
                     .push(matcher.clone());
-            } else {
+            } else if matcher.name != METRIC_NAME {
                 let _ = matchers.insert(matcher.clone());
             }
         }

--- a/tests/cases/standalone/common/tql/basic.result
+++ b/tests/cases/standalone/common/tql/basic.result
@@ -20,6 +20,35 @@ TQL EVAL (0, 10, '5s') test;
 | 2.0 | 1970-01-01T00:00:10 | a |
 +-----+---------------------+---+
 
+-- SQLNESS SORT_RESULT 2 1
+TQL EVAL (0, 10, '5s') {__name__="test"};
+
++-----+---------------------+---+
+| i   | j                   | k |
++-----+---------------------+---+
+| 1.0 | 1970-01-01T00:00:05 | b |
+| 1.0 | 1970-01-01T00:00:10 | b |
+| 2.0 | 1970-01-01T00:00:05 | a |
+| 2.0 | 1970-01-01T00:00:10 | a |
++-----+---------------------+---+
+
+-- SQLNESS SORT_RESULT 2 1
+TQL EVAL (0, 10, '5s') {__name__="test", __field__="i"};
+
++-----+---+---------------------+
+| i   | k | j                   |
++-----+---+---------------------+
+| 1.0 | b | 1970-01-01T00:00:05 |
+| 1.0 | b | 1970-01-01T00:00:10 |
+| 2.0 | a | 1970-01-01T00:00:05 |
+| 2.0 | a | 1970-01-01T00:00:10 |
++-----+---+---------------------+
+
+-- NOT SUPPORTED: `__name__` matcher without equal condition
+TQL EVAL (0, 10, '5s') {__name__!="test"};
+
+Error: 2000(InvalidSyntax), vector selector must contain at least one non-empty matcher
+
 -- the point at 1ms will be shadowed by the point at 2ms
 TQL EVAL (0, 10, '5s') test{k="a"};
 

--- a/tests/cases/standalone/common/tql/basic.sql
+++ b/tests/cases/standalone/common/tql/basic.sql
@@ -7,6 +7,15 @@ INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
 -- evaluate at 0s, 5s and 10s. No point at 0s.
 TQL EVAL (0, 10, '5s') test;
 
+-- SQLNESS SORT_RESULT 2 1
+TQL EVAL (0, 10, '5s') {__name__="test"};
+
+-- SQLNESS SORT_RESULT 2 1
+TQL EVAL (0, 10, '5s') {__name__="test", __field__="i"};
+
+-- NOT SUPPORTED: `__name__` matcher without equal condition
+TQL EVAL (0, 10, '5s') {__name__!="test"};
+
 -- the point at 1ms will be shadowed by the point at 2ms
 TQL EVAL (0, 10, '5s') test{k="a"};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Fix the bug reported by @dekelpilli in https://github.com/GreptimeTeam/greptimedb/issues/1042#issuecomment-1903431191

The `__name__` matcher is not removed after special preprocess logic, resulting in the afterword plan phase treating it as a column name.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
