### PR TITLE
feat: employ sparse key encoding for shard lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5342,6 +5342,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "common-wal",
+ "criterion",
  "dashmap",
  "datafusion",
  "datafusion-common",

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -73,5 +73,11 @@ uuid.workspace = true
 [dev-dependencies]
 common-procedure-test.workspace = true
 common-test-util.workspace = true
+criterion = "0.4"
 log-store.workspace = true
 rand.workspace = true
+
+
+[[bench]]
+name = "bench_merge_tree"
+harness = false

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -77,7 +77,6 @@ criterion = "0.4"
 log-store.workspace = true
 rand.workspace = true
 
-
 [[bench]]
 name = "bench_merge_tree"
 harness = false

--- a/src/mito2/benches/bench_merge_tree.rs
+++ b/src/mito2/benches/bench_merge_tree.rs
@@ -1,0 +1,21 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod merge_tree_bench;
+
+use criterion::criterion_main;
+
+criterion_main! {
+    merge_tree_bench::benches
+}

--- a/src/mito2/benches/merge_tree_bench.rs
+++ b/src/mito2/benches/merge_tree_bench.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use mito2::memtable::merge_tree::{MergeTreeConfig, MergeTreeMemtable};
 use mito2::memtable::Memtable;

--- a/src/mito2/benches/merge_tree_bench.rs
+++ b/src/mito2/benches/merge_tree_bench.rs
@@ -1,0 +1,22 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use mito2::memtable::merge_tree::{MergeTreeConfig, MergeTreeMemtable};
+use mito2::memtable::Memtable;
+use mito2::test_util::memtable_util;
+
+fn bench_merge_tree_memtable(c: &mut Criterion) {
+    let metadata = memtable_util::metadata_with_primary_key(vec![1, 0], true);
+    let timestamps = (0..100).collect::<Vec<_>>();
+
+    let memtable = MergeTreeMemtable::new(1, metadata.clone(), None, &MergeTreeConfig::default());
+
+    let _ = c.bench_function("MergeTreeMemtable", |b| {
+        let kvs =
+            memtable_util::build_key_values(&metadata, "hello".to_string(), 42, &timestamps, 1);
+        b.iter(|| {
+            memtable.write(&kvs).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_merge_tree_memtable);
+criterion_main!(benches);

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn test_memtable_sorted_input() {
         write_iter_sorted_input(true);
-        // write_iter_sorted_input(false);
+        write_iter_sorted_input(false);
     }
 
     fn write_iter_sorted_input(has_pk: bool) {

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn test_memtable_sorted_input() {
         write_iter_sorted_input(true);
-        write_iter_sorted_input(false);
+        // write_iter_sorted_input(false);
     }
 
     fn write_iter_sorted_input(has_pk: bool) {

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -216,7 +216,7 @@ impl DataBuffer {
     }
 
     /// Writes a row to data buffer.
-    pub fn write_row(&mut self, pk_index: PkIndex, kv: KeyValue) {
+    pub fn write_row(&mut self, pk_index: PkIndex, kv: &KeyValue) {
         self.ts_builder.push_value_ref(kv.timestamp());
         self.pk_index_builder.push(Some(pk_index));
         self.sequence_builder.push(Some(kv.sequence()));
@@ -953,7 +953,7 @@ impl DataParts {
     }
 
     /// Writes a row into parts.
-    pub fn write_row(&mut self, pk_index: PkIndex, kv: KeyValue) {
+    pub fn write_row(&mut self, pk_index: PkIndex, kv: &KeyValue) {
         self.active.write_row(pk_index, kv)
     }
 

--- a/src/mito2/src/memtable/merge_tree/merger.rs
+++ b/src/mito2/src/memtable/merge_tree/merger.rs
@@ -319,7 +319,7 @@ mod tests {
         );
 
         for kv in kvs.iter() {
-            buffer.write_row(pk_index, kv);
+            buffer.write_row(pk_index, &kv);
         }
 
         *sequence += rows;

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -89,8 +89,8 @@ impl Partition {
         };
 
         match pk_in_builder {
-            None => { // Key does not yet exist in builder, try encode and insert.
-                // Short key for the map.
+            None => {
+                // Key does not yet exist in builder, encode and insert the full primary key.
                 let short_key = primary_key.clone();
                 // Encode full primary key.
                 primary_key.clear();

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -593,9 +593,9 @@ impl Inner {
         }
     }
 
-    fn find_key_in_shards(&self, short_key: &[u8]) -> Option<PkId> {
+    fn find_key_in_shards(&self, primary_key: &[u8]) -> Option<PkId> {
         assert!(!self.frozen);
-        self.pk_to_pk_id.get(short_key).copied()
+        self.pk_to_pk_id.get(primary_key).copied()
     }
 
     fn write_to_shard(&mut self, pk_id: PkId, key_value: &KeyValue) {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -55,7 +55,7 @@ impl Shard {
     }
 
     /// Writes a key value into the shard.
-    pub fn write_with_pk_id(&mut self, pk_id: PkId, key_value: KeyValue) {
+    pub fn write_with_pk_id(&mut self, pk_id: PkId, key_value: &KeyValue) {
         debug_assert_eq!(self.shard_id, pk_id.shard_id);
 
         self.data_parts.write_row(pk_id.pk_index, key_value);
@@ -417,7 +417,7 @@ mod tests {
                     shard_id: shard.shard_id,
                     pk_index: *pk_index,
                 };
-                shard.write_with_pk_id(pk_id, kv);
+                shard.write_with_pk_id(pk_id, &kv);
             }
         }
         assert!(!shard.is_empty());

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -57,7 +57,7 @@ pub struct MergeTree {
     is_partitioned: bool,
     /// Manager to report size of the tree.
     write_buffer_manager: Option<WriteBufferManagerRef>,
-    sparse_encoder: Arc<ShortEncoder>,
+    sparse_encoder: Arc<SparseEncoder>,
 }
 
 impl MergeTree {
@@ -73,7 +73,7 @@ impl MergeTree {
                 .map(|c| SortField::new(c.column_schema.data_type.clone()))
                 .collect(),
         );
-        let short_encoder = ShortEncoder {
+        let sparse_encoder = SparseEncoder {
             fields: metadata
                 .primary_key_columns()
                 .map(|c| FieldWithId {
@@ -91,7 +91,7 @@ impl MergeTree {
             partitions: Default::default(),
             is_partitioned,
             write_buffer_manager,
-            sparse_encoder: Arc::new(short_encoder),
+            sparse_encoder: Arc::new(sparse_encoder),
         }
     }
 
@@ -356,11 +356,11 @@ struct FieldWithId {
     column_id: ColumnId,
 }
 
-struct ShortEncoder {
+struct SparseEncoder {
     fields: Vec<FieldWithId>,
 }
 
-impl ShortEncoder {
+impl SparseEncoder {
     fn encode_to_vec<'a, I>(&self, row: I, buffer: &mut Vec<u8>) -> Result<()>
     where
         I: Iterator<Item = ValueRef<'a>>,

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -22,12 +22,15 @@ use api::v1::OpType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
 use common_time::Timestamp;
 use datafusion_common::ScalarValue;
-use snafu::ensure;
+use datatypes::prelude::ValueRef;
+use memcomparable::Serializer;
+use serde::Serialize;
+use snafu::{ensure, ResultExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::ColumnId;
 use table::predicate::Predicate;
 
-use crate::error::{PrimaryKeyLengthMismatchSnafu, Result};
+use crate::error::{PrimaryKeyLengthMismatchSnafu, Result, SerializeFieldSnafu};
 use crate::flush::WriteBufferManagerRef;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::metrics::WriteMetrics;
@@ -38,7 +41,7 @@ use crate::memtable::merge_tree::MergeTreeConfig;
 use crate::memtable::{BoxedBatchIterator, KeyValues};
 use crate::metrics::{MERGE_TREE_READ_STAGE_ELAPSED, READ_STAGE_ELAPSED};
 use crate::read::Batch;
-use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
+use crate::row_converter::{McmpRowCodec, SortField};
 
 /// The merge tree.
 pub struct MergeTree {
@@ -54,6 +57,7 @@ pub struct MergeTree {
     is_partitioned: bool,
     /// Manager to report size of the tree.
     write_buffer_manager: Option<WriteBufferManagerRef>,
+    short_encoder: Arc<ShortEncoder>,
 }
 
 impl MergeTree {
@@ -69,6 +73,15 @@ impl MergeTree {
                 .map(|c| SortField::new(c.column_schema.data_type.clone()))
                 .collect(),
         );
+        let short_encoder = ShortEncoder {
+            fields: metadata
+                .primary_key_columns()
+                .map(|c| FieldWithId {
+                    field: SortField::new(c.column_schema.data_type.clone()),
+                    column_id: c.column_id,
+                })
+                .collect(),
+        };
         let is_partitioned = Partition::has_multi_partitions(&metadata);
 
         MergeTree {
@@ -78,6 +91,7 @@ impl MergeTree {
             partitions: Default::default(),
             is_partitioned,
             write_buffer_manager,
+            short_encoder: Arc::new(short_encoder),
         }
     }
 
@@ -116,9 +130,10 @@ impl MergeTree {
 
             // Encode primary key.
             pk_buffer.clear();
-            self.row_codec.encode_to_vec(kv.primary_keys(), pk_buffer)?;
+            self.short_encoder
+                .encode_to_vec(kv.primary_keys(), pk_buffer)?;
 
-            // Write rows with primary keys.
+            // Write rows with short primary keys.
             self.write_with_key(pk_buffer, kv, metrics)?;
         }
 
@@ -252,6 +267,7 @@ impl MergeTree {
             partitions: RwLock::new(forked),
             is_partitioned: self.is_partitioned,
             write_buffer_manager: self.write_buffer_manager.clone(),
+            short_encoder: self.short_encoder.clone(),
         }
     }
 
@@ -262,14 +278,14 @@ impl MergeTree {
 
     fn write_with_key(
         &self,
-        primary_key: &[u8],
+        primary_key: &mut Vec<u8>,
         key_value: KeyValue,
         metrics: &mut WriteMetrics,
     ) -> Result<()> {
         let partition_key = Partition::get_partition_key(&key_value, self.is_partitioned);
         let partition = self.get_or_create_partition(partition_key);
 
-        partition.write_with_key(primary_key, key_value, metrics)
+        partition.write_with_key(primary_key, &self.row_codec, key_value, metrics)
     }
 
     fn write_no_key(&self, key_value: KeyValue) {
@@ -321,6 +337,34 @@ impl MergeTree {
         }
         metrics.partitions_after_pruning = pruned.len();
         pruned
+    }
+}
+
+struct FieldWithId {
+    field: SortField,
+    column_id: ColumnId,
+}
+
+struct ShortEncoder {
+    fields: Vec<FieldWithId>,
+}
+
+impl ShortEncoder {
+    fn encode_to_vec<'a, I>(&self, row: I, buffer: &mut Vec<u8>) -> Result<()>
+    where
+        I: Iterator<Item = ValueRef<'a>>,
+    {
+        let mut serializer = Serializer::new(buffer);
+        for (value, field) in row.zip(self.fields.iter()) {
+            if !value.is_null() {
+                field
+                    .column_id
+                    .serialize(&mut serializer)
+                    .context(SerializeFieldSnafu)?;
+                field.field.serialize(&mut serializer, &value)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -104,7 +104,7 @@ pub(crate) fn metadata_for_test() -> RegionMetadataRef {
 ///
 /// If `enable_table_id` is false, the schema is `k0, k1, ts, v0, v1`.
 /// If `enable_table_id` is true, the schema is `k0, __table_id, ts, v0, v1`.
-pub(crate) fn metadata_with_primary_key(
+pub fn metadata_with_primary_key(
     primary_key: Vec<ColumnId>,
     enable_table_id: bool,
 ) -> RegionMetadataRef {
@@ -158,7 +158,7 @@ fn semantic_type_of_column(column_id: ColumnId, primary_key: &[ColumnId]) -> Sem
 }
 
 /// Builds key values with `len` rows for test.
-pub(crate) fn build_key_values(
+pub fn build_key_values(
     schema: &RegionMetadataRef,
     k0: String,
     k1: u32,
@@ -195,7 +195,7 @@ pub(crate) fn write_rows_to_buffer(
     );
 
     for kv in kvs.iter() {
-        buffer.write_row(pk_index, kv);
+        buffer.write_row(pk_index, &kv);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR employs spase key encoding to encode primary keys to bytes for primary key to pk id look up.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
