### PR TITLE
fix: decouple columns in projection and prune

### DIFF
--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -311,14 +311,11 @@ impl ParquetReaderBuilder {
         // Prunes row groups by min-max index.
         if let Some(predicate) = &self.predicate {
             let region_meta = read_format.metadata();
-            let column_ids = match &self.projection {
-                Some(ids) => ids.iter().cloned().collect(),
-                None => region_meta
-                    .column_metadatas
-                    .iter()
-                    .map(|c| c.column_id)
-                    .collect(),
-            };
+            let column_ids = region_meta
+                .column_metadatas
+                .iter()
+                .map(|c| c.column_id)
+                .collect();
 
             let row_groups = row_group_ids
                 .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Min/max index from parquet stats doesn't take efforts if predicates are referencing unprojected column.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
