### PR TITLE
ci: add builder result outputs in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,8 @@ jobs:
             arch: x86_64-apple-darwin
             artifacts-dir-prefix: greptime-darwin-amd64-pyo3
     runs-on: ${{ matrix.os }}
+    outputs:
+      build-macos-result: ${{ steps.set-build-macos-result.outputs.build-macos-result }}
     needs: [
       allocate-runners,
     ]
@@ -260,6 +262,8 @@ jobs:
             features: pyo3_backend,servers/dashboard
             artifacts-dir-prefix: greptime-windows-amd64-pyo3
     runs-on: ${{ matrix.os }}
+    outputs:
+      build-windows-result: ${{ steps.set-build-windows-result.outputs.build-windows-result }}
     needs: [
       allocate-runners,
     ]
@@ -295,6 +299,8 @@ jobs:
       build-linux-arm64-artifacts,
     ]
     runs-on: ubuntu-2004-16-cores
+    outputs:
+      build-image-result: ${{ steps.set-build-image-result.outputs.build-image-result }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -310,7 +316,7 @@ jobs:
           version: ${{ needs.allocate-runners.outputs.version }}
 
       - name: Set build image result
-        id: set-image-build-result
+        id: set-build-image-result
         run: |
           echo "build-image-result=success" >> $GITHUB_OUTPUT    
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Notification job cannot get build result in this checker: 
```
if: ${{ needs.release-images-to-dockerhub.outputs.build-image-result == 'success' && needs.build-windows-artifacts.outputs.build-windows-result == 'success' && needs.build-macos-artifacts.outputs.build-macos-result == 'success' }}
```

$GITHUB_OUTPUT share between job but need to define outputs, like [this](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).
 


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
