### PR TITLE
feat: Partition memtables by time if compaction window is provided

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -35,6 +35,7 @@ pub mod key_values;
 pub mod merge_tree;
 pub mod time_series;
 pub(crate) mod version;
+pub mod time_partition;
 
 /// Id for memtables.
 ///

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -33,9 +33,9 @@ use crate::read::Batch;
 
 pub mod key_values;
 pub mod merge_tree;
+pub mod time_partition;
 pub mod time_series;
 pub(crate) mod version;
-pub mod time_partition;
 
 /// Id for memtables.
 ///

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -26,6 +26,7 @@ use table::predicate::Predicate;
 
 use crate::error::Result;
 use crate::flush::WriteBufferManagerRef;
+use crate::memtable::key_values::KeyValue;
 pub use crate::memtable::key_values::KeyValues;
 use crate::memtable::merge_tree::MergeTreeConfig;
 use crate::metrics::WRITE_BUFFER_BYTES;
@@ -83,8 +84,11 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Returns the id of this memtable.
     fn id(&self) -> MemtableId;
 
-    /// Write key values into the memtable.
+    /// Writes key values into the memtable.
     fn write(&self, kvs: &KeyValues) -> Result<()>;
+
+    /// Writes one key value pair into the memtable.
+    fn write_one(&self, key_value: KeyValue) -> Result<()>;
 
     /// Scans the memtable.
     /// `projection` selects columns to read, `None` means reading all columns.

