### PR TITLE
refactor: make MergeTreeMemtable the default choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5380,6 +5380,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "toml 0.8.8",
  "uuid",
 ]
 

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -138,6 +138,18 @@ mem_threshold_on_create = "64M"
 # File system path to store intermediate files for external sorting (default `{data_home}/index_intermediate`).
 intermediate_path = ""
 
+[region_engine.mito.memtable]
+# Memtable type.
+# - "experimental": experimental memtable
+# - "time_series": time-series memtable (deprecated)
+type = "experimental"
+# The max number of keys in one shard.
+index_max_keys_per_shard = 8192
+# The max rows of data inside the actively writing buffer in one shard.
+data_freeze_threshold = 32768
+# Max dictionary bytes.
+fork_dictionary_bytes = "1GiB"
+
 # Log options, see `standalone.example.toml`
 # [logging]
 # dir = "/tmp/greptimedb/logs"

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -245,10 +245,15 @@ mem_threshold_on_create = "64M"
 intermediate_path = ""
 
 [region_engine.mito.memtable]
+# Memtable type.
+# - "experimental": experimental memtable
+# - "time_series": time-series memtable (deprecated)
 type = "experimental"
+# The max number of keys in one shard.
 index_max_keys_per_shard = 8192
+# The max rows of data inside the actively writing buffer in one shard.
 data_freeze_threshold = 32768
-dedup = true
+# Max dictionary bytes.
 fork_dictionary_bytes = "1GiB"
 
 # Log options

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -244,6 +244,13 @@ mem_threshold_on_create = "64M"
 # File system path to store intermediate files for external sorting (default `{data_home}/index_intermediate`).
 intermediate_path = ""
 
+[region_engine.mito.memtable]
+type = "experimental"
+index_max_keys_per_shard = 8192
+data_freeze_threshold = 32768
+dedup = true
+fork_dictionary_bytes = "1GiB"
+
 # Log options
 # [logging]
 # Specify logs directory.

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -75,6 +75,7 @@ common-procedure-test.workspace = true
 common-test-util.workspace = true
 criterion = "0.4"
 log-store.workspace = true
+toml.workspace = true
 rand.workspace = true
 
 [[bench]]

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -75,8 +75,8 @@ common-procedure-test.workspace = true
 common-test-util.workspace = true
 criterion = "0.4"
 log-store.workspace = true
-toml.workspace = true
 rand.workspace = true
+toml.workspace = true
 
 [[bench]]
 name = "bench_merge_tree"

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -44,7 +44,7 @@ use crate::memtable::{
 };
 
 /// Use `1/DICTIONARY_SIZE_FACTOR` of OS memory as dictionary size.
-const DICTIONARY_SIZE_FACTOR: u64 = 16;
+const DICTIONARY_SIZE_FACTOR: u64 = 8;
 
 /// Id of a shard, only unique inside a partition.
 type ShardId = u32;
@@ -74,7 +74,7 @@ pub struct MergeTreeConfig {
 
 impl Default for MergeTreeConfig {
     fn default() -> Self {
-        let mut fork_dictionary_bytes = ReadableSize::mb(512);
+        let mut fork_dictionary_bytes = ReadableSize::gb(1);
         if let Some(sys_memory) = common_config::utils::get_sys_total_memory() {
             let adjust_dictionary_bytes =
                 std::cmp::min(sys_memory / DICTIONARY_SIZE_FACTOR, fork_dictionary_bytes);
@@ -85,7 +85,7 @@ impl Default for MergeTreeConfig {
 
         Self {
             index_max_keys_per_shard: 8192,
-            data_freeze_threshold: 102400,
+            data_freeze_threshold: 32768,
             dedup: true,
             fork_dictionary_bytes,
         }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -785,6 +785,13 @@ write_buffer_size = "8MiB"
 mem_threshold_on_create = "64.0MiB"
 intermediate_path = ""
 
+[datanode.region_engine.mito.memtable]
+type = "experimental"
+index_max_keys_per_shard = 8192
+data_freeze_threshold = 32768
+dedup = true
+fork_dictionary_bytes = "1GiB"
+
 [[datanode.region_engine]]
 
 [datanode.region_engine.file]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#2804 

## What's changed and what's your intention?

Though still in experimental stage, we can replace `TimeSeriesMemtable` with `MergeTreeMemtable`.

This PR also modifies some of the default config of `MergeTreeMemtable`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
