### PR TITLE
fix(util): join_path function should not trim leading `/`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ endif
 build: ## Build debug version greptime.
 	cargo ${CARGO_EXTENSION} build ${CARGO_BUILD_OPTS}
 
-.POHNY: build-by-dev-builder
+.PHONY: build-by-dev-builder
 build-by-dev-builder: ## Build greptime by dev-builder.
 	docker run --network=host \
 	-v ${PWD}:/greptimedb -v ${CARGO_REGISTRY_CACHE}:/root/.cargo/registry \
@@ -144,11 +144,12 @@ multi-platform-buildx: ## Create buildx multi-platform builder.
 	docker buildx inspect ${BUILDX_BUILDER_NAME} || docker buildx create --name ${BUILDX_BUILDER_NAME} --driver docker-container --bootstrap --use
 
 ##@ Test
+.PHONY: test
 test: nextest ## Run unit and integration tests.
 	cargo nextest run ${NEXTEST_OPTS}
 
-.PHONY: nextest ## Install nextest tools.
-nextest:
+.PHONY: nextest
+nextest: ## Install nextest tools.
 	cargo --list | grep nextest || cargo install cargo-nextest --locked
 
 .PHONY: sqlness-test

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -81,12 +81,6 @@ pub fn join_path(parent: &str, child: &str) -> String {
     normalize_path(&output)
 }
 
-/// Modified from the `opendal::raw::normalize_path`
-///
-/// # The different
-///
-/// It only keeps `/` ahead if the original path starts with `/`.
-///
 /// Make sure all operation are constructed by normalized path:
 ///
 /// - Path endswith `/` means it's a dir path.
@@ -95,7 +89,7 @@ pub fn join_path(parent: &str, child: &str) -> String {
 /// # Normalize Rules
 ///
 /// - All whitespace will be trimmed: ` abc/def ` => `abc/def`
-/// - **(Removed❗️)** ~~ All leading / will be trimmed: `///abc` => `abc`~~
+/// - Repeated leading / will be trimmed: `///abc` => `/abc`
 /// - Internal // will be replaced by /: `abc///def` => `abc/def`
 /// - Empty path will be `/`: `` => `/`
 pub fn normalize_path(path: &str) -> String {
@@ -113,7 +107,7 @@ pub fn normalize_path(path: &str) -> String {
     let mut p = path
         .split('/')
         .filter(|v| !v.is_empty())
-        .collect::<Vec<&str>>()
+        .collect::<Vec<_>>()
         .join("/");
 
     // If path is not starting with `\` but it should

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -110,12 +110,12 @@ pub fn normalize_path(path: &str) -> String {
         .collect::<Vec<_>>()
         .join("/");
 
-    // If path is not starting with `\` but it should
+    // If path is not starting with `/` but it should
     if !p.starts_with('/') && has_leading {
         p.insert(0, '/');
     }
 
-    // If path is not ending with `\` but it should
+    // If path is not ending with `/` but it should
     if !p.ends_with('/') && has_trailing {
         p.push('/');
     }
@@ -169,10 +169,14 @@ mod tests {
         assert_eq!("/", join_path("", "/"));
         assert_eq!("/", join_path("/", "/"));
         assert_eq!("a/", join_path("a", ""));
+        assert_eq!("/a", join_path("/", "a"));
         assert_eq!("a/b/c.txt", join_path("a/b", "c.txt"));
         assert_eq!("/a/b/c.txt", join_path("/a/b", "c.txt"));
         assert_eq!("/a/b/c/", join_path("/a/b", "c/"));
         assert_eq!("/a/b/c/", join_path("/a/b", "/c/"));
         assert_eq!("/a/b/c.txt", join_path("/a/b", "//c.txt"));
+        assert_eq!("abc/def", join_path(" abc", "/def "));
+        assert_eq!("/abc", join_path("//", "/abc"));
+        assert_eq!("abc/def", join_path("abc/", "//def"));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed, and what's your intention?

Replaced `opendal::raw::normalize_path` with own implementation of `normalize_path` in order to fix expected behaviour of not trimming leading `'/'`.

Also fixed some typing errors (I believe) when I was reading the Makefile.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
Closes #3212