### PR TITLE
fix: fix f64 has no sufficient precision during parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 rskafka = "0.5"
 rust_decimal = "1.33"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_with = "3"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.7"

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -2387,4 +2387,12 @@ mod tests {
         );
         check_value_ref_size_eq(&ValueRef::Decimal128(Decimal128::new(1234, 3, 1)), 32)
     }
+
+    #[test]
+    fn test_incorrect_default_value_issue_3479() {
+        let value = OrderedF64::from(0.047318541668048164);
+        let serialized = serde_json::to_string(&value).unwrap();
+        let deserialized: OrderedF64 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(value, deserialized);
+    }
 }

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -1495,4 +1495,25 @@ ENGINE=mito";
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let _ = result.unwrap();
     }
+
+    #[test]
+    fn test_incorrect_default_value_issue_3479() {
+        let sql = r#"CREATE TABLE `ExcePTuRi`(
+non TIMESTAMP(6) TIME INDEX,
+`iUSTO` DOUBLE DEFAULT 0.047318541668048164
+)"#;
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+        assert_eq!(1, result.len());
+        match &result[0] {
+            Statement::CreateTable(c) => {
+                assert_eq!(
+                    "`iUSTO` DOUBLE DEFAULT 0.047318541668048164",
+                    c.columns[1].to_string()
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
 }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -905,6 +905,29 @@ mod tests {
     }
 
     #[test]
+    fn test_incorrect_default_value_issue_3479() {
+        let opts = vec![ColumnOptionDef {
+            name: None,
+            option: ColumnOption::Default(Expr::Value(SqlValue::Number(
+                "0.047318541668048164".into(),
+                false,
+            ))),
+        }];
+        let constraint = parse_column_default_constraint(
+            "coll",
+            &ConcreteDataType::float64_datatype(),
+            &opts,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!("0.047318541668048164", constraint.to_string());
+        let encoded: Vec<u8> = constraint.clone().try_into().unwrap();
+        let decoded = ColumnDefaultConstraint::try_from(encoded.as_ref()).unwrap();
+        assert_eq!(decoded, constraint);
+    }
+
+    #[test]
     pub fn test_sql_column_def_to_grpc_column_def() {
         // test basic
         let column_def = ColumnDef {

--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -155,6 +155,23 @@ CREATE TABLE test_like_2 LIKE test_like_1;
 
 Error: 4000(TableAlreadyExists), Table already exists: `greptime.public.test_like_2`
 
+CREATE TABLE `ExcePTuRi`(
+non TIMESTAMP(6) TIME INDEX,
+`iUSTO` DOUBLE DEFAULT 0.047318541668048164
+)
+ENGINE=mito;
+
+Affected Rows: 0
+
+DESC table `ExcePTuRi`;
+
++--------+----------------------+-----+------+----------------------+---------------+
+| Column | Type                 | Key | Null | Default              | Semantic Type |
++--------+----------------------+-----+------+----------------------+---------------+
+| non    | TimestampMicrosecond | PRI | NO   |                      | TIMESTAMP     |
+| iUSTO  | Float64              |     | YES  | 0.047318541668048164 | FIELD         |
++--------+----------------------+-----+------+----------------------+---------------+
+
 DESC TABLE test_like_1;
 
 +--------+----------------------+-----+------+---------+---------------+
@@ -180,6 +197,10 @@ DROP TABLE test_like_1;
 Affected Rows: 0
 
 DROP TABLE test_like_2;
+
+Affected Rows: 0
+
+DROP table `ExcePTuRi`;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/create/create.sql
+++ b/tests/cases/standalone/common/create/create.sql
@@ -64,6 +64,14 @@ CREATE TABLE test_like_2 LIKE test_like_1;
 
 CREATE TABLE test_like_2 LIKE test_like_1;
 
+CREATE TABLE `ExcePTuRi`(
+non TIMESTAMP(6) TIME INDEX,
+`iUSTO` DOUBLE DEFAULT 0.047318541668048164
+)
+ENGINE=mito;
+
+DESC table `ExcePTuRi`;
+
 DESC TABLE test_like_1;
 
 DESC TABLE test_like_2;
@@ -71,3 +79,5 @@ DESC TABLE test_like_2;
 DROP TABLE test_like_1;
 
 DROP TABLE test_like_2;
+
+DROP table `ExcePTuRi`;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #3479
## What's changed and what's your intention?

Enable the `float_roundtrip` of `serde_json`, it makes f64 -> JSON -> f64 produces output identical to the input.
However, this comes at an approximately 2x performance cost for parsing floats compared to the default best-effort precision.

See also: 
- https://github.com/serde-rs/json/blob/master/
- https://github.com/serde-rs/json/issues/536


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
