### PR TITLE
feat: replace pk index with pk_weight during freeze

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -238,11 +238,13 @@ fn data_buffer_to_record_batches(
             rows.into_iter().map(|(_, key)| key.pk_weight),
         )) as Arc<_>
     } else {
-        arrow::compute::take(&pk_index_v.to_arrow_array(), &indices_to_take, None)
-            .context(error::ComputeArrowSnafu)?
+        pk_index_v.to_arrow_array()
     };
 
-    columns.push(pk_array);
+    columns.push(
+        arrow::compute::take(&pk_array, &indices_to_take, None)
+            .context(error::ComputeArrowSnafu)?,
+    );
 
     columns.push(
         arrow::compute::take(&ts_v.to_arrow_array(), &indices_to_take, None)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Impl `DataBuffer::freeze` method, which sorts rows in `DataBuffer` according to pk weights and replaces pk_index values with pk_weights directly.


## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
