### PR TITLE
fix: use `fe_opts` after `setup_frontend_plugins` in standalone

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -368,17 +368,16 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     async fn build(self, opts: MixOptions) -> Result<Instance> {
-        let mut fe_opts = opts.frontend.clone();
+        info!("Standalone start command: {:#?}", self);
+        info!("Building standalone instance with {opts:#?}");
+
+        let mut fe_opts = opts.frontend;
         #[allow(clippy::unnecessary_mut_passed)]
         let fe_plugins = plugins::setup_frontend_plugins(&mut fe_opts) // mut ref is MUST, DO NOT change it
             .await
             .context(StartFrontendSnafu)?;
 
-        let dn_opts = opts.datanode.clone();
-
-        info!("Standalone start command: {:#?}", self);
-
-        info!("Building standalone instance with {opts:#?}");
+        let dn_opts = opts.datanode;
 
         set_default_timezone(fe_opts.default_timezone.as_deref()).context(InitTimezoneSnafu)?;
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -380,8 +380,7 @@ impl StartCommand {
 
         info!("Building standalone instance with {opts:#?}");
 
-        set_default_timezone(opts.frontend.default_timezone.as_deref())
-            .context(InitTimezoneSnafu)?;
+        set_default_timezone(fe_opts.default_timezone.as_deref()).context(InitTimezoneSnafu)?;
 
         // Ensure the data_home directory exists.
         fs::create_dir_all(path::Path::new(&opts.data_home)).context(CreateDirSnafu {
@@ -437,11 +436,11 @@ impl StartCommand {
             .await
             .context(StartFrontendSnafu)?;
 
-        let servers = Services::new(opts.clone(), Arc::new(frontend.clone()), fe_plugins)
+        let servers = Services::new(fe_opts.clone(), Arc::new(frontend.clone()), fe_plugins)
             .build()
             .context(StartFrontendSnafu)?;
         frontend
-            .build_servers(opts, servers)
+            .build_servers(fe_opts, servers)
             .context(StartFrontendSnafu)?;
 
         Ok(Instance {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Use `fe_opts` processed by `setup_frontend_plugins` instead of original `MixOptions::FrontendOptions`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
