### PR TITLE
feat: support multi params in promql range function macro

### DIFF
--- a/src/promql/src/functions/aggr_over_time.rs
+++ b/src/promql/src/functions/aggr_over_time.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 
 use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{ScalarUDF, Signature, TypeSignature, Volatility};
 use datafusion::physical_plan::ColumnarValue;

--- a/src/promql/src/functions/changes.rs
+++ b/src/promql/src/functions/changes.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{ScalarUDF, Signature, TypeSignature, Volatility};
 use datafusion::physical_plan::ColumnarValue;

--- a/src/promql/src/functions/deriv.rs
+++ b/src/promql/src/functions/deriv.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{ScalarUDF, Signature, TypeSignature, Volatility};
 use datafusion::physical_plan::ColumnarValue;

--- a/src/promql/src/functions/resets.rs
+++ b/src/promql/src/functions/resets.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 
 use common_macro::range_fn;
 use datafusion::arrow::array::{Float64Array, TimestampMillisecondArray};
-use datafusion::arrow::datatypes::TimeUnit;
 use datafusion::common::DataFusionError;
 use datafusion::logical_expr::{ScalarUDF, Signature, TypeSignature, Volatility};
 use datafusion::physical_plan::ColumnarValue;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Support multi params in promql range function macro

The PromQL's function mark with `#[range_fn]` will generate code like

```rust
#[range_fn(
    name = "MultiparamRunc",
    ret = "Int64Array",
    display_name = "prom_multi_param_func"
)]
pub fn multi_param_func(
    _: &TimestampMillisecondArray,
    _values: &Float64Array,
    _a: &StringArray,
    _b: &Int64Array,
) -> Option<i64> {
    Some(0)
}

```

