### PR TITLE
chore: adjust MySQL connection log

### DIFF
--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(assert_matches)]
 #![feature(try_blocks)]
 #![feature(exclusive_wrapper)]
+#![feature(let_chains)]
 
 use datatypes::schema::Schema;
 use query::plan::LogicalPlan;

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use auth::UserProviderRef;
 use common_runtime::Runtime;
-use common_telemetry::error;
-use common_telemetry::logging::{info, warn};
+use common_telemetry::logging::warn;
+use common_telemetry::{debug, error};
 use futures::StreamExt;
 use opensrv_mysql::{
     plain_run_with_options, secure_run_with_options, AsyncMysqlIntermediary, IntermediaryOptions,
@@ -157,13 +157,17 @@ impl MysqlServer {
         spawn_ref: Arc<MysqlSpawnRef>,
         spawn_config: Arc<MysqlSpawnConfig>,
     ) -> Result<()> {
-        info!("MySQL connection coming from: {}", stream.peer_addr()?);
+        debug!("MySQL connection coming from: {}", stream.peer_addr()?);
         let _handle = io_runtime.spawn(async move {
             crate::metrics::METRIC_MYSQL_CONNECTIONS.inc();
-            if let Err(e)  = Self::do_handle(stream, spawn_ref, spawn_config).await {
-                // TODO(LFC): Write this error to client as well, in MySQL text protocol.
-                // Looks like we have to expose opensrv-mysql's `PacketWriter`?
-                warn!(e; "Internal error occurred during query exec, server actively close the channel to let client try next time")
+            if let Err(e) = Self::do_handle(stream, spawn_ref, spawn_config).await {
+                if let Error::InternalIo { error } = &e && error.kind() == std::io::ErrorKind::ConnectionAborted {
+                    // This is a client-side error, we don't need to log it.
+                } else {
+                    // TODO(LFC): Write this error to client as well, in MySQL text protocol.
+                    // Looks like we have to expose opensrv-mysql's `PacketWriter`?
+                    warn!(e; "Internal error occurred during query exec, server actively close the channel to let client try next time");
+                }
             }
             crate::metrics::METRIC_MYSQL_CONNECTIONS.dec();
         });

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -19,8 +19,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use auth::UserProviderRef;
 use common_runtime::Runtime;
-use common_telemetry::logging::warn;
-use common_telemetry::{debug, error};
+use common_telemetry::{debug, error, warn};
 use futures::StreamExt;
 use opensrv_mysql::{
     plain_run_with_options, secure_run_with_options, AsyncMysqlIntermediary, IntermediaryOptions,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This pr prevents tedious log info from MySQL port being scanned 
1. adjusts MySQL connection remote addr log from info to debug
2. stops logging `ConnectionAborted` error

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
