### PR TITLE
feat: make tls certificates/keys reloadable (part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,6 +3586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,6 +4379,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4564,6 +4593,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
 dependencies = [
  "indexmap 2.1.0",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -5654,6 +5703,25 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -8995,6 +9063,7 @@ dependencies = [
  "lazy_static",
  "mime_guess",
  "mysql_async",
+ "notify",
  "once_cell",
  "openmetrics-parser",
  "opensrv-mysql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9096,6 +9096,7 @@ dependencies = [
  "sql",
  "strum 0.25.0",
  "table",
+ "tempfile",
  "tikv-jemalloc-ctl",
  "tokio",
  "tokio-postgres",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -59,6 +59,7 @@ influxdb_line_protocol = { git = "https://github.com/evenyag/influxdb_iox", bran
 itertools.workspace = true
 lazy_static.workspace = true
 mime_guess = "2.0"
+notify = "6.1"
 once_cell.workspace = true
 openmetrics-parser = "0.4"
 opensrv-mysql = "0.7.0"

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -122,6 +122,7 @@ script = { workspace = true, features = ["python"] }
 serde_json.workspace = true
 session = { workspace = true, features = ["testing"] }
 table.workspace = true
+tempfile = "3.0.0"
 tokio-postgres = "0.7"
 tokio-postgres-rustls = "0.11"
 tokio-test = "0.4"

--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -441,6 +441,12 @@ pub enum Error {
         "Invalid parameter, physical_table is not expected when metric engine is disabled"
     ))]
     UnexpectedPhysicalTable { location: Location },
+
+    #[snafu(display("Failed to initialize a watcher for file"))]
+    FileWatch {
+        #[snafu(source)]
+        error: notify::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -462,7 +468,8 @@ impl ErrorExt for Error {
             | CatalogError { .. }
             | GrpcReflectionService { .. }
             | BuildHttpResponse { .. }
-            | Arrow { .. } => StatusCode::Internal,
+            | Arrow { .. }
+            | FileWatch { .. } => StatusCode::Internal,
 
             UnsupportedDataType { .. } => StatusCode::Unsupported,
 

--- a/src/servers/src/mysql/server.rs
+++ b/src/servers/src/mysql/server.rs
@@ -33,6 +33,7 @@ use crate::error::{Error, Result};
 use crate::mysql::handler::MysqlInstanceShim;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 use crate::server::{AbortableStream, BaseTcpServer, Server};
+use crate::tls::ReloadableTlsServerConfig;
 
 // Default size of ResultSet write buffer: 100KB
 const DEFAULT_RESULT_SET_WRITE_BUFFER_SIZE: usize = 100 * 1024;
@@ -68,7 +69,7 @@ impl MysqlSpawnRef {
 pub struct MysqlSpawnConfig {
     // tls config
     force_tls: bool,
-    tls: Option<Arc<ServerConfig>>,
+    tls: Arc<ReloadableTlsServerConfig>,
     // other shim config
     reject_no_database: bool,
 }
@@ -76,7 +77,7 @@ pub struct MysqlSpawnConfig {
 impl MysqlSpawnConfig {
     pub fn new(
         force_tls: bool,
-        tls: Option<Arc<ServerConfig>>,
+        tls: Arc<ReloadableTlsServerConfig>,
         reject_no_database: bool,
     ) -> MysqlSpawnConfig {
         MysqlSpawnConfig {
@@ -87,7 +88,7 @@ impl MysqlSpawnConfig {
     }
 
     fn tls(&self) -> Option<Arc<ServerConfig>> {
-        self.tls.clone()
+        self.tls.get_server_config()
     }
 }
 

--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -187,6 +187,10 @@ impl ReloadableTlsServerConfig {
 }
 
 pub fn watch_tls_config(tls_server_config: Arc<ReloadableTlsServerConfig>) -> Result<()> {
+    if tls_server_config.get_tls_option().mode == TlsMode::Disable {
+        return Ok(());
+    }
+
     let tls_server_config_for_watcher = tls_server_config.clone();
 
     let (tx, rx) = channel::<notify::Result<notify::Event>>();

--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -13,14 +13,21 @@
 // limitations under the License.
 
 use std::fs::File;
-use std::io::{BufReader, Error, ErrorKind};
+use std::io::{BufReader, Error as IoError, ErrorKind};
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
+use common_telemetry::{error, info};
+use notify::{EventKind, RecursiveMode, Watcher};
 use rustls::ServerConfig;
 use rustls_pemfile::{certs, pkcs8_private_keys, rsa_private_keys};
 use rustls_pki_types::{CertificateDer, PrivateKeyDer};
 use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
 use strum::EnumString;
+
+use crate::error::{FileWatchSnafu, InternalIoSnafu, Result};
 
 /// TlsMode is used for Mysql and Postgres server start up.
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq, EnumString)]
@@ -74,27 +81,38 @@ impl TlsOption {
         tls_option
     }
 
-    pub fn setup(&self) -> Result<Option<ServerConfig>, Error> {
+    pub fn setup(&self) -> Result<Option<ServerConfig>> {
         if let TlsMode::Disable = self.mode {
             return Ok(None);
         }
-        let cert = certs(&mut BufReader::new(File::open(&self.cert_path)?))
-            .collect::<Result<Vec<CertificateDer>, Error>>()?;
+        let cert = certs(&mut BufReader::new(
+            File::open(&self.cert_path).context(InternalIoSnafu)?,
+        ))
+        .collect::<std::result::Result<Vec<CertificateDer>, IoError>>()
+        .context(InternalIoSnafu)?;
 
         let key = {
-            let mut pkcs8 = pkcs8_private_keys(&mut BufReader::new(File::open(&self.key_path)?))
-                .map(|key| key.map(PrivateKeyDer::from))
-                .collect::<Result<Vec<PrivateKeyDer>, Error>>()?;
+            let mut pkcs8 = pkcs8_private_keys(&mut BufReader::new(
+                File::open(&self.key_path).context(InternalIoSnafu)?,
+            ))
+            .map(|key| key.map(PrivateKeyDer::from))
+            .collect::<std::result::Result<Vec<PrivateKeyDer>, IoError>>()
+            .context(InternalIoSnafu)?;
+
             if !pkcs8.is_empty() {
                 pkcs8.remove(0)
             } else {
-                let mut rsa = rsa_private_keys(&mut BufReader::new(File::open(&self.key_path)?))
-                    .map(|key| key.map(PrivateKeyDer::from))
-                    .collect::<Result<Vec<PrivateKeyDer>, Error>>()?;
+                let mut rsa = rsa_private_keys(&mut BufReader::new(
+                    File::open(&self.key_path).context(InternalIoSnafu)?,
+                ))
+                .map(|key| key.map(PrivateKeyDer::from))
+                .collect::<std::result::Result<Vec<PrivateKeyDer>, IoError>>()
+                .context(InternalIoSnafu)?;
                 if !rsa.is_empty() {
                     rsa.remove(0)
                 } else {
-                    return Err(Error::new(ErrorKind::InvalidInput, "invalid key"));
+                    return Err(IoError::new(ErrorKind::InvalidInput, "invalid key"))
+                        .context(InternalIoSnafu);
                 }
             }
         };
@@ -111,32 +129,95 @@ impl TlsOption {
     pub fn should_force_tls(&self) -> bool {
         !matches!(self.mode, TlsMode::Disable | TlsMode::Prefer)
     }
+
+    pub fn cert_path(&self) -> &Path {
+        Path::new(&self.cert_path)
+    }
+
+    pub fn key_path(&self) -> &Path {
+        Path::new(&self.key_path)
+    }
 }
 
+/// A mutable container for TLS server config
+///
+/// This struct allows dynamic reloading of server certificates and keys
 pub struct ReloadableTlsServerConfig {
     tls_option: TlsOption,
     config: RwLock<Option<Arc<ServerConfig>>>,
+    version: AtomicUsize,
 }
 
 impl ReloadableTlsServerConfig {
-    pub fn try_new(tls_option: TlsOption) -> Result<ReloadableTlsServerConfig, Error> {
+    /// Create server config by loading configuration from `TlsOption`
+    pub fn try_new(tls_option: TlsOption) -> Result<ReloadableTlsServerConfig> {
         let server_config = tls_option.setup()?;
         Ok(Self {
             tls_option,
             config: RwLock::new(server_config.map(Arc::new)),
+            version: AtomicUsize::new(0),
         })
     }
 
     /// Reread server certificates and keys from file system.
-    pub fn reload(&self) -> Result<(), Error> {
+    pub fn reload(&self) -> Result<()> {
         let server_config = self.tls_option.setup()?;
         *self.config.write().unwrap() = server_config.map(Arc::new);
+        self.version.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
 
+    /// Get the server config hold by this container
     pub fn get_server_config(&self) -> Option<Arc<ServerConfig>> {
         self.config.read().unwrap().clone()
     }
+
+    /// Get associated `TlsOption`
+    pub fn get_tls_option(&self) -> &TlsOption {
+        &self.tls_option
+    }
+
+    /// Get version of current config
+    ///
+    /// this version will auto increase when server config get reloaded.
+    pub fn get_version(&self) -> usize {
+        self.version.load(Ordering::Relaxed)
+    }
+}
+
+pub fn watch_tls_config(tls_server_config: Arc<ReloadableTlsServerConfig>) -> Result<()> {
+    let tls_server_config_for_watcher = tls_server_config.clone();
+    let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+        if let Ok(event) = res {
+            match event.kind {
+                EventKind::Modify(_) | EventKind::Create(_) => {
+                    info!("Detected TLS cert/key file change: {:?}", event);
+                    if let Err(err) = tls_server_config_for_watcher.reload() {
+                        error!(err; "Failed to reload TLS server config");
+                    }
+                }
+                _ => {}
+            }
+        }
+    })
+    .context(FileWatchSnafu)?;
+
+    // Add a path to be watched. All files and directories at that path and
+    // below will be monitored for changes.
+    watcher
+        .watch(
+            tls_server_config.get_tls_option().cert_path(),
+            RecursiveMode::NonRecursive,
+        )
+        .context(FileWatchSnafu)?;
+    watcher
+        .watch(
+            tls_server_config.get_tls_option().key_path(),
+            RecursiveMode::NonRecursive,
+        )
+        .context(FileWatchSnafu)?;
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -264,4 +345,7 @@ mod tests {
         assert!(!t.key_path.is_empty());
         assert!(!t.cert_path.is_empty());
     }
+
+    #[test]
+    fn test_tls_file_change_watch() {}
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Part 1 of implementation for #3255

This patch caches TLS `ServerConfig` in a mutable container to make it possible to update by other threads. `TlsAcceptor` is a lightweight container of `ServerConfig` so it's OK to create for each connnection.

This patch also includes a file system watcher to detect file change of certificates/keys and reload them as needed.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
