### PR TITLE
fix: typo in lint config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,9 @@ license = "Apache-2.0"
 
 [workspace.lints]
 clippy.print_stdout = "warn"
-clippy.print_sterr = "warn"
+clippy.print_stderr = "warn"
 clippy.implicit_clone = "warn"
+rust.unknown_lints = "deny"
 
 [workspace.dependencies]
 ahash = { version = "0.8", features = ["compile-time-rng"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Fix a typo from https://github.com/GreptimeTeam/greptimedb/pull/3352, which would emit warnings like

![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/2f0a3315-a4ca-40f1-8194-75db74aabbec)

I also add a `deny` lint to prevent the same error. It works like

<img width="637" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/b84a28a7-3f36-4320-b512-0ec4b3909863">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
