### PR TITLE
fix: treat "0" and "1" as valid boolean values.

### DIFF
--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -685,7 +685,7 @@ mod tests {
         let sql_val = SqlValue::Number("3.0".to_string(), false);
         let v = sql_value_to_value("a", &ConcreteDataType::boolean_datatype(), &sql_val, None);
         assert!(v.is_err());
-        assert!(format!("{v:?}").contains("Failed to parse number '3.0' to boolean column type!"));
+        assert!(format!("{v:?}").contains("Failed to parse number '3.0' to boolean column type"));
 
         let sql_val = SqlValue::Boolean(true);
         let v = sql_value_to_value("a", &ConcreteDataType::float64_datatype(), &sql_val, None);

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -178,7 +178,7 @@ macro_rules! parse_number_to_value {
                     "0" => Ok(Value::Boolean(false)),
                     "1" => Ok(Value::Boolean(true)),
                     _ => ParseSqlValueSnafu {
-                        msg: format!("Failed to parse number '{}' to boolean column type!", $n)}.fail(),
+                        msg: format!("Failed to parse number '{}' to boolean column type", $n)}.fail(),
                 }
             }
             _ => ParseSqlValueSnafu {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

fix #3368 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
