### PR TITLE
fix: stop printing ANSI colors in file logging layer

### DIFF
--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -144,7 +144,7 @@ pub fn init_global_logging(
     // JSON log layer.
     let rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
     let (rolling_writer, rolling_writer_guard) = tracing_appender::non_blocking(rolling_appender);
-    let file_logging_layer = Layer::new().with_writer(rolling_writer);
+    let file_logging_layer = Layer::new().with_writer(rolling_writer).with_ansi(false);
     guards.push(rolling_writer_guard);
 
     // error JSON log layer.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

close #3323 

The terminal sequences are mainly ANSI color control chars, not that meaningful in log files while creating some disturbing chars for human eyes when using raw tools like "less without `-R`" to view the log files, so disable them:
<img width="1058" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/990479/eb308dcb-9e94-4620-9f39-683fac524c4b">
However, the console logs are untouched:
<img width="767" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/990479/66c4ba54-80fe-4caa-9c7f-782778aba9b2">

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
