### PR TITLE
feat(flow): impl ScalarExpr&Scalar Function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,6 +3407,7 @@ dependencies = [
  "datatypes",
  "hydroflow",
  "itertools 0.10.5",
+ "num-traits",
  "serde",
  "servers",
  "session",

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -17,6 +17,7 @@ common-time.workspace = true
 datatypes.workspace = true
 hydroflow = "0.5.0"
 itertools.workspace = true
+num-traits = "0.2"
 serde.workspace = true
 servers.workspace = true
 session.workspace = true

--- a/src/flow/src/expr/error.rs
+++ b/src/flow/src/expr/error.rs
@@ -58,4 +58,7 @@ pub enum EvalError {
 
     #[snafu(display("Optimize error: {reason}"))]
     Optimize { reason: String, location: Location },
+
+    #[snafu(display("Unsupported temporal filter: {reason}"))]
+    UnsupportedTemporalFilter { reason: String, location: Location },
 }

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -241,16 +241,13 @@ impl VariadicFunc {
 fn and(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
     // If any is false, then return false. Else, if any is null, then return null. Else, return true.
     let mut null = false;
-    let mut err = None;
     for expr in exprs {
         match expr.eval(values) {
             Ok(Value::Boolean(true)) => {}
             Ok(Value::Boolean(false)) => return Ok(Value::Boolean(false)), // short-circuit
             Ok(Value::Null) => null = true,
             Err(this_err) => {
-                if err.is_none() {
-                    err = Some(this_err)
-                }
+                return Err(this_err);
             } // retain first error encountered
             Ok(x) => InvalidArgumentSnafu {
                 reason: format!(
@@ -262,26 +259,22 @@ fn and(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
             .fail()?,
         }
     }
-    match (err, null) {
-        (Some(err), _) => Err(err),
-        (None, true) => Ok(Value::Null),
-        (None, false) => Ok(Value::Boolean(true)),
+    match null {
+        true => Ok(Value::Null),
+        false => Ok(Value::Boolean(true)),
     }
 }
 
 fn or(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
     // If any is false, then return false. Else, if any is null, then return null. Else, return true.
     let mut null = false;
-    let mut err = None;
     for expr in exprs {
         match expr.eval(values) {
             Ok(Value::Boolean(true)) => return Ok(Value::Boolean(true)), // short-circuit
-            Ok(Value::Boolean(false)) => {}                              // short-circuit
+            Ok(Value::Boolean(false)) => {}
             Ok(Value::Null) => null = true,
             Err(this_err) => {
-                if err.is_none() {
-                    err = Some(this_err)
-                }
+                return Err(this_err);
             } // retain first error encountered
             Ok(x) => InvalidArgumentSnafu {
                 reason: format!(
@@ -293,10 +286,9 @@ fn or(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
             .fail()?,
         }
     }
-    match (err, null) {
-        (Some(err), _) => Err(err),
-        (None, true) => Ok(Value::Null),
-        (None, false) => Ok(Value::Boolean(false)),
+    match null {
+        true => Ok(Value::Null),
+        false => Ok(Value::Boolean(false)),
     }
 }
 
@@ -305,12 +297,8 @@ where
     T: TryFrom<Value, Error = datatypes::Error> + num_traits::Num,
     Value: From<T>,
 {
-    let left = T::try_from(left)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
-    let right = T::try_from(right)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let left = T::try_from(left).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
+    let right = T::try_from(right).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
     Ok(Value::from(left + right))
 }
 
@@ -319,12 +307,8 @@ where
     T: TryFrom<Value, Error = datatypes::Error> + num_traits::Num,
     Value: From<T>,
 {
-    let left = T::try_from(left)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
-    let right = T::try_from(right)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let left = T::try_from(left).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
+    let right = T::try_from(right).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
     Ok(Value::from(left - right))
 }
 
@@ -333,12 +317,8 @@ where
     T: TryFrom<Value, Error = datatypes::Error> + num_traits::Num,
     Value: From<T>,
 {
-    let left = T::try_from(left)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
-    let right = T::try_from(right)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let left = T::try_from(left).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
+    let right = T::try_from(right).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
     Ok(Value::from(left * right))
 }
 
@@ -348,12 +328,8 @@ where
     <T as TryFrom<Value>>::Error: std::fmt::Debug,
     Value: From<T>,
 {
-    let left = T::try_from(left)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
-    let right = T::try_from(right)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let left = T::try_from(left).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
+    let right = T::try_from(right).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
     if right.is_zero() {
         return Err(DivisionByZeroSnafu {}.build());
     }
@@ -366,12 +342,8 @@ where
     <T as TryFrom<Value>>::Error: std::fmt::Debug,
     Value: From<T>,
 {
-    let left = T::try_from(left)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
-    let right = T::try_from(right)
-        .map_err(|e| e.to_string())
-        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let left = T::try_from(left).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
+    let right = T::try_from(right).map_err(|e| TryFromValueSnafu { msg: e.to_string() }.build())?;
     Ok(Value::from(left % right))
 }
 

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -101,3 +101,26 @@ pub enum VariadicFunc {
     And,
     Or,
 }
+
+impl UnaryFunc {
+    pub fn eval(&self, values: &[Value], expr: &ScalarExpr) -> Result<Value, EvalError> {
+        todo!()
+    }
+}
+
+impl BinaryFunc {
+    pub fn eval(
+        &self,
+        values: &[Value],
+        expr1: &ScalarExpr,
+        expr2: &ScalarExpr,
+    ) -> Result<Value, EvalError> {
+        todo!()
+    }
+}
+
+impl VariadicFunc {
+    pub fn eval(&self, values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
+        todo!()
+    }
+}

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -62,19 +62,7 @@ impl UnaryFunc {
                 Ok(Value::from(!bool))
             }
             Self::IsNull => Ok(Value::from(arg.is_null())),
-            Self::IsTrue => {
-                let bool = if let Value::Boolean(bool) = arg {
-                    Ok(bool)
-                } else {
-                    TypeMismatchSnafu {
-                        expected: ConcreteDataType::boolean_datatype(),
-                        actual: arg.data_type(),
-                    }
-                    .fail()?
-                }?;
-                Ok(Value::from(bool))
-            }
-            Self::IsFalse => {
+            Self::IsTrue | Self::IsFalse => {
                 let bool = if let Value::Boolean(bool) = arg {
                     Ok(bool)
                 } else {

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -21,12 +21,11 @@ use hydroflow::bincode::Error;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use crate::expr::error::{CastValueSnafu, DivisionByZeroSnafu};
-use crate::expr::{InvalidArgumentSnafu, ScalarExpr};
-use crate::{
-    expr::error::{EvalError, TryFromValueSnafu, TypeMismatchSnafu},
-    repr::Row,
+use crate::expr::error::{
+    CastValueSnafu, DivisionByZeroSnafu, EvalError, TryFromValueSnafu, TypeMismatchSnafu,
 };
+use crate::expr::{InvalidArgumentSnafu, ScalarExpr};
+use crate::repr::Row;
 
 /// UnmaterializableFunc is a function that can't be eval independently,
 /// and require special handling

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -72,7 +72,11 @@ impl UnaryFunc {
                     }
                     .fail()?
                 }?;
-                Ok(Value::from(!bool))
+                if matches!(self, Self::IsTrue) {
+                    Ok(Value::from(bool))
+                } else {
+                    Ok(Value::from(!bool))
+                }
             }
             Self::StepTimestamp => {
                 if let Value::DateTime(datetime) = arg {
@@ -165,6 +169,7 @@ impl BinaryFunc {
             Self::Lte => Ok(Value::from(left <= right)),
             Self::Gt => Ok(Value::from(left > right)),
             Self::Gte => Ok(Value::from(left >= right)),
+
             Self::AddInt16 => Ok(add::<i16>(left, right)?),
             Self::AddInt32 => Ok(add::<i32>(left, right)?),
             Self::AddInt64 => Ok(add::<i64>(left, right)?),

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -47,6 +47,74 @@ pub enum UnaryFunc {
     StepTimestamp,
     Cast(ConcreteDataType),
 }
+
+impl UnaryFunc {
+    pub fn eval(&self, values: &[Value], expr: &ScalarExpr) -> Result<Value, EvalError> {
+        let arg = expr.eval(values)?;
+        match self {
+            Self::Not => {
+                let bool = if let Value::Boolean(bool) = arg {
+                    Ok(bool)
+                } else {
+                    TypeMismatchSnafu {
+                        expected: ConcreteDataType::boolean_datatype(),
+                        actual: arg.data_type(),
+                    }
+                    .fail()?
+                }?;
+                Ok(Value::from(!bool))
+            }
+            Self::IsNull => Ok(Value::from(arg.is_null())),
+            Self::IsTrue => {
+                let bool = if let Value::Boolean(bool) = arg {
+                    Ok(bool)
+                } else {
+                    TypeMismatchSnafu {
+                        expected: ConcreteDataType::boolean_datatype(),
+                        actual: arg.data_type(),
+                    }
+                    .fail()?
+                }?;
+                Ok(Value::from(bool))
+            }
+            Self::IsFalse => {
+                let bool = if let Value::Boolean(bool) = arg {
+                    Ok(bool)
+                } else {
+                    TypeMismatchSnafu {
+                        expected: ConcreteDataType::boolean_datatype(),
+                        actual: arg.data_type(),
+                    }
+                    .fail()?
+                }?;
+                Ok(Value::from(!bool))
+            }
+            Self::StepTimestamp => {
+                if let Value::DateTime(datetime) = arg {
+                    let datetime = DateTime::from(datetime.val() + 1);
+                    Ok(Value::from(datetime))
+                } else {
+                    TypeMismatchSnafu {
+                        expected: ConcreteDataType::datetime_datatype(),
+                        actual: arg.data_type(),
+                    }
+                    .fail()?
+                }
+            }
+            Self::Cast(to) => {
+                let arg_ty = arg.data_type();
+                let res = cast(arg, to).context({
+                    CastValueSnafu {
+                        from: arg_ty,
+                        to: to.clone(),
+                    }
+                })?;
+                Ok(res)
+            }
+        }
+    }
+}
+
 /// TODO(discord9): support more binary functions for more types
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash)]
 pub enum BinaryFunc {
@@ -96,18 +164,6 @@ pub enum BinaryFunc {
     ModUInt64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash)]
-pub enum VariadicFunc {
-    And,
-    Or,
-}
-
-impl UnaryFunc {
-    pub fn eval(&self, values: &[Value], expr: &ScalarExpr) -> Result<Value, EvalError> {
-        todo!()
-    }
-}
-
 impl BinaryFunc {
     pub fn eval(
         &self,
@@ -115,12 +171,206 @@ impl BinaryFunc {
         expr1: &ScalarExpr,
         expr2: &ScalarExpr,
     ) -> Result<Value, EvalError> {
-        todo!()
+        let left = expr1.eval(values)?;
+        let right = expr2.eval(values)?;
+        match self {
+            Self::Eq => Ok(Value::from(left == right)),
+            Self::NotEq => Ok(Value::from(left != right)),
+            Self::Lt => Ok(Value::from(left < right)),
+            Self::Lte => Ok(Value::from(left <= right)),
+            Self::Gt => Ok(Value::from(left > right)),
+            Self::Gte => Ok(Value::from(left >= right)),
+            Self::AddInt16 => Ok(add::<i16>(left, right)?),
+            Self::AddInt32 => Ok(add::<i32>(left, right)?),
+            Self::AddInt64 => Ok(add::<i64>(left, right)?),
+            Self::AddUInt16 => Ok(add::<u16>(left, right)?),
+            Self::AddUInt32 => Ok(add::<u32>(left, right)?),
+            Self::AddUInt64 => Ok(add::<u64>(left, right)?),
+            Self::AddFloat32 => Ok(add::<f32>(left, right)?),
+            Self::AddFloat64 => Ok(add::<f64>(left, right)?),
+
+            Self::SubInt16 => Ok(sub::<i16>(left, right)?),
+            Self::SubInt32 => Ok(sub::<i32>(left, right)?),
+            Self::SubInt64 => Ok(sub::<i64>(left, right)?),
+            Self::SubUInt16 => Ok(sub::<u16>(left, right)?),
+            Self::SubUInt32 => Ok(sub::<u32>(left, right)?),
+            Self::SubUInt64 => Ok(sub::<u64>(left, right)?),
+            Self::SubFloat32 => Ok(sub::<f32>(left, right)?),
+            Self::SubFloat64 => Ok(sub::<f64>(left, right)?),
+
+            Self::MulInt16 => Ok(mul::<i16>(left, right)?),
+            Self::MulInt32 => Ok(mul::<i32>(left, right)?),
+            Self::MulInt64 => Ok(mul::<i64>(left, right)?),
+            Self::MulUInt16 => Ok(mul::<u16>(left, right)?),
+            Self::MulUInt32 => Ok(mul::<u32>(left, right)?),
+            Self::MulUInt64 => Ok(mul::<u64>(left, right)?),
+            Self::MulFloat32 => Ok(mul::<f32>(left, right)?),
+            Self::MulFloat64 => Ok(mul::<f64>(left, right)?),
+
+            Self::DivInt16 => Ok(div::<i16>(left, right)?),
+            Self::DivInt32 => Ok(div::<i32>(left, right)?),
+            Self::DivInt64 => Ok(div::<i64>(left, right)?),
+            Self::DivUInt16 => Ok(div::<u16>(left, right)?),
+            Self::DivUInt32 => Ok(div::<u32>(left, right)?),
+            Self::DivUInt64 => Ok(div::<u64>(left, right)?),
+            Self::DivFloat32 => Ok(div::<f32>(left, right)?),
+            Self::DivFloat64 => Ok(div::<f64>(left, right)?),
+
+            Self::ModInt16 => Ok(rem::<i16>(left, right)?),
+            Self::ModInt32 => Ok(rem::<i32>(left, right)?),
+            Self::ModInt64 => Ok(rem::<i64>(left, right)?),
+            Self::ModUInt16 => Ok(rem::<u16>(left, right)?),
+            Self::ModUInt32 => Ok(rem::<u32>(left, right)?),
+            Self::ModUInt64 => Ok(rem::<u64>(left, right)?),
+        }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Hash)]
+pub enum VariadicFunc {
+    And,
+    Or,
 }
 
 impl VariadicFunc {
     pub fn eval(&self, values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
-        todo!()
+        match self {
+            VariadicFunc::And => and(values, exprs),
+            VariadicFunc::Or => or(values, exprs),
+        }
     }
+}
+
+fn and(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
+    // If any is false, then return false. Else, if any is null, then return null. Else, return true.
+    let mut null = false;
+    let mut err = None;
+    for expr in exprs {
+        match expr.eval(values) {
+            Ok(Value::Boolean(true)) => {}
+            Ok(Value::Boolean(false)) => return Ok(Value::Boolean(false)), // short-circuit
+            Ok(Value::Null) => null = true,
+            Err(this_err) => {
+                if err.is_none() {
+                    err = Some(this_err)
+                }
+            } // retain first error encountered
+            Ok(x) => InvalidArgumentSnafu {
+                reason: format!(
+                    "`and()` only support boolean type, found value {:?} of type {:?}",
+                    x,
+                    x.data_type()
+                ),
+            }
+            .fail()?,
+        }
+    }
+    match (err, null) {
+        (Some(err), _) => Err(err),
+        (None, true) => Ok(Value::Null),
+        (None, false) => Ok(Value::Boolean(true)),
+    }
+}
+
+fn or(values: &[Value], exprs: &[ScalarExpr]) -> Result<Value, EvalError> {
+    // If any is false, then return false. Else, if any is null, then return null. Else, return true.
+    let mut null = false;
+    let mut err = None;
+    for expr in exprs {
+        match expr.eval(values) {
+            Ok(Value::Boolean(true)) => return Ok(Value::Boolean(true)), // short-circuit
+            Ok(Value::Boolean(false)) => {}                              // short-circuit
+            Ok(Value::Null) => null = true,
+            Err(this_err) => {
+                if err.is_none() {
+                    err = Some(this_err)
+                }
+            } // retain first error encountered
+            Ok(x) => InvalidArgumentSnafu {
+                reason: format!(
+                    "`or()` only support boolean type, found value {:?} of type {:?}",
+                    x,
+                    x.data_type()
+                ),
+            }
+            .fail()?,
+        }
+    }
+    match (err, null) {
+        (Some(err), _) => Err(err),
+        (None, true) => Ok(Value::Null),
+        (None, false) => Ok(Value::Boolean(false)),
+    }
+}
+
+fn add<T>(left: Value, right: Value) -> Result<Value, EvalError>
+where
+    T: TryFrom<Value, Error = datatypes::Error> + std::ops::Add<Output = T>,
+    Value: From<T>,
+{
+    let left = T::try_from(left)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let right = T::try_from(right)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    Ok(Value::from(left + right))
+}
+
+fn sub<T>(left: Value, right: Value) -> Result<Value, EvalError>
+where
+    T: TryFrom<Value, Error = datatypes::Error> + std::ops::Sub<Output = T>,
+    Value: From<T>,
+{
+    let left = T::try_from(left)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let right = T::try_from(right)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    Ok(Value::from(left - right))
+}
+
+fn mul<T>(left: Value, right: Value) -> Result<Value, EvalError>
+where
+    T: TryFrom<Value, Error = datatypes::Error> + std::ops::Mul<Output = T>,
+    Value: From<T>,
+{
+    let left = T::try_from(left)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let right = T::try_from(right)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    Ok(Value::from(left * right))
+}
+
+fn div<T>(left: Value, right: Value) -> Result<Value, EvalError>
+where
+    T: TryFrom<Value, Error = datatypes::Error> + std::ops::Div<Output = T>,
+    <T as TryFrom<Value>>::Error: std::fmt::Debug,
+    Value: From<T>,
+{
+    let left = T::try_from(left)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let right = T::try_from(right)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    Ok(Value::from(left / right))
+}
+
+fn rem<T>(left: Value, right: Value) -> Result<Value, EvalError>
+where
+    T: TryFrom<Value, Error = datatypes::Error> + std::ops::Rem<Output = T>,
+    <T as TryFrom<Value>>::Error: std::fmt::Debug,
+    Value: From<T>,
+{
+    let left = T::try_from(left)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    let right = T::try_from(right)
+        .map_err(|e| e.to_string())
+        .map_err(|e| TryFromValueSnafu { msg: e }.build())?;
+    Ok(Value::from(left % right))
 }

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ops::Div;
-
 use common_time::DateTime;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::types::cast;
@@ -23,10 +21,8 @@ use hydroflow::bincode::Error;
 use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 
-use super::ScalarExpr;
 use crate::expr::error::{CastValueSnafu, DivisionByZeroSnafu};
-use crate::expr::InvalidArgumentSnafu;
-// TODO(discord9): more function & eval
+use crate::expr::{InvalidArgumentSnafu, ScalarExpr};
 use crate::{
     expr::error::{EvalError, TryFromValueSnafu, TypeMismatchSnafu},
     repr::Row,

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -321,74 +321,78 @@ impl ScalarExpr {
     }
 }
 
-#[test]
-fn test_extract_bound() {
-    let test_list = [
-        // col(0) == now
-        (
-            ScalarExpr::CallBinary {
-                func: BinaryFunc::Eq,
-                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
-                expr2: Box::new(ScalarExpr::Column(0)),
-            },
-            Ok((
-                Some(ScalarExpr::Column(0)),
-                Some(ScalarExpr::CallUnary {
-                    func: UnaryFunc::StepTimestamp,
-                    expr: Box::new(ScalarExpr::Column(0)),
-                }),
-            )),
-        ),
-        // now < col(0)
-        (
-            ScalarExpr::CallBinary {
-                func: BinaryFunc::Lt,
-                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
-                expr2: Box::new(ScalarExpr::Column(0)),
-            },
-            Ok((None, Some(ScalarExpr::Column(0)))),
-        ),
-        // now <= col(0)
-        (
-            ScalarExpr::CallBinary {
-                func: BinaryFunc::Lte,
-                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
-                expr2: Box::new(ScalarExpr::Column(0)),
-            },
-            Ok((
-                None,
-                Some(ScalarExpr::CallUnary {
-                    func: UnaryFunc::StepTimestamp,
-                    expr: Box::new(ScalarExpr::Column(0)),
-                }),
-            )),
-        ),
-        // now > col(0) -> now >= col(0) + 1
-        (
-            ScalarExpr::CallBinary {
-                func: BinaryFunc::Gt,
-                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
-                expr2: Box::new(ScalarExpr::Column(0)),
-            },
-            Ok((
-                Some(ScalarExpr::CallUnary {
-                    func: UnaryFunc::StepTimestamp,
-                    expr: Box::new(ScalarExpr::Column(0)),
-                }),
-                None,
-            )),
-        ),
-        // now >= col(0)
-        (
-            ScalarExpr::CallBinary {
-                func: BinaryFunc::Gte,
-                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
-                expr2: Box::new(ScalarExpr::Column(0)),
-            },
-            Ok((Some(ScalarExpr::Column(0)), None)),
-        ),
-    ];
-    for (expr, expected) in test_list.iter() {
-        assert_eq!(expr.extract_bound(), *expected);
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_extract_bound() {
+        let test_list = [
+            // col(0) == now
+            (
+                ScalarExpr::CallBinary {
+                    func: BinaryFunc::Eq,
+                    expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                    expr2: Box::new(ScalarExpr::Column(0)),
+                },
+                Ok((
+                    Some(ScalarExpr::Column(0)),
+                    Some(ScalarExpr::CallUnary {
+                        func: UnaryFunc::StepTimestamp,
+                        expr: Box::new(ScalarExpr::Column(0)),
+                    }),
+                )),
+            ),
+            // now < col(0)
+            (
+                ScalarExpr::CallBinary {
+                    func: BinaryFunc::Lt,
+                    expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                    expr2: Box::new(ScalarExpr::Column(0)),
+                },
+                Ok((None, Some(ScalarExpr::Column(0)))),
+            ),
+            // now <= col(0)
+            (
+                ScalarExpr::CallBinary {
+                    func: BinaryFunc::Lte,
+                    expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                    expr2: Box::new(ScalarExpr::Column(0)),
+                },
+                Ok((
+                    None,
+                    Some(ScalarExpr::CallUnary {
+                        func: UnaryFunc::StepTimestamp,
+                        expr: Box::new(ScalarExpr::Column(0)),
+                    }),
+                )),
+            ),
+            // now > col(0) -> now >= col(0) + 1
+            (
+                ScalarExpr::CallBinary {
+                    func: BinaryFunc::Gt,
+                    expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                    expr2: Box::new(ScalarExpr::Column(0)),
+                },
+                Ok((
+                    Some(ScalarExpr::CallUnary {
+                        func: UnaryFunc::StepTimestamp,
+                        expr: Box::new(ScalarExpr::Column(0)),
+                    }),
+                    None,
+                )),
+            ),
+            // now >= col(0)
+            (
+                ScalarExpr::CallBinary {
+                    func: BinaryFunc::Gte,
+                    expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                    expr2: Box::new(ScalarExpr::Column(0)),
+                },
+                Ok((Some(ScalarExpr::Column(0)), None)),
+            ),
+        ];
+        for (expr, expected) in test_list.iter() {
+            assert_eq!(expr.extract_bound(), *expected);
+        }
     }
 }

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -127,7 +127,7 @@ impl ScalarExpr {
     }
 
     /// Returns the set of columns that are referenced by `self`.
-    pub fn support(&self) -> BTreeSet<usize> {
+    pub fn get_all_ref_columns(&self) -> BTreeSet<usize> {
         let mut support = BTreeSet::new();
         self.visit_post_nolimit(&mut |e| {
             if let ScalarExpr::Column(i) = e {
@@ -280,13 +280,6 @@ impl ScalarExpr {
             mut expr2,
         } = self.clone()
         {
-            let expr_1_contains_now = expr1.contains_temporal();
-            let expr_2_contains_now = expr2.contains_temporal();
-
-            if !(expr_1_contains_now ^ expr_2_contains_now) {
-                return unsupported_err("one side of the comparison must be `now()`");
-            }
-
             // TODO: support simple transform like `now() + a < b` to `now() < b - a`
 
             let expr1_is_now =

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -124,6 +124,7 @@ impl ScalarExpr {
         });
     }
 
+    /// Returns the set of columns that are referenced by `self`.
     pub fn support(&self) -> BTreeSet<usize> {
         let mut support = BTreeSet::new();
         self.visit_post_nolimit(&mut |e| {

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -294,7 +294,7 @@ impl ScalarExpr {
             let expr2_is_now =
                 *expr2 == ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now);
 
-            if expr1_is_now ^ expr2_is_now {
+            if !(expr1_is_now ^ expr2_is_now) {
                 return unsupported_err("None of the sides of the comparison is `now()`");
             }
 

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -59,3 +59,336 @@ pub enum ScalarExpr {
         els: Box<ScalarExpr>,
     },
 }
+
+impl ScalarExpr {
+    pub fn call_unary(self, func: UnaryFunc) -> Self {
+        ScalarExpr::CallUnary {
+            func,
+            expr: Box::new(self),
+        }
+    }
+
+    pub fn call_binary(self, other: Self, func: BinaryFunc) -> Self {
+        ScalarExpr::CallBinary {
+            func,
+            expr1: Box::new(self),
+            expr2: Box::new(other),
+        }
+    }
+
+    pub fn eval(&self, values: &[Value]) -> Result<Value, EvalError> {
+        match self {
+            ScalarExpr::Column(index) => Ok(values[*index].clone()),
+            ScalarExpr::Literal(row_res, _ty) => Ok(row_res.clone()),
+            ScalarExpr::CallUnmaterializable(f) => OptimizeSnafu {
+                reason: "Can't eval unmaterializable function".to_string(),
+            }
+            .fail(),
+            ScalarExpr::CallUnary { func, expr } => func.eval(values, expr),
+            ScalarExpr::CallBinary { func, expr1, expr2 } => func.eval(values, expr1, expr2),
+            ScalarExpr::CallVariadic { func, exprs } => func.eval(values, exprs),
+            ScalarExpr::If { cond, then, els } => match cond.eval(values) {
+                Ok(Value::Boolean(true)) => then.eval(values),
+                Ok(Value::Boolean(false)) => els.eval(values),
+                _ => InvalidArgumentSnafu {
+                    reason: "if condition must be boolean".to_string(),
+                }
+                .fail(),
+            },
+        }
+    }
+
+    /// Rewrites column indices with their value in `permutation`.
+    ///
+    /// This method is applicable even when `permutation` is not a
+    /// strict permutation, and it only needs to have entries for
+    /// each column referenced in `self`.
+    pub fn permute(&mut self, permutation: &[usize]) {
+        self.visit_mut_post_nolimit(&mut |e| {
+            if let ScalarExpr::Column(old_i) = e {
+                *old_i = permutation[*old_i];
+            }
+        });
+    }
+
+    /// Rewrites column indices with their value in `permutation`.
+    ///
+    /// This method is applicable even when `permutation` is not a
+    /// strict permutation, and it only needs to have entries for
+    /// each column referenced in `self`.
+    pub fn permute_map(&mut self, permutation: &BTreeMap<usize, usize>) {
+        self.visit_mut_post_nolimit(&mut |e| {
+            if let ScalarExpr::Column(old_i) = e {
+                *old_i = permutation[old_i];
+            }
+        });
+    }
+
+    pub fn support(&self) -> BTreeSet<usize> {
+        let mut support = BTreeSet::new();
+        self.visit_post_nolimit(&mut |e| {
+            if let ScalarExpr::Column(i) = e {
+                support.insert(*i);
+            }
+        });
+        support
+    }
+
+    pub fn as_literal(&self) -> Option<Value> {
+        if let ScalarExpr::Literal(lit, _column_type) = self {
+            Some(lit.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_literal(&self) -> bool {
+        matches!(self, ScalarExpr::Literal(..))
+    }
+
+    pub fn is_literal_true(&self) -> bool {
+        Some(Value::Boolean(true)) == self.as_literal()
+    }
+
+    pub fn is_literal_false(&self) -> bool {
+        Some(Value::Boolean(false)) == self.as_literal()
+    }
+
+    pub fn is_literal_null(&self) -> bool {
+        Some(Value::Null) == self.as_literal()
+    }
+
+    pub fn literal_null() -> Self {
+        ScalarExpr::Literal(Value::Null, ConcreteDataType::null_datatype())
+    }
+
+    pub fn literal(res: Value, typ: ConcreteDataType) -> Self {
+        ScalarExpr::Literal(res, typ)
+    }
+
+    pub fn literal_false() -> Self {
+        ScalarExpr::Literal(Value::Boolean(false), ConcreteDataType::boolean_datatype())
+    }
+
+    pub fn literal_true() -> Self {
+        ScalarExpr::Literal(Value::Boolean(true), ConcreteDataType::boolean_datatype())
+    }
+}
+
+impl ScalarExpr {
+    /// visit post-order without stack call limit, but may cause stack overflow
+    fn visit_post_nolimit<F>(&self, f: &mut F)
+    where
+        F: FnMut(&Self),
+    {
+        self.visit_children(|e| e.visit_post_nolimit(f));
+        f(self);
+    }
+
+    fn visit_children<F>(&self, mut f: F)
+    where
+        F: FnMut(&Self),
+    {
+        match self {
+            ScalarExpr::Column(_)
+            | ScalarExpr::Literal(_, _)
+            | ScalarExpr::CallUnmaterializable(_) => (),
+            ScalarExpr::CallUnary { func: _, expr } => f(expr),
+            ScalarExpr::CallBinary {
+                func: as_any,
+                expr1,
+                expr2,
+            } => {
+                f(expr1);
+                f(expr2);
+            }
+            ScalarExpr::CallVariadic { func: _, exprs } => {
+                for expr in exprs {
+                    f(expr);
+                }
+            }
+            ScalarExpr::If { cond, then, els } => {
+                f(cond);
+                f(then);
+                f(els);
+            }
+        }
+    }
+
+    fn visit_mut_post_nolimit<F>(&mut self, f: &mut F)
+    where
+        F: FnMut(&mut Self),
+    {
+        self.visit_mut_children(|e: &mut Self| e.visit_mut_post_nolimit(f));
+        f(self);
+    }
+
+    fn visit_mut_children<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Self),
+    {
+        match self {
+            ScalarExpr::Column(_)
+            | ScalarExpr::Literal(_, _)
+            | ScalarExpr::CallUnmaterializable(_) => (),
+            ScalarExpr::CallUnary { func, expr } => f(expr),
+            ScalarExpr::CallBinary { func, expr1, expr2 } => {
+                f(expr1);
+                f(expr2);
+            }
+            ScalarExpr::CallVariadic { func, exprs } => {
+                for expr in exprs {
+                    f(expr);
+                }
+            }
+            ScalarExpr::If { cond, then, els } => {
+                f(cond);
+                f(then);
+                f(els);
+            }
+        }
+    }
+}
+
+impl ScalarExpr {
+    /// if expr contains function `Now`
+    pub fn contains_temporal(&self) -> bool {
+        let mut contains = false;
+        self.visit_post_nolimit(&mut |e| {
+            if let ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now) = e {
+                contains = true;
+            }
+        });
+        contains
+    }
+
+    /// extract lower or upper bound of `Now` for expr, where `lower bound <= expr < upper bound`
+    ///
+    /// returned bool indicates whether the bound is upper bound:
+    ///
+    /// false for lower bound, true for upper bound
+    /// TODO(discord9): allow simple transform like `now() + a < b` to `now() < b - a`
+    pub fn extract_bound(&self) -> Result<(Option<Self>, Option<Self>), String> {
+        let unsupported_err = |msg: &str| {
+            Err(format!(
+                    "Unsupported temporal predicate: {msg}. NOTE: Use `now()` in direct comparison: {:?}",
+                    self
+                ))
+        };
+        if let Self::CallBinary {
+            mut func,
+            mut expr1,
+            mut expr2,
+        } = self.clone()
+        {
+            if !(expr1.contains_temporal() ^ expr2.contains_temporal()) {
+                return unsupported_err("one side of the comparison must be `now()`");
+            }
+            if !expr1.contains_temporal()
+                && *expr2 == ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)
+            {
+                std::mem::swap(&mut expr1, &mut expr2);
+                func = match func {
+                    BinaryFunc::Eq => BinaryFunc::Eq,
+                    BinaryFunc::NotEq => BinaryFunc::NotEq,
+                    BinaryFunc::Lt => BinaryFunc::Gt,
+                    BinaryFunc::Lte => BinaryFunc::Gte,
+                    BinaryFunc::Gt => BinaryFunc::Lt,
+                    BinaryFunc::Gte => BinaryFunc::Lte,
+                    _ => {
+                        return unsupported_err("The top level operator must be comparison");
+                    }
+                };
+            }
+            // TODO: support simple transform like `now() + a < b` to `now() < b - a`
+            if expr2.contains_temporal()
+                || *expr1 != ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)
+            {
+                return unsupported_err("None of the sides of the comparison is `now()`");
+            }
+            let step = |expr: ScalarExpr| expr.call_unary(UnaryFunc::StepTimestamp);
+            match func {
+                BinaryFunc::Eq => Ok((Some(*expr2.clone()), Some(step(*expr2)))),
+                BinaryFunc::Lt => Ok((None, Some(*expr2))),
+                BinaryFunc::Lte => Ok((None, Some(step(*expr2)))),
+                BinaryFunc::Gt => Ok((Some(step(*expr2)), None)),
+                BinaryFunc::Gte => Ok((Some(*expr2), None)),
+                _ => unreachable!("Already checked"),
+            }
+        } else {
+            unsupported_err("None of the sides of the comparison is `now()`")
+        }
+    }
+}
+
+#[test]
+fn test_extract_bound() {
+    let test_list = [
+        // col(0) == now
+        (
+            ScalarExpr::CallBinary {
+                func: BinaryFunc::Eq,
+                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                expr2: Box::new(ScalarExpr::Column(0)),
+            },
+            Ok((
+                Some(ScalarExpr::Column(0)),
+                Some(ScalarExpr::CallUnary {
+                    func: UnaryFunc::StepTimestamp,
+                    expr: Box::new(ScalarExpr::Column(0)),
+                }),
+            )),
+        ),
+        // now < col(0)
+        (
+            ScalarExpr::CallBinary {
+                func: BinaryFunc::Lt,
+                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                expr2: Box::new(ScalarExpr::Column(0)),
+            },
+            Ok((None, Some(ScalarExpr::Column(0)))),
+        ),
+        // now <= col(0)
+        (
+            ScalarExpr::CallBinary {
+                func: BinaryFunc::Lte,
+                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                expr2: Box::new(ScalarExpr::Column(0)),
+            },
+            Ok((
+                None,
+                Some(ScalarExpr::CallUnary {
+                    func: UnaryFunc::StepTimestamp,
+                    expr: Box::new(ScalarExpr::Column(0)),
+                }),
+            )),
+        ),
+        // now > col(0) -> now >= col(0) + 1
+        (
+            ScalarExpr::CallBinary {
+                func: BinaryFunc::Gt,
+                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                expr2: Box::new(ScalarExpr::Column(0)),
+            },
+            Ok((
+                Some(ScalarExpr::CallUnary {
+                    func: UnaryFunc::StepTimestamp,
+                    expr: Box::new(ScalarExpr::Column(0)),
+                }),
+                None,
+            )),
+        ),
+        // now >= col(0)
+        (
+            ScalarExpr::CallBinary {
+                func: BinaryFunc::Gte,
+                expr1: Box::new(ScalarExpr::CallUnmaterializable(UnmaterializableFunc::Now)),
+                expr2: Box::new(ScalarExpr::Column(0)),
+            },
+            Ok((Some(ScalarExpr::Column(0)), None)),
+        ),
+    ];
+    for (expr, expected) in test_list.iter() {
+        assert_eq!(expr.extract_bound(), *expected);
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Add impl for ScalarExpr&Scalar Functions

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Added impl code which eval Unary, Binary and Variadic Func

- Added utilty functions for `ScalarExpr` like get supporting(column being used in expression) column for a ScalarExpr.

- Most importantly, added utility functions for Temporal Filter, which can extract bounding condition including `now()` function and comparsion expression and express sliding windows etc.

- Summarize your change (**mandatory**)
useful methods for Scalar Expr, and `eval` method for Scalar function

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
