### PR TITLE
feat: Add freeze and fork method to the memtable

### DIFF
--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -466,7 +466,11 @@ impl FlushScheduler {
         }
 
         // Now we can flush the region directly.
-        version_control.freeze_mutable(&task.memtable_builder);
+        version_control
+            .freeze_mutable(&task.memtable_builder)
+            .inspect(|e| {
+                error!(e; "Failed to freeze the mutable memtable for region {}", region_id);
+            })?;
         // Submit a flush job.
         let job = task.into_flush_job(version_control);
         if let Err(e) = self.scheduler.schedule(job) {

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -464,7 +464,7 @@ impl FlushScheduler {
         }
 
         // Now we can flush the region directly.
-        version_control.freeze_mutable().inspect(|e| {
+        version_control.freeze_mutable().inspect_err(|e| {
             error!(e; "Failed to freeze the mutable memtable for region {}", region_id);
         })?;
         // Submit a flush job.

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -315,7 +315,7 @@ impl RegionFlushTask {
             }
 
             let file_id = FileId::random();
-            let iter = mem.iter(None, None);
+            let iter = mem.iter(None, None)?;
             let source = Source::Iter(iter);
             let create_inverted_index = self.engine_config.inverted_index.create_on_flush.auto();
             let mem_threshold_index_create = self

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -60,7 +60,7 @@ impl MemtableStats {
     }
 }
 
-pub type BoxedBatchIterator = Box<dyn Iterator<Item = Result<Batch>> + Send + Sync>;
+pub type BoxedBatchIterator = Box<dyn Iterator<Item = Result<Batch>> + Send>;
 
 /// In memory write buffer.
 pub trait Memtable: Send + Sync + fmt::Debug {

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -87,6 +87,9 @@ pub trait Memtable: Send + Sync + fmt::Debug {
 
     /// Returns the [MemtableStats] info of Memtable.
     fn stats(&self) -> MemtableStats;
+
+    /// Forks this memtable and returns a new mutable memtable with specific memtable `id`.
+    fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
 }
 
 pub type MemtableRef = Arc<dyn Memtable>;
@@ -157,6 +160,11 @@ impl AllocTracker {
     /// Returns bytes allocated.
     pub(crate) fn bytes_allocated(&self) -> usize {
         self.bytes_allocated.load(Ordering::Relaxed)
+    }
+
+    /// Returns the write buffer manager.
+    pub(crate) fn write_buffer_manager(&self) -> Option<WriteBufferManagerRef> {
+        self.write_buffer_manager.clone()
     }
 }
 

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -82,13 +82,13 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;
 
-    /// Marks the memtable as immutable.
+    /// Turns a mutable memtable into an immutable memtable.
     fn freeze(&self) -> Result<()>;
 
     /// Returns the [MemtableStats] info of Memtable.
     fn stats(&self) -> MemtableStats;
 
-    /// Forks this memtable and returns a new mutable memtable with specific memtable `id`.
+    /// Forks this (immutable) memtable and returns a new mutable memtable with specific memtable `id`.
     ///
     /// A region must freeze the memtable before invoking this method.
     fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -82,8 +82,8 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;
 
-    /// Mark the memtable as immutable.
-    fn mark_immutable(&self) -> Result<()>;
+    /// Marks the memtable as immutable.
+    fn freeze(&self) -> Result<()>;
 
     /// Returns the [MemtableStats] info of Memtable.
     fn stats(&self) -> MemtableStats;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -97,7 +97,7 @@ pub type MemtableRef = Arc<dyn Memtable>;
 /// Builder to build a new [Memtable].
 pub trait MemtableBuilder: Send + Sync + fmt::Debug {
     /// Builds a new memtable instance.
-    fn build(&self, metadata: &RegionMetadataRef) -> MemtableRef;
+    fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
 }
 
 pub type MemtableBuilderRef = Arc<dyn MemtableBuilder>;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -83,7 +83,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     fn is_empty(&self) -> bool;
 
     /// Mark the memtable as immutable.
-    fn mark_immutable(&self);
+    fn mark_immutable(&self) -> Result<()>;
 
     /// Returns the [MemtableStats] info of Memtable.
     fn stats(&self) -> MemtableStats;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -89,6 +89,8 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     fn stats(&self) -> MemtableStats;
 
     /// Forks this memtable and returns a new mutable memtable with specific memtable `id`.
+    ///
+    /// A region must freeze the memtable before invoking this method.
     fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef;
 }
 

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -77,7 +77,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> BoxedBatchIterator;
+    ) -> Result<BoxedBatchIterator>;
 
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -24,7 +24,7 @@ mod shard_builder;
 mod tree;
 
 use std::fmt;
-use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
 use store_api::metadata::RegionMetadataRef;
@@ -242,7 +242,6 @@ impl MergeTreeMemtable {
 /// Builder to build a [MergeTreeMemtable].
 #[derive(Debug, Default)]
 pub struct MergeTreeMemtableBuilder {
-    id: AtomicU32,
     write_buffer_manager: Option<WriteBufferManagerRef>,
     config: MergeTreeConfig,
 }
@@ -251,7 +250,6 @@ impl MergeTreeMemtableBuilder {
     /// Creates a new builder with specific `write_buffer_manager`.
     pub fn new(write_buffer_manager: Option<WriteBufferManagerRef>) -> Self {
         Self {
-            id: AtomicU32::new(0),
             write_buffer_manager,
             config: MergeTreeConfig::default(),
         }
@@ -259,8 +257,7 @@ impl MergeTreeMemtableBuilder {
 }
 
 impl MemtableBuilder for MergeTreeMemtableBuilder {
-    fn build(&self, metadata: &RegionMetadataRef) -> MemtableRef {
-        let id = self.id.fetch_add(1, Ordering::Relaxed);
+    fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
         Arc::new(MergeTreeMemtable::new(
             id,
             metadata.clone(),

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -152,7 +152,7 @@ impl Memtable for MergeTreeMemtable {
         }
     }
 
-    fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
+    fn fork(&self, _id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
         unimplemented!()
     }
 }

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -148,6 +148,10 @@ impl Memtable for MergeTreeMemtable {
             time_range: Some((min_timestamp, max_timestamp)),
         }
     }
+
+    fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
+        unimplemented!()
+    }
 }
 
 impl MergeTreeMemtable {

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -117,7 +117,7 @@ impl Memtable for MergeTreeMemtable {
         self.tree.is_empty()
     }
 
-    fn mark_immutable(&self) -> Result<()> {
+    fn freeze(&self) -> Result<()> {
         self.alloc_tracker.done_allocating();
 
         // TODO(yingwen): Freeze the tree.

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -117,8 +117,11 @@ impl Memtable for MergeTreeMemtable {
         self.tree.is_empty()
     }
 
-    fn mark_immutable(&self) {
+    fn mark_immutable(&self) -> Result<()> {
         self.alloc_tracker.done_allocating();
+
+        // TODO(yingwen): Freeze the tree.
+        Ok(())
     }
 
     fn stats(&self) -> MemtableStats {

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -108,7 +108,7 @@ impl Memtable for MergeTreeMemtable {
         &self,
         _projection: Option<&[ColumnId]>,
         _predicate: Option<Predicate>,
-    ) -> BoxedBatchIterator {
+    ) -> Result<BoxedBatchIterator> {
         // FIXME(yingwen): Change return value to `Result<BoxedBatchIterator>`.
         todo!()
     }

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -228,7 +228,7 @@ impl Memtable for TimeSeriesMemtable {
         self.series_set.series.read().unwrap().is_empty()
     }
 
-    fn mark_immutable(&self) -> Result<()> {
+    fn freeze(&self) -> Result<()> {
         self.alloc_tracker.done_allocating();
 
         Ok(())

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -15,7 +15,7 @@
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, Bound, HashSet};
 use std::fmt::{Debug, Formatter};
-use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
@@ -52,7 +52,6 @@ const INITIAL_BUILDER_CAPACITY: usize = 0;
 /// Builder to build [TimeSeriesMemtable].
 #[derive(Debug, Default)]
 pub struct TimeSeriesMemtableBuilder {
-    id: AtomicU32,
     write_buffer_manager: Option<WriteBufferManagerRef>,
 }
 
@@ -60,15 +59,13 @@ impl TimeSeriesMemtableBuilder {
     /// Creates a new builder with specific `write_buffer_manager`.
     pub fn new(write_buffer_manager: Option<WriteBufferManagerRef>) -> Self {
         Self {
-            id: AtomicU32::new(0),
             write_buffer_manager,
         }
     }
 }
 
 impl MemtableBuilder for TimeSeriesMemtableBuilder {
-    fn build(&self, metadata: &RegionMetadataRef) -> MemtableRef {
-        let id = self.id.fetch_add(1, Ordering::Relaxed);
+    fn build(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
         Arc::new(TimeSeriesMemtable::new(
             metadata.clone(),
             id,

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -228,8 +228,10 @@ impl Memtable for TimeSeriesMemtable {
         self.series_set.series.read().unwrap().is_empty()
     }
 
-    fn mark_immutable(&self) {
+    fn mark_immutable(&self) -> Result<()> {
         self.alloc_tracker.done_allocating();
+
+        Ok(())
     }
 
     fn stats(&self) -> MemtableStats {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -257,6 +257,14 @@ impl Memtable for TimeSeriesMemtable {
             time_range: Some((min_timestamp, max_timestamp)),
         }
     }
+
+    fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
+        Arc::new(TimeSeriesMemtable::new(
+            metadata.clone(),
+            id,
+            self.alloc_tracker.write_buffer_manager(),
+        ))
+    }
 }
 
 type SeriesRwLockMap = RwLock<BTreeMap<Vec<u8>, Arc<RwLock<Series>>>>;

--- a/src/mito2/src/memtable/version.rs
+++ b/src/mito2/src/memtable/version.rs
@@ -76,7 +76,7 @@ impl MemtableVersion {
         // soft limit.
         self.mutable.freeze()?;
         // Fork the memtable.
-        let mutable = self.mutable.fork(self.mutable.id() + 1, metadata);
+        let mutable = self.mutable.fork(self.next_memtable_id(), metadata);
 
         // Pushes the mutable memtable to immutable list.
         let immutables = self
@@ -120,5 +120,10 @@ impl MemtableVersion {
     /// immutable memtables.
     pub(crate) fn is_empty(&self) -> bool {
         self.mutable.is_empty() && self.immutables.is_empty()
+    }
+
+    /// Returns the next memtable id.
+    pub(crate) fn next_memtable_id(&self) -> MemtableId {
+        self.mutable.id() + 1
     }
 }

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -213,7 +213,7 @@ impl SeqScan {
     async fn build_sources(&self) -> Result<Vec<Source>> {
         let mut sources = Vec::with_capacity(self.memtables.len() + self.files.len());
         for mem in &self.memtables {
-            let iter = mem.iter(Some(self.mapper.column_ids()), self.predicate.clone());
+            let iter = mem.iter(Some(self.mapper.column_ids()), self.predicate.clone())?;
             sources.push(Source::Iter(iter));
         }
         for file in &self.files {

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -168,7 +168,8 @@ impl RegionOpener {
         let manifest_manager =
             RegionManifestManager::new(metadata.clone(), region_manifest_options).await?;
 
-        let mutable = self.memtable_builder.build(&metadata);
+        // Initial memtable id is 0.
+        let mutable = self.memtable_builder.build(0, &metadata);
 
         let version = VersionBuilder::new(metadata, mutable)
             .options(options)
@@ -258,7 +259,8 @@ impl RegionOpener {
             access_layer.clone(),
             self.cache_manager.clone(),
         ));
-        let mutable = self.memtable_builder.build(&metadata);
+        // Initial memtable id is 0.
+        let mutable = self.memtable_builder.build(0, &metadata);
         let version = VersionBuilder::new(metadata, mutable)
             .add_files(file_purger.clone(), manifest.files.values().cloned())
             .flushed_entry_id(manifest.flushed_entry_id)

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -77,7 +77,7 @@ impl VersionControl {
     }
 
     /// Freezes the mutable memtable if it is not empty.
-    pub(crate) fn freeze_mutable(&self, _builder: &MemtableBuilderRef) -> Result<()> {
+    pub(crate) fn freeze_mutable(&self) -> Result<()> {
         let version = self.current().version;
         if version.memtables.mutable.is_empty() {
             return Ok(());

--- a/src/mito2/src/region/version.rs
+++ b/src/mito2/src/region/version.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::SequenceNumber;
 
+use crate::error::Result;
 use crate::manifest::action::RegionEdit;
 use crate::memtable::version::{MemtableVersion, MemtableVersionRef};
 use crate::memtable::{MemtableBuilderRef, MemtableId, MemtableRef};
@@ -76,14 +77,16 @@ impl VersionControl {
     }
 
     /// Freezes the mutable memtable if it is not empty.
-    pub(crate) fn freeze_mutable(&self, builder: &MemtableBuilderRef) {
+    pub(crate) fn freeze_mutable(&self, _builder: &MemtableBuilderRef) -> Result<()> {
         let version = self.current().version;
         if version.memtables.mutable.is_empty() {
-            return;
+            return Ok(());
         }
-        let new_mutable = builder.build(&version.metadata);
         // Safety: Immutable memtable is None.
-        let new_memtables = version.memtables.freeze_mutable(new_mutable).unwrap();
+        let new_memtables = version
+            .memtables
+            .freeze_mutable(&version.metadata)?
+            .unwrap();
         // Create a new version with memtable switched.
         let new_version = Arc::new(
             VersionBuilder::from_version(version)
@@ -93,6 +96,8 @@ impl VersionControl {
 
         let mut version_data = self.data.write().unwrap();
         version_data.version = new_version;
+
+        Ok(())
     }
 
     /// Apply edit to current version.

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -62,8 +62,8 @@ impl Memtable for EmptyMemtable {
         &self,
         _projection: Option<&[ColumnId]>,
         _filters: Option<Predicate>,
-    ) -> BoxedBatchIterator {
-        Box::new(std::iter::empty())
+    ) -> Result<BoxedBatchIterator> {
+        Ok(Box::new(std::iter::empty()))
     }
 
     fn is_empty(&self) -> bool {

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -85,16 +85,11 @@ impl Memtable for EmptyMemtable {
 
 /// Empty memtable builder.
 #[derive(Debug, Default)]
-pub(crate) struct EmptyMemtableBuilder {
-    /// Next memtable id.
-    next_id: AtomicU32,
-}
+pub(crate) struct EmptyMemtableBuilder {}
 
 impl MemtableBuilder for EmptyMemtableBuilder {
-    fn build(&self, _metadata: &RegionMetadataRef) -> MemtableRef {
-        Arc::new(EmptyMemtable::new(
-            self.next_id.fetch_add(1, Ordering::Relaxed),
-        ))
+    fn build(&self, id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
+        Arc::new(EmptyMemtable::new(id))
     }
 }
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -75,6 +75,10 @@ impl Memtable for EmptyMemtable {
     fn stats(&self) -> MemtableStats {
         MemtableStats::default()
     }
+
+    fn fork(&self, id: MemtableId, _metadata: &RegionMetadataRef) -> MemtableRef {
+        Arc::new(EmptyMemtable::new(id))
+    }
 }
 
 /// Empty memtable builder.

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -70,7 +70,7 @@ impl Memtable for EmptyMemtable {
         true
     }
 
-    fn mark_immutable(&self) {}
+    fn mark_immutable(&self) -> Result<()> {}
 
     fn stats(&self) -> MemtableStats {
         MemtableStats::default()

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -70,7 +70,9 @@ impl Memtable for EmptyMemtable {
         true
     }
 
-    fn mark_immutable(&self) -> Result<()> {}
+    fn freeze(&self) -> Result<()> {
+        Ok(())
+    }
 
     fn stats(&self) -> MemtableStats {
         MemtableStats::default()

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -105,7 +105,7 @@ impl VersionControlBuilder {
 
     pub(crate) fn build_version(&self) -> Version {
         let metadata = Arc::new(self.metadata.clone());
-        let mutable = self.memtable_builder.build(&metadata);
+        let mutable = self.memtable_builder.build(0, &metadata);
         VersionBuilder::new(metadata, mutable)
             .add_files(self.file_purger.clone(), self.files.values().cloned())
             .build()

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -143,7 +143,6 @@ impl<S> RegionWorkerLoop<S> {
             senders: Vec::new(),
             request_sender: self.sender.clone(),
             access_layer: region.access_layer.clone(),
-            memtable_builder: self.memtable_builder.clone(),
             file_purger: region.file_purger.clone(),
             listener: self.listener.clone(),
             engine_config,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR changes some APIs of the memtable
- Renames `mark_immutable()` to `freeze()`. `freeze()` turns a mutable memtable into an immutable memtable and this operation is fallible.
- Adds a `fork()` method to create a new mutable memtable from an immutable memtable.
  - It allows the new memtable to reuse some data in the old memtable
- The `iter()` method is fallible.

Now the region instead of the memtable builder generates the memtable id. So the memtable builder needs to take a memtable id to build a new memtable.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804