### PR TITLE
refactor: add same SST files

### DIFF
--- a/src/mito2/src/sst/version.rs
+++ b/src/mito2/src/sst/version.rs
@@ -55,7 +55,7 @@ impl SstVersion {
     ) {
         for file in files_to_add {
             let level = file.level;
-            let _ = self.levels[level as usize]
+            self.levels[level as usize]
                 .files
                 .entry(file.file_id)
                 .or_insert_with(|| FileHandle::new(file, file_purger.clone()));

--- a/src/mito2/src/sst/version.rs
+++ b/src/mito2/src/sst/version.rs
@@ -55,10 +55,10 @@ impl SstVersion {
     ) {
         for file in files_to_add {
             let level = file.level;
-            let handle = FileHandle::new(file, file_purger.clone());
-            let file_id = handle.file_id();
-            let old = self.levels[level as usize].files.insert(file_id, handle);
-            assert!(old.is_none(), "Adds an existing file: {file_id}");
+            let _ = self.levels[level as usize]
+                .files
+                .entry(file.file_id)
+                .or_insert_with(|| FileHandle::new(file, file_purger.clone()));
         }
     }
 
@@ -156,4 +156,33 @@ fn new_level_meta_vec() -> LevelMetaArray {
         .collect::<Vec<_>>()
         .try_into()
         .unwrap() // safety: LevelMetaArray is a fixed length array with length MAX_LEVEL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::new_noop_file_purger;
+
+    #[test]
+    fn test_add_files() {
+        let purger = new_noop_file_purger();
+
+        let files = (1..=3)
+            .map(|_| FileMeta {
+                file_id: FileId::random(),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+
+        let mut version = SstVersion::new();
+        // files[1] is added multiple times, and that's ok.
+        version.add_files(purger.clone(), files[..=1].iter().cloned());
+        version.add_files(purger, files[1..].iter().cloned());
+
+        let added_files = &version.levels()[0].files;
+        assert_eq!(added_files.len(), 3);
+        files.iter().for_each(|f| {
+            assert!(added_files.contains_key(&f.file_id));
+        });
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Make adding same SST file multiple times possible, instead of panic there.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
