### PR TITLE
feat: change how region id maps to region worker

### DIFF
--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -273,7 +273,8 @@ impl WorkerGroup {
 }
 
 fn region_id_to_index(id: RegionId, num_workers: usize) -> usize {
-    (id.table_id() as usize % num_workers) + (id.region_number() as usize % num_workers)
+    ((id.table_id() as usize % num_workers) + (id.region_number() as usize % num_workers))
+        % num_workers
 }
 
 async fn write_cache_from_config(
@@ -757,10 +758,15 @@ mod tests {
 
     #[test]
     fn test_region_id_to_index() {
-        let region_id = RegionId::new(1, 2);
         let num_workers = 4;
+
+        let region_id = RegionId::new(1, 2);
         let index = region_id_to_index(region_id, num_workers);
         assert_eq!(index, 3);
+
+        let region_id = RegionId::new(2, 3);
+        let index = region_id_to_index(region_id, num_workers);
+        assert_eq!(index, 1);
     }
 
     #[tokio::test]

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -25,8 +25,6 @@ mod handle_open;
 mod handle_truncate;
 mod handle_write;
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -206,10 +204,7 @@ impl WorkerGroup {
 
     /// Get worker for specific `region_id`.
     fn worker(&self, region_id: RegionId) -> &RegionWorker {
-        let mut hasher = DefaultHasher::new();
-        region_id.hash(&mut hasher);
-        let value = hasher.finish() as usize;
-        let index = value_to_index(value, self.workers.len());
+        let index = region_id_to_index(region_id, self.workers.len());
 
         &self.workers[index]
     }
@@ -277,8 +272,8 @@ impl WorkerGroup {
     }
 }
 
-fn value_to_index(value: usize, num_workers: usize) -> usize {
-    value % num_workers
+fn region_id_to_index(id: RegionId, num_workers: usize) -> usize {
+    (id.table_id() as usize % num_workers) + (id.region_number() as usize % num_workers)
 }
 
 async fn write_cache_from_config(
@@ -761,16 +756,11 @@ mod tests {
     use crate::test_util::TestEnv;
 
     #[test]
-    fn test_value_to_index() {
-        let num_workers = 1;
-        for i in 0..10 {
-            assert_eq!(0, value_to_index(i, num_workers));
-        }
-
+    fn test_region_id_to_index() {
+        let region_id = RegionId::new(1, 2);
         let num_workers = 4;
-        for i in 0..10 {
-            assert_eq!(i % 4, value_to_index(i, num_workers));
-        }
+        let index = region_id_to_index(region_id, num_workers);
+        assert_eq!(index, 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Change the static region worker mapping method. Remove hashing and use modulo instead.

Hashing mapping is not quite predictable. The new mapping considers table id and region number separately, so regions from one table won't get into the same worker.

This is a workaround and the workload skew problem still exists, and will exist if we don't support mechanisms like work stealing or dynamic mapping.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
