### PR TITLE
feat: read column and region info from state cache

### DIFF
--- a/src/metric-engine/src/engine/state.rs
+++ b/src/metric-engine/src/engine/state.rs
@@ -131,4 +131,25 @@ impl MetricEngineState {
 
         Ok(())
     }
+
+    /// Check if a physical column exists.
+    pub fn is_physical_column_exist(
+        &self,
+        physical_region_id: RegionId,
+        column_name: &str,
+    ) -> Result<bool> {
+        let data_region_id = to_data_region_id(physical_region_id);
+        let exist = self
+            .physical_columns()
+            .get(&data_region_id)
+            .context(PhysicalRegionNotFoundSnafu {
+                region_id: data_region_id,
+            })?
+            .contains(column_name);
+        Ok(exist)
+    }
+
+    pub fn is_logical_region_exist(&self, logical_region_id: RegionId) -> bool {
+        self.logical_regions().contains_key(&logical_region_id)
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Closes https://github.com/GreptimeTeam/greptimedb/issues/3220

Change the metadata retrieving behavior from read underlying mito to memory state cache. This can alleviate the high CPU usage a lot.

CPU curve afterward:
<img width="789" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/ed48a9e6-a040-43ee-b89a-ee97fd6f81e6">

(There are three flush in this graph)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/3220