### PR TITLE
refactor: separate the quote char and value

### DIFF
--- a/tests-fuzz/src/context.rs
+++ b/tests-fuzz/src/context.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 
 use partition::partition::PartitionDef;
 
-use crate::ir::{Column, CreateTableExpr};
+use crate::ir::{Column, CreateTableExpr, Ident};
 
 pub type TableContextRef = Arc<TableContext>;
 
 /// TableContext stores table info.
 pub struct TableContext {
-    pub name: String,
+    pub name: Ident,
     pub columns: Vec<Column>,
 
     // GreptimeDB specific options
@@ -41,7 +41,7 @@ impl From<&CreateTableExpr> for TableContext {
         }: &CreateTableExpr,
     ) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.clone(),
             columns: columns.clone(),
             partition: partition.clone(),
             primary_keys: primary_keys.clone(),

--- a/tests-fuzz/src/generator.rs
+++ b/tests-fuzz/src/generator.rs
@@ -62,7 +62,7 @@ macro_rules! impl_random {
                 while result.len() != amount {
                     result.insert($values.choose(rng).unwrap().clone());
                 }
-                let mut result = result.into_iter().collect::<Vec<_>>();
+                let mut result = result.into_iter().map(Into::into).collect::<Vec<_>>();
                 // Shuffles the result slice.
                 result.shuffle(rng);
                 result

--- a/tests-fuzz/src/generator/alter_expr.rs
+++ b/tests-fuzz/src/generator/alter_expr.rs
@@ -25,7 +25,7 @@ use crate::fake::WordGenerator;
 use crate::generator::{ColumnOptionGenerator, ConcreteDataTypeGenerator, Generator, Random};
 use crate::ir::alter_expr::{AlterTableExpr, AlterTableOperation};
 use crate::ir::{
-    column_options_generator, droppable_columns, generate_columns, ColumnTypeGenerator,
+    column_options_generator, droppable_columns, generate_columns, ColumnTypeGenerator, Ident,
 };
 
 /// Generates the [AlterTableOperation::AddColumn] of [AlterTableExpr].
@@ -36,7 +36,7 @@ pub struct AlterExprAddColumnGenerator<R: Rng + 'static> {
     #[builder(default)]
     location: bool,
     #[builder(default = "Box::new(WordGenerator)")]
-    name_generator: Box<dyn Random<String, R>>,
+    name_generator: Box<dyn Random<Ident, R>>,
     #[builder(default = "Box::new(column_options_generator)")]
     column_options_generator: ColumnOptionGenerator<R>,
     #[builder(default = "Box::new(ColumnTypeGenerator)")]
@@ -74,7 +74,7 @@ impl<R: Rng + 'static> Generator<AlterTableExpr, R> for AlterExprAddColumnGenera
         )
         .remove(0);
         Ok(AlterTableExpr {
-            table_name: self.table_ctx.name.to_string(),
+            table_name: self.table_ctx.name.clone(),
             alter_options: AlterTableOperation::AddColumn { column, location },
         })
     }
