### PR TITLE
feat(metasrv): implement maintenance

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -90,13 +90,13 @@ use crate::kv_backend::KvBackendRef;
 use crate::rpc::router::{region_distribution, RegionRoute, RegionStatus};
 use crate::DatanodeId;
 
-pub const REMOVED_PREFIX: &str = "__removed";
-
 pub const NAME_PATTERN: &str = r"[a-zA-Z_:-][a-zA-Z0-9_:\-\.]*";
+pub const MAINTENANCE_KEY: &str = "maintenance";
 
 const DATANODE_TABLE_KEY_PREFIX: &str = "__dn_table";
 const TABLE_REGION_KEY_PREFIX: &str = "__table_region";
 
+pub const REMOVED_PREFIX: &str = "__removed";
 pub const TABLE_INFO_KEY_PREFIX: &str = "__table_info";
 pub const TABLE_NAME_KEY_PREFIX: &str = "__table_name";
 pub const CATALOG_NAME_KEY_PREFIX: &str = "__catalog_name";

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -301,6 +301,14 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to parse bool: {}", err_msg))]
+    ParseBool {
+        err_msg: String,
+        #[snafu(source)]
+        error: std::str::ParseBoolError,
+        location: Location,
+    },
+
     #[snafu(display("Invalid arguments: {}", err_msg))]
     InvalidArguments { err_msg: String, location: Location },
 
