### PR TITLE
ci: build GreptimeDB binary for later use

### DIFF
--- a/.github/actions/build-greptime-binary/action.yml
+++ b/.github/actions/build-greptime-binary/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   cargo-profile:
     description: Cargo profile to build
-    required: true
+    required: false
   artifacts-dir:
     description: Directory to store artifacts
     required: true
@@ -37,14 +37,21 @@ runs:
           FEATURES=${{ inputs.features }} \
           BASE_IMAGE=${{ inputs.base-image }}
 
+    - name: Pack GreptimeDB binaries
+      shell: bash
+      env:
+        # If inputs.cargo-profile is empty, we will use 'debug' as default.
+        PROFILE_TARGET: ${{ inputs.cargo-profile == '' && 'debug' || inputs.cargo-profile }}
+      run: |
+        mkdir -p ${{ inputs.artifacts-dir }} && \
+        sudo mv ./target/$PROFILE_TARGET/greptime ${{ inputs.artifacts-dir }} && \
+        sudo mv ./target/$PROFILE_TARGET/sqlness-runner ${{ inputs.artifacts-dir }}
+
     - name: Upload artifacts
       uses: ./.github/actions/upload-artifacts
       if: ${{ inputs.build-android-artifacts == 'false' }}
-      env:
-        PROFILE_TARGET: ${{ inputs.cargo-profile == 'dev' && 'debug' || inputs.cargo-profile }}
       with:
         artifacts-dir: ${{ inputs.artifacts-dir }}
-        target-file: ./target/$PROFILE_TARGET/greptime
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
 

--- a/.github/actions/build-greptime-binary/action.yml
+++ b/.github/actions/build-greptime-binary/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   cargo-profile:
     description: Cargo profile to build
-    required: false
+    required: true
   artifacts-dir:
     description: Directory to store artifacts
     required: true
@@ -37,21 +37,14 @@ runs:
           FEATURES=${{ inputs.features }} \
           BASE_IMAGE=${{ inputs.base-image }}
 
-    - name: Pack GreptimeDB binaries
-      shell: bash
-      env:
-        # If inputs.cargo-profile is empty, we will use 'debug' as default.
-        PROFILE_TARGET: ${{ inputs.cargo-profile == '' && 'debug' || inputs.cargo-profile }}
-      run: |
-        mkdir -p ${{ inputs.artifacts-dir }} && \
-        sudo mv ./target/$PROFILE_TARGET/greptime ${{ inputs.artifacts-dir }} && \
-        sudo mv ./target/$PROFILE_TARGET/sqlness-runner ${{ inputs.artifacts-dir }}
-
     - name: Upload artifacts
       uses: ./.github/actions/upload-artifacts
       if: ${{ inputs.build-android-artifacts == 'false' }}
+      env:
+        PROFILE_TARGET: ${{ inputs.cargo-profile == 'dev' && 'debug' || inputs.cargo-profile }}
       with:
         artifacts-dir: ${{ inputs.artifacts-dir }}
+        target-file: ./target/$PROFILE_TARGET/greptime
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
 

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -52,13 +52,13 @@ runs:
     # Note: The artifacts will be double zip compressed(related issue: https://github.com/actions/upload-artifact/issues/39).
     # However, when we use 'actions/download-artifact@v3' to download the artifacts, it will be automatically unzipped.
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts-dir }}
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.tar.gz
 
     - name: Upload checksum
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts-dir }}.sha256sum
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.sha256sum

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -4,9 +4,6 @@ inputs:
   artifacts-dir:
     description: Directory to store artifacts
     required: true
-  target-file:
-    description: The path of the target artifact
-    required: true
   version:
     description: Version of the artifact
     required: true
@@ -17,13 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Create artifacts directory
-      working-directory: ${{ inputs.working-dir }}
-      shell: bash
-      run: |
-        mkdir -p ${{ inputs.artifacts-dir }} && \
-        cp ${{ inputs.target-file }} ${{ inputs.artifacts-dir }}
-
     # The compressed artifacts will use the following layout:
     # greptime-linux-amd64-pyo3-v0.3.0sha256sum
     # greptime-linux-amd64-pyo3-v0.3.0.tar.gz
