### PR TITLE
fix(index): sanitize S3 upload buffer size

### DIFF
--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -294,6 +294,14 @@ impl InvertedIndexConfig {
             self.intermediate_path = join_dir(data_home, "index_intermediate");
         }
 
+        if self.write_buffer_size < MULTIPART_UPLOAD_MINIMUM_SIZE {
+            self.write_buffer_size = MULTIPART_UPLOAD_MINIMUM_SIZE;
+            warn!(
+                "Sanitize index write buffer size to {}",
+                self.write_buffer_size
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

A tiny fix.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
