### PR TITLE
fix: SQL insertion and column default constraint aware of timezone

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -507,7 +507,7 @@ pub fn check_permission(
 }
 
 fn validate_param(name: &ObjectName, query_ctx: &QueryContextRef) -> Result<()> {
-    let (catalog, schema, _) = table_idents_to_full_name(name, query_ctx.clone())
+    let (catalog, schema, _) = table_idents_to_full_name(name, query_ctx)
         .map_err(BoxedError::new)
         .context(ExternalSnafu)?;
 

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -105,7 +105,7 @@ impl GrpcQueryHandler for Instance {
                         // TODO(weny): supports to create multiple region table.
                         let _ = self
                             .statement_executor
-                            .create_table_inner(&mut expr, None)
+                            .create_table_inner(&mut expr, None, &ctx)
                             .await?;
                         Output::AffectedRows(0)
                     }

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_to_expr_with_default_timestamp_vaue() {
+    fn test_create_to_expr_with_default_timestamp_value() {
         let sql = "CREATE TABLE monitor (v double,ts TIMESTAMP default '2024-01-30T00:01:01',TIME INDEX (ts)) engine=mito;";
         let stmt =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
@@ -466,9 +466,9 @@ mod tests {
         // query context with system timezone UTC.
         let expr = create_to_expr(&create_table, QueryContext::arc()).unwrap();
         let ts_column = &expr.column_defs[1];
-        let constrait = assert_ts_column(ts_column);
+        let constraint = assert_ts_column(ts_column);
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-30 00:01:01+0000")
         );
 
@@ -478,9 +478,9 @@ mod tests {
             .build();
         let expr = create_to_expr(&create_table, ctx).unwrap();
         let ts_column = &expr.column_defs[1];
-        let constrait = assert_ts_column(ts_column);
+        let constraint = assert_ts_column(ts_column);
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-29 16:01:01+0000")
         );
     }
@@ -519,9 +519,9 @@ mod tests {
 
         assert_eq!(1, add_columns.len());
         let ts_column = add_columns[0].column_def.clone().unwrap();
-        let constrait = assert_ts_column(&ts_column);
+        let constraint = assert_ts_column(&ts_column);
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-30 00:01:01+0000")
         );
 
@@ -539,9 +539,9 @@ mod tests {
 
         assert_eq!(1, add_columns.len());
         let ts_column = add_columns[0].column_def.clone().unwrap();
-        let constrait = assert_ts_column(&ts_column);
+        let constraint = assert_ts_column(&ts_column);
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-29 16:01:01+0000")
         );
     }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -181,7 +181,7 @@ impl Inserter {
     ) -> Result<Output> {
         let inserts =
             StatementToRegion::new(self.catalog_manager.as_ref(), &self.partition_manager, ctx)
-                .convert(insert)
+                .convert(insert, ctx)
                 .await?;
 
         let affected_rows = self.do_request(inserts, ctx).await?;
@@ -334,7 +334,7 @@ impl Inserter {
 
         // create physical table
         let res = statement_executor
-            .create_table_inner(create_table_expr, None)
+            .create_table_inner(create_table_expr, None, ctx)
             .await;
 
         match res {
@@ -431,7 +431,7 @@ impl Inserter {
 
         // TODO(weny): multiple regions table.
         let res = statement_executor
-            .create_table_inner(create_table_expr, None)
+            .create_table_inner(create_table_expr, None, ctx)
             .await;
 
         match res {

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -160,7 +160,7 @@ impl StatementExecutor {
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
             Statement::DropTable(stmt) => {
                 let (catalog, schema, table) =
-                    table_idents_to_full_name(stmt.table_name(), query_ctx)
+                    table_idents_to_full_name(stmt.table_name(), &query_ctx)
                         .map_err(BoxedError::new)
                         .context(error::ExternalSnafu)?;
                 let table_name = TableName::new(catalog, schema, table);
@@ -168,7 +168,7 @@ impl StatementExecutor {
             }
             Statement::TruncateTable(stmt) => {
                 let (catalog, schema, table) =
-                    table_idents_to_full_name(stmt.table_name(), query_ctx)
+                    table_idents_to_full_name(stmt.table_name(), &query_ctx)
                         .map_err(BoxedError::new)
                         .context(error::ExternalSnafu)?;
                 let table_name = TableName::new(catalog, schema, table);
@@ -186,7 +186,7 @@ impl StatementExecutor {
 
             Statement::ShowCreateTable(show) => {
                 let (catalog, schema, table) =
-                    table_idents_to_full_name(&show.table_name, query_ctx.clone())
+                    table_idents_to_full_name(&show.table_name, &query_ctx)
                         .map_err(BoxedError::new)
                         .context(error::ExternalSnafu)?;
 
@@ -298,9 +298,10 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
         CopyTable::To(arg) => arg,
         CopyTable::From(arg) => arg,
     };
-    let (catalog_name, schema_name, table_name) = table_idents_to_full_name(&table_name, query_ctx)
-        .map_err(BoxedError::new)
-        .context(ExternalSnafu)?;
+    let (catalog_name, schema_name, table_name) =
+        table_idents_to_full_name(&table_name, &query_ctx)
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?;
 
     let pattern = with
         .get(common_datasource::file_format::FILE_PATTERN)

--- a/src/operator/src/statement/describe.rs
+++ b/src/operator/src/statement/describe.rs
@@ -33,7 +33,7 @@ impl StatementExecutor {
         stmt: DescribeTable,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
-        let (catalog, schema, table) = table_idents_to_full_name(stmt.name(), query_ctx)
+        let (catalog, schema, table) = table_idents_to_full_name(stmt.name(), &query_ctx)
             .map_err(BoxedError::new)
             .context(ExternalSnafu)?;
 

--- a/src/operator/src/table.rs
+++ b/src/operator/src/table.rs
@@ -31,16 +31,16 @@ use crate::insert::InserterRef;
 /// Converts maybe fully-qualified table name (`<catalog>.<schema>.<table>`) to tuple.
 pub fn table_idents_to_full_name(
     obj_name: &ObjectName,
-    query_ctx: QueryContextRef,
+    query_ctx: &QueryContextRef,
 ) -> Result<(String, String, String)> {
     match &obj_name.0[..] {
         [table] => Ok((
-            query_ctx.current_catalog().to_owned(),
-            query_ctx.current_schema().to_owned(),
+            query_ctx.current_catalog().to_string(),
+            query_ctx.current_schema().to_string(),
             table.value.clone(),
         )),
         [schema, table] => Ok((
-            query_ctx.current_catalog().to_owned(),
+            query_ctx.current_catalog().to_string(),
             schema.value.clone(),
             table.value.clone(),
         )),

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -786,8 +786,10 @@ fn ensure_value_lists_strictly_increased<'a>(
                         }
                     }
 
-                    let x = sql_value_to_value(column_name, &cdt, x)?;
-                    let y = sql_value_to_value(column_name, &cdt, y)?;
+                    // We only want to comnpare the `x` and `y` values,
+                    // so the `timezone` can be ignored.
+                    let x = sql_value_to_value(column_name, &cdt, x, None)?;
+                    let y = sql_value_to_value(column_name, &cdt, y, None)?;
                     match x.cmp(&y) {
                         Ordering::Less => break,
                         Ordering::Equal => equal_tuples += 1,

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -293,15 +293,9 @@ fn parse_column_default_constraint(
         .find(|o| matches!(o.option, ColumnOption::Default(_)))
     {
         let default_constraint = match &opt.option {
-            ColumnOption::Default(Expr::Value(v)) => {
-                // Ignore `timezone` here, will be transformed in DDL functions.
-                ColumnDefaultConstraint::Value(sql_value_to_value(
-                    column_name,
-                    data_type,
-                    v,
-                    timezone,
-                )?)
-            }
+            ColumnOption::Default(Expr::Value(v)) => ColumnDefaultConstraint::Value(
+                sql_value_to_value(column_name, data_type, v, timezone)?,
+            ),
             ColumnOption::Default(Expr::Function(func)) => {
                 let mut func = format!("{func}").to_lowercase();
                 // normalize CURRENT_TIMESTAMP to CURRENT_TIMESTAMP()

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -973,10 +973,10 @@ mod tests {
         );
         assert!(!grpc_column_def.default_constraint.is_empty());
 
-        let constrait =
+        let constraint =
             ColumnDefaultConstraint::try_from(&grpc_column_def.default_constraint[..]).unwrap();
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-29 16:01:01+0000")
         );
 
@@ -990,10 +990,10 @@ mod tests {
         );
         assert!(!grpc_column_def.default_constraint.is_empty());
 
-        let constrait =
+        let constraint =
             ColumnDefaultConstraint::try_from(&grpc_column_def.default_constraint[..]).unwrap();
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-30 00:01:01+0000")
         );
     }
@@ -1108,9 +1108,9 @@ mod tests {
         );
         assert!(column_schema.is_nullable());
 
-        let constrait = column_schema.default_constraint().unwrap();
+        let constraint = column_schema.default_constraint().unwrap();
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-29 16:01:01+0000")
         );
 
@@ -1124,9 +1124,9 @@ mod tests {
         );
         assert!(column_schema.is_nullable());
 
-        let constrait = column_schema.default_constraint().unwrap();
+        let constraint = column_schema.default_constraint().unwrap();
         assert!(
-            matches!(constrait, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
+            matches!(constraint, ColumnDefaultConstraint::Value(Value::Timestamp(ts))
                          if ts.to_iso8601_string() == "2024-01-30 00:01:01+0000")
         );
     }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -710,6 +710,21 @@ mod tests {
         } else {
             unreachable!()
         }
+
+        // with timezone
+        let value = sql_value_to_value(
+            "date",
+            &ConcreteDataType::date_datatype(),
+            &SqlValue::DoubleQuotedString("2022-02-22".to_string()),
+            Some(&Timezone::from_tz_string("+07:00").unwrap()),
+        )
+        .unwrap();
+        assert_eq!(ConcreteDataType::date_datatype(), value.data_type());
+        if let Value::Date(d) = value {
+            assert_eq!("2022-02-21", d.to_string());
+        } else {
+            unreachable!()
+        }
     }
 
     #[test]
@@ -818,6 +833,24 @@ mod tests {
             None,
         )
         .is_err());
+
+        // with timezone
+        match parse_string_to_value(
+            "timestamp_col",
+            "2022-02-22T00:01:01".to_string(),
+            &ConcreteDataType::timestamp_datatype(TimeUnit::Nanosecond),
+            Some(&Timezone::from_tz_string("Asia/Shanghai").unwrap()),
+        )
+        .unwrap()
+        {
+            Value::Timestamp(ts) => {
+                assert_eq!(1645459261000000000, ts.value());
+                assert_eq!(TimeUnit::Nanosecond, ts.unit());
+            }
+            _ => {
+                unreachable!()
+            }
+        }
     }
 
     #[test]

--- a/tests/cases/standalone/common/alter/alter_table_default.result
+++ b/tests/cases/standalone/common/alter/alter_table_default.result
@@ -1,0 +1,72 @@
+--- alter table to add new column with default timestamp values aware of session timezone test ---
+CREATE TABLE test1 (i INTEGER, j TIMESTAMP time index, PRIMARY KEY(i));
+
+Affected Rows: 0
+
+INSERT INTO test1 values (1, 1), (2, 2);
+
+Affected Rows: 2
+
+SELECT * FROM test1;
+
++---+-------------------------+
+| i | j                       |
++---+-------------------------+
+| 1 | 1970-01-01T00:00:00.001 |
+| 2 | 1970-01-01T00:00:00.002 |
++---+-------------------------+
+
+--- add ts1 column ---
+ALTER TABLE test1 ADD COLUMN ts1 TIMESTAMP DEFAULT '2024-01-30 00:01:01' PRIMARY KEY;
+
+Affected Rows: 0
+
+INSERT INTO test1 values (3, 3, DEFAULT), (4, 4,  '2024-01-31 00:01:01');
+
+Affected Rows: 2
+
+SELECT i, ts1 FROM test1;
+
++---+---------------------+
+| i | ts1                 |
++---+---------------------+
+| 1 | 2024-01-30T00:01:01 |
+| 2 | 2024-01-30T00:01:01 |
+| 3 | 2024-01-30T00:01:01 |
+| 4 | 2024-01-31T00:01:01 |
++---+---------------------+
+
+SET time_zone = 'Asia/Shanghai';
+
+Affected Rows: 0
+
+--- add ts2 column, default value is the same as ts1, but with different session timezone ---
+ALTER TABLE test1 ADD COLUMN ts2 TIMESTAMP DEFAULT '2024-01-30 00:01:01' PRIMARY KEY;
+
+Affected Rows: 0
+
+INSERT INTO test1 values (5, 5, DEFAULT, DEFAULT), (6, 6, DEFAULT, '2024-01-31 00:01:01');
+
+Affected Rows: 2
+
+SELECT i, ts1, ts2 FROM test1;
+
++---+---------------------+---------------------+
+| i | ts1                 | ts2                 |
++---+---------------------+---------------------+
+| 1 | 2024-01-30T00:01:01 | 2024-01-29T16:01:01 |
+| 2 | 2024-01-30T00:01:01 | 2024-01-29T16:01:01 |
+| 3 | 2024-01-30T00:01:01 | 2024-01-29T16:01:01 |
+| 4 | 2024-01-31T00:01:01 | 2024-01-29T16:01:01 |
+| 5 | 2024-01-30T00:01:01 | 2024-01-29T16:01:01 |
+| 6 | 2024-01-30T00:01:01 | 2024-01-30T16:01:01 |
++---+---------------------+---------------------+
+
+SET time_zone = 'UTC';
+
+Affected Rows: 0
+
+DROP TABLE test1;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/alter/alter_table_default.sql
+++ b/tests/cases/standalone/common/alter/alter_table_default.sql
@@ -1,0 +1,27 @@
+--- alter table to add new column with default timestamp values aware of session timezone test ---
+
+CREATE TABLE test1 (i INTEGER, j TIMESTAMP time index, PRIMARY KEY(i));
+
+INSERT INTO test1 values (1, 1), (2, 2);
+
+SELECT * FROM test1;
+
+--- add ts1 column ---
+ALTER TABLE test1 ADD COLUMN ts1 TIMESTAMP DEFAULT '2024-01-30 00:01:01' PRIMARY KEY;
+
+INSERT INTO test1 values (3, 3, DEFAULT), (4, 4,  '2024-01-31 00:01:01');
+
+SELECT i, ts1 FROM test1;
+
+SET time_zone = 'Asia/Shanghai';
+
+--- add ts2 column, default value is the same as ts1, but with different session timezone ---
+ALTER TABLE test1 ADD COLUMN ts2 TIMESTAMP DEFAULT '2024-01-30 00:01:01' PRIMARY KEY;
+
+INSERT INTO test1 values (5, 5, DEFAULT, DEFAULT), (6, 6, DEFAULT, '2024-01-31 00:01:01');
+
+SELECT i, ts1, ts2 FROM test1;
+
+SET time_zone = 'UTC';
+
+DROP TABLE test1;

--- a/tests/cases/standalone/common/insert/insert_default_timezone.result
+++ b/tests/cases/standalone/common/insert/insert_default_timezone.result
@@ -1,0 +1,66 @@
+--- insert timestamp with default values aware of session timezone test ---
+CREATE TABLE test1 (i INTEGER, j TIMESTAMP default '2024-01-30 00:01:01' TIME INDEX, PRIMARY KEY(i));
+
+Affected Rows: 0
+
+INSERT INTO test1 VALUES (1, DEFAULT), (2, DEFAULT), (3, '2024-01-31 00:01:01'), (4, '2025-02-01 00:01:01');
+
+Affected Rows: 4
+
+SELECT * FROM test1;
+
++---+---------------------+
+| i | j                   |
++---+---------------------+
+| 1 | 2024-01-30T00:01:01 |
+| 2 | 2024-01-30T00:01:01 |
+| 3 | 2024-01-31T00:01:01 |
+| 4 | 2025-02-01T00:01:01 |
++---+---------------------+
+
+SET time_zone = 'Asia/Shanghai';
+
+Affected Rows: 0
+
+CREATE TABLE test2 (i INTEGER, j TIMESTAMP default '2024-01-30 00:01:01' TIME INDEX, PRIMARY KEY(i));
+
+Affected Rows: 0
+
+INSERT INTO test2 VALUES (1, DEFAULT), (2, DEFAULT), (3, '2024-01-31 00:01:01'), (4, '2025-02-01 00:01:01');
+
+Affected Rows: 4
+
+SELECT * FROM test2;
+
++---+---------------------+
+| i | j                   |
++---+---------------------+
+| 1 | 2024-01-29T16:01:01 |
+| 2 | 2024-01-29T16:01:01 |
+| 3 | 2024-01-30T16:01:01 |
+| 4 | 2025-01-31T16:01:01 |
++---+---------------------+
+
+SELECT * FROM test1;
+
++---+---------------------+
+| i | j                   |
++---+---------------------+
+| 1 | 2024-01-30T00:01:01 |
+| 2 | 2024-01-30T00:01:01 |
+| 3 | 2024-01-31T00:01:01 |
+| 4 | 2025-02-01T00:01:01 |
++---+---------------------+
+
+SET time_zone = 'UTC';
+
+Affected Rows: 0
+
+DROP TABLE test1;
+
+Affected Rows: 0
+
+DROP TABLE test2;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/insert/insert_default_timezone.sql
+++ b/tests/cases/standalone/common/insert/insert_default_timezone.sql
@@ -1,0 +1,23 @@
+--- insert timestamp with default values aware of session timezone test ---
+
+CREATE TABLE test1 (i INTEGER, j TIMESTAMP default '2024-01-30 00:01:01' TIME INDEX, PRIMARY KEY(i));
+
+INSERT INTO test1 VALUES (1, DEFAULT), (2, DEFAULT), (3, '2024-01-31 00:01:01'), (4, '2025-02-01 00:01:01');
+
+SELECT * FROM test1;
+
+SET time_zone = 'Asia/Shanghai';
+
+CREATE TABLE test2 (i INTEGER, j TIMESTAMP default '2024-01-30 00:01:01' TIME INDEX, PRIMARY KEY(i));
+
+INSERT INTO test2 VALUES (1, DEFAULT), (2, DEFAULT), (3, '2024-01-31 00:01:01'), (4, '2025-02-01 00:01:01');
+
+SELECT * FROM test2;
+
+SELECT * FROM test1;
+
+SET time_zone = 'UTC';
+
+DROP TABLE test1;
+
+DROP TABLE test2;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

真 の Final Piece of #2907 :

* SQL insertion with date/datetime/timestamp literals should respect the session timezone while parsing.
* Create table or alter table that contains column default constraint value aware of session timezone.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

#2907 