### PR TITLE
build: do not retry for connrefused

### DIFF
--- a/scripts/fetch-dashboard-assets.sh
+++ b/scripts/fetch-dashboard-assets.sh
@@ -26,7 +26,6 @@ function retry_fetch() {
     curl \
       --connect-timeout 10 \
       --retry 3 \
-      --retry-connrefused \
       -fsSL $url --output $filename || \
       {
         echo "Failed to download $url"

--- a/scripts/fetch-dashboard-assets.sh
+++ b/scripts/fetch-dashboard-assets.sh
@@ -23,11 +23,7 @@ function retry_fetch() {
     local url=$1
     local filename=$2
 
-    curl \
-      --connect-timeout 10 \
-      --retry 3 \
-      -fsSL $url --output $filename || \
-      {
+    curl --connect-timeout 10 --retry 3 -fsSL $url --output $filename || {
         echo "Failed to download $url"
         echo "You may try to set http_proxy and https_proxy environment variables."
         if [[ -z "$GITHUB_PROXY_URL" ]]; then


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This closes https://github.com/GreptimeTeam/greptimedb/issues/3401.

Mainly, it's because centos7's curl is older than that having this option supported. But if a cURL request hits connrefused, it's highly possibly the network is not connected. So no retry on such situation can be acceptable.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
