### PR TITLE
ci: try fix log location

### DIFF
--- a/.github/actions/build-windows-artifacts/action.yml
+++ b/.github/actions/build-windows-artifacts/action.yml
@@ -65,7 +65,7 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: sqlness-logs
-        path: ${{ runner.temp }}/greptime-*.log
+        path: /tmp/greptime-*.log
         retention-days: 3
 
     - name: Build greptime binary

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,7 +1,7 @@
 on:
   merge_group:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - 'docs/**'
       - 'config/**'
@@ -57,7 +57,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        with: 
+        with:
           # Shares across multiple jobs
           # Shares with `Clippy` job
           shared-key: "check-lint"
@@ -75,7 +75,7 @@ jobs:
           toolchain: stable
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        with: 
+        with:
           # Shares across multiple jobs
           shared-key: "check-toml"
       - name: Install taplo
@@ -136,13 +136,12 @@ jobs:
         run: tar -xvf ./bins.tar.gz
       - name: Run sqlness
         run: RUST_BACKTRACE=1 ./bins/sqlness-runner -c ./tests/cases --bins-dir ./bins
-      # FIXME: Logs cannot found be on failure (or even success). Need to figure out the cause.
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: sqlness-logs
-          path: ${{ runner.temp }}/greptime-*.log
+          path: /tmp/greptime-*.log
           retention-days: 3
 
   sqlness-kafka-wal:
@@ -167,13 +166,12 @@ jobs:
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run sqlness
         run: RUST_BACKTRACE=1 ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases --bins-dir ./bins
-      # FIXME: Logs cannot be found on failure (or even success). Need to figure out the cause.
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: sqlness-logs
-          path: ${{ runner.temp }}/greptime-*.log
+          path: /tmp/greptime-*.log
           retention-days: 3
 
   fmt:
@@ -191,7 +189,7 @@ jobs:
           components: rustfmt
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        with: 
+        with:
           # Shares across multiple jobs
           shared-key: "check-rust-fmt"
       - name: Run cargo fmt
@@ -212,7 +210,7 @@ jobs:
           components: clippy
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
-        with: 
+        with:
           # Shares across multiple jobs
           # Shares with `Check` job
           shared-key: "check-lint"

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: sqlness-logs
-          path: ${{ runner.temp }}/greptime-*.log
+          path: /tmp/greptime-*.log
           retention-days: 3
 
   test-on-windows:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

> No files were found with the provided path: /home/runner/work/_temp/greptime-*.log. No artifacts will be uploaded.

Try `/tmp/greptime-*.log`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
