### PR TITLE
feat: enable concurrent write

### DIFF
--- a/src/common/datasource/src/buffered_writer.rs
+++ b/src/common/datasource/src/buffered_writer.rs
@@ -47,7 +47,7 @@ pub trait ArrowWriterCloser {
 impl<
         T: AsyncWrite + Send + Unpin,
         U: DfRecordBatchEncoder + ArrowWriterCloser,
-        F: FnMut(String) -> Fut,
+        F: Fn(String) -> Fut,
         Fut: Future<Output = Result<T>>,
     > LazyBufferedWriter<T, U, F>
 {
@@ -75,7 +75,7 @@ impl<
 impl<
         T: AsyncWrite + Send + Unpin,
         U: DfRecordBatchEncoder,
-        F: FnMut(String) -> Fut,
+        F: Fn(String) -> Fut,
         Fut: Future<Output = Result<T>>,
     > LazyBufferedWriter<T, U, F>
 {
@@ -149,7 +149,7 @@ impl<
         if let Some(ref mut writer) = self.writer {
             Ok(writer)
         } else {
-            let writer = (self.writer_factory)(self.path.clone()).await?;
+            let writer = (self.writer_factory)(self.path.to_string()).await?;
             Ok(self.writer.insert(writer))
         }
     }

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -193,13 +193,15 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
     store: ObjectStore,
     path: &str,
     threshold: usize,
+    concurrent: usize,
     encoder_factory: U,
 ) -> Result<usize> {
     let buffer = SharedBuffer::with_capacity(threshold);
     let encoder = encoder_factory(buffer.clone());
     let mut writer = LazyBufferedWriter::new(threshold, buffer, encoder, path, |path| async {
         store
-            .writer(&path)
+            .writer_with(&path)
+            .concurrent(concurrent)
             .await
             .context(error::WriteObjectSnafu { path })
     });

--- a/src/common/datasource/src/file_format.rs
+++ b/src/common/datasource/src/file_format.rs
@@ -193,7 +193,7 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
     store: ObjectStore,
     path: &str,
     threshold: usize,
-    concurrent: usize,
+    concurrency: usize,
     encoder_factory: U,
 ) -> Result<usize> {
     let buffer = SharedBuffer::with_capacity(threshold);
@@ -201,7 +201,7 @@ pub async fn stream_to_file<T: DfRecordBatchEncoder, U: Fn(SharedBuffer) -> T>(
     let mut writer = LazyBufferedWriter::new(threshold, buffer, encoder, path, |path| async {
         store
             .writer_with(&path)
-            .concurrent(concurrent)
+            .concurrent(concurrency)
             .await
             .context(error::WriteObjectSnafu { path })
     });

--- a/src/common/datasource/src/file_format/csv.rs
+++ b/src/common/datasource/src/file_format/csv.rs
@@ -193,8 +193,9 @@ pub async fn stream_to_csv(
     store: ObjectStore,
     path: &str,
     threshold: usize,
+    concurrent: usize,
 ) -> Result<usize> {
-    stream_to_file(stream, store, path, threshold, |buffer| {
+    stream_to_file(stream, store, path, threshold, concurrent, |buffer| {
         csv::Writer::new(buffer)
     })
     .await

--- a/src/common/datasource/src/file_format/csv.rs
+++ b/src/common/datasource/src/file_format/csv.rs
@@ -193,9 +193,9 @@ pub async fn stream_to_csv(
     store: ObjectStore,
     path: &str,
     threshold: usize,
-    concurrent: usize,
+    concurrency: usize,
 ) -> Result<usize> {
-    stream_to_file(stream, store, path, threshold, concurrent, |buffer| {
+    stream_to_file(stream, store, path, threshold, concurrency, |buffer| {
         csv::Writer::new(buffer)
     })
     .await

--- a/src/common/datasource/src/file_format/json.rs
+++ b/src/common/datasource/src/file_format/json.rs
@@ -152,9 +152,9 @@ pub async fn stream_to_json(
     store: ObjectStore,
     path: &str,
     threshold: usize,
-    concurrent: usize,
+    concurrency: usize,
 ) -> Result<usize> {
-    stream_to_file(stream, store, path, threshold, concurrent, |buffer| {
+    stream_to_file(stream, store, path, threshold, concurrency, |buffer| {
         json::LineDelimitedWriter::new(buffer)
     })
     .await

--- a/src/common/datasource/src/file_format/json.rs
+++ b/src/common/datasource/src/file_format/json.rs
@@ -152,8 +152,9 @@ pub async fn stream_to_json(
     store: ObjectStore,
     path: &str,
     threshold: usize,
+    concurrent: usize,
 ) -> Result<usize> {
-    stream_to_file(stream, store, path, threshold, |buffer| {
+    stream_to_file(stream, store, path, threshold, concurrent, |buffer| {
         json::LineDelimitedWriter::new(buffer)
     })
     .await

--- a/src/common/datasource/src/lib.rs
+++ b/src/common/datasource/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![feature(assert_matches)]
+#![feature(type_alias_impl_trait)]
 
 pub mod buffered_writer;
 pub mod compression;

--- a/src/common/datasource/src/test_util.rs
+++ b/src/common/datasource/src/test_util.rs
@@ -113,6 +113,7 @@ pub async fn setup_stream_to_json_test(origin_path: &str, threshold: impl Fn(usi
         tmp_store.clone(),
         &output_path,
         threshold(size),
+        8
     )
     .await
     .is_ok());
@@ -150,6 +151,7 @@ pub async fn setup_stream_to_csv_test(origin_path: &str, threshold: impl Fn(usiz
         tmp_store.clone(),
         &output_path,
         threshold(size),
+        8
     )
     .await
     .is_ok());

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -30,7 +30,7 @@ use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::IndexerBuilder;
 use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
-use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
+use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENT};
 
 /// A cache for uploading files to remote object stores.
 ///
@@ -180,6 +180,7 @@ impl WriteCache {
         let mut writer = remote_store
             .writer_with(upload_path)
             .buffer(DEFAULT_WRITE_BUFFER_SIZE.as_bytes() as usize)
+            .concurrent(DEFAULT_WRITE_CONCURRENT)
             .await
             .context(error::OpenDalSnafu)?;
 

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -30,7 +30,7 @@ use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::IndexerBuilder;
 use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
-use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENT};
+use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
 
 /// A cache for uploading files to remote object stores.
 ///
@@ -180,7 +180,7 @@ impl WriteCache {
         let mut writer = remote_store
             .writer_with(upload_path)
             .buffer(DEFAULT_WRITE_BUFFER_SIZE.as_bytes() as usize)
-            .concurrent(DEFAULT_WRITE_CONCURRENT)
+            .concurrent(DEFAULT_WRITE_CONCURRENCY)
             .await
             .context(error::OpenDalSnafu)?;
 

--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -27,4 +27,4 @@ pub(crate) mod version;
 pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
 
 /// Default number of concurrent write, it only works on object store backend(e.g., S3).
-pub const DEFAULT_WRITE_CONCURRENT: usize = 8;
+pub const DEFAULT_WRITE_CONCURRENCY: usize = 8;

--- a/src/mito2/src/sst.rs
+++ b/src/mito2/src/sst.rs
@@ -25,3 +25,6 @@ pub(crate) mod version;
 
 /// Default write buffer size, it should be greater than the default minimum upload part of S3 (5mb).
 pub const DEFAULT_WRITE_BUFFER_SIZE: ReadableSize = ReadableSize::mb(8);
+
+/// Default number of concurrent write, it only works on object store backend(e.g., S3).
+pub const DEFAULT_WRITE_CONCURRENT: usize = 8;

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -35,6 +35,7 @@ use crate::sst::index::Indexer;
 use crate::sst::parquet::format::WriteFormat;
 use crate::sst::parquet::helper::parse_parquet_metadata;
 use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
+use crate::sst::DEFAULT_WRITE_CONCURRENT;
 
 /// Parquet SST writer.
 pub struct ParquetWriter {
@@ -90,6 +91,7 @@ impl ParquetWriter {
             write_format.arrow_schema(),
             Some(writer_props),
             opts.write_buffer_size.as_bytes() as usize,
+            DEFAULT_WRITE_CONCURRENT,
         )
         .await
         .context(WriteBufferSnafu)?;

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -35,7 +35,7 @@ use crate::sst::index::Indexer;
 use crate::sst::parquet::format::WriteFormat;
 use crate::sst::parquet::helper::parse_parquet_metadata;
 use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
-use crate::sst::DEFAULT_WRITE_CONCURRENT;
+use crate::sst::DEFAULT_WRITE_CONCURRENCY;
 
 /// Parquet SST writer.
 pub struct ParquetWriter {
@@ -91,7 +91,7 @@ impl ParquetWriter {
             write_format.arrow_schema(),
             Some(writer_props),
             opts.write_buffer_size.as_bytes() as usize,
-            DEFAULT_WRITE_CONCURRENT,
+            DEFAULT_WRITE_CONCURRENCY,
         )
         .await
         .context(WriteBufferSnafu)?;

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -43,6 +43,9 @@ use crate::statement::StatementExecutor;
 /// Buffer size to flush data to object stores.
 const WRITE_BUFFER_THRESHOLD: ReadableSize = ReadableSize::mb(8);
 
+/// Default number of concurrent write, it only works on object store backend(e.g., S3).
+const WRITE_CONCURRENT: usize = 8;
+
 impl StatementExecutor {
     async fn stream_to_file(
         &self,
@@ -59,6 +62,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
+                WRITE_CONCURRENT,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),
@@ -67,6 +71,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
+                WRITE_CONCURRENT,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),
@@ -75,6 +80,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
+                WRITE_CONCURRENT,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -44,7 +44,7 @@ use crate::statement::StatementExecutor;
 const WRITE_BUFFER_THRESHOLD: ReadableSize = ReadableSize::mb(8);
 
 /// Default number of concurrent write, it only works on object store backend(e.g., S3).
-const WRITE_CONCURRENT: usize = 8;
+const WRITE_CONCURRENCY: usize = 8;
 
 impl StatementExecutor {
     async fn stream_to_file(
@@ -62,7 +62,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
-                WRITE_CONCURRENT,
+                WRITE_CONCURRENCY,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),
@@ -71,7 +71,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
-                WRITE_CONCURRENT,
+                WRITE_CONCURRENCY,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),
@@ -80,7 +80,7 @@ impl StatementExecutor {
                 object_store,
                 path,
                 threshold,
-                WRITE_CONCURRENT,
+                WRITE_CONCURRENCY,
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

1. set `DEFAULT_WRITE_CONCURRENT` to 8.
2. Enable concurrent write for `Copy To` and `ParquetWriter`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
