### PR TITLE
fix: split write metadata request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1924,6 +1924,7 @@ dependencies = [
  "futures-util",
  "humantime-serde",
  "hyper",
+ "itertools 0.10.5",
  "lazy_static",
  "prometheus",
  "prost 0.12.3",

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -31,6 +31,7 @@ etcd-client.workspace = true
 futures-util.workspace = true
 futures.workspace = true
 humantime-serde.workspace = true
+itertools.workspace = true
 lazy_static.workspace = true
 prometheus.workspace = true
 prost.workspace = true

--- a/src/common/meta/src/ddl/create_logical_tables.rs
+++ b/src/common/meta/src/ddl/create_logical_tables.rs
@@ -159,7 +159,10 @@ impl CreateLogicalTablesProcedure {
         let num_tables = tables_data.len();
 
         if num_tables > 0 {
-            manager.create_logic_tables_metadata(tables_data).await?;
+            const BATCH_SIZE: usize = 20;
+            for chunk in tables_data.chunks(BATCH_SIZE) {
+                manager.create_logic_tables_metadata(chunk.to_vec()).await?;
+            }
         }
 
         let table_ids = self.creator.data.real_table_ids();

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -56,6 +56,7 @@ pub mod table_region;
 pub mod table_route;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
+mod txn_helper;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
@@ -277,7 +278,7 @@ impl<T: Serialize + DeserializeOwned + TableMetaValue> DeserializedValueWithByte
     }
 
     /// Returns original `bytes`
-    pub fn into_bytes(&self) -> Vec<u8> {
+    pub fn get_raw_bytes(&self) -> Vec<u8> {
         self.bytes.to_vec()
     }
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -458,8 +458,14 @@ impl TableMetadataManager {
         Ok(())
     }
 
+    pub fn max_logical_tables_per_batch(&self) -> usize {
+        // The batch size is max_txn_size / 3 because the size of the `tables_data`
+        // is 3 times the size of the `tables_data`.
+        self.kv_backend.max_txn_size() / 3
+    }
+
     /// Creates metadata for multiple logical tables and return an error if different metadata exists.
-    pub async fn create_logic_tables_metadata(
+    pub async fn create_logical_tables_metadata(
         &self,
         tables_data: Vec<(RawTableInfo, TableRouteValue)>,
     ) -> Result<()> {
@@ -1002,13 +1008,13 @@ mod tests {
         let tables_data = vec![(table_info.clone(), table_route_value.clone())];
         // creates metadata.
         table_metadata_manager
-            .create_logic_tables_metadata(tables_data.clone())
+            .create_logical_tables_metadata(tables_data.clone())
             .await
             .unwrap();
 
         // if metadata was already created, it should be ok.
         assert!(table_metadata_manager
-            .create_logic_tables_metadata(tables_data)
+            .create_logical_tables_metadata(tables_data)
             .await
             .is_ok());
 
@@ -1018,7 +1024,7 @@ mod tests {
         let modified_tables_data = vec![(table_info.clone(), modified_table_route_value)];
         // if remote metadata was exists, it should return an error.
         assert!(table_metadata_manager
-            .create_logic_tables_metadata(modified_tables_data)
+            .create_logical_tables_metadata(modified_tables_data)
             .await
             .is_err());
 

--- a/src/common/meta/src/key/table_info.rs
+++ b/src/common/meta/src/key/table_info.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 use table::metadata::{RawTableInfo, TableId};
 use table::table_reference::TableReference;
 
-use super::{DeserializedValueWithBytes, TableMetaValue, TABLE_INFO_KEY_PREFIX};
+use super::{txn_helper, DeserializedValueWithBytes, TableMetaValue, TABLE_INFO_KEY_PREFIX};
 use crate::error::Result;
 use crate::key::{to_removed_key, TableMetaKey};
-use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp, TxnOpResponse};
+use crate::kv_backend::txn::{Txn, TxnOp, TxnOpResponse};
 use crate::kv_backend::KvBackendRef;
 use crate::rpc::store::BatchGetRequest;
 use crate::table_name::TableName;
@@ -112,7 +112,7 @@ impl TableInfoManager {
         let raw_key = key.as_raw_key();
         let txn = Txn::new().and_then(vec![TxnOp::Get(raw_key.clone())]);
 
-        (txn, Self::build_decode_fn(raw_key))
+        (txn, txn_helper::build_txn_response_decoder_fn(raw_key))
     }
 
     /// Builds a create table info transaction, it expected the `__table_info/{table_id}` wasn't occupied.
@@ -127,18 +127,12 @@ impl TableInfoManager {
         let key = TableInfoKey::new(table_id);
         let raw_key = key.as_raw_key();
 
-        let txn = Txn::new()
-            .when(vec![Compare::with_not_exist_value(
-                raw_key.clone(),
-                CompareOp::Equal,
-            )])
-            .and_then(vec![TxnOp::Put(
-                raw_key.clone(),
-                table_info_value.try_as_raw_value()?,
-            )])
-            .or_else(vec![TxnOp::Get(raw_key.clone())]);
+        let txn = txn_helper::build_put_if_absent_txn(
+            raw_key.clone(),
+            table_info_value.try_as_raw_value()?,
+        );
 
-        Ok((txn, Self::build_decode_fn(raw_key)))
+        Ok((txn, txn_helper::build_txn_response_decoder_fn(raw_key)))
     }
 
     /// Builds a update table info transaction, it expected the remote value equals the `current_current_table_info_value`.
@@ -154,21 +148,12 @@ impl TableInfoManager {
     )> {
         let key = TableInfoKey::new(table_id);
         let raw_key = key.as_raw_key();
-        let raw_value = current_table_info_value.into_bytes();
+        let raw_value = current_table_info_value.get_raw_bytes();
+        let new_raw_value: Vec<u8> = new_table_info_value.try_as_raw_value()?;
 
-        let txn = Txn::new()
-            .when(vec![Compare::with_value(
-                raw_key.clone(),
-                CompareOp::Equal,
-                raw_value,
-            )])
-            .and_then(vec![TxnOp::Put(
-                raw_key.clone(),
-                new_table_info_value.try_as_raw_value()?,
-            )])
-            .or_else(vec![TxnOp::Get(raw_key.clone())]);
+        let txn = txn_helper::build_compare_and_put_txn(raw_key.clone(), raw_value, new_raw_value);
 
-        Ok((txn, Self::build_decode_fn(raw_key)))
+        Ok((txn, txn_helper::build_txn_response_decoder_fn(raw_key)))
     }
 
     /// Builds a delete table info transaction.
@@ -179,7 +164,7 @@ impl TableInfoManager {
     ) -> Result<Txn> {
         let key = TableInfoKey::new(table_id);
         let raw_key = key.as_raw_key();
-        let raw_value = table_info_value.into_bytes();
+        let raw_value = table_info_value.get_raw_bytes();
         let removed_key = to_removed_key(&String::from_utf8_lossy(&raw_key));
 
         let txn = Txn::new().and_then(vec![
@@ -188,26 +173,6 @@ impl TableInfoManager {
         ]);
 
         Ok(txn)
-    }
-
-    fn build_decode_fn(
-        raw_key: Vec<u8>,
-    ) -> impl FnOnce(&Vec<TxnOpResponse>) -> Result<Option<DeserializedValueWithBytes<TableInfoValue>>>
-    {
-        move |kvs: &Vec<TxnOpResponse>| {
-            kvs.iter()
-                .filter_map(|resp| {
-                    if let TxnOpResponse::ResponseGet(r) = resp {
-                        Some(r)
-                    } else {
-                        None
-                    }
-                })
-                .flat_map(|r| &r.kvs)
-                .find(|kv| kv.key == raw_key)
-                .map(|kv| DeserializedValueWithBytes::from_inner_slice(&kv.value))
-                .transpose()
-        }
     }
 
     #[cfg(test)]

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -20,12 +20,12 @@ use snafu::{ensure, OptionExt, ResultExt};
 use store_api::storage::{RegionId, RegionNumber};
 use table::metadata::TableId;
 
-use super::{DeserializedValueWithBytes, TableMetaValue};
+use super::{txn_helper, DeserializedValueWithBytes, TableMetaValue};
 use crate::error::{
     Result, SerdeJsonSnafu, TableRouteNotFoundSnafu, UnexpectedLogicalRouteTableSnafu,
 };
 use crate::key::{to_removed_key, RegionDistribution, TableMetaKey, TABLE_ROUTE_PREFIX};
-use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp, TxnOpResponse};
+use crate::kv_backend::txn::{Txn, TxnOp, TxnOpResponse};
 use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute};
 use crate::rpc::store::BatchGetRequest;
@@ -231,7 +231,7 @@ impl TableRouteManager {
         let raw_key = key.as_raw_key();
         let txn = Txn::new().and_then(vec![TxnOp::Get(raw_key.clone())]);
 
-        (txn, Self::build_decode_fn(raw_key))
+        (txn, txn_helper::build_txn_response_decoder_fn(raw_key))
     }
 
     /// Builds a create table route transaction. it expected the `__table_route/{table_id}` wasn't occupied.
@@ -246,18 +246,12 @@ impl TableRouteManager {
         let key = TableRouteKey::new(table_id);
         let raw_key = key.as_raw_key();
 
-        let txn = Txn::new()
-            .when(vec![Compare::with_not_exist_value(
-                raw_key.clone(),
-                CompareOp::Equal,
-            )])
-            .and_then(vec![TxnOp::Put(
-                raw_key.clone(),
-                table_route_value.try_as_raw_value()?,
-            )])
-            .or_else(vec![TxnOp::Get(raw_key.clone())]);
+        let txn = txn_helper::build_put_if_absent_txn(
+            raw_key.clone(),
+            table_route_value.try_as_raw_value()?,
+        );
 
-        Ok((txn, Self::build_decode_fn(raw_key)))
+        Ok((txn, txn_helper::build_txn_response_decoder_fn(raw_key)))
     }
 
     /// Builds a update table route transaction, it expected the remote value equals the `current_table_route_value`.
@@ -273,19 +267,12 @@ impl TableRouteManager {
     )> {
         let key = TableRouteKey::new(table_id);
         let raw_key = key.as_raw_key();
-        let raw_value = current_table_route_value.into_bytes();
+        let raw_value = current_table_route_value.get_raw_bytes();
         let new_raw_value: Vec<u8> = new_table_route_value.try_as_raw_value()?;
 
-        let txn = Txn::new()
-            .when(vec![Compare::with_value(
-                raw_key.clone(),
-                CompareOp::Equal,
-                raw_value,
-            )])
-            .and_then(vec![TxnOp::Put(raw_key.clone(), new_raw_value)])
-            .or_else(vec![TxnOp::Get(raw_key.clone())]);
+        let txn = txn_helper::build_compare_and_put_txn(raw_key.clone(), raw_value, new_raw_value);
 
-        Ok((txn, Self::build_decode_fn(raw_key)))
+        Ok((txn, txn_helper::build_txn_response_decoder_fn(raw_key)))
     }
 
     /// Builds a delete table route transaction, it expected the remote value equals the `table_route_value`.
@@ -296,7 +283,7 @@ impl TableRouteManager {
     ) -> Result<Txn> {
         let key = TableRouteKey::new(table_id);
         let raw_key = key.as_raw_key();
-        let raw_value = table_route_value.into_bytes();
+        let raw_value = table_route_value.get_raw_bytes();
         let removed_key = to_removed_key(&String::from_utf8_lossy(&raw_key));
 
         let txn = Txn::new().and_then(vec![
@@ -305,27 +292,6 @@ impl TableRouteManager {
         ]);
 
         Ok(txn)
-    }
-
-    fn build_decode_fn(
-        raw_key: Vec<u8>,
-    ) -> impl FnOnce(&Vec<TxnOpResponse>) -> Result<Option<DeserializedValueWithBytes<TableRouteValue>>>
-    {
-        move |response: &Vec<TxnOpResponse>| {
-            response
-                .iter()
-                .filter_map(|resp| {
-                    if let TxnOpResponse::ResponseGet(r) = resp {
-                        Some(r)
-                    } else {
-                        None
-                    }
-                })
-                .flat_map(|r| &r.kvs)
-                .find(|kv| kv.key == raw_key)
-                .map(|kv| DeserializedValueWithBytes::from_inner_slice(&kv.value))
-                .transpose()
-        }
     }
 
     pub async fn get(

--- a/src/common/meta/src/key/txn_helper.rs
+++ b/src/common/meta/src/key/txn_helper.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 

--- a/src/common/meta/src/key/txn_helper.rs
+++ b/src/common/meta/src/key/txn_helper.rs
@@ -1,0 +1,50 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::error::Result;
+use crate::key::{DeserializedValueWithBytes, TableMetaValue};
+use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp, TxnOpResponse};
+
+pub(crate) fn build_txn_response_decoder_fn<T>(
+    raw_key: Vec<u8>,
+) -> impl FnOnce(&Vec<TxnOpResponse>) -> Result<Option<DeserializedValueWithBytes<T>>>
+where
+    T: Serialize + DeserializeOwned + TableMetaValue,
+{
+    move |txn_res: &Vec<TxnOpResponse>| {
+        txn_res
+            .iter()
+            .filter_map(|resp| {
+                if let TxnOpResponse::ResponseGet(r) = resp {
+                    Some(r)
+                } else {
+                    None
+                }
+            })
+            .flat_map(|r| &r.kvs)
+            .find(|kv| kv.key == raw_key)
+            .map(|kv| DeserializedValueWithBytes::from_inner_slice(&kv.value))
+            .transpose()
+    }
+}
+
+pub(crate) fn build_put_if_absent_txn(key: Vec<u8>, value: Vec<u8>) -> Txn {
+    Txn::new()
+        .when(vec![Compare::with_not_exist_value(
+            key.clone(),
+            CompareOp::Equal,
+        )])
+        .and_then(vec![TxnOp::Put(key.clone(), value)])
+        .or_else(vec![TxnOp::Get(key)])
+}
+
+pub(crate) fn build_compare_and_put_txn(key: Vec<u8>, old_value: Vec<u8>, value: Vec<u8>) -> Txn {
+    Txn::new()
+        .when(vec![Compare::with_value(
+            key.clone(),
+            CompareOp::Equal,
+            old_value,
+        )])
+        .and_then(vec![TxnOp::Put(key.clone(), value)])
+        .or_else(vec![TxnOp::Get(key)])
+}

--- a/src/common/meta/src/kv_backend/etcd.rs
+++ b/src/common/meta/src/kv_backend/etcd.rs
@@ -21,7 +21,7 @@ use etcd_client::{
 };
 use snafu::{ensure, OptionExt, ResultExt};
 
-use super::KvBackendRef;
+use super::{txn, KvBackendRef};
 use crate::error::{self, Error, Result};
 use crate::kv_backend::txn::{Txn as KvTxn, TxnResponse as KvTxnResponse};
 use crate::kv_backend::{KvBackend, TxnService};
@@ -37,7 +37,7 @@ use crate::rpc::KeyValue;
 // The etcd default configuration's `--max-txn-ops` is 128.
 //
 // For more detail, see: https://etcd.io/docs/v3.5/op-guide/configuration/
-const MAX_TXN_SIZE: usize = 128;
+const MAX_TXN_SIZE: usize = txn::MAX_TXN_SIZE;
 
 fn convert_key_value(kv: etcd_client::KeyValue) -> KeyValue {
     let (key, value) = kv.into_key_value();

--- a/src/common/meta/src/kv_backend/txn.rs
+++ b/src/common/meta/src/kv_backend/txn.rs
@@ -18,15 +18,17 @@ use crate::rpc::store::{DeleteRangeResponse, PutResponse, RangeResponse};
 
 mod etcd;
 
-// Maximum number of operations permitted in a transaction.
-pub const MAX_TXN_SIZE: usize = 128;
-
 #[async_trait::async_trait]
 pub trait TxnService: Sync + Send {
     type Error: ErrorExt;
 
     async fn txn(&self, _txn: Txn) -> Result<TxnResponse, Self::Error> {
         unimplemented!("txn is not implemented")
+    }
+
+    /// Maximum number of operations permitted in a transaction.
+    fn max_txn_size(&self) -> usize {
+        usize::MAX
     }
 }
 

--- a/src/common/meta/src/kv_backend/txn.rs
+++ b/src/common/meta/src/kv_backend/txn.rs
@@ -18,6 +18,9 @@ use crate::rpc::store::{DeleteRangeResponse, PutResponse, RangeResponse};
 
 mod etcd;
 
+// Maximum number of operations permitted in a transaction.
+pub const MAX_TXN_SIZE: usize = 128;
+
 #[async_trait::async_trait]
 pub trait TxnService: Sync + Send {
     type Error: ErrorExt;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Creating logical tables requires batch writing metadata by utilizing `txn` for executing a write transaction. However, our txn has a default upper limit of 128 operations due to the constraints set by etcd storage. We prefer not to have users alter the default etcd configuration to maintain user experience.
To work around this limitation, I divide the data before batching it for writing. Even though these operations are not within a single transaction, rest assured that they are secure and will be retried by the `procedure` until all succeed.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

Close #3285 
