### PR TITLE
fix: fix incorrect StatusCode parsing

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -215,6 +215,8 @@ mod tests {
             let num = code as u32;
             assert_eq!(StatusCode::from_u32(num), Some(code));
         }
+
+        assert_eq!(StatusCode::from_u32(10000), None);
     }
 
     #[test]

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -14,10 +14,10 @@
 
 use std::fmt;
 
-use strum::{AsRefStr, EnumString};
+use strum::{AsRefStr, EnumIter, EnumString, FromRepr};
 
 /// Common status code for public API.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, AsRefStr)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumString, AsRefStr, EnumIter, FromRepr)]
 pub enum StatusCode {
     // ====== Begin of common status code ==============
     /// Success.
@@ -181,48 +181,7 @@ impl StatusCode {
     }
 
     pub fn from_u32(value: u32) -> Option<Self> {
-        match value {
-            v if v == StatusCode::Success as u32 => Some(StatusCode::Success),
-            v if v == StatusCode::Unknown as u32 => Some(StatusCode::Unknown),
-            v if v == StatusCode::Unsupported as u32 => Some(StatusCode::Unsupported),
-            v if v == StatusCode::Unexpected as u32 => Some(StatusCode::Unexpected),
-            v if v == StatusCode::Internal as u32 => Some(StatusCode::Internal),
-            v if v == StatusCode::InvalidArguments as u32 => Some(StatusCode::InvalidArguments),
-            v if v == StatusCode::Cancelled as u32 => Some(StatusCode::Cancelled),
-            v if v == StatusCode::InvalidSyntax as u32 => Some(StatusCode::InvalidSyntax),
-            v if v == StatusCode::PlanQuery as u32 => Some(StatusCode::PlanQuery),
-            v if v == StatusCode::EngineExecuteQuery as u32 => Some(StatusCode::EngineExecuteQuery),
-            v if v == StatusCode::TableAlreadyExists as u32 => Some(StatusCode::TableAlreadyExists),
-            v if v == StatusCode::TableNotFound as u32 => Some(StatusCode::TableNotFound),
-            v if v == StatusCode::RegionNotFound as u32 => Some(StatusCode::RegionNotFound),
-            v if v == StatusCode::RegionNotReady as u32 => Some(StatusCode::RegionNotReady),
-            v if v == StatusCode::RegionBusy as u32 => Some(StatusCode::RegionBusy),
-            v if v == StatusCode::RegionAlreadyExists as u32 => {
-                Some(StatusCode::RegionAlreadyExists)
-            }
-            v if v == StatusCode::RegionReadonly as u32 => Some(StatusCode::RegionReadonly),
-            v if v == StatusCode::TableColumnNotFound as u32 => {
-                Some(StatusCode::TableColumnNotFound)
-            }
-            v if v == StatusCode::TableColumnExists as u32 => Some(StatusCode::TableColumnExists),
-            v if v == StatusCode::DatabaseNotFound as u32 => Some(StatusCode::DatabaseNotFound),
-            v if v == StatusCode::StorageUnavailable as u32 => Some(StatusCode::StorageUnavailable),
-            v if v == StatusCode::RuntimeResourcesExhausted as u32 => {
-                Some(StatusCode::RuntimeResourcesExhausted)
-            }
-            v if v == StatusCode::RateLimited as u32 => Some(StatusCode::RateLimited),
-            v if v == StatusCode::UserNotFound as u32 => Some(StatusCode::UserNotFound),
-            v if v == StatusCode::UnsupportedPasswordType as u32 => {
-                Some(StatusCode::UnsupportedPasswordType)
-            }
-            v if v == StatusCode::UserPasswordMismatch as u32 => {
-                Some(StatusCode::UserPasswordMismatch)
-            }
-            v if v == StatusCode::AuthHeaderNotFound as u32 => Some(StatusCode::AuthHeaderNotFound),
-            v if v == StatusCode::InvalidAuthHeader as u32 => Some(StatusCode::InvalidAuthHeader),
-            v if v == StatusCode::AccessDenied as u32 => Some(StatusCode::AccessDenied),
-            _ => None,
-        }
+        StatusCode::from_repr(value as usize)
     }
 }
 
@@ -235,6 +194,8 @@ impl fmt::Display for StatusCode {
 
 #[cfg(test)]
 mod tests {
+    use strum::IntoEnumIterator;
+
     use super::*;
 
     fn assert_status_code_display(code: StatusCode, msg: &str) {
@@ -246,6 +207,14 @@ mod tests {
     fn test_display_status_code() {
         assert_status_code_display(StatusCode::Unknown, "Unknown");
         assert_status_code_display(StatusCode::TableAlreadyExists, "TableAlreadyExists");
+    }
+
+    #[test]
+    fn test_from_u32() {
+        for code in StatusCode::iter() {
+            let num = code as u32;
+            assert_eq!(StatusCode::from_u32(num), Some(code));
+        }
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix incorrect StatusCode parsing

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
close #3279