### PR TITLE
feat: distinguish between different read paths

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -802,7 +802,7 @@ mod tests {
             true,
             true,
         )
-            .unwrap();
+        .unwrap();
 
         assert_eq!(
             vec![1, 2, 1, 2],

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -63,8 +63,8 @@ pub struct Merger<T: Node> {
 }
 
 impl<T> Merger<T>
-where
-    T: Node,
+    where
+        T: Node,
 {
     pub(crate) fn try_new(nodes: Vec<T>) -> Result<Self> {
         let mut heap = BinaryHeap::with_capacity(nodes.len());
@@ -372,7 +372,7 @@ impl Node for DataNode {
     }
 }
 
-fn timestamp_array_to_i64_slice(arr: &ArrayRef) -> &[i64] {
+pub(crate) fn timestamp_array_to_i64_slice(arr: &ArrayRef) -> &[i64] {
     match arr.data_type() {
         DataType::Timestamp(t, _) => match t {
             TimeUnit::Second => arr
@@ -470,12 +470,16 @@ mod tests {
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 1, vec![2, 3], &mut seq);
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![1, 2], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Part(
+            buffer1.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer2, &metadata, 1, vec![3], &mut seq);
         write_rows_to_buffer(&mut buffer2, &metadata, 0, vec![1], &mut seq);
-        let node2 = DataNode::new(DataSource::Buffer(buffer2.read(weight).unwrap()));
+        let node2 = DataNode::new(DataSource::Part(
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         check_merger_read(
             vec![node1, node2],
@@ -497,15 +501,21 @@ mod tests {
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 1, vec![2, 3], &mut seq);
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![1, 2], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Part(
+            buffer1.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer2, &metadata, 1, vec![3], &mut seq);
-        let node2 = DataNode::new(DataSource::Buffer(buffer2.read(weight).unwrap()));
+        let node2 = DataNode::new(DataSource::Part(
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer3 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer3, &metadata, 0, vec![2, 3], &mut seq);
-        let node3 = DataNode::new(DataSource::Buffer(buffer3.read(weight).unwrap()));
+        let node3 = DataNode::new(DataSource::Part(
+            buffer3.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         check_merger_read(
             vec![node1, node3, node2],
@@ -528,15 +538,21 @@ mod tests {
         let weight = &[0, 1, 2];
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![1, 2, 3], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Part(
+            buffer1.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer2, &metadata, 1, vec![2, 3], &mut seq);
-        let node2 = DataNode::new(DataSource::Buffer(buffer2.read(weight).unwrap()));
+        let node2 = DataNode::new(DataSource::Part(
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer3 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer3, &metadata, 0, vec![2, 3], &mut seq);
-        let node3 = DataNode::new(DataSource::Buffer(buffer3.read(weight).unwrap()));
+        let node3 = DataNode::new(DataSource::Part(
+            buffer3.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         check_merger_read(
             vec![node1, node3, node2],
@@ -558,18 +574,18 @@ mod tests {
         let weight = &[0, 1, 2];
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![1, 2, 3], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(Some(weight)).unwrap()));
 
         let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer2, &metadata, 1, vec![2, 3], &mut seq);
         let node2 = DataNode::new(DataSource::Part(
-            buffer2.freeze(weight).unwrap().read().unwrap(),
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
         ));
 
         let mut buffer3 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer3, &metadata, 0, vec![2, 3], &mut seq);
         let node3 = DataNode::new(DataSource::Part(
-            buffer3.freeze(weight).unwrap().read().unwrap(),
+            buffer3.freeze(Some(weight), true).unwrap().read().unwrap(),
         ));
 
         check_merger_read(
@@ -592,18 +608,24 @@ mod tests {
         let weight = &[0, 1, 2];
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![1, 2, 2], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Part(
+            buffer1.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
+
+        let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
+        write_rows_to_buffer(&mut buffer2, &metadata, 0, vec![2], &mut seq);
+        let node2 = DataNode::new(DataSource::Part(
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer3 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer3, &metadata, 0, vec![2], &mut seq);
-        let node3 = DataNode::new(DataSource::Buffer(buffer3.read(weight).unwrap()));
-
-        let mut buffer4 = DataBuffer::with_capacity(metadata.clone(), 10);
-        write_rows_to_buffer(&mut buffer4, &metadata, 0, vec![2], &mut seq);
-        let node4 = DataNode::new(DataSource::Buffer(buffer4.read(weight).unwrap()));
+        let node3 = DataNode::new(DataSource::Part(
+            buffer3.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         check_merger_read(
-            vec![node1, node3, node4],
+            vec![node1, node2, node3],
             &[
                 (0, vec![(1, 0)]),
                 (0, vec![(2, 4)]),
@@ -620,11 +642,15 @@ mod tests {
         let weight = &[0, 1, 2];
         let mut seq = 0;
         write_rows_to_buffer(&mut buffer1, &metadata, 0, vec![0, 1], &mut seq);
-        let node1 = DataNode::new(DataSource::Buffer(buffer1.read(weight).unwrap()));
+        let node1 = DataNode::new(DataSource::Part(
+            buffer1.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         let mut buffer2 = DataBuffer::with_capacity(metadata.clone(), 10);
         write_rows_to_buffer(&mut buffer2, &metadata, 0, vec![1], &mut seq);
-        let node2 = DataNode::new(DataSource::Buffer(buffer2.read(weight).unwrap()));
+        let node2 = DataNode::new(DataSource::Part(
+            buffer2.freeze(Some(weight), true).unwrap().read().unwrap(),
+        ));
 
         check_merger_read(
             vec![node1, node2],

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -63,8 +63,8 @@ pub struct Merger<T: Node> {
 }
 
 impl<T> Merger<T>
-    where
-        T: Node,
+where
+    T: Node,
 {
     pub(crate) fn try_new(nodes: Vec<T>) -> Result<Self> {
         let mut heap = BinaryHeap::with_capacity(nodes.len());

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -78,11 +78,11 @@ impl ShardBuilder {
         let data_part = match &key_dict {
             Some(dict) => {
                 let pk_weights = dict.pk_weights_to_sort_data();
-                self.data_buffer.freeze(&pk_weights)?
+                self.data_buffer.freeze(Some(&pk_weights), true)?
             }
             None => {
                 let pk_weights = [0];
-                self.data_buffer.freeze(&pk_weights)?
+                self.data_buffer.freeze(Some(&pk_weights), true)?
             }
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR handles different `read`/`freeze` paths of `DataBuffer` in different components 😵‍💫

- For `DataBuffer::read` inside `ShardBuilder`
    - `pk_weights` must be present, yielded rows are sorted according to weights
    - `replace_pk_index` set to false as pk dict are not frozen yet
    - `keep_data` set to true

- For `DataBuffer::freeze` inside `ShardBuilder`
    - `pk_weights` must be present, yielded rows are sorted according to weights
    - `replace_pk_index` set to true so that yielded `DataPart` contains only weights
    - `keep_data` set to false as we need to take the values

- For `DataBuffer::read` inside `Shard`
    - `pk_weights` set to None as DataBuffer in Shard has already replaced pk_index with weights, rows are sorted by "pk_index" directly
    - `replace_pk_index` set to false for the same reason
    - `keep_data` set to true


- For `DataBuffer::freeze` inside `Shard`
    - `pk_weights` set to None as DataBuffer in Shard has already replaced pk_index with weights, rows are sorted by "pk_index" directly
    - `replace_pk_index` set to false for the same reason
    - `keep_data` set to false as we need to take the values


## Checklist

- [X]  I have written the necessary rustdoc comments.
- [X]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
