### PR TITLE
ci: run CI jobs in draft PR

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -42,7 +42,6 @@ jobs:
 
   check:
     name: Check
-    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -67,7 +66,6 @@ jobs:
 
   toml:
     name: Toml Check
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -87,7 +85,6 @@ jobs:
 
   build:
     name: Build GreptimeDB binaries
-    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -122,7 +119,6 @@ jobs:
 
   sqlness:
     name: Sqlness Test
-    if: github.event.pull_request.draft == false
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -150,7 +146,6 @@ jobs:
 
   sqlness-kafka-wal:
     name: Sqlness Test with Kafka Wal
-    if: github.event.pull_request.draft == false
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
@@ -181,7 +176,6 @@ jobs:
 
   fmt:
     name: Rustfmt
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -203,7 +197,6 @@ jobs:
 
   clippy:
     name: Clippy
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,34 +38,29 @@ jobs:
 
   check:
     name: Check
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No action required"'
 
   fmt:
     name: Rustfmt
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No action required"'
 
   clippy:
     name: Clippy
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No action required"'
 
   coverage:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No action required"'
 
   sqlness:
     name: Sqlness Test
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - run: 'echo "No action required"'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Run `docs.yml` and `develop.yml` jobs in draft PR. Only `coverage` is ignored as it uses a large runner.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
