### PR TITLE
feat: return request outdated error on handling alter

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -68,6 +68,8 @@ pub enum StatusCode {
     // ====== Begin of storage related status code =====
     /// Storage is temporarily unable to handle the request
     StorageUnavailable = 5000,
+    /// Request is outdated, e.g., version mismatch
+    RequestOutdated = 5001,
     // ====== End of storage related status code =======
 
     // ====== Begin of server related status code =====
@@ -135,7 +137,8 @@ impl StatusCode {
             | StatusCode::AuthHeaderNotFound
             | StatusCode::InvalidAuthHeader
             | StatusCode::AccessDenied
-            | StatusCode::PermissionDenied => false,
+            | StatusCode::PermissionDenied
+            | StatusCode::RequestOutdated => false,
         }
     }
 
@@ -172,7 +175,8 @@ impl StatusCode {
             | StatusCode::AuthHeaderNotFound
             | StatusCode::InvalidAuthHeader
             | StatusCode::AccessDenied
-            | StatusCode::PermissionDenied => false,
+            | StatusCode::PermissionDenied
+            | StatusCode::RequestOutdated => false,
         }
     }
 

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -222,15 +222,14 @@ impl AlterTableProcedure {
                 alter_region_tasks.push(async move {
                     if let Err(err) = requester.handle(request).await {
                         if err.status_code() != StatusCode::RequestOutdated {
-                         // Treat request outdated as success.
-                         // The engine will throw this code when the schema version not match.
-                         // As this procedure has locked the table, the only reason for this error
-                         // is procedure is succeeded before and is retrying.
+                            // Treat request outdated as success.
+                            // The engine will throw this code when the schema version not match.
+                            // As this procedure has locked the table, the only reason for this error
+                            // is procedure is succeeded before and is retrying.
                             return Err(handle_operate_region_error(datanode)(err));
                         }
                     }
                     Ok(())
-                    }
                 });
             }
         }

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -226,7 +226,7 @@ impl AlterTableProcedure {
                         // Treat request outdated as success.
                         // The engine will throw this code when the schema version not match.
                         // As this procedure has locked the table, the only reason for this error
-                        // is procedure is successed before and is retrying.
+                        // is procedure is succeeded before and is retrying.
                         Err(e) if e.status_code() == StatusCode::RequestOutdated => Ok(()),
                         Err(e) => Err(handle_operate_region_error(datanode)(e)),
                     }

