### PR TITLE
feat: Implement partition eviction and only add value size to write buffer size

### DIFF
--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -103,6 +103,7 @@ impl Memtable for MergeTreeMemtable {
 
         let mut metrics = WriteMetrics::default();
         let mut pk_buffer = Vec::new();
+        // Ensures the memtable always updates stats.
         let res = self.tree.write(kvs, &mut pk_buffer, &mut metrics);
 
         self.update_stats(&metrics);
@@ -159,8 +160,7 @@ impl Memtable for MergeTreeMemtable {
     fn fork(&self, id: MemtableId, metadata: &RegionMetadataRef) -> MemtableRef {
         let tree = self.tree.fork(metadata.clone());
 
-        let memtable =
-            MergeTreeMemtable::with_tree(id, tree, self.alloc_tracker.write_buffer_manager());
+        let memtable = MergeTreeMemtable::with_tree(id, tree);
         Arc::new(memtable)
     }
 }
@@ -173,23 +173,17 @@ impl MergeTreeMemtable {
         write_buffer_manager: Option<WriteBufferManagerRef>,
         config: &MergeTreeConfig,
     ) -> Self {
-        Self::with_tree(id, MergeTree::new(metadata, config), write_buffer_manager)
+        Self::with_tree(
+            id,
+            MergeTree::new(metadata, config, write_buffer_manager.clone()),
+        )
     }
 
     /// Creates a mutable memtable from the tree.
     ///
     /// It also adds the bytes used by shared parts (e.g. index) to the memory usage.
-    fn with_tree(
-        id: MemtableId,
-        tree: MergeTree,
-        write_buffer_manager: Option<WriteBufferManagerRef>,
-    ) -> Self {
-        let alloc_tracker = AllocTracker::new(write_buffer_manager);
-        // Track space allocated by the tree.
-        let allocated = tree.shared_memory_size();
-        // Here we still add the bytes of shared parts to the tracker as the old memtable
-        // will release its tracker soon.
-        alloc_tracker.on_allocation(allocated);
+    fn with_tree(id: MemtableId, tree: MergeTree) -> Self {
+        let alloc_tracker = AllocTracker::new(tree.write_buffer_manager());
 
         Self {
             id,
@@ -202,8 +196,8 @@ impl MergeTreeMemtable {
 
     /// Updates stats of the memtable.
     fn update_stats(&self, metrics: &WriteMetrics) {
-        self.alloc_tracker
-            .on_allocation(metrics.key_bytes + metrics.value_bytes);
+        // Only let the tracker tracks value bytes.
+        self.alloc_tracker.on_allocation(metrics.value_bytes);
 
         loop {
             let current_min = self.min_timestamp.load(Ordering::Relaxed);

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -75,7 +75,7 @@ impl Default for MergeTreeConfig {
             index_max_keys_per_shard: 8192,
             data_freeze_threshold: 102400,
             dedup: true,
-            fork_dictionary_bytes: ReadableSize::mb(384),
+            fork_dictionary_bytes: ReadableSize::mb(512),
         }
     }
 }

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -28,6 +28,7 @@ use std::fmt;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 
+use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
@@ -64,6 +65,8 @@ pub struct MergeTreeConfig {
     pub data_freeze_threshold: usize,
     /// Whether to delete duplicates rows.
     pub dedup: bool,
+    /// Total bytes of dictionary to keep in fork.
+    pub fork_dictionary_bytes: ReadableSize,
 }
 
 impl Default for MergeTreeConfig {
@@ -72,6 +75,7 @@ impl Default for MergeTreeConfig {
             index_max_keys_per_shard: 8192,
             data_freeze_threshold: 102400,
             dedup: true,
+            fork_dictionary_bytes: ReadableSize::mb(384),
         }
     }
 }

--- a/src/mito2/src/memtable/merge_tree/dict.rs
+++ b/src/mito2/src/memtable/merge_tree/dict.rs
@@ -51,7 +51,7 @@ pub struct KeyDictBuilder {
 impl KeyDictBuilder {
     /// Creates a new builder that can hold up to `capacity` keys.
     pub fn new(capacity: usize, write_buffer_manager: Option<WriteBufferManagerRef>) -> Self {
-        let tracker = AllocTracker::new(write_buffer_manager.clone());
+        let tracker = AllocTracker::new(None);
         Self {
             capacity,
             num_keys: 0,

--- a/src/mito2/src/memtable/merge_tree/dict.rs
+++ b/src/mito2/src/memtable/merge_tree/dict.rs
@@ -127,6 +127,7 @@ impl KeyDictBuilder {
             *pk_index = i as PkIndex;
         }
         self.num_keys = 0;
+        self.key_bytes = 0;
 
         Some(KeyDict {
             pk_to_index,

--- a/src/mito2/src/memtable/merge_tree/dict.rs
+++ b/src/mito2/src/memtable/merge_tree/dict.rs
@@ -130,6 +130,8 @@ impl KeyDictBuilder {
             *pk_index = i as PkIndex;
         }
         self.num_keys = 0;
+        // Done allocating for current tracker.
+        self.tracker.done_allocating();
 
         Some(KeyDict {
             pk_to_index,

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -184,6 +184,23 @@ impl Partition {
         inner.num_rows > 0
     }
 
+    /// Gets the stats of the partition.
+    pub(crate) fn stats(&self) -> PartitionStats {
+        let inner = self.inner.read().unwrap();
+        let num_rows = inner.num_rows;
+        let shard_num = inner.shards.len();
+        let shared_memory_size = inner
+            .shards
+            .iter()
+            .map(|shard| shard.shared_memory_size())
+            .sum();
+        PartitionStats {
+            num_rows,
+            shard_num,
+            shared_memory_size,
+        }
+    }
+
     /// Get partition key from the key value.
     pub(crate) fn get_partition_key(key_value: &KeyValue, is_partitioned: bool) -> PartitionKey {
         if !is_partitioned {
@@ -210,6 +227,12 @@ impl Partition {
     pub(crate) fn is_partition_column(name: &str) -> bool {
         name == DATA_SCHEMA_TABLE_ID_COLUMN_NAME
     }
+}
+
+pub(crate) struct PartitionStats {
+    pub(crate) num_rows: usize,
+    pub(crate) shard_num: usize,
+    pub(crate) shared_memory_size: usize,
 }
 
 /// Reader to scan rows in a partition.

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -82,14 +82,6 @@ impl Shard {
         })
     }
 
-    /// Returns the memory size of the shard part.
-    pub fn shared_memory_size(&self) -> usize {
-        self.key_dict
-            .as_ref()
-            .map(|dict| dict.shared_memory_size())
-            .unwrap_or(0)
-    }
-
     /// Forks a shard.
     pub fn fork(&self, metadata: RegionMetadataRef) -> Shard {
         Shard {
@@ -365,7 +357,7 @@ mod tests {
         metadata: RegionMetadataRef,
         input: &[KeyValues],
     ) -> Shard {
-        let mut dict_builder = KeyDictBuilder::new(1024);
+        let mut dict_builder = KeyDictBuilder::new(1024, None);
         let mut metrics = WriteMetrics::default();
         let mut keys = Vec::with_capacity(input.len());
         for kvs in input {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -96,6 +96,14 @@ impl Shard {
     pub fn is_empty(&self) -> bool {
         self.data_parts.is_empty()
     }
+
+    /// Returns the memory size of the shard part.
+    pub(crate) fn shared_memory_size(&self) -> usize {
+        self.key_dict
+            .as_ref()
+            .map(|dict| dict.shared_memory_size())
+            .unwrap_or(0)
+    }
 }
 
 /// Source that returns [DataBatch].

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -365,7 +365,7 @@ mod tests {
         metadata: RegionMetadataRef,
         input: &[KeyValues],
     ) -> Shard {
-        let mut dict_builder = KeyDictBuilder::new(1024, None);
+        let mut dict_builder = KeyDictBuilder::new(1024);
         let mut metrics = WriteMetrics::default();
         let mut keys = Vec::with_capacity(input.len());
         for kvs in input {

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use store_api::metadata::RegionMetadataRef;
 
 use crate::error::Result;
+use crate::flush::WriteBufferManagerRef;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::data::{
     DataBatch, DataBuffer, DataBufferReader, DataParts, DATA_INIT_CAP,
@@ -48,10 +49,14 @@ impl ShardBuilder {
         metadata: RegionMetadataRef,
         config: &MergeTreeConfig,
         shard_id: ShardId,
+        write_buffer_manager: Option<WriteBufferManagerRef>,
     ) -> ShardBuilder {
         ShardBuilder {
             current_shard_id: shard_id,
-            dict_builder: KeyDictBuilder::new(config.index_max_keys_per_shard),
+            dict_builder: KeyDictBuilder::new(
+                config.index_max_keys_per_shard,
+                write_buffer_manager,
+            ),
             data_buffer: DataBuffer::with_capacity(metadata, DATA_INIT_CAP, config.dedup),
             data_freeze_threshold: config.data_freeze_threshold,
             dedup: config.dedup,
@@ -202,7 +207,7 @@ mod tests {
         let metadata = metadata_for_test();
         let input = input_with_key(&metadata);
         let config = MergeTreeConfig::default();
-        let mut shard_builder = ShardBuilder::new(metadata.clone(), &config, 1);
+        let mut shard_builder = ShardBuilder::new(metadata.clone(), &config, 1, None);
         let mut metrics = WriteMetrics::default();
         assert!(shard_builder.finish(metadata.clone()).unwrap().is_none());
         assert_eq!(1, shard_builder.current_shard_id);

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -212,7 +212,7 @@ impl MergeTree {
                 .collect::<Vec<_>>()
         };
 
-        // TODO(yingwen): Optimize eviction strategy.
+        // TODO(yingwen): Optimize eviction strategy. Now we evict the whole partition.
         let fork_size = self.config.fork_dictionary_bytes.as_bytes() as usize;
         if total_shared_size > fork_size {
             // Sort partitions by memory size desc.
@@ -235,7 +235,7 @@ impl MergeTree {
 
         let mut forked = BTreeMap::new();
         for (part_key, part, _) in part_infos {
-            let forked_part = part.fork(&metadata, &self.config, self.write_buffer_manager.clone());
+            let forked_part = part.fork(&metadata, &self.config);
             forked.insert(part_key, Arc::new(forked_part));
         }
 
@@ -277,13 +277,7 @@ impl MergeTree {
         let mut partitions = self.partitions.write().unwrap();
         partitions
             .entry(partition_key)
-            .or_insert_with(|| {
-                Arc::new(Partition::new(
-                    self.metadata.clone(),
-                    &self.config,
-                    self.write_buffer_manager.clone(),
-                ))
-            })
+            .or_insert_with(|| Arc::new(Partition::new(self.metadata.clone(), &self.config)))
             .clone()
     }
 

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -28,9 +28,9 @@ lazy_static! {
     /// Global write buffer size in bytes.
     pub static ref WRITE_BUFFER_BYTES: IntGauge =
         register_int_gauge!("greptime_mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
-    /// Global dictionary buffer size in bytes.
-    pub static ref DICT_BUFFER_BYTES: IntGauge =
-        register_int_gauge!("greptime_mito_dict_buffer_bytes", "mito dict buffer bytes").unwrap();
+    /// Global memtable dictionary size in bytes.
+    pub static ref MEMTABLE_DICT_BYTES: IntGauge =
+        register_int_gauge!("greptime_mito_memtable_dict_bytes", "mito memtable dictionary size in bytes").unwrap();
     /// Gauge for open regions
     pub static ref REGION_COUNT: IntGauge =
         register_int_gauge!("greptime_mito_region_count", "mito region count").unwrap();

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -28,6 +28,9 @@ lazy_static! {
     /// Global write buffer size in bytes.
     pub static ref WRITE_BUFFER_BYTES: IntGauge =
         register_int_gauge!("greptime_mito_write_buffer_bytes", "mito write buffer bytes").unwrap();
+    /// Global dictionary buffer size in bytes.
+    pub static ref DICT_BUFFER_BYTES: IntGauge =
+        register_int_gauge!("greptime_mito_dict_buffer_bytes", "mito dict buffer bytes").unwrap();
     /// Gauge for open regions
     pub static ref REGION_COUNT: IntGauge =
         register_int_gauge!("greptime_mito_region_count", "mito region count").unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR implements a simple eviction strategy to control the total dictionary size in the memtable. It sort partitions by dictionary size and evicts large partitions until the total dictionary size in less than fork_dictionary_bytes.

It also adds a new metrics to track dictionary size and only add value size to write buffer size.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804