### PR TITLE
feat: support fraction part in timestamp

### DIFF
--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -24,8 +24,8 @@ use crate::timezone::{get_timezone, Timezone};
 use crate::util::{datetime_to_utc, format_utc_datetime};
 use crate::{Date, Interval};
 
-const DATETIME_FORMAT: &str = "%F %T";
-const DATETIME_FORMAT_WITH_TZ: &str = "%F %T%z";
+const DATETIME_FORMAT: &str = "%F %H:%M:%S%.f";
+const DATETIME_FORMAT_WITH_TZ: &str = "%F %H:%M:%S%.f%z";
 
 /// [DateTime] represents the **milliseconds elapsed since "1970-01-01 00:00:00 UTC" (UNIX Epoch)**.
 #[derive(
@@ -245,6 +245,18 @@ mod tests {
         assert_eq!(
             0,
             DateTime::from_str("1970-01-01 08:00:00", None)
+                .unwrap()
+                .val()
+        );
+        assert_eq!(
+            42,
+            DateTime::from_str("1970-01-01 08:00:00.042", None)
+                .unwrap()
+                .val()
+        );
+        assert_eq!(
+            42,
+            DateTime::from_str("1970-01-01 08:00:00.042424", None)
                 .unwrap()
                 .val()
         );

--- a/src/common/time/src/datetime.rs
+++ b/src/common/time/src/datetime.rs
@@ -298,6 +298,10 @@ mod tests {
             .unwrap()
             .val();
         assert_eq!(28800000, ts);
+        let ts = DateTime::from_str("1970-01-01 00:00:00.042+0000", None)
+            .unwrap()
+            .val();
+        assert_eq!(42, ts);
 
         // the string has the time zone info, the argument doesn't change the result
         let ts = DateTime::from_str(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
allow parsing Timestampe wiht fraction part like `1970-01-01 00:00:00.042`, which is supported in arrow's  Array cast, so it make sense to maintance consistency

- Summarize your change (**mandatory**)
support decimal fraction part in `DateTime::from_str` , i.e. `1970-01-01 00:00:00.042`

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
