### PR TITLE
fix: cli export database default value

### DIFF
--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -58,8 +58,8 @@ pub struct ExportCommand {
     #[clap(long)]
     output_dir: String,
 
-    /// The name of the catalog to export. Default to "greptime-*"".
-    #[clap(long, default_value = "")]
+    /// The name of the catalog to export.
+    #[clap(long, default_value = "greptime-*")]
     database: String,
 
     /// Parallelism of the export.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This closes https://github.com/GreptimeTeam/greptimedb/issues/3250.

This should be too trivial to test.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
