### PR TITLE
feat: support `Create Table ... Like`

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -472,8 +472,8 @@ pub fn check_permission(
             validate_param(&stmt.name, query_ctx)?;
         }
         Statement::CreateTableLike(stmt) => {
-            validate_param(&stmt.name, query_ctx)?;
-            validate_param(&stmt.target, query_ctx)?;
+            validate_param(&stmt.table_name, query_ctx)?;
+            validate_param(&stmt.source_name, query_ctx)?;
         }
         Statement::DropTable(drop_stmt) => {
             validate_param(drop_stmt.table_name(), query_ctx)?;

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -460,8 +460,10 @@ pub fn check_permission(
         // database ops won't be checked
         Statement::CreateDatabase(_) | Statement::ShowDatabases(_) => {}
         // show create table and alter are not supported yet
-        Statement::ShowCreateTable(_) | Statement::CreateExternalTable(_) | Statement::Alter(_) => {
-        }
+        Statement::ShowCreateTable(_)
+        | Statement::CreateExternalTable(_)
+        | Statement::CreateTableLike(_)
+        | Statement::Alter(_) => {}
         // set/show variable now only alter/show variable in session
         Statement::SetVariables(_) | Statement::ShowVariables(_) => {}
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -460,10 +460,8 @@ pub fn check_permission(
         // database ops won't be checked
         Statement::CreateDatabase(_) | Statement::ShowDatabases(_) => {}
         // show create table and alter are not supported yet
-        Statement::ShowCreateTable(_)
-        | Statement::CreateExternalTable(_)
-        | Statement::CreateTableLike(_)
-        | Statement::Alter(_) => {}
+        Statement::ShowCreateTable(_) | Statement::CreateExternalTable(_) | Statement::Alter(_) => {
+        }
         // set/show variable now only alter/show variable in session
         Statement::SetVariables(_) | Statement::ShowVariables(_) => {}
 
@@ -472,6 +470,10 @@ pub fn check_permission(
         }
         Statement::CreateTable(stmt) => {
             validate_param(&stmt.name, query_ctx)?;
+        }
+        Statement::CreateTableLike(stmt) => {
+            validate_param(&stmt.name, query_ctx)?;
+            validate_param(&stmt.target, query_ctx)?;
         }
         Statement::DropTable(drop_stmt) => {
             validate_param(drop_stmt.table_name(), query_ctx)?;

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -181,7 +181,7 @@ pub(crate) async fn create_external_expr(
     Ok(expr)
 }
 
-/// Convert `CreateTable` statement to `CreateTableExpr` gRPC request.
+/// Convert `CreateTable` statement to [`CreateTableExpr`] gRPC request.
 pub fn create_to_expr(create: &CreateTable, query_ctx: QueryContextRef) -> Result<CreateTableExpr> {
     let (catalog_name, schema_name, table_name) =
         table_idents_to_full_name(&create.name, &query_ctx)

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -181,7 +181,7 @@ pub(crate) async fn create_external_expr(
     Ok(expr)
 }
 
-/// Convert `CreateTable` statement to `CreateExpr` gRPC request.
+/// Convert `CreateTable` statement to `CreateTableExpr` gRPC request.
 pub fn create_to_expr(create: &CreateTable, query_ctx: QueryContextRef) -> Result<CreateTableExpr> {
     let (catalog_name, schema_name, table_name) =
         table_idents_to_full_name(&create.name, &query_ctx)

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -153,6 +153,10 @@ impl StatementExecutor {
                 let _ = self.create_table(stmt, query_ctx).await?;
                 Ok(Output::AffectedRows(0))
             }
+            Statement::CreateTableLike(stmt) => {
+                let _ = self.create_table_like(stmt, query_ctx).await?;
+                Ok(Output::AffectedRows(0))
+            }
             Statement::CreateExternalTable(stmt) => {
                 let _ = self.create_external_table(stmt, query_ctx).await?;
                 Ok(Output::AffectedRows(0))
@@ -174,7 +178,6 @@ impl StatementExecutor {
                 let table_name = TableName::new(catalog, schema, table);
                 self.truncate_table(table_name).await
             }
-
             Statement::CreateDatabase(stmt) => {
                 self.create_database(
                     query_ctx.current_catalog(),
@@ -183,7 +186,6 @@ impl StatementExecutor {
                 )
                 .await
             }
-
             Statement::ShowCreateTable(show) => {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(&show.table_name, &query_ctx)

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -81,7 +81,7 @@ impl StatementExecutor {
         stmt: CreateTableLike,
         ctx: QueryContextRef,
     ) -> Result<TableRef> {
-        let (catalog, schema, table) = table_idents_to_full_name(&stmt.target, &ctx)
+        let (catalog, schema, table) = table_idents_to_full_name(&stmt.source_name, &ctx)
             .map_err(BoxedError::new)
             .context(error::ExternalSnafu)?;
         let table_ref = self
@@ -100,7 +100,7 @@ impl StatementExecutor {
         let mut create_stmt =
             show_create_table::create_table_stmt(&table_ref.table_info(), quote_style)
                 .context(error::ParseQuerySnafu)?;
-        create_stmt.name = stmt.name;
+        create_stmt.name = stmt.table_name;
         create_stmt.if_not_exists = false;
 
         let partitions = create_partitions_stmt(partitions)?.and_then(|mut partitions| {

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -38,9 +38,10 @@ use partition::partition::{PartitionBound, PartitionDef};
 use query::sql::show_create_table;
 use regex::Regex;
 use session::context::QueryContextRef;
+use session::table_name::table_idents_to_full_name;
 use snafu::{ensure, IntoError, OptionExt, ResultExt};
 use sql::statements::alter::AlterTable;
-use sql::statements::create::{CreateExternalTable, CreateTable, Partitions};
+use sql::statements::create::{CreateExternalTable, CreateTable, CreateTableLike, Partitions};
 use table::dist_table::DistTable;
 use table::metadata::{self, RawTableInfo, RawTableMeta, TableId, TableInfo, TableType};
 use table::requests::{AlterKind, AlterTableRequest, TableOptions};
@@ -57,7 +58,6 @@ use crate::error::{
 };
 use crate::expr_factory;
 use crate::statement::show::create_partitions_stmt;
-use crate::table::table_idents_to_full_name;
 
 lazy_static! {
     static ref NAME_PATTERN_REG: Regex = Regex::new(&format!("^{NAME_PATTERN}$")).unwrap();

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -76,7 +76,7 @@ impl StatementExecutor {
     }
 }
 
-fn create_partitions_stmt(partitions: Vec<PartitionInfo>) -> Result<Option<Partitions>> {
+pub(crate) fn create_partitions_stmt(partitions: Vec<PartitionInfo>) -> Result<Option<Partitions>> {
     if partitions.is_empty() {
         return Ok(None);
     }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod show_create_table;
+mod show_create_table;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -37,6 +37,7 @@ use object_store::ObjectStore;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use session::context::QueryContextRef;
+pub use show_create_table::create_table_stmt;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::create::Partitions;
 use sql::statements::show::{ShowDatabases, ShowKind, ShowTables, ShowVariables};
@@ -260,7 +261,7 @@ pub fn show_create_table(
 
     let quote_style = query_ctx.quote_style();
 
-    let mut stmt = show_create_table::create_table_stmt(&table_info, quote_style)?;
+    let mut stmt = create_table_stmt(&table_info, quote_style)?;
     stmt.partitions = partitions.map(|mut p| {
         p.set_quote(quote_style);
         p

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod show_create_table;
+pub mod show_create_table;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -258,14 +258,7 @@ pub fn show_create_table(
     let table_info = table.table_info();
     let table_name = &table_info.name;
 
-    // Default to double quote and fallback to back quote
-    let quote_style = if query_ctx.sql_dialect().is_delimited_identifier_start('"') {
-        '"'
-    } else if query_ctx.sql_dialect().is_delimited_identifier_start('\'') {
-        '\''
-    } else {
-        '`'
-    };
+    let quote_style = query_ctx.quote_style();
 
     let mut stmt = show_create_table::create_table_stmt(&table_info, quote_style)?;
     stmt.partitions = partitions.map(|mut p| {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -172,6 +172,17 @@ impl QueryContext {
             session.set_timezone(tz.as_ref().clone())
         }
     }
+
+    /// Default to double quote and fallback to back quote
+    pub fn quote_style(&self) -> char {
+        if self.sql_dialect().is_delimited_identifier_start('"') {
+            '"'
+        } else if self.sql_dialect().is_delimited_identifier_start('\'') {
+            '\''
+        } else {
+            '`'
+        }
+    }
 }
 
 impl QueryContextBuilder {

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -80,14 +80,17 @@ impl<'a> ParserContext<'a> {
             .try_with_sql(sql)
             .context(SyntaxSnafu)?;
 
+        Self::_parse_table_name(&mut parser, sql)
+    }
+
+    pub(crate) fn _parse_table_name(parser: &mut Parser, sql: &'a str) -> Result<ObjectName> {
         let raw_table_name = parser.parse_object_name().context(error::UnexpectedSnafu {
             sql,
             expected: "a table name",
             actual: parser.peek_token().to_string(),
         })?;
-        let table_name = Self::canonicalize_object_name(raw_table_name);
 
-        Ok(table_name)
+        Ok(Self::canonicalize_object_name(raw_table_name))
     }
 
     pub fn parse_function(sql: &'a str, dialect: &dyn Dialect) -> Result<Expr> {

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -75,21 +75,22 @@ impl<'a> ParserContext<'a> {
     }
 
     pub fn parse_table_name(sql: &'a str, dialect: &dyn Dialect) -> Result<ObjectName> {
-        let mut parser = Parser::new(dialect)
+        let parser = Parser::new(dialect)
             .with_options(ParserOptions::new().with_trailing_commas(true))
             .try_with_sql(sql)
             .context(SyntaxSnafu)?;
-
-        Self::_parse_table_name(&mut parser, sql)
+        ParserContext { parser, sql }.intern_parse_table_name()
     }
 
-    pub(crate) fn _parse_table_name(parser: &mut Parser, sql: &'a str) -> Result<ObjectName> {
-        let raw_table_name = parser.parse_object_name().context(error::UnexpectedSnafu {
-            sql,
-            expected: "a table name",
-            actual: parser.peek_token().to_string(),
-        })?;
-
+    pub(crate) fn intern_parse_table_name(&mut self) -> Result<ObjectName> {
+        let raw_table_name = self
+            .parser
+            .parse_object_name()
+            .context(error::UnexpectedSnafu {
+                sql: self.sql,
+                expected: "a table name",
+                actual: self.parser.peek_token().to_string(),
+            })?;
         Ok(Self::canonicalize_object_name(raw_table_name))
     }
 

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -66,7 +66,7 @@ impl<'a> ParserContext<'a> {
         let if_not_exists =
             self.parser
                 .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
-        let table_name = ParserContext::_parse_table_name(&mut self.parser, self.sql)?;
+        let table_name = self.intern_parse_table_name()?;
         let (columns, constraints) = self.parse_columns()?;
         let engine = self.parse_table_engine(common_catalog::consts::FILE_ENGINE)?;
         let options = self
@@ -128,10 +128,10 @@ impl<'a> ParserContext<'a> {
             self.parser
                 .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
 
-        let table_name = ParserContext::_parse_table_name(&mut self.parser, self.sql)?;
+        let table_name = self.intern_parse_table_name()?;
 
         if self.parser.parse_keyword(Keyword::LIKE) {
-            let source_name = ParserContext::_parse_table_name(&mut self.parser, self.sql)?;
+            let source_name = self.intern_parse_table_name()?;
 
             return Ok(Statement::CreateTableLike(CreateTableLike {
                 table_name,

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -131,11 +131,11 @@ impl<'a> ParserContext<'a> {
         let table_name = self.parse_table_name()?;
 
         if self.parser.parse_keyword(Keyword::LIKE) {
-            let target_table_name = self.parse_table_name()?;
+            let source_name = self.parse_table_name()?;
 
             return Ok(Statement::CreateTableLike(CreateTableLike {
-                name: table_name,
-                target: target_table_name,
+                table_name,
+                source_name,
             }));
         }
 
@@ -754,8 +754,8 @@ mod tests {
         assert_eq!(1, stmts.len());
         match &stmts[0] {
             Statement::CreateTableLike(c) => {
-                assert_eq!(c.name.to_string(), "t1");
-                assert_eq!(c.target.to_string(), "t2");
+                assert_eq!(c.table_name.to_string(), "t1");
+                assert_eq!(c.source_name.to_string(), "t2");
             }
             _ => unreachable!(),
         }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -219,6 +219,13 @@ pub struct CreateExternalTable {
     pub engine: String,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Visit, VisitMut)]
+pub struct CreateTableLike {
+    /// Table name
+    pub name: ObjectName,
+    pub target: ObjectName,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::dialect::GreptimeDbDialect;

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -222,8 +222,9 @@ pub struct CreateExternalTable {
 #[derive(Debug, PartialEq, Eq, Clone, Visit, VisitMut)]
 pub struct CreateTableLike {
     /// Table name
-    pub name: ObjectName,
-    pub target: ObjectName,
+    pub table_name: ObjectName,
+    /// The table that is designated to be imitated by `Like`
+    pub source_name: ObjectName,
 }
 
 #[cfg(test)]

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -19,7 +19,9 @@ use sqlparser_derive::{Visit, VisitMut};
 use super::show::ShowVariables;
 use crate::error::{ConvertToDfStatementSnafu, Error};
 use crate::statements::alter::AlterTable;
-use crate::statements::create::{CreateDatabase, CreateExternalTable, CreateTable};
+use crate::statements::create::{
+    CreateDatabase, CreateExternalTable, CreateTable, CreateTableLike,
+};
 use crate::statements::delete::Delete;
 use crate::statements::describe::DescribeTable;
 use crate::statements::drop::DropTable;
@@ -45,6 +47,8 @@ pub enum Statement {
     CreateTable(CreateTable),
     // CREATE EXTERNAL TABLE
     CreateExternalTable(CreateExternalTable),
+    // CREATE TABLE ... LIKE
+    CreateTableLike(CreateTableLike),
     // DROP TABLE
     DropTable(DropTable),
     // CREATE DATABASE

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -143,7 +143,7 @@ DROP TABLE neg_default_value;
 
 Affected Rows: 0
 
-CREATE TABLE test_like_1 (i INTEGER, j TIMESTAMP TIME INDEX);
+CREATE TABLE test_like_1 (PK STRING PRIMARY KEY, i INTEGER DEFAULT 7, j TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
@@ -160,7 +160,8 @@ DESC TABLE test_like_1;
 +--------+----------------------+-----+------+---------+---------------+
 | Column | Type                 | Key | Null | Default | Semantic Type |
 +--------+----------------------+-----+------+---------+---------------+
-| i      | Int32                |     | YES  |         | FIELD         |
+| pk     | String               | PRI | YES  |         | TAG           |
+| i      | Int32                |     | YES  | 7       | FIELD         |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 +--------+----------------------+-----+------+---------+---------------+
 
@@ -169,7 +170,8 @@ DESC TABLE test_like_2;
 +--------+----------------------+-----+------+---------+---------------+
 | Column | Type                 | Key | Null | Default | Semantic Type |
 +--------+----------------------+-----+------+---------+---------------+
-| i      | Int32                |     | YES  |         | FIELD         |
+| pk     | String               | PRI | YES  |         | TAG           |
+| i      | Int32                |     | YES  | 7       | FIELD         |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 +--------+----------------------+-----+------+---------+---------------+
 

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -143,3 +143,41 @@ DROP TABLE neg_default_value;
 
 Affected Rows: 0
 
+CREATE TABLE test_like_1 (i INTEGER, j TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+CREATE TABLE test_like_2 LIKE test_like_1;
+
+Affected Rows: 0
+
+CREATE TABLE test_like_2 LIKE test_like_1;
+
+Error: 4000(TableAlreadyExists), Table already exists: `greptime.public.test_like_2`
+
+DESC TABLE test_like_1;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
++--------+----------------------+-----+------+---------+---------------+
+
+DESC TABLE test_like_2;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | Int32                |     | YES  |         | FIELD         |
+| j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
++--------+----------------------+-----+------+---------+---------------+
+
+DROP TABLE test_like_1;
+
+Affected Rows: 0
+
+DROP TABLE test_like_2;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/create/create.sql
+++ b/tests/cases/standalone/common/create/create.sql
@@ -58,7 +58,7 @@ desc TABLE neg_default_value;
 
 DROP TABLE neg_default_value;
 
-CREATE TABLE test_like_1 (i INTEGER, j TIMESTAMP TIME INDEX);
+CREATE TABLE test_like_1 (PK STRING PRIMARY KEY, i INTEGER DEFAULT 7, j TIMESTAMP TIME INDEX);
 
 CREATE TABLE test_like_2 LIKE test_like_1;
 

--- a/tests/cases/standalone/common/create/create.sql
+++ b/tests/cases/standalone/common/create/create.sql
@@ -57,3 +57,17 @@ CREATE TABLE neg_default_value(i INT DEFAULT -1024, ts TIMESTAMP TIME INDEX);
 desc TABLE neg_default_value;
 
 DROP TABLE neg_default_value;
+
+CREATE TABLE test_like_1 (i INTEGER, j TIMESTAMP TIME INDEX);
+
+CREATE TABLE test_like_2 LIKE test_like_1;
+
+CREATE TABLE test_like_2 LIKE test_like_1;
+
+DESC TABLE test_like_1;
+
+DESC TABLE test_like_2;
+
+DROP TABLE test_like_1;
+
+DROP TABLE test_like_2;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Support: `create table xxx like yyy`
ref: https://dev.mysql.com/doc/refman/8.0/en/create-table-like.html

```shell
public=> CREATE TABLE t1 ( a INT, b STRING, c INT, ts timestamp TIME INDEX);
OK 0
public=> CREATE TABLE t2 LIKE t1;
OK 0
public=> DESCRIBE t2;
 Column |         Type         | Key | Null | Default | Semantic Type 
--------+----------------------+-----+------+---------+---------------
 a      | Int32                |     | YES  |         | FIELD
 b      | String               |     | YES  |         | FIELD
 c      | Int32                |     | YES  |         | FIELD
 ts     | TimestampMillisecond | PRI | NO   |         | TIMESTAMP
(4 rows)
```

Tips: 
I was using this case: `CREATE TABLE t1 ( a INT, b STRING, c INT, ts timestamp TIME INDEX);` then run `CREATE TABLE t2 LIKE t1;`, the `create_partitions_stmt` method returned Some and caused the index to go out of bounds, so I did additional checks. Is this a bug? Because this table does not specify `Partitions`
![bebd5cede7cdff3aef71baa6efbb7a2](https://github.com/GreptimeTeam/greptimedb/assets/91525956/4b604621-0ff8-4efe-bd47-4901996bc2ee)


ref: https://github.com/GreptimeTeam/greptimedb/pull/3372/files#diff-2563d4135f7e232aaec6a39204e6e9afc21801dff0c957772ce4dd7d3bd271d4R109

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2509