### PR TITLE
chore: bump version to v0.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.7.0
+  NEXT_RELEASE_VERSION: v0.8.0
 
 jobs:
   allocate-runners:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -1219,7 +1219,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1510,7 +1510,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1546,7 +1546,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1629,7 +1629,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1672,7 +1672,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-recursion",
@@ -1944,11 +1944,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "common-procedure"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1980,7 +1980,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2043,7 +2043,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "client",
  "common-query",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2099,14 +2099,14 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "build-data",
 ]
 
 [[package]]
 name = "common-wal"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2812,7 +2812,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3302,7 +3302,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "bimap",
@@ -3458,7 +3458,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -3522,7 +3522,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
  "strfmt",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "tokio",
  "toml 0.8.8",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4848,7 +4848,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5137,7 +5137,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anymap",
  "api",
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anymap",
  "api",
@@ -5933,7 +5933,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6223,7 +6223,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6779,7 +6779,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "auth",
  "common-base",
@@ -7046,7 +7046,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash 0.8.6",
  "async-recursion",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -7378,7 +7378,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -7439,7 +7439,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -8757,7 +8757,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -9030,7 +9030,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aide",
  "api",
@@ -9134,7 +9134,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -9404,7 +9404,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "common-base",
@@ -9456,7 +9456,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -9803,7 +9803,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -9976,7 +9976,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anymap",
  "async-trait",
@@ -10088,7 +10088,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -10113,7 +10113,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -10170,7 +10170,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.6.0",
+ "substrait 0.7.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

- https://github.com/GreptimeTeam/greptimedb/issues/3427

## What's changed and what's your intention?

This PR bumps the db version to v0.7.0.

Wait for #3427 finished.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
