### PR TITLE
refactor: change the receivers of merge tree components

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -15,7 +15,6 @@
 //! Memtables are write buffers for regions.
 
 pub mod key_values;
-#[allow(dead_code)]
 pub mod merge_tree;
 pub mod time_series;
 pub(crate) mod version;

--- a/src/mito2/src/memtable/merge_tree/dedup.rs
+++ b/src/mito2/src/memtable/merge_tree/dedup.rs
@@ -176,7 +176,7 @@ mod tests {
             frozens.push(part1);
         }
 
-        let mut parts = DataParts::new(meta, 10, true).with_frozen(frozens);
+        let parts = DataParts::new(meta, 10, true).with_frozen(frozens);
 
         let mut res = Vec::with_capacity(expected.len());
         let mut reader = DedupReader::try_new(MockSource(parts.read().unwrap())).unwrap();

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -105,13 +105,12 @@ impl Partition {
 
     /// Scans data in the partition.
     pub fn read(&self, mut context: ReadPartitionContext) -> Result<PartitionReader> {
-        // TODO(yingwen): Change to acquire read lock if `read()` takes `&self`.
         let nodes = {
-            let mut inner = self.inner.write().unwrap();
+            let inner = self.inner.read().unwrap();
             let mut nodes = Vec::with_capacity(inner.shards.len() + 1);
             let bulder_reader = inner.shard_builder.read(&mut context.pk_weights)?;
             nodes.push(ShardNode::new(ShardSource::Builder(bulder_reader)));
-            for shard in &mut inner.shards {
+            for shard in &inner.shards {
                 let shard_reader = shard.read()?;
                 nodes.push(ShardNode::new(ShardSource::Shard(shard_reader)));
             }

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -72,7 +72,7 @@ impl Shard {
 
     /// Scans the shard.
     // TODO(yingwen): Push down projection to data parts.
-    pub fn read(&mut self) -> Result<ShardReader> {
+    pub fn read(&self) -> Result<ShardReader> {
         let parts_reader = self.data_parts.read()?;
 
         Ok(ShardReader {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -136,10 +136,6 @@ pub struct ShardReader {
 }
 
 impl ShardReader {
-    fn shard_id(&self) -> ShardId {
-        self.shard_id
-    }
-
     fn is_valid(&self) -> bool {
         self.parts_reader.is_valid()
     }

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -106,7 +106,7 @@ impl ShardBuilder {
     }
 
     /// Scans the shard builder.
-    pub fn read(&mut self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
+    pub fn read(&self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
         let dict_reader = self.dict_builder.read();
         dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
         let data_reader = self.data_buffer.read(Some(pk_weights_buffer))?;

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -132,10 +132,6 @@ pub struct ShardBuilderReader {
 }
 
 impl ShardBuilderReader {
-    pub fn shard_id(&self) -> ShardId {
-        self.shard_id
-    }
-
     pub fn is_valid(&self) -> bool {
         self.data_reader.is_valid()
     }
@@ -164,14 +160,12 @@ impl ShardBuilderReader {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
 
     use super::*;
-    use crate::memtable::merge_tree::dict::KeyDictBuilder;
     use crate::memtable::merge_tree::metrics::WriteMetrics;
     use crate::memtable::KeyValues;
     use crate::test_util::memtable_util::{
-        build_key_values_with_ts_seq_values, encode_key_by_kv, encode_keys, metadata_for_test,
+        build_key_values_with_ts_seq_values, encode_key_by_kv, metadata_for_test,
     };
 
     fn input_with_key(metadata: &RegionMetadataRef) -> Vec<KeyValues> {
@@ -201,27 +195,6 @@ mod tests {
                 2,
             ),
         ]
-    }
-
-    fn new_shard_builder(
-        shard_id: ShardId,
-        metadata: RegionMetadataRef,
-        input: &[KeyValues],
-    ) -> Shard {
-        let mut dict_builder = KeyDictBuilder::new(1024);
-        let mut metrics = WriteMetrics::default();
-        let mut keys = Vec::with_capacity(input.len());
-        for kvs in input {
-            encode_keys(&metadata, kvs, &mut keys);
-        }
-        for key in &keys {
-            dict_builder.insert_key(key, &mut metrics);
-        }
-
-        let dict = dict_builder.finish().unwrap();
-        let data_parts = DataParts::new(metadata, DATA_INIT_CAP, true);
-
-        Shard::new(shard_id, Some(Arc::new(dict)), data_parts, true)
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
Change the receivers of merge tree components' read methods to `&self` instead of `&mut self` so that `Partition::read` does not need to acquire write lock.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804
