### PR TITLE
feat: skip filling NULL for put and delete requests

### DIFF
--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -247,6 +247,10 @@ impl WriteRequest {
         // Need to add a default value for this column.
         let proto_value = self.column_default_value(column)?;
 
+        if proto_value.value_data.is_none() {
+            return Ok(());
+        }
+
         // Insert default value to each row.
         for row in &mut self.rows.rows {
             row.values.push(proto_value.clone());
@@ -989,16 +993,13 @@ mod tests {
         request.fill_missing_columns(&metadata).unwrap();
 
         let expect_rows = Rows {
-            schema: vec![
-                new_column_schema(
-                    "ts",
-                    ColumnDataType::TimestampMillisecond,
-                    SemanticType::Timestamp,
-                ),
-                new_column_schema("k0", ColumnDataType::Int64, SemanticType::Tag),
-            ],
+            schema: vec![new_column_schema(
+                "ts",
+                ColumnDataType::TimestampMillisecond,
+                SemanticType::Timestamp,
+            )],
             rows: vec![Row {
-                values: vec![ts_ms_value(1), Value { value_data: None }],
+                values: vec![ts_ms_value(1)],
             }],
         };
         assert_eq!(expect_rows, request.rows);
@@ -1104,17 +1105,11 @@ mod tests {
                     ColumnDataType::TimestampMillisecond,
                     SemanticType::Timestamp,
                 ),
-                new_column_schema("f0", ColumnDataType::Int64, SemanticType::Field),
                 new_column_schema("f1", ColumnDataType::Int64, SemanticType::Field),
             ],
             // Column f1 is not nullable and we use 0 for padding.
             rows: vec![Row {
-                values: vec![
-                    i64_value(100),
-                    ts_ms_value(1),
-                    Value { value_data: None },
-                    i64_value(0),
-                ],
+                values: vec![i64_value(100), ts_ms_value(1), i64_value(0)],
             }],
         };
         assert_eq!(expect_rows, request.rows);
@@ -1173,17 +1168,11 @@ mod tests {
                     ColumnDataType::TimestampMillisecond,
                     SemanticType::Timestamp,
                 ),
-                new_column_schema("f0", ColumnDataType::Int64, SemanticType::Field),
                 new_column_schema("f1", ColumnDataType::Int64, SemanticType::Field),
             ],
             // Column f1 is not nullable and we use 0 for padding.
             rows: vec![Row {
-                values: vec![
-                    i64_value(100),
-                    ts_ms_value(1),
-                    Value { value_data: None },
-                    i64_value(0),
-                ],
+                values: vec![i64_value(100), ts_ms_value(1), i64_value(0)],
             }],
         };
         assert_eq!(expect_rows, request.rows);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


As the title. Test result:

- Cut put latency by half

![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/c339e42c-899b-4caf-8a8b-a2853abb5231)

- Double put throughput (18w to 42w)


| Before | After |
|--------|--------|
| ![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/37c1dbe0-c4f1-4348-b98a-850c96a6cfc1) | ![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/fda37378-2a36-44cc-b809-7d574d19896e) | 

- No regression in TSBS (and somehow has a little improvement...)

Before
```
Summary:
loaded 1036800000 metrics in 190.468sec with 6 workers (mean rate 5443439.71 metrics/sec)
loaded 103680000 rows in 190.468sec with 6 workers (mean rate 544343.97 rows/sec)
```

After
```
Summary:
loaded 1036800000 metrics in 187.196sec with 6 workers (mean rate 5538568.26 metrics/sec)
loaded 103680000 rows in 187.196sec with 6 workers (mean rate 553856.83 rows/sec)
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