@@ -709,6 +717,7 @@ impl ErrorExt for Error {
             | Error::InvalidStatKey { .. }
             | Error::InvalidInactiveRegionKey { .. }
             | Error::ParseNum { .. }
+            | Error::ParseBool { .. }
             | Error::ParseAddr { .. }
             | Error::ParseDuration { .. }
             | Error::UnsupportedSelectorType { .. }

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -170,7 +170,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_maintenance_mode() {
         let region_failover_manager = create_region_failover_manager();
-        let in_memory = region_failover_manager.create_context().in_memory.clone();
+        let kv_backend = region_failover_manager.create_context().kv_backend.clone();
         let _handler = RegionFailureHandler::try_new(
             None,
             region_failover_manager.clone(),
@@ -184,13 +184,13 @@ mod tests {
             value: vec![],
             prev_kv: false,
         };
-        let _ = in_memory.put(kv_req.clone()).await.unwrap();
+        let _ = kv_backend.put(kv_req.clone()).await.unwrap();
         assert_matches!(
             region_failover_manager.is_maintenance_mode().await,
             Ok(true)
         );
 
-        let _ = in_memory
+        let _ = kv_backend
             .delete(MAINTENANCE_KEY.as_bytes(), false)
             .await
             .unwrap();

--- a/src/meta-srv/src/handler/failure_handler.rs
+++ b/src/meta-srv/src/handler/failure_handler.rs
@@ -107,6 +107,9 @@ impl HeartbeatHandler for RegionFailureHandler {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches::assert_matches;
+
+    use common_meta::key::MAINTENANCE_KEY;
     use store_api::region_engine::RegionRole;
     use store_api::storage::RegionId;
 
@@ -162,5 +165,38 @@ mod tests {
         handler.handle(req, &mut ctx, acc).await.unwrap();
         let dump = handler.failure_detect_runner.dump().await;
         assert_eq!(dump.iter().collect::<Vec<_>>().len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_maintenance_mode() {
+        let region_failover_manager = create_region_failover_manager();
+        let in_memory = region_failover_manager.create_context().in_memory.clone();
+        let _handler = RegionFailureHandler::try_new(
+            None,
+            region_failover_manager.clone(),
+            PhiAccrualFailureDetectorOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let kv_req = common_meta::rpc::store::PutRequest {
+            key: Vec::from(MAINTENANCE_KEY),
+            value: vec![],
+            prev_kv: false,
+        };
+        let _ = in_memory.put(kv_req.clone()).await.unwrap();
+        assert_matches!(
+            region_failover_manager.is_maintenance_mode().await,
+            Ok(true)
+        );
+
+        let _ = in_memory
+            .delete(MAINTENANCE_KEY.as_bytes(), false)
+            .await
+            .unwrap();
+        assert_matches!(
+            region_failover_manager.is_maintenance_mode().await,
+            Ok(false)
+        );
     }
 }

--- a/src/meta-srv/src/handler/failure_handler/runner.rs
+++ b/src/meta-srv/src/handler/failure_handler/runner.rs
@@ -151,7 +151,7 @@ impl FailureDetectRunner {
                         return;
                     }
                     Err(err) => {
-                        error!("Failed to check maintenance mode: {}", err);
+                        error!(err; "Failed to check maintenance mode");
                         return;
                     }
                 }

--- a/src/meta-srv/src/handler/failure_handler/runner.rs
+++ b/src/meta-srv/src/handler/failure_handler/runner.rs
@@ -140,51 +140,59 @@ impl FailureDetectRunner {
         let election = self.election.clone();
         let region_failover_manager = self.region_failover_manager.clone();
         let runner_handle = common_runtime::spawn_bg(async move {
+            async fn maybe_region_failover(
+                failure_detectors: &Arc<FailureDetectorContainer>,
+                region_failover_manager: &Arc<RegionFailoverManager>,
+            ) {
+                match region_failover_manager.is_maintenance_mode().await {
+                    Ok(false) => {}
+                    Ok(true) => {
+                        info!("Maintenance mode is enabled, skip failover");
+                        return;
+                    }
+                    Err(err) => {
+                        error!("Failed to check maintenance mode: {}", err);
+                        return;
+                    }
+                }
+
+                let failed_regions = failure_detectors
+                    .iter()
+                    .filter_map(|e| {
+                        // Intentionally not place `current_time_millis()` out of the iteration.
+                        // The failure detection determination should be happened "just in time",
+                        // i.e., failed or not has to be compared with the most recent "now".
+                        // Besides, it might reduce the false positive of failure detection,
+                        // because during the iteration, heartbeats are coming in as usual,
+                        // and the `phi`s are still updating.
+                        if !e.failure_detector().is_available(current_time_millis()) {
+                            Some(e.region_ident().clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<RegionIdent>>();
+
+                for r in failed_regions {
+                    if let Err(e) = region_failover_manager.do_region_failover(&r).await {
+                        error!(e; "Failed to do region failover for {r}");
+                    } else {
+                        // Now that we know the region is starting to do failover, remove it
+                        // from the failure detectors, avoiding the failover procedure to be
+                        // triggered again.
+                        // If the region is back alive (the failover procedure runs successfully),
+                        // it will be added back to the failure detectors again.
+                        failure_detectors.remove(&r);
+                    }
+                }
+            }
+
             loop {
                 let start = Instant::now();
 
                 let is_leader = election.as_ref().map(|x| x.is_leader()).unwrap_or(true);
                 if is_leader {
-                    let failed_regions = failure_detectors
-                        .iter()
-                        .filter_map(|e| {
-                            // Intentionally not place `current_time_millis()` out of the iteration.
-                            // The failure detection determination should be happened "just in time",
-                            // i.e., failed or not has to be compared with the most recent "now".
-                            // Besides, it might reduce the false positive of failure detection,
-                            // because during the iteration, heartbeats are coming in as usual,
-                            // and the `phi`s are still updating.
-                            if !e.failure_detector().is_available(current_time_millis()) {
-                                Some(e.region_ident().clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<Vec<RegionIdent>>();
-
-                    match region_failover_manager.is_maintenance_mode().await {
-                        Ok(false) => {
-                            for r in failed_regions {
-                                if let Err(e) = region_failover_manager.do_region_failover(&r).await
-                                {
-                                    error!(e; "Failed to do region failover for {r}");
-                                } else {
-                                    // Now that we know the region is starting to do failover, remove it
-                                    // from the failure detectors, avoiding the failover procedure to be
-                                    // triggered again.
-                                    // If the region is back alive (the failover procedure runs successfully),
-                                    // it will be added back to the failure detectors again.
-                                    failure_detectors.remove(&r);
-                                }
-                            }
-                        }
-                        Ok(true) => {
-                            info!("Maintenance mode is enabled, skip failover");
-                        }
-                        Err(err) => {
-                            error!("Failed to check maintenance mode: {}", err);
-                        }
-                    }
+                    maybe_region_failover(&failure_detectors, &region_failover_manager).await;
                 }
 
                 let elapsed = Instant::now().duration_since(start);

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -22,11 +22,10 @@ use common_base::Plugins;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
 use common_grpc::channel_manager;
 use common_meta::ddl::ProcedureExecutorRef;
-use common_meta::key::{TableMetadataManagerRef, MAINTENANCE_KEY};
+use common_meta::key::TableMetadataManagerRef;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackend, ResettableKvBackendRef};
 use common_meta::peer::Peer;
 use common_meta::region_keeper::MemoryRegionKeeperRef;
-use common_meta::rpc::store::PutRequest;
 use common_meta::wal_options_allocator::WalOptionsAllocatorRef;
 use common_meta::{distributed_time_constants, ClusterId};
 use common_procedure::options::ProcedureConfig;
@@ -363,20 +362,6 @@ impl MetaSrv {
                 .start()
                 .await
                 .context(StartProcedureManagerSnafu)?;
-        }
-
-        if self
-            .kv_backend
-            .exists(MAINTENANCE_KEY.as_bytes())
-            .await
-            .context(KvBackendSnafu)?
-        {
-            let req = PutRequest {
-                key: Vec::from(MAINTENANCE_KEY),
-                value: vec![],
-                prev_kv: false,
-            };
-            self.in_memory.put(req).await.context(KvBackendSnafu)?;
         }
 
         info!("MetaSrv started");

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -260,6 +260,7 @@ impl MetaSrvBuilder {
                     let region_failover_manager = Arc::new(RegionFailoverManager::new(
                         distributed_time_constants::REGION_LEASE_SECS,
                         in_memory.clone(),
+                        kv_backend.clone(),
                         mailbox.clone(),
                         procedure_manager.clone(),
                         (selector.clone(), selector_ctx.clone()),

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -26,7 +26,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common_meta::key::datanode_table::DatanodeTableKey;
-use common_meta::key::TableMetadataManagerRef;
+use common_meta::key::{TableMetadataManagerRef, MAINTENANCE_KEY};
 use common_meta::kv_backend::ResettableKvBackendRef;
 use common_meta::lock_key::{CatalogLock, RegionLock, SchemaLock, TableLock};
 use common_meta::table_name::TableName;
@@ -157,6 +157,10 @@ impl RegionFailoverManager {
         } else {
             None
         }
+    }
+
+    pub(crate) async fn is_maintenance_mode(&self) -> Result<bool> {
+        self.in_memory.exists(MAINTENANCE_KEY.as_bytes()).await
     }
 
     pub(crate) async fn do_region_failover(&self, failed_region: &RegionIdent) -> Result<()> {

--- a/src/meta-srv/src/procedure/region_failover.rs
+++ b/src/meta-srv/src/procedure/region_failover.rs
@@ -45,7 +45,9 @@ use snafu::ResultExt;
 use store_api::storage::{RegionId, RegionNumber};
 use table::metadata::TableId;
 
-use crate::error::{self, RegisterProcedureLoaderSnafu, Result, TableMetadataManagerSnafu};
+use crate::error::{
+    self, KvBackendSnafu, RegisterProcedureLoaderSnafu, Result, TableMetadataManagerSnafu,
+};
 use crate::lock::DistLockRef;
 use crate::metasrv::{SelectorContext, SelectorRef};
 use crate::service::mailbox::MailboxRef;
@@ -160,7 +162,10 @@ impl RegionFailoverManager {
     }
 
     pub(crate) async fn is_maintenance_mode(&self) -> Result<bool> {
-        self.in_memory.exists(MAINTENANCE_KEY.as_bytes()).await
+        self.in_memory
+            .exists(MAINTENANCE_KEY.as_bytes())
+            .await
+            .context(KvBackendSnafu)
     }
 
     pub(crate) async fn do_region_failover(&self, failed_region: &RegionIdent) -> Result<()> {

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -15,10 +15,9 @@
 mod health;
 mod heartbeat;
 mod leader;
+mod maintenance;
 mod meta;
-// TODO(weny): removes it.
 mod node_lease;
-#[allow(dead_code)]
 mod region_migration;
 mod route;
 mod util;
@@ -98,6 +97,14 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
         meta_peer_client: meta_srv.meta_peer_client().clone(),
     };
     let router = router.route("/region-migration", handler);
+
+    let handler = maintenance::MaintenanceHandler {
+        kv_backend: meta_srv.kv_backend().clone(),
+        in_memory: meta_srv.in_memory().clone(),
+    };
+    let router = router
+        .route("/maintenance", handler.clone())
+        .route("/maintenance/set", handler);
 
     let router = Router::nest("/admin", router);
 

--- a/src/meta-srv/src/service/admin.rs
+++ b/src/meta-srv/src/service/admin.rs
@@ -100,7 +100,6 @@ pub fn make_admin_service(meta_srv: MetaSrv) -> Admin {
 
     let handler = maintenance::MaintenanceHandler {
         kv_backend: meta_srv.kv_backend().clone(),
-        in_memory: meta_srv.in_memory().clone(),
     };
     let router = router
         .route("/maintenance", handler.clone())

--- a/src/meta-srv/src/service/admin/maintenance.rs
+++ b/src/meta-srv/src/service/admin/maintenance.rs
@@ -62,13 +62,12 @@ impl MaintenanceHandler {
                 err_msg: "'enable' must be 'true' or 'false'",
             })?;
 
-        let req = PutRequest {
-            key: Vec::from(MAINTENANCE_KEY),
-            value: vec![],
-            prev_kv: false,
-        };
-
         let response = if enable {
+            let req = PutRequest {
+                key: Vec::from(MAINTENANCE_KEY),
+                value: vec![],
+                prev_kv: false,
+            };
             self.kv_backend
                 .put(req.clone())
                 .await

--- a/src/meta-srv/src/service/admin/maintenance.rs
+++ b/src/meta-srv/src/service/admin/maintenance.rs
@@ -1,0 +1,99 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+
+use common_meta::key::MAINTENANCE_KEY;
+use common_meta::kv_backend::{KvBackendRef, ResettableKvBackendRef};
+use common_meta::rpc::store::PutRequest;
+use snafu::{OptionExt, ResultExt};
+use tonic::codegen::http;
+use tonic::codegen::http::Response;
+
+use crate::error::{InvalidHttpBodySnafu, MissingRequiredParameterSnafu, ParseBoolSnafu};
+use crate::service::admin::HttpHandler;
+
+#[derive(Clone)]
+pub struct MaintenanceHandler {
+    pub kv_backend: KvBackendRef,
+    pub in_memory: ResettableKvBackendRef,
+}
+
+impl MaintenanceHandler {
+    async fn get_maintenance(&self) -> crate::Result<Response<String>> {
+        let enabled = self.in_memory.exists(MAINTENANCE_KEY.as_bytes()).await?;
+        let response = if enabled {
+            "Maintenance mode is enabled"
+        } else {
+            "Maintenance mode is disabled"
+        };
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(response.into())
+            .context(InvalidHttpBodySnafu)
+    }
+
+    async fn set_maintenance(
+        &self,
+        params: &HashMap<String, String>,
+    ) -> crate::Result<Response<String>> {
+        let enable = params
+            .get("enable")
+            .map(|v| v.parse::<bool>())
+            .context(MissingRequiredParameterSnafu { param: "enable" })?
+            .context(ParseBoolSnafu {
+                err_msg: "'enable' must be 'true' or 'false'",
+            })?;
+
+        let req = PutRequest {
+            key: Vec::from(MAINTENANCE_KEY),
+            value: vec![],
+            prev_kv: false,
+        };
+
+        let response = if enable {
+            self.kv_backend.put(req.clone()).await?;
+            self.in_memory.put(req).await?;
+            "Maintenance mode enabled"
+        } else {
+            self.kv_backend
+                .delete(MAINTENANCE_KEY.as_bytes(), false)
+                .await?;
+            self.in_memory
+                .delete(MAINTENANCE_KEY.as_bytes(), false)
+                .await?;
+            "Maintenance mode disabled"
+        };
+
+        http::Response::builder()
+            .status(http::StatusCode::OK)
+            .body(response.into())
+            .context(InvalidHttpBodySnafu)
+    }
+}
+
+#[async_trait::async_trait]
+impl HttpHandler for MaintenanceHandler {
+    async fn handle(
+        &self,
+        path: &str,
+        params: &HashMap<String, String>,
+    ) -> crate::Result<Response<String>> {
+        if path.ends_with("/set") {
+            self.set_maintenance(params).await
+        } else {
+            self.get_maintenance().await
+        }
+    }
+}

--- a/src/meta-srv/src/test_util.rs
+++ b/src/meta-srv/src/test_util.rs
@@ -86,6 +86,7 @@ pub(crate) fn create_region_failover_manager() -> Arc<RegionFailoverManager> {
     Arc::new(RegionFailoverManager::new(
         10,
         in_memory,
+        kv_backend.clone(),
         mailbox,
         procedure_manager,
         (selector, selector_ctx),

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -352,6 +352,7 @@ async fn run_region_failover_procedure(
         RegionFailoverContext {
             region_lease_secs: 10,
             in_memory: meta_srv.in_memory().clone(),
+            kv_backend: meta_srv.kv_backend().clone(),
             mailbox: meta_srv.mailbox().clone(),
             selector,
             selector_ctx: SelectorContext {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

* This closes #2211.
* This closes #1586.

## What's changed and what's your intention?

Add "/maintenance" and "/maintenance/set" endpoint on metasrv admin APIs.

Skip failure failed_regions handling if `is_maintenance_mode`.

cc @xifyang 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