@@ -95,11 +95,9 @@ impl<R: Rng> Generator<AlterTableExpr, R> for AlterExprDropColumnGenerator<R> {
     fn generate(&self, rng: &mut R) -> Result<AlterTableExpr> {
         let droppable = droppable_columns(&self.table_ctx.columns);
         ensure!(!droppable.is_empty(), error::DroppableColumnsSnafu);
-        let name = droppable[rng.gen_range(0..droppable.len())]
-            .name
-            .to_string();
+        let name = droppable[rng.gen_range(0..droppable.len())].name.clone();
         Ok(AlterTableExpr {
-            table_name: self.table_ctx.name.to_string(),
+            table_name: self.table_ctx.name.clone(),
             alter_options: AlterTableOperation::DropColumn { name },
         })
     }
@@ -111,7 +109,7 @@ impl<R: Rng> Generator<AlterTableExpr, R> for AlterExprDropColumnGenerator<R> {
 pub struct AlterExprRenameGenerator<R: Rng> {
     table_ctx: TableContextRef,
     #[builder(default = "Box::new(WordGenerator)")]
-    name_generator: Box<dyn Random<String, R>>,
+    name_generator: Box<dyn Random<Ident, R>>,
 }
 
 impl<R: Rng> Generator<AlterTableExpr, R> for AlterExprRenameGenerator<R> {
@@ -120,7 +118,7 @@ impl<R: Rng> Generator<AlterTableExpr, R> for AlterExprRenameGenerator<R> {
     fn generate(&self, rng: &mut R) -> Result<AlterTableExpr> {
         let new_table_name = self.name_generator.gen(rng);
         Ok(AlterTableExpr {
-            table_name: self.table_ctx.name.to_string(),
+            table_name: self.table_ctx.name.clone(),
             alter_options: AlterTableOperation::RenameTable { new_table_name },
         })
     }
@@ -155,7 +153,7 @@ mod tests {
             .generate(&mut rng)
             .unwrap();
         let serialized = serde_json::to_string(&expr).unwrap();
-        let expected = r#"{"table_name":"animI","alter_options":{"AddColumn":{"column":{"name":"velit","column_type":{"Int32":{}},"options":[{"DefaultValue":{"Int32":853246610}}]},"location":null}}}"#;
+        let expected = r#"{"table_name":{"value":"animI","quote_style":null},"alter_options":{"AddColumn":{"column":{"name":{"value":"velit","quote_style":null},"column_type":{"Int32":{}},"options":[{"DefaultValue":{"Int32":853246610}}]},"location":null}}}"#;
         assert_eq!(expected, serialized);
 
         let expr = AlterExprRenameGeneratorBuilder::default()
@@ -165,8 +163,7 @@ mod tests {
             .generate(&mut rng)
             .unwrap();
         let serialized = serde_json::to_string(&expr).unwrap();
-        let expected =
-            r#"{"table_name":"animI","alter_options":{"RenameTable":{"new_table_name":"iure"}}}"#;
+        let expected = r#"{"table_name":{"value":"animI","quote_style":null},"alter_options":{"RenameTable":{"new_table_name":{"value":"iure","quote_style":null}}}}"#;
         assert_eq!(expected, serialized);
 
         let expr = AlterExprDropColumnGeneratorBuilder::default()
@@ -176,7 +173,7 @@ mod tests {
             .generate(&mut rng)
             .unwrap();
         let serialized = serde_json::to_string(&expr).unwrap();
-        let expected = r#"{"table_name":"animI","alter_options":{"DropColumn":{"name":"toTAm"}}}"#;
+        let expected = r#"{"table_name":{"value":"animI","quote_style":null},"alter_options":{"DropColumn":{"name":{"value":"toTAm","quote_style":null}}}}"#;
         assert_eq!(expected, serialized);
     }
 }

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -26,7 +26,7 @@ use crate::ir::create_expr::CreateTableExprBuilder;
 use crate::ir::{
     column_options_generator, generate_columns, generate_random_value,
     partible_column_options_generator, ts_column_options_generator, ColumnTypeGenerator,
-    CreateTableExpr, PartibleColumnTypeGenerator, TsColumnTypeGenerator,
+    CreateTableExpr, Ident, PartibleColumnTypeGenerator, TsColumnTypeGenerator,
 };
 
 #[derive(Builder)]
@@ -39,7 +39,7 @@ pub struct CreateTableExprGenerator<R: Rng + 'static> {
     if_not_exists: bool,
     #[builder(setter(into))]
     name: String,
-    name_generator: Box<dyn Random<String, R>>,
+    name_generator: Box<dyn Random<Ident, R>>,
     ts_column_type_generator: ConcreteDataTypeGenerator<R>,
     column_type_generator: ConcreteDataTypeGenerator<R>,
     partible_column_type_generator: ConcreteDataTypeGenerator<R>,
@@ -93,7 +93,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
             let name = column_names.pop().unwrap();
             let column = generate_columns(
                 rng,
-                vec![name.to_string()],
+                vec![name.clone()],
                 self.ts_column_type_generator.as_ref(),
                 self.ts_column_options_generator.as_ref(),
             )
@@ -111,7 +111,10 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
                     partition_bounds.sort();
                 }
                 partition_bounds.push(PartitionBound::MaxValue);
-                builder.partition(PartitionDef::new(vec![name], partition_bounds));
+                builder.partition(PartitionDef::new(
+                    vec![name.value.to_string()],
+                    partition_bounds,
+                ));
             }
 
             columns.push(column);
@@ -122,7 +125,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
                 let name = column_names.pop().unwrap();
                 let column = generate_columns(
                     rng,
-                    vec![name.to_string()],
+                    vec![name.clone()],
                     self.partible_column_type_generator.as_ref(),
                     self.partible_column_options_generator.as_ref(),
                 )
@@ -139,7 +142,10 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
                     partition_bounds.sort();
                 }
                 partition_bounds.push(PartitionBound::MaxValue);
-                builder.partition(PartitionDef::new(vec![name], partition_bounds));
+                builder.partition(PartitionDef::new(
+                    vec![name.value.to_string()],
+                    partition_bounds,
+                ));
                 columns.push(column);
             }
             // Generates the ts column.
@@ -230,7 +236,7 @@ mod tests {
             .unwrap();
 
         let serialized = serde_json::to_string(&expr).unwrap();
-        let expected = r#"{"table_name":"tEmporIbUS","columns":[{"name":"IMpEdIT","column_type":{"String":null},"options":["PrimaryKey","NotNull"]},{"name":"natuS","column_type":{"Timestamp":{"Nanosecond":null}},"options":["TimeIndex"]},{"name":"ADIPisCI","column_type":{"Int16":{}},"options":[{"DefaultValue":{"Int16":4864}}]},{"name":"EXpEdita","column_type":{"Int64":{}},"options":["PrimaryKey"]},{"name":"cUlpA","column_type":{"Float64":{}},"options":["NotNull"]},{"name":"MOLeStIAs","column_type":{"Boolean":null},"options":["Null"]},{"name":"cUmquE","column_type":{"Float32":{}},"options":[{"DefaultValue":{"Float32":0.21569687}}]},{"name":"toTAm","column_type":{"Float64":{}},"options":["NotNull"]},{"name":"deBitIs","column_type":{"Float32":{}},"options":["Null"]},{"name":"QUi","column_type":{"Int64":{}},"options":["Null"]}],"if_not_exists":true,"partition":{"partition_columns":["IMpEdIT"],"partition_bounds":[{"Value":{"String":"򟘲"}},{"Value":{"String":"򴥫"}},"MaxValue"]},"engine":"mito2","options":{},"primary_keys":[0,3]}"#;
+        let expected = r#"{"table_name":{"value":"tEmporIbUS","quote_style":null},"columns":[{"name":{"value":"IMpEdIT","quote_style":null},"column_type":{"String":null},"options":["PrimaryKey","NotNull"]},{"name":{"value":"natuS","quote_style":null},"column_type":{"Timestamp":{"Nanosecond":null}},"options":["TimeIndex"]},{"name":{"value":"ADIPisCI","quote_style":null},"column_type":{"Int16":{}},"options":[{"DefaultValue":{"Int16":4864}}]},{"name":{"value":"EXpEdita","quote_style":null},"column_type":{"Int64":{}},"options":["PrimaryKey"]},{"name":{"value":"cUlpA","quote_style":null},"column_type":{"Float64":{}},"options":["NotNull"]},{"name":{"value":"MOLeStIAs","quote_style":null},"column_type":{"Boolean":null},"options":["Null"]},{"name":{"value":"cUmquE","quote_style":null},"column_type":{"Float32":{}},"options":[{"DefaultValue":{"Float32":0.21569687}}]},{"name":{"value":"toTAm","quote_style":null},"column_type":{"Float64":{}},"options":["NotNull"]},{"name":{"value":"deBitIs","quote_style":null},"column_type":{"Float32":{}},"options":["Null"]},{"name":{"value":"QUi","quote_style":null},"column_type":{"Int64":{}},"options":["Null"]}],"if_not_exists":true,"partition":{"partition_columns":["IMpEdIT"],"partition_bounds":[{"Value":{"String":"򟘲"}},{"Value":{"String":"򴥫"}},"MaxValue"]},"engine":"mito2","options":{},"primary_keys":[0,3]}"#;
         assert_eq!(expected, serialized);
     }
 }

