### PR TITLE
docs: add v0.7 TSBS benchmark result

### DIFF
--- a/docs/benchmarks/tsbs/v0.7.0.md
+++ b/docs/benchmarks/tsbs/v0.7.0.md
@@ -23,15 +23,15 @@
 
 ## Write performance
 
-| Environment        | Ingest rate（rows/s） |
+| Environment        | Ingest rate (rows/s)  |
 | ------------------ | --------------------- |
-| Local              | 3695814.64             |
-| EC2 c5d.2xlarge    | 2987166.64             |
+| Local              | 3695814.64            |
+| EC2 c5d.2xlarge    | 2987166.64            |
 
 
 ## Query performance
 
-| Query type            | Local (ms) | EC2 c5d.2xlarge (ms) |
+| Query type            | Local (ms) | EC2 c5d.2xlarge (ms)   |
 | --------------------- | ---------- | ---------------------- |
 | cpu-max-all-1         | 30.56      | 54.74                  |
 | cpu-max-all-8         | 52.69      | 70.50                  |

--- a/docs/benchmarks/tsbs/v0.7.0.md
+++ b/docs/benchmarks/tsbs/v0.7.0.md
@@ -18,6 +18,7 @@
 | CPU     | 8 core         |
 | Memory  | 16GB           |
 | Disk    | 50GB (GP3)     |
+| OS      | Ubuntu 22.04.1 |
 
 
 ## Write performance

--- a/docs/benchmarks/tsbs/v0.7.0.md
+++ b/docs/benchmarks/tsbs/v0.7.0.md
@@ -1,0 +1,49 @@
+# TSBS benchmark - v0.7.0
+
+## Environment
+
+### Local
+|        |                                    |
+| ------ | ---------------------------------- |
+| CPU    | AMD Ryzen 7 7735HS (8 core 3.2GHz) |
+| Memory | 32GB                               |
+| Disk   | SOLIDIGM SSDPFKNU010TZ             |
+| OS     | Ubuntu 22.04.2 LTS                 |
+
+### Amazon EC2
+
+|         |                |
+| ------- | -------------- |
+| Machine | c5d.2xlarge    |
+| CPU     | 8 core         |
+| Memory  | 16GB           |
+| Disk    | 50GB (GP3)     |
+
+
+## Write performance
+
+| Environment        | Ingest rate（rows/s） |
+| ------------------ | --------------------- |
+| Local              | 3695814.64             |
+| EC2 c5d.2xlarge    | 2987166.64             |
+
+
+## Query performance
+
+| Query type            | Local (ms) | EC2 c5d.2xlarge (ms) |
+| --------------------- | ---------- | ---------------------- |
+| cpu-max-all-1         | 30.56      | 54.74                  |
+| cpu-max-all-8         | 52.69      | 70.50                  |
+| double-groupby-1      | 664.30     | 1366.63                |
+| double-groupby-5      | 1391.26    | 2141.71                |
+| double-groupby-all    | 2828.94    | 3389.59                |
+| groupby-orderby-limit | 718.92     | 1213.90                |
+| high-cpu-1            | 29.21      | 52.98                  |
+| high-cpu-all          | 5514.12    | 7194.91                |
+| lastpoint             | 7571.40    | 9423.41                |
+| single-groupby-1-1-1  | 19.09      | 7.77                   |
+| single-groupby-1-1-12 | 27.28      | 51.64                  |
+| single-groupby-1-8-1  | 31.85      | 11.64                  |
+| single-groupby-5-1-1  | 16.14      | 9.67                   |
+| single-groupby-5-1-12 | 27.21      | 53.62                  |
+| single-groupby-5-8-1  | 39.62      | 14.96                  |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR adds TSBS benchmark results of v0.7

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
