### PR TITLE
ci: use another mirror for etcd image

### DIFF
--- a/tests-integration/fixtures/etcd/docker-compose-standalone.yml
+++ b/tests-integration/fixtures/etcd/docker-compose-standalone.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   etcd:
-    image: public.ecr.aws/bitnami/etcd:3.5
+    image: ghcr.io/zcube/bitnami-compat/etcd:3.5
     ports:
       - "2379:2379"
       - "2380:2380"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Try to pull etcd from https://github.com/zcube/bitnami-compat/pkgs/container/bitnami-compat%2Fetcd to avoid rate limit. Another registry we can try is https://quay.io/repository/coreos/etcd?tab=tags&tag=latest

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
