### PR TITLE
feat: postpone null expansion as much as possible 

### DIFF
--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -128,7 +128,7 @@ impl MetricEngineInner {
     /// - Generate tsid
     fn modify_rows(&self, table_id: TableId, rows: &mut Rows) -> Result<()> {
         // gather tag column indices
-        let mut tag_col_indices = rows
+        let tag_col_indices = rows
             .schema
             .iter()
             .enumerate()

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -128,7 +128,7 @@ impl MetricEngineInner {
     /// - Generate tsid
     fn modify_rows(&self, table_id: TableId, rows: &mut Rows) -> Result<()> {
         // gather tag column indices
-        let tag_col_indices = rows
+        let mut tag_col_indices = rows
             .schema
             .iter()
             .enumerate()

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -763,8 +763,7 @@ impl From<ValueBuilder> for Values {
         let fields = value
             .fields
             .iter_mut()
-            .enumerate()
-            .map(|(i, v)| {
+            .map(|v| {
                 if let Some(v) = v {
                     v.to_vector()
                 } else {

--- a/src/mito2/src/read/null_expand.rs
+++ b/src/mito2/src/read/null_expand.rs
@@ -64,28 +64,19 @@ impl BatchReader for NullExpandReader {
                     .data_type
                     .clone();
                 if let Some(prev_null_vec) = self.null_buf.get_mut(&data_type) {
-                    // field.data = null_vec.clone();
                     if prev_null_vec.len() >= length {
                         field.data = prev_null_vec.slice(0, length);
                     } else {
                         let new_null_vec = Self::make_null_vec(&data_type, length);
-                        // self.null_buf.insert(data_type, null_vec.clone());
                         *prev_null_vec = new_null_vec.clone();
                         field.data = new_null_vec;
                     }
                 } else {
-                    // let mut builder = data_type.create_mutable_vector(length);
-                    // builder.push_nulls(length);
-                    // let null_vec = builder.to_vector();
                     let null_vec = Self::make_null_vec(&data_type, length);
                     self.null_buf.insert(data_type, null_vec.clone());
                     field.data = null_vec;
                 }
             }
-            // if let Some(null_buf) = self.null_buf.get(&field.data_type()) {
-            //     field.set_null_bitmap(null_buf.clone());
-            // }
-            // if
         });
 
         Ok(Some(batch))

--- a/src/mito2/src/read/null_expand.rs
+++ b/src/mito2/src/read/null_expand.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A reader transformer to expand possible [NullVector].
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use datatypes::data_type::{ConcreteDataType, DataType};
+use datatypes::vectors::VectorRef;
+use store_api::metadata::RegionMetadataRef;
+
+use crate::error::Result;
+use crate::read::{Batch, BatchReader, BoxedBatchReader};
+
+pub struct NullExpandReader {
+    input: BoxedBatchReader,
+    null_buf: HashMap<ConcreteDataType, VectorRef>,
+    metadata: RegionMetadataRef,
+}
+
+impl NullExpandReader {
+    pub fn new(input: BoxedBatchReader, metadata: RegionMetadataRef) -> Self {
+        Self {
+            input,
+            null_buf: HashMap::new(),
+            metadata,
+        }
+    }
+
+    fn make_null_vec(data_type: &ConcreteDataType, length: usize) -> VectorRef {
+        let mut builder = data_type.create_mutable_vector(length);
+        builder.push_nulls(length);
+        builder.to_vector()
+    }
+}
+
+#[async_trait]
+impl BatchReader for NullExpandReader {
+    async fn next_batch(&mut self) -> Result<Option<Batch>> {
+        let Some(mut batch) = self.input.next_batch().await? else {
+            return Ok(None);
+        };
+
+        batch.fields.iter_mut().for_each(|field| {
+            if matches!(field.data.data_type(), ConcreteDataType::Null(..)) {
+                let length = field.data.len();
+                let data_type = self
+                    .metadata
+                    .column_by_id(field.column_id)
+                    .unwrap()
+                    .column_schema
+                    .data_type
+                    .clone();
+                if let Some(prev_null_vec) = self.null_buf.get_mut(&data_type) {
+                    // field.data = null_vec.clone();
+                    if prev_null_vec.len() >= length {
+                        field.data = prev_null_vec.slice(0, length);
+                    } else {
+                        let new_null_vec = Self::make_null_vec(&data_type, length);
+                        // self.null_buf.insert(data_type, null_vec.clone());
+                        *prev_null_vec = new_null_vec.clone();
+                        field.data = new_null_vec;
+                    }
+                } else {
+                    // let mut builder = data_type.create_mutable_vector(length);
+                    // builder.push_nulls(length);
+                    // let null_vec = builder.to_vector();
+                    let null_vec = Self::make_null_vec(&data_type, length);
+                    self.null_buf.insert(data_type, null_vec.clone());
+                    field.data = null_vec;
+                }
+            }
+            // if let Some(null_buf) = self.null_buf.get(&field.data_type()) {
+            //     field.set_null_bitmap(null_buf.clone());
+            // }
+            // if
+        });
+
+        Ok(Some(batch))
+    }
+}

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -28,6 +28,7 @@ use table::predicate::Predicate;
 use tokio::sync::{mpsc, Semaphore};
 use tokio_stream::wrappers::ReceiverStream;
 
+use super::null_expand::NullExpandReader;
 use crate::access_layer::AccessLayerRef;
 use crate::cache::{CacheManager, CacheManagerRef};
 use crate::error::Result;
@@ -152,6 +153,10 @@ impl SeqScan {
         } else {
             self.build_reader().await?
         };
+        reader = Box::new(NullExpandReader::new(
+            reader,
+            self.mapper.metadata().clone(),
+        ));
         let elapsed = start.elapsed();
         metrics.build_reader_cost = elapsed;
         metrics.scan_cost = elapsed;

--- a/tests-integration/src/grpc.rs
+++ b/tests-integration/src/grpc.rs
@@ -30,6 +30,7 @@ mod test {
     use common_meta::rpc::router::region_distribution;
     use common_query::Output;
     use common_recordbatch::RecordBatches;
+    use common_telemetry::info;
     use frontend::instance::Instance;
     use query::parser::QueryLanguageParser;
     use query::plan::LogicalPlan;
@@ -288,6 +289,7 @@ CREATE TABLE {table_name} (
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_standalone_insert_and_query() {
+        common_telemetry::init_default_ut_logging();
         let standalone = GreptimeDbStandaloneBuilder::new("test_standalone_insert_and_query")
             .build()
             .await;
@@ -567,6 +569,7 @@ CREATE TABLE {table_name} (
     }
 
     async fn test_insert_delete_and_query_on_auto_created_table(instance: &Instance) {
+        info!("running case test_insert_delete_and_query_on_auto_created_table");
         let insert = InsertRequest {
             table_name: "auto_created_table".to_string(),
             columns: vec![


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


I.e., try the best to keep `NullVector` in memtable.

### Result
#### write bench

Saves ~40GB peek memory, from >64GB to ~24GB. Alleviate write stall from ~30s to ~6s.

- Before

<img width="797" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/07bc5117-5b2f-49d1-8e11-85e51d0a0e52">


- After
<img width="786" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/14e650f8-4489-42e7-9d47-a2aaf4017b6c">


#### TSBS read bench

the `last_point` case has regression



| test                  | before(ms) | after(ms) | change |
| --------------------- | ---------- | --------- | ------ |
| cpu-max-all-1         | 14.13      | 12.08     |        |
| cpu-max-all-8         | 79.57      | 59.29     |        |
| double-groupby-1      | 728.76     | 716.26    |        |
| double-groupby-5      | 1193.33    | 1162.45   |        |
| double-groupby-all    | 1902.98    | 1853.60   |        |
| groupby-orderby-limit | 499.06     | 576.94    |        |
| high-cpu-1            | 9.69       | 9.31      |        |
| high-cpu-all          | 6402.76    | 6262.76   |        |
| **lastpoint***        | 6141.70    | 6871.30   | ⬆      |
| single-groupby-1-1-1  | 10.51      | 9.44      |        |
| single-groupby-1-1-12 | 8.58       | 8.45      |        |
| single-groupby-1-8-1  | 20.39      | 20.83     |        |
| single-groupby-5-1-1  | 9.26       | 9.85      |        |
| single-groupby-5-1-12 | 10.00      | 9.83      |        |
| single-groupby-5-8-1  | 30.37      | 31.19     |        |


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
