### PR TITLE
test: fix list_files_and_parse_table_name path issue on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6078,6 +6078,7 @@ dependencies = [
  "meter-macros",
  "object-store",
  "partition",
+ "path-slash",
  "prometheus",
  "query",
  "regex",
@@ -6351,6 +6352,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pathdiff"

--- a/src/common/datasource/src/object_store.rs
+++ b/src/common/datasource/src/object_store.rs
@@ -56,6 +56,7 @@ pub fn parse_url(url: &str) -> Result<(String, Option<String>, String)> {
 pub fn build_backend(url: &str, connection: &HashMap<String, String>) -> Result<ObjectStore> {
     let (schema, host, path) = parse_url(url)?;
     let (root, _) = find_dir_and_filename(&path);
+    println!("schema {schema}, host {host:?} path {path} root {root}");
 
     match schema.to_uppercase().as_str() {
         S3_SCHEMA => {

--- a/src/common/datasource/src/object_store.rs
+++ b/src/common/datasource/src/object_store.rs
@@ -56,7 +56,6 @@ pub fn parse_url(url: &str) -> Result<(String, Option<String>, String)> {
 pub fn build_backend(url: &str, connection: &HashMap<String, String>) -> Result<ObjectStore> {
     let (schema, host, path) = parse_url(url)?;
     let (root, _) = find_dir_and_filename(&path);
-    println!("schema {schema}, host {host:?} path {path} root {root}");
 
     match schema.to_uppercase().as_str() {
         S3_SCHEMA => {

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -58,3 +58,4 @@ tonic.workspace = true
 
 [dev-dependencies]
 common-test-util.workspace = true
+path-slash = "0.2"

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -224,7 +224,8 @@ mod tests {
         object_store.write("d", "").await.unwrap();
         object_store.write("e.f.parquet", "").await.unwrap();
 
-        let location = dir.path().to_slash().unwrap().to_string();
+        let location = normalize_dir(dir.path().to_slash().unwrap());
+        println!("location is {}", location);
         let request = CopyDatabaseRequest {
             catalog_name: "catalog_0".to_string(),
             schema_name: "schema_0".to_string(),

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -224,7 +224,7 @@ mod tests {
         object_store.write("d", "").await.unwrap();
         object_store.write("e.f.parquet", "").await.unwrap();
 
-        let location = normalize_dir(dir.path().to_slash().unwrap());
+        let location = normalize_dir(&dir.path().to_slash().unwrap());
         println!("location is {}", location);
         let request = CopyDatabaseRequest {
             catalog_name: "catalog_0".to_string(),

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -225,7 +225,6 @@ mod tests {
         object_store.write("e.f.parquet", "").await.unwrap();
 
         let location = normalize_dir(&dir.path().to_slash().unwrap());
-        println!("location is {}", location);
         let request = CopyDatabaseRequest {
             catalog_name: "catalog_0".to_string(),
             schema_name: "schema_0".to_string(),

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -206,6 +206,7 @@ mod tests {
     use object_store::services::Fs;
     use object_store::util::normalize_dir;
     use object_store::ObjectStore;
+    use path_slash::PathExt;
     use table::requests::CopyDatabaseRequest;
 
     use crate::statement::copy_database::{list_files_to_copy, parse_file_name_to_copy};
@@ -223,10 +224,11 @@ mod tests {
         object_store.write("d", "").await.unwrap();
         object_store.write("e.f.parquet", "").await.unwrap();
 
+        let location = dir.path().to_slash().unwrap().to_string();
         let request = CopyDatabaseRequest {
             catalog_name: "catalog_0".to_string(),
             schema_name: "schema_0".to_string(),
-            location: store_dir,
+            location,
             with: [("FORMAT".to_string(), "parquet".to_string())]
                 .into_iter()
                 .collect(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR converts the temp dir path to an object store style path in `list_files_and_parse_table_name`.

The `C:\Users\abc\temp` becomes `C:/Users/abc/temp` which is the supported form of us.

Users who'd like to use copy database on Windows should use unix-like path. See https://github.com/GreptimeTeam/greptimedb/issues/3195

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/3301