@@ -51,13 +41,13 @@ runs:
     # Note: The artifacts will be double zip compressed(related issue: https://github.com/actions/upload-artifact/issues/39).
     # However, when we use 'actions/download-artifact@v3' to download the artifacts, it will be automatically unzipped.
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts-dir }}
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.tar.gz
 
     - name: Upload checksum
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifacts-dir }}.sha256sum
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.sha256sum

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   target-file:
     description: The path of the target artifact
-    required: true
+    required: false
   version:
     description: Version of the artifact
     required: true
@@ -18,6 +18,7 @@ runs:
   using: composite
   steps:
     - name: Create artifacts directory
+      if: ${{ inputs.target-file != '' }}
       working-directory: ${{ inputs.working-dir }}
       shell: bash
       run: |

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -4,6 +4,9 @@ inputs:
   artifacts-dir:
     description: Directory to store artifacts
     required: true
+  target-file:
+    description: The path of the target artifact
+    required: true
   version:
     description: Version of the artifact
     required: true
@@ -14,6 +17,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Create artifacts directory
+      working-directory: ${{ inputs.working-dir }}
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.artifacts-dir }} && \
+        cp ${{ inputs.target-file }} ${{ inputs.artifacts-dir }}
+
     # The compressed artifacts will use the following layout:
     # greptime-linux-amd64-pyo3-v0.3.0sha256sum
     # greptime-linux-amd64-pyo3-v0.3.0.tar.gz
@@ -41,13 +51,13 @@ runs:
     # Note: The artifacts will be double zip compressed(related issue: https://github.com/actions/upload-artifact/issues/39).
     # However, when we use 'actions/download-artifact@v3' to download the artifacts, it will be automatically unzipped.
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifacts-dir }}
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.tar.gz
 
     - name: Upload checksum
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifacts-dir }}.sha256sum
         path: ${{ inputs.working-dir }}/${{ inputs.artifacts-dir }}.sha256sum

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
+        os: [ ubuntu-20.04-8-cores ]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Unzip binaries
         run: tar -xvf ./bins.tar.gz
       - name: Run sqlness
-        run: GREPTIME_BINS_DIR=./bins ./bins/sqlness-runner -c ./tests/cases
+        run: ./bins/sqlness-runner -c ./tests/cases --bins-dir ./bins
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3
@@ -158,7 +158,7 @@ jobs:
         working-directory: tests-integration/fixtures/kafka
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run sqlness
-        run: GREPTIME_BINS_DIR=./bins ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases
+        run: ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases --bins-dir ./bins
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -86,14 +86,27 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/build-greptime-binary
+      - uses: arduino/setup-protoc@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          base-image: ubuntu
-          features: ''
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build greptime binaries
+        shell: bash
+        run: cargo build
+      - name: Pack greptime binaries
+        shell: bash
+        run: |
+          mkdir bins && \
+          mv ./target/debug/greptime bins && \
+          mv ./target/debug/sqlness-runner bins
+      - name: Print greptime binaries info
+        run: ls -lh bins
+      - name: Upload artifacts
+        uses: ./.github/actions/upload-artifacts
+        with:
           artifacts-dir: bins
           version: current
-      - name: Print bins info
-        run: ls -lh ./bins
 
   sqlness:
     name: Sqlness Test
@@ -102,7 +115,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04-8-cores ]
+        os: [ ubuntu-20.04 ]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-20.04-8-cores ]
+        os: [ ubuntu-20.04 ]
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -76,8 +76,8 @@ jobs:
       - name: Run taplo
         run: taplo format --check
 
-  sqlness:
-    name: Sqlness Test
+  build:
+    name: Build GreptimeDB binaries
     if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
@@ -86,16 +86,35 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-protoc@v1
+      - uses: ./.github/actions/build-greptime-binary
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@master
+          base-image: ubuntu
+          features: ''
+          artifacts-dir: bins
+          version: current
+      - name: Print bins info
+        run: ls -lh ./bins
+
+  sqlness:
+    name: Sqlness Test
+    if: github.event.pull_request.draft == false
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04-8-cores ]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+          name: bins
+          path: .
+      - name: Unzip binaries
+        run: tar -xvf ./bins.tar.gz
       - name: Run sqlness
