### PR TITLE
ci: align docs workflow jobs with develop.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,6 +61,18 @@ jobs:
 
   sqlness:
     name: Sqlness Test
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
+    steps:
+      - run: 'echo "No action required"'
+
+  sqlness-kafka-wal:
+    name: Sqlness Test with Kafka Wal
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04 ]
     steps:
       - run: 'echo "No action required"'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

(yet another fix for the dumb GHA ruleset)

Align the jobs to `develop.yml`.

<img width="894" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/841844b6-7b86-45ea-b1d0-d440812a28ba">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
