### PR TITLE
chore: skip reorder workspace tables in taplo

### DIFF
--- a/taplo.toml
+++ b/taplo.toml
@@ -34,3 +34,7 @@ crlf = false
 [[rule]]
 keys = ["build-dependencies", "dependencies", "dev-dependencies", "workspace.dependencies"]
 formatting = { reorder_keys = true }
+
+[[rule]]
+keys = ["package", "workspace.package"]
+formatting = { reorder_keys = false }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


`taplo format --check` would report an error on my env. It would reorder the `package` table:

<img width="852" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/11356395-66fe-4508-b5a4-271c7be92ce7">

This patch adds `package` and `workspace.package` to the no-sorting rule. As the `package` tables contain fields that have different meanings. E.g., conventionally, the `package_name` sits in the first line and then version and license etc.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
