### PR TITLE
refactor: set the actual bound port in server handler

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -43,6 +43,10 @@ impl Instance {
     pub fn datanode_mut(&mut self) -> &mut Datanode {
         &mut self.datanode
     }
+
+    pub fn datanode(&self) -> &Datanode {
+        &self.datanode
+    }
 }
 
 #[async_trait]
@@ -235,6 +239,7 @@ impl StartCommand {
             .with_default_grpc_server(&datanode.region_server())
             .enable_http_service()
             .build()
+            .await
             .context(StartDatanodeSnafu)?;
         datanode.setup_services(services);
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -43,12 +43,16 @@ pub struct Instance {
 }
 
 impl Instance {
-    fn new(frontend: FeInstance) -> Self {
+    pub fn new(frontend: FeInstance) -> Self {
         Self { frontend }
     }
 
     pub fn mut_inner(&mut self) -> &mut FeInstance {
         &mut self.frontend
+    }
+
+    pub fn inner(&self) -> &FeInstance {
+        &self.frontend
     }
 }
 
@@ -271,6 +275,7 @@ impl StartCommand {
 
         let servers = Services::new(opts.clone(), Arc::new(instance.clone()), plugins)
             .build()
+            .await
             .context(StartFrontendSnafu)?;
         instance
             .build_servers(opts, servers)

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -32,11 +32,11 @@ lazy_static::lazy_static! {
 }
 
 #[async_trait]
-pub trait App {
+pub trait App: Send {
     fn name(&self) -> &str;
 
     /// A hook for implementor to make something happened before actual startup. Defaults to no-op.
-    fn pre_start(&mut self) -> error::Result<()> {
+    async fn pre_start(&mut self) -> error::Result<()> {
         Ok(())
     }
 
@@ -46,24 +46,21 @@ pub trait App {
 }
 
 pub async fn start_app(mut app: Box<dyn App>) -> error::Result<()> {
-    let name = app.name().to_string();
+    info!("Starting app: {}", app.name());
 
-    app.pre_start()?;
+    app.pre_start().await?;
 
-    tokio::select! {
-        result = app.start() => {
-            if let Err(err) = result {
-                error!(err; "Failed to start app {name}!");
-            }
-        }
-        _ = tokio::signal::ctrl_c() => {
-            if let Err(err) = app.stop().await {
-                error!(err; "Failed to stop app {name}!");
-            }
-            info!("Goodbye!");
-        }
+    app.start().await?;
+
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        error!("Failed to listen for ctrl-c signal: {}", e);
+        // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
+        // the underlying system. So we stop the app instead of running nonetheless to let people
+        // investigate the issue.
     }
 
+    app.stop().await?;
+    info!("Goodbye!");
     Ok(())
 }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -441,6 +441,7 @@ impl StartCommand {
 
         let servers = Services::new(fe_opts.clone(), Arc::new(frontend.clone()), fe_plugins)
             .build()
+            .await
             .context(StartFrontendSnafu)?;
         frontend
             .build_servers(fe_opts, servers)

--- a/src/datanode/src/datanode.rs
+++ b/src/datanode/src/datanode.rs
@@ -14,7 +14,6 @@
 
 //! Datanode implementation.
 
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -32,7 +31,6 @@ use common_wal::config::kafka::DatanodeKafkaConfig;
 use common_wal::config::raft_engine::RaftEngineConfig;
 use common_wal::config::DatanodeWalConfig;
 use file_engine::engine::FileRegionEngine;
-use futures::future;
 use futures_util::future::try_join_all;
 use futures_util::TryStreamExt;
 use log_store::kafka::log_store::KafkaLogStore;
@@ -45,7 +43,7 @@ use object_store::manager::{ObjectStoreManager, ObjectStoreManagerRef};
 use object_store::util::normalize_dir;
 use query::QueryEngineFactory;
 use servers::export_metrics::ExportMetricsTask;
-use servers::server::{start_server, ServerHandlers};
+use servers::server::ServerHandlers;
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
 use store_api::path_utils::{region_dir, WAL_DIR};
@@ -97,7 +95,11 @@ impl Datanode {
             t.start(None).context(StartServerSnafu)?
         }
 
-        self.start_services().await
+        self.services.start_all().await.context(StartServerSnafu)
+    }
+
+    pub fn server_handlers(&self) -> &ServerHandlers {
+        &self.services
     }
 
     pub fn start_telemetry(&self) {
@@ -127,24 +129,12 @@ impl Datanode {
         self.services = services;
     }
 
-    /// Start services of datanode. This method call will block until services are shutdown.
-    pub async fn start_services(&mut self) -> Result<()> {
-        let _ = future::try_join_all(self.services.values().map(start_server))
-            .await
-            .context(StartServerSnafu)?;
-        Ok(())
-    }
-
-    async fn shutdown_services(&self) -> Result<()> {
-        let _ = future::try_join_all(self.services.values().map(|server| server.0.shutdown()))
+    pub async fn shutdown(&self) -> Result<()> {
+        self.services
+            .shutdown_all()
             .await
             .context(ShutdownServerSnafu)?;
-        Ok(())
-    }
 
-    pub async fn shutdown(&self) -> Result<()> {
-        // We must shutdown services first
-        self.shutdown_services().await?;
         let _ = self.greptimedb_telemetry_task.stop().await;
         if let Some(heartbeat_task) = &self.heartbeat_task {
             heartbeat_task
@@ -268,7 +258,7 @@ impl DatanodeBuilder {
                 .context(StartServerSnafu)?;
 
         Ok(Datanode {
-            services: HashMap::new(),
+            services: ServerHandlers::default(),
             heartbeat_task,
             region_server,
             greptimedb_telemetry_task,

--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use catalog::kvbackend::KvBackendCatalogManager;
@@ -28,6 +27,7 @@ use operator::statement::StatementExecutor;
 use operator::table::TableMutationOperator;
 use partition::manager::PartitionRuleManager;
 use query::QueryEngineFactory;
+use servers::server::ServerHandlers;
 
 use crate::error::Result;
 use crate::heartbeat::HeartbeatTask;
@@ -141,7 +141,7 @@ impl FrontendBuilder {
             statement_executor,
             query_engine,
             plugins,
-            servers: Arc::new(HashMap::new()),
+            servers: ServerHandlers::default(),
             heartbeat_task: self.heartbeat_task,
             inserter,
             deleter,

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -78,7 +78,7 @@ pub struct MetaSrvBuilder {
     lock: Option<DistLockRef>,
     datanode_manager: Option<DatanodeManagerRef>,
     plugins: Option<Plugins>,
-    table_metadata_allocator: Option<TableMetadataAllocator>,
+    table_metadata_allocator: Option<TableMetadataAllocatorRef>,
 }
 
 impl MetaSrvBuilder {
@@ -150,7 +150,7 @@ impl MetaSrvBuilder {
 
     pub fn table_metadata_allocator(
         mut self,
-        table_metadata_allocator: TableMetadataAllocator,
+        table_metadata_allocator: TableMetadataAllocatorRef,
     ) -> Self {
         self.table_metadata_allocator = Some(table_metadata_allocator);
         self
@@ -211,7 +211,7 @@ impl MetaSrvBuilder {
             options.wal.clone(),
             kv_backend.clone(),
         ));
-        let table_metadata_allocator = Arc::new(table_metadata_allocator.unwrap_or_else(|| {
+        let table_metadata_allocator = table_metadata_allocator.unwrap_or_else(|| {
             let sequence = Arc::new(
                 SequenceBuilder::new(TABLE_ID_SEQ, kv_backend.clone())
                     .initial(MIN_USER_TABLE_ID as u64)
@@ -222,13 +222,13 @@ impl MetaSrvBuilder {
                 selector_ctx.clone(),
                 selector.clone(),
             ));
-            TableMetadataAllocator::with_peer_allocator(
+            Arc::new(TableMetadataAllocator::with_peer_allocator(
                 sequence,
                 wal_options_allocator.clone(),
                 table_metadata_manager.table_name_manager().clone(),
                 peer_allocator,
-            )
-        }));
+            ))
+        });
 
         let opening_region_keeper = Arc::new(MemoryRegionKeeper::default());
 

--- a/src/servers/src/server.rs
+++ b/src/servers/src/server.rs
@@ -62,7 +62,7 @@ impl ServerHandlers {
         handlers.get(name).map(|x| x.1)
     }
 
-    /// Starts all the managed services. It will block until all the services are started. 
+    /// Starts all the managed services. It will block until all the services are started.
     /// And it will set the actual bound address to the service.
     pub async fn start_all(&self) -> Result<()> {
         let mut handlers = self.handlers.write().await;

--- a/src/servers/src/server.rs
+++ b/src/servers/src/server.rs
@@ -62,8 +62,8 @@ impl ServerHandlers {
         handlers.get(name).map(|x| x.1)
     }
 
-    /// Starts all the managed services. It will block until all the services are started. And it will
-    /// set the actual bound address to the service.
+    /// Starts all the managed services. It will block until all the services are started. 
+    /// And it will set the actual bound address to the service.
     pub async fn start_all(&self) -> Result<()> {
         let mut handlers = self.handlers.write().await;
         try_join_all(handlers.values_mut().map(|(server, addr)| async move {

--- a/src/servers/src/server.rs
+++ b/src/servers/src/server.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use common_runtime::Runtime;
 use common_telemetry::logging::{error, info};
-use futures::future::{AbortHandle, AbortRegistration, Abortable};
+use futures::future::{try_join_all, AbortHandle, AbortRegistration, Abortable};
 use snafu::{ensure, ResultExt};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 
@@ -29,14 +29,66 @@ use crate::error::{self, Result};
 
 pub(crate) type AbortableStream = Abortable<TcpListenerStream>;
 
-pub type ServerHandlers = HashMap<String, ServerHandler>;
-
 pub type ServerHandler = (Box<dyn Server>, SocketAddr);
 
-pub async fn start_server(server_handler: &ServerHandler) -> Result<Option<SocketAddr>> {
-    let (server, addr) = server_handler;
-    info!("Starting {} at {}", server.name(), addr);
-    server.start(*addr).await.map(Some)
+/// [ServerHandlers] is used to manage the lifecycle of all the services like http or grpc in the GreptimeDB server.
+#[derive(Clone, Default)]
+pub struct ServerHandlers {
+    handlers: Arc<RwLock<HashMap<String, ServerHandler>>>,
+}
+
+impl ServerHandlers {
+    pub fn new() -> Self {
+        Self {
+            handlers: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn insert(&self, handler: ServerHandler) {
+        let mut handlers = self.handlers.write().await;
+        handlers.insert(handler.0.name().to_string(), handler);
+    }
+
+    /// Finds the __actual__ bound address of the service by its name.
+    ///
+    /// This is useful in testing. We can configure the service to bind to port 0 first, then start
+    /// the server to get the real bound port number. This way we avoid doing careful assignment of
+    /// the port number to the service in the test.
+    ///
+    /// Note that the address is guaranteed to be correct only after the `start_all` method is
+    /// successfully invoked. Otherwise you may find the address to be what you configured before.
+    pub async fn addr(&self, name: &str) -> Option<SocketAddr> {
+        let handlers = self.handlers.read().await;
+        handlers.get(name).map(|x| x.1)
+    }
+
+    /// Starts all the managed services. It will block until all the services are started. And it will
+    /// set the actual bound address to the service.
+    pub async fn start_all(&self) -> Result<()> {
+        let mut handlers = self.handlers.write().await;
+        try_join_all(handlers.values_mut().map(|(server, addr)| async move {
+            let bind_addr = server.start(*addr).await?;
+            *addr = bind_addr;
+            info!("Service {} is started at {}", server.name(), bind_addr);
+            Ok::<(), error::Error>(())
+        }))
+        .await?;
+        Ok(())
+    }
+
+    /// Shutdown all the managed services. It will block until all the services are shutdown.
+    pub async fn shutdown_all(&self) -> Result<()> {
+        // Even though the `shutdown` method in server does not require mut self, we still acquire
+        // write lock to pair with `start_all` method.
+        let handlers = self.handlers.write().await;
+        try_join_all(handlers.values().map(|(server, _)| async move {
+            server.shutdown().await?;
+            info!("Service {} is shutdown!", server.name());
+            Ok::<(), error::Error>(())
+        }))
+        .await?;
+        Ok(())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

... so we can use port 0 in testing. Also make http service not blocking the future.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
