### PR TITLE
fix: mitigate memory spike during startup

### DIFF
--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -427,11 +427,11 @@ pub(crate) async fn replay_memtable<S: LogStore>(
                 .unwrap_or(0);
             region_write_ctx.push_mutation(mutation.op_type, mutation.rows, OptionOutputTx::none());
         }
-    }
 
-    // set next_entry_id and write to memtable.
-    region_write_ctx.set_next_entry_id(last_entry_id + 1);
-    region_write_ctx.write_memtable();
+        // set next_entry_id and write to memtable.
+        region_write_ctx.set_next_entry_id(last_entry_id + 1);
+        region_write_ctx.write_memtable();
+    }
 
     if allow_stale_entries && stale_entry_found {
         wal.obsolete(region_id, flushed_entry_id, wal_options)

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -398,10 +398,9 @@ pub(crate) async fn replay_memtable<S: LogStore>(
     // Last entry id should start from flushed entry id since there might be no
     // data in the WAL.
     let mut last_entry_id = flushed_entry_id;
-    let mut region_write_ctx = RegionWriteCtx::new(region_id, version_control, wal_options.clone());
-
     let replay_from_entry_id = flushed_entry_id + 1;
     let mut stale_entry_found = false;
+
     let mut wal_stream = wal.scan(region_id, replay_from_entry_id, wal_options)?;
     while let Some(res) = wal_stream.next().await {
         let (entry_id, entry) = res?;
@@ -417,8 +416,10 @@ pub(crate) async fn replay_memtable<S: LogStore>(
                 }
             );
         }
-
         last_entry_id = last_entry_id.max(entry_id);
+
+        let mut region_write_ctx =
+            RegionWriteCtx::new(region_id, version_control, wal_options.clone());
         for mutation in entry.mutations {
             rows_replayed += mutation
                 .rows


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

Previously, we aggregate all mutations from wal and write them into the memtable in a batching manner. Now, the mutations are written into the memtable in a streaming manner. We believe this transition could mitigate the memory spike issue during startup.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
fixes #3226 

