### PR TITLE
feat: merge tree data parts 

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -566,6 +566,12 @@ pub enum Error {
         error: parquet::errors::ParquetError,
         location: Location,
     },
+
+    #[snafu(display("Failed to iter data part"))]
+    ReadDataPart {
+        #[snafu(source)]
+        error: parquet::errors::ParquetError,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -669,7 +675,7 @@ impl ErrorExt for Error {
             FilterRecordBatch { source, .. } => source.status_code(),
             Upload { .. } => StatusCode::StorageUnavailable,
             BiError { .. } => StatusCode::Internal,
-            EncodeMemtable { .. } => StatusCode::Internal,
+            EncodeMemtable { .. } | ReadDataPart { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -532,7 +532,10 @@ impl<'a> DataPartEncoder<'a> {
 
 /// Data parts under a shard.
 pub struct DataParts {
-    parts: Vec<DataPart>,
+    /// The active writing buffer.
+    pub(crate) active: DataBuffer,
+    /// immutable (encoded) parts.
+    pub(crate) frozen: Vec<DataPart>,
 }
 
 /// Format of immutable data part.
@@ -548,7 +551,7 @@ impl DataPart {
     }
 
     /// Reads frozen data part and yields [DataBatch]es.
-    pub fn read(&self, _pk_weights: &[u16]) -> Result<DataPartReader> {
+    pub fn read(&self) -> Result<DataPartReader> {
         match self {
             DataPart::Parquet(data_bytes) => DataPartReader::new(data_bytes.data.clone(), None),
         }
@@ -1024,7 +1027,7 @@ mod tests {
         let encoder = DataPartEncoder::new(&meta, weights, Some(4));
         let encoded = encoder.write(&mut buffer).unwrap();
 
-        let mut iter = encoded.read(weights).unwrap();
+        let mut iter = encoded.read().unwrap();
         check_part_values_equal(&mut iter, expected_values);
     }
 

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -35,7 +35,6 @@ use datatypes::vectors::{
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
-use parquet::format::FileMetaData;
 use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::{OP_TYPE_COLUMN_NAME, SEQUENCE_COLUMN_NAME};
@@ -522,10 +521,9 @@ impl<'a> DataPartEncoder<'a> {
             true,
         )?;
         writer.write(&rb).context(error::EncodeMemtableSnafu)?;
-        let metadata = writer.close().context(error::EncodeMemtableSnafu)?;
+        let _metadata = writer.close().context(error::EncodeMemtableSnafu)?;
         Ok(DataPart::Parquet(ParquetPart {
             data: Bytes::from(bytes),
-            metadata,
         }))
     }
 }
@@ -654,7 +652,6 @@ impl DataPartReader {
 /// Parquet-encoded `DataPart`.
 pub struct ParquetPart {
     data: Bytes,
-    metadata: FileMetaData,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -547,8 +547,7 @@ impl DataPart {
         }
     }
 
-    /// Reads frozen data parts and yields record batches.
-    /// Returned record batches are ga
+    /// Reads frozen data part and yields [DataBatch]es.
     pub fn read(&self, _pk_weights: &[u16]) -> Result<DataPartReader> {
         match self {
             DataPart::Parquet(data_bytes) => DataPartReader::new(data_bytes.data.clone(), None),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

- Define `DataPart` and `DataParts`, and add `read` method for it.
- Rename `iter` method in `DataBuffer` to `read` as it no long implements `Iterator` trait.


## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804