### PR TITLE
feat: Implement iter for the new memtable

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -89,10 +89,6 @@ impl<'a> DataBatch<'a> {
         self.range
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.range.len()
-    }
-
     pub(crate) fn is_empty(&self) -> bool {
         self.range.is_empty()
     }

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -89,6 +89,10 @@ impl<'a> DataBatch<'a> {
         self.range
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.range.len()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.range.is_empty()
     }

--- a/src/mito2/src/memtable/merge_tree/dict.rs
+++ b/src/mito2/src/memtable/merge_tree/dict.rs
@@ -188,8 +188,8 @@ impl DictBuilderReader {
     }
 
     /// Returns pk weights to sort a data part and replaces pk indices.
-    pub(crate) fn pk_weights_to_sort_data(&self) -> Vec<u16> {
-        compute_pk_weights(&self.sorted_pk_indices)
+    pub(crate) fn pk_weights_to_sort_data(&self, pk_weights: &mut Vec<u16>) {
+        compute_pk_weights(&self.sorted_pk_indices, pk_weights)
     }
 
     /// Returns pk indices sorted by keys.
@@ -199,12 +199,11 @@ impl DictBuilderReader {
 }
 
 /// Returns pk weights to sort a data part and replaces pk indices.
-fn compute_pk_weights(sorted_pk_indices: &[PkIndex]) -> Vec<u16> {
-    let mut pk_weights = vec![0; sorted_pk_indices.len()];
+fn compute_pk_weights(sorted_pk_indices: &[PkIndex], pk_weights: &mut Vec<u16>) {
+    pk_weights.resize(sorted_pk_indices.len(), 0);
     for (weight, pk_index) in sorted_pk_indices.iter().enumerate() {
         pk_weights[*pk_index as usize] = weight as u16;
     }
-    pk_weights
 }
 
 /// A key dictionary.
@@ -240,7 +239,9 @@ impl KeyDict {
 
     /// Returns pk weights to sort a data part and replaces pk indices.
     pub(crate) fn pk_weights_to_sort_data(&self) -> Vec<u16> {
-        compute_pk_weights(&self.key_positions)
+        let mut pk_weights = Vec::with_capacity(self.key_positions.len());
+        compute_pk_weights(&self.key_positions, &mut pk_weights);
+        pk_weights
     }
 
     /// Returns the shared memory size.

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -29,8 +29,8 @@ use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::data::{DataBatch, DataParts, DATA_INIT_CAP};
 use crate::memtable::merge_tree::metrics::WriteMetrics;
-use crate::memtable::merge_tree::shard::{Shard, ShardReader};
-use crate::memtable::merge_tree::shard_builder::{ShardBuilder, ShardBuilderReader};
+use crate::memtable::merge_tree::shard::Shard;
+use crate::memtable::merge_tree::shard_builder::ShardBuilder;
 use crate::memtable::merge_tree::{MergeTreeConfig, PkId, ShardId};
 use crate::read::{Batch, BatchBuilder};
 use crate::row_converter::{McmpRowCodec, RowCodec};
@@ -316,11 +316,6 @@ fn convert_batch(
     }
 
     builder.build()
-}
-
-enum ShardSource {
-    Builder(ShardBuilderReader),
-    Shard(ShardReader),
 }
 
 pub type PartitionRef = Arc<Partition>;

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -287,7 +287,7 @@ fn convert_batch(
     key: Option<&[u8]>,
     data_batch: &DataBatch,
 ) -> Result<Batch> {
-    let record_batch = data_batch.record_batch();
+    let record_batch = data_batch.slice_record_batch();
     let primary_key = key.map(|k| k.to_vec()).unwrap_or_default();
     let mut builder = BatchBuilder::new(primary_key);
     builder

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -132,6 +132,10 @@ impl ShardMerger {
         self.merger.next()
     }
 
+    pub(crate) fn current_key(&self) -> Option<&[u8]> {
+        self.merger.current_node().current_key()
+    }
+
     pub(crate) fn current_data_batch(&self) -> DataBatch {
         let batch = self.merger.current_node().current_data_batch();
         batch.slice(0, self.merger.current_rows())
@@ -181,6 +185,10 @@ struct ShardNode {
 impl ShardNode {
     fn new(source: ShardSource) -> Self {
         Self { source }
+    }
+
+    fn current_key(&self) -> Option<&[u8]> {
+        self.source.current_key()
     }
 
     fn current_data_batch(&self) -> DataBatch {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -99,13 +99,13 @@ impl ShardReader {
     }
 
     fn current_key(&self) -> Option<&[u8]> {
-        let pk_index = self.parts_reader.current_data_batch().pk_index;
+        let pk_index = self.parts_reader.current_data_batch().pk_index();
         self.key_dict
             .as_ref()
             .map(|dict| dict.key_by_pk_index(pk_index))
     }
 
-    fn current_batch(&self) -> &DataBatch {
+    fn current_batch(&self) -> DataBatch {
         self.parts_reader.current_data_batch()
     }
 }

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -14,12 +14,16 @@
 
 //! Shard in a partition.
 
+use std::cmp::Ordering;
+
 use store_api::metadata::RegionMetadataRef;
 
 use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::data::{DataBatch, DataParts, DataPartsReader, DATA_INIT_CAP};
 use crate::memtable::merge_tree::dict::KeyDictRef;
+use crate::memtable::merge_tree::merger::{Merger, Node};
+use crate::memtable::merge_tree::shard_builder::ShardBuilderReader;
 use crate::memtable::merge_tree::{PkId, ShardId};
 
 /// Shard stores data related to the same key dictionary.
@@ -105,8 +109,125 @@ impl ShardReader {
             .map(|dict| dict.key_by_pk_index(pk_index))
     }
 
-    fn current_batch(&self) -> DataBatch {
+    fn current_data_batch(&self) -> DataBatch {
         self.parts_reader.current_data_batch()
+    }
+}
+
+pub(crate) struct ShardMerger {
+    merger: Merger<ShardNode>,
+}
+
+impl ShardMerger {
+    pub(crate) fn is_valid(&self) -> bool {
+        self.merger.is_valid()
+    }
+
+    pub(crate) fn next(&mut self) -> Result<()> {
+        self.merger.next()
+    }
+
+    pub(crate) fn current_data_batch(&self) -> DataBatch {
+        let batch = self.merger.current_node().current_data_batch();
+        batch.slice(0, self.merger.current_rows())
+    }
+}
+
+enum ShardSource {
+    Builder(ShardBuilderReader),
+    Shard(ShardReader),
+}
+
+impl ShardSource {
+    fn is_valid(&self) -> bool {
+        match self {
+            ShardSource::Builder(r) => r.is_valid(),
+            ShardSource::Shard(r) => r.is_valid(),
+        }
+    }
+
+    fn next(&mut self) -> Result<()> {
+        match self {
+            ShardSource::Builder(r) => r.next(),
+            ShardSource::Shard(r) => r.next(),
+        }
+    }
+
+    fn current_key(&self) -> Option<&[u8]> {
+        match self {
+            ShardSource::Builder(r) => r.current_key(),
+            ShardSource::Shard(r) => r.current_key(),
+        }
+    }
+
+    fn current_data_batch(&self) -> DataBatch {
+        match self {
+            ShardSource::Builder(r) => r.current_data_batch(),
+            ShardSource::Shard(r) => r.current_data_batch(),
+        }
+    }
+}
+
+/// Node for the merger to get items.
+struct ShardNode {
+    source: ShardSource,
+}
+
+impl ShardNode {
+    fn new(source: ShardSource) -> Self {
+        Self { source }
+    }
+
+    fn current_data_batch(&self) -> DataBatch {
+        self.source.current_data_batch()
+    }
+}
+
+impl PartialEq for ShardNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.source.current_key() == other.source.current_key()
+    }
+}
+
+impl Eq for ShardNode {}
+
+impl Ord for ShardNode {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.source
+            .current_key()
+            .cmp(&other.source.current_key())
+            .reverse()
+    }
+}
+
+impl PartialOrd for ShardNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Node for ShardNode {
+    fn is_valid(&self) -> bool {
+        self.source.is_valid()
+    }
+
+    fn is_behind(&self, other: &Self) -> bool {
+        // We expect a key only belongs to one shard.
+        debug_assert_ne!(self.source.current_key(), other.source.current_key());
+        self.source.current_key() < other.source.current_key()
+    }
+
+    fn advance(&mut self, len: usize) -> Result<()> {
+        debug_assert_eq!(self.source.current_data_batch().len(), len);
+        self.source.next()
+    }
+
+    fn current_item_len(&self) -> usize {
+        self.current_data_batch().len()
+    }
+
+    fn search_key_in_current_item(&self, _other: &Self) -> Result<usize, usize> {
+        Err(self.source.current_data_batch().len())
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -65,7 +65,7 @@ impl Shard {
 
     /// Scans the shard.
     // TODO(yingwen): Push down projection to data parts.
-    pub fn scan(&self) -> ShardReader {
+    pub fn scan(&self) -> ShardReaderImpl {
         unimplemented!()
     }
 
@@ -88,12 +88,17 @@ impl Shard {
 }
 
 /// Reader to read rows in a shard.
-pub struct ShardReader {
+pub struct ShardReaderImpl {
+    shard_id: ShardId,
     key_dict: Option<KeyDictRef>,
     parts_reader: DataPartsReader,
 }
 
-impl ShardReader {
+impl ShardReaderImpl {
+    fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
     fn is_valid(&self) -> bool {
         self.parts_reader.is_valid()
     }
@@ -135,7 +140,7 @@ impl ShardMerger {
 
 enum ShardSource {
     Builder(ShardBuilderReader),
-    Shard(ShardReader),
+    Shard(ShardReaderImpl),
 }
 
 impl ShardSource {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -120,6 +120,14 @@ impl ShardReaderImpl {
             .map(|dict| dict.key_by_pk_index(pk_index))
     }
 
+    fn current_pk_id(&self) -> PkId {
+        let pk_index = self.parts_reader.current_data_batch().pk_index();
+        PkId {
+            shard_id: self.shard_id,
+            pk_index,
+        }
+    }
+
     fn current_data_batch(&self) -> DataBatch {
         self.parts_reader.current_data_batch()
     }
@@ -141,6 +149,10 @@ impl ShardMerger {
 
     pub(crate) fn next(&mut self) -> Result<()> {
         self.merger.next()
+    }
+
+    pub(crate) fn current_pk_id(&self) -> PkId {
+        self.merger.current_node().current_pk_id()
     }
 
     pub(crate) fn current_key(&self) -> Option<&[u8]> {
@@ -173,6 +185,13 @@ impl ShardSource {
         }
     }
 
+    fn current_pk_id(&self) -> PkId {
+        match self {
+            ShardSource::Builder(r) => r.current_pk_id(),
+            ShardSource::Shard(r) => r.current_pk_id(),
+        }
+    }
+
     fn current_key(&self) -> Option<&[u8]> {
         match self {
             ShardSource::Builder(r) => r.current_key(),
@@ -196,6 +215,10 @@ pub(crate) struct ShardNode {
 impl ShardNode {
     pub(crate) fn new(source: ShardSource) -> Self {
         Self { source }
+    }
+
+    fn current_pk_id(&self) -> PkId {
+        self.source.current_pk_id()
     }
 
     fn current_key(&self) -> Option<&[u8]> {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -72,10 +72,10 @@ impl Shard {
 
     /// Scans the shard.
     // TODO(yingwen): Push down projection to data parts.
-    pub fn read(&mut self) -> Result<ShardReaderImpl> {
+    pub fn read(&mut self) -> Result<ShardReader> {
         let parts_reader = self.data_parts.read()?;
 
-        Ok(ShardReaderImpl {
+        Ok(ShardReader {
             shard_id: self.shard_id,
             key_dict: self.key_dict.clone(),
             parts_reader,
@@ -102,13 +102,13 @@ impl Shard {
 }
 
 /// Reader to read rows in a shard.
-pub struct ShardReaderImpl {
+pub struct ShardReader {
     shard_id: ShardId,
     key_dict: Option<KeyDictRef>,
     parts_reader: DataPartsReader,
 }
 
-impl ShardReaderImpl {
+impl ShardReader {
     fn shard_id(&self) -> ShardId {
         self.shard_id
     }
@@ -175,7 +175,7 @@ impl ShardMerger {
 
 pub(crate) enum ShardSource {
     Builder(ShardBuilderReader),
-    Shard(ShardReaderImpl),
+    Shard(ShardReader),
 }
 
 impl ShardSource {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -273,16 +273,16 @@ impl Node for ShardNode {
     }
 
     fn advance(&mut self, len: usize) -> Result<()> {
-        debug_assert_eq!(self.source.current_data_batch().len(), len);
+        debug_assert_eq!(self.source.current_data_batch().num_rows(), len);
         self.source.next()
     }
 
     fn current_item_len(&self) -> usize {
-        self.current_data_batch().len()
+        self.current_data_batch().num_rows()
     }
 
     fn search_key_in_current_item(&self, _other: &Self) -> Result<usize, usize> {
-        Err(self.source.current_data_batch().len())
+        Err(self.source.current_data_batch().num_rows())
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -26,7 +26,7 @@ use crate::memtable::merge_tree::data::{
 use crate::memtable::merge_tree::dict::{DictBuilderReader, KeyDictBuilder};
 use crate::memtable::merge_tree::metrics::WriteMetrics;
 use crate::memtable::merge_tree::shard::Shard;
-use crate::memtable::merge_tree::{MergeTreeConfig, ShardId};
+use crate::memtable::merge_tree::{MergeTreeConfig, PkId, ShardId};
 
 /// Builder to write keys and data to a shard that the key dictionary
 /// is still active.
@@ -144,6 +144,14 @@ impl ShardBuilderReader {
     pub fn current_key(&self) -> Option<&[u8]> {
         let pk_index = self.data_reader.current_data_batch().pk_index();
         Some(self.dict_reader.key_by_pk_index(pk_index))
+    }
+
+    pub fn current_pk_id(&self) -> PkId {
+        let pk_index = self.data_reader.current_data_batch().pk_index();
+        PkId {
+            shard_id: self.shard_id,
+            pk_index,
+        }
     }
 
     pub fn current_data_batch(&self) -> DataBatch {

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -112,20 +112,20 @@ pub struct ShardBuilderReader {
 }
 
 impl ShardBuilderReader {
-    fn is_valid(&self) -> bool {
+    pub fn is_valid(&self) -> bool {
         self.data_reader.is_valid()
     }
 
-    fn next(&mut self) -> Result<()> {
+    pub fn next(&mut self) -> Result<()> {
         self.data_reader.next()
     }
 
-    fn current_key(&self) -> Option<&[u8]> {
+    pub fn current_key(&self) -> Option<&[u8]> {
         let pk_index = self.data_reader.current_data_batch().pk_index();
         Some(self.dict_reader.key_by_pk_index(pk_index))
     }
 
-    fn current_batch(&self) -> DataBatch {
+    pub fn current_data_batch(&self) -> DataBatch {
         self.data_reader.current_data_batch()
     }
 }

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -106,7 +106,7 @@ impl ShardBuilder {
     pub fn read(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
         let dict_reader = self.dict_builder.read();
         dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
-        let data_reader = self.data_buffer.read(Some(&pk_weights_buffer))?;
+        let data_reader = self.data_buffer.read(Some(pk_weights_buffer))?;
 
         Ok(ShardBuilderReader {
             shard_id: self.current_shard_id,

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -103,7 +103,7 @@ impl ShardBuilder {
     }
 
     /// Scans the shard builder.
-    pub fn scan(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
+    pub fn read(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
         let dict_reader = self.dict_builder.read();
         dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
         let data_reader = self.data_buffer.read(Some(&pk_weights_buffer))?;

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -31,6 +31,8 @@ use crate::memtable::merge_tree::{MergeTreeConfig, ShardId};
 /// Builder to write keys and data to a shard that the key dictionary
 /// is still active.
 pub struct ShardBuilder {
+    /// Id of the current shard to build.
+    current_shard_id: ShardId,
     /// Builder for the key dictionary.
     dict_builder: KeyDictBuilder,
     /// Buffer to store data.
@@ -41,8 +43,13 @@ pub struct ShardBuilder {
 
 impl ShardBuilder {
     /// Returns a new builder.
-    pub fn new(metadata: RegionMetadataRef, config: &MergeTreeConfig) -> ShardBuilder {
+    pub fn new(
+        metadata: RegionMetadataRef,
+        config: &MergeTreeConfig,
+        shard_id: ShardId,
+    ) -> ShardBuilder {
         ShardBuilder {
+            current_shard_id: shard_id,
             dict_builder: KeyDictBuilder::new(config.index_max_keys_per_shard),
             data_buffer: DataBuffer::with_capacity(metadata, DATA_INIT_CAP),
             data_freeze_threshold: config.data_freeze_threshold,
@@ -61,15 +68,16 @@ impl ShardBuilder {
         self.dict_builder.is_full() || self.data_buffer.num_rows() == self.data_freeze_threshold
     }
 
+    /// Returns the current shard id of the builder.
+    pub fn current_shard_id(&self) -> ShardId {
+        self.current_shard_id
+    }
+
     /// Builds a new shard and resets the builder.
     ///
     /// Returns `None` if the builder is empty.
-    pub fn finish(
-        &mut self,
-        shard_id: ShardId,
-        metadata: RegionMetadataRef,
-    ) -> Result<Option<Shard>> {
-        if self.data_buffer.is_empty() {
+    pub fn finish(&mut self, metadata: RegionMetadataRef) -> Result<Option<Shard>> {
+        if self.is_empty() {
             return Ok(None);
         }
 
@@ -88,6 +96,8 @@ impl ShardBuilder {
         // build data parts.
         let data_parts = DataParts::new(metadata, DATA_INIT_CAP).with_frozen(vec![data_part]);
         let key_dict = key_dict.map(Arc::new);
+        let shard_id = self.current_shard_id;
+        self.current_shard_id += 1;
 
         Ok(Some(Shard::new(shard_id, key_dict, data_parts)))
     }
@@ -99,19 +109,30 @@ impl ShardBuilder {
         let data_reader = self.data_buffer.read(Some(&pk_weights_buffer))?;
 
         Ok(ShardBuilderReader {
+            shard_id: self.current_shard_id,
             dict_reader,
             data_reader,
         })
+    }
+
+    /// Returns true if the builder is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data_buffer.is_empty()
     }
 }
 
 /// Reader to scan a shard builder.
 pub struct ShardBuilderReader {
+    shard_id: ShardId,
     dict_reader: DictBuilderReader,
     data_reader: DataBufferReader,
 }
 
 impl ShardBuilderReader {
+    pub fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
     pub fn is_valid(&self) -> bool {
         self.data_reader.is_valid()
     }
@@ -197,9 +218,10 @@ mod tests {
         let metadata = metadata_for_test();
         let input = input_with_key(&metadata);
         let config = MergeTreeConfig::default();
-        let mut shard_builder = ShardBuilder::new(metadata.clone(), &config);
+        let mut shard_builder = ShardBuilder::new(metadata.clone(), &config, 1);
         let mut metrics = WriteMetrics::default();
-        assert!(shard_builder.finish(1, metadata.clone()).unwrap().is_none());
+        assert!(shard_builder.finish(metadata.clone()).unwrap().is_none());
+        assert_eq!(1, shard_builder.current_shard_id);
 
         for key_values in &input {
             for kv in key_values.iter() {
@@ -207,6 +229,8 @@ mod tests {
                 shard_builder.write_with_key(&key, kv, &mut metrics);
             }
         }
-        shard_builder.finish(1, metadata).unwrap().unwrap();
+        let shard = shard_builder.finish(metadata).unwrap().unwrap();
+        assert_eq!(1, shard.shard_id);
+        assert_eq!(2, shard_builder.current_shard_id);
     }
 }

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -111,7 +111,6 @@ pub struct ShardBuilderReader {
     data_reader: DataBufferReader,
 }
 
-// TODO(yingwen): Can we use generic for data reader?
 impl ShardBuilderReader {
     fn is_valid(&self) -> bool {
         self.data_reader.is_valid()
@@ -126,7 +125,7 @@ impl ShardBuilderReader {
         Some(self.dict_reader.key_by_pk_index(pk_index))
     }
 
-    fn current_batch(&self) -> DataBatch {
+    fn current_batch(&self) -> &DataBatch {
         self.data_reader.current_data_batch()
     }
 }

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -96,7 +96,7 @@ impl ShardBuilder {
     pub fn scan(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
         let dict_reader = self.dict_builder.read();
         dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
-        let data_reader = self.data_buffer.read(&pk_weights_buffer)?;
+        let data_reader = self.data_buffer.read(Some(&pk_weights_buffer))?;
 
         Ok(ShardBuilderReader {
             dict_reader,
@@ -125,7 +125,7 @@ impl ShardBuilderReader {
         Some(self.dict_reader.key_by_pk_index(pk_index))
     }
 
-    fn current_batch(&self) -> &DataBatch {
+    fn current_batch(&self) -> DataBatch {
         self.data_reader.current_data_batch()
     }
 }

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -93,10 +93,10 @@ impl ShardBuilder {
     }
 
     /// Scans the shard builder.
-    pub fn scan(&mut self) -> Result<ShardBuilderReader> {
+    pub fn scan(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
         let dict_reader = self.dict_builder.read();
-        let pk_weights = dict_reader.pk_weights_to_sort_data();
-        let data_reader = self.data_buffer.read(&pk_weights)?;
+        dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
+        let data_reader = self.data_buffer.read(&pk_weights_buffer)?;
 
         Ok(ShardBuilderReader {
             dict_reader,

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -122,7 +122,7 @@ impl MergeTree {
     }
 
     /// Scans the tree.
-    pub fn scan(
+    pub fn read(
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -317,8 +317,8 @@ impl TreeIter {
         };
 
         debug_assert!(part_reader.is_valid());
-        let batch = part_reader.current_batch();
-        part_reader.next();
+        let batch = part_reader.convert_current_batch()?;
+        part_reader.next()?;
         if part_reader.is_valid() {
             return Ok(Some(batch));
         }

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -159,7 +159,12 @@ impl MergeTree {
             partitions,
             current_reader: None,
         };
-        let context = ReadPartitionContext::new(projection, filters);
+        let context = ReadPartitionContext::new(
+            self.metadata.clone(),
+            self.row_codec.clone(),
+            projection,
+            filters,
+        );
         iter.fetch_next_partition(context)?;
 
         Ok(Box::new(iter))

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -32,7 +32,7 @@ use crate::error::{PrimaryKeyLengthMismatchSnafu, Result};
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::metrics::WriteMetrics;
 use crate::memtable::merge_tree::partition::{
-    Partition, PartitionKey, PartitionReader, PartitionRef,
+    Partition, PartitionKey, PartitionReader, PartitionRef, ReadPartitionRequest,
 };
 use crate::memtable::merge_tree::MergeTreeConfig;
 use crate::memtable::time_series::primary_key_schema;
@@ -151,16 +151,16 @@ impl MergeTree {
             .map(|pk| pk.column_schema.data_type.clone())
             .collect();
 
-        let iter = TreeIter {
+        let mut iter = TreeIter {
             metadata: self.metadata.clone(),
             pk_schema,
             pk_datatypes,
-            projection,
-            filters,
             row_codec: self.row_codec.clone(),
             partitions,
             current_reader: None,
         };
+        let part_read_request = ReadPartitionRequest::new(projection, filters);
+        iter.fetch_next_partition(part_read_request)?;
 
         Ok(Box::new(iter))
     }
@@ -281,8 +281,6 @@ struct TreeIter {
     metadata: RegionMetadataRef,
     pk_schema: arrow::datatypes::SchemaRef,
     pk_datatypes: Vec<ConcreteDataType>,
-    projection: HashSet<ColumnId>,
-    filters: Vec<SimpleFilterEvaluator>,
     row_codec: Arc<McmpRowCodec>,
     partitions: VecDeque<PartitionRef>,
     current_reader: Option<PartitionReader>,
@@ -292,6 +290,44 @@ impl Iterator for TreeIter {
     type Item = Result<Batch>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        unimplemented!()
+        self.next_batch().transpose()
+    }
+}
+
+impl TreeIter {
+    /// Fetch next partition.
+    fn fetch_next_partition(&mut self, mut request: ReadPartitionRequest) -> Result<()> {
+        while let Some(partition) = self.partitions.pop_front() {
+            let part_reader = partition.read(request)?;
+            if !part_reader.is_valid() {
+                request = part_reader.into_request();
+                continue;
+            }
+            self.current_reader = Some(part_reader);
+            break;
+        }
+
+        Ok(())
+    }
+
+    /// Fetches next batch.
+    fn next_batch(&mut self) -> Result<Option<Batch>> {
+        let Some(part_reader) = &mut self.current_reader else {
+            return Ok(None);
+        };
+
+        debug_assert!(part_reader.is_valid());
+        let batch = part_reader.current_batch();
+        part_reader.next();
+        if part_reader.is_valid() {
+            return Ok(Some(batch));
+        }
+
+        // Safety: current reader is Some.
+        let part_reader = self.current_reader.take().unwrap();
+        let request = part_reader.into_request();
+        self.fetch_next_partition(request)?;
+
+        Ok(Some(batch))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR mainly implements the `iter()` method for the new memtable.
- The `iter()` method returns a `TreeIter` to iterate partitions
- The memtable can use filters to prune partitions
- The `TreeIter` read partitions one by one
- For each partition, the iter creates a `PartitionReader`
- The `PartitionReader` merges `DataBatches` from different `ShardReaderImpls` and the `ShardBuilderReaders`
- Each `ShardReader` merges `DataBatches` from different data parts.

Unresolved problem:
- Integrates with the `DedupReader`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804