### PR TITLE
ci: attempt to setup docker cache for etcd

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -282,7 +282,7 @@ jobs:
       - name: Docker Cache
         uses: ScribeMD/docker-cache@0.3.7
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles('tests-integration/fixtures/etcd/docker-compose-standalone.yml') }}
+          key: docker-${{ runner.os }}-coverage
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
       - name: Install cargo-llvm-cov

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -117,7 +117,7 @@ jobs:
           artifacts-dir: bins
           version: current
 
-  fuzztest: 
+  fuzztest:
     name: Fuzz Test
     needs: build
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
       - name: Unzip binaries
         run: tar -xvf ./bins.tar.gz
       - name: Run GreptimeDB
-        run: | 
+        run: |
           ./bins/greptime standalone start&
       - name: Fuzz Test
         uses: ./.github/actions/fuzz-test
@@ -279,6 +279,10 @@ jobs:
         with:
           # Shares cross multiple jobs
           shared-key: "coverage-test"
+      - name: Docker Cache
+        uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('tests-integration/fixtures/etcd/docker-compose-standalone.yml') }}
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Try to setup docker cache to prevent limitation of pulling etcd images.



## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
