### PR TITLE
fix: remove unused imports in memtable_util.rs

### DIFF
--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -14,7 +14,6 @@
 
 //! Memtable test utilities.
 
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use api::helper::ColumnDataTypeWrapper;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

remove unused imports in memtable_util.rs. Clippy does not deny these unused imports as we explicitly allow this.

https://github.com/GreptimeTeam/greptimedb/blob/f81e37f508db98b7ade460f323dbc1640e0520af/src/mito2/src/lib.rs#L23

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
