### PR TITLE
fix: partition region id

### DIFF
--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -235,8 +235,12 @@ fn create_partitions_from_region_routes(
             })?;
         let partition_def = PartitionDef::try_from(partition)?;
 
+        // The region routes belong to the physical table but are shared among all logical tables.
+        // That it to say, the region id points to the physical table, so we need to use the actual
+        // table id (which may be a logical table) to renew the region id.
+        let id = RegionId::new(table_id, r.region.id.region_number());
         partitions.push(PartitionInfo {
-            id: r.region.id,
+            id,
             partition: partition_def,
         });
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

The region routes belong to the physical table but are shared among all logical tables.
That it to say, the region id points to the physical table, so we need to use the actual table id (which may be a logical table) to renew the region id when we want construct the `PartitionInfo`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
