### PR TITLE
feat: zero copy on split rows

### DIFF
--- a/src/partition/src/splitter.rs
+++ b/src/partition/src/splitter.rs
@@ -79,21 +79,36 @@ impl<'a> SplitReadRowHelper<'a> {
     }
 
     fn split_rows(mut self) -> Result<HashMap<RegionNumber, Rows>> {
-        let request_splits = self
-            .split_to_regions()?
-            .into_iter()
-            .map(|(region_number, row_indexes)| {
-                let rows = row_indexes
-                    .into_iter()
-                    .map(|row_idx| std::mem::take(&mut self.rows[row_idx]))
-                    .collect();
-                let rows = Rows {
-                    schema: self.schema.clone(),
-                    rows,
-                };
-                (region_number, rows)
-            })
-            .collect::<HashMap<_, _>>();
+        let regions = self.split_to_regions()?;
+        let request_splits = if regions.len() == 1 {
+            // fast path, zero copy
+            regions
+                .into_keys()
+                .map(|region_number| {
+                    let rows = std::mem::take(&mut self.rows);
+                    let rows = Rows {
+                        schema: self.schema.clone(),
+                        rows,
+                    };
+                    (region_number, rows)
+                })
+                .collect::<HashMap<_, _>>()
+        } else {
+            regions
+                .into_iter()
+                .map(|(region_number, row_indexes)| {
+                    let rows = row_indexes
+                        .into_iter()
+                        .map(|row_idx| std::mem::take(&mut self.rows[row_idx]))
+                        .collect();
+                    let rows = Rows {
+                        schema: self.schema.clone(),
+                        rows,
+                    };
+                    (region_number, rows)
+                })
+                .collect::<HashMap<_, _>>()
+        };
 
         Ok(request_splits)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

If a table has multiple regions, then when writing, it is necessary to split the data according to regions, which will incur memory copy overhead.
There is a scenario where the writes of the same client instance usually only contain data from one region (depending on the partition key). In this case, we should avoid memory copying.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
