### PR TITLE
fix: init parquet reader metrics twice

### DIFF
--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -176,10 +176,7 @@ impl ParquetReaderBuilder {
             cache_manager: self.cache_manager.clone(),
         };
 
-        let metrics = Metrics {
-            build_cost: start.elapsed(),
-            ..Default::default()
-        };
+        metrics.build_cost = start.elapsed();
 
         let predicate = if let Some(p) = &self.predicate {
             p.exprs()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR avoids initializing the reader metrics twice, which resets row group metrics

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