--- a/src/mito2/src/memtable/key_values.rs
+++ b/src/mito2/src/memtable/key_values.rs
@@ -71,7 +71,7 @@ impl KeyValues {
 /// Primary key columns have the same order as region's primary key. Field
 /// columns are ordered by their position in the region schema (The same order
 /// as users defined while creating the region).
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct KeyValue<'a> {
     row: &'a Row,
     schema: &'a Vec<ColumnSchema>,

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -36,6 +36,7 @@ use table::predicate::Predicate;
 
 use crate::error::Result;
 use crate::flush::WriteBufferManagerRef;
+use crate::memtable::key_values::KeyValue;
 use crate::memtable::merge_tree::metrics::WriteMetrics;
 use crate::memtable::merge_tree::tree::MergeTree;
 use crate::memtable::{
@@ -121,6 +122,17 @@ impl Memtable for MergeTreeMemtable {
         let mut pk_buffer = Vec::new();
         // Ensures the memtable always updates stats.
         let res = self.tree.write(kvs, &mut pk_buffer, &mut metrics);
+
+        self.update_stats(&metrics);
+
+        res
+    }
+
+    fn write_one(&self, key_value: KeyValue) -> Result<()> {
+        let mut metrics = WriteMetrics::default();
+        let mut pk_buffer = Vec::new();
+        // Ensures the memtable always updates stats.
+        let res = self.tree.write_one(key_value, &mut pk_buffer, &mut metrics);
 
         self.update_stats(&metrics);
 

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -302,16 +302,14 @@ impl MemtableBuilder for MergeTreeMemtableBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use common_time::Timestamp;
     use datafusion_common::{Column, ScalarValue};
     use datafusion_expr::{BinaryExpr, Expr, Operator};
     use datatypes::scalars::ScalarVector;
-    use datatypes::vectors::{Int64Vector, TimestampMillisecondVector};
+    use datatypes::vectors::Int64Vector;
 
     use super::*;
-    use crate::test_util::memtable_util;
+    use crate::test_util::memtable_util::{self, collect_iter_timestamps};
 
     #[test]
     fn test_memtable_sorted_input() {
@@ -334,23 +332,10 @@ mod tests {
         let expected_ts = kvs
             .iter()
             .map(|kv| kv.timestamp().as_timestamp().unwrap().unwrap().value())
-            .collect::<BTreeSet<_>>();
+            .collect::<Vec<_>>();
 
         let iter = memtable.iter(None, None).unwrap();
-        let read = iter
-            .flat_map(|batch| {
-                batch
-                    .unwrap()
-                    .timestamps()
-                    .as_any()
-                    .downcast_ref::<TimestampMillisecondVector>()
-                    .unwrap()
-                    .iter_data()
-                    .collect::<Vec<_>>()
-                    .into_iter()
-            })
-            .map(|v| v.unwrap().0.value())
-            .collect::<BTreeSet<_>>();
+        let read = collect_iter_timestamps(iter);
         assert_eq!(expected_ts, read);
 
         let stats = memtable.stats();
@@ -398,20 +383,7 @@ mod tests {
         memtable.write(&kvs).unwrap();
 
         let iter = memtable.iter(None, None).unwrap();
-        let read = iter
-            .flat_map(|batch| {
-                batch
-                    .unwrap()
-                    .timestamps()
-                    .as_any()
-                    .downcast_ref::<TimestampMillisecondVector>()
-                    .unwrap()
-                    .iter_data()
-                    .collect::<Vec<_>>()
-                    .into_iter()
-            })
-            .map(|v| v.unwrap().0.value())
-            .collect::<Vec<_>>();
+        let read = collect_iter_timestamps(iter);
         assert_eq!(vec![0, 1, 2, 3, 4, 5, 6, 7], read);
 
         let iter = memtable.iter(None, None).unwrap();
@@ -526,20 +498,7 @@ mod tests {
 
         let expect = data.into_iter().map(|x| x.2).collect::<Vec<_>>();
         let iter = memtable.iter(None, None).unwrap();
-        let read = iter
-            .flat_map(|batch| {
-                batch
-                    .unwrap()
-                    .timestamps()
-                    .as_any()
-                    .downcast_ref::<TimestampMillisecondVector>()
-                    .unwrap()
-                    .iter_data()
-                    .collect::<Vec<_>>()
-                    .into_iter()
-            })
-            .map(|v| v.unwrap().0.value())
-            .collect::<Vec<_>>();
+        let read = collect_iter_timestamps(iter);
         assert_eq!(expect, read);
     }
 
@@ -576,20 +535,7 @@ mod tests {
             let iter = memtable
                 .iter(None, Some(Predicate::new(vec![expr.into()])))
                 .unwrap();
-            let read = iter
-                .flat_map(|batch| {
-                    batch
-                        .unwrap()
-                        .timestamps()
-                        .as_any()
-                        .downcast_ref::<TimestampMillisecondVector>()
-                        .unwrap()
-                        .iter_data()
-                        .collect::<Vec<_>>()
-                        .into_iter()
-                })
-                .map(|v| v.unwrap().0.value())
-                .collect::<Vec<_>>();
+            let read = collect_iter_timestamps(iter);
             assert_eq!(timestamps, read);
         }
     }

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -148,6 +148,54 @@ impl MergeTree {
         Ok(())
     }
 
+    /// Write one key value pair into the tree.
+    ///
+    /// # Panics
+    /// Panics if the tree is immutable (frozen).
+    pub fn write_one(
+        &self,
+        kv: KeyValue,
+        pk_buffer: &mut Vec<u8>,
+        metrics: &mut WriteMetrics,
+    ) -> Result<()> {
+        let has_pk = !self.metadata.primary_key.is_empty();
+
+        ensure!(
+            kv.num_primary_keys() == self.row_codec.num_fields(),
+            PrimaryKeyLengthMismatchSnafu {
+                expect: self.row_codec.num_fields(),
+                actual: kv.num_primary_keys(),
+            }
+        );
+        // Safety: timestamp of kv must be both present and a valid timestamp value.
+        let ts = kv.timestamp().as_timestamp().unwrap().unwrap().value();
+        metrics.min_ts = metrics.min_ts.min(ts);
+        metrics.max_ts = metrics.max_ts.max(ts);
+        metrics.value_bytes += kv.fields().map(|v| v.data_size()).sum::<usize>();
+
+        if !has_pk {
+            // No primary key.
+            return self.write_no_key(kv);
+        }
+
+        // Encode primary key.
+        pk_buffer.clear();
+        if self.is_partitioned {
+            // Use sparse encoder for metric engine.
+            self.sparse_encoder
+                .encode_to_vec(kv.primary_keys(), pk_buffer)?;
+        } else {
+            self.row_codec.encode_to_vec(kv.primary_keys(), pk_buffer)?;
+        }
+
+        // Write rows with
+        self.write_with_key(pk_buffer, kv, metrics)?;
+
+        metrics.value_bytes += std::mem::size_of::<Timestamp>() + std::mem::size_of::<OpType>();
+
+        Ok(())
+    }
+
     /// Scans the tree.
     pub fn read(
         &self,

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use common_time::Timestamp;
-use smallvec::SmallVec;
+use smallvec::{smallvec, SmallVec};
 use store_api::metadata::RegionMetadataRef;
 
 use crate::error::Result;
@@ -78,47 +78,89 @@ impl TimePartitions {
 
     /// Append memtables in partitions to `memtables`.
     pub fn list_memtables(&self, memtables: &mut Vec<MemtableRef>) {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        memtables.extend(inner.parts.iter().map(|part| part.memtable.clone()));
     }
 
     /// Returns the number of partitions.
     pub fn num_partitions(&self) -> usize {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        inner.parts.len()
     }
 
     /// Returns true if all memtables are empty.
     pub fn is_empty(&self) -> bool {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        inner.parts.is_empty()
     }
 
     /// Freezes all memtables.
     pub fn freeze(&self) -> Result<()> {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        for part in &*inner.parts {
+            part.memtable.freeze()?;
+        }
+        Ok(())
     }
 
     /// Forks latest partition.
     pub fn fork(&self, metadata: &RegionMetadataRef) -> Self {
-        unimplemented!()
+        let mut inner = self.inner.lock().unwrap();
+        let latest_part = inner
+            .parts
+            .iter()
+            .max_by_key(|part| part.time_range.map(|range| range.min_timestamp))
+            .cloned();
+
+        let Some(old_part) = latest_part else {
+            return Self::new(
+                metadata.clone(),
+                self.builder.clone(),
+                inner.next_memtable_id,
+                self.part_duration,
+            );
+        };
+        let memtable = old_part.memtable.fork(inner.alloc_memtable_id(), metadata);
+        let new_part = TimePartition {
+            memtable,
+            time_range: old_part.time_range,
+        };
+        Self {
+            inner: Mutex::new(PartitionsInner::with_partition(
+                new_part,
+                inner.next_memtable_id,
+            )),
+            part_duration: self.part_duration,
+            metadata: metadata.clone(),
+            builder: self.builder.clone(),
+        }
     }
 
     /// Returns partition duration.
     pub(crate) fn part_duration(&self) -> Option<Duration> {
-        unimplemented!()
+        self.part_duration
     }
 
     /// Returns memory usage.
     pub(crate) fn memory_usage(&self) -> usize {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        inner
+            .parts
+            .iter()
+            .map(|part| part.memtable.stats().estimated_bytes)
+            .sum()
     }
 
     /// Append memtables in partitions to small vec.
     pub(crate) fn list_memtables_to_small_vec(&self, memtables: &mut SmallMemtableVec) {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        memtables.extend(inner.parts.iter().map(|part| part.memtable.clone()));
     }
 
     /// Returns the next memtable id.
     pub(crate) fn next_memtable_id(&self) -> MemtableId {
-        unimplemented!()
+        let inner = self.inner.lock().unwrap();
+        inner.next_memtable_id
     }
 }
 
@@ -132,12 +174,28 @@ struct PartitionsInner {
 
 impl PartitionsInner {
     fn new(next_memtable_id: MemtableId) -> Self {
-        unimplemented!()
+        Self {
+            parts: Default::default(),
+            next_memtable_id,
+        }
+    }
+
+    fn with_partition(part: TimePartition, next_memtable_id: MemtableId) -> Self {
+        Self {
+            parts: smallvec![part],
+            next_memtable_id,
+        }
+    }
+
+    fn alloc_memtable_id(&mut self) -> MemtableId {
+        let id = self.next_memtable_id;
+        self.next_memtable_id += 1;
+        id
     }
 }
 
 /// Time range of a partition.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 struct PartTimeRange {
     /// Inclusive min timestamp of rows in the partition.
     min_timestamp: Timestamp,

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -152,7 +152,7 @@ impl TimePartitions {
     /// Returns true if all memtables are empty.
     pub fn is_empty(&self) -> bool {
         let inner = self.inner.lock().unwrap();
-        inner.parts.is_empty()
+        inner.parts.iter().all(|part| part.memtable.is_empty())
     }
 
     /// Freezes all memtables.
@@ -415,6 +415,7 @@ mod tests {
         let builder = Arc::new(MergeTreeMemtableBuilder::default());
         let partitions = TimePartitions::new(metadata.clone(), builder, 0, None);
         assert_eq!(1, partitions.num_partitions());
+        assert!(partitions.is_empty());
 
         let kvs = memtable_util::build_key_values(
             &metadata,
@@ -426,6 +427,7 @@ mod tests {
         partitions.write(&kvs).unwrap();
 
         assert_eq!(1, partitions.num_partitions());
+        assert!(!partitions.is_empty());
         assert!(!partitions.is_empty());
         let mut memtables = Vec::new();
         partitions.list_memtables(&mut memtables);
@@ -453,6 +455,7 @@ mod tests {
         // It should creates a new partition.
         partitions.write(&kvs).unwrap();
         assert_eq!(1, partitions.num_partitions());
+        assert!(!partitions.is_empty());
 
         let kvs = memtable_util::build_key_values(
             &metadata,
@@ -499,6 +502,7 @@ mod tests {
         // It should creates a new partition.
         partitions.write(&kvs).unwrap();
         assert_eq!(1, partitions.num_partitions());
+        assert!(!partitions.is_empty());
 
         let kvs = memtable_util::build_key_values(
             &metadata,

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -85,13 +85,14 @@ impl TimePartitions {
     ) -> Self {
         let mut inner = PartitionsInner::new(next_memtable_id);
         if part_duration.is_none() {
+            let memtable = builder.build(inner.alloc_memtable_id(), &metadata);
             debug!(
-                "Creates a time partition for all timestamps, region: {}",
-                metadata.region_id
+                "Creates a time partition for all timestamps, region: {}, memtable_id: {}",
+                metadata.region_id,
+                memtable.id(),
             );
-
             let part = TimePartition {
-                memtable: builder.build(inner.alloc_memtable_id(), &metadata),
+                memtable,
                 time_range: None,
             };
             inner.parts.push(part);
@@ -303,8 +304,11 @@ impl TimePartitions {
                         .builder
                         .build(inner.alloc_memtable_id(), &self.metadata);
                     debug!(
-                        "Create time partition {:?} for region {}, duration: {:?}",
-                        range, self.metadata.region_id, part_duration
+                        "Create time partition {:?} for region {}, duration: {:?}, memtable_id: {}",
+                        range,
+                        self.metadata.region_id,
+                        part_duration,
+                        memtable.id(),
                     );
                     let pos = inner.parts.len();
                     inner.parts.push(TimePartition {

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -1,0 +1,88 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Partitions memtables by time.
+
+use std::{time::Duration, sync::Mutex};
+
+use common_time::Timestamp;
+use smallvec::SmallVec;
+
+use crate::memtable::{MemtableRef, KeyValues, MemtableId};
+use crate::error::Result;
+
+/// A partition holds rows with timestamps between `[min, max)`.
+#[derive(Debug, Clone)]
+pub struct TimePartition {
+    /// Memtable of the partition.
+    memtable: MemtableRef,
+    /// Time range of the partition. `None` means there is no time range.
+    time_range: Option<PartTimeRange>
+}
+
+type PartitionVec = SmallVec<[TimePartition; 2]>;
+
+/// Partitions.
+#[derive(Debug)]
+pub struct TimePartitions {
+    /// Mutable data of partitions.
+    inner: Mutex<PartitionsInner>,
+    /// Duration of a partition.
+    ///
+    /// `None` means there is only one partition.
+    part_duration: Option<Duration>,
+}
+
+impl TimePartitions {
+    fn write(&self, kvs: &KeyValues) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Append memtables in partitions to `memtables`.
+    fn list_memtables(&self, memtables: &mut Vec<MemtableRef>) {
+        unimplemented!()
+    }
+
+    /// Returns true if all memtables are empty.
+    fn is_empty(&self) -> bool {
+        unimplemented!()
+    }
+
+    /// Freezes all memtables.
+    fn freeze(&self) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Forks latest partition.
+    fn fork(&self) -> Self {
+        unimplemented!()
+    }
+}
+
+#[derive(Debug)]
+struct PartitionsInner {
+    /// All partitions.
+    parts: PartitionVec,
+    /// Next memtable id.
+    next_memtable_id: MemtableId,
+}
+
+/// Time range of a partition.
+#[derive(Debug, Clone)]
+struct PartTimeRange {
+    /// Inclusive min timestamp of rows in the partition.
+    min_timestamp: Timestamp,
+    /// Exclusive max timestamp of rows in the partition.
+    max_timestamp: Timestamp,
+}

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -329,7 +329,7 @@ impl TimePartitions {
 ///
 /// It always use bucket size in seconds which should fit all timestamp resolution.
 fn partition_start_timestamp(ts: Timestamp, bucket: Duration) -> Option<Timestamp> {
-    // Safety: We convert it to seconds so it nerver returns Some.
+    // Safety: We convert it to seconds so it never returns Some.
     let ts_sec = ts.convert_to(TimeUnit::Second).unwrap();
     let bucket_sec: i64 = bucket.as_secs().try_into().ok()?;
     let start_sec = ts_sec.align_by_bucket(bucket_sec)?;

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -14,13 +14,16 @@
 
 //! Partitions memtables by time.
 
-use std::{time::Duration, sync::Mutex};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use common_time::Timestamp;
 use smallvec::SmallVec;
+use store_api::metadata::RegionMetadataRef;
 
-use crate::memtable::{MemtableRef, KeyValues, MemtableId};
 use crate::error::Result;
+use crate::memtable::version::SmallMemtableVec;
+use crate::memtable::{KeyValues, MemtableBuilderRef, MemtableId, MemtableRef};
 
 /// A partition holds rows with timestamps between `[min, max)`.
 #[derive(Debug, Clone)]
@@ -28,7 +31,7 @@ pub struct TimePartition {
     /// Memtable of the partition.
     memtable: MemtableRef,
     /// Time range of the partition. `None` means there is no time range.
-    time_range: Option<PartTimeRange>
+    time_range: Option<PartTimeRange>,
 }
 
 type PartitionVec = SmallVec<[TimePartition; 2]>;
@@ -42,30 +45,79 @@ pub struct TimePartitions {
     ///
     /// `None` means there is only one partition.
     part_duration: Option<Duration>,
+    /// Metadata of the region.
+    metadata: RegionMetadataRef,
+    /// Builder of memtables.
+    builder: MemtableBuilderRef,
 }
 
+pub type TimePartitionsRef = Arc<TimePartitions>;
+
 impl TimePartitions {
-    fn write(&self, kvs: &KeyValues) -> Result<()> {
+    /// Returns a new empty partition list with optional duration.
+    pub fn new(
+        metadata: RegionMetadataRef,
+        builder: MemtableBuilderRef,
+        next_memtable_id: MemtableId,
+        part_duration: Option<Duration>,
+    ) -> Self {
+        Self {
+            inner: Mutex::new(PartitionsInner::new(next_memtable_id)),
+            part_duration,
+            metadata,
+            builder,
+        }
+    }
+
+    /// Write key values to memtables.
+    ///
+    /// It creates new partitions if necessary.
+    pub fn write(&self, kvs: &KeyValues) -> Result<()> {
         unimplemented!()
     }
 
     /// Append memtables in partitions to `memtables`.
-    fn list_memtables(&self, memtables: &mut Vec<MemtableRef>) {
+    pub fn list_memtables(&self, memtables: &mut Vec<MemtableRef>) {
+        unimplemented!()
+    }
+
+    /// Returns the number of partitions.
+    pub fn num_partitions(&self) -> usize {
         unimplemented!()
     }
 
     /// Returns true if all memtables are empty.
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         unimplemented!()
     }
 
     /// Freezes all memtables.
-    fn freeze(&self) -> Result<()> {
+    pub fn freeze(&self) -> Result<()> {
         unimplemented!()
     }
 
     /// Forks latest partition.
-    fn fork(&self) -> Self {
+    pub fn fork(&self, metadata: &RegionMetadataRef) -> Self {
+        unimplemented!()
+    }
+
+    /// Returns partition duration.
+    pub(crate) fn part_duration(&self) -> Option<Duration> {
+        unimplemented!()
+    }
+
+    /// Returns memory usage.
+    pub(crate) fn memory_usage(&self) -> usize {
+        unimplemented!()
+    }
+
+    /// Append memtables in partitions to small vec.
+    pub(crate) fn list_memtables_to_small_vec(&self, memtables: &mut SmallMemtableVec) {
+        unimplemented!()
+    }
+
+    /// Returns the next memtable id.
+    pub(crate) fn next_memtable_id(&self) -> MemtableId {
         unimplemented!()
     }
 }
@@ -76,6 +128,12 @@ struct PartitionsInner {
     parts: PartitionVec,
     /// Next memtable id.
     next_memtable_id: MemtableId,
+}
+
+impl PartitionsInner {
+    fn new(next_memtable_id: MemtableId) -> Self {
+        unimplemented!()
+    }
 }
 
 /// Time range of a partition.

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -85,6 +85,11 @@ impl TimePartitions {
     ) -> Self {
         let mut inner = PartitionsInner::new(next_memtable_id);
         if part_duration.is_none() {
+            debug!(
+                "Creates a time partition for all timestamps, region: {}",
+                metadata.region_id
+            );
+
             let part = TimePartition {
                 memtable: builder.build(inner.alloc_memtable_id(), &metadata),
                 time_range: None,
@@ -298,7 +303,7 @@ impl TimePartitions {
                         .builder
                         .build(inner.alloc_memtable_id(), &self.metadata);
                     debug!(
-                        "Create partition {:?} for region {}, duration: {:?}",
+                        "Create time partition {:?} for region {}, duration: {:?}",
                         range, self.metadata.region_id, part_duration
                     );
                     let pos = inner.parts.len();

--- a/src/mito2/src/memtable/time_partition.rs
+++ b/src/mito2/src/memtable/time_partition.rs
@@ -304,11 +304,12 @@ impl TimePartitions {
                         .builder
                         .build(inner.alloc_memtable_id(), &self.metadata);
                     debug!(
-                        "Create time partition {:?} for region {}, duration: {:?}, memtable_id: {}",
+                        "Create time partition {:?} for region {}, duration: {:?}, memtable_id: {}, parts_total: {}",
                         range,
                         self.metadata.region_id,
                         part_duration,
                         memtable.id(),
+                        inner.parts.len() + 1
                     );
                     let pos = inner.parts.len();
                     inner.parts.push(TimePartition {

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -37,6 +37,7 @@ use crate::error::{
 };
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
 use crate::manifest::storage::manifest_compress_type;
+use crate::memtable::time_partition::TimePartitions;
 use crate::memtable::MemtableBuilderRef;
 use crate::region::options::RegionOptions;
 use crate::region::version::{VersionBuilder, VersionControl, VersionControlRef};
@@ -169,7 +170,13 @@ impl RegionOpener {
             RegionManifestManager::new(metadata.clone(), region_manifest_options).await?;
 
         // Initial memtable id is 0.
-        let mutable = self.memtable_builder.build(0, &metadata);
+        let part_duration = options.compaction.time_window();
+        let mutable = Arc::new(TimePartitions::new(
+            metadata.clone(),
+            self.memtable_builder,
+            0,
+            part_duration,
+        ));
 
         debug!("Create region {} with options: {:?}", region_id, options);
 
@@ -265,7 +272,13 @@ impl RegionOpener {
             self.cache_manager.clone(),
         ));
         // Initial memtable id is 0.
-        let mutable = self.memtable_builder.build(0, &metadata);
+        let part_duration = region_options.compaction.time_window();
+        let mutable = Arc::new(TimePartitions::new(
+            metadata.clone(),
+            self.memtable_builder.clone(),
+            0,
+            part_duration,
+        ));
         let version = VersionBuilder::new(metadata, mutable)
             .add_files(file_purger.clone(), manifest.files.values().cloned())
             .flushed_entry_id(manifest.flushed_entry_id)

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -94,6 +94,14 @@ pub enum CompactionOptions {
     Twcs(TwcsOptions),
 }
 
+impl CompactionOptions {
+    pub(crate) fn time_window(&self) -> Option<Duration> {
+        match self {
+            CompactionOptions::Twcs(opts) => opts.time_window,
+        }
+    }
+}
+
 impl Default for CompactionOptions {
     fn default() -> Self {
         Self::Twcs(TwcsOptions::default())

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -58,7 +58,7 @@ impl Memtable for EmptyMemtable {
         Ok(())
     }
 
-    fn write_one(&self, key_value: KeyValue) -> Result<()> {
+    fn write_one(&self, _key_value: KeyValue) -> Result<()> {
         Ok(())
     }
 

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -58,6 +58,10 @@ impl Memtable for EmptyMemtable {
         Ok(())
     }
 
+    fn write_one(&self, key_value: KeyValue) -> Result<()> {
+        Ok(())
+    }
+
     fn iter(
         &self,
         _projection: Option<&[ColumnId]>,

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -26,7 +26,6 @@ use store_api::storage::RegionId;
 
 use crate::manifest::action::RegionEdit;
 use crate::memtable::time_partition::TimePartitions;
-use crate::memtable::MemtableBuilder;
 use crate::region::version::{Version, VersionBuilder, VersionControl};
 use crate::sst::file::{FileId, FileMeta};
 use crate::sst::file_purger::FilePurgerRef;

--- a/src/mito2/src/test_util/version_util.rs
+++ b/src/mito2/src/test_util/version_util.rs
@@ -25,6 +25,7 @@ use store_api::metadata::{ColumnMetadata, RegionMetadata, RegionMetadataBuilder}
 use store_api::storage::RegionId;
 
 use crate::manifest::action::RegionEdit;
+use crate::memtable::time_partition::TimePartitions;
 use crate::memtable::MemtableBuilder;
 use crate::region::version::{Version, VersionBuilder, VersionControl};
 use crate::sst::file::{FileId, FileMeta};
@@ -101,7 +102,12 @@ impl VersionControlBuilder {
 
     pub(crate) fn build_version(&self) -> Version {
         let metadata = Arc::new(self.metadata.clone());
-        let mutable = self.memtable_builder.build(0, &metadata);
+        let mutable = Arc::new(TimePartitions::new(
+            metadata.clone(),
+            self.memtable_builder.clone(),
+            0,
+            None,
+        ));
         VersionBuilder::new(metadata, mutable)
             .add_files(self.file_purger.clone(), self.files.values().cloned())
             .build()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR introduces a new struct `TimePartitions` to partition mutable memtables by time.
- It uses the compaction time window (`compaction.twcs.time_window`) as the partition time range
- Each partition holds timestamps between `[start_time, start_time + time_window)`
- We uses the `timestamp / time_window * time_window` to locate the proper partition
- If the compaction time window is not provided, it only has one partition and all timestamps belong to that partition
- Once we freeze a memtable version,  we move all memtables in `TimePartitions` to immutable memtable list.


With this feature, a region can strictly divide data by the time in memory. It also ensures flushed SSTs only belong to a single time window.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
