### PR TITLE
fix: range fix in modulo function tests

### DIFF
--- a/src/common/function/src/scalars/math/modulo.rs
+++ b/src/common/function/src/scalars/math/modulo.rs
@@ -128,7 +128,7 @@ mod tests {
         ];
         let result = function.eval(FunctionContext::default(), &args).unwrap();
         assert_eq!(result.len(), 4);
-        for i in 0..3 {
+        for i in 0..4 {
             let p: i64 = (nums[i] % divs[i]) as i64;
             assert!(matches!(result.get(i), Value::Int64(v) if v == p));
         }
@@ -160,7 +160,7 @@ mod tests {
         ];
         let result = function.eval(FunctionContext::default(), &args).unwrap();
         assert_eq!(result.len(), 4);
-        for i in 0..3 {
+        for i in 0..4 {
             let p: u64 = (nums[i] % divs[i]) as u64;
             assert!(matches!(result.get(i), Value::UInt64(v) if v == p));
         }
@@ -192,7 +192,7 @@ mod tests {
         ];
         let result = function.eval(FunctionContext::default(), &args).unwrap();
         assert_eq!(result.len(), 4);
-        for i in 0..3 {
+        for i in 0..4 {
             let p: f64 = nums[i] % divs[i];
             assert!(matches!(result.get(i), Value::Float64(v) if v == p));
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

In tests for `modulo` function, the check range should be `0..4` rather than `0..3`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)

#3147