### PR TITLE
chore: add metris for memtable read path

### DIFF
--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -27,6 +27,7 @@ use crate::memtable::merge_tree::dict::{DictBuilderReader, KeyDictBuilder};
 use crate::memtable::merge_tree::metrics::WriteMetrics;
 use crate::memtable::merge_tree::shard::Shard;
 use crate::memtable::merge_tree::{MergeTreeConfig, PkId, ShardId};
+use crate::metrics::MERGE_TREE_READ_STAGE_ELAPSED;
 
 /// Builder to write keys and data to a shard that the key dictionary
 /// is still active.
@@ -107,10 +108,21 @@ impl ShardBuilder {
 
     /// Scans the shard builder.
     pub fn read(&self, pk_weights_buffer: &mut Vec<u16>) -> Result<ShardBuilderReader> {
-        let dict_reader = self.dict_builder.read();
-        dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
-        let data_reader = self.data_buffer.read(Some(pk_weights_buffer))?;
+        let dict_reader = {
+            let _timer = MERGE_TREE_READ_STAGE_ELAPSED
+                .with_label_values(&["shard_builder_read_pk"])
+                .start_timer();
+            self.dict_builder.read()
+        };
 
+        {
+            let _timer = MERGE_TREE_READ_STAGE_ELAPSED
+                .with_label_values(&["sort_pk"])
+                .start_timer();
+            dict_reader.pk_weights_to_sort_data(pk_weights_buffer);
+        }
+
+        let data_reader = self.data_buffer.read(Some(pk_weights_buffer))?;
         Ok(ShardBuilderReader {
             shard_id: self.current_shard_id,
             dict_reader,

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -254,4 +254,24 @@ lazy_static! {
     pub static ref INDEX_INTERMEDIATE_FLUSH_OP_TOTAL: IntCounter = INDEX_IO_OP_TOTAL
         .with_label_values(&["flush", "intermediate"]);
     // ------- End of index metrics.
+
+    /// Merge tree memtable data buffer freeze metrics
+    pub static ref MERGE_TREE_DATA_BUFFER_FREEZE_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_merge_tree_buffer_freeze_stage_elapsed",
+        "mito merge tree data buffer freeze stage elapsed",
+        &[STAGE_LABEL],
+        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0]
+    )
+    .unwrap();
+
+    /// Merge tree memtable read path metrics
+    pub static ref MERGE_TREE_READ_STAGE_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_merge_tree_read_stage_elapsed",
+        "mito merge tree read stage elapsed",
+        &[STAGE_LABEL],
+        vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0]
+    )
+    .unwrap();
+
+    // ------- End of merge tree memtable metrics.
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR adds following metrics for the read path of MergeTreeMemtable:


MERGE_TREE_DATA_BUFFER_FREEZE_STAGE_ELAPSED
- DataPartEncoder
    - drain_data_buffer_to_record_batches (buffer_to_batch)
    - ArrowWriter::write (encode)

MERGE_TREE_READ_STAGE_ELAPSED
- TreeIter
    - TreeIter::fetch_next_partition (fetch_next_partition)
    - TreeIter::next_batch
        - PartitionReader::convert_current_batch (partition_data_batch_to_batch)
        - PartitionReader::prune_batch_by_key (partition_prune_pk)
        - PartitionReader::next (partition_read_source)
            - ShardBuilderReader::next (*)
                - DataBufferRead::next (read_data_buffer)
            - ShardReader::next
                - DataPartsReader::next (read_data_parts)
                    - DataBuffer::read (data_buffer_to_batch)
                    - DataPart::read (read_data_part) : mostly spend on reading parquet bytes


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
