### PR TITLE
feat: Defines more structs and methods for a partitioned merge tree

### DIFF
--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -94,7 +94,8 @@ impl Memtable for MergeTreeMemtable {
         // TODO(yingwen): Validate schema while inserting rows.
 
         let mut metrics = WriteMetrics::default();
-        let res = self.tree.write(kvs, &mut metrics);
+        let mut pk_buffer = Vec::new();
+        let res = self.tree.write(kvs, &mut pk_buffer, &mut metrics);
 
         self.update_stats(&metrics);
 

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -16,11 +16,19 @@
 //!
 //! We only support partitioning the tree by pre-defined internal columns.
 
+use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 
+use common_recordbatch::filter::SimpleFilterEvaluator;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::ColumnId;
+
+use crate::error::Result;
+use crate::memtable::key_values::KeyValue;
+use crate::memtable::merge_tree::metrics::WriteMetrics;
 use crate::memtable::merge_tree::shard::Shard;
 use crate::memtable::merge_tree::shard_builder::ShardBuilder;
-use crate::memtable::merge_tree::ShardId;
+use crate::memtable::merge_tree::{MergeTreeConfig, PkId, ShardId};
 
 /// Key of a partition.
 pub type PartitionKey = u32;
@@ -30,13 +38,113 @@ pub struct Partition {
     inner: RwLock<Inner>,
 }
 
+impl Partition {
+    /// Creates a new partition.
+    pub fn new(_metadata: RegionMetadataRef, _config: &MergeTreeConfig) -> Self {
+        unimplemented!()
+    }
+
+    /// Writes to the partition with a primary key.
+    pub fn write_with_key(
+        &self,
+        primary_key: &[u8],
+        key_value: KeyValue,
+        metrics: &mut WriteMetrics,
+    ) -> Result<()> {
+        let mut inner = self.inner.write().unwrap();
+        // Now we ensure one key only exists in one shard.
+        if let Some(pk_id) = inner.find_key_in_shards(primary_key) {
+            // Key already in shards.
+            return inner.write_to_shard(pk_id, key_value);
+        }
+
+        // Write to the shard builder.
+        inner
+            .shard_builder
+            .write_with_key(primary_key, key_value, metrics)?;
+        if inner.shard_builder.should_freeze() {
+            let shard_id = inner.active_shard_id;
+            let shard = inner.shard_builder.finish(shard_id)?;
+            inner.active_shard_id += 1;
+            inner.shards.push(shard);
+        }
+
+        Ok(())
+    }
+
+    /// Writes to the partition without a primary key.
+    pub fn write_on_key(&self, key_value: KeyValue, metrics: &mut WriteMetrics) -> Result<()> {
+        let mut inner = self.inner.write().unwrap();
+        // If no primary key, always write to the first shard.
+        if inner.shards.is_empty() {
+            let shard_id = inner.active_shard_id;
+            inner.shards.push(Shard::new_no_dict(shard_id));
+            inner.active_shard_id += 1;
+        }
+
+        // A dummy pk id.
+        let pk_id = PkId {
+            shard_id: inner.active_shard_id - 1,
+            pk_index: 0,
+        };
+        inner.shards[0].write_key_value(pk_id, key_value, metrics)
+    }
+
+    /// Scans data in the partition.
+    pub fn scan(
+        &self,
+        _projection: HashSet<ColumnId>,
+        _filters: Vec<SimpleFilterEvaluator>,
+    ) -> Result<PartitionReader> {
+        unimplemented!()
+    }
+
+    /// Freezes the partition.
+    pub fn freeze(&mut self) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Forks the partition.
+    pub fn fork(&self, _metadata: RegionMetadataRef) -> Partition {
+        unimplemented!()
+    }
+
+    /// Returns shared memory size of the partition.
+    pub fn shared_memory_size(&self) -> usize {
+        unimplemented!()
+    }
+}
+
+/// Reader to scan rows in a partition.
+///
+/// It can merge rows from multiple shards.
+pub struct PartitionReader {}
+
 pub type PartitionRef = Arc<Partition>;
 
 /// Inner struct of the partition.
+///
+/// A key only exists in one shard.
 struct Inner {
     /// Shard whose dictionary is active.
     shard_builder: ShardBuilder,
-    next_shard_id: ShardId,
+    active_shard_id: ShardId,
     /// Shards with frozon dictionary.
     shards: Vec<Shard>,
+}
+
+impl Inner {
+    fn find_key_in_shards(&self, primary_key: &[u8]) -> Option<PkId> {
+        for shard in &self.shards {
+            if let Some(pkid) = shard.find_key(primary_key) {
+                return Some(pkid);
+            }
+        }
+
+        None
+    }
+
+    fn write_to_shard(&mut self, _pk_id: PkId, _key_value: KeyValue) -> Result<()> {
+        unimplemented!()
+    }
 }

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -101,12 +101,17 @@ impl Partition {
     }
 
     /// Freezes the partition.
-    pub fn freeze(&mut self) -> Result<()> {
+    pub fn freeze(&self) -> Result<()> {
         unimplemented!()
     }
 
     /// Forks the partition.
-    pub fn fork(&self, _metadata: RegionMetadataRef) -> Partition {
+    pub fn fork(&self, _metadata: &RegionMetadataRef) -> Partition {
+        unimplemented!()
+    }
+
+    /// Returns true if the partition has data.
+    pub fn has_data(&self) -> bool {
         unimplemented!()
     }
 

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -141,6 +141,11 @@ impl Partition {
             .map(|meta| meta.column_schema.name == DATA_SCHEMA_TABLE_ID_COLUMN_NAME)
             .unwrap_or(false)
     }
+
+    /// Returns true if this is a partition column.
+    pub(crate) fn is_partition_column(name: &str) -> bool {
+        name == DATA_SCHEMA_TABLE_ID_COLUMN_NAME
+    }
 }
 
 /// Reader to scan rows in a partition.

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -74,7 +74,7 @@ impl Partition {
     }
 
     /// Writes to the partition without a primary key.
-    pub fn write_on_key(&self, key_value: KeyValue, metrics: &mut WriteMetrics) -> Result<()> {
+    pub fn write_no_key(&self, key_value: KeyValue, metrics: &mut WriteMetrics) -> Result<()> {
         let mut inner = self.inner.write().unwrap();
         // If no primary key, always write to the first shard.
         if inner.shards.is_empty() {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -14,9 +14,17 @@
 
 //! Shard in a partition.
 
+use std::collections::HashSet;
+
+use common_recordbatch::filter::SimpleFilterEvaluator;
+use store_api::storage::ColumnId;
+
+use crate::error::Result;
+use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::data::DataParts;
 use crate::memtable::merge_tree::dict::KeyDictRef;
-use crate::memtable::merge_tree::ShardId;
+use crate::memtable::merge_tree::metrics::WriteMetrics;
+use crate::memtable::merge_tree::{PkId, ShardId};
 
 /// Shard stores data related to the same key dictionary.
 pub struct Shard {
@@ -26,3 +34,37 @@ pub struct Shard {
     /// Data in the shard.
     data_parts: DataParts,
 }
+
+impl Shard {
+    /// Returns a shard without dictionary.
+    pub fn new_no_dict(_shard_id: ShardId) -> Shard {
+        unimplemented!()
+    }
+
+    /// Returns the pk id of the key if it exists.
+    pub fn find_key(&self, _key: &[u8]) -> Option<PkId> {
+        unimplemented!()
+    }
+
+    /// Writes a key value into the shard.
+    pub fn write_key_value(
+        &mut self,
+        _pk_id: PkId,
+        _key_value: KeyValue,
+        _metrics: &mut WriteMetrics,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Scans the shard.
+    pub fn scan(
+        &self,
+        _projection: &HashSet<ColumnId>,
+        _filters: &[SimpleFilterEvaluator],
+    ) -> ShardReader {
+        unimplemented!()
+    }
+}
+
+/// Reader to read rows in a shard.
+pub struct ShardReader {}

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -14,8 +14,13 @@
 
 //! Builder of a shard.
 
+use crate::error::Result;
+use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::data::DataBuffer;
 use crate::memtable::merge_tree::dict::KeyDictBuilder;
+use crate::memtable::merge_tree::metrics::WriteMetrics;
+use crate::memtable::merge_tree::shard::Shard;
+use crate::memtable::merge_tree::ShardId;
 
 /// Builder to write keys and data to a shard that the key dictionary
 /// is still active.
@@ -24,4 +29,40 @@ pub struct ShardBuilder {
     dict_builder: KeyDictBuilder,
     /// Buffer to store data.
     data_buffer: DataBuffer,
+    /// Max keys in an index shard.
+    index_max_keys_per_shard: usize,
+    /// Number of rows to freeze a data part.
+    data_freeze_threshold: usize,
+}
+
+impl ShardBuilder {
+    /// Write a key value with its encoded primary key.
+    pub fn write_with_key(
+        &mut self,
+        _key: &[u8],
+        _key_value: KeyValue,
+        _metrics: &mut WriteMetrics,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Returns true if the builder is empty.
+    pub fn is_empty(&self) -> bool {
+        unimplemented!()
+    }
+
+    /// Returns true if the builder need to freeze.
+    pub fn should_freeze(&self) -> bool {
+        unimplemented!()
+    }
+
+    /// Builds a new shard and resets the builder.
+    pub fn finish(&mut self, _shard_id: ShardId) -> Result<Shard> {
+        unimplemented!()
+    }
+
+    /// Builds a new shard.
+    pub fn finish_cloned(&mut self, _shard_id: ShardId) -> Result<Shard> {
+        unimplemented!()
+    }
 }

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -240,7 +240,7 @@ impl MergeTree {
         let partition_key = Partition::get_partition_key(&key_value, self.is_partitioned);
         let partition = self.get_or_create_partition(partition_key);
 
-        partition.write_on_key(key_value, metrics)
+        partition.write_no_key(key_value, metrics)
     }
 
     fn get_or_create_partition(&self, partition_key: PartitionKey) -> PartitionRef {

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -112,7 +112,7 @@ impl MergeTree {
             self.row_codec.encode_to_vec(kv.primary_keys(), pk_buffer)?;
 
             // Write rows with primary keys.
-            self.write_with_key(&pk_buffer, kv, metrics)?;
+            self.write_with_key(pk_buffer, kv, metrics)?;
         }
 
         metrics.value_bytes +=
@@ -261,7 +261,7 @@ impl MergeTree {
                     let mut pruned = VecDeque::new();
                     for (key, partition) in partitions.iter() {
                         if filter
-                            .evaluate_scalar(&ScalarValue::UInt32(Some(*key as u32)))
+                            .evaluate_scalar(&ScalarValue::UInt32(Some(*key)))
                             .unwrap_or(true)
                         {
                             pruned.push_back(partition.clone());

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -320,7 +320,9 @@ impl SeriesSet {
 
 /// Creates an arrow [SchemaRef](arrow::datatypes::SchemaRef) that only contains primary keys
 /// of given region schema
-fn primary_key_schema(region_metadata: &RegionMetadataRef) -> arrow::datatypes::SchemaRef {
+pub(crate) fn primary_key_schema(
+    region_metadata: &RegionMetadataRef,
+) -> arrow::datatypes::SchemaRef {
     let fields = region_metadata
         .primary_key_columns()
         .map(|pk| {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR defines more methods and structs related to `Partition` and `Shard` for the merge tree.
- The `Partition` provides two methods `write_with_key()` and `write_no_key()` to write a row with or without a primary key
- We can scan the partition by the `scan()` method
- We can also freeze or fork a partition
- `Shard` also has similar methods
- We use the value of `__table_id` column as partition key
- The merge tree finds a partition according to the partition key to a row


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804 