### PR TITLE
feat: Use a partition level map to look up pk index

### DIFF
--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -461,61 +461,54 @@ mod tests {
     }
 
     #[test]
-    fn write_iter_multi_keys() {
+    fn test_write_iter_multi_keys() {
+        write_iter_multi_keys(1, 100);
+        write_iter_multi_keys(2, 100);
+        write_iter_multi_keys(4, 100);
+        write_iter_multi_keys(8, 5);
+        write_iter_multi_keys(2, 10);
+    }
+
+    fn write_iter_multi_keys(max_keys: usize, freeze_threshold: usize) {
         let metadata = memtable_util::metadata_with_primary_key(vec![1, 0], true);
-        let memtable =
-            MergeTreeMemtable::new(1, metadata.clone(), None, &MergeTreeConfig::default());
+        let memtable = MergeTreeMemtable::new(
+            1,
+            metadata.clone(),
+            None,
+            &MergeTreeConfig {
+                index_max_keys_per_shard: max_keys,
+                data_freeze_threshold: freeze_threshold,
+                ..Default::default()
+            },
+        );
 
         let mut data = Vec::new();
+        // 4 partitions, each partition 4 pks.
         for i in 0..4 {
-            // key: i, a
-            let offset = 100 * (i as i64 + 1);
-            let timestamps = [1 + offset, 7 + offset, 5 + offset, 6 + offset];
-            let kvs = memtable_util::build_key_values(
-                &metadata,
-                "a".to_string(),
-                i,
-                &timestamps,
-                0, // sequence 0, 1, 2, 3
-            );
-            memtable.write(&kvs).unwrap();
-            for ts in timestamps {
-                data.push((i, "a", ts));
+            for j in 0..4 {
+                // key: i, a{j}
+                let timestamps = [11, 13, 1, 5, 3, 7, 9];
+                let key = format!("a{j}");
+                let kvs =
+                    memtable_util::build_key_values(&metadata, key.clone(), i, &timestamps, 0);
+                memtable.write(&kvs).unwrap();
+                for ts in timestamps {
+                    data.push((i, key.clone(), ts));
+                }
+            }
+            for j in 0..4 {
+                // key: i, a{j}
+                let timestamps = [10, 2, 4, 8, 6];
+                let key = format!("a{j}");
+                let kvs =
+                    memtable_util::build_key_values(&metadata, key.clone(), i, &timestamps, 200);
+                memtable.write(&kvs).unwrap();
+                for ts in timestamps {
+                    data.push((i, key.clone(), ts));
+                }
             }
         }
-        for i in 0..4 {
-            // key: i, b
-            let offset = 10 * (i as i64 + 1);
-            let timestamps = [3 + offset, 2 + offset];
-            let kvs = memtable_util::build_key_values(
-                &metadata,
-                "b".to_string(),
-                i,
-                &timestamps,
-                4, // sequence 4, 5
-            );
-            memtable.write(&kvs).unwrap();
-            for ts in timestamps {
-                data.push((i, "b", ts));
-            }
-        }
-        for i in 0..4 {
-            // key: i, a
-            let offset = 100 * (i as i64 + 1);
-            let timestamps = [8 + offset, 3 + offset, 4 + offset];
-            let kvs = memtable_util::build_key_values(
-                &metadata,
-                "a".to_string(),
-                i,
-                &timestamps,
-                6, // sequence 6, 7, 8
-            );
-            memtable.write(&kvs).unwrap();
-            for ts in timestamps {
-                data.push((i, "a", ts));
-            }
-        }
-        data.sort_unstable_by_key(|x| (x.0, x.1, x.2));
+        data.sort_unstable();
 
         let expect = data.into_iter().map(|x| x.2).collect::<Vec<_>>();
         let iter = memtable.iter(None, None).unwrap();

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -52,17 +52,6 @@ impl Shard {
         }
     }
 
-    /// Returns the pk id of the key if it exists.
-    pub fn find_id_by_key(&self, key: &[u8]) -> Option<PkId> {
-        let key_dict = self.key_dict.as_ref()?;
-        let pk_index = key_dict.get_pk_index(key)?;
-
-        Some(PkId {
-            shard_id: self.shard_id,
-            pk_index,
-        })
-    }
-
     /// Writes a key value into the shard.
     pub fn write_with_pk_id(&mut self, pk_id: PkId, key_value: KeyValue) {
         debug_assert_eq!(self.shard_id, pk_id.shard_id);
@@ -381,37 +370,37 @@ mod tests {
         Shard::new(shard_id, Some(Arc::new(dict)), data_parts, true)
     }
 
-    #[test]
-    fn test_shard_find_by_key() {
-        let metadata = metadata_for_test();
-        let input = input_with_key(&metadata);
-        let shard = new_shard_with_dict(8, metadata, &input);
-        for i in 0..input.len() {
-            let key = encode_key("shard", i as u32);
-            assert_eq!(
-                PkId {
-                    shard_id: 8,
-                    pk_index: i as PkIndex,
-                },
-                shard.find_id_by_key(&key).unwrap()
-            );
-        }
-        assert!(shard.find_id_by_key(&encode_key("shard", 100)).is_none());
-    }
+    // #[test]
+    // fn test_shard_find_by_key() {
+    //     let metadata = metadata_for_test();
+    //     let input = input_with_key(&metadata);
+    //     let shard = new_shard_with_dict(8, metadata, &input);
+    //     for i in 0..input.len() {
+    //         let key = encode_key("shard", i as u32);
+    //         assert_eq!(
+    //             PkId {
+    //                 shard_id: 8,
+    //                 pk_index: i as PkIndex,
+    //             },
+    //             shard.find_id_by_key(&key).unwrap()
+    //         );
+    //     }
+    //     assert!(shard.find_id_by_key(&encode_key("shard", 100)).is_none());
+    // }
 
-    #[test]
-    fn test_write_shard() {
-        let metadata = metadata_for_test();
-        let input = input_with_key(&metadata);
-        let mut shard = new_shard_with_dict(8, metadata, &input);
-        assert!(shard.is_empty());
-        for key_values in &input {
-            for kv in key_values.iter() {
-                let key = encode_key_by_kv(&kv);
-                let pk_id = shard.find_id_by_key(&key).unwrap();
-                shard.write_with_pk_id(pk_id, kv);
-            }
-        }
-        assert!(!shard.is_empty());
-    }
+    // #[test]
+    // fn test_write_shard() {
+    //     let metadata = metadata_for_test();
+    //     let input = input_with_key(&metadata);
+    //     let mut shard = new_shard_with_dict(8, metadata, &input);
+    //     assert!(shard.is_empty());
+    //     for key_values in &input {
+    //         for kv in key_values.iter() {
+    //             let key = encode_key_by_kv(&kv);
+    //             let pk_id = shard.find_id_by_key(&key).unwrap();
+    //             shard.write_with_pk_id(pk_id, kv);
+    //         }
+    //     }
+    //     assert!(!shard.is_empty());
+    // }
 }

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -308,7 +308,7 @@ impl Node for ShardNode {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use super::*;
@@ -318,8 +318,7 @@ mod tests {
     use crate::memtable::merge_tree::PkIndex;
     use crate::memtable::KeyValues;
     use crate::test_util::memtable_util::{
-        build_key_values_with_ts_seq_values, encode_key, encode_key_by_kv, encode_keys,
-        metadata_for_test,
+        build_key_values_with_ts_seq_values, encode_keys, metadata_for_test,
     };
 
     /// Returns key values and expect pk index.
@@ -376,7 +375,7 @@ mod tests {
             dict_builder.insert_key(key, &mut metrics);
         }
 
-        let dict = dict_builder.finish().unwrap();
+        let dict = dict_builder.finish(&mut BTreeMap::new()).unwrap();
         let data_parts = DataParts::new(metadata, DATA_INIT_CAP, true);
 
         Shard::new(shard_id, Some(Arc::new(dict)), data_parts, true)

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -59,10 +59,20 @@ impl ShardBuilder {
     }
 
     /// Write a key value with its encoded primary key.
-    pub fn write_with_key(&mut self, key: &[u8], key_value: KeyValue, metrics: &mut WriteMetrics) {
+    pub fn write_with_key(
+        &mut self,
+        key: &[u8],
+        key_value: KeyValue,
+        metrics: &mut WriteMetrics,
+    ) -> PkId {
         // Safety: we check whether the builder need to freeze before.
         let pk_index = self.dict_builder.insert_key(key, metrics);
         self.data_buffer.write_row(pk_index, key_value);
+
+        PkId {
+            shard_id: self.current_shard_id,
+            pk_index,
+        }
     }
 
     /// Returns true if the builder need to freeze.

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -22,7 +22,6 @@ use api::v1::{Row, Rows, SemanticType};
 use datatypes::arrow::array::UInt64Array;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::schema::ColumnSchema;
-use datatypes::value::ValueRef;
 use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::storage::{ColumnId, RegionId, SequenceNumber};
 use table::predicate::Predicate;
@@ -289,16 +288,6 @@ pub(crate) fn encode_keys(
         let key = row_codec.encode(kv.primary_keys()).unwrap();
         keys.push(key);
     }
-}
-
-/// Encode one key.
-pub(crate) fn encode_key(k0: &str, k1: u32) -> Vec<u8> {
-    let row_codec = McmpRowCodec::new(vec![
-        SortField::new(ConcreteDataType::string_datatype()),
-        SortField::new(ConcreteDataType::uint32_datatype()),
-    ]);
-    let key = [ValueRef::String(k0), ValueRef::UInt32(k1)];
-    row_codec.encode(key.into_iter()).unwrap()
 }
 
 /// Encode one key.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR adds a partition level map to replace the shard level map to look up pk indices. This can improve pk index lookup performance as we don't need to iterate all shards to find the pk index.
- Pk indices inside a dictionary builder can't be compared directly. We collect pk indices after we freeze a dictionary and then write them to the partition level map.
- Now we evict the whole partition once we reach the dictionary memory limit so we can also drop the map on eviction.

This PR also fixes an issue that a key may be written to multiple shards if we find the key before finishing a shard builder.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804