### PR TITLE
refactor: Remove Item from merger's Node trait

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -449,7 +449,7 @@ impl DataBufferReader {
     /// # Panics
     /// If Current reader is exhausted.
     pub(crate) fn current_data_batch(&self) -> DataBatch {
-        let range = self.current_range.clone().unwrap();
+        let range = self.current_range.unwrap();
         DataBatch {
             rb: &self.batch,
             range,
@@ -742,7 +742,7 @@ impl DataPartReader {
     /// # Panics
     /// If reader is exhausted.
     pub(crate) fn current_data_batch(&self) -> DataBatch {
-        let range = self.current_range.clone().unwrap();
+        let range = self.current_range.unwrap();
         DataBatch {
             rb: self.current_batch.as_ref().unwrap(),
             range,

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -50,6 +50,15 @@ const PK_INDEX_COLUMN_NAME: &str = "__pk_index";
 /// Initial capacity for the data buffer.
 pub(crate) const DATA_INIT_CAP: usize = 8;
 
+/// Range of a data batch.
+#[derive(Debug, Clone)]
+pub struct DataBatchRange {
+    /// Primary key index of this batch.
+    pub(crate) pk_index: PkIndex,
+    /// Range of current primary key inside record batch
+    pub(crate) range: Range<usize>,
+}
+
 /// Data part batches returns by `DataParts::read`.
 #[derive(Debug, Clone)]
 pub struct DataBatch {
@@ -735,7 +744,8 @@ pub struct DataPartsReader {
 
 impl DataPartsReader {
     pub(crate) fn current_data_batch(&self) -> &DataBatch {
-        self.merger.current_item()
+        // FIXME(yingwen): Get range.
+        self.merger.current_node().current_data_batch()
     }
 
     pub(crate) fn next(&mut self) -> Result<()> {

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -55,9 +55,9 @@ pub(crate) const DATA_INIT_CAP: usize = 8;
 pub(crate) struct DataBatchRange {
     /// Primary key index of this batch.
     pub(crate) pk_index: PkIndex,
-    /// Start of current primary key inside record batch
+    /// Start of current primary key inside record batch.
     pub(crate) start: usize,
-    /// End of current primary key inside record batch
+    /// End of current primary key inside record batch.
     pub(crate) end: usize,
 }
 
@@ -72,7 +72,7 @@ impl DataBatchRange {
 }
 
 /// Data part batches returns by `DataParts::read`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct DataBatch<'a> {
     /// Record batch of data.
     rb: &'a RecordBatch,

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -241,12 +241,13 @@ pub struct DataNode {
     current_data_batch: Option<DataBatch>,
 }
 
+// TODO(yingwen): Avoid clone.
 impl DataNode {
     pub(crate) fn new(source: DataSource) -> Self {
-        let current_data_batch = source.current_data_batch();
+        let current_data_batch = source.current_data_batch().clone();
         Self {
             source,
-            current_data_batch: Some(current_data_batch),
+            current_data_batch: Some(current_data_batch.clone()),
         }
     }
 
@@ -266,7 +267,7 @@ pub enum DataSource {
 }
 
 impl DataSource {
-    pub(crate) fn current_data_batch(&self) -> DataBatch {
+    pub(crate) fn current_data_batch(&self) -> &DataBatch {
         match self {
             DataSource::Buffer(buffer) => buffer.current_data_batch(),
             DataSource::Part(p) => p.current_data_batch(),
@@ -278,7 +279,7 @@ impl DataSource {
             DataSource::Buffer(b) => {
                 b.next()?;
                 if b.is_valid() {
-                    Some(b.current_data_batch())
+                    Some(b.current_data_batch().clone())
                 } else {
                     None
                 }
@@ -286,7 +287,7 @@ impl DataSource {
             DataSource::Part(p) => {
                 p.next()?;
                 if p.is_valid() {
-                    Some(p.current_data_batch())
+                    Some(p.current_data_batch().clone())
                 } else {
                     None
                 }

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -50,7 +50,7 @@ pub struct Merger<T: Node> {
     heap: BinaryHeap<T>,
     /// Current node to read.
     ///
-    /// The node is always empty if it is not None.
+    /// The node is always valid if it is not None.
     current_node: Option<T>,
     /// The number of rows in current node that are valid to read.
     current_rows: usize,
@@ -95,11 +95,7 @@ impl<T: Node> Merger<T> {
     /// Advances the merger to the next item.
     pub(crate) fn next(&mut self) -> Result<()> {
         self.maybe_advance_current_node()?;
-        if self.current_node.is_some() {
-            // Current node is still valid.
-            debug_assert!(self.heap.is_empty());
-            return Ok(());
-        }
+        debug_assert!(self.current_node.is_none());
 
         // Finds node and range to read from the heap.
         let Some(top_node) = self.heap.pop() else {
@@ -153,14 +149,8 @@ impl<T: Node> Merger<T> {
             return Ok(());
         }
 
-        if self.heap.is_empty() {
-            // No other nodes in the heap, we can still put it into current node.
-            self.current_node = Some(node);
-        } else {
-            // Puts the node into the heap.
-            self.heap.push(node);
-        }
-
+        // Puts the node into the heap.
+        self.heap.push(node);
         Ok(())
     }
 }

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -17,12 +17,6 @@ use std::collections::BinaryHeap;
 use std::fmt::Debug;
 use std::ops::Range;
 
-use datatypes::arrow::array::{
-    ArrayRef, TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
-    TimestampSecondArray,
-};
-use datatypes::arrow::datatypes::{DataType, TimeUnit};
-
 use crate::error::Result;
 use crate::memtable::merge_tree::data::{DataBatch, DataBufferReader, DataPartReader};
 use crate::memtable::merge_tree::PkIndex;
@@ -307,42 +301,13 @@ impl Node for DataNode {
     }
 }
 
-// TODO(yingwen): Move to data mod.
-pub(crate) fn timestamp_array_to_i64_slice(arr: &ArrayRef) -> &[i64] {
-    match arr.data_type() {
-        DataType::Timestamp(t, _) => match t {
-            TimeUnit::Second => arr
-                .as_any()
-                .downcast_ref::<TimestampSecondArray>()
-                .unwrap()
-                .values(),
-            TimeUnit::Millisecond => arr
-                .as_any()
-                .downcast_ref::<TimestampMillisecondArray>()
-                .unwrap()
-                .values(),
-            TimeUnit::Microsecond => arr
-                .as_any()
-                .downcast_ref::<TimestampMicrosecondArray>()
-                .unwrap()
-                .values(),
-            TimeUnit::Nanosecond => arr
-                .as_any()
-                .downcast_ref::<TimestampNanosecondArray>()
-                .unwrap()
-                .values(),
-        },
-        _ => unreachable!(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use datatypes::arrow::array::UInt64Array;
     use store_api::metadata::RegionMetadataRef;
 
     use super::*;
-    use crate::memtable::merge_tree::data::DataBuffer;
+    use crate::memtable::merge_tree::data::{timestamp_array_to_i64_slice, DataBuffer};
     use crate::test_util::memtable_util::{build_key_values_with_ts_seq_values, metadata_for_test};
 
     fn write_rows_to_buffer(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR removes the associated type `Item` from the `Node` trait of the merger mod. It is helpful to support `?Size` item of a node.

Now the `DataBatch` is a slice of the referencing `RecordBatch`.
- It doesn't own the `RecordBatch`.
- It should only access the range of the `RecordBatch`.
- `DataBatchRange` maintains the range of a `DataBatch`.

This avoids slicing the `RecordBatch` via `RecordBatch::slice()`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804