-        run: cargo sqlness
+        run: GREPTIME_BINS_DIR=./bins ./bins/sqlness-runner -c ./tests/cases
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3
@@ -107,6 +126,7 @@ jobs:
   sqlness-kafka-wal:
     name: Sqlness Test with Kafka Wal
     if: github.event.pull_request.draft == false
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -114,19 +134,18 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
-      - uses: arduino/setup-protoc@v1
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+          name: bins
+          path: .
+      - name: Unzip binaries
+        run: tar -xvf ./bins.tar.gz
       - name: Setup kafka server
         working-directory: tests-integration/fixtures/kafka
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run sqlness
-        run: cargo sqlness -w kafka -k 127.0.0.1:9092
+        run: GREPTIME_BINS_DIR=./bins ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3

--- a/docker/dev-builder/ubuntu/Dockerfile
+++ b/docker/dev-builder/ubuntu/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get -y purge python3.8 && \
 # wildcard here. However, that requires the git's config files and the submodules all owned by the very same user.
 # It's troublesome to do this since the dev build runs in Docker, which is under user "root"; while outside the Docker,
 # it can be a different user that have prepared the submodules.
-RUN git config --global --add safe.directory ‘*’
+RUN git config --global --add safe.directory *
 
 # Install Python dependencies.
 COPY $DOCKER_BUILD_ROOT/docker/python/requirements.txt /etc/greptime/requirements.txt

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -83,8 +83,12 @@ impl EnvController for Env {
 }
 
 impl Env {
-    pub fn new(data_home: PathBuf, server_addr: Option<String>, wal: WalConfig) -> Self {
-        let bins_dir = std::env::var("GREPTIME_BINS_DIR").map(PathBuf::from).ok();
+    pub fn new(
+        data_home: PathBuf,
+        server_addr: Option<String>,
+        wal: WalConfig,
+        bins_dir: Option<PathBuf>,
+    ) -> Self {
         Self {
             data_home,
             server_addr,
@@ -257,7 +261,7 @@ impl Env {
         let program = "greptime.exe";
 
         let bins_dir = self.bins_dir.lock().unwrap().clone().expect(
-            "GreptimeDB binary is not available. Please set the GREPTIME_BINS_DIR environment variable to the directory that contains the pre-built GreptimeDB binary. Or you may call `self.build_db()` beforehand.",
+            "GreptimeDB binary is not available. Please pass in the path to the directory that contains the pre-built GreptimeDB binary. Or you may call `self.build_db()` beforehand.",
         );
 
         let mut process = Command::new(program)

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -62,6 +62,11 @@ struct Args {
     /// from starting a kafka cluster, and use the given endpoint as kafka backend.
     #[clap(short, long)]
     kafka_wal_broker_endpoints: Option<String>,
+
+    /// The path to the directory where GreptimeDB's binaries resides.
+    /// If not set, sqlness will build GreptimeDB on the fly.
+    #[clap(long)]
+    bins_dir: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -94,6 +99,9 @@ async fn main() {
         },
     };
 
-    let runner = Runner::new(config, Env::new(data_home, args.server_addr, wal));
+    let runner = Runner::new(
+        config,
+        Env::new(data_home, args.server_addr, wal, args.bins_dir),
+    );
     runner.run().await.unwrap();
 }

--- a/tests/runner/src/util.rs
+++ b/tests/runner/src/util.rs
@@ -91,7 +91,7 @@ pub fn get_workspace_root() -> String {
     runner_crate_path.into_os_string().into_string().unwrap()
 }
 
-pub fn get_binary_dir(mode: &str) -> String {
+pub fn get_binary_dir(mode: &str) -> PathBuf {
     // first go to the workspace root.
     let mut workspace_root = PathBuf::from(get_workspace_root());
 
@@ -99,7 +99,7 @@ pub fn get_binary_dir(mode: &str) -> String {
     workspace_root.push("target");
     workspace_root.push(mode);
 
-    workspace_root.into_os_string().into_string().unwrap()
+    workspace_root
 }
 
 /// Spin-waiting a socket address is available, or timeout.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Reuse the built GreptimeDB binary in CI. Let's see if it can save some time and money.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
