### PR TITLE
fix: $TARGET_BIN not found when docker run the image 

### DIFF
--- a/docker/ci/centos/Dockerfile
+++ b/docker/ci/centos/Dockerfile
@@ -1,7 +1,5 @@
 FROM centos:7
 
-ENV TARGET_BIN=greptime
-
 RUN yum install -y epel-release \
     openssl \
     openssl-devel  \
@@ -11,8 +9,8 @@ RUN yum install -y epel-release \
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
+ADD $TARGETARCH/greptime /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["$TARGET_BIN"]
+ENTRYPOINT ["greptime"]

--- a/docker/ci/centos/Dockerfile
+++ b/docker/ci/centos/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:7
 
+ENV TARGET_BIN=greptime
+
 RUN yum install -y epel-release \
     openssl \
     openssl-devel  \
@@ -9,8 +11,8 @@ RUN yum install -y epel-release \
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/greptime /greptime/bin/
+ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["greptime"]
+ENTRYPOINT ["$TARGET_BIN"]

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -19,8 +19,8 @@ RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
+ADD $TARGETARCH/${TARGET_BIN} /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["$TARGET_BIN"]
+ENTRYPOINT ["${TARGET_BIN}"]

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -17,12 +17,12 @@ COPY $DOCKER_BUILD_ROOT/docker/python/requirements.txt /etc/greptime/requirement
 
 RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
-ARG TARGETARCH
+#ARG TARGETARCH
 
-ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
+ADD $TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
 ENV TARGET_BIN=$TARGET_BIN
 
-ENTRYPOINT ["$TARGET_BIN"]
+ENTRYPOINT ["sh", "-c", "exec $TARGET_BIN \"$@\"", "--"]

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -4,7 +4,8 @@ FROM ubuntu:22.04
 ARG DOCKER_BUILD_ROOT=.
 # The binary name of GreptimeDB executable.
 # Defaults to "greptime", but sometimes in other projects it might be different.
-ENV TARGET_BIN=greptime
+ARG TARGET_BIN=greptime
+ENV TARGET_BIN=$TARGET_BIN
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -5,7 +5,6 @@ ARG DOCKER_BUILD_ROOT=.
 # The binary name of GreptimeDB executable.
 # Defaults to "greptime", but sometimes in other projects it might be different.
 ARG TARGET_BIN=greptime
-ENV TARGET_BIN=$TARGET_BIN
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
@@ -23,5 +22,7 @@ ARG TARGETARCH
 ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
+
+ENV TARGET_BIN=$TARGET_BIN
 
 ENTRYPOINT ["$TARGET_BIN"]

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -17,9 +17,9 @@ COPY $DOCKER_BUILD_ROOT/docker/python/requirements.txt /etc/greptime/requirement
 
 RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
-#ARG TARGETARCH
+ARG TARGETARCH
 
-ADD $TARGET_BIN /greptime/bin/
+ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:22.04
 
 # The root path under which contains all the dependencies to build this Dockerfile.
 ARG DOCKER_BUILD_ROOT=.
+# The binary name of GreptimeDB executable.
+# Defaults to "greptime", but sometimes in other projects it might be different.
+ENV TARGET_BIN=greptime
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
@@ -16,8 +19,8 @@ RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/greptime /greptime/bin/
+ADD $TARGETARCH/$TARGET_BIN /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["greptime"]
+ENTRYPOINT ["$TARGET_BIN"]

--- a/docker/ci/ubuntu/Dockerfile
+++ b/docker/ci/ubuntu/Dockerfile
@@ -2,9 +2,6 @@ FROM ubuntu:22.04
 
 # The root path under which contains all the dependencies to build this Dockerfile.
 ARG DOCKER_BUILD_ROOT=.
-# The binary name of GreptimeDB executable.
-# Defaults to "greptime", but sometimes in other projects it might be different.
-ARG TARGET_BIN=greptime
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     ca-certificates \
@@ -19,8 +16,8 @@ RUN python3 -m pip install -r /etc/greptime/requirements.txt
 
 ARG TARGETARCH
 
-ADD $TARGETARCH/${TARGET_BIN} /greptime/bin/
+ADD $TARGETARCH/greptime /greptime/bin/
 
 ENV PATH /greptime/bin/:$PATH
 
-ENTRYPOINT ["${TARGET_BIN}"]
+ENTRYPOINT ["greptime"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This fixes https://github.com/GreptimeTeam/greptimedb/issues/3298

Start the latest version of the greptime docker image and have an error:

```
Events:
  Type     Reason     Age                 From               Message
  ----     ------     ----                ----               -------
  Normal   Scheduled  2m12s               default-scheduler  Successfully assigned default/e2e-cluster-meta-c4b459789-z88zc to kind-control-plane
  Normal   Pulled     22s                 kubelet            Successfully pulled image "greptime/greptimedb:latest" in 1m50.002557716s (1m50.002580925s including waiting)
  Normal   Created    17s (x2 over 22s)   kubelet            Created container meta
  Warning  Failed     17s (x2 over 21s)   kubelet            Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "$TARGET_BIN": executable file not found in $PATH: unknown
  Normal   Pulled     17s                 kubelet            Successfully pulled image "greptime/greptimedb:latest" in 2.782102751s (2.782123793s including waiting)
  Warning  BackOff    12s (x3 over 17s)   kubelet            Back-off restarting failed container meta in pod e2e-cluster-meta-c4b459789-z88zc_default(834ac864-18c2-47ef-b7da-3a1d3b35a870)
  Normal   Pulling    1s (x3 over 2m12s)  kubelet            Pulling image "greptime/greptimedb:latest"
```

This is related to https://github.com/moby/moby/issues/18492.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
