### PR TITLE
feat(mito): Checks whether a region should flush periodically

### DIFF
--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -56,6 +56,7 @@ pin-project.workspace = true
 prometheus.workspace = true
 prost.workspace = true
 puffin.workspace = true
+rand.workspace = true
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true
@@ -75,7 +76,6 @@ common-procedure-test.workspace = true
 common-test-util.workspace = true
 criterion = "0.4"
 log-store.workspace = true
-rand.workspace = true
 toml.workspace = true
 
 [[bench]]

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -373,6 +373,7 @@ impl MitoEngine {
         object_store_manager: ObjectStoreManagerRef,
         write_buffer_manager: Option<crate::flush::WriteBufferManagerRef>,
         listener: Option<crate::engine::listener::EventListenerRef>,
+        time_provider: crate::time_provider::TimeProviderRef,
     ) -> Result<MitoEngine> {
         config.sanitize(data_home)?;
 
@@ -385,6 +386,7 @@ impl MitoEngine {
                     object_store_manager,
                     write_buffer_manager,
                     listener,
+                    time_provider,
                 )
                 .await?,
                 config,

--- a/src/mito2/src/engine/flush_test.rs
+++ b/src/mito2/src/engine/flush_test.rs
@@ -279,12 +279,12 @@ async fn test_flush_reopen_region() {
 }
 
 #[derive(Debug)]
-struct FixedTimeProvider {
+struct MockTimeProvider {
     now: AtomicI64,
     elapsed: AtomicI64,
 }
 
-impl TimeProvider for FixedTimeProvider {
+impl TimeProvider for MockTimeProvider {
     fn current_time_millis(&self) -> i64 {
         self.now.load(Ordering::Relaxed)
     }
@@ -298,7 +298,7 @@ impl TimeProvider for FixedTimeProvider {
     }
 }
 
-impl FixedTimeProvider {
+impl MockTimeProvider {
     fn new(now: i64) -> Self {
         Self {
             now: AtomicI64::new(now),
@@ -321,7 +321,7 @@ async fn test_auto_flush_engine() {
     let write_buffer_manager = Arc::new(MockWriteBufferManager::default());
     let listener = Arc::new(FlushListener::default());
     let now = current_time_millis();
-    let time_provider = Arc::new(FixedTimeProvider::new(now));
+    let time_provider = Arc::new(MockTimeProvider::new(now));
     let engine = env
         .create_engine_with_time(
             MitoConfig {

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -40,6 +40,7 @@ pub mod request;
 pub mod row_converter;
 pub(crate) mod schedule;
 pub mod sst;
+mod time_provider;
 pub mod wal;
 mod worker;
 

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -23,7 +23,6 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use common_telemetry::info;
-use common_time::util::current_time_millis;
 use common_wal::options::WalOptions;
 use snafu::{ensure, OptionExt};
 use store_api::metadata::RegionMetadataRef;
@@ -37,6 +36,7 @@ use crate::memtable::MemtableId;
 use crate::region::version::{VersionControlRef, VersionRef};
 use crate::request::OnFailure;
 use crate::sst::file_purger::FilePurgerRef;
+use crate::time_provider::TimeProviderRef;
 
 /// This is the approximate factor to estimate the size of wal.
 const ESTIMATED_WAL_FACTOR: f32 = 0.42825;
@@ -83,6 +83,9 @@ pub(crate) struct MitoRegion {
     last_flush_millis: AtomicI64,
     /// Whether the region is writable.
     writable: AtomicBool,
+
+    /// Provider to get current time.
+    time_provider: TimeProviderRef,
 }
 
 pub(crate) type MitoRegionRef = Arc<MitoRegion>;
@@ -119,7 +122,7 @@ impl MitoRegion {
 
     /// Update flush time to current time.
     pub(crate) fn update_flush_millis(&self) {
-        let now = current_time_millis();
+        let now = self.time_provider.current_time_millis();
         self.last_flush_millis.store(now, Ordering::Relaxed);
     }
 

--- a/src/mito2/src/time_provider.rs
+++ b/src/mito2/src/time_provider.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Abstraction to get current time.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common_time::util::current_time_millis;
+
+/// Trait to get current time and deal with durations.
+///
+/// We define the trait to simplify time related tests.
+pub trait TimeProvider: std::fmt::Debug + Send + Sync {
+    /// Returns current time in millis.
+    fn current_time_millis(&self) -> i64;
+
+    /// Returns millis elapsed since specify time.
+    fn elapsed_since(&self, current_millis: i64) -> i64;
+
+    /// Computes the actual duration to wait from an expected one.
+    fn wait_duration(&self, duration: Duration) -> Duration {
+        duration
+    }
+}
+
+pub type TimeProviderRef = Arc<dyn TimeProvider>;
+
+/// Default implementation of the time provider based on std.
+#[derive(Debug)]
+pub struct StdTimeProvider;
+
+impl TimeProvider for StdTimeProvider {
+    fn current_time_millis(&self) -> i64 {
+        current_time_millis()
+    }
+
+    fn elapsed_since(&self, current_millis: i64) -> i64 {
+        current_time_millis() - current_millis
+    }
+}

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -678,8 +678,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             return;
         }
 
-        println!("try to flush periodically");
-
         if let Err(e) = self.flush_periodically() {
             error!(e; "Failed to flush regions periodically");
         }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -311,7 +311,7 @@ async fn write_cache_from_config(
     Ok(Some(Arc::new(cache)))
 }
 
-/// Computes a inital check delay for a worker.
+/// Computes a initial check delay for a worker.
 pub(crate) fn worker_init_check_delay() -> Duration {
     let init_check_delay = thread_rng().gen_range(0..MAX_INITIAL_CHECK_DELAY_SECS);
     Duration::from_secs(init_check_delay)

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -678,11 +678,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             return;
         }
 
+        self.last_periodical_check_millis = self.time_provider.current_time_millis();
+
         if let Err(e) = self.flush_periodically() {
             error!(e; "Failed to flush regions periodically");
         }
-
-        self.last_periodical_check_millis = self.time_provider.current_time_millis();
     }
 
     /// Handles region background request

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -17,7 +17,6 @@
 use std::sync::Arc;
 
 use common_telemetry::{error, info, warn};
-use common_time::util::current_time_millis;
 use store_api::logstore::LogStore;
 use store_api::region_request::RegionFlushRequest;
 use store_api::storage::RegionId;
@@ -80,7 +79,7 @@ impl<S> RegionWorkerLoop<S> {
     /// Finds some regions to flush to reduce write buffer usage.
     fn flush_regions_on_engine_full(&mut self) -> Result<()> {
         let regions = self.regions.list_regions();
-        let now = current_time_millis();
+        let now = self.time_provider.current_time_millis();
         let min_last_flush_time = now - self.config.auto_flush_interval.as_millis() as i64;
         let mut max_mutable_size = 0;
         // Region with max mutable memtable size.
@@ -132,7 +131,7 @@ impl<S> RegionWorkerLoop<S> {
     /// Flushes regions periodically.
     pub(crate) fn flush_periodically(&mut self) -> Result<()> {
         let regions = self.regions.list_regions();
-        let now = current_time_millis();
+        let now = self.time_provider.current_time_millis();
         let min_last_flush_time = now - self.config.auto_flush_interval.as_millis() as i64;
 
         for region in &regions {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR checks whether a region should flush periodically and flush it if its last flush time is earlier than `auto_flush_interval`. The previous implementation only triggers the check on flush, which implies the write buffer is full. It might cause the database to hold a large amount of data for a long time if users stop ingesting data.

This PR
- adds a timeout to receive a channel so the worker can handle some tasks periodically
- adds a `TimeProvider` to get the current timestamp and checks elapsed time, this also simplifies test implementation


Each worker will start with a random check delay between `[0, MAX_INITIAL_CHECK_DELAY_SECS)` to avoid them flush together.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
