### PR TITLE
feat: don't map semantic type in metric engine

### DIFF
--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -89,7 +89,6 @@ impl DataRegion {
             .enumerate()
             .map(|(delta, mut c)| {
                 if c.semantic_type == SemanticType::Tag {
-                    c.column_schema = c.column_schema.with_nullable_set();
                     if !c.column_schema.data_type.is_string() {
                         return ColumnTypeMismatchSnafu {
                             column_type: c.column_schema.data_type,

--- a/src/metric-engine/src/data_region.rs
+++ b/src/metric-engine/src/data_region.rs
@@ -46,9 +46,9 @@ impl DataRegion {
 
     /// Submit an alter request to underlying physical region.
     ///
-    /// This method will change the semantic type of those given columns.
-    /// [SemanticType::Tag] will become [SemanticType::Field]. The procedure framework
-    /// ensures there is no concurrent conflict.
+    /// This method will change the nullability of those given columns.
+    /// [SemanticType::Tag] will become nullable column as it's shared between
+    /// logical regions.
     ///
     /// Invoker don't need to set up or verify the column id. This method will adjust
     /// it using underlying schema.
@@ -89,7 +89,7 @@ impl DataRegion {
             .enumerate()
             .map(|(delta, mut c)| {
                 if c.semantic_type == SemanticType::Tag {
-                    c.semantic_type = SemanticType::Field;
+                    c.column_schema = c.column_schema.with_nullable_set();
                     if !c.column_schema.data_type.is_string() {
                         return ColumnTypeMismatchSnafu {
                             column_type: c.column_schema.data_type,

--- a/src/metric-engine/src/engine/put.rs
+++ b/src/metric-engine/src/engine/put.rs
@@ -123,7 +123,6 @@ impl MetricEngineInner {
     }
 
     /// Perform metric engine specific logic to incoming rows.
-    /// - Change the semantic type of tag columns to field
     /// - Add table_id column
     /// - Generate tsid
     fn modify_rows(&self, table_id: TableId, rows: &mut Rows) -> Result<()> {
@@ -141,18 +140,6 @@ impl MetricEngineInner {
             })
             .collect::<Vec<_>>();
 
-        // generate new schema
-        rows.schema = rows
-            .schema
-            .clone()
-            .into_iter()
-            .map(|mut col| {
-                if col.semantic_type == SemanticType::Tag as i32 {
-                    col.semantic_type = SemanticType::Field as i32;
-                }
-                col
-            })
-            .collect::<Vec<_>>();
         // add table_name column
         rows.schema.push(ColumnSchema {
             column_name: DATA_SCHEMA_TABLE_ID_COLUMN_NAME.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Avoid memory problem caused by null fields. By not mapping tag to field in metric engine.

Peak memory drops from ~24GB to ~10GB 
<img width="790" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/62a403bf-3a4b-4d7e-9a5c-6bc7252f299f">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
