### PR TITLE
feat: acquire all locks in procedure 

### DIFF
--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -28,7 +28,8 @@ use async_trait::async_trait;
 use common_meta::key::datanode_table::DatanodeTableKey;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::kv_backend::ResettableKvBackendRef;
-use common_meta::lock_key::{RegionLock, TableLock};
+use common_meta::lock_key::{CatalogLock, RegionLock, SchemaLock, TableLock};
+use common_meta::table_name::TableName;
 use common_meta::{ClusterId, RegionIdent};
 use common_procedure::error::{
     Error as ProcedureError, FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu,
@@ -44,7 +45,7 @@ use snafu::ResultExt;
 use store_api::storage::{RegionId, RegionNumber};
 use table::metadata::TableId;
 
-use crate::error::{RegisterProcedureLoaderSnafu, Result, TableMetadataManagerSnafu};
+use crate::error::{self, RegisterProcedureLoaderSnafu, Result, TableMetadataManagerSnafu};
 use crate::lock::DistLockRef;
 use crate::metasrv::{SelectorContext, SelectorRef};
 use crate::service::mailbox::MailboxRef;
@@ -164,7 +165,14 @@ impl RegionFailoverManager {
             return Ok(());
         };
 
-        if !self.table_exists(failed_region).await? {
+        let table_info = self
+            .table_metadata_manager
+            .table_info_manager()
+            .get(failed_region.table_id)
+            .await
+            .context(error::TableMetadataManagerSnafu)?;
+
+        if table_info.is_none() {
             // The table could be dropped before the failure detector knows it. Then the region
             // failover is not needed.
             // Or the table could be renamed. But we will have a new region ident to detect failure.
@@ -178,7 +186,15 @@ impl RegionFailoverManager {
         }
 
         let context = self.create_context();
-        let procedure = RegionFailoverProcedure::new(failed_region.clone(), context);
+        // Safety: Check before.
+        let table_info = table_info.unwrap();
+        let TableName {
+            catalog_name,
+            schema_name,
+            ..
+        } = table_info.table_name();
+        let procedure =
+            RegionFailoverProcedure::new(catalog_name, schema_name, failed_region.clone(), context);
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
         let procedure_id = procedure_with_id.id;
         info!("Starting region failover procedure {procedure_id} for region {failed_region:?}");
@@ -206,16 +222,6 @@ impl RegionFailoverManager {
         Ok(())
     }
 
-    async fn table_exists(&self, failed_region: &RegionIdent) -> Result<bool> {
-        Ok(self
-            .table_metadata_manager
-            .table_route_manager()
-            .get_region_distribution(failed_region.table_id)
-            .await
-            .context(TableMetadataManagerSnafu)?
-            .is_some())
-    }
-
     async fn failed_region_exists(&self, failed_region: &RegionIdent) -> Result<bool> {
         let table_id = failed_region.table_id;
         let datanode_id = failed_region.datanode_id;
@@ -238,10 +244,17 @@ impl RegionFailoverManager {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+struct LockMeta {
+    catalog: String,
+    schema: String,
+}
+
 /// A "Node" in the state machine of region failover procedure.
 /// Contains the current state and the data.
 #[derive(Serialize, Deserialize, Debug)]
 struct Node {
+    lock_meta: LockMeta,
     failed_region: RegionIdent,
     state: Box<dyn State>,
 }
@@ -330,9 +343,15 @@ pub struct RegionFailoverProcedure {
 impl RegionFailoverProcedure {
     const TYPE_NAME: &'static str = "metasrv-procedure::RegionFailover";
 
-    pub fn new(failed_region: RegionIdent, context: RegionFailoverContext) -> Self {
+    pub fn new(
+        catalog: String,
+        schema: String,
+        failed_region: RegionIdent,
+        context: RegionFailoverContext,
+    ) -> Self {
         let state = RegionFailoverStart::new();
         let node = Node {
+            lock_meta: LockMeta { catalog, schema },
             failed_region,
             state: Box::new(state),
         };
@@ -372,8 +391,9 @@ impl Procedure for RegionFailoverProcedure {
 
     fn lock_key(&self) -> LockKey {
         let region_ident = &self.node.failed_region;
-        // TODO(weny): acquires the catalog, schema read locks.
         let lock_key = vec![
+            CatalogLock::Read(&self.node.lock_meta.catalog).into(),
+            SchemaLock::read(&self.node.lock_meta.catalog, &self.node.lock_meta.catalog).into(),
             TableLock::Read(region_ident.table_id).into(),
             RegionLock::Write(RegionId::new(
                 region_ident.table_id,
@@ -568,6 +588,8 @@ mod tests {
         let failed_region = env.failed_region(1).await;
 
         let mut procedure = Box::new(RegionFailoverProcedure::new(
+            "greptime".into(),
+            "public".into(),
             failed_region.clone(),
             env.context.clone(),
         )) as BoxedProcedure;
@@ -671,7 +693,7 @@ mod tests {
 
         assert_eq!(
             procedure.dump().unwrap(),
-            r#"{"failed_region":{"cluster_id":0,"datanode_id":1,"table_id":1,"region_number":1,"engine":"mito2"},"state":{"region_failover_state":"RegionFailoverEnd"}}"#
+            r#"{"lock_meta":{"catalog":"greptime","schema":"public"},"failed_region":{"cluster_id":0,"datanode_id":1,"table_id":1,"region_number":1,"engine":"mito2"},"state":{"region_failover_state":"RegionFailoverEnd"}}"#
         );
 
         // Verifies that the failed region (region 1) is moved from failed datanode (datanode 1) to the candidate datanode.
@@ -700,6 +722,10 @@ mod tests {
 
         let state = RegionFailoverStart::new();
         let node = Node {
+            lock_meta: LockMeta {
+                catalog: "greptime".into(),
+                schema: "public".into(),
+            },
             failed_region,
             state: Box::new(state),
         };
@@ -711,12 +737,12 @@ mod tests {
         let s = procedure.dump().unwrap();
         assert_eq!(
             s,
-            r#"{"failed_region":{"cluster_id":0,"datanode_id":1,"table_id":1,"region_number":1,"engine":"mito2"},"state":{"region_failover_state":"RegionFailoverStart","failover_candidate":null}}"#
+            r#"{"lock_meta":{"catalog":"greptime","schema":"public"},"failed_region":{"cluster_id":0,"datanode_id":1,"table_id":1,"region_number":1,"engine":"mito2"},"state":{"region_failover_state":"RegionFailoverStart","failover_candidate":null}}"#,
         );
         let n: Node = serde_json::from_str(&s).unwrap();
         assert_eq!(
             format!("{n:?}"),
-            r#"Node { failed_region: RegionIdent { cluster_id: 0, datanode_id: 1, table_id: 1, region_number: 1, engine: "mito2" }, state: RegionFailoverStart { failover_candidate: None } }"#
+            r#"Node { lock_meta: LockMeta { catalog: "greptime", schema: "public" }, failed_region: RegionIdent { cluster_id: 0, datanode_id: 1, table_id: 1, region_number: 1, engine: "mito2" }, state: RegionFailoverStart { failover_candidate: None } }"#,
         );
     }
 
@@ -765,6 +791,10 @@ mod tests {
 
         let state = RegionFailoverStart::new();
         let node = Node {
+            lock_meta: LockMeta {
+                catalog: "greptime".into(),
+                schema: "public".into(),
+            },
             failed_region,
             state: Box::new(state),
         };

--- a/src/meta-srv/src/procedure/region_migration.rs
+++ b/src/meta-srv/src/procedure/region_migration.rs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 pub(crate) mod downgrade_leader_region;
-// TODO(weny): remove it.
-#[allow(dead_code)]
 pub(crate) mod manager;
 pub(crate) mod migration_abort;
 pub(crate) mod migration_end;
@@ -185,8 +183,6 @@ impl ContextFactory for DefaultContextFactory {
     }
 }
 
-// TODO(weny): remove it.
-#[allow(dead_code)]
 /// The context of procedure execution.
 pub struct Context {
     persistent_ctx: PersistentContext,
@@ -368,7 +364,6 @@ pub struct RegionMigrationProcedure {
     context: Context,
 }
 
-// TODO(weny): remove it.
 #[allow(dead_code)]
 impl RegionMigrationProcedure {
     const TYPE_NAME: &'static str = "metasrv-procedure::RegionMigration";

--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -226,6 +226,8 @@ mod tests {
 
     fn new_persistent_context() -> PersistentContext {
         PersistentContext {
+            catalog: "greptime".into(),
+            schema: "public".into(),
             from_peer: Peer::empty(1),
             to_peer: Peer::empty(2),
             region_id: RegionId::new(1024, 1),

--- a/src/meta-srv/src/procedure/region_migration/manager.rs
+++ b/src/meta-srv/src/procedure/region_migration/manager.rs
@@ -18,9 +18,11 @@ use std::fmt::Display;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
+use common_meta::key::table_info::TableInfoValue;
 use common_meta::key::table_route::TableRouteValue;
 use common_meta::peer::Peer;
 use common_meta::rpc::router::RegionRoute;
+use common_meta::table_name::TableName;
 use common_meta::ClusterId;
 use common_procedure::{watcher, ProcedureId, ProcedureManagerRef, ProcedureWithId};
 use common_telemetry::{error, info};
@@ -90,26 +92,6 @@ impl Display for RegionMigrationProcedureTask {
             "cluster: {}, region: {}, from_peer: {}, to_peer: {}",
             self.cluster_id, self.region_id, self.from_peer, self.to_peer
         )
-    }
-}
-
-impl From<RegionMigrationProcedureTask> for PersistentContext {
-    fn from(
-        RegionMigrationProcedureTask {
-            cluster_id,
-            region_id,
-            from_peer,
-            to_peer,
-            replay_timeout,
-        }: RegionMigrationProcedureTask,
-    ) -> Self {
-        PersistentContext {
-            cluster_id,
-            from_peer,
-            to_peer,
-            region_id,
-            replay_timeout,
-        }
     }
 }
 
@@ -184,6 +166,22 @@ impl RegionMigrationManager {
             .context(error::TableRouteNotFoundSnafu {
                 table_id: region_id.table_id(),
             })?;
+
+        Ok(table_route)
+    }
+
+    async fn retrieve_table_info(&self, region_id: RegionId) -> Result<TableInfoValue> {
+        let table_route = self
+            .context_factory
+            .table_metadata_manager
+            .table_info_manager()
+            .get(region_id.table_id())
+            .await
+            .context(error::TableMetadataManagerSnafu)?
+            .context(error::TableInfoNotFoundSnafu {
+                table_id: region_id.table_id(),
+            })?
+            .into_inner();
 
         Ok(table_route)
     }
@@ -279,8 +277,31 @@ impl RegionMigrationManager {
 
         self.verify_region_leader_peer(&region_route, &task)?;
 
-        let procedure =
-            RegionMigrationProcedure::new(task.clone().into(), self.context_factory.clone());
+        let table_info = self.retrieve_table_info(region_id).await?;
+        let TableName {
+            catalog_name,
+            schema_name,
+            ..
+        } = table_info.table_name();
+        let RegionMigrationProcedureTask {
+            cluster_id,
+            region_id,
+            from_peer,
+            to_peer,
+            replay_timeout,
+        } = task.clone();
+        let procedure = RegionMigrationProcedure::new(
+            PersistentContext {
+                catalog: catalog_name,
+                schema: schema_name,
+                cluster_id,
+                region_id,
+                from_peer,
+                to_peer,
+                replay_timeout,
+            },
+            self.context_factory.clone(),
+        );
         let procedure_with_id = ProcedureWithId::with_random_id(Box::new(procedure));
         let procedure_id = procedure_with_id.id;
         info!("Starting region migration procedure {procedure_id} for {task}");

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -297,16 +297,6 @@ pub(crate) struct ProcedureMigrationTestSuite {
 pub(crate) type BeforeTest =
     Arc<dyn Fn(&mut ProcedureMigrationTestSuite) -> BoxFuture<'_, ()> + Send + Sync>;
 
-/// Custom assertion.
-pub(crate) type CustomAssertion = Arc<
-    dyn Fn(
-            &mut ProcedureMigrationTestSuite,
-            Result<(Box<dyn State>, Status)>,
-        ) -> BoxFuture<'_, Result<()>>
-        + Send
-        + Sync,
->;
-
 /// State assertion function.
 pub(crate) type StateAssertion = Arc<dyn Fn(&dyn State) + Send + Sync>;
 
@@ -316,14 +306,11 @@ pub(crate) type StatusAssertion = Arc<dyn Fn(Status) + Send + Sync>;
 /// Error assertion function.
 pub(crate) type ErrorAssertion = Arc<dyn Fn(Error) + Send + Sync>;
 
-// TODO(weny): Remove it.
-#[allow(dead_code)]
 /// The type of assertion.
 #[derive(Clone)]
 pub(crate) enum Assertion {
     Simple(StateAssertion, StatusAssertion),
     Error(ErrorAssertion),
-    Custom(CustomAssertion),
 }
 
 impl Assertion {
@@ -383,9 +370,6 @@ impl ProcedureMigrationTestSuite {
             Assertion::Error(error_assert) => {
                 let error = result.unwrap_err();
                 error_assert(error);
-            }
-            Assertion::Custom(assert_fn) => {
-                assert_fn(self, result).await?;
             }
         }
 

--- a/src/meta-srv/src/procedure/region_migration/test_util.rs
+++ b/src/meta-srv/src/procedure/region_migration/test_util.rs
@@ -278,6 +278,8 @@ pub fn send_mock_reply(
 /// Generates a [PersistentContext].
 pub fn new_persistent_context(from: u64, to: u64, region_id: RegionId) -> PersistentContext {
     PersistentContext {
+        catalog: "greptime".into(),
+        schema: "public".into(),
         from_peer: Peer::empty(from),
         to_peer: Peer::empty(to),
         region_id,

--- a/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/upgrade_candidate_region.rs
@@ -232,6 +232,8 @@ mod tests {
 
     fn new_persistent_context() -> PersistentContext {
         PersistentContext {
+            catalog: "greptime".into(),
+            schema: "public".into(),
             from_peer: Peer::empty(1),
             to_peer: Peer::empty(2),
             region_id: RegionId::new(1024, 1),

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -346,6 +346,8 @@ async fn run_region_failover_procedure(
     let meta_srv = &cluster.meta_srv;
     let procedure_manager = meta_srv.procedure_manager();
     let procedure = RegionFailoverProcedure::new(
+        "greptime".into(),
+        "public".into(),
         failed_region.clone(),
         RegionFailoverContext {
             region_lease_secs: 10,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#825 
## What's changed and what's your intention?

To implement the `Drop Database` procedure, we must ensure all procedures acquire a lock from the top to the leaf (Ensure that the locks of each procedure intersect).

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
