### PR TITLE
fix: correct the case sensitivity behavior for PromQL

### DIFF
--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -292,14 +292,16 @@ impl PromPlanner {
                     (None, None) => {
                         let left_input = self.prom_expr_to_plan(*lhs.clone()).await?;
                         let left_field_columns = self.ctx.field_columns.clone();
-                        let mut left_table_ref: OwnedTableReference =
-                            self.ctx.table_name.clone().unwrap_or_default().into();
+                        let mut left_table_ref = OwnedTableReference::bare(
+                            self.ctx.table_name.clone().unwrap_or_default(),
+                        );
                         let left_context = self.ctx.clone();
 
                         let right_input = self.prom_expr_to_plan(*rhs.clone()).await?;
                         let right_field_columns = self.ctx.field_columns.clone();
-                        let mut right_table_ref: OwnedTableReference =
-                            self.ctx.table_name.clone().unwrap_or_default().into();
+                        let mut right_table_ref = OwnedTableReference::bare(
+                            self.ctx.table_name.clone().unwrap_or_default(),
+                        );
                         let right_context = self.ctx.clone();
 
                         // TODO(ruihang): avoid join if left and right are the same table
@@ -572,6 +574,7 @@ impl PromPlanner {
                     .context(NoMetricMatcherSnafu)?,
             );
         }
+
         self.ctx.table_name = metric_name;
 
         let mut matchers = HashSet::new();
@@ -1883,7 +1886,7 @@ impl PromPlanner {
             .chain(self.ctx.time_index_column.iter())
             .map(|col| {
                 Ok(DfExpr::Column(Column::new(
-                    self.ctx.table_name.clone(),
+                    self.ctx.table_name.clone().map(TableReference::bare),
                     col,
                 )))
             });
@@ -1911,6 +1914,9 @@ impl PromPlanner {
         let project_fields = non_field_columns_iter
             .chain(field_columns_iter)
             .collect::<Result<Vec<_>>>()?;
+
+        common_telemetry::info!("[DEBUG] input: {:?}", input);
+        common_telemetry::info!("[DEBUG] project_fields: {:?}", project_fields);
 
         LogicalPlanBuilder::from(input)
             .project(project_fields)

--- a/src/promql/src/planner.rs
+++ b/src/promql/src/planner.rs
@@ -1915,9 +1915,6 @@ impl PromPlanner {
             .chain(field_columns_iter)
             .collect::<Result<Vec<_>>>()?;
 
-        common_telemetry::info!("[DEBUG] input: {:?}", input);
-        common_telemetry::info!("[DEBUG] project_fields: {:?}", project_fields);
-
         LogicalPlanBuilder::from(input)
             .project(project_fields)
             .context(DataFusionPlanningSnafu)?

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -622,6 +622,10 @@ desc table RUNTIME_METRICS;
 | timestamp   | TimestampMillisecond |     | NO   |         | FIELD         |
 +-------------+----------------------+-----+------+---------+---------------+
 
+drop table my_db.foo;
+
+Affected Rows: 0
+
 use public;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -117,4 +117,6 @@ select * from CHECK_CONSTRAINTS;
 
 desc table RUNTIME_METRICS;
 
+drop table my_db.foo;
+
 use public;

--- a/tests/cases/standalone/common/tql/case_sensitive.result
+++ b/tests/cases/standalone/common/tql/case_sensitive.result
@@ -26,14 +26,14 @@ insert into "MemTotal" values
 
 Affected Rows: 6
 
-select * from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
+select table_name from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
 
-+---------------+--------------+--------------+------------+----------+--------+
-| table_catalog | table_schema | table_name   | table_type | table_id | engine |
-+---------------+--------------+--------------+------------+----------+--------+
-| greptime      | public       | MemAvailable | BASE TABLE | 1024     | mito   |
-| greptime      | public       | MemTotal     | BASE TABLE | 1025     | mito   |
-+---------------+--------------+--------------+------------+----------+--------+
++--------------+
+| table_name   |
++--------------+
+| MemAvailable |
+| MemTotal     |
++--------------+
 
 -- SQLNESS SORT_RESULT 3 1
 tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);

--- a/tests/cases/standalone/common/tql/case_sensitive.result
+++ b/tests/cases/standalone/common/tql/case_sensitive.result
@@ -1,0 +1,77 @@
+create table "MemAvailable" (ts timestamp time index, instance string primary key, val double);
+
+Affected Rows: 0
+
+create table "MemTotal" (ts timestamp time index, instance string primary key, val double);
+
+Affected Rows: 0
+
+insert into "MemAvailable" values
+    (0, 'host0', 10),
+    (5000, 'host0', 20),
+    (10000, 'host0', 30),
+    (0, 'host1', 40),
+    (5000, 'host1', 50),
+    (10000, 'host1', 60);
+
+Affected Rows: 6
+
+insert into "MemTotal" values
+    (0, 'host0', 100),
+    (5000, 'host0', 100),
+    (10000, 'host0', 100),
+    (0, 'host1', 100),
+    (5000, 'host1', 100),
+    (10000, 'host1', 100);
+
+Affected Rows: 6
+
+select * from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
+
++---------------+--------------+--------------+------------+----------+--------+
+| table_catalog | table_schema | table_name   | table_type | table_id | engine |
++---------------+--------------+--------------+------------+----------+--------+
+| greptime      | public       | MemAvailable | BASE TABLE | 1024     | mito   |
+| greptime      | public       | MemTotal     | BASE TABLE | 1025     | mito   |
++---------------+--------------+--------------+------------+----------+--------+
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);
+
++---------------------+---------------------------------------------------------------------+
+| ts                  | MemAvailable.SUM(val / Float64(4)) + MemTotal.SUM(val / Float64(4)) |
++---------------------+---------------------------------------------------------------------+
+| 1970-01-01T00:00:00 | 62.5                                                                |
+| 1970-01-01T00:00:05 | 67.5                                                                |
+| 1970-01-01T00:00:10 | 72.5                                                                |
++---------------------+---------------------------------------------------------------------+
+
+drop table "MemTotal";
+
+Affected Rows: 0
+
+create schema "AnotherSchema";
+
+Affected Rows: 1
+
+create table "AnotherSchema"."MemTotal" (ts timestamp time index, instance string primary key, val double);
+
+Affected Rows: 0
+
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);
+
+Error: 4001(TableNotFound), Table not found: greptime.public.MemTotal
+
+-- Cross schema is not supported
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum({__name__="AnotherSchema.MemTotal"} / 4);
+
+Error: 4001(TableNotFound), Table not found: greptime.public.AnotherSchema.MemTotal
+
+drop table "MemAvailable";
+
+Affected Rows: 0
+
+drop table "AnotherSchema"."MemTotal";
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/tql/case_sensitive.sql
+++ b/tests/cases/standalone/common/tql/case_sensitive.sql
@@ -1,0 +1,39 @@
+create table "MemAvailable" (ts timestamp time index, instance string primary key, val double);
+
+create table "MemTotal" (ts timestamp time index, instance string primary key, val double);
+
+insert into "MemAvailable" values
+    (0, 'host0', 10),
+    (5000, 'host0', 20),
+    (10000, 'host0', 30),
+    (0, 'host1', 40),
+    (5000, 'host1', 50),
+    (10000, 'host1', 60);
+
+insert into "MemTotal" values
+    (0, 'host0', 100),
+    (5000, 'host0', 100),
+    (10000, 'host0', 100),
+    (0, 'host1', 100),
+    (5000, 'host1', 100),
+    (10000, 'host1', 100);
+
+select * from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
+
+-- SQLNESS SORT_RESULT 3 1
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);
+
+drop table "MemTotal";
+
+create schema "AnotherSchema";
+
+create table "AnotherSchema"."MemTotal" (ts timestamp time index, instance string primary key, val double);
+
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);
+
+-- Cross schema is not supported
+tql eval (0,10,'5s') sum(MemAvailable / 4) + sum({__name__="AnotherSchema.MemTotal"} / 4);
+
+drop table "MemAvailable";
+
+drop table "AnotherSchema"."MemTotal";

--- a/tests/cases/standalone/common/tql/case_sensitive.sql
+++ b/tests/cases/standalone/common/tql/case_sensitive.sql
@@ -18,7 +18,7 @@ insert into "MemTotal" values
     (5000, 'host1', 100),
     (10000, 'host1', 100);
 
-select * from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
+select table_name from information_schema.tables where table_type = 'BASE TABLE' order by table_id;
 
 -- SQLNESS SORT_RESULT 3 1
 tql eval (0,10,'5s') sum(MemAvailable / 4) + sum(MemTotal / 4);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Use `TableReference::bare` to avoid unnecessary escaping or parsing

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
