### PR TITLE
refactor(index): move option `segment_row_count` from WriteOptions to IndexOptions

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -140,7 +140,6 @@ impl AccessLayer {
                 file_id,
                 file_path: index_file_path,
                 metadata: &request.metadata,
-                segment_row_count: write_opts.index_segment_row_count,
                 row_group_size: write_opts.row_group_size,
                 object_store: self.object_store.clone(),
                 intermediate_manager: self.intermediate_manager.clone(),

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -114,7 +114,6 @@ impl WriteCache {
             file_id,
             file_path: self.file_cache.cache_file_path(puffin_key),
             metadata: &write_request.metadata,
-            segment_row_count: write_opts.index_segment_row_count,
             row_group_size: write_opts.row_group_size,
             object_store: self.file_cache.local_store(),
             intermediate_manager: self.intermediate_manager.clone(),

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -130,7 +130,6 @@ pub(crate) struct IndexerBuilder<'a> {
     pub(crate) file_path: String,
     pub(crate) metadata: &'a RegionMetadataRef,
     pub(crate) row_group_size: usize,
-    pub(crate) segment_row_count: usize,
     pub(crate) object_store: ObjectStore,
     pub(crate) intermediate_manager: IntermediateManager,
     pub(crate) index_options: IndexOptions,
@@ -156,7 +155,9 @@ impl<'a> IndexerBuilder<'a> {
             return Indexer::default();
         }
 
-        let Some(mut segment_row_count) = NonZeroUsize::new(self.segment_row_count) else {
+        let Some(mut segment_row_count) =
+            NonZeroUsize::new(self.index_options.inverted_index.segment_row_count)
+        else {
             warn!(
                 "Segment row count is 0, skip creating index, region_id: {}, file_id: {}",
                 self.metadata.region_id, self.file_id,
@@ -287,7 +288,6 @@ mod tests {
             file_id: FileId::random(),
             file_path: "test".to_string(),
             metadata: &metadata,
-            segment_row_count: 16,
             row_group_size: 1024,
             object_store: mock_object_store(),
             intermediate_manager: mock_intm_mgr(),
@@ -308,7 +308,6 @@ mod tests {
             file_id: FileId::random(),
             file_path: "test".to_string(),
             metadata: &metadata,
-            segment_row_count: 16,
             row_group_size: 1024,
             object_store: mock_object_store(),
             intermediate_manager: mock_intm_mgr(),
@@ -329,7 +328,6 @@ mod tests {
             file_id: FileId::random(),
             file_path: "test".to_string(),
             metadata: &metadata,
-            segment_row_count: 16,
             row_group_size: 1024,
             object_store: mock_object_store(),
             intermediate_manager: mock_intm_mgr(),
@@ -350,7 +348,6 @@ mod tests {
             file_id: FileId::random(),
             file_path: "test".to_string(),
             metadata: &metadata,
-            segment_row_count: 0,
             row_group_size: 0,
             object_store: mock_object_store(),
             intermediate_manager: mock_intm_mgr(),

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -39,8 +39,6 @@ pub const PARQUET_METADATA_KEY: &str = "greptime:metadata";
 pub(crate) const DEFAULT_READ_BATCH_SIZE: usize = 1024;
 /// Default row group size for parquet files.
 const DEFAULT_ROW_GROUP_SIZE: usize = 100 * DEFAULT_READ_BATCH_SIZE;
-/// Default segment row count for inverted index.
-const DEFAULT_INDEX_SEGMENT_ROW_COUNT: usize = 1024;
 
 /// Parquet write options.
 #[derive(Debug)]
@@ -49,8 +47,6 @@ pub struct WriteOptions {
     pub write_buffer_size: ReadableSize,
     /// Row group size.
     pub row_group_size: usize,
-    /// Segment row count for inverted index.
-    pub index_segment_row_count: usize,
 }
 
 impl Default for WriteOptions {
@@ -58,7 +54,6 @@ impl Default for WriteOptions {
         WriteOptions {
             write_buffer_size: DEFAULT_WRITE_BUFFER_SIZE,
             row_group_size: DEFAULT_ROW_GROUP_SIZE,
-            index_segment_row_count: DEFAULT_INDEX_SEGMENT_ROW_COUNT,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Make `segment_row_count` configurable.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
