### PR TITLE
fix: only register region keeper while creating physical table

### DIFF
--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -232,12 +232,14 @@ impl CreateTableProcedure {
         region_routes: &[RegionRoute],
         request_builder: CreateRequestBuilder,
     ) -> Result<Status> {
-        // Registers opening regions
-        let guards = self
-            .creator
-            .register_opening_regions(&self.context, region_routes)?;
-        if !guards.is_empty() {
-            self.creator.opening_regions = guards;
+        if self.creator.data.table_route.is_physical() {
+            // Registers opening regions
+            let guards = self
+                .creator
+                .register_opening_regions(&self.context, region_routes)?;
+            if !guards.is_empty() {
+                self.creator.opening_regions = guards;
+            }
         }
 
         let create_table_data = &self.creator.data;

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -53,6 +53,7 @@ use servers::Mode;
 use tempfile::TempDir;
 use tonic::transport::Server;
 use tower::service_fn;
+use uuid::Uuid;
 
 use crate::test_util::{
     self, create_datanode_opts, create_tmp_dir_and_datanode_opts, FileDirGuard, StorageGuard,
@@ -96,7 +97,9 @@ impl GreptimeDbClusterBuilder {
             let backend = EtcdStore::with_endpoints(endpoints)
                 .await
                 .expect("malformed endpoints");
-            Arc::new(ChrootKvBackend::new(cluster_name.into(), backend))
+            // Each retry requires a new isolation namespace.
+            let chroot = format!("{}{}", cluster_name, Uuid::new_v4());
+            Arc::new(ChrootKvBackend::new(chroot.into(), backend))
         };
 
         Self {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Only register region keeper while creating physical table

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