--- a/tests-fuzz/src/generator/insert_expr.rs
+++ b/tests-fuzz/src/generator/insert_expr.rs
@@ -22,8 +22,8 @@ use crate::context::TableContextRef;
 use crate::error::{Error, Result};
 use crate::fake::WordGenerator;
 use crate::generator::{Generator, Random};
-use crate::ir::generate_random_value;
 use crate::ir::insert_expr::InsertIntoExpr;
+use crate::ir::{generate_random_value, Ident};
 
 /// Generates [InsertIntoExpr].
 #[derive(Builder)]
@@ -33,7 +33,7 @@ pub struct InsertExprGenerator<R: Rng + 'static> {
     #[builder(default = "1")]
     rows: usize,
     #[builder(default = "Box::new(WordGenerator)")]
-    word_generator: Box<dyn Random<String, R>>,
+    word_generator: Box<dyn Random<Ident, R>>,
     #[builder(default)]
     _phantom: PhantomData<R>,
 }

--- a/tests-fuzz/src/ir/alter_expr.rs
+++ b/tests-fuzz/src/ir/alter_expr.rs
@@ -16,11 +16,11 @@ use common_query::AddColumnLocation;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::ir::Column;
+use crate::ir::{Column, Ident};
 
 #[derive(Debug, Builder, Clone, Serialize, Deserialize)]
 pub struct AlterTableExpr {
-    pub table_name: String,
+    pub table_name: Ident,
     pub alter_options: AlterTableOperation,
 }
 