--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -223,6 +223,10 @@ impl AlterTableProcedure {
                     let result = requester.handle(request).await;
                     match result {
                         Ok(_) => Ok(()),
+                        // Treat request outdated as success.
+                        // The engine will throw this code when the schema version not match.
+                        // As this procedure has locked the table, the only reason for this error
+                        // is procedure is successed before and is retrying.
                         Err(e) if e.status_code() == StatusCode::RequestOutdated => Ok(()),
                         Err(e) => Err(handle_operate_region_error(datanode)(e)),
                     }

--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -75,14 +75,14 @@ impl DataRegion {
 
             let result = self.mito.handle_request(region_id, request).await;
             match result {
-                Ok(_) => {}
+                Ok(_) => return Ok(()),
                 Err(e) if e.status_code() == StatusCode::RequestOutdated => {
                     info!("Retrying alter {region_id} due to outdated schema version, times {retries}");
                     retries += 1;
                     continue;
                 }
                 Err(e) => {
-                    Err(e).context(MitoWriteOperationSnafu)?;
+                    return Err(e).context(MitoWriteOperationSnafu)?;
                 }
             }
         }

--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -119,7 +119,7 @@ impl DataRegion {
 
         // overwrite semantic type
         let columns = columns
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(delta, c)| {
                 let mut c = c.clone();

--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -168,15 +168,18 @@ impl MetricEngineInner {
                 }
             }
         }
-        info!("Found new columns {new_columns:?} to add to physical region {data_region_id}");
 
-        self.add_columns_to_physical_data_region(
-            data_region_id,
-            metadata_region_id,
-            logical_region_id,
-            new_columns,
-        )
-        .await?;
+        if !new_columns.is_empty() {
+            info!("Found new columns {new_columns:?} to add to physical region {data_region_id}");
+
+            self.add_columns_to_physical_data_region(
+                data_region_id,
+                metadata_region_id,
+                logical_region_id,
+                new_columns,
+            )
+            .await?;
+        }
 
         // register logical region to metadata region
         self.metadata_region

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -283,7 +283,7 @@ async fn test_alter_region_retry() {
         .handle_request(region_id, RegionRequest::Alter(request))
         .await
         .unwrap_err();
-    assert!(matches!(err.status_code(), StatusCode::RequestOutdated));
+    assert_eq!(err.status_code(), StatusCode::RequestOutdated);
 
     let expected = "\
 +-------+-------+---------+---------------------+

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -16,6 +16,8 @@ use std::collections::HashMap;
 
 use api::v1::value::ValueData;
 use api::v1::{ColumnDataType, Row, Rows, SemanticType};
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_recordbatch::RecordBatches;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
@@ -277,10 +279,11 @@ async fn test_alter_region_retry() {
         .unwrap();
     // Retries request.
     let request = add_tag1();
-    engine
+    let err = engine
         .handle_request(region_id, RegionRequest::Alter(request))
         .await
-        .unwrap();
+        .unwrap_err();
+    assert!(matches!(err.status_code(), StatusCode::RequestOutdated));
 
     let expected = "\
 +-------+-------+---------+---------------------+

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -388,11 +388,7 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display(
-        "Schema version doesn't match. Expect greater than {} but gives {}",
-        expect,
-        actual
-    ))]
+    #[snafu(display("Schema version doesn't match. Expect {} but gives {}", expect, actual))]
     InvalidRegionRequestSchemaVersion {
         expect: u64,
         actual: u64,

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -388,6 +388,17 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Schema version doesn't match. Expect greater than {} but gives {}",
+        expect,
+        actual
+    ))]
+    InvalidRegionRequestSchemaVersion {
+        expect: u64,
+        actual: u64,
+        location: Location,
+    },
+
     #[snafu(display("Region {} is read only", region_id))]
     RegionReadonly {
         region_id: RegionId,
@@ -591,6 +602,9 @@ impl ErrorExt for Error {
             | ConvertColumnDataType { .. }
             | ColumnNotFound { .. }
             | InvalidMetadata { .. } => StatusCode::InvalidArguments,
+
+            InvalidRegionRequestSchemaVersion { .. } => StatusCode::RequestOutdated,
+
             RegionMetadataNotFound { .. }
             | Join { .. }
             | WorkerStopped { .. }

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use common_telemetry::{debug, error, info, warn};
+use common_telemetry::{debug, error, info};
 use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::region_request::RegionAlterRequest;
@@ -48,9 +48,9 @@ impl<S> RegionWorkerLoop<S> {
 
         // Get the version before alter.
         let version = region.version();
-        if version.metadata.schema_version > request.schema_version {
+        if version.metadata.schema_version != request.schema_version {
             // This is possible if we retry the request.
-            warn!(
+            debug!(
                 "Ignores alter request, region id:{}, region schema version {} is greater than request schema version {}",
                 region_id, version.metadata.schema_version, request.schema_version
             );

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -51,7 +51,7 @@ impl<S> RegionWorkerLoop<S> {
         if version.metadata.schema_version != request.schema_version {
             // This is possible if we retry the request.
             debug!(
-                "Ignores alter request, region id:{}, region schema version {} is greater than request schema version {}",
+                "Ignores alter request, region id:{}, region schema version {} is not equal to request schema version {}",
                 region_id, version.metadata.schema_version, request.schema_version
             );
             // Returns an error.

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -565,7 +565,9 @@ pub fn status_to_tonic_code(status_code: StatusCode) -> Code {
         | StatusCode::Internal
         | StatusCode::PlanQuery
         | StatusCode::EngineExecuteQuery => Code::Internal,
-        StatusCode::InvalidArguments | StatusCode::InvalidSyntax => Code::InvalidArgument,
+        StatusCode::InvalidArguments | StatusCode::InvalidSyntax | StatusCode::RequestOutdated => {
+            Code::InvalidArgument
+        }
         StatusCode::Cancelled => Code::Cancelled,
         StatusCode::TableAlreadyExists
         | StatusCode::TableColumnExists


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Mito engine returns ok on outdated requests. It confuses the caller to know if the request is actually performed. This PR changes the behavior on outdated alter request. It will now return a new status code `RequestOutdated` instead of an incorrect success.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
