### PR TITLE
refactor: introduce new `Output` with `OutputMeta`

### DIFF
--- a/benchmarks/src/bin/nyc-taxi.rs
+++ b/benchmarks/src/bin/nyc-taxi.rs
@@ -29,7 +29,7 @@ use client::api::v1::column::Values;
 use client::api::v1::{
     Column, ColumnDataType, ColumnDef, CreateTableExpr, InsertRequest, InsertRequests, SemanticType,
 };
-use client::{Client, Database, Output, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use client::{Client, Database, OutputData, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use futures_util::TryStreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -502,9 +502,9 @@ async fn do_query(num_iter: usize, db: &Database, table_name: &str) {
         for i in 0..num_iter {
             let now = Instant::now();
             let res = db.sql(&query).await.unwrap();
-            match res {
-                Output::AffectedRows(_) | Output::RecordBatches(_) => (),
-                Output::Stream(stream, _) => {
+            match res.data {
+                OutputData::AffectedRows(_) | OutputData::RecordBatches(_) => (),
+                OutputData::Stream(stream) => {
                     stream.try_collect::<Vec<_>>().await.unwrap();
                 }
             }

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -25,7 +25,7 @@ use arrow_flight::Ticket;
 use async_stream::stream;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_grpc::flight::{FlightDecoder, FlightMessage};
-use common_query::{Output, OutputData};
+use common_query::Output;
 use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::RecordBatchStreamWrapper;
 use common_telemetry::logging;
@@ -307,7 +307,7 @@ impl Database {
                         reason: "Expect 'AffectedRows' Flight messages to be the one and the only!"
                     }
                 );
-                Ok(Output::new_data(OutputData::AffectedRows(rows)))
+                Ok(Output::new_with_affectedrows(rows))
             }
             FlightMessage::Recordbatch(_) | FlightMessage::Metrics(_) => {
                 IllegalFlightMessagesSnafu {
@@ -340,9 +340,7 @@ impl Database {
                     output_ordering: None,
                     metrics: Default::default(),
                 };
-                Ok(Output::new_data(OutputData::Stream(Box::pin(
-                    record_batch_stream,
-                ))))
+                Ok(Output::new_with_stream(Box::pin(record_batch_stream)))
             }
         }
     }

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -25,7 +25,7 @@ use arrow_flight::Ticket;
 use async_stream::stream;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_grpc::flight::{FlightDecoder, FlightMessage};
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_recordbatch::error::ExternalSnafu;
 use common_recordbatch::RecordBatchStreamWrapper;
 use common_telemetry::logging;
@@ -307,7 +307,7 @@ impl Database {
                         reason: "Expect 'AffectedRows' Flight messages to be the one and the only!"
                     }
                 );
-                Ok(Output::AffectedRows(rows))
+                Ok(Output::new_data(OutputData::AffectedRows(rows)))
             }
             FlightMessage::Recordbatch(_) | FlightMessage::Metrics(_) => {
                 IllegalFlightMessagesSnafu {
@@ -340,7 +340,9 @@ impl Database {
                     output_ordering: None,
                     metrics: Default::default(),
                 };
-                Ok(Output::new_stream(Box::pin(record_batch_stream)))
+                Ok(Output::new_data(OutputData::Stream(Box::pin(
+                    record_batch_stream,
+                ))))
             }
         }
     }

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -307,7 +307,7 @@ impl Database {
                         reason: "Expect 'AffectedRows' Flight messages to be the one and the only!"
                     }
                 );
