### PR TITLE
fix: IntermediateWriter closes underlying writer twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
  "regex",
  "regex-automata 0.2.0",
  "snafu",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]

--- a/src/index/Cargo.toml
+++ b/src/index/Cargo.toml
@@ -25,5 +25,6 @@ snafu.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+tempfile.workspace = true
 tokio-util.workspace = true
 tokio.workspace = true

--- a/src/index/src/inverted_index/create/sort/intermediate_rw.rs
+++ b/src/index/src/inverted_index/create/sort/intermediate_rw.rs
@@ -23,7 +23,7 @@ use snafu::ResultExt;
 
 use crate::inverted_index::create::sort::SortedStream;
 use crate::inverted_index::error::{
-    CloseSnafu, FlushSnafu, ReadSnafu, Result, UnknownIntermediateCodecMagicSnafu, WriteSnafu,
+    ReadSnafu, Result, UnknownIntermediateCodecMagicSnafu, WriteSnafu,
 };
 use crate::inverted_index::Bytes;
 
@@ -49,10 +49,10 @@ impl<W: AsyncWrite + Unpin> IntermediateWriter<W> {
 
         let value_stream = stream::iter(values.into_iter().map(Ok));
         let frame_write = FramedWrite::new(&mut self.writer, encoder);
+        // `forward()` will flush and close the writer when the stream ends
         value_stream.forward(frame_write).await?;
 
-        self.writer.flush().await.context(FlushSnafu)?;
-        self.writer.close().await.context(CloseSnafu)
+        Ok(())
     }
 }
 
@@ -85,24 +85,32 @@ impl<R: AsyncRead + Unpin + Send + 'static> IntermediateReader<R> {
 
 #[cfg(test)]
 mod tests {
-    use futures::io::Cursor;
+    use std::io::{Seek, SeekFrom};
+
+    use futures::io::{AllowStdIo, Cursor};
+    use tempfile::tempfile;
 
     use super::*;
     use crate::inverted_index::error::Error;
 
     #[tokio::test]
     async fn test_intermediate_read_write_basic() {
-        let mut buf = vec![];
+        let file_r = tempfile().unwrap();
+        let file_w = file_r.try_clone().unwrap();
+        let mut buf_r = AllowStdIo::new(file_r);
+        let buf_w = AllowStdIo::new(file_w);
 
         let values = BTreeMap::from_iter([
             (Bytes::from("a"), BitVec::from_slice(&[0b10101010])),
             (Bytes::from("b"), BitVec::from_slice(&[0b01010101])),
         ]);
 
-        let writer = IntermediateWriter::new(&mut buf);
+        let writer = IntermediateWriter::new(buf_w);
         writer.write_all(values.clone()).await.unwrap();
+        // reset the handle
+        buf_r.seek(SeekFrom::Start(0)).unwrap();
 
-        let reader = IntermediateReader::new(Cursor::new(buf));
+        let reader = IntermediateReader::new(buf_r);
         let mut stream = reader.into_stream().await.unwrap();
 
         let a = stream.next().await.unwrap().unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

`futures_util::forward()` will flush and close the writer when stream is finished. From its document https://docs.rs/futures-util/0.3.30/futures_util/stream/trait.StreamExt.html#method.forward :

>It will complete once the stream is exhausted, the sink has received and flushed all items, and the sink is closed.

Test can pass before because `Vec` won't report errors when it gets closed twice.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
