### PR TITLE
fix!: remove error message from http header to avoid panic

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -605,9 +605,7 @@ macro_rules! define_into_tonic_status {
             fn from(err: $Error) -> Self {
                 use tonic::codegen::http::{HeaderMap, HeaderValue};
                 use tonic::metadata::MetadataMap;
-                use $crate::http::header::constants::{
-                    GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG,
-                };
+                use $crate::http::header::constants::GREPTIME_DB_HEADER_ERROR_CODE;
 
                 let mut headers = HeaderMap::<HeaderValue>::with_capacity(2);
 
@@ -619,10 +617,6 @@ macro_rules! define_into_tonic_status {
                     HeaderValue::from(status_code as u32),
                 );
                 let root_error = err.output_msg();
-
-                if let Ok(err_msg) = HeaderValue::from_bytes(root_error.as_bytes()) {
-                    let _ = headers.insert(GREPTIME_DB_HEADER_ERROR_MSG, err_msg);
-                }
 
                 let metadata = MetadataMap::from_headers(headers);
                 tonic::Status::with_metadata(

--- a/src/servers/src/http/error_result.rs
+++ b/src/servers/src/http/error_result.rs
@@ -21,7 +21,7 @@ use common_telemetry::logging::{debug, error};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::http::header::constants::{GREPTIME_DB_HEADER_ERROR_CODE, GREPTIME_DB_HEADER_ERROR_MSG};
+use crate::http::header::constants::GREPTIME_DB_HEADER_ERROR_CODE;
 use crate::http::header::{GREPTIME_DB_HEADER_EXECUTION_TIME, GREPTIME_DB_HEADER_FORMAT};
 use crate::http::ResponseFormat;
 
@@ -78,15 +78,10 @@ impl IntoResponse for ErrorResponse {
     fn into_response(self) -> Response {
         let ty = self.ty.as_str();
         let code = self.code;
-        let msg = self.error.clone();
         let execution_time = self.execution_time_ms;
         let mut resp = Json(self).into_response();
         resp.headers_mut()
             .insert(GREPTIME_DB_HEADER_ERROR_CODE, HeaderValue::from(code));
-        resp.headers_mut().insert(
-            GREPTIME_DB_HEADER_ERROR_MSG,
-            HeaderValue::from_str(&msg).expect("malformed error msg"),
-        );
         resp.headers_mut()
             .insert(&GREPTIME_DB_HEADER_FORMAT, HeaderValue::from_static(ty));
         resp.headers_mut().insert(

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -36,7 +36,6 @@ pub mod constants {
     pub const GREPTIME_DB_HEADER_NAME: &str = "x-greptime-db-name";
     pub const GREPTIME_TIMEZONE_HEADER_NAME: &str = "x-greptime-timezone";
     pub const GREPTIME_DB_HEADER_ERROR_CODE: &str = common_error::GREPTIME_DB_HEADER_ERROR_CODE;
-    pub const GREPTIME_DB_HEADER_ERROR_MSG: &str = common_error::GREPTIME_DB_HEADER_ERROR_MSG;
 }
 
 pub static GREPTIME_DB_HEADER_FORMAT: HeaderName =


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch removes `GREPTIME_DB_HEADER_ERROR_MSG` which tries to include error message in http header. Because the error message often contains characters that is invalid for http header, and the message size can also be too long for header.

Panic information:

```
2024-03-13T18:56:39.986929Z ERROR common_telemetry::panic_hook: panicked at greptimedb/src/servers/src/http/error_result.rs:88:41:
malformed error msg: InvalidHeaderValue backtrace=   0: common_telemetry::panic_hook::set_panic_hook::{{closure}}
             at home/runner/work/greptimedb-cloud/greptimedb-cloud/greptimedb/src/common/telemetry/src/panic_hook.rs:37:25
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/alloc/src/boxed.rs:2029:9
      std::panicking::rust_panic_with_hook
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/std/src/panicking.rs:783:13
   2: std::panicking::begin_panic_handler::{{closure}}
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/std/src/panicking.rs:657:13
   3: std::sys_common::backtrace::__rust_end_short_backtrace
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/std/src/sys_common/backtrace.rs:171:18
   4: rust_begin_unwind
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/std/src/panicking.rs:645:5
   5: core::panicking::panic_fmt
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/core/src/panicking.rs:72:14
   6: core::result::unwrap_failed
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/core/src/result.rs:1649:5
   7: core::result::Result<T,E>::expect
             at rustc/3f28fe133475ec5faf3413b556bf3cfb0d51336c/library/core/src/result.rs:1030:23
      <servers::http::error_result::ErrorResponse as axum_core::response::into_response::IntoResponse>::into_response
             at home/runner/work/greptimedb-cloud/greptimedb-cloud/greptimedb/src/servers/src/http/error_result.rs:88:13
   8: <servers::http::HttpResponse as axum_core::response::into_response::IntoResponse>::into_response
             at home/runner/work/greptimedb-cloud/greptimedb-cloud/greptimedb/src/servers/src/http.rs:354:42
   9: <F as axum::handler::Handler<(M,T1,T2,T3,T4),S,B>>::call::{{closure}}
             at home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/axum-0.6.20/src/handler/mod.rs:250:21
  10: <core::pin::Pin<P> as core::future::future::Future>::poll
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
