### PR TITLE
chore: remove unused deprecated table_dir_with_catalog_and_schema

### DIFF
--- a/src/store-api/src/path_utils.rs
+++ b/src/store-api/src/path_utils.rs
@@ -32,12 +32,6 @@ pub fn region_name(table_id: TableId, region_number: RegionNumber) -> String {
     format!("{table_id}_{region_number:010}")
 }
 
-// TODO(jeremy): There are still some dependencies on it. Someone will be here soon to remove it.
-pub fn table_dir_with_catalog_and_schema(catalog: &str, schema: &str, table_id: TableId) -> String {
-    let path = format!("{}/{}", catalog, schema);
-    table_dir(&path, table_id)
-}
-
 #[inline]
 pub fn table_dir(path: &str, table_id: TableId) -> String {
     format!("{DATA_DIR}{path}/{table_id}/")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

TRIVIAL AS IS.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