@@ -32,7 +32,7 @@ pub enum AlterTableOperation {
         location: Option<AddColumnLocation>,
     },
     /// `DROP COLUMN <name>`
-    DropColumn { name: String },
+    DropColumn { name: Ident },
     /// `RENAME <new_table_name>`
-    RenameTable { new_table_name: String },
+    RenameTable { new_table_name: Ident },
 }

--- a/tests-fuzz/src/ir/create_expr.rs
+++ b/tests-fuzz/src/ir/create_expr.rs
@@ -20,7 +20,7 @@ use derive_builder::Builder;
 use partition::partition::PartitionDef;
 use serde::{Deserialize, Serialize};
 
-use crate::ir::Column;
+use crate::ir::{Column, Ident};
 
 // The column options
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
@@ -50,7 +50,7 @@ impl Display for ColumnOption {
 #[derive(Debug, Builder, Clone, Serialize, Deserialize)]
 pub struct CreateTableExpr {
     #[builder(setter(into))]
-    pub table_name: String,
+    pub table_name: Ident,
     pub columns: Vec<Column>,
     #[builder(default)]
     pub if_not_exists: bool,

--- a/tests-fuzz/src/test_utils.rs
+++ b/tests-fuzz/src/test_utils.rs
@@ -20,35 +20,35 @@ use crate::ir::Column;
 
 pub fn new_test_ctx() -> TableContext {
     TableContext {
-        name: "test".to_string(),
+        name: "test".into(),
         columns: vec![
             Column {
-                name: "host".to_string(),
+                name: "host".into(),
                 column_type: ConcreteDataType::string_datatype(),
                 options: vec![ColumnOption::PrimaryKey],
             },
             Column {
-                name: "idc".to_string(),
+                name: "idc".into(),
                 column_type: ConcreteDataType::string_datatype(),
                 options: vec![ColumnOption::PrimaryKey],
             },
             Column {
-                name: "cpu_util".to_string(),
+                name: "cpu_util".into(),
                 column_type: ConcreteDataType::float64_datatype(),
                 options: vec![],
             },
             Column {
-                name: "memory_util".to_string(),
+                name: "memory_util".into(),
                 column_type: ConcreteDataType::float64_datatype(),
                 options: vec![],
             },
             Column {
-                name: "disk_util".to_string(),
+                name: "disk_util".into(),
                 column_type: ConcreteDataType::float64_datatype(),
                 options: vec![],
             },
             Column {
-                name: "ts".to_string(),
+                name: "ts".into(),
                 column_type: ConcreteDataType::timestamp_millisecond_datatype(),
                 options: vec![ColumnOption::TimeIndex],
             },

--- a/tests-fuzz/src/translator/mysql/alter_expr.rs
+++ b/tests-fuzz/src/translator/mysql/alter_expr.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+
 use common_query::AddColumnLocation;
 use datatypes::data_type::ConcreteDataType;
 use sql::statements::concrete_data_type_to_sql_data_type;
@@ -41,16 +43,16 @@ impl DslTranslator<AlterTableExpr, String> for AlterTableExprTranslator {
 }
 
 impl AlterTableExprTranslator {
-    fn format_drop(name: &str, column: &str) -> String {
+    fn format_drop(name: impl Display, column: impl Display) -> String {
         format!("ALTER TABLE {name} DROP COLUMN {column};")
     }
 
-    fn format_rename(name: &str, new_name: &str) -> String {
+    fn format_rename(name: impl Display, new_name: impl Display) -> String {
         format!("ALTER TABLE {name} RENAME {new_name};")
     }
 
     fn format_add_column(
-        name: &str,
+        name: impl Display,
         column: &Column,
         location: &Option<AddColumnLocation>,
     ) -> String {
@@ -119,10 +121,10 @@ mod tests {
     #[test]
     fn test_alter_table_expr() {
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
+            table_name: "test".into(),
             alter_options: AlterTableOperation::AddColumn {
                 column: Column {
-                    name: "host".to_string(),
+                    name: "host".into(),
                     column_type: ConcreteDataType::string_datatype(),
                     options: vec![ColumnOption::PrimaryKey],
                 },
@@ -137,9 +139,9 @@ mod tests {
         );
 
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
+            table_name: "test".into(),
             alter_options: AlterTableOperation::RenameTable {
-                new_table_name: "foo".to_string(),
+                new_table_name: "foo".into(),
             },
         };
 
@@ -147,10 +149,8 @@ mod tests {
         assert_eq!("ALTER TABLE test RENAME foo;", output);
 
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
-            alter_options: AlterTableOperation::DropColumn {
-                name: "foo".to_string(),
-            },
+            table_name: "test".into(),
+            alter_options: AlterTableOperation::DropColumn { name: "foo".into() },
         };
 
         let output = AlterTableExprTranslator.translate(&alter_expr).unwrap();

--- a/tests-fuzz/src/translator/mysql/insert_expr.rs
+++ b/tests-fuzz/src/translator/mysql/insert_expr.rs
@@ -25,7 +25,7 @@ impl DslTranslator<InsertIntoExpr, String> for InsertIntoExprTranslator {
         let columns = input
             .columns
             .iter()
-            .map(|c| c.name.as_str())
+            .map(|c| c.name.to_string())
             .collect::<Vec<_>>()
             .join(", ")
             .to_string();

--- a/tests-fuzz/src/translator/mysql/select_expr.rs
+++ b/tests-fuzz/src/translator/mysql/select_expr.rs
@@ -25,7 +25,7 @@ impl DslTranslator<SelectExpr, String> for SelectExprTranslator {
         let columns = input
             .columns
             .iter()
-            .map(|c| c.name.as_str())
+            .map(|c| c.name.to_string())
             .collect::<Vec<_>>()
             .join(", ")
             .to_string();

--- a/tests-fuzz/src/translator/postgres/alter_expr.rs
+++ b/tests-fuzz/src/translator/postgres/alter_expr.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Display;
+
 use datatypes::data_type::ConcreteDataType;
 use sql::statements::concrete_data_type_to_sql_data_type;
 
@@ -41,15 +43,15 @@ impl DslTranslator<AlterTableExpr, String> for AlterTableExprTranslator {
 }
 
 impl AlterTableExprTranslator {
-    fn format_drop(name: &str, column: &str) -> String {
+    fn format_drop(name: impl Display, column: impl Display) -> String {
         format!("ALTER TABLE {name} DROP COLUMN {column};")
     }
 
-    fn format_rename(name: &str, new_name: &str) -> String {
+    fn format_rename(name: impl Display, new_name: impl Display) -> String {
         format!("ALTER TABLE {name} RENAME TO {new_name};")
     }
 
-    fn format_add_column(name: &str, column: &Column) -> String {
+    fn format_add_column(name: impl Display, column: &Column) -> String {
         format!(
             "{};",
             vec![format!(
@@ -116,10 +118,10 @@ mod tests {
     #[test]
     fn test_alter_table_expr() {
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
+            table_name: "test".into(),
             alter_options: AlterTableOperation::AddColumn {
                 column: Column {
-                    name: "host".to_string(),
+                    name: "host".into(),
                     column_type: ConcreteDataType::string_datatype(),
                     options: vec![ColumnOption::PrimaryKey],
                 },
@@ -132,9 +134,9 @@ mod tests {
         assert_eq!("ALTER TABLE test ADD COLUMN host STRING;", output);
 
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
+            table_name: "test".into(),
             alter_options: AlterTableOperation::RenameTable {
-                new_table_name: "foo".to_string(),
+                new_table_name: "foo".into(),
             },
         };
 
@@ -142,10 +144,8 @@ mod tests {
         assert_eq!("ALTER TABLE test RENAME TO foo;", output);
 
         let alter_expr = AlterTableExpr {
-            table_name: "test".to_string(),
-            alter_options: AlterTableOperation::DropColumn {
-                name: "foo".to_string(),
-            },
+            table_name: "test".into(),
+            alter_options: AlterTableOperation::DropColumn { name: "foo".into() },
         };
 
         let output = AlterTableExprTranslator.translate(&alter_expr).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#3174 

## What's changed and what's your intention?

Separating the quote char and value allows us to cover more cases easily.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
