### PR TITLE
refactor: make http api returns non-200 status code

### DIFF
--- a/src/servers/src/http/error_result.rs
+++ b/src/servers/src/http/error_result.rs
@@ -1,3 +1,5 @@
+// Copyright 2023 Greptime Team
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#2888 

## What's changed and what's your intention?

to make HTTP API returns status code, I changed the returning value of `ErrorResponse::into_response` and map `code` to `StatusCode`. Here is the returning mapping:


```rust
Success, Cancelled ==> OK(200);

Unsupported, InvalidArguments, InvalidSyntax, RequestOutdated, 
RegionAlreadyExists, TableColumnExists, TableAlreadyExists, 
DatabaseNotFound, TableNotFound, TableColumnNotFound ==> `BAD_REQUEST`(400);

PermissionDenied, AuthHeaderNotFound, InvalidAuthHeader, 
UserNotFound, UnsupportedPasswordType, UserPasswordMismatch, 
RegionReadonly ==> `UNAUTHORIZED`(401)

AccessDenied ==> `FORBIDDEN`(403)

Internal, Unexpected, Unknown, StorageUnavailable,
RegionNotReady, RegionBusy, RateLimited, RuntimeResourcesExhausted, 
PlanQuery, EngineExecuteQuery ==> `INTERNAL_SERVER_ERROR`(500)
```

I also changed some test code to match these status code.

**some code may need to be changed on front-end**(like [dashboard](https://github.com/GreptimeTeam/dashboard)) to handle these error code

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