-                Ok(Output::new_with_affectedrows(rows))
+                Ok(Output::new_with_affected_rows(rows))
             }
             FlightMessage::Recordbatch(_) | FlightMessage::Metrics(_) => {
                 IllegalFlightMessagesSnafu {

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -26,7 +26,7 @@ use api::v1::greptime_response::Response;
 use api::v1::{AffectedRows, GreptimeResponse};
 pub use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_error::status_code::StatusCode;
-pub use common_query::Output;
+pub use common_query::{Output, OutputData, OutputMeta};
 pub use common_recordbatch::{RecordBatches, SendableRecordBatchStream};
 use snafu::OptionExt;
 

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -19,8 +19,7 @@ use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
 use client::api::v1::auth_header::AuthScheme;
 use client::api::v1::Basic;
-use client::{Client, Database, DEFAULT_SCHEMA_NAME};
-use common_query::Output;
+use client::{Client, Database, OutputData, DEFAULT_SCHEMA_NAME};
 use common_recordbatch::util::collect;
 use common_telemetry::{debug, error, info, warn};
 use datatypes::scalars::ScalarVector;
@@ -142,7 +141,7 @@ impl Export {
                     .with_context(|_| RequestDatabaseSnafu {
                         sql: "show databases".to_string(),
                     })?;
-            let Output::Stream(stream, _) = result else {
+            let OutputData::Stream(stream) = result.data else {
                 NotDataFromOutputSnafu.fail()?
             };
             let record_batch = collect(stream)
@@ -183,7 +182,7 @@ impl Export {
             .sql(&sql)
             .await
             .with_context(|_| RequestDatabaseSnafu { sql })?;
-        let Output::Stream(stream, _) = result else {
+        let OutputData::Stream(stream) = result.data else {
             NotDataFromOutputSnafu.fail()?
         };
         let Some(record_batch) = collect(stream)
@@ -235,7 +234,7 @@ impl Export {
             .sql(&sql)
             .await
             .with_context(|_| RequestDatabaseSnafu { sql })?;
-        let Output::Stream(stream, _) = result else {
+        let OutputData::Stream(stream) = result.data else {
             NotDataFromOutputSnafu.fail()?
         };
         let record_batch = collect(stream)

--- a/src/cmd/src/cli/repl.rs
+++ b/src/cmd/src/cli/repl.rs
@@ -19,7 +19,7 @@ use std::time::Instant;
 use catalog::kvbackend::{
     CachedMetaKvBackend, CachedMetaKvBackendBuilder, KvBackendCatalogManager,
 };
-use client::{Client, Database, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+use client::{Client, Database, OutputData, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_base::Plugins;
 use common_error::ext::ErrorExt;
 use common_query::Output;
@@ -184,15 +184,15 @@ impl Repl {
         }
         .context(RequestDatabaseSnafu { sql: &sql })?;
 
-        let either = match output {
-            Output::Stream(s, _) => {
+        let either = match output.data {
+            OutputData::Stream(s) => {
                 let x = RecordBatches::try_collect(s)
                     .await
                     .context(CollectRecordBatchesSnafu)?;
                 Either::Left(x)
             }
-            Output::RecordBatches(x) => Either::Left(x),
-            Output::AffectedRows(rows) => Either::Right(rows),
+            OutputData::RecordBatches(x) => Either::Left(x),
+            OutputData::AffectedRows(rows) => Either::Right(rows),
         };
 
         let end = Instant::now();

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -48,6 +48,7 @@ pub enum OutputData {
 /// OutputMeta stores meta information produced/generated during the execution
 #[derive(Debug, Default)]
 pub struct OutputMeta {
+    /// May exist for query output. One can retrieve execution metrics from this plan.
     pub plan: Option<Arc<dyn PhysicalPlan>>,
     pub cost: usize,
 }

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -30,19 +30,22 @@ pub mod prelude;
 mod signature;
 use sqlparser_derive::{Visit, VisitMut};
 
+/// new Output struct with output data(previously Output) and output meta
 #[derive(Debug)]
 pub struct Output {
     pub data: OutputData,
     pub meta: OutputMeta,
 }
 
-// sql output
+/// Original Output struct
+/// carrying result data to response/client/user interface
 pub enum OutputData {
     AffectedRows(usize),
     RecordBatches(RecordBatches),
     Stream(SendableRecordBatchStream),
 }
 
+/// OutputMeta stores meta information produced/generated during the execution
 #[derive(Debug, Default)]
 pub struct OutputMeta {
     pub plan: Option<Arc<dyn PhysicalPlan>>,

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -30,35 +30,66 @@ pub mod prelude;
 mod signature;
 use sqlparser_derive::{Visit, VisitMut};
 
+#[derive(Debug)]
+pub struct Output {
+    pub data: OutputData,
+    pub meta: OutputMeta,
+}
+
 // sql output
-pub enum Output {
+pub enum OutputData {
     AffectedRows(usize),
     RecordBatches(RecordBatches),
-    Stream(SendableRecordBatchStream, Option<Arc<dyn PhysicalPlan>>),
+    Stream(SendableRecordBatchStream),
+}
+
+#[derive(Debug, Default)]
+pub struct OutputMeta {
+    pub plan: Option<Arc<dyn PhysicalPlan>>,
+    pub cost: usize,
 }
 
 impl Output {
-    // helper function to build original `Output::Stream`
-    pub fn new_stream(stream: SendableRecordBatchStream) -> Self {
-        Output::Stream(stream, None)
+    pub fn new_data(data: OutputData) -> Self {
+        Self {
+            data,
+            meta: Default::default(),
+        }
+    }
+
+    pub fn new(data: OutputData, meta: OutputMeta) -> Self {
+        Self { data, meta }
     }
 }
 
-impl Debug for Output {
+impl Debug for OutputData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Output::AffectedRows(rows) => write!(f, "Output::AffectedRows({rows})"),
-            Output::RecordBatches(recordbatches) => {
-                write!(f, "Output::RecordBatches({recordbatches:?})")
+            OutputData::AffectedRows(rows) => write!(f, "OutputData::AffectedRows({rows})"),
+            OutputData::RecordBatches(recordbatches) => {
+                write!(f, "OutputData::RecordBatches({recordbatches:?})")
             }
-            Output::Stream(_, df) => {
-                if df.is_some() {
-                    write!(f, "Output::Stream(<stream>, Some<physical_plan>)")
-                } else {
-                    write!(f, "Output::Stream(<stream>)")
-                }
+            OutputData::Stream(_) => {
+                write!(f, "OutputData::Stream(<stream>)")
             }
         }
+    }
+}
+
+impl OutputMeta {
+    pub fn new(plan: Option<Arc<dyn PhysicalPlan>>, cost: usize) -> Self {
+        Self { plan, cost }
+    }
+
+    pub fn new_with_plan(plan: Arc<dyn PhysicalPlan>) -> Self {
+        Self {
+            plan: Some(plan),
+            cost: 0,
+        }
+    }
+
+    pub fn new_with_cost(cost: usize) -> Self {
+        Self { plan: None, cost }
     }
 }
 

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -50,9 +50,23 @@ pub struct OutputMeta {
 }
 
 impl Output {
-    pub fn new_data(data: OutputData) -> Self {
+    pub fn new_with_affectedrows(affected_rows: usize) -> Self {
         Self {
-            data,
+            data: OutputData::AffectedRows(affected_rows),
+            meta: Default::default(),
+        }
+    }
+
+    pub fn new_with_recordbatches(recordbatches: RecordBatches) -> Self {
+        Self {
+            data: OutputData::RecordBatches(recordbatches),
+            meta: Default::default(),
+        }
+    }
+
+    pub fn new_with_stream(stream: SendableRecordBatchStream) -> Self {
+        Self {
+            data: OutputData::Stream(stream),
             meta: Default::default(),
         }
     }

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -54,14 +54,14 @@ pub struct OutputMeta {
 }
 
 impl Output {
-    pub fn new_with_affectedrows(affected_rows: usize) -> Self {
+    pub fn new_with_affected_rows(affected_rows: usize) -> Self {
         Self {
             data: OutputData::AffectedRows(affected_rows),
             meta: Default::default(),
         }
     }
 
-    pub fn new_with_recordbatches(recordbatches: RecordBatches) -> Self {
+    pub fn new_with_record_batches(recordbatches: RecordBatches) -> Self {
         Self {
             data: OutputData::RecordBatches(recordbatches),
             meta: Default::default(),

--- a/src/common/test-util/src/recordbatch.rs
+++ b/src/common/test-util/src/recordbatch.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use client::Database;
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::util;
 
 pub enum ExpectedOutput<'a> {
@@ -23,22 +23,24 @@ pub enum ExpectedOutput<'a> {
 
 pub async fn execute_and_check_output(db: &Database, sql: &str, expected: ExpectedOutput<'_>) {
     let output = db.sql(sql).await.unwrap();
+    let output = output.data;
+
     match (&output, expected) {
-        (Output::AffectedRows(x), ExpectedOutput::AffectedRows(y)) => {
+        (OutputData::AffectedRows(x), ExpectedOutput::AffectedRows(y)) => {
             assert_eq!(*x, y, "actual: \n{}", x)
         }
-        (Output::RecordBatches(_), ExpectedOutput::QueryResult(x))
-        | (Output::Stream(_, _), ExpectedOutput::QueryResult(x)) => {
+        (OutputData::RecordBatches(_), ExpectedOutput::QueryResult(x))
+        | (OutputData::Stream(_), ExpectedOutput::QueryResult(x)) => {
             check_output_stream(output, x).await
         }
         _ => panic!(),
     }
 }
 
-pub async fn check_output_stream(output: Output, expected: &str) {
+pub async fn check_output_stream(output: OutputData, expected: &str) {
     let recordbatches = match output {
-        Output::Stream(stream, _) => util::collect_batches(stream).await.unwrap(),
-        Output::RecordBatches(recordbatches) => recordbatches,
+        OutputData::Stream(stream) => util::collect_batches(stream).await.unwrap(),
+        OutputData::RecordBatches(recordbatches) => recordbatches,
         _ => unreachable!(),
     };
     let pretty_print = recordbatches.pretty_print().unwrap();

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -27,7 +27,7 @@ use common_error::ext::BoxedError;
 use common_error::status_code::StatusCode;
 use common_query::logical_plan::Expr;
 use common_query::physical_plan::DfPhysicalPlanAdapter;
-use common_query::{DfPhysicalPlan, Output};
+use common_query::{DfPhysicalPlan, OutputData};
 use common_recordbatch::SendableRecordBatchStream;
 use common_runtime::Runtime;
 use common_telemetry::tracing::{self, info_span};
@@ -651,11 +651,11 @@ impl RegionServerInner {
             .await
             .context(ExecuteLogicalPlanSnafu)?;
 
-        match result {
-            Output::AffectedRows(_) | Output::RecordBatches(_) => {
+        match result.data {
+            OutputData::AffectedRows(_) | OutputData::RecordBatches(_) => {
                 UnsupportedOutputSnafu { expected: "stream" }.fail()
             }
-            Output::Stream(stream, _) => Ok(stream),
+            OutputData::Stream(stream) => Ok(stream),
         }
     }
 

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -18,7 +18,6 @@ use api::v1::query_request::Query;
 use api::v1::{DeleteRequests, InsertRequests, RowDeleteRequests, RowInsertRequests};
 use async_trait::async_trait;
 use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
-use client::OutputData;
 use common_meta::table_name::TableName;
 use common_query::Output;
 use common_telemetry::tracing;
@@ -114,7 +113,7 @@ impl GrpcQueryHandler for Instance {
                             .statement_executor
                             .create_table_inner(&mut expr, None, &ctx)
                             .await?;
-                        Output::new_data(OutputData::AffectedRows(0))
+                        Output::new_with_affectedrows(0)
                     }
                     DdlExpr::Alter(expr) => self.statement_executor.alter_table_inner(expr).await?,
                     DdlExpr::CreateDatabase(expr) => {

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -18,6 +18,7 @@ use api::v1::query_request::Query;
 use api::v1::{DeleteRequests, InsertRequests, RowDeleteRequests, RowInsertRequests};
 use async_trait::async_trait;
 use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use client::OutputData;
 use common_meta::table_name::TableName;
 use common_query::Output;
 use common_telemetry::tracing;
@@ -113,7 +114,7 @@ impl GrpcQueryHandler for Instance {
                             .statement_executor
                             .create_table_inner(&mut expr, None, &ctx)
                             .await?;
-                        Output::AffectedRows(0)
+                        Output::new_data(OutputData::AffectedRows(0))
                     }
                     DdlExpr::Alter(expr) => self.statement_executor.alter_table_inner(expr).await?,
                     DdlExpr::CreateDatabase(expr) => {

--- a/src/frontend/src/instance/grpc.rs
+++ b/src/frontend/src/instance/grpc.rs
@@ -113,7 +113,7 @@ impl GrpcQueryHandler for Instance {
                             .statement_executor
                             .create_table_inner(&mut expr, None, &ctx)
                             .await?;
-                        Output::new_with_affectedrows(0)
+                        Output::new_with_affected_rows(0)
                     }
                     DdlExpr::Alter(expr) => self.statement_executor.alter_table_inner(expr).await?,
                     DdlExpr::CreateDatabase(expr) => {

--- a/src/frontend/src/instance/opentsdb.rs
+++ b/src/frontend/src/instance/opentsdb.rs
@@ -47,8 +47,8 @@ impl OpentsdbProtocolHandler for Instance {
             .map_err(BoxedError::new)
             .context(servers::error::ExecuteGrpcQuerySnafu)?;
 
-        Ok(match output {
-            common_query::Output::AffectedRows(rows) => rows,
+        Ok(match output.data {
+            common_query::OutputData::AffectedRows(rows) => rows,
             _ => unreachable!(),
         })
     }

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -19,6 +19,7 @@ use api::prom_store::remote::{Query, QueryResult, ReadRequest, ReadResponse, Wri
 use api::v1::RowInsertRequests;
 use async_trait::async_trait;
 use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
+use client::OutputData;
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
@@ -77,7 +78,7 @@ fn negotiate_response_type(accepted_response_types: &[i32]) -> ServerResult<Resp
 }
 
 async fn to_query_result(table_name: &str, output: Output) -> ServerResult<QueryResult> {
-    let Output::Stream(stream, _) = output else {
+    let OutputData::Stream(stream) = output.data else {
         unreachable!()
     };
     let recordbatches = RecordBatches::try_collect(stream)

--- a/src/operator/src/delete.rs
+++ b/src/operator/src/delete.rs
@@ -19,7 +19,6 @@ use std::{iter, mem};
 use api::v1::region::{DeleteRequests as RegionDeleteRequests, RegionRequestHeader};
 use api::v1::{DeleteRequests, RowDeleteRequests};
 use catalog::CatalogManagerRef;
-use client::OutputData;
 use common_meta::datanode_manager::{AffectedRows, DatanodeManagerRef};
 use common_meta::peer::Peer;
 use common_query::Output;
@@ -92,9 +91,8 @@ impl Deleter {
         .await?;
 
         let affected_rows = self.do_request(deletes, &ctx).await?;
-        Ok(Output::new_data(OutputData::AffectedRows(
-            affected_rows as _,
-        )))
+
+        Ok(Output::new_with_affectedrows(affected_rows))
     }
 
     pub async fn handle_table_delete(

--- a/src/operator/src/delete.rs
+++ b/src/operator/src/delete.rs
@@ -92,7 +92,7 @@ impl Deleter {
 
         let affected_rows = self.do_request(deletes, &ctx).await?;
 
-        Ok(Output::new_with_affectedrows(affected_rows))
+        Ok(Output::new_with_affected_rows(affected_rows))
     }
 
     pub async fn handle_table_delete(

--- a/src/operator/src/delete.rs
+++ b/src/operator/src/delete.rs
@@ -19,6 +19,7 @@ use std::{iter, mem};
 use api::v1::region::{DeleteRequests as RegionDeleteRequests, RegionRequestHeader};
 use api::v1::{DeleteRequests, RowDeleteRequests};
 use catalog::CatalogManagerRef;
+use client::OutputData;
 use common_meta::datanode_manager::{AffectedRows, DatanodeManagerRef};
 use common_meta::peer::Peer;
 use common_query::Output;
@@ -91,7 +92,9 @@ impl Deleter {
         .await?;
 
         let affected_rows = self.do_request(deletes, &ctx).await?;
-        Ok(Output::AffectedRows(affected_rows as _))
+        Ok(Output::new_data(OutputData::AffectedRows(
+            affected_rows as _,
+        )))
     }
 
     pub async fn handle_table_delete(

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -22,7 +22,6 @@ use api::v1::{
     RowInsertRequests, SemanticType,
 };
 use catalog::CatalogManagerRef;
-use client::OutputData;
 use common_catalog::consts::default_engine;
 use common_grpc_expr::util::{extract_new_columns, ColumnExpr};
 use common_meta::datanode_manager::{AffectedRows, DatanodeManagerRef};
@@ -112,9 +111,7 @@ impl Inserter {
         .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::new_data(OutputData::AffectedRows(
-            affected_rows as _,
-        )))
+        Ok(Output::new_with_affectedrows(affected_rows))
     }
 
     /// Handle row inserts request with metric engine.
@@ -152,9 +149,7 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::new_data(OutputData::AffectedRows(
-            affected_rows as _,
-        )))
+        Ok(Output::new_with_affectedrows(affected_rows))
     }
 
     pub async fn handle_table_insert(
@@ -190,9 +185,7 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, ctx).await?;
-        Ok(Output::new_data(OutputData::AffectedRows(
-            affected_rows as _,
-        )))
+        Ok(Output::new_with_affectedrows(affected_rows))
     }
 }
 

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -111,7 +111,7 @@ impl Inserter {
         .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::new_with_affectedrows(affected_rows))
+        Ok(Output::new_with_affected_rows(affected_rows))
     }
 
     /// Handle row inserts request with metric engine.
@@ -149,7 +149,7 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::new_with_affectedrows(affected_rows))
+        Ok(Output::new_with_affected_rows(affected_rows))
     }
 
     pub async fn handle_table_insert(
@@ -185,7 +185,7 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, ctx).await?;
-        Ok(Output::new_with_affectedrows(affected_rows))
+        Ok(Output::new_with_affected_rows(affected_rows))
     }
 }
 

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -22,6 +22,7 @@ use api::v1::{
     RowInsertRequests, SemanticType,
 };
 use catalog::CatalogManagerRef;
+use client::OutputData;
 use common_catalog::consts::default_engine;
 use common_grpc_expr::util::{extract_new_columns, ColumnExpr};
 use common_meta::datanode_manager::{AffectedRows, DatanodeManagerRef};
@@ -111,7 +112,9 @@ impl Inserter {
         .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::AffectedRows(affected_rows as _))
+        Ok(Output::new_data(OutputData::AffectedRows(
+            affected_rows as _,
+        )))
     }
 
     /// Handle row inserts request with metric engine.
@@ -149,7 +152,9 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, &ctx).await?;
-        Ok(Output::AffectedRows(affected_rows as _))
+        Ok(Output::new_data(OutputData::AffectedRows(
+            affected_rows as _,
+        )))
     }
 
     pub async fn handle_table_insert(
@@ -185,7 +190,9 @@ impl Inserter {
                 .await?;
 
         let affected_rows = self.do_request(inserts, ctx).await?;
-        Ok(Output::AffectedRows(affected_rows as _))
+        Ok(Output::new_data(OutputData::AffectedRows(
+            affected_rows as _,
+        )))
     }
 }
 

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -123,11 +123,11 @@ impl StatementExecutor {
                     CopyDirection::Export => self
                         .copy_table_to(req, query_ctx)
                         .await
-                        .map(Output::new_with_affectedrows),
+                        .map(Output::new_with_affected_rows),
                     CopyDirection::Import => self
                         .copy_table_from(req, query_ctx)
                         .await
-                        .map(Output::new_with_affectedrows),
+                        .map(Output::new_with_affected_rows),
                 }
             }
 
@@ -152,15 +152,15 @@ impl StatementExecutor {
 
             Statement::CreateTable(stmt) => {
                 let _ = self.create_table(stmt, query_ctx).await?;
-                Ok(Output::new_with_affectedrows(0))
+                Ok(Output::new_with_affected_rows(0))
             }
             Statement::CreateTableLike(stmt) => {
                 let _ = self.create_table_like(stmt, query_ctx).await?;
-                Ok(Output::new_with_affectedrows(0))
+                Ok(Output::new_with_affected_rows(0))
             }
             Statement::CreateExternalTable(stmt) => {
                 let _ = self.create_external_table(stmt, query_ctx).await?;
-                Ok(Output::new_with_affectedrows(0))
+                Ok(Output::new_with_affected_rows(0))
             }
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
             Statement::DropTable(stmt) => {
@@ -231,7 +231,7 @@ impl StatementExecutor {
                         .fail()
                     }
                 }
-                Ok(Output::new_with_affectedrows(0))
+                Ok(Output::new_with_affected_rows(0))
             }
             Statement::ShowVariables(show_variable) => self.show_variable(show_variable, query_ctx),
         }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -24,7 +24,6 @@ mod tql;
 use std::sync::Arc;
 
 use catalog::CatalogManagerRef;
-use client::OutputData;
 use common_error::ext::BoxedError;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::ddl::ProcedureExecutorRef;
@@ -124,11 +123,11 @@ impl StatementExecutor {
                     CopyDirection::Export => self
                         .copy_table_to(req, query_ctx)
                         .await
-                        .map(|u| Output::new_data(OutputData::AffectedRows(u))),
+                        .map(Output::new_with_affectedrows),
                     CopyDirection::Import => self
                         .copy_table_from(req, query_ctx)
                         .await
-                        .map(|u| Output::new_data(OutputData::AffectedRows(u))),
+                        .map(Output::new_with_affectedrows),
                 }
             }
 
@@ -153,15 +152,15 @@ impl StatementExecutor {
 
             Statement::CreateTable(stmt) => {
                 let _ = self.create_table(stmt, query_ctx).await?;
-                Ok(Output::new_data(OutputData::AffectedRows(0)))
+                Ok(Output::new_with_affectedrows(0))
             }
             Statement::CreateTableLike(stmt) => {
                 let _ = self.create_table_like(stmt, query_ctx).await?;
-                Ok(Output::new_data(OutputData::AffectedRows(0)))
+                Ok(Output::new_with_affectedrows(0))
             }
             Statement::CreateExternalTable(stmt) => {
                 let _ = self.create_external_table(stmt, query_ctx).await?;
-                Ok(Output::new_data(OutputData::AffectedRows(0)))
+                Ok(Output::new_with_affectedrows(0))
             }
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
             Statement::DropTable(stmt) => {
@@ -232,7 +231,7 @@ impl StatementExecutor {
                         .fail()
                     }
                 }
-                Ok(Output::new_data(OutputData::AffectedRows(0)))
+                Ok(Output::new_with_affectedrows(0))
             }
             Statement::ShowVariables(show_variable) => self.show_variable(show_variable, query_ctx),
         }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -24,6 +24,7 @@ mod tql;
 use std::sync::Arc;
 
 use catalog::CatalogManagerRef;
+use client::OutputData;
 use common_error::ext::BoxedError;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::ddl::ProcedureExecutorRef;
@@ -123,11 +124,11 @@ impl StatementExecutor {
                     CopyDirection::Export => self
                         .copy_table_to(req, query_ctx)
                         .await
-                        .map(Output::AffectedRows),
+                        .map(|u| Output::new_data(OutputData::AffectedRows(u))),
                     CopyDirection::Import => self
                         .copy_table_from(req, query_ctx)
                         .await
-                        .map(Output::AffectedRows),
+                        .map(|u| Output::new_data(OutputData::AffectedRows(u))),
                 }
             }
 
@@ -152,15 +153,15 @@ impl StatementExecutor {
 
             Statement::CreateTable(stmt) => {
                 let _ = self.create_table(stmt, query_ctx).await?;
-                Ok(Output::AffectedRows(0))
+                Ok(Output::new_data(OutputData::AffectedRows(0)))
             }
             Statement::CreateTableLike(stmt) => {
                 let _ = self.create_table_like(stmt, query_ctx).await?;
-                Ok(Output::AffectedRows(0))
+                Ok(Output::new_data(OutputData::AffectedRows(0)))
             }
             Statement::CreateExternalTable(stmt) => {
                 let _ = self.create_external_table(stmt, query_ctx).await?;
-                Ok(Output::AffectedRows(0))
+                Ok(Output::new_data(OutputData::AffectedRows(0)))
             }
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
             Statement::DropTable(stmt) => {
@@ -231,7 +232,7 @@ impl StatementExecutor {
                         .fail()
                     }
                 }
-                Ok(Output::AffectedRows(0))
+                Ok(Output::new_data(OutputData::AffectedRows(0)))
             }
             Statement::ShowVariables(show_variable) => self.show_variable(show_variable, query_ctx),
         }

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -15,11 +15,10 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use client::OutputData;
+use client::Output;
 use common_datasource::file_format::Format;
 use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::build_backend;
-use common_query::Output;
 use common_telemetry::{debug, error, info, tracing};
 use object_store::Entry;
 use regex::Regex;
@@ -97,7 +96,7 @@ impl StatementExecutor {
                 .await?;
             exported_rows += exported;
         }
-        Ok(Output::new_data(OutputData::AffectedRows(exported_rows)))
+        Ok(Output::new_with_affectedrows(exported_rows))
     }
 
     /// Imports data to database from a given location and returns total rows imported.
@@ -170,7 +169,7 @@ impl StatementExecutor {
                 }
             }
         }
-        Ok(Output::new_data(OutputData::AffectedRows(rows_inserted)))
+        Ok(Output::new_with_affectedrows(rows_inserted))
     }
 }
 

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
+use client::OutputData;
 use common_datasource::file_format::Format;
 use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::build_backend;
@@ -96,7 +97,7 @@ impl StatementExecutor {
                 .await?;
             exported_rows += exported;
         }
-        Ok(Output::AffectedRows(exported_rows))
+        Ok(Output::new_data(OutputData::AffectedRows(exported_rows)))
     }
 
     /// Imports data to database from a given location and returns total rows imported.
@@ -169,7 +170,7 @@ impl StatementExecutor {
                 }
             }
         }
-        Ok(Output::AffectedRows(rows_inserted))
+        Ok(Output::new_data(OutputData::AffectedRows(rows_inserted)))
     }
 }
 

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -96,7 +96,7 @@ impl StatementExecutor {
                 .await?;
             exported_rows += exported;
         }
-        Ok(Output::new_with_affectedrows(exported_rows))
+        Ok(Output::new_with_affected_rows(exported_rows))
     }
 
     /// Imports data to database from a given location and returns total rows imported.
@@ -169,7 +169,7 @@ impl StatementExecutor {
                 }
             }
         }
-        Ok(Output::new_with_affectedrows(rows_inserted))
+        Ok(Output::new_with_affected_rows(rows_inserted))
     }
 }
 

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use client::OutputData;
 use common_base::readable_size::ReadableSize;
 use common_datasource::file_format::csv::stream_to_csv;
 use common_datasource::file_format::json::stream_to_json;
@@ -21,7 +22,6 @@ use common_datasource::file_format::parquet::stream_to_parquet;
 use common_datasource::file_format::Format;
 use common_datasource::object_store::{build_backend, parse_url};
 use common_datasource::util::find_dir_and_filename;
-use common_query::Output;
 use common_recordbatch::adapter::DfRecordBatchStreamAdapter;
 use common_recordbatch::SendableRecordBatchStream;
 use common_telemetry::{debug, tracing};
@@ -134,9 +134,9 @@ impl StatementExecutor {
             .execute(LogicalPlan::DfPlan(plan), query_ctx)
             .await
             .context(ExecLogicalPlanSnafu)?;
-        let stream = match output {
-            Output::Stream(stream, _) => stream,
-            Output::RecordBatches(record_batches) => record_batches.as_stream(),
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(record_batches) => record_batches.as_stream(),
             _ => unreachable!(),
         };
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -19,6 +19,7 @@ use api::helper::ColumnDataTypeWrapper;
 use api::v1::{column_def, AlterExpr, CreateTableExpr};
 use catalog::CatalogManagerRef;
 use chrono::Utc;
+use client::OutputData;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
@@ -338,10 +339,10 @@ impl StatementExecutor {
                 .await
                 .context(error::InvalidateTableCacheSnafu)?;
 
-            Ok(Output::AffectedRows(0))
+            Ok(Output::new_data(OutputData::AffectedRows(0)))
         } else if drop_if_exists {
             // DROP TABLE IF EXISTS meets table not found - ignored
-            Ok(Output::AffectedRows(0))
+            Ok(Output::new_data(OutputData::AffectedRows(0)))
         } else {
             Err(TableNotFoundSnafu {
                 table_name: table_name.to_string(),
@@ -367,7 +368,7 @@ impl StatementExecutor {
         let table_id = table.table_info().table_id();
         self.truncate_table_procedure(&table_name, table_id).await?;
 
-        Ok(Output::AffectedRows(0))
+        Ok(Output::new_data(OutputData::AffectedRows(0)))
     }
 
     fn verify_alter(
@@ -471,7 +472,7 @@ impl StatementExecutor {
             .await
             .context(error::InvalidateTableCacheSnafu)?;
 
-        Ok(Output::AffectedRows(0))
+        Ok(Output::new_data(OutputData::AffectedRows(0)))
     }
 
     async fn create_table_procedure(
@@ -580,7 +581,7 @@ impl StatementExecutor {
 
         if exists {
             return if create_if_not_exists {
-                Ok(Output::AffectedRows(1))
+                Ok(Output::new_data(OutputData::AffectedRows(1)))
             } else {
                 error::SchemaExistsSnafu { name: database }.fail()
             };
@@ -592,7 +593,7 @@ impl StatementExecutor {
             .await
             .context(TableMetadataManagerSnafu)?;
 
-        Ok(Output::AffectedRows(1))
+        Ok(Output::new_data(OutputData::AffectedRows(1)))
     }
 }
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -338,10 +338,10 @@ impl StatementExecutor {
                 .await
                 .context(error::InvalidateTableCacheSnafu)?;
 
-            Ok(Output::new_with_affectedrows(0))
+            Ok(Output::new_with_affected_rows(0))
         } else if drop_if_exists {
             // DROP TABLE IF EXISTS meets table not found - ignored
-            Ok(Output::new_with_affectedrows(0))
+            Ok(Output::new_with_affected_rows(0))
         } else {
             Err(TableNotFoundSnafu {
                 table_name: table_name.to_string(),
@@ -367,7 +367,7 @@ impl StatementExecutor {
         let table_id = table.table_info().table_id();
         self.truncate_table_procedure(&table_name, table_id).await?;
 
-        Ok(Output::new_with_affectedrows(0))
+        Ok(Output::new_with_affected_rows(0))
     }
 
     fn verify_alter(
@@ -471,7 +471,7 @@ impl StatementExecutor {
             .await
             .context(error::InvalidateTableCacheSnafu)?;
 
-        Ok(Output::new_with_affectedrows(0))
+        Ok(Output::new_with_affected_rows(0))
     }
 
     async fn create_table_procedure(
@@ -580,7 +580,7 @@ impl StatementExecutor {
 
         if exists {
             return if create_if_not_exists {
-                Ok(Output::new_with_affectedrows(1))
+                Ok(Output::new_with_affected_rows(1))
             } else {
                 error::SchemaExistsSnafu { name: database }.fail()
             };
@@ -592,7 +592,7 @@ impl StatementExecutor {
             .await
             .context(TableMetadataManagerSnafu)?;
 
-        Ok(Output::new_with_affectedrows(1))
+        Ok(Output::new_with_affected_rows(1))
     }
 }
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -19,7 +19,6 @@ use api::helper::ColumnDataTypeWrapper;
 use api::v1::{column_def, AlterExpr, CreateTableExpr};
 use catalog::CatalogManagerRef;
 use chrono::Utc;
-use client::OutputData;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_catalog::format_full_table_name;
 use common_error::ext::BoxedError;
@@ -339,10 +338,10 @@ impl StatementExecutor {
                 .await
                 .context(error::InvalidateTableCacheSnafu)?;
 
-            Ok(Output::new_data(OutputData::AffectedRows(0)))
+            Ok(Output::new_with_affectedrows(0))
         } else if drop_if_exists {
             // DROP TABLE IF EXISTS meets table not found - ignored
-            Ok(Output::new_data(OutputData::AffectedRows(0)))
+            Ok(Output::new_with_affectedrows(0))
         } else {
             Err(TableNotFoundSnafu {
                 table_name: table_name.to_string(),
@@ -368,7 +367,7 @@ impl StatementExecutor {
         let table_id = table.table_info().table_id();
         self.truncate_table_procedure(&table_name, table_id).await?;
 
-        Ok(Output::new_data(OutputData::AffectedRows(0)))
+        Ok(Output::new_with_affectedrows(0))
     }
 
     fn verify_alter(
@@ -472,7 +471,7 @@ impl StatementExecutor {
             .await
             .context(error::InvalidateTableCacheSnafu)?;
 
-        Ok(Output::new_data(OutputData::AffectedRows(0)))
+        Ok(Output::new_with_affectedrows(0))
     }
 
     async fn create_table_procedure(
@@ -581,7 +580,7 @@ impl StatementExecutor {
 
         if exists {
             return if create_if_not_exists {
-                Ok(Output::new_data(OutputData::AffectedRows(1)))
+                Ok(Output::new_with_affectedrows(1))
             } else {
                 error::SchemaExistsSnafu { name: database }.fail()
             };
@@ -593,7 +592,7 @@ impl StatementExecutor {
             .await
             .context(TableMetadataManagerSnafu)?;
 
-        Ok(Output::new_data(OutputData::AffectedRows(1)))
+        Ok(Output::new_with_affectedrows(1))
     }
 }
 

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -148,7 +148,7 @@ impl DatafusionQueryEngine {
             };
             affected_rows += rows;
         }
-        Ok(Output::new_data(OutputData::AffectedRows(affected_rows)))
+        Ok(Output::new_with_affectedrows(affected_rows))
     }
 
     #[tracing::instrument(skip_all)]

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -148,7 +148,7 @@ impl DatafusionQueryEngine {
             };
             affected_rows += rows;
         }
-        Ok(Output::new_with_affectedrows(affected_rows))
+        Ok(Output::new_with_affected_rows(affected_rows))
     }
 
     #[tracing::instrument(skip_all)]

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -29,7 +29,7 @@ use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::build_backend;
 use common_datasource::util::find_dir_and_filename;
 use common_query::prelude::GREPTIME_TIMESTAMP;
-use common_query::{Output, OutputData};
+use common_query::Output;
 use common_recordbatch::adapter::RecordBatchStreamAdapter;
 use common_recordbatch::RecordBatches;
 use common_time::timezone::get_timezone;
@@ -237,9 +237,9 @@ async fn query_from_information_schema_table(
         .await
         .context(error::DataFusionSnafu)?;
 
-    Ok(Output::new_data(OutputData::Stream(Box::pin(
+    Ok(Output::new_with_stream(Box::pin(
         RecordBatchStreamAdapter::try_new(stream).context(error::CreateRecordBatchSnafu)?,
-    ))))
+    )))
 }
 
 pub async fn show_tables(
@@ -302,7 +302,7 @@ pub fn show_variable(stmt: ShowVariables, query_ctx: QueryContextRef) -> Result<
         vec![Arc::new(StringVector::from(vec![value])) as _],
     )
     .context(error::CreateRecordBatchSnafu)?;
-    Ok(Output::new_data(OutputData::RecordBatches(records)))
+    Ok(Output::new_with_recordbatches(records))
 }
 
 pub fn show_create_table(
@@ -328,7 +328,7 @@ pub fn show_create_table(
     let records = RecordBatches::try_from_columns(SHOW_CREATE_TABLE_OUTPUT_SCHEMA.clone(), columns)
         .context(error::CreateRecordBatchSnafu)?;
 
-    Ok(Output::new_data(OutputData::RecordBatches(records)))
+    Ok(Output::new_with_recordbatches(records))
 }
 
 pub fn describe_table(table: TableRef) -> Result<Output> {
@@ -344,7 +344,7 @@ pub fn describe_table(table: TableRef) -> Result<Output> {
     ];
     let records = RecordBatches::try_from_columns(DESCRIBE_TABLE_OUTPUT_SCHEMA.clone(), columns)
         .context(error::CreateRecordBatchSnafu)?;
-    Ok(Output::new_data(OutputData::RecordBatches(records)))
+    Ok(Output::new_with_recordbatches(records))
 }
 
 fn describe_column_names(columns_schemas: &[ColumnSchema]) -> VectorRef {

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -302,7 +302,7 @@ pub fn show_variable(stmt: ShowVariables, query_ctx: QueryContextRef) -> Result<
         vec![Arc::new(StringVector::from(vec![value])) as _],
     )
     .context(error::CreateRecordBatchSnafu)?;
-    Ok(Output::new_with_recordbatches(records))
+    Ok(Output::new_with_record_batches(records))
 }
 
 pub fn show_create_table(
@@ -328,7 +328,7 @@ pub fn show_create_table(
     let records = RecordBatches::try_from_columns(SHOW_CREATE_TABLE_OUTPUT_SCHEMA.clone(), columns)
         .context(error::CreateRecordBatchSnafu)?;
 
-    Ok(Output::new_with_recordbatches(records))
+    Ok(Output::new_with_record_batches(records))
 }
 
 pub fn describe_table(table: TableRef) -> Result<Output> {
@@ -344,7 +344,7 @@ pub fn describe_table(table: TableRef) -> Result<Output> {
     ];
     let records = RecordBatches::try_from_columns(DESCRIBE_TABLE_OUTPUT_SCHEMA.clone(), columns)
         .context(error::CreateRecordBatchSnafu)?;
-    Ok(Output::new_with_recordbatches(records))
+    Ok(Output::new_with_record_batches(records))
 }
 
 fn describe_column_names(columns_schemas: &[ColumnSchema]) -> VectorRef {

--- a/src/query/src/tests.rs
+++ b/src/query/src/tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use catalog::memory::MemoryCatalogManager;
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::{util, RecordBatch};
 use session::context::QueryContext;
 use table::TableRef;
@@ -43,7 +43,7 @@ async fn exec_selection(engine: QueryEngineRef, sql: &str) -> Vec<RecordBatch> {
         .plan(stmt, query_ctx.clone())
         .await
         .unwrap();
-    let Output::Stream(stream, _) = engine.execute(plan, query_ctx).await.unwrap() else {
+    let OutputData::Stream(stream) = engine.execute(plan, query_ctx).await.unwrap().data else {
         unreachable!()
     };
     util::collect(stream).await.unwrap()

--- a/src/query/src/tests/query_engine_test.rs
+++ b/src/query/src/tests/query_engine_test.rs
@@ -20,7 +20,7 @@ use common_base::Plugins;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, NUMBERS_TABLE_ID};
 use common_error::ext::BoxedError;
 use common_query::prelude::{create_udf, make_scalar_function, Volatility};
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::{util, RecordBatch};
 use datafusion::datasource::DefaultTableSource;
 use datafusion_expr::logical_plan::builder::LogicalPlanBuilder;
@@ -79,8 +79,8 @@ async fn test_datafusion_query_engine() -> Result<()> {
 
     let output = engine.execute(plan, QueryContext::arc()).await?;
 
-    let recordbatch = match output {
-        Output::Stream(recordbatch, _) => recordbatch,
+    let recordbatch = match output.data {
+        OutputData::Stream(recordbatch) => recordbatch,
         _ => unreachable!(),
     };
 

--- a/src/script/benches/py_benchmark.rs
+++ b/src/script/benches/py_benchmark.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use catalog::memory::MemoryCatalogManager;
 use common_catalog::consts::NUMBERS_TABLE_ID;
-use common_query::Output;
+use common_query::OutputData;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use futures::Future;
 use once_cell::sync::{Lazy, OnceCell};
@@ -69,9 +69,9 @@ async fn run_compiled(script: &PyScript) {
         .execute(HashMap::default(), EvalContext::default())
         .await
         .unwrap();
-    let _res = match output {
-        Output::Stream(s, _) => common_recordbatch::util::collect_batches(s).await.unwrap(),
-        Output::RecordBatches(rbs) => rbs,
+    let _res = match output.data {
+        OutputData::Stream(s) => common_recordbatch::util::collect_batches(s).await.unwrap(),
+        OutputData::RecordBatches(rbs) => rbs,
         _ => unreachable!(),
     };
 }

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -211,6 +211,8 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptManager<E> {
 
 #[cfg(test)]
 mod tests {
+    use common_query::OutputData;
+
     use super::*;
     use crate::test::setup_scripts_manager;
 
@@ -261,8 +263,8 @@ def test() -> vector[str]:
             .await
             .unwrap();
 
-        match output {
-            Output::RecordBatches(batches) => {
+        match output.data {
+            OutputData::RecordBatches(batches) => {
                 let expected = "\
 +-------+
 | n     |

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -25,7 +25,7 @@ use common_function::function::Function;
 use common_function::function_registry::FUNCTION_REGISTRY;
 use common_query::error::{PyUdfSnafu, UdfTempRecordBatchSnafu};
 use common_query::prelude::Signature;
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_recordbatch::error::{ExternalSnafu, Result as RecordBatchResult};
 use common_recordbatch::{
     RecordBatch, RecordBatchStream, RecordBatches, SendableRecordBatchStream,
@@ -311,10 +311,10 @@ impl Script for PyScript {
                 .await
                 .context(DatabaseQuerySnafu)?;
             let copr = self.copr.clone();
-            match res {
-                Output::Stream(stream, _) => Ok(Output::new_stream(Box::pin(CoprStream::try_new(
-                    stream, copr, params, ctx,
-                )?))),
+            match res.data {
+                OutputData::Stream(stream) => Ok(Output::new_data(OutputData::Stream(Box::pin(
+                    CoprStream::try_new(stream, copr, params, ctx)?,
+                )))),
                 _ => unreachable!(),
             }
         } else {
@@ -324,7 +324,7 @@ impl Script for PyScript {
                 .await
                 .context(TokioJoinSnafu)??;
             let batches = RecordBatches::try_new(batch.schema.clone(), vec![batch]).unwrap();
-            Ok(Output::RecordBatches(batches))
+            Ok(Output::new_data(OutputData::RecordBatches(batches)))
         }
     }
 }
@@ -410,8 +410,8 @@ def test(number) -> vector[u32]:
             .execute(HashMap::default(), EvalContext::default())
             .await
             .unwrap();
-        let res = common_recordbatch::util::collect_batches(match output {
-            Output::Stream(s, _) => s,
+        let res = common_recordbatch::util::collect_batches(match output.data {
+            OutputData::Stream(s) => s,
             _ => unreachable!(),
         })
         .await
@@ -441,8 +441,8 @@ def test(**params) -> vector[i64]:
             .execute(params, EvalContext::default())
             .await
             .unwrap();
-        let res = match _output {
-            Output::RecordBatches(s) => s,
+        let res = match _output.data {
+            OutputData::RecordBatches(s) => s,
             _ => todo!(),
         };
         let rb = res.iter().next().expect("One and only one recordbatch");
@@ -471,8 +471,8 @@ def test(number) -> vector[u32]:
             .execute(HashMap::new(), EvalContext::default())
             .await
             .unwrap();
-        let res = common_recordbatch::util::collect_batches(match _output {
-            Output::Stream(s, _) => s,
+        let res = common_recordbatch::util::collect_batches(match _output.data {
+            OutputData::Stream(s) => s,
             _ => todo!(),
         })
         .await
@@ -503,8 +503,8 @@ def test(a, b, c) -> vector[f64]:
             .execute(HashMap::new(), EvalContext::default())
             .await
             .unwrap();
-        match output {
-            Output::Stream(stream, _) => {
+        match output.data {
+            OutputData::Stream(stream) => {
                 let numbers = util::collect(stream).await.unwrap();
 
                 assert_eq!(1, numbers.len());
@@ -541,8 +541,8 @@ def test(a) -> vector[i64]:
             .execute(HashMap::new(), EvalContext::default())
             .await
             .unwrap();
-        match output {
-            Output::Stream(stream, _) => {
+        match output.data {
+            OutputData::Stream(stream) => {
                 let numbers = util::collect(stream).await.unwrap();
 
                 assert_eq!(1, numbers.len());

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -324,7 +324,7 @@ impl Script for PyScript {
                 .await
                 .context(TokioJoinSnafu)??;
             let batches = RecordBatches::try_new(batch.schema.clone(), vec![batch]).unwrap();
-            Ok(Output::new_with_recordbatches(batches))
+            Ok(Output::new_with_record_batches(batches))
         }
     }
 }

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -312,9 +312,9 @@ impl Script for PyScript {
                 .context(DatabaseQuerySnafu)?;
             let copr = self.copr.clone();
             match res.data {
-                OutputData::Stream(stream) => Ok(Output::new_data(OutputData::Stream(Box::pin(
+                OutputData::Stream(stream) => Ok(Output::new_with_stream(Box::pin(
                     CoprStream::try_new(stream, copr, params, ctx)?,
-                )))),
+                ))),
                 _ => unreachable!(),
             }
         } else {
@@ -324,7 +324,7 @@ impl Script for PyScript {
                 .await
                 .context(TokioJoinSnafu)??;
             let batches = RecordBatches::try_new(batch.schema.clone(), vec![batch]).unwrap();
-            Ok(Output::new_data(OutputData::RecordBatches(batches)))
+            Ok(Output::new_with_recordbatches(batches))
         }
     }
 }

--- a/src/script/src/python/ffi_types/copr.rs
+++ b/src/script/src/python/ffi_types/copr.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::result::Result as StdResult;
 use std::sync::{Arc, Weak};
 
+use common_query::OutputData;
 use common_recordbatch::{RecordBatch, RecordBatches};
 use datatypes::arrow::compute;
 use datatypes::data_type::{ConcreteDataType, DataType};
@@ -399,13 +400,14 @@ impl PyQueryEngine {
                         .await
                         .map_err(|e| e.to_string());
                     match res {
-                        Ok(common_query::Output::AffectedRows(cnt)) => {
-                            Ok(Either::AffectedRows(cnt))
-                        }
-                        Ok(common_query::Output::RecordBatches(rbs)) => Ok(Either::Rb(rbs)),
-                        Ok(common_query::Output::Stream(s, _)) => Ok(Either::Rb(
-                            common_recordbatch::util::collect_batches(s).await.unwrap(),
-                        )),
+                        Ok(o) => match o.data {
+                            OutputData::AffectedRows(cnt) => Ok(Either::AffectedRows(cnt)),
+                            OutputData::RecordBatches(rbs) => Ok(Either::Rb(rbs)),
+                            OutputData::Stream(s) => Ok(Either::Rb(
+                                common_recordbatch::util::collect_batches(s).await.unwrap(),
+                            )),
+                        },
+
                         Err(e) => Err(e),
                     }
                 })?;

--- a/src/script/src/python/ffi_types/pair_tests.rs
+++ b/src/script/src/python/ffi_types/pair_tests.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::compute::kernels::numeric;
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::RecordBatch;
 use datafusion::arrow::array::Float64Array;
 use datafusion::arrow::compute;
@@ -87,9 +87,9 @@ async fn integrated_py_copr_test() {
             .execute(HashMap::default(), EvalContext::default())
             .await
             .unwrap();
-        let res = match output {
-            Output::Stream(s, _) => common_recordbatch::util::collect_batches(s).await.unwrap(),
-            Output::RecordBatches(rbs) => rbs,
+        let res = match output.data {
+            OutputData::Stream(s) => common_recordbatch::util::collect_batches(s).await.unwrap(),
+            OutputData::RecordBatches(rbs) => rbs,
             _ => unreachable!(),
         };
         let rb = res.iter().next().expect("One and only one recordbatch");

--- a/src/script/src/table.rs
+++ b/src/script/src/table.rs
@@ -24,7 +24,7 @@ use api::v1::{
 };
 use catalog::error::CompileScriptInternalSnafu;
 use common_error::ext::{BoxedError, ErrorExt};
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::{util as record_util, RecordBatch, SendableRecordBatchStream};
 use common_telemetry::logging;
 use common_time::util;
@@ -230,9 +230,9 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptsTable<E> {
             .execute(LogicalPlan::DfPlan(plan), query_ctx(&table_info))
             .await
             .context(ExecuteInternalStatementSnafu)?;
-        let stream = match output {
-            Output::Stream(stream, _) => stream,
-            Output::RecordBatches(record_batches) => record_batches.as_stream(),
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(record_batches) => record_batches.as_stream(),
             _ => unreachable!(),
         };
 
@@ -285,9 +285,9 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptsTable<E> {
             .execute(LogicalPlan::DfPlan(plan), query_ctx(&table_info))
             .await
             .context(ExecuteInternalStatementSnafu)?;
-        let stream = match output {
-            Output::Stream(stream, _) => stream,
-            Output::RecordBatches(record_batches) => record_batches.as_stream(),
+        let stream = match output.data {
+            OutputData::Stream(stream) => stream,
+            OutputData::RecordBatches(record_batches) => record_batches.as_stream(),
             _ => unreachable!(),
         };
         Ok(stream)

--- a/src/script/src/test.rs
+++ b/src/script/src/test.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use api::v1::greptime_request::Request;
 use async_trait::async_trait;
 use catalog::memory::MemoryCatalogManager;
-use common_query::{Output, OutputData};
+use common_query::Output;
 use common_recordbatch::RecordBatch;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
@@ -73,6 +73,6 @@ impl GrpcQueryHandler for MockGrpcQueryHandler {
     type Error = Error;
 
     async fn do_query(&self, _query: Request, _ctx: QueryContextRef) -> Result<Output> {
-        Ok(Output::new_data(OutputData::AffectedRows(1)))
+        Ok(Output::new_with_affectedrows(1))
     }
 }

--- a/src/script/src/test.rs
+++ b/src/script/src/test.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use api::v1::greptime_request::Request;
 use async_trait::async_trait;
 use catalog::memory::MemoryCatalogManager;
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_recordbatch::RecordBatch;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
@@ -73,6 +73,6 @@ impl GrpcQueryHandler for MockGrpcQueryHandler {
     type Error = Error;
 
     async fn do_query(&self, _query: Request, _ctx: QueryContextRef) -> Result<Output> {
-        Ok(Output::AffectedRows(1))
+        Ok(Output::new_data(OutputData::AffectedRows(1)))
     }
 }

--- a/src/script/src/test.rs
+++ b/src/script/src/test.rs
@@ -73,6 +73,6 @@ impl GrpcQueryHandler for MockGrpcQueryHandler {
     type Error = Error;
 
     async fn do_query(&self, _query: Request, _ctx: QueryContextRef) -> Result<Output> {
-        Ok(Output::new_with_affectedrows(1))
+        Ok(Output::new_with_affected_rows(1))
     }
 }

--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -17,7 +17,7 @@ use api::v1::greptime_response::Response as RawResponse;
 use api::v1::{AffectedRows, GreptimeRequest, GreptimeResponse, ResponseHeader};
 use async_trait::async_trait;
 use common_error::status_code::StatusCode;
-use common_query::Output;
+use common_query::OutputData;
 use futures::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -42,8 +42,8 @@ impl GreptimeDatabase for DatabaseService {
     ) -> TonicResult<Response<GreptimeResponse>> {
         let request = request.into_inner();
         let output = self.handler.handle_request(request).await?;
-        let message = match output {
-            Output::AffectedRows(rows) => GreptimeResponse {
+        let message = match output.data {
+            OutputData::AffectedRows(rows) => GreptimeResponse {
                 header: Some(ResponseHeader {
                     status: Some(api::v1::Status {
                         status_code: StatusCode::Success as _,
@@ -52,7 +52,7 @@ impl GreptimeDatabase for DatabaseService {
                 }),
                 response: Some(RawResponse::AffectedRows(AffectedRows { value: rows as _ })),
             },
-            Output::Stream(_, _) | Output::RecordBatches(_) => {
+            OutputData::Stream(_) | OutputData::RecordBatches(_) => {
                 return Err(Status::unimplemented("GreptimeDatabase::Handle for query"));
             }
         };
@@ -69,9 +69,9 @@ impl GreptimeDatabase for DatabaseService {
         while let Some(request) = stream.next().await {
             let request = request?;
             let output = self.handler.handle_request(request).await?;
-            match output {
-                Output::AffectedRows(rows) => affected_rows += rows,
-                Output::Stream(_, _) | Output::RecordBatches(_) => {
+            match output.data {
+                OutputData::AffectedRows(rows) => affected_rows += rows,
+                OutputData::Stream(_) | OutputData::RecordBatches(_) => {
                     return Err(Status::unimplemented(
                         "GreptimeDatabase::HandleRequests for query",
                     ));

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -25,7 +25,7 @@ use arrow_flight::{
 };
 use async_trait::async_trait;
 use common_grpc::flight::{FlightEncoder, FlightMessage};
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_telemetry::tracing::info_span;
 use common_telemetry::tracing_context::{FutureExt, TracingContext};
 use futures::Stream;
@@ -174,16 +174,16 @@ fn to_flight_data_stream(
     output: Output,
     tracing_context: TracingContext,
 ) -> TonicStream<FlightData> {
-    match output {
-        Output::Stream(stream, _) => {
+    match output.data {
+        OutputData::Stream(stream) => {
             let stream = FlightRecordBatchStream::new(stream, tracing_context);
             Box::pin(stream) as _
         }
-        Output::RecordBatches(x) => {
+        OutputData::RecordBatches(x) => {
             let stream = FlightRecordBatchStream::new(x.as_stream(), tracing_context);
             Box::pin(stream) as _
         }
-        Output::AffectedRows(rows) => {
+        OutputData::AffectedRows(rows) => {
             let stream = tokio_stream::once(Ok(
                 FlightEncoder::default().encode(FlightMessage::AffectedRows(rows))
             ));

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -804,7 +804,7 @@ mod test {
     use axum::http::StatusCode;
     use axum::routing::get;
     use axum_test_helper::TestClient;
-    use common_query::Output;
+    use common_query::{Output, OutputData};
     use common_recordbatch::RecordBatches;
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
@@ -925,7 +925,9 @@ mod test {
         let schema = Arc::new(Schema::new(column_schemas));
 
         let recordbatches = RecordBatches::try_new(schema.clone(), vec![]).unwrap();
-        let outputs = vec![Ok(Output::RecordBatches(recordbatches))];
+        let outputs = vec![Ok(Output::new_data(OutputData::RecordBatches(
+            recordbatches,
+        )))];
 
         let json_resp = GreptimedbV1Response::from_output(outputs).await;
         if let HttpResponse::GreptimedbV1(json_resp) = json_resp {
@@ -969,7 +971,9 @@ mod test {
         ] {
             let recordbatches =
                 RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()]).unwrap();
-            let outputs = vec![Ok(Output::RecordBatches(recordbatches))];
+            let outputs = vec![Ok(Output::new_data(OutputData::RecordBatches(
+                recordbatches,
+            )))];
             let json_resp = match format {
                 ResponseFormat::Arrow => ArrowResponse::from_output(outputs).await,
                 ResponseFormat::Csv => CsvResponse::from_output(outputs).await,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -804,7 +804,7 @@ mod test {
     use axum::http::StatusCode;
     use axum::routing::get;
     use axum_test_helper::TestClient;
-    use common_query::{Output, OutputData};
+    use common_query::Output;
     use common_recordbatch::RecordBatches;
     use datatypes::prelude::*;
     use datatypes::schema::{ColumnSchema, Schema};
@@ -925,9 +925,7 @@ mod test {
         let schema = Arc::new(Schema::new(column_schemas));
 
         let recordbatches = RecordBatches::try_new(schema.clone(), vec![]).unwrap();
-        let outputs = vec![Ok(Output::new_data(OutputData::RecordBatches(
-            recordbatches,
-        )))];
+        let outputs = vec![Ok(Output::new_with_recordbatches(recordbatches))];
 
         let json_resp = GreptimedbV1Response::from_output(outputs).await;
         if let HttpResponse::GreptimedbV1(json_resp) = json_resp {
@@ -971,9 +969,7 @@ mod test {
         ] {
             let recordbatches =
                 RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()]).unwrap();
-            let outputs = vec![Ok(Output::new_data(OutputData::RecordBatches(
-                recordbatches,
-            )))];
+            let outputs = vec![Ok(Output::new_with_recordbatches(recordbatches))];
             let json_resp = match format {
                 ResponseFormat::Arrow => ArrowResponse::from_output(outputs).await,
                 ResponseFormat::Csv => CsvResponse::from_output(outputs).await,

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -925,7 +925,7 @@ mod test {
         let schema = Arc::new(Schema::new(column_schemas));
 
         let recordbatches = RecordBatches::try_new(schema.clone(), vec![]).unwrap();
-        let outputs = vec![Ok(Output::new_with_recordbatches(recordbatches))];
+        let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
 
         let json_resp = GreptimedbV1Response::from_output(outputs).await;
         if let HttpResponse::GreptimedbV1(json_resp) = json_resp {
@@ -969,7 +969,7 @@ mod test {
         ] {
             let recordbatches =
                 RecordBatches::try_new(schema.clone(), vec![recordbatch.clone()]).unwrap();
-            let outputs = vec![Ok(Output::new_with_recordbatches(recordbatches))];
+            let outputs = vec![Ok(Output::new_with_record_batches(recordbatches))];
             let json_resp = match format {
                 ResponseFormat::Arrow => ArrowResponse::from_output(outputs).await,
                 ResponseFormat::Csv => CsvResponse::from_output(outputs).await,

--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -229,7 +229,7 @@ fn select_variable(query: &str, query_context: QueryContextRef) -> Option<Output
     let schema = Arc::new(Schema::new(fields));
     // unwrap is safe because the schema and data are definitely able to form a recordbatch, they are all string type
     let batches = RecordBatches::try_from_columns(schema, values).unwrap();
-    Some(Output::new_with_recordbatches(batches))
+    Some(Output::new_with_record_batches(batches))
 }
 
 fn check_select_variable(query: &str, query_context: QueryContextRef) -> Option<Output> {
@@ -254,13 +254,13 @@ fn check_show_variables(query: &str) -> Option<Output> {
     } else {
         None
     };
-    recordbatches.map(Output::new_with_recordbatches)
+    recordbatches.map(Output::new_with_record_batches)
 }
 
 // Check for SET or others query, this is the final check of the federated query.
 fn check_others(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
     if OTHER_NOT_SUPPORTED_STMT.is_match(query.as_bytes()) {
-        return Some(Output::new_with_recordbatches(RecordBatches::empty()));
+        return Some(Output::new_with_record_batches(RecordBatches::empty()));
     }
 
     let recordbatches = if SELECT_DATABASE_PATTERN.is_match(query) {
@@ -274,7 +274,7 @@ fn check_others(query: &str, query_ctx: QueryContextRef) -> Option<Output> {
     } else {
         None
     };
-    recordbatches.map(Output::new_with_recordbatches)
+    recordbatches.map(Output::new_with_record_batches)
 }
 
 // Check whether the query is a federated or driver setup command,

--- a/src/servers/src/mysql/writer.rs
+++ b/src/servers/src/mysql/writer.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 
 use common_error::ext::ErrorExt;
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_recordbatch::{RecordBatch, SendableRecordBatchStream};
 use common_telemetry::{debug, error};
 use datatypes::prelude::{ConcreteDataType, Value};
@@ -80,22 +80,22 @@ impl<'a, W: AsyncWrite + Unpin> MysqlResultWriter<'a, W> {
         // We don't support sending multiple query result because the RowWriter's lifetime is bound to
         // a local variable.
         match output {
-            Ok(output) => match output {
-                Output::Stream(stream, _) => {
+            Ok(output) => match output.data {
+                OutputData::Stream(stream) => {
                     let query_result = QueryResult {
                         schema: stream.schema(),
                         stream,
                     };
                     Self::write_query_result(query_result, self.writer, self.query_context).await?;
                 }
-                Output::RecordBatches(recordbatches) => {
+                OutputData::RecordBatches(recordbatches) => {
                     let query_result = QueryResult {
                         schema: recordbatches.schema(),
                         stream: recordbatches.as_stream(),
                     };
                     Self::write_query_result(query_result, self.writer, self.query_context).await?;
                 }
-                Output::AffectedRows(rows) => {
+                OutputData::AffectedRows(rows) => {
                     let next_writer = Self::write_affected_rows(self.writer, rows).await?;
                     return Ok(Some(MysqlResultWriter::new(
                         next_writer,

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -103,7 +103,7 @@ impl PromQueryInterceptor for NoopInterceptor {
         _query_ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error> {
         match output.data {
-            OutputData::AffectedRows(1) => Ok(Output::new_with_affectedrows(2)),
+            OutputData::AffectedRows(1) => Ok(Output::new_with_affected_rows(2)),
             _ => Ok(output),
         }
     }
@@ -122,7 +122,7 @@ fn test_prom_interceptor() {
     let fail = PromQueryInterceptor::pre_execute(&di, &query, ctx.clone());
     assert!(fail.is_err());
 
-    let output = Output::new_with_affectedrows(1);
+    let output = Output::new_with_affected_rows(1);
     let two = PromQueryInterceptor::post_execute(&di, output, ctx);
     assert!(two.is_ok());
     matches!(

--- a/src/servers/tests/interceptor.rs
+++ b/src/servers/tests/interceptor.rs
@@ -103,7 +103,7 @@ impl PromQueryInterceptor for NoopInterceptor {
         _query_ctx: QueryContextRef,
     ) -> std::result::Result<Output, Self::Error> {
         match output.data {
-            OutputData::AffectedRows(1) => Ok(Output::new_data(OutputData::AffectedRows(2))),
+            OutputData::AffectedRows(1) => Ok(Output::new_with_affectedrows(2)),
             _ => Ok(output),
         }
     }
@@ -122,7 +122,7 @@ fn test_prom_interceptor() {
     let fail = PromQueryInterceptor::pre_execute(&di, &query, ctx.clone());
     assert!(fail.is_err());
 
-    let output = Output::new_data(OutputData::AffectedRows(1));
+    let output = Output::new_with_affectedrows(1);
     let two = PromQueryInterceptor::post_execute(&di, output, ctx);
     assert!(two.is_ok());
     matches!(

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use common_query::Output;
+use common_query::OutputData;
 use common_recordbatch::RecordBatch;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
@@ -70,8 +70,8 @@ def hello() -> vector[str]:
         .execute_script(query_ctx.clone(), name, HashMap::new())
         .await?;
 
-    match output {
-        Output::RecordBatches(batches) => {
+    match output.data {
+        OutputData::RecordBatches(batches) => {
             let expected = "\
 +-------+
 | n     |
@@ -88,12 +88,12 @@ def hello() -> vector[str]:
         .await
         .remove(0)
         .unwrap();
-    match res {
-        common_query::Output::AffectedRows(_) => (),
-        common_query::Output::RecordBatches(_) => {
+    match res.data {
+        OutputData::AffectedRows(_) => (),
+        OutputData::RecordBatches(_) => {
             unreachable!()
         }
-        common_query::Output::Stream(s, _) => {
+        OutputData::Stream(s) => {
             let batches = common_recordbatch::util::collect_batches(s).await.unwrap();
             let expected = "\
 +---------+

--- a/tests-integration/src/influxdb.rs
+++ b/tests-integration/src/influxdb.rs
@@ -16,7 +16,7 @@
 mod test {
     use std::sync::Arc;
 
-    use common_query::Output;
+    use client::OutputData;
     use common_recordbatch::RecordBatches;
     use frontend::instance::Instance;
     use servers::influxdb::InfluxdbRequest;
@@ -80,7 +80,7 @@ monitor1,host=host2 memory=1027";
             )
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
 
@@ -109,7 +109,7 @@ monitor1,host=host2 memory=1027 1663840496400340001";
             )
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();

--- a/tests-integration/src/opentsdb.rs
+++ b/tests-integration/src/opentsdb.rs
@@ -16,7 +16,7 @@
 mod tests {
     use std::sync::Arc;
 
-    use common_query::Output;
+    use client::OutputData;
     use common_recordbatch::RecordBatches;
     use frontend::instance::Instance;
     use itertools::Itertools;
@@ -83,8 +83,8 @@ mod tests {
             .await
             .remove(0)
             .unwrap();
-        match output {
-            Output::Stream(stream, _) => {
+        match output.data {
+            OutputData::Stream(stream) => {
                 let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
                 let pretty_print = recordbatches.pretty_print().unwrap();
                 let expected = vec![

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -16,8 +16,7 @@
 mod test {
     use std::sync::Arc;
 
-    use client::DEFAULT_CATALOG_NAME;
-    use common_query::Output;
+    use client::{OutputData, DEFAULT_CATALOG_NAME};
     use common_recordbatch::RecordBatches;
     use frontend::instance::Instance;
     use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
@@ -75,7 +74,7 @@ mod test {
             )
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
@@ -97,7 +96,7 @@ mod test {
             )
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
@@ -117,7 +116,7 @@ mod test {
             .do_query("SELECT * FROM my_test_histo_sum", ctx.clone())
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();
@@ -135,7 +134,7 @@ mod test {
             .do_query("SELECT * FROM my_test_histo_count", ctx.clone())
             .await;
         let output = output.remove(0).unwrap();
-        let Output::Stream(stream, _) = output else {
+        let OutputData::Stream(stream) = output.data else {
             unreachable!()
         };
         let recordbatches = RecordBatches::try_collect(stream).await.unwrap();

--- a/tests-integration/src/tests/instance_kafka_wal_test.rs
+++ b/tests-integration/src/tests/instance_kafka_wal_test.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use client::OutputData;
 use common_query::Output;
 use common_recordbatch::util;
 use datatypes::vectors::{TimestampMillisecondVector, VectorRef};
@@ -33,7 +34,7 @@ async fn test_create_database_and_insert_query(instance: Option<Box<dyn Rebuilda
     let instance = instance.frontend();
 
     let output = execute_sql(&instance, "create database test").await;
-    assert!(matches!(output, Output::AffectedRows(1)));
+    assert!(matches!(output.data, OutputData::AffectedRows(1)));
 
     let output = execute_sql(
         &instance,
@@ -46,7 +47,7 @@ async fn test_create_database_and_insert_query(instance: Option<Box<dyn Rebuilda
 )"#,
     )
     .await;
-    assert!(matches!(output, Output::AffectedRows(0)));
+    assert!(matches!(output.data, OutputData::AffectedRows(0)));
 
     let output = execute_sql(
         &instance,
@@ -56,11 +57,11 @@ async fn test_create_database_and_insert_query(instance: Option<Box<dyn Rebuilda
                            "#,
     )
     .await;
-    assert!(matches!(output, Output::AffectedRows(2)));
+    assert!(matches!(output.data, OutputData::AffectedRows(2)));
 
     let query_output = execute_sql(&instance, "select ts from test.demo order by ts limit 1").await;
-    match query_output {
-        Output::Stream(s, _) => {
+    match query_output.data {
+        OutputData::Stream(s) => {
             let batches = util::collect(s).await.unwrap();
             assert_eq!(1, batches[0].num_columns());
             assert_eq!(

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -15,6 +15,7 @@
 use std::env;
 use std::sync::Arc;
 
+use client::OutputData;
 use common_query::Output;
 use common_recordbatch::util;
 use common_telemetry::warn;
@@ -329,9 +330,9 @@ pub(crate) async fn check_unordered_output_stream(output: Output, expected: &str
             .unwrap()
     };
 
-    let recordbatches = match output {
-        Output::Stream(stream, _) => util::collect_batches(stream).await.unwrap(),
-        Output::RecordBatches(recordbatches) => recordbatches,
+    let recordbatches = match output.data {
+        OutputData::Stream(stream) => util::collect_batches(stream).await.unwrap(),
+        OutputData::RecordBatches(recordbatches) => recordbatches,
         _ => unreachable!(),
     };
     let pretty_print = sort_table(&recordbatches.pretty_print().unwrap());

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use catalog::kvbackend::{CachedMetaKvBackend, KvBackendCatalogManager};
+use client::OutputData;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_meta::key::table_route::TableRouteKey;
 use common_meta::key::{RegionDistribution, TableMetaKey};
@@ -104,7 +105,7 @@ pub async fn test_region_failover(store_type: StorageType) {
     let results = insert_values(&frontend, logical_timer).await;
     logical_timer += 1000;
     for result in results {
-        assert!(matches!(result.unwrap(), Output::AffectedRows(1)));
+        assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     assert!(has_route_cache(&frontend, table_id).await);
@@ -144,7 +145,7 @@ pub async fn test_region_failover(store_type: StorageType) {
     let frontend = cluster.frontend.clone();
     let results = insert_values(&frontend, logical_timer).await;
     for result in results {
-        assert!(matches!(result.unwrap(), Output::AffectedRows(1)));
+        assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
     }
 
     assert_values(&frontend).await;
@@ -226,7 +227,7 @@ async fn assert_values(instance: &Arc<Instance>) {
 | 55 | 2023-05-31T04:51:55 |
 | 55 | 2023-05-31T04:51:56 |
 +----+---------------------+";
-    check_output_stream(result.unwrap(), expected).await;
+    check_output_stream(result.unwrap().data, expected).await;
 }
 
 async fn prepare_testing_table(cluster: &GreptimeDbCluster) -> TableId {

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -443,7 +443,7 @@ impl Database for GreptimeDB {
                 .trim_end_matches(';');
             client.set_schema(database);
             Box::new(ResultDisplayer {
-                result: Ok(Output::new_data(OutputData::AffectedRows(0))),
+                result: Ok(Output::new_with_affectedrows(0)),
             }) as _
         } else if query.trim().to_lowercase().starts_with("set time_zone") {
             // set time_zone='xxx'
@@ -460,7 +460,7 @@ impl Database for GreptimeDB {
             client.set_timezone(timezone);
 
             Box::new(ResultDisplayer {
-                result: Ok(Output::new_data(OutputData::AffectedRows(0))),
+                result: Ok(Output::new_with_affectedrows(0)),
             }) as _
         } else {
             let mut result = client.sql(&query).await;
@@ -471,7 +471,7 @@ impl Database for GreptimeDB {
             {
                 match RecordBatches::try_collect(stream).await {
                     Ok(recordbatches) => {
-                        result = Ok(Output::new_data(OutputData::RecordBatches(recordbatches)));
+                        result = Ok(Output::new_with_recordbatches(recordbatches));
                     }
                     Err(e) => {
                         let status_code = e.status_code();

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -28,7 +28,7 @@ use client::{
     Client, Database as DB, Error as ClientError, DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME,
 };
 use common_error::ext::ErrorExt;
-use common_query::Output;
+use common_query::{Output, OutputData};
 use common_recordbatch::RecordBatches;
 use serde::Serialize;
 use sqlness::{Database, EnvController, QueryContext};
@@ -443,7 +443,7 @@ impl Database for GreptimeDB {
                 .trim_end_matches(';');
             client.set_schema(database);
             Box::new(ResultDisplayer {
-                result: Ok(Output::AffectedRows(0)),
+                result: Ok(Output::new_data(OutputData::AffectedRows(0))),
             }) as _
         } else if query.trim().to_lowercase().starts_with("set time_zone") {
             // set time_zone='xxx'
@@ -460,13 +460,19 @@ impl Database for GreptimeDB {
             client.set_timezone(timezone);
 
             Box::new(ResultDisplayer {
-                result: Ok(Output::AffectedRows(0)),
+                result: Ok(Output::new_data(OutputData::AffectedRows(0))),
             }) as _
         } else {
             let mut result = client.sql(&query).await;
-            if let Ok(Output::Stream(stream, _)) = result {
+            if let Ok(Output {
+                data: OutputData::Stream(stream),
+                ..
+            }) = result
+            {
                 match RecordBatches::try_collect(stream).await {
-                    Ok(recordbatches) => result = Ok(Output::RecordBatches(recordbatches)),
+                    Ok(recordbatches) => {
+                        result = Ok(Output::new_data(OutputData::RecordBatches(recordbatches)));
+                    }
                     Err(e) => {
                         let status_code = e.status_code();
                         let msg = e.output_msg();
@@ -567,11 +573,11 @@ struct ResultDisplayer {
 impl Display for ResultDisplayer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.result {
-            Ok(result) => match result {
-                Output::AffectedRows(rows) => {
+            Ok(result) => match &result.data {
+                OutputData::AffectedRows(rows) => {
                     write!(f, "Affected Rows: {rows}")
                 }
-                Output::RecordBatches(recordbatches) => {
+                OutputData::RecordBatches(recordbatches) => {
                     let pretty = recordbatches.pretty_print().map_err(|e| e.to_string());
                     match pretty {
                         Ok(s) => write!(f, "{s}"),
@@ -580,7 +586,7 @@ impl Display for ResultDisplayer {
                         }
                     }
                 }
-                Output::Stream(_, _) => unreachable!(),
+                OutputData::Stream(_) => unreachable!(),
             },
             Err(e) => {
                 let status_code = e.status_code();

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -443,7 +443,7 @@ impl Database for GreptimeDB {
                 .trim_end_matches(';');
             client.set_schema(database);
             Box::new(ResultDisplayer {
-                result: Ok(Output::new_with_affectedrows(0)),
+                result: Ok(Output::new_with_affected_rows(0)),
             }) as _
         } else if query.trim().to_lowercase().starts_with("set time_zone") {
             // set time_zone='xxx'
@@ -460,7 +460,7 @@ impl Database for GreptimeDB {
             client.set_timezone(timezone);
 
             Box::new(ResultDisplayer {
-                result: Ok(Output::new_with_affectedrows(0)),
+                result: Ok(Output::new_with_affected_rows(0)),
             }) as _
         } else {
             let mut result = client.sql(&query).await;
@@ -471,7 +471,7 @@ impl Database for GreptimeDB {
             {
                 match RecordBatches::try_collect(stream).await {
                     Ok(recordbatches) => {
-                        result = Ok(Output::new_with_recordbatches(recordbatches));
+                        result = Ok(Output::new_with_record_batches(recordbatches));
                     }
                     Err(e) => {
                         let status_code = e.status_code();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
closes #3457

## What's changed and what's your intention?

This pr refactors `Output`, turning the old one into `OutputData` and adding new `OutputMeta`. Since it's widely used across the project, we try to minimize the change by focusing on only changing the struct. Related feature addition will be made in a separate pr.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
