### PR TITLE
chore: bump version to v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1248,7 +1248,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1558,7 +1558,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1594,7 +1594,7 @@ dependencies = [
  "session",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -1677,7 +1677,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1720,7 +1720,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "common-base",
  "humantime-serde",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-recursion",
@@ -1992,11 +1992,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.7.0"
+version = "0.7.1"
 
 [[package]]
 name = "common-procedure"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "common-base",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "atty",
  "backtrace",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "client",
  "common-query",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2147,14 +2147,14 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "build-data",
 ]
 
 [[package]]
 name = "common-wal"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2860,7 +2860,7 @@ dependencies = [
  "snafu",
  "sql",
  "store-api",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "bimap",
@@ -3519,7 +3519,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -3583,7 +3583,7 @@ dependencies = [
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
  "strfmt",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "tokio",
  "toml 0.8.8",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4931,7 +4931,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anymap",
  "api",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anymap",
  "api",
@@ -6016,7 +6016,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -6306,7 +6306,7 @@ dependencies = [
  "sql",
  "sqlparser 0.38.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=6a93567ae38d42be5c8d08b13c8ff4dde26502ef)",
  "store-api",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "tokio",
  "tonic 0.10.2",
@@ -6537,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "async-trait",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "auth",
  "common-base",
@@ -7164,7 +7164,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash 0.8.6",
  "async-recursion",
@@ -7375,7 +7375,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -7496,7 +7496,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -7557,7 +7557,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -8874,7 +8874,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -9158,7 +9158,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aide",
  "api",
@@ -9264,7 +9264,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -9534,7 +9534,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "common-base",
@@ -9586,7 +9586,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9793,7 +9793,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -9933,7 +9933,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -10106,7 +10106,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anymap",
  "async-trait",
@@ -10218,7 +10218,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -10247,7 +10247,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -10304,7 +10304,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.7.0",
+ "substrait 0.7.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3509

## What's changed and what's your intention?
Bump version to v0.7.1

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
