### PR TITLE
build(deps): axum-tets-helper has included patch-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,23 +787,6 @@ dependencies = [
 
 [[package]]
 name = "axum-test-helper"
-version = "0.1.1"
-source = "git+https://github.com/sunng87/axum-test-helper.git?branch=patch-1#5aa7843ce2250144ea1b7f589f274c00cf1af4ab"
-dependencies = [
- "axum",
- "bytes",
- "http",
- "http-body",
- "hyper",
- "reqwest",
- "serde",
- "tokio",
- "tower",
- "tower-service",
-]
-
-[[package]]
-name = "axum-test-helper"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "298f62fa902c2515c169ab0bfb56c593229f33faa01131215d58e3d4898e3aa9"
@@ -8892,7 +8875,7 @@ dependencies = [
  "auth",
  "axum",
  "axum-macros",
- "axum-test-helper 0.3.0",
+ "axum-test-helper",
  "base64 0.21.5",
  "bytes",
  "catalog",
@@ -9965,7 +9948,7 @@ dependencies = [
  "async-trait",
  "auth",
  "axum",
- "axum-test-helper 0.1.1",
+ "axum-test-helper",
  "catalog",
  "chrono",
  "client",

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -13,7 +13,7 @@ arrow-flight.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum.workspace = true
-axum-test-helper = { git = "https://github.com/sunng87/axum-test-helper.git", branch = "patch-1" }
+axum-test-helper = "0.3.0"
 catalog.workspace = true
 chrono.workspace = true
 client = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

See https://github.com/cloudwalk/axum-test-helper/pull/8 and compared with https://github.com/cloudwalk/axum-test-helper/compare/main...sunng87:axum-test-helper:patch-1.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