```rust
pub struct MultiparamRunc {}
impl MultiparamRunc {
    pub const fn name() -> &'static str {
        "prom_multi_param_func"
    }
    pub fn scalar_udf() -> ScalarUDF {
        ScalarUDF {
            name: Self::name().to_string(),
            signature: Signature::new(
                TypeSignature::Exact(Self::input_type()),
                Volatility::Immutable,
            ),
            return_type: Arc::new(|_| Ok(Arc::new(Self::return_type()))),
            fun: Arc::new(Self::calc),
        }
    }
    fn input_type() -> Vec<DataType> {
        <[_]>::into_vec(
            #[rustc_box]
            ::alloc::boxed::Box::new([
                RangeArray::convert_data_type(
                    TimestampMillisecondArray::new_null(0).data_type().clone(),
                ),
                RangeArray::convert_data_type(
                    Float64Array::new_null(0).data_type().clone(),
                ),
                RangeArray::convert_data_type(
                    StringArray::new_null(0).data_type().clone(),
                ),
                RangeArray::convert_data_type(
                    Int64Array::new_null(0).data_type().clone(),
                ),
            ]),
        )
    }
    fn return_type() -> DataType {
        Int64Array::new_null(0).data_type().clone()
    }
}
impl MultiparamRunc {
    fn calc(input: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
        match (&input.len(), &4usize) {
            (left_val, right_val) => {
                if !(*left_val == *right_val) {
                    let kind = ::core::panicking::AssertKind::Eq;
                    ::core::panicking::assert_failed(
                        kind,
                        &*left_val,
                        &*right_val,
                        ::core::option::Option::None,
                    );
                }
            }
        };
        let param_0_range_array = RangeArray::try_new(
            extract_array(&input[0usize])?.to_data().into(),
        )?;
        let param_1_range_array = RangeArray::try_new(
            extract_array(&input[1usize])?.to_data().into(),
        )?;
        let param_2_range_array = RangeArray::try_new(
            extract_array(&input[2usize])?.to_data().into(),
        )?;
        let param_3_range_array = RangeArray::try_new(
            extract_array(&input[3usize])?.to_data().into(),
        )?;
        {
            let len_first = param_0_range_array.len();
            if len_first != param_0_range_array.len() {
                return Err(
                    DataFusionError::Execution({
                        let res = ::alloc::fmt::format(
                            format_args!(
                                "RangeArray have different lengths in PromQL function {0}: array1={1}, array2={2}",
                                MultiparamRunc::name(),
                                len_first,
                                param_0_range_array.len(),
                            ),
                        );
                        res
                    }),
                );
            }
            if len_first != param_1_range_array.len() {
                return Err(
                    DataFusionError::Execution({
                        let res = ::alloc::fmt::format(
                            format_args!(
                                "RangeArray have different lengths in PromQL function {0}: array1={1}, array2={2}",
                                MultiparamRunc::name(),
                                len_first,
                                param_1_range_array.len(),
                            ),
                        );
                        res
                    }),
                );
            }
            if len_first != param_2_range_array.len() {
                return Err(
                    DataFusionError::Execution({
                        let res = ::alloc::fmt::format(
                            format_args!(
                                "RangeArray have different lengths in PromQL function {0}: array1={1}, array2={2}",
                                MultiparamRunc::name(),
                                len_first,
                                param_2_range_array.len(),
                            ),
                        );
                        res
                    }),
                );
            }
            if len_first != param_3_range_array.len() {
                return Err(
                    DataFusionError::Execution({
                        let res = ::alloc::fmt::format(
                            format_args!(
                                "RangeArray have different lengths in PromQL function {0}: array1={1}, array2={2}",
                                MultiparamRunc::name(),
                                len_first,
                                param_3_range_array.len(),
                            ),
                        );
                        res
                    }),
                );
            }
        }
        let mut result_array = Vec::new();
        for index in 0..param_0_range_array.len() {
            let param_0 = param_0_range_array
                .get(index)
                .unwrap()
                .as_any()
                .downcast_ref::<TimestampMillisecondArray>()
                .unwrap()
                .clone();
            let param_1 = param_1_range_array
                .get(index)
                .unwrap()
                .as_any()
                .downcast_ref::<Float64Array>()
                .unwrap()
                .clone();
            let param_2 = param_2_range_array
                .get(index)
                .unwrap()
                .as_any()
                .downcast_ref::<StringArray>()
                .unwrap()
                .clone();
            let param_3 = param_3_range_array
                .get(index)
                .unwrap()
                .as_any()
                .downcast_ref::<Int64Array>()
                .unwrap()
                .clone();
            {
                let len_first = param_0.len();
                if len_first != param_0.len() {
                    return Err(
                        DataFusionError::Execution({
                            let res = ::alloc::fmt::format(
                                format_args!(
                                    "RangeArray\'s element {0} have different lengths in PromQL function {1}: array1={2}, array2={3}",
                                    index,
                                    MultiparamRunc::name(),
                                    len_first,
                                    param_0.len(),
                                ),
                            );
                            res
                        }),
                    );
                }
                if len_first != param_1.len() {
                    return Err(
                        DataFusionError::Execution({
                            let res = ::alloc::fmt::format(
                                format_args!(
                                    "RangeArray\'s element {0} have different lengths in PromQL function {1}: array1={2}, array2={3}",
                                    index,
                                    MultiparamRunc::name(),
                                    len_first,
                                    param_1.len(),
                                ),
                            );
                            res
                        }),
                    );
                }
                if len_first != param_2.len() {
                    return Err(
                        DataFusionError::Execution({
                            let res = ::alloc::fmt::format(
                                format_args!(
                                    "RangeArray\'s element {0} have different lengths in PromQL function {1}: array1={2}, array2={3}",
                                    index,
                                    MultiparamRunc::name(),
                                    len_first,
                                    param_2.len(),
                                ),
                            );
                            res
                        }),
                    );
                }
                if len_first != param_3.len() {
                    return Err(
                        DataFusionError::Execution({
                            let res = ::alloc::fmt::format(
                                format_args!(
                                    "RangeArray\'s element {0} have different lengths in PromQL function {1}: array1={2}, array2={3}",
                                    index,
                                    MultiparamRunc::name(),
                                    len_first,
                                    param_3.len(),
                                ),
                            );
                            res
                        }),
                    );
                }
            }
            let result = multi_param_func(
                &param_0,
                &param_1,
                &param_2,
                &param_3,
            );
            result_array.push(result);
        }
        let result = ColumnarValue::Array(
            Arc::new(Int64Array::from_iter(result_array)),
        );
        Ok(result)
    }
}
fn multi_param_func(
    _: &TimestampMillisecondArray,
    _values: &Float64Array,
    _a: &StringArray,
    _b: &Int64Array,
) -> Option<i64> {
    { Some(0) }
}
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

Closes https://github.com/GreptimeTeam/greptimedb/issues/3454