### PR TITLE
feat: impl some "set"s to adapt to some client apps

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -68,6 +68,7 @@ static OTHER_NOT_SUPPORTED_STMT: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^(SET sql_mode(.*))",
         "(?i)^(SET SQL_SELECT_LIMIT(.*))",
         "(?i)^(SET @@(.*))",
+        "(?i)^(SET PROFILING(.*))",
 
         "(?i)^(SHOW COLLATION)",
         "(?i)^(SHOW CHARSET)",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The "set"s are:

- ignored:
  - `set bytea_output` and `set datestyle` (both have issues tracked) from pg
  - `set profiling` from mysql. It's not something we will impl (rather we may prefer tracing instead). Plus it's deprecated. See [here](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_profiling)
- validated:
  - `set client_encoding` from pg. Must be "utf8" because it's universal and sufficient, and we don't bother to convert bytes around.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
