### PR TITLE
chore: specify binary name

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -102,7 +102,7 @@ jobs:
           shared-key: "build-binaries"
       - name: Build greptime binaries
         shell: bash
-        run: cargo build
+        run: cargo build --bin greptime --bin sqlness-runner
       - name: Pack greptime binaries
         shell: bash
         run: |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Each fuzz test will add a new binary target. Therefore, we should specify the binary name in `Cargo build`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
