### PR TITLE
fix: allow passing extra table options

### DIFF
--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -27,6 +27,18 @@ const SESSION_TOKEN: &str = "session_token";
 const REGION: &str = "region";
 const ENABLE_VIRTUAL_HOST_STYLE: &str = "enable_virtual_host_style";
 
+pub fn is_supported_in_s3(key: &str) -> bool {
+    [
+        ENDPOINT,
+        ACCESS_KEY_ID,
+        SECRET_ACCESS_KEY,
+        SESSION_TOKEN,
+        REGION,
+        ENABLE_VIRTUAL_HOST_STYLE,
+    ]
+    .contains(&key)
+}
+
 pub fn build_s3_backend(
     host: &str,
     path: &str,
@@ -84,4 +96,19 @@ pub fn build_s3_backend(
         .layer(object_store::layers::TracingLayer)
         .layer(object_store::layers::PrometheusMetricsLayer)
         .finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_is_supported_in_s3() {
+        assert!(is_supported_in_s3(ENDPOINT));
+        assert!(is_supported_in_s3(ACCESS_KEY_ID));
+        assert!(is_supported_in_s3(SECRET_ACCESS_KEY));
+        assert!(is_supported_in_s3(SESSION_TOKEN));
+        assert!(is_supported_in_s3(REGION));
+        assert!(is_supported_in_s3(ENABLE_VIRTUAL_HOST_STYLE));
+        assert!(!is_supported_in_s3("foo"))
+    }
 }

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -27,15 +27,6 @@ const SESSION_TOKEN: &str = "session_token";
 const REGION: &str = "region";
 const ENABLE_VIRTUAL_HOST_STYLE: &str = "enable_virtual_host_style";
 
-pub fn is_supported_in_s3(key: &str) -> bool {
-    key == ENDPOINT
-        || key == ACCESS_KEY_ID
-        || key == SECRET_ACCESS_KEY
-        || key == SESSION_TOKEN
-        || key == REGION
-        || key == ENABLE_VIRTUAL_HOST_STYLE
-}
-
 pub fn build_s3_backend(
     host: &str,
     path: &str,
@@ -93,19 +84,4 @@ pub fn build_s3_backend(
         .layer(object_store::layers::TracingLayer)
         .layer(object_store::layers::PrometheusMetricsLayer)
         .finish())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn test_is_supported_in_s3() {
-        assert!(is_supported_in_s3(ENDPOINT));
-        assert!(is_supported_in_s3(ACCESS_KEY_ID));
-        assert!(is_supported_in_s3(SECRET_ACCESS_KEY));
-        assert!(is_supported_in_s3(SESSION_TOKEN));
-        assert!(is_supported_in_s3(REGION));
-        assert!(is_supported_in_s3(ENABLE_VIRTUAL_HOST_STYLE));
-        assert!(!is_supported_in_s3("foo"))
-    }
 }

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -171,6 +171,8 @@ impl RegionOpener {
         // Initial memtable id is 0.
         let mutable = self.memtable_builder.build(0, &metadata);
 
+        debug!("Create region {} with options: {:?}", region_id, options);
+
         let version = VersionBuilder::new(metadata, mutable)
             .options(options)
             .build();
@@ -249,6 +251,9 @@ impl RegionOpener {
 
         let region_id = self.region_id;
         let object_store = self.object_store(&region_options.storage)?.clone();
+
+        debug!("Open region {} with options: {:?}", region_id, self.options);
+
         let access_layer = Arc::new(AccessLayer::new(
             self.region_dir.clone(),
             object_store,

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 //! Options for a region.
+//!
+//! If we add options in this mod, we also need to modify [store_api::mito_engine_options].
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -358,6 +360,7 @@ mod tests {
             ("compaction.type", "twcs"),
             ("storage", "S3"),
             ("index.inverted_index.ignore_column_ids", "1,2,3"),
+            ("index.inverted_index.segment_row_count", "512"),
             (
                 WAL_OPTIONS_KEY,
                 &serde_json::to_string(&wal_options).unwrap(),
@@ -376,7 +379,7 @@ mod tests {
             index_options: IndexOptions {
                 inverted_index: InvertedIndexOptions {
                     ignore_column_ids: vec![1, 2, 3],
-                    segment_row_count: 1024,
+                    segment_row_count: 512,
                 },
             },
         };

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -117,9 +117,6 @@ pub enum Error {
         source: datatypes::error::Error,
     },
 
-    #[snafu(display("Invalid table option key: {}", key))]
-    InvalidTableOption { key: String, location: Location },
-
     #[snafu(display("Failed to serialize column default constraint"))]
     SerializeColumnDefaultConstraint {
         location: Location,
@@ -183,7 +180,6 @@ impl ErrorExt for Error {
             | InvalidTableName { .. }
             | InvalidSqlValue { .. }
             | TimestampOverflow { .. }
-            | InvalidTableOption { .. }
             | InvalidCast { .. } => StatusCode::InvalidArguments,
 
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -117,6 +117,9 @@ pub enum Error {
         source: datatypes::error::Error,
     },
 
+    #[snafu(display("Unrecognized table option key: {}", key))]
+    InvalidTableOption { key: String, location: Location },
+
     #[snafu(display("Failed to serialize column default constraint"))]
     SerializeColumnDefaultConstraint {
         location: Location,
@@ -180,6 +183,7 @@ impl ErrorExt for Error {
             | InvalidTableName { .. }
             | InvalidSqlValue { .. }
             | TimestampOverflow { .. }
+            | InvalidTableOption { .. }
             | InvalidCast { .. } => StatusCode::InvalidArguments,
 
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -764,7 +764,7 @@ mod tests {
                 expected_if_not_exist: true,
             },
             Test {
-                sql: "CREATE EXTERNAL TABLE IF NOT EXISTS city ENGINE=foo with(location='/var/data/city.csv',format='csv',foo.foo='bar');",
+                sql: "CREATE EXTERNAL TABLE IF NOT EXISTS city ENGINE=foo with(location='/var/data/city.csv',format='csv','foo.foo'='bar');",
                 expected_table_name: "city",
                 expected_options: HashMap::from([
                     ("location".to_string(), "/var/data/city.csv".to_string()),

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -23,12 +23,11 @@ use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::IsOptional::Mandatory;
 use sqlparser::parser::{Parser, ParserError};
 use sqlparser::tokenizer::{Token, TokenWithLocation, Word};
-use table::requests::valid_table_option;
 
 use crate::ast::{ColumnDef, Ident, TableConstraint};
 use crate::error::{
-    self, InvalidColumnOptionSnafu, InvalidTableOptionSnafu, InvalidTimeIndexSnafu,
-    MissingTimeIndexSnafu, Result, SyntaxSnafu,
+    self, InvalidColumnOptionSnafu, InvalidTimeIndexSnafu, MissingTimeIndexSnafu, Result,
+    SyntaxSnafu,
 };
 use crate::parser::ParserContext;
 use crate::statements::create::{
@@ -82,14 +81,6 @@ impl<'a> ParserContext<'a> {
                 }
             })
             .collect::<HashMap<String, String>>();
-        for key in options.keys() {
-            ensure!(
-                valid_table_option(key),
-                InvalidTableOptionSnafu {
-                    key: key.to_string()
-                }
-            );
-        }
         Ok(Statement::CreateExternalTable(CreateExternalTable {
             name: table_name,
             columns,
@@ -148,14 +139,6 @@ impl<'a> ParserContext<'a> {
             .parser
             .parse_options(Keyword::WITH)
             .context(error::SyntaxSnafu)?;
-        for option in options.iter() {
-            ensure!(
-                valid_table_option(&option.name.value),
-                InvalidTableOptionSnafu {
-                    key: option.name.value.to_string()
-                }
-            );
-        }
         // Sorts options so that `test_display_create_table` can always pass.
         let options = options.into_iter().sorted().collect();
         let create_table = CreateTable {
@@ -750,25 +733,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_external_table_options() {
-        let sql = "CREATE EXTERNAL TABLE city (
-            host string,
-            ts int64,
-            cpu float64 default 0,
-            memory float64,
-            TIME INDEX (ts),
-            PRIMARY KEY(ts, host)
-        ) with(location='/var/data/city.csv',format='csv',foo='bar');";
-
-        let result =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
-        assert!(matches!(
-            result,
-            Err(error::Error::InvalidTableOption { .. })
-        ));
-    }
-
-    #[test]
     fn test_parse_create_external_table() {
         struct Test<'a> {
             sql: &'a str,
@@ -795,6 +759,17 @@ mod tests {
                 expected_options: HashMap::from([
                     ("location".to_string(), "/var/data/city.csv".to_string()),
                     ("format".to_string(), "csv".to_string()),
+                ]),
+                expected_engine: "foo",
+                expected_if_not_exist: true,
+            },
+            Test {
+                sql: "CREATE EXTERNAL TABLE IF NOT EXISTS city ENGINE=foo with(location='/var/data/city.csv',format='csv',foo.foo='bar');",
+                expected_table_name: "city",
+                expected_options: HashMap::from([
+                    ("location".to_string(), "/var/data/city.csv".to_string()),
+                    ("format".to_string(), "csv".to_string()),
+                    ("foo.foo".to_string(), "bar".to_string()),
                 ]),
                 expected_engine: "foo",
                 expected_if_not_exist: true,

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -23,6 +23,7 @@ use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::IsOptional::Mandatory;
 use sqlparser::parser::{Parser, ParserError};
 use sqlparser::tokenizer::{Token, TokenWithLocation, Word};
+use table::requests::validate_table_option;
 
 use crate::ast::{ColumnDef, Ident, TableConstraint};
 use crate::error::{
@@ -83,7 +84,7 @@ impl<'a> ParserContext<'a> {
             .collect::<HashMap<String, String>>();
         for key in options.keys() {
             ensure!(
-                valid_table_option(key),
+                validate_table_option(key),
                 InvalidTableOptionSnafu {
                     key: key.to_string()
                 }
@@ -149,7 +150,7 @@ impl<'a> ParserContext<'a> {
             .context(error::SyntaxSnafu)?;
         for option in options.iter() {
             ensure!(
-                valid_table_option(&option.name.value),
+                validate_table_option(&option.name.value),
                 InvalidTableOptionSnafu {
                     key: option.name.value.to_string()
                 }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -351,7 +351,7 @@ ENGINE=mito
       )
       PARTITION ON COLUMNS (host) ()
       engine=mito
-      with(regions=1, ttl='7d', hello='world');
+      with(regions=1, ttl='7d', compaction.type='world');
 ";
         let result =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
@@ -362,5 +362,21 @@ ENGINE=mito
             }
             _ => unreachable!(),
         }
+
+        let sql = r"create table if not exists demo(
+            host string,
+            ts timestamp,
+            cpu double default 0,
+            memory double,
+            TIME INDEX (ts),
+            PRIMARY KEY(host)
+      )
+      PARTITION ON COLUMNS (host) ()
+      engine=mito
+      with(regions=1, ttl='7d', hello='world');
+";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(matches!(result, Err(InvalidTableOption { .. })));
     }
 }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -343,7 +343,7 @@ ENGINE=mito
     fn test_validate_table_options() {
         let sql = r"create table if not exists demo(
             host string,
-            ts bigint,
+            ts timestamp,
             cpu double default 0,
             memory double,
             TIME INDEX (ts),

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -230,6 +230,7 @@ pub struct CreateTableLike {
 #[cfg(test)]
 mod tests {
     use crate::dialect::GreptimeDbDialect;
+    use crate::error::Error;
     use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
@@ -351,7 +352,7 @@ ENGINE=mito
       )
       PARTITION ON COLUMNS (host) ()
       engine=mito
-      with(regions=1, ttl='7d', compaction.type='world');
+      with(regions=1, ttl='7d', 'compaction.type'='world');
 ";
         let result =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
@@ -377,6 +378,6 @@ ENGINE=mito
 ";
         let result =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
-        assert!(matches!(result, Err(InvalidTableOption { .. })));
+        assert!(matches!(result, Err(Error::InvalidTableOption { .. })));
     }
 }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -230,7 +230,6 @@ pub struct CreateTableLike {
 #[cfg(test)]
 mod tests {
     use crate::dialect::GreptimeDbDialect;
-    use crate::error::Error::InvalidTableOption;
     use crate::parser::{ParseOptions, ParserContext};
     use crate::statements::statement::Statement;
 
@@ -355,7 +354,13 @@ ENGINE=mito
       with(regions=1, ttl='7d', hello='world');
 ";
         let result =
-            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
-        assert!(matches!(result, Err(InvalidTableOption { .. })))
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+        match &result[0] {
+            Statement::CreateTable(c) => {
+                assert_eq!(3, c.options.len());
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/store-api/src/lib.rs
+++ b/src/store-api/src/lib.rs
@@ -20,6 +20,7 @@ pub mod logstore;
 pub mod manifest;
 pub mod metadata;
 pub mod metric_engine_consts;
+pub mod mito_engine_options;
 pub mod path_utils;
 pub mod region_engine;
 pub mod region_request;

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Option keys for the mito engine.
+//! We define them in this mod so the create parser can use it to validate table options.
+
+use common_wal::options::WAL_OPTIONS_KEY;
+
+/// Returns true if the `key` is a valid option key for the mito engine.
+pub fn is_mito_engine_option_key(key: &str) -> bool {
+    [
+        "ttl",
+        "compaction.type",
+        "compaction.twcs.max_active_window_files",
+        "compaction.twcs.max_inactive_window_files",
+        "compaction.twcs.time_window",
+        "storage",
+        "index.inverted_index.ignore_column_ids",
+        "index.inverted_index.segment_row_count",
+        WAL_OPTIONS_KEY,
+    ]
+    .contains(&key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_mito_engine_option_key() {
+        assert!(is_mito_engine_option_key("ttl"));
+        assert!(is_mito_engine_option_key("compaction.type"));
+        assert!(is_mito_engine_option_key(
+            "compaction.twcs.max_active_window_files"
+        ));
+        assert!(is_mito_engine_option_key(
+            "compaction.twcs.max_inactive_window_files"
+        ));
+        assert!(is_mito_engine_option_key("compaction.twcs.time_window"));
+        assert!(is_mito_engine_option_key("storage"));
+        assert!(is_mito_engine_option_key(
+            "index.inverted_index.ignore_column_ids"
+        ));
+        assert!(is_mito_engine_option_key(
+            "index.inverted_index.segment_row_count"
+        ));
+        assert!(is_mito_engine_option_key("wal_options"));
+        assert!(!is_mito_engine_option_key("foo"));
+    }
+}

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -26,6 +26,7 @@ use datatypes::prelude::VectorRef;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use serde::{Deserialize, Serialize};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
+use store_api::mito_engine_options::is_mito_engine_option_key;
 use store_api::storage::RegionNumber;
 
 use crate::error;
@@ -38,8 +39,13 @@ pub const FILE_TABLE_LOCATION_KEY: &str = "location";
 pub const FILE_TABLE_PATTERN_KEY: &str = "pattern";
 pub const FILE_TABLE_FORMAT_KEY: &str = "format";
 
-pub fn valid_table_option(key: &str) -> bool {
+/// Returns true if the `key` is a valid key for any engine or storage.
+pub fn validate_table_option(key: &str) -> bool {
     if is_supported_in_s3(key) {
+        return true;
+    }
+
+    if is_mito_engine_option_key(key) {
         return true;
     }
 
@@ -353,14 +359,14 @@ mod tests {
 
     #[test]
     fn test_validate_table_option() {
-        assert!(valid_table_option(FILE_TABLE_LOCATION_KEY));
-        assert!(valid_table_option(FILE_TABLE_FORMAT_KEY));
-        assert!(valid_table_option(FILE_TABLE_PATTERN_KEY));
-        assert!(valid_table_option(TTL_KEY));
-        assert!(valid_table_option(REGIONS_KEY));
-        assert!(valid_table_option(WRITE_BUFFER_SIZE_KEY));
-        assert!(valid_table_option(STORAGE_KEY));
-        assert!(!valid_table_option("foo"));
+        assert!(validate_table_option(FILE_TABLE_LOCATION_KEY));
+        assert!(validate_table_option(FILE_TABLE_FORMAT_KEY));
+        assert!(validate_table_option(FILE_TABLE_PATTERN_KEY));
+        assert!(validate_table_option(TTL_KEY));
+        assert!(validate_table_option(REGIONS_KEY));
+        assert!(validate_table_option(WRITE_BUFFER_SIZE_KEY));
+        assert!(validate_table_option(STORAGE_KEY));
+        assert!(!validate_table_option("foo"));
     }
 
     #[test]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -19,13 +19,11 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
-use common_datasource::object_store::s3::is_supported_in_s3;
 use common_query::AddColumnLocation;
 use common_time::range::TimestampRange;
 use datatypes::prelude::VectorRef;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use serde::{Deserialize, Serialize};
-use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 use store_api::storage::RegionNumber;
 
 use crate::error;
@@ -315,21 +313,6 @@ impl TruncateTableRequest {
     }
 }
 
-pub fn valid_table_option(key: &str) -> bool {
-    matches!(
-        key,
-        FILE_TABLE_LOCATION_KEY
-            | FILE_TABLE_FORMAT_KEY
-            | FILE_TABLE_PATTERN_KEY
-            | WRITE_BUFFER_SIZE_KEY
-            | TTL_KEY
-            | REGIONS_KEY
-            | STORAGE_KEY
-            | PHYSICAL_TABLE_METADATA_KEY
-            | LOGICAL_TABLE_METADATA_KEY
-    ) | is_supported_in_s3(key)
-}
-
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct CopyDatabaseRequest {
     pub catalog_name: String,
@@ -343,18 +326,6 @@ pub struct CopyDatabaseRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_validate_table_option() {
-        assert!(valid_table_option(FILE_TABLE_LOCATION_KEY));
-        assert!(valid_table_option(FILE_TABLE_FORMAT_KEY));
-        assert!(valid_table_option(FILE_TABLE_PATTERN_KEY));
-        assert!(valid_table_option(TTL_KEY));
-        assert!(valid_table_option(REGIONS_KEY));
-        assert!(valid_table_option(WRITE_BUFFER_SIZE_KEY));
-        assert!(valid_table_option(STORAGE_KEY));
-        assert!(!valid_table_option("foo"));
-    }
 
     #[test]
     fn test_serialize_table_options() {

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -19,11 +19,13 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
+use common_datasource::object_store::s3::is_supported_in_s3;
 use common_query::AddColumnLocation;
 use common_time::range::TimestampRange;
 use datatypes::prelude::VectorRef;
 use datatypes::schema::{ColumnSchema, RawSchema};
 use serde::{Deserialize, Serialize};
+use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 use store_api::storage::RegionNumber;
 
 use crate::error;
@@ -35,6 +37,28 @@ pub const FILE_TABLE_META_KEY: &str = "__private.file_table_meta";
 pub const FILE_TABLE_LOCATION_KEY: &str = "location";
 pub const FILE_TABLE_PATTERN_KEY: &str = "pattern";
 pub const FILE_TABLE_FORMAT_KEY: &str = "format";
+
+pub fn valid_table_option(key: &str) -> bool {
+    if is_supported_in_s3(key) {
+        return true;
+    }
+
+    [
+        // common keys:
+        WRITE_BUFFER_SIZE_KEY,
+        TTL_KEY,
+        REGIONS_KEY,
+        STORAGE_KEY,
+        // file engine keys:
+        FILE_TABLE_LOCATION_KEY,
+        FILE_TABLE_FORMAT_KEY,
+        FILE_TABLE_PATTERN_KEY,
+        // metric engine keys:
+        PHYSICAL_TABLE_METADATA_KEY,
+        LOGICAL_TABLE_METADATA_KEY,
+    ]
+    .contains(&key)
+}
 
 #[derive(Debug, Clone)]
 pub struct CreateDatabaseRequest {
@@ -326,6 +350,18 @@ pub struct CopyDatabaseRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_table_option() {
+        assert!(valid_table_option(FILE_TABLE_LOCATION_KEY));
+        assert!(valid_table_option(FILE_TABLE_FORMAT_KEY));
+        assert!(valid_table_option(FILE_TABLE_PATTERN_KEY));
+        assert!(valid_table_option(TTL_KEY));
+        assert!(valid_table_option(REGIONS_KEY));
+        assert!(valid_table_option(WRITE_BUFFER_SIZE_KEY));
+        assert!(valid_table_option(STORAGE_KEY));
+        assert!(!valid_table_option("foo"));
+    }
 
     #[test]
     fn test_serialize_table_options() {

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -160,7 +160,7 @@ PARTITION ON COLUMNS (n) (
 }
 
 #[apply(both_instances_cases)]
-async fn test_validate_external_table_options(instance: Arc<dyn MockInstance>) {
+async fn test_extra_external_table_options(instance: Arc<dyn MockInstance>) {
     let frontend = instance.frontend();
     let format = "json";
     let location = find_testing_resource("/tests/data/json/various_type.json");
@@ -178,8 +178,8 @@ async fn test_validate_external_table_options(instance: Arc<dyn MockInstance>) {
           ) WITH (foo='bar', location='{location}', format='{format}');"#,
     );
 
-    let result = try_execute_sql(&frontend, sql).await;
-    assert!(matches!(result, Err(Error::ParseSql { .. })));
+    let output = execute_sql(&frontend, sql).await.data;
+    assert!(matches!(output, OutputData::AffectedRows(0)));
 }
 
 #[apply(both_instances_cases)]

--- a/tests-integration/src/tests/instance_test.rs
+++ b/tests-integration/src/tests/instance_test.rs
@@ -178,8 +178,8 @@ async fn test_extra_external_table_options(instance: Arc<dyn MockInstance>) {
           ) WITH (foo='bar', location='{location}', format='{format}');"#,
     );
 
-    let output = execute_sql(&frontend, sql).await.data;
-    assert!(matches!(output, OutputData::AffectedRows(0)));
+    let result = try_execute_sql(&frontend, sql).await;
+    assert!(matches!(result, Err(Error::ParseSql { .. })));
 }
 
 #[apply(both_instances_cases)]

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -55,3 +55,30 @@ drop table test_opts;
 
 Affected Rows: 0
 
+create table if not exists test_mito_options(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with(
+    'regions'=1,
+    'ttl'='7d',
+    'compaction.type'='twcs',
+    'compaction.twcs.max_active_window_files'='8',
+    'compaction.twcs.max_inactive_window_files'='2',
+    'compaction.twcs.time_window'='1d',
+    'index.inverted_index.ignore_column_ids'='1,2,3',
+    'index.inverted_index.segment_row_count'='512',
+    'wal_options'='{"wal.provider":"raft_engine"}',
+);
+
+Affected Rows: 0
+
+drop table test_mito_options;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -1,3 +1,26 @@
+CREATE TABLE not_supported_table_options_keys (
+  id INT UNSIGNED,
+  host STRING,
+  cpu DOUBLE,
+  disk FLOAT,
+  ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
+  TIME INDEX (ts),
+  PRIMARY KEY (id, host)
+)
+PARTITION ON COLUMNS (id) (
+  id < 5,
+  id >= 5 AND id < 9,
+  id >= 9
+)
+ENGINE=mito
+WITH(
+  foo = 123,
+  ttl = '7d',
+  write_buffer_size = 1024
+);
+
+Error: 1004(InvalidArguments), Unrecognized table option key: foo
+
 create table if not exists test_opts(
     host string,
     ts timestamp,

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -1,0 +1,34 @@
+create table if not exists test_opts(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with(regions=1, ttl='7d', 'compaction.twcs.time_window'='1d');
+
+Affected Rows: 0
+
+drop table test_opts;
+
+Affected Rows: 0
+
+create table if not exists test_opts(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('regions'=1, 'ttl'='7d', 'compaction.twcs.time_window'='1d');
+
+Affected Rows: 0
+
+drop table test_opts;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -7,7 +7,7 @@ create table if not exists test_opts(
     PRIMARY KEY(host)
 )
 engine=mito
-with(regions=1, ttl='7d', 'compaction.twcs.time_window'='1d');
+with(regions=1, ttl='7d', 'compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
 
 Affected Rows: 0
 
@@ -24,7 +24,7 @@ create table if not exists test_opts(
     PRIMARY KEY(host)
 )
 engine=mito
-with('regions'=1, 'ttl'='7d', 'compaction.twcs.time_window'='1d');
+with('regions'=1, 'ttl'='7d', 'compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -7,7 +7,7 @@ create table if not exists test_opts(
     PRIMARY KEY(host)
 )
 engine=mito
-with(regions=1, ttl='7d', 'compaction.twcs.time_window'='1d');
+with(regions=1, ttl='7d', 'compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
 
 drop table test_opts;
 
@@ -20,6 +20,6 @@ create table if not exists test_opts(
     PRIMARY KEY(host)
 )
 engine=mito
-with('regions'=1, 'ttl'='7d', 'compaction.twcs.time_window'='1d');
+with('regions'=1, 'ttl'='7d', 'compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
 
 drop table test_opts;

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -1,0 +1,25 @@
+create table if not exists test_opts(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with(regions=1, ttl='7d', 'compaction.twcs.time_window'='1d');
+
+drop table test_opts;
+
+create table if not exists test_opts(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('regions'=1, 'ttl'='7d', 'compaction.twcs.time_window'='1d');
+
+drop table test_opts;

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -44,3 +44,26 @@ engine=mito
 with('regions'=1, 'ttl'='7d', 'compaction.type'='twcs', 'compaction.twcs.time_window'='1d');
 
 drop table test_opts;
+
+create table if not exists test_mito_options(
+    host string,
+    ts timestamp,
+    cpu double default 0,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with(
+    'regions'=1,
+    'ttl'='7d',
+    'compaction.type'='twcs',
+    'compaction.twcs.max_active_window_files'='8',
+    'compaction.twcs.max_inactive_window_files'='2',
+    'compaction.twcs.time_window'='1d',
+    'index.inverted_index.ignore_column_ids'='1,2,3',
+    'index.inverted_index.segment_row_count'='512',
+    'wal_options'='{"wal.provider":"raft_engine"}',
+);
+
+drop table test_mito_options;

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -1,3 +1,24 @@
+CREATE TABLE not_supported_table_options_keys (
+  id INT UNSIGNED,
+  host STRING,
+  cpu DOUBLE,
+  disk FLOAT,
+  ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
+  TIME INDEX (ts),
+  PRIMARY KEY (id, host)
+)
+PARTITION ON COLUMNS (id) (
+  id < 5,
+  id >= 5 AND id < 9,
+  id >= 9
+)
+ENGINE=mito
+WITH(
+  foo = 123,
+  ttl = '7d',
+  write_buffer_size = 1024
+);
+
 create table if not exists test_opts(
     host string,
     ts timestamp,

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -77,29 +77,6 @@ drop table table_without_partition;
 
 Affected Rows: 0
 
-CREATE TABLE not_supported_table_options_keys (
-  id INT UNSIGNED,
-  host STRING,
-  cpu DOUBLE,
-  disk FLOAT,
-  ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
-  TIME INDEX (ts),
-  PRIMARY KEY (id, host)
-)
-PARTITION ON COLUMNS (id) (
-  id < 5,
-  id >= 5 AND id < 9,
-  id >= 9
-)
-ENGINE=mito
-WITH(
-  foo = 123,
-  ttl = '7d',
-  write_buffer_size = 1024
-);
-
-Error: 1004(InvalidArguments), Invalid table option key: foo
-
 CREATE TABLE not_supported_table_storage_option (
   id INT UNSIGNED,
   host STRING,

--- a/tests/cases/standalone/common/show/show_create.sql
+++ b/tests/cases/standalone/common/show/show_create.sql
@@ -30,26 +30,6 @@ show create table table_without_partition;
 
 drop table table_without_partition;
 
-CREATE TABLE not_supported_table_options_keys (
-  id INT UNSIGNED,
-  host STRING,
-  cpu DOUBLE,
-  disk FLOAT,
-  ts TIMESTAMP NOT NULL DEFAULT current_timestamp(),
-  TIME INDEX (ts),
-  PRIMARY KEY (id, host)
-)
-PARTITION ON COLUMNS (id) (
-  id < 5,
-  id >= 5 AND id < 9,
-  id >= 9
-)
-ENGINE=mito
-WITH(
-  foo = 123,
-  ttl = '7d',
-  write_buffer_size = 1024
-);
 CREATE TABLE not_supported_table_storage_option (
   id INT UNSIGNED,
   host STRING,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/3476

## What's changed and what's your intention?

This PR removes the validation for table options in the create parser as different engine might require different extra options.

Now we can specify engine related options via `with` statement. The following statement sets compaction time window to 1 day.
```sql
CREATE TABLE IF NOT EXISTS `test_table` (
    `ts` TIMESTAMP(3) NOT NULL DEFAULT current_timestamp(),
    `id` INT NULL,
    `content` STRING NULL,
    TIME INDEX (`ts`),
    PRIMARY KEY (`id`)
)
ENGINE=mito
WITH(
    'compaction.type' = 'twcs',
    'compaction.twcs.time_window' = '1d',
    regions = 1
);
```

Note that `compaction.type` is required if we want to set compaction options.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
