### PR TITLE
build: make binary name a Dockerfile "ARG"

### DIFF
--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 
 # The root path under which contains all the dependencies to build this Dockerfile.
 ARG DOCKER_BUILD_ROOT=.
+# The binary name of GreptimeDB executable.
+# Defaults to "greptime", but sometimes in other projects it might be different.
+ARG TARGET_BIN=greptime
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
@@ -16,8 +19,8 @@ RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/greptime /greptime/bin/
+ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["greptime"]
+ENTRYPOINT ["$TARGET_BIN"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

For building other projects.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
