### PR TITLE
feat: read metadata from write cache

### DIFF
--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -89,7 +89,10 @@ impl CacheManager {
         let key = IndexKey::new(region_id, file_id, FileType::Parquet);
         if let Some(write_cache) = &self.write_cache {
             if let Some(metadata) = write_cache.file_cache().get_parquet_meta_data(key).await {
-                return Some(Arc::new(metadata));
+                let metadata = Arc::new(metadata);
+                // Put metadata into sst meta cache
+                self.put_parquet_meta_data(region_id, file_id, metadata.clone());
+                return Some(metadata);
             }
         };
 

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -88,11 +88,7 @@ impl CacheManager {
         // Try to get metadata from write cache
         let key = IndexKey::new(region_id, file_id, FileType::Parquet);
         if let Some(write_cache) = &self.write_cache {
-            if let Some(metadata) = write_cache
-                .file_cache()
-                .try_get_parquet_meta_data(key)
-                .await
-            {
+            if let Some(metadata) = write_cache.file_cache().get_parquet_meta_data(key).await {
                 return Some(Arc::new(metadata));
             }
         };

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -74,7 +74,6 @@ impl CacheManager {
         &self,
         region_id: RegionId,
         file_id: FileId,
-        file_size: u64,
     ) -> Option<Arc<ParquetMetaData>> {
         // Try to get metadata from sst meta cache
         let metadata = self.sst_meta_cache.as_ref().and_then(|sst_meta_cache| {
@@ -91,7 +90,7 @@ impl CacheManager {
         if let Some(write_cache) = &self.write_cache {
             if let Some(metadata) = write_cache
                 .file_cache()
-                .try_get_parquet_meta_data(key, file_size)
+                .try_get_parquet_meta_data(key)
                 .await
             {
                 return Some(Arc::new(metadata));
@@ -348,7 +347,7 @@ mod tests {
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
         assert!(cache
-            .get_parquet_meta_data(region_id, file_id, 0)
+            .get_parquet_meta_data(region_id, file_id)
             .await
             .is_none());
 
@@ -376,18 +375,18 @@ mod tests {
         let region_id = RegionId::new(1, 1);
         let file_id = FileId::random();
         assert!(cache
-            .get_parquet_meta_data(region_id, file_id, 0)
+            .get_parquet_meta_data(region_id, file_id)
             .await
             .is_none());
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
         assert!(cache
-            .get_parquet_meta_data(region_id, file_id, 0)
+            .get_parquet_meta_data(region_id, file_id)
             .await
             .is_some());
         cache.remove_parquet_meta_data(region_id, file_id);
         assert!(cache
-            .get_parquet_meta_data(region_id, file_id, 0)
+            .get_parquet_meta_data(region_id, file_id)
             .await
             .is_none());
     }

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -32,6 +32,7 @@ use parquet::file::metadata::ParquetMetaData;
 use store_api::storage::RegionId;
 
 use crate::cache::cache_size::parquet_meta_size;
+use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::write_cache::WriteCacheRef;
 use crate::metrics::{CACHE_BYTES, CACHE_HIT, CACHE_MISS};
 use crate::sst::file::FileId;
@@ -69,15 +70,35 @@ impl CacheManager {
     }
 
     /// Gets cached [ParquetMetaData].
-    pub fn get_parquet_meta_data(
+    pub async fn get_parquet_meta_data(
         &self,
         region_id: RegionId,
         file_id: FileId,
+        file_size: u64,
     ) -> Option<Arc<ParquetMetaData>> {
-        self.sst_meta_cache.as_ref().and_then(|sst_meta_cache| {
+        // Try to get metadata from sst meta cache
+        let metadata = self.sst_meta_cache.as_ref().and_then(|sst_meta_cache| {
             let value = sst_meta_cache.get(&SstMetaKey(region_id, file_id));
             update_hit_miss(value, SST_META_TYPE)
-        })
+        });
+
+        if metadata.is_some() {
+            return metadata;
+        }
+
+        // Try to get metadata from write cache
+        let key = IndexKey::new(region_id, file_id, FileType::Parquet);
+        if let Some(write_cache) = &self.write_cache {
+            if let Some(metadata) = write_cache
+                .file_cache()
+                .try_get_parquet_meta_data(key, file_size)
+                .await
+            {
+                return Some(Arc::new(metadata));
+            }
+        };
+
+        None
     }
 
     /// Puts [ParquetMetaData] into the cache.
@@ -315,8 +336,8 @@ mod tests {
     use super::*;
     use crate::cache::test_util::parquet_meta;
 
-    #[test]
-    fn test_disable_cache() {
+    #[tokio::test]
+    async fn test_disable_cache() {
         let cache = CacheManager::default();
         assert!(cache.sst_meta_cache.is_none());
         assert!(cache.vector_cache.is_none());
@@ -326,7 +347,10 @@ mod tests {
         let file_id = FileId::random();
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
-        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+        assert!(cache
+            .get_parquet_meta_data(region_id, file_id, 0)
+            .await
+            .is_none());
 
         let value = Value::Int64(10);
         let vector: VectorRef = Arc::new(Int64Vector::from_slice([10, 10, 10, 10]));
@@ -346,17 +370,26 @@ mod tests {
         assert!(cache.write_cache().is_none());
     }
 
-    #[test]
-    fn test_parquet_meta_cache() {
+    #[tokio::test]
+    async fn test_parquet_meta_cache() {
         let cache = CacheManager::builder().sst_meta_cache_size(2000).build();
         let region_id = RegionId::new(1, 1);
         let file_id = FileId::random();
-        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+        assert!(cache
+            .get_parquet_meta_data(region_id, file_id, 0)
+            .await
+            .is_none());
         let metadata = parquet_meta();
         cache.put_parquet_meta_data(region_id, file_id, metadata);
-        assert!(cache.get_parquet_meta_data(region_id, file_id).is_some());
+        assert!(cache
+            .get_parquet_meta_data(region_id, file_id, 0)
+            .await
+            .is_some());
         cache.remove_parquet_meta_data(region_id, file_id);
-        assert!(cache.get_parquet_meta_data(region_id, file_id).is_none());
+        assert!(cache
+            .get_parquet_meta_data(region_id, file_id, 0)
+            .await
+            .is_none());
     }
 
     #[test]

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -122,7 +122,7 @@ impl FileCache {
             }
             Err(e) => {
                 if e.kind() != ErrorKind::NotFound {
-                    warn!("Failed to get file for key {:?}, err: {}", key, e);
+                    warn!(e; "Failed to get file for key {:?}", key);
                 }
             }
             Ok(None) => {}
@@ -156,7 +156,7 @@ impl FileCache {
             }
             Err(e) => {
                 if e.kind() != ErrorKind::NotFound {
-                    warn!("Failed to get file for key {:?}, err: {}", key, e);
+                    warn!(e; "Failed to get file for key {:?}", key);
                 }
 
                 // We removes the file from the index.
@@ -228,8 +228,9 @@ impl FileCache {
         self.local_store.clone()
     }
 
-    /// Try to get the parquet metadata in file cache.
-    pub(crate) async fn try_get_parquet_meta_data(&self, key: IndexKey) -> Option<ParquetMetaData> {
+    /// Get the parquet metadata in file cache.
+    /// If the file is not in the cache or fail to load metadata, return None.
+    pub(crate) async fn get_parquet_meta_data(&self, key: IndexKey) -> Option<ParquetMetaData> {
         // Check if file cache contrains the key
         if let Some(index_value) = self.memory_index.get(&key).await {
             // Load metadata from file cache
@@ -246,8 +247,8 @@ impl FileCache {
                 Err(e) => {
                     if !e.is_object_not_found() {
                         warn!(
-                            "Failed to get parquet metadata for key {:?}, err: {}",
-                            key, e
+                            e; "Failed to get parquet metadata for key {:?}",
+                            key
                         );
                     }
                     // We removes the file from the index.

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -228,13 +228,13 @@ impl FileCache {
         self.local_store.clone()
     }
 
-    /// Returns the parquet metadata of the file.
+    /// Try to get the parquet metadata in file cache.
     pub(crate) async fn try_get_parquet_meta_data(
         &self,
         key: IndexKey,
         file_size: u64,
     ) -> Option<ParquetMetaData> {
-        // Check whether file cache contrains the key
+        // Check if file cache contrains the key
         if self.memory_index.get(&key).await.is_none() {
             CACHE_MISS.with_label_values(&[FILE_TYPE]).inc();
             return None;

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -258,7 +258,7 @@ impl FileCache {
             }
         } else {
             CACHE_MISS.with_label_values(&[FILE_TYPE]).inc();
-            return None;
+            None
         }
     }
 

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -88,7 +88,8 @@ mod tests {
     use crate::sst::parquet::reader::ParquetReaderBuilder;
     use crate::sst::parquet::writer::ParquetWriter;
     use crate::test_util::sst_util::{
-        new_batch_by_range, new_source, sst_file_handle, sst_region_metadata,
+        assert_parquet_metadata_eq, new_batch_by_range, new_source, sst_file_handle,
+        sst_region_metadata,
     };
     use crate::test_util::{check_reader_result, TestEnv};
 
@@ -258,34 +259,7 @@ mod tests {
         let reader = builder.build().await.unwrap();
         let reader_metadata = reader.parquet_metadata();
 
-        // Because ParquetMetaData doesn't implement PartialEq,
-        // check all fields manually
-        macro_rules! assert_metadata {
-            ( $writer:expr, $reader:expr, $($method:ident,)+ ) => {
-                $(
-                    assert_eq!($writer.$method(), $reader.$method());
-                )+
-            }
-        }
-
-        assert_metadata!(
-            writer_metadata.file_metadata(),
-            reader_metadata.file_metadata(),
-            version,
-            num_rows,
-            created_by,
-            key_value_metadata,
-            schema_descr,
-            column_orders,
-        );
-
-        assert_metadata!(
-            writer_metadata,
-            reader_metadata,
-            row_groups,
-            column_index,
-            offset_index,
-        );
+        assert_parquet_metadata_eq(writer_metadata, reader_metadata)
     }
 
     #[tokio::test]

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -16,7 +16,7 @@
 
 mod format;
 pub(crate) mod helper;
-mod metadata;
+pub(crate) mod metadata;
 mod page_reader;
 pub mod reader;
 pub mod row_group;

--- a/src/mito2/src/sst/parquet/metadata.rs
+++ b/src/mito2/src/sst/parquet/metadata.rs
@@ -69,6 +69,7 @@ impl<'a> MetadataLoader<'a> {
     pub async fn load(&self) -> Result<ParquetMetaData> {
         let object_store = &self.object_store;
         let path = self.file_path;
+
         let file_size = self.get_file_size().await?;
 
         if file_size < FOOTER_SIZE as u64 {

--- a/src/mito2/src/sst/parquet/metadata.rs
+++ b/src/mito2/src/sst/parquet/metadata.rs
@@ -69,7 +69,6 @@ impl<'a> MetadataLoader<'a> {
     pub async fn load(&self) -> Result<ParquetMetaData> {
         let object_store = &self.object_store;
         let path = self.file_path;
-
         let file_size = self.get_file_size().await?;
 
         if file_size < FOOTER_SIZE as u64 {

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -246,7 +246,7 @@ impl ParquetReaderBuilder {
         let region_id = self.file_handle.region_id();
         let file_id = self.file_handle.file_id();
         // Tries to get from global cache.
-        if let Some(manager) = self.cache_manager.as_ref() {
+        if let Some(manager) = &self.cache_manager {
             if let Some(metadata) = manager.get_parquet_meta_data(region_id, file_id).await {
                 return Ok(metadata);
             }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -247,10 +247,7 @@ impl ParquetReaderBuilder {
         let file_id = self.file_handle.file_id();
         // Tries to get from global cache.
         if let Some(manager) = self.cache_manager.as_ref() {
-            if let Some(metadata) = manager
-                .get_parquet_meta_data(region_id, file_id, file_size)
-                .await
-            {
+            if let Some(metadata) = manager.get_parquet_meta_data(region_id, file_id).await {
                 return Ok(metadata);
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- read parquet metadata from write cache.
- refactor some test code.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
#2965