### PR TITLE
ci: refine windows output env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
       - name: Set build windows result
         id: set-build-windows-result
         run: |
-          echo "build-windows-result=success" >> $GITHUB_OUTPUT    
+          echo "build-windows-result=success" >> $Env:GITHUB_OUTPUT
 
   release-images-to-dockerhub:
     name: Build and push images to DockerHub


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
related to: https://github.com/actions/runner/issues/2224

## What's changed and what's your intention?
The release notification failed to get `build-windows-result` variables. 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
