### PR TITLE
fix: disable ansi contorl char when stdout is redirected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,7 @@ dependencies = [
 name = "common-telemetry"
 version = "0.6.0"
 dependencies = [
+ "atty",
  "backtrace",
  "common-error",
  "console-subscriber",

--- a/src/common/telemetry/Cargo.toml
+++ b/src/common/telemetry/Cargo.toml
@@ -9,6 +9,7 @@ tokio-console = ["console-subscriber", "tokio/tracing"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
 
 [dependencies]
+atty = "0.2"
 backtrace = "0.3"
 common-error.workspace = true
 console-subscriber = { version = "0.1", optional = true }

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -132,11 +132,16 @@ pub fn init_global_logging(
     // Enable log compatible layer to convert log record to tracing span.
     LogTracer::init().expect("log tracer must be valid");
 
+    // stdout log layer.
     let stdout_logging_layer = if opts.append_stdout {
         let (stdout_writer, stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
         guards.push(stdout_guard);
 
-        Some(Layer::new().with_writer(stdout_writer))
+        Some(
+            Layer::new()
+                .with_writer(stdout_writer)
+                .with_ansi(atty::is(atty::Stream::Stdout)),
+        )
     } else {
         None
     };
@@ -144,7 +149,7 @@ pub fn init_global_logging(
     // JSON log layer.
     let rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
     let (rolling_writer, rolling_writer_guard) = tracing_appender::non_blocking(rolling_appender);
-    let file_logging_layer = Layer::new().with_writer(rolling_writer);
+    let file_logging_layer = Layer::new().with_writer(rolling_writer).with_ansi(false);
     guards.push(rolling_writer_guard);
 
     // error JSON log layer.

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -146,13 +146,13 @@ pub fn init_global_logging(
         None
     };
 
-    // JSON log layer.
+    // file log layer.
     let rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
     let (rolling_writer, rolling_writer_guard) = tracing_appender::non_blocking(rolling_appender);
     let file_logging_layer = Layer::new().with_writer(rolling_writer);
     guards.push(rolling_writer_guard);
 
-    // error JSON log layer.
+    // error file log layer.
     let err_rolling_appender =
         RollingFileAppender::new(Rotation::HOURLY, dir, format!("{}-{}", app_name, "err"));
     let (err_rolling_writer, err_rolling_writer_guard) =

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -149,7 +149,7 @@ pub fn init_global_logging(
     // file log layer.
     let rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
     let (rolling_writer, rolling_writer_guard) = tracing_appender::non_blocking(rolling_appender);
-    let file_logging_layer = Layer::new().with_writer(rolling_writer);
+    let file_logging_layer = Layer::new().with_writer(rolling_writer).with_ansi(false);
     guards.push(rolling_writer_guard);
 
     // error file log layer.
@@ -157,7 +157,9 @@ pub fn init_global_logging(
         RollingFileAppender::new(Rotation::HOURLY, dir, format!("{}-{}", app_name, "err"));
     let (err_rolling_writer, err_rolling_writer_guard) =
         tracing_appender::non_blocking(err_rolling_appender);
-    let err_file_logging_layer = Layer::new().with_writer(err_rolling_writer);
+    let err_file_logging_layer = Layer::new()
+        .with_writer(err_rolling_writer)
+        .with_ansi(false);
     guards.push(err_rolling_writer_guard);
 
     // resolve log level settings from:

--- a/src/common/telemetry/src/logging.rs
+++ b/src/common/telemetry/src/logging.rs
@@ -149,7 +149,7 @@ pub fn init_global_logging(
     // JSON log layer.
     let rolling_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
     let (rolling_writer, rolling_writer_guard) = tracing_appender::non_blocking(rolling_appender);
-    let file_logging_layer = Layer::new().with_writer(rolling_writer).with_ansi(false);
+    let file_logging_layer = Layer::new().with_writer(rolling_writer);
     guards.push(rolling_writer_guard);
 
     // error JSON log layer.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Check if stdout is redirected for the logging layer. And disable ansi control char if it's redirected to a non-tty file.

log with `greptime standalone start`:
<img width="688" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/905fba7f-0f4b-4372-9283-c26c084b91b4">

log with `greptime standalone start > greptime.log`
<img width="784" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/4b1123cf-043a-4d42-904b-a7b8b24036bc">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

Closes #3323