### PR TITLE
feat: improve prom write requests decode performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9160,6 +9160,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "digest",
  "futures",
+ "hashbrown 0.14.3",
  "headers",
  "hex",
  "hostname",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -49,6 +49,7 @@ datatypes.workspace = true
 derive_builder.workspace = true
 digest = "0.10"
 futures = "0.3"
+hashbrown = "0.14"
 headers = "0.3"
 hex = { version = "0.4" }
 hostname = "0.3.1"

--- a/src/servers/src/prom_row_builder.rs
+++ b/src/servers/src/prom_row_builder.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::string::ToString;
 
 use api::prom_store::remote::Sample;
@@ -23,6 +21,8 @@ use api::v1::{
     Value,
 };
 use common_query::prelude::{GREPTIME_TIMESTAMP, GREPTIME_VALUE};
+use hashbrown::hash_map::Entry;
+use hashbrown::HashMap;
 
 use crate::proto::PromLabel;
 use crate::repeated_field::Clear;
@@ -85,7 +85,7 @@ impl Default for TableBuilder {
 
 impl TableBuilder {
     pub(crate) fn with_capacity(cols: usize, rows: usize) -> Self {
-        let mut col_indexes = HashMap::with_capacity(cols);
+        let mut col_indexes = HashMap::with_capacity_and_hasher(cols, Default::default());
         col_indexes.insert(GREPTIME_TIMESTAMP.to_string(), 0);
         col_indexes.insert(GREPTIME_VALUE.to_string(), 1);
 

--- a/src/servers/src/proto.rs
+++ b/src/servers/src/proto.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use std::ops::Deref;
+use std::slice;
 
 use api::prom_store::remote::Sample;
 use api::v1::RowInsertRequests;
 use bytes::{Buf, Bytes};
 use prost::encoding::message::merge;
-use prost::encoding::{decode_key, decode_varint, DecodeContext, WireType};
+use prost::encoding::{decode_key, decode_varint, WireType};
 use prost::DecodeError;
 
 use crate::prom_row_builder::TablesBuilder;
@@ -36,29 +37,22 @@ pub struct PromLabel {
 }
 
 impl Clear for PromLabel {
-    fn clear(&mut self) {
-        self.name.clear();
-        self.value.clear();
-    }
+    fn clear(&mut self) {}
 }
 
 impl PromLabel {
-    pub fn merge_field<B>(
+    pub fn merge_field(
         &mut self,
         tag: u32,
         wire_type: WireType,
-        buf: &mut B,
-        ctx: DecodeContext,
-    ) -> Result<(), DecodeError>
-    where
-        B: Buf,
-    {
+        buf: &mut Bytes,
+    ) -> Result<(), DecodeError> {
         const STRUCT_NAME: &str = "PromLabel";
         match tag {
             1u32 => {
                 // decode label name
                 let value = &mut self.name;
-                prost::encoding::bytes::merge(wire_type, value, buf, ctx).map_err(|mut error| {
+                merge_bytes(value, buf).map_err(|mut error| {
                     error.push(STRUCT_NAME, "name");
                     error
                 })
@@ -66,14 +60,63 @@ impl PromLabel {
             2u32 => {
                 // decode label value
                 let value = &mut self.value;
-                prost::encoding::bytes::merge(wire_type, value, buf, ctx).map_err(|mut error| {
+                merge_bytes(value, buf).map_err(|mut error| {
                     error.push(STRUCT_NAME, "value");
                     error
                 })
             }
-            _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
+            _ => prost::encoding::skip_field(wire_type, tag, buf, Default::default()),
         }
     }
+}
+
+#[inline(always)]
+fn copy_to_bytes(data: &mut Bytes, len: usize) -> Bytes {
+    if len == data.remaining() {
+        core::mem::replace(data, Bytes::new())
+    } else {
+        let ret = split_to(data, len);
+        data.advance(len);
+        ret
+    }
+}
+
+/// Similar to `Bytes::split_to`, but directly operates on underlying memory region.
+/// # Safety
+/// This function is safe as long as `data` is backed by a consecutive region of memory,
+/// for example `Vec<u8>` or `&[u8]`, and caller must ensure that `buf` outlives
+/// the `Bytes` returned.
+#[inline(always)]
+fn split_to(buf: &mut Bytes, end: usize) -> Bytes {
+    let len = buf.len();
+    assert!(
+        end <= len,
+        "range end out of bounds: {:?} <= {:?}",
+        end,
+        len,
+    );
+
+    if end == 0 {
+        return Bytes::new();
+    }
+
+    let ptr = buf.as_ptr();
+    let x = unsafe { slice::from_raw_parts(ptr, end) };
+    // `Bytes::drop` does nothing when it's built via `from_static`.
+    Bytes::from_static(x)
+}
+
+/// Reads a variable-length encoded bytes field from `buf` and assign it to `value`.
+/// # Safety
+/// Callers must ensure `buf` outlives `value`.
+#[inline(always)]
+fn merge_bytes(value: &mut Bytes, buf: &mut Bytes) -> Result<(), DecodeError> {
+    let len = decode_varint(buf)?;
+    if len > buf.remaining() as u64 {
+        return Err(DecodeError::new("buffer underflow"));
+    }
+    *value = copy_to_bytes(buf, len as usize);
+    Ok(())
 }
 
 #[derive(Default)]
@@ -92,16 +135,12 @@ impl Clear for PromTimeSeries {
 }
 
 impl PromTimeSeries {
-    pub fn merge_field<B>(
+    pub fn merge_field(
         &mut self,
         tag: u32,
         wire_type: WireType,
-        buf: &mut B,
-        ctx: DecodeContext,
-    ) -> Result<(), DecodeError>
-    where
-        B: Buf,
-    {
+        buf: &mut Bytes,
+    ) -> Result<(), DecodeError> {
         const STRUCT_NAME: &str = "PromTimeSeries";
         match tag {
             1u32 => {
@@ -120,7 +159,7 @@ impl PromTimeSeries {
                 let limit = remaining - len as usize;
                 while buf.remaining() > limit {
                     let (tag, wire_type) = decode_key(buf)?;
-                    label.merge_field(tag, wire_type, buf, ctx.clone())?;
+                    label.merge_field(tag, wire_type, buf)?;
                 }
                 if buf.remaining() != limit {
                     return Err(DecodeError::new("delimited length exceeded"));
@@ -135,15 +174,17 @@ impl PromTimeSeries {
             }
             2u32 => {
                 let sample = self.samples.push_default();
-                merge(WireType::LengthDelimited, sample, buf, ctx).map_err(|mut error| {
-                    error.push(STRUCT_NAME, "samples");
-                    error
-                })?;
+                merge(WireType::LengthDelimited, sample, buf, Default::default()).map_err(
+                    |mut error| {
+                        error.push(STRUCT_NAME, "samples");
+                        error
+                    },
+                )?;
                 Ok(())
             }
             // skip exemplars
-            3u32 => prost::encoding::skip_field(wire_type, tag, buf, ctx),
-            _ => prost::encoding::skip_field(wire_type, tag, buf, ctx),
+            3u32 => prost::encoding::skip_field(wire_type, tag, buf, Default::default()),
+            _ => prost::encoding::skip_field(wire_type, tag, buf, Default::default()),
         }
     }
 
@@ -178,13 +219,8 @@ impl PromWriteRequest {
         self.table_data.as_insert_requests()
     }
 
-    pub fn merge<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
-    where
-        B: Buf,
-        Self: Sized,
-    {
+    pub fn merge(&mut self, mut buf: Bytes) -> Result<(), DecodeError> {
         const STRUCT_NAME: &str = "PromWriteRequest";
-        let ctx = DecodeContext::default();
         while buf.has_remaining() {
             let (tag, wire_type) = decode_key(&mut buf)?;
             assert_eq!(WireType::LengthDelimited, wire_type);
@@ -203,8 +239,7 @@ impl PromWriteRequest {
                     let limit = remaining - len as usize;
                     while buf.remaining() > limit {
                         let (tag, wire_type) = decode_key(&mut buf)?;
-                        self.series
-                            .merge_field(tag, wire_type, &mut buf, ctx.clone())?;
+                        self.series.merge_field(tag, wire_type, &mut buf)?;
                     }
                     if buf.remaining() != limit {
                         return Err(DecodeError::new("delimited length exceeded"));
@@ -213,9 +248,9 @@ impl PromWriteRequest {
                 }
                 3u32 => {
                     // we can ignore metadata for now.
-                    prost::encoding::skip_field(wire_type, tag, &mut buf, ctx.clone())?;
+                    prost::encoding::skip_field(wire_type, tag, &mut buf, Default::default())?;
                 }
-                _ => prost::encoding::skip_field(wire_type, tag, &mut buf, ctx.clone())?,
+                _ => prost::encoding::skip_field(wire_type, tag, &mut buf, Default::default())?,
             }
         }
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
N/A
## What's changed and what's your intention?

This PR aims to improve the decode performance of `PromWriteRequest`, which has been addressed in #3425, but still we observe some room for optimization.

### Decoding `WriteRequest`
- First we can eliminate one `copy_to_bytes` invocation by inling `prost::encoding::bytes::merge`
- Then we dive into `copy_to_bytes`, and we observe that `copy_to_bytes` is way slower than Golang's byte slice operation
    - For a `bytes = bytes[..idx]` operation repeated for 120k times (which is the case when decoding lables from 10k timeseries in a `WriteRequest`), Rust's `Bytes` takes 1.2ms, while Golang's byte slice takes 30us
    - The reason for this performance difference is that `Bytes` also handles reference counting when built from `Vec<u8>`, while Golang's byte slice only has `ptr`, `len`, `cap` fields and Garbage collector handles the reference counting, which bring little overhead when bytes are pooled.
    - Considering the bytes fields of `PromLabel` are short-lived and are converted to string and added to `TableBuilder` soon after a `PromTimeseries` decoding is finished, so that the original decompressed `Bytes` always outlive `PromLabel::name` and `PromLabel::value`, we can introduce some unsafe operation, such as directly construct a new `Bytes` from raw pointer and len/cap fields, that's what `servers::proto::copy_to_bytes` does.
    - For the same test mentioned above, `servers::proto::copy_to_bytes` takes 200us, still slower than Golang, but fairly acceptable. 
    - With this optimization, **decoding a 10k timeseries `WriteRequest` cost time improved from 3.0ms to 1.8ms**. For refence, VictoriaMetrics' WriteRequets decoding takes 1.2ms.

### Building `RowInsertRequests`

Aside from decoding improvement, we also find out that `PromWriteRequest::as_row_insert_requests` takes more time than decoding.

- During decoding `PromTimeseries`, we need to builtd the schemas for each metric (table), which involves two hashmap lookups.
- We can use ahasher hashmap instead of Rust's default siphasher hashmap, to get a roughly 40% improvement in terms of hashtable lookups (Rust's default hashmap is quite slow btw).
- Compared to siphasher, ahasher is not a cryptographically secure hasher, but it doesn't matter in our case.
- I also compared other hashmaps like [fxhashmap](https://github.com/cbreeden/fxhash) which is used internally in rustc, but did not notice significant improvent.

### Results
Still, decoding a `WriteRequest` with 10k timeseries and 60k labels

```
     Running benches/bench_prom.rs (target/release/deps/bench_prom-ac6fa2abc4d24957)
decode/write_request    time:   [13.816 ms 13.882 ms 13.954 ms]
                        change: [-0.9281% -0.3477% +0.2455%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
decode/prom_write_request
                        time:   [5.7520 ms 5.7591 ms 5.7666 ms]
                        change: [+0.5254% +0.7116% +0.9096%] (p = 0.00 < 0.05)
                        Change within noise threshold.

```


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
