### PR TITLE
perf: Reduce decode overhead during pruning keys in the memtable

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -994,9 +994,11 @@ impl DataPartsReaderBuilder {
         for p in self.parts {
             nodes.push(DataNode::new(DataSource::Part(p)));
         }
+        let num_parts = nodes.len();
         let merger = Merger::try_new(nodes)?;
         Ok(DataPartsReader {
             merger,
+            num_parts,
             elapsed: Default::default(),
         })
     }
@@ -1005,6 +1007,7 @@ impl DataPartsReaderBuilder {
 /// Reader for all parts inside a `DataParts`.
 pub struct DataPartsReader {
     merger: Merger<DataNode>,
+    num_parts: usize,
     elapsed: Duration,
 }
 
@@ -1031,6 +1034,10 @@ impl DataPartsReader {
 
     pub(crate) fn is_valid(&self) -> bool {
         self.merger.is_valid()
+    }
+
+    pub(crate) fn num_parts(&self) -> usize {
+        self.num_parts
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/dedup.rs
+++ b/src/mito2/src/memtable/merge_tree/dedup.rs
@@ -45,7 +45,7 @@ impl<T: DataBatchSource> DataBatchSource for DedupReader<T> {
     }
 
     fn next(&mut self) -> Result<()> {
-        loop {
+        while self.inner.is_valid() {
             match &mut self.prev_batch_last_row {
                 None => {
                     // First shot, fill prev_batch_last_row and current_batch_range with first batch.

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -379,6 +379,7 @@ impl PrimaryKeyFilter {
 
         // evaluate filters against primary key values
         let mut result = true;
+        self.offsets_buf.clear();
         for filter in &*self.filters {
             if Partition::is_partition_column(filter.column_name()) {
                 continue;

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -394,7 +394,6 @@ impl PrimaryKeyFilter {
             // index of the column in primary keys.
             // Safety: A tag column is always in primary key.
             let index = self.metadata.primary_key_index(column.column_id).unwrap();
-
             let value = match self.codec.decode_value_at(pk, index, &mut self.offsets_buf) {
                 Ok(v) => v,
                 Err(e) => {

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -402,6 +402,9 @@ impl PrimaryKeyFilter {
                 }
             };
 
+            // TODO(yingwen): `evaluate_scalar()` creates temporary arrays to compare scalars. We
+            // can compare the bytes directly without allocation and matching types as we use
+            // comparable encoding.
             // Safety: arrow schema and datatypes are constructed from the same source.
             let scalar_value = value
                 .try_to_scalar_value(&column.column_schema.data_type)

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -38,7 +38,7 @@ use crate::memtable::merge_tree::shard_builder::ShardBuilder;
 use crate::memtable::merge_tree::{MergeTreeConfig, PkId};
 use crate::metrics::MERGE_TREE_READ_STAGE_ELAPSED;
 use crate::read::{Batch, BatchBuilder};
-use crate::row_converter::McmpRowCodec;
+use crate::row_converter::{McmpRowCodec, RowCodec};
 
 /// Key of a partition.
 pub type PartitionKey = u32;

--- a/src/mito2/src/memtable/merge_tree/partition.rs
+++ b/src/mito2/src/memtable/merge_tree/partition.rs
@@ -22,7 +22,6 @@ use std::time::{Duration, Instant};
 
 use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
-use datatypes::value::Value;
 use store_api::metadata::RegionMetadataRef;
 use store_api::metric_engine_consts::DATA_SCHEMA_TABLE_ID_COLUMN_NAME;
 use store_api::storage::ColumnId;
@@ -39,7 +38,7 @@ use crate::memtable::merge_tree::shard_builder::ShardBuilder;
 use crate::memtable::merge_tree::{MergeTreeConfig, PkId};
 use crate::metrics::MERGE_TREE_READ_STAGE_ELAPSED;
 use crate::read::{Batch, BatchBuilder};
-use crate::row_converter::{McmpRowCodec, RowCodec};
+use crate::row_converter::McmpRowCodec;
 
 /// Key of a partition.
 pub type PartitionKey = u32;
@@ -124,6 +123,15 @@ impl Partition {
 
     /// Scans data in the partition.
     pub fn read(&self, mut context: ReadPartitionContext) -> Result<PartitionReader> {
+        let key_filter = if context.need_prune_key {
+            Some(PrimaryKeyFilter {
+                metadata: context.metadata.clone(),
+                filters: context.filters.clone(),
+                codec: context.row_codec.clone(),
+            })
+        } else {
+            None
+        };
         let (builder_source, shard_reader_builders) = {
             let inner = self.inner.read().unwrap();
             let mut shard_source = Vec::with_capacity(inner.shards.len() + 1);
@@ -144,12 +152,17 @@ impl Partition {
 
         let mut nodes = shard_reader_builders
             .into_iter()
-            .map(|builder| Ok(ShardNode::new(ShardSource::Shard(builder.build()?))))
+            .map(|builder| {
+                Ok(ShardNode::new(ShardSource::Shard(
+                    builder.build(key_filter.clone())?,
+                )))
+            })
             .collect::<Result<Vec<_>>>()?;
 
         if let Some(builder) = builder_source {
             // Move the initialization of ShardBuilderReader out of read lock.
-            let shard_builder_reader = builder.build(Some(&context.pk_weights))?;
+            let shard_builder_reader =
+                builder.build(Some(&context.pk_weights), key_filter.clone())?;
             nodes.push(ShardNode::new(ShardSource::Builder(shard_builder_reader)));
         }
 
@@ -267,10 +280,9 @@ pub(crate) struct PartitionStats {
 
 #[derive(Default)]
 struct PartitionReaderMetrics {
-    prune_pk: Duration,
+    // prune_pk: Duration,
     read_source: Duration,
     data_batch_to_batch: Duration,
-    keys_before_pruning: usize,
     keys_after_pruning: usize,
 }
 
@@ -280,20 +292,11 @@ struct PartitionReaderMetrics {
 pub struct PartitionReader {
     context: ReadPartitionContext,
     source: BoxedDataBatchSource,
-    last_yield_pk_id: Option<PkId>,
-    values_buffer: Vec<Value>,
 }
 
 impl PartitionReader {
     fn new(context: ReadPartitionContext, source: BoxedDataBatchSource) -> Result<Self> {
-        let mut reader = Self {
-            context,
-            source,
-            last_yield_pk_id: None,
-            values_buffer: Vec::new(),
-        };
-        // Find next valid batch.
-        reader.prune_batch_by_key()?;
+        let reader = Self { context, source };
 
         Ok(reader)
     }
@@ -308,8 +311,7 @@ impl PartitionReader {
     /// # Panics
     /// Panics if the reader is invalid.
     pub fn next(&mut self) -> Result<()> {
-        self.advance_source()?;
-        self.prune_batch_by_key()
+        self.advance_source()
     }
 
     /// Converts current data batch into a [Batch].
@@ -339,123 +341,141 @@ impl PartitionReader {
         self.context.metrics.read_source += read_source.elapsed();
         Ok(())
     }
+}
 
-    fn prune_batch_by_key(&mut self) -> Result<()> {
-        if self.context.metadata.primary_key.is_empty() || !self.context.need_prune_key {
-            // Nothing to prune.
-            return Ok(());
+#[derive(Clone)]
+pub(crate) struct PrimaryKeyFilter {
+    metadata: RegionMetadataRef,
+    filters: Arc<Vec<SimpleFilterEvaluator>>,
+    codec: Arc<McmpRowCodec>,
+}
+
+impl PrimaryKeyFilter {
+    pub(crate) fn prune_primary_key(&self, pk: &[u8]) -> bool {
+        if self.filters.is_empty() {
+            return true;
         }
 
-        while self.source.is_valid() {
-            let pk_id = self.source.current_pk_id();
-            if let Some(yield_pk_id) = self.last_yield_pk_id {
-                if pk_id == yield_pk_id {
-                    // If this batch has the same key as last returned batch.
-                    // We can return it without evaluating filters.
-                    break;
+        // no primary key, we simply return true.
+        if self.metadata.primary_key.is_empty() {
+            return true;
+        }
+
+        // evaluate filters against primary key values
+        let mut result = true;
+        for filter in &*self.filters {
+            if Partition::is_partition_column(filter.column_name()) {
+                continue;
+            }
+            let Some(column) = self.metadata.column_by_name(filter.column_name()) else {
+                continue;
+            };
+            // ignore filters that are not referencing primary key columns
+            if column.semantic_type != SemanticType::Tag {
+                continue;
+            }
+            // index of the column in primary keys.
+            // Safety: A tag column is always in primary key.
+            let index = self.metadata.primary_key_index(column.column_id).unwrap();
+
+            let value = match self.codec.decode_value_at(pk, index) {
+                Ok(v) => v,
+                Err(e) => {
+                    common_telemetry::error!(e; "Failed to decode primary key");
+                    return true;
                 }
-            }
-            let key = self.source.current_key().unwrap();
-            self.context.metrics.keys_before_pruning += 1;
-            // Prune batch by primary key.
-            if prune_primary_key(
-                &self.context.metadata,
-                &self.context.filters,
-                &self.context.row_codec,
-                key,
-                &mut self.context.metrics,
-                &mut self.values_buffer,
-            ) {
-                // We need this key.
-                self.last_yield_pk_id = Some(pk_id);
-                self.context.metrics.keys_after_pruning += 1;
-                break;
-            }
-            self.advance_source()?;
+            };
+
+            // Safety: arrow schema and datatypes are constructed from the same source.
+            let scalar_value = value
+                .try_to_scalar_value(&column.column_schema.data_type)
+                .unwrap();
+            result &= filter.evaluate_scalar(&scalar_value).unwrap_or(true);
         }
-        Ok(())
+
+        result
     }
 }
 
-fn prune_primary_key(
-    metadata: &RegionMetadataRef,
-    filters: &[SimpleFilterEvaluator],
-    codec: &McmpRowCodec,
-    pk: &[u8],
-    metrics: &mut PartitionReaderMetrics,
-    values_buffer: &mut Vec<Value>,
-) -> bool {
-    let start = Instant::now();
-    let res = prune_primary_key_inner(metadata, filters, codec, pk, values_buffer);
-    metrics.prune_pk += start.elapsed();
-    res
-}
+// fn prune_primary_key(
+//     metadata: &RegionMetadataRef,
+//     filters: &[SimpleFilterEvaluator],
+//     codec: &McmpRowCodec,
+//     pk: &[u8],
+//     metrics: &mut PartitionReaderMetrics,
+//     values_buffer: &mut Vec<Value>,
+// ) -> bool {
+//     let start = Instant::now();
+//     let res = prune_primary_key_inner(metadata, filters, codec, pk, values_buffer);
+//     metrics.prune_pk += start.elapsed();
+//     res
+// }
 
-// TODO(yingwen): Improve performance of key pruning. Now we need to find index and
-// then decode and convert each value.
-/// Returns true if the `pk` is still needed.
-fn prune_primary_key_inner(
-    metadata: &RegionMetadataRef,
-    filters: &[SimpleFilterEvaluator],
-    codec: &McmpRowCodec,
-    pk: &[u8],
-    _values_buffer: &mut Vec<Value>,
-) -> bool {
-    if filters.is_empty() {
-        return true;
-    }
+// // TODO(yingwen): Improve performance of key pruning. Now we need to find index and
+// // then decode and convert each value.
+// /// Returns true if the `pk` is still needed.
+// fn prune_primary_key_inner(
+//     metadata: &RegionMetadataRef,
+//     filters: &[SimpleFilterEvaluator],
+//     codec: &McmpRowCodec,
+//     pk: &[u8],
+//     _values_buffer: &mut Vec<Value>,
+// ) -> bool {
+//     if filters.is_empty() {
+//         return true;
+//     }
 
-    // no primary key, we simply return true.
-    if metadata.primary_key.is_empty() {
-        return true;
-    }
+//     // no primary key, we simply return true.
+//     if metadata.primary_key.is_empty() {
+//         return true;
+//     }
 
-    // if let Err(e) = codec.decode_to_vec(pk, values_buffer) {
-    //     common_telemetry::error!(e; "Failed to decode primary key");
-    //     return true;
-    // }
+//     // if let Err(e) = codec.decode_to_vec(pk, values_buffer) {
+//     //     common_telemetry::error!(e; "Failed to decode primary key");
+//     //     return true;
+//     // }
 
-    // evaluate filters against primary key values
-    let mut result = true;
-    for filter in filters {
-        if Partition::is_partition_column(filter.column_name()) {
-            continue;
-        }
-        let Some(column) = metadata.column_by_name(filter.column_name()) else {
-            continue;
-        };
-        // ignore filters that are not referencing primary key columns
-        if column.semantic_type != SemanticType::Tag {
-            continue;
-        }
-        // index of the column in primary keys.
-        // Safety: A tag column is always in primary key.
-        let index = metadata.primary_key_index(column.column_id).unwrap();
+//     // evaluate filters against primary key values
+//     let mut result = true;
+//     for filter in filters {
+//         if Partition::is_partition_column(filter.column_name()) {
+//             continue;
+//         }
+//         let Some(column) = metadata.column_by_name(filter.column_name()) else {
+//             continue;
+//         };
+//         // ignore filters that are not referencing primary key columns
+//         if column.semantic_type != SemanticType::Tag {
+//             continue;
+//         }
+//         // index of the column in primary keys.
+//         // Safety: A tag column is always in primary key.
+//         let index = metadata.primary_key_index(column.column_id).unwrap();
 
-        let value = match codec.decode_value_at(pk, index) {
-            Ok(v) => v,
-            Err(e) => {
-                common_telemetry::error!(e; "Failed to decode primary key");
-                return true;
-            }
-        };
+//         let value = match codec.decode_value_at(pk, index) {
+//             Ok(v) => v,
+//             Err(e) => {
+//                 common_telemetry::error!(e; "Failed to decode primary key");
+//                 return true;
+//             }
+//         };
 
-        // Safety: arrow schema and datatypes are constructed from the same source.
-        let scalar_value = value
-            .try_to_scalar_value(&column.column_schema.data_type)
-            .unwrap();
-        result &= filter.evaluate_scalar(&scalar_value).unwrap_or(true);
-    }
+//         // Safety: arrow schema and datatypes are constructed from the same source.
+//         let scalar_value = value
+//             .try_to_scalar_value(&column.column_schema.data_type)
+//             .unwrap();
+//         result &= filter.evaluate_scalar(&scalar_value).unwrap_or(true);
+//     }
 
-    result
-}
+//     result
+// }
 
 /// Structs to reuse across readers to avoid allocating for each reader.
 pub(crate) struct ReadPartitionContext {
     metadata: RegionMetadataRef,
     row_codec: Arc<McmpRowCodec>,
     projection: HashSet<ColumnId>,
-    filters: Vec<SimpleFilterEvaluator>,
+    filters: Arc<Vec<SimpleFilterEvaluator>>,
     /// Buffer to store pk weights.
     pk_weights: Vec<u16>,
     need_prune_key: bool,
@@ -464,10 +484,10 @@ pub(crate) struct ReadPartitionContext {
 
 impl Drop for ReadPartitionContext {
     fn drop(&mut self) {
-        let partition_prune_pk = self.metrics.prune_pk.as_secs_f64();
-        MERGE_TREE_READ_STAGE_ELAPSED
-            .with_label_values(&["partition_prune_pk"])
-            .observe(partition_prune_pk);
+        // let partition_prune_pk = self.metrics.prune_pk.as_secs_f64();
+        // MERGE_TREE_READ_STAGE_ELAPSED
+        //     .with_label_values(&["partition_prune_pk"])
+        //     .observe(partition_prune_pk);
         let partition_read_source = self.metrics.read_source.as_secs_f64();
         MERGE_TREE_READ_STAGE_ELAPSED
             .with_label_values(&["partition_read_source"])
@@ -477,13 +497,11 @@ impl Drop for ReadPartitionContext {
             .with_label_values(&["partition_data_batch_to_batch"])
             .observe(partition_data_batch_to_batch);
 
-        if self.metrics.keys_before_pruning != 0 {
+        if self.metrics.keys_after_pruning != 0 {
             common_telemetry::debug!(
-                "TreeIter pruning, before: {}, after: {}, partition_read_source: {}s, partition_prune_pk: {}s, partition_data_batch_to_batch: {}s",
-                self.metrics.keys_before_pruning,
+                "TreeIter partitions metrics, after: {}, partition_read_source: {}s, partition_data_batch_to_batch: {}s",
                 self.metrics.keys_after_pruning,
                 partition_read_source,
-                partition_prune_pk,
                 partition_data_batch_to_batch,
             );
         }
@@ -502,7 +520,7 @@ impl ReadPartitionContext {
             metadata,
             row_codec,
             projection,
-            filters,
+            filters: Arc::new(filters),
             pk_weights: Vec::new(),
             need_prune_key,
             metrics: Default::default(),

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -213,7 +213,7 @@ impl ShardReader {
     }
 
     fn prune_batch_by_key(&mut self) -> Result<()> {
-        let Some(key_filter) = &self.key_filter else {
+        let Some(key_filter) = &mut self.key_filter else {
             return Ok(());
         };
 
@@ -225,7 +225,8 @@ impl ShardReader {
                 }
             }
             self.keys_before_pruning += 1;
-            let key = self.current_key().unwrap();
+            // Safety: `key_filter` is some so the shard has primary keys.
+            let key = self.key_dict.as_ref().unwrap().key_by_pk_index(pk_index);
             let now = Instant::now();
             if key_filter.prune_primary_key(key) {
                 self.prune_pk_cost += now.elapsed();

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -249,7 +249,7 @@ impl Drop for ShardReader {
             .observe(shard_prune_pk);
         if self.keys_before_pruning > 0 {
             common_telemetry::debug!(
-                "ShardReader metrics, data parts: {}, before pruning: {}, after pruning: {}, prune cost: {}s, data build cost: {}s",
+                "ShardReader metrics, data parts: {}, before pruning: {}, after pruning: {}, prune cost: {}s, build cost: {}s",
                 self.parts_reader.num_parts(),
                 self.keys_before_pruning,
                 self.keys_after_pruning,

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -243,13 +243,15 @@ impl Drop for ShardReader {
         MERGE_TREE_READ_STAGE_ELAPSED
             .with_label_values(&["shard_prune_pk"])
             .observe(shard_prune_pk);
-        common_telemetry::debug!(
-            "ShardReader metrics, data parts: {}, before pruning: {}, after pruning: {}, cost: {:?}s",
-            self.parts_reader.num_parts(),
-            self.keys_before_pruning,
-            self.keys_after_pruning,
-            shard_prune_pk,
-        );
+        if self.keys_before_pruning > 0 {
+            common_telemetry::debug!(
+                "ShardReader metrics, data parts: {}, before pruning: {}, after pruning: {}, cost: {:?}s",
+                self.parts_reader.num_parts(),
+                self.keys_before_pruning,
+                self.keys_after_pruning,
+                shard_prune_pk,
+            );
+        }
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -15,6 +15,7 @@
 //! Shard in a partition.
 
 use std::cmp::Ordering;
+use std::time::{Duration, Instant};
 
 use store_api::metadata::RegionMetadataRef;
 
@@ -25,8 +26,10 @@ use crate::memtable::merge_tree::data::{
 };
 use crate::memtable::merge_tree::dict::KeyDictRef;
 use crate::memtable::merge_tree::merger::{Merger, Node};
+use crate::memtable::merge_tree::partition::PrimaryKeyFilter;
 use crate::memtable::merge_tree::shard_builder::ShardBuilderReader;
-use crate::memtable::merge_tree::{PkId, ShardId};
+use crate::memtable::merge_tree::{PkId, PkIndex, ShardId};
+use crate::metrics::MERGE_TREE_READ_STAGE_ELAPSED;
 
 /// Shard stores data related to the same key dictionary.
 pub struct Shard {
@@ -131,18 +134,14 @@ pub struct ShardReaderBuilder {
 }
 
 impl ShardReaderBuilder {
-    pub(crate) fn build(self) -> Result<ShardReader> {
+    pub(crate) fn build(self, key_filter: Option<PrimaryKeyFilter>) -> Result<ShardReader> {
         let ShardReaderBuilder {
             shard_id,
             key_dict,
             inner,
         } = self;
         let parts_reader = inner.build()?;
-        Ok(ShardReader {
-            shard_id,
-            key_dict,
-            parts_reader,
-        })
+        ShardReader::new(shard_id, key_dict, parts_reader, key_filter)
     }
 }
 
@@ -151,9 +150,36 @@ pub struct ShardReader {
     shard_id: ShardId,
     key_dict: Option<KeyDictRef>,
     parts_reader: DataPartsReader,
+    key_filter: Option<PrimaryKeyFilter>,
+    last_yield_pk_index: Option<PkIndex>,
+    keys_before_pruning: usize,
+    keys_after_pruning: usize,
+    prune_pk_cost: Duration,
 }
 
 impl ShardReader {
+    fn new(
+        shard_id: ShardId,
+        key_dict: Option<KeyDictRef>,
+        parts_reader: DataPartsReader,
+        key_filter: Option<PrimaryKeyFilter>,
+    ) -> Result<Self> {
+        let has_pk = key_dict.is_some();
+        let mut reader = Self {
+            shard_id,
+            key_dict,
+            parts_reader,
+            key_filter: if has_pk { key_filter } else { None },
+            last_yield_pk_index: None,
+            keys_before_pruning: 0,
+            keys_after_pruning: 0,
+            prune_pk_cost: Duration::default(),
+        };
+        reader.prune_batch_by_key()?;
+
+        Ok(reader)
+    }
+
     fn is_valid(&self) -> bool {
         self.parts_reader.is_valid()
     }
@@ -179,6 +205,49 @@ impl ShardReader {
 
     fn current_data_batch(&self) -> DataBatch {
         self.parts_reader.current_data_batch()
+    }
+
+    fn prune_batch_by_key(&mut self) -> Result<()> {
+        let Some(key_filter) = &self.key_filter else {
+            return Ok(());
+        };
+
+        while self.parts_reader.is_valid() {
+            let pk_index = self.parts_reader.current_data_batch().pk_index();
+            if let Some(yield_pk_index) = self.last_yield_pk_index {
+                if pk_index == yield_pk_index {
+                    break;
+                }
+            }
+            self.keys_before_pruning += 1;
+            let key = self.current_key().unwrap();
+            let now = Instant::now();
+            if key_filter.prune_primary_key(key) {
+                self.prune_pk_cost += now.elapsed();
+                self.last_yield_pk_index = Some(pk_index);
+                self.keys_after_pruning += 1;
+                break;
+            }
+            self.prune_pk_cost += now.elapsed();
+            self.parts_reader.next()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for ShardReader {
+    fn drop(&mut self) {
+        let shard_prune_pk = self.prune_pk_cost.as_secs_f64();
+        MERGE_TREE_READ_STAGE_ELAPSED
+            .with_label_values(&["shard_prune_pk"])
+            .observe(shard_prune_pk);
+        common_telemetry::debug!(
+            "ShardReader metrics, before pruning: {}, after pruning: {}, cost: {:?}s",
+            self.keys_before_pruning,
+            self.keys_after_pruning,
+            shard_prune_pk,
+        );
     }
 }
 
@@ -422,7 +491,7 @@ mod tests {
         }
         assert!(!shard.is_empty());
 
-        let mut reader = shard.read().unwrap().build().unwrap();
+        let mut reader = shard.read().unwrap().build(None).unwrap();
         let mut timestamps = Vec::new();
         while reader.is_valid() {
             let rb = reader.current_data_batch().slice_record_batch();

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -185,7 +185,8 @@ impl ShardReader {
     }
 
     fn next(&mut self) -> Result<()> {
-        self.parts_reader.next()
+        self.parts_reader.next()?;
+        self.prune_batch_by_key()
     }
 
     fn current_key(&self) -> Option<&[u8]> {

--- a/src/mito2/src/memtable/merge_tree/shard.rs
+++ b/src/mito2/src/memtable/merge_tree/shard.rs
@@ -244,7 +244,8 @@ impl Drop for ShardReader {
             .with_label_values(&["shard_prune_pk"])
             .observe(shard_prune_pk);
         common_telemetry::debug!(
-            "ShardReader metrics, before pruning: {}, after pruning: {}, cost: {:?}s",
+            "ShardReader metrics, data parts: {}, before pruning: {}, after pruning: {}, cost: {:?}s",
+            self.parts_reader.num_parts(),
             self.keys_before_pruning,
             self.keys_after_pruning,
             shard_prune_pk,

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -227,7 +227,8 @@ impl ShardBuilderReader {
     }
 
     pub fn next(&mut self) -> Result<()> {
-        self.data_reader.next()
+        self.data_reader.next()?;
+        self.prune_batch_by_key()
     }
 
     pub fn current_key(&self) -> Option<&[u8]> {

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -283,12 +283,14 @@ impl Drop for ShardBuilderReader {
         MERGE_TREE_READ_STAGE_ELAPSED
             .with_label_values(&["shard_builder_prune_pk"])
             .observe(shard_builder_prune_pk);
-        common_telemetry::debug!(
-            "ShardBuilderReader metrics, before pruning: {}, after pruning: {}, cost: {}s",
-            self.keys_before_pruning,
-            self.keys_after_pruning,
-            shard_builder_prune_pk,
-        );
+        if self.keys_before_pruning > 0 {
+            common_telemetry::debug!(
+                "ShardBuilderReader metrics, before pruning: {}, after pruning: {}, cost: {}s",
+                self.keys_before_pruning,
+                self.keys_after_pruning,
+                shard_builder_prune_pk,
+            );
+        }
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/shard_builder.rs
+++ b/src/mito2/src/memtable/merge_tree/shard_builder.rs
@@ -259,7 +259,7 @@ impl ShardBuilderReader {
     }
 
     fn prune_batch_by_key(&mut self) -> Result<()> {
-        let Some(key_filter) = &self.key_filter else {
+        let Some(key_filter) = &mut self.key_filter else {
             return Ok(());
         };
 
@@ -271,7 +271,7 @@ impl ShardBuilderReader {
                 }
             }
             self.keys_before_pruning += 1;
-            let key = self.current_key().unwrap();
+            let key = self.dict_reader.key_by_pk_index(pk_index);
             let now = Instant::now();
             if key_filter.prune_primary_key(key) {
                 self.prune_pk_cost += now.elapsed();

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -223,12 +223,9 @@ impl SortField {
         deserializer: &mut Deserializer<&[u8]>,
     ) -> Result<usize> {
         let pos = deserializer.position();
-        match bytes[pos] {
-            0 => {
-                deserializer.advance(1);
-                return Ok(1);
-            }
-            _ => (),
+        if bytes[pos] == 0 {
+            deserializer.advance(1);
+            return Ok(1);
         }
 
         let to_skip = match &self.data_type {

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -46,6 +46,9 @@ pub trait RowCodec {
 
     /// Decode row values from bytes.
     fn decode(&self, bytes: &[u8]) -> Result<Vec<Value>>;
+
+    /// Decode row values from bytes to a vec.
+    fn decode_to_vec(&self, bytes: &[u8], values: &mut Vec<Value>) -> Result<()>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -268,6 +271,17 @@ impl RowCodec for McmpRowCodec {
             values.push(value);
         }
         Ok(values)
+    }
+
+    fn decode_to_vec(&self, bytes: &[u8], values: &mut Vec<Value>) -> Result<()> {
+        values.clear();
+        values.reserve(self.fields.len());
+        let mut deserializer = Deserializer::new(bytes);
+        for f in &self.fields {
+            let value = f.deserialize(&mut deserializer)?;
+            values.push(value);
+        }
+        Ok(())
     }
 }
 

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -298,12 +298,13 @@ impl McmpRowCodec {
 
         offsets_buf.clear();
         let mut offset = 0;
-        offsets_buf.push(offset);
         for i in 0..pos {
+            offsets_buf.push(offset);
             let skip = self.fields[i].skip_deserialize(bytes, &mut deserializer)?;
             offset += skip;
-            offsets_buf.push(offset);
         }
+        // Push offset for the this field.
+        offsets_buf.push(offset);
         self.fields[pos].deserialize(&mut deserializer)
     }
 }

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -296,6 +296,8 @@ impl McmpRowCodec {
     }
 
     /// Decode value at `pos` in `bytes`.
+    ///
+    /// The i-th element in offsets buffer is how many bytes to skip in order to read value at `pos`.
     pub fn decode_value_at(
         &self,
         bytes: &[u8],

--- a/src/mito2/src/row_converter.rs
+++ b/src/mito2/src/row_converter.rs
@@ -293,7 +293,7 @@ impl McmpRowCodec {
         offsets_buf: &mut Vec<usize>,
     ) -> Result<Value> {
         let mut deserializer = Deserializer::new(bytes);
-        if pos <= offsets_buf.len() {
+        if pos < offsets_buf.len() {
             // We computed the offset before.
             let to_skip = offsets_buf[pos];
             deserializer.advance(to_skip);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?
This PR improves the pruning speed of the new memtable
- Adds `decode_value_at()` method to decode a value at a specific position in the primary key
  - It will skip values before the position
  - Stores offsets in a buffer so we can reuse them while there are multiple filters to prune
- Adds a `PrimaryKeyFilter` to filter primary keys via `decode_value_at()`
- Pushes down filters to `Shards` and `ShardBuilder` to reduce DataBatch returned to the partition reader


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
- #2804 