### PR TITLE
chore: http header with metrics

### DIFF
--- a/src/common/function/src/handlers.rs
+++ b/src/common/function/src/handlers.rs
@@ -18,6 +18,7 @@ use async_trait::async_trait;
 use common_base::AffectedRows;
 use common_meta::rpc::procedure::{MigrateRegionRequest, ProcedureStateResponse};
 use common_query::error::Result;
+use common_query::Output;
 use session::context::QueryContextRef;
 use store_api::storage::RegionId;
 use table::requests::{CompactTableRequest, DeleteRequest, FlushTableRequest, InsertRequest};
@@ -26,7 +27,7 @@ use table::requests::{CompactTableRequest, DeleteRequest, FlushTableRequest, Ins
 #[async_trait]
 pub trait TableMutationHandler: Send + Sync {
     /// Inserts rows into the table.
-    async fn insert(&self, request: InsertRequest, ctx: QueryContextRef) -> Result<AffectedRows>;
+    async fn insert(&self, request: InsertRequest, ctx: QueryContextRef) -> Result<Output>;
 
     /// Delete rows from the table.
     async fn delete(&self, request: DeleteRequest, ctx: QueryContextRef) -> Result<AffectedRows>;

--- a/src/common/function/src/state.rs
+++ b/src/common/function/src/state.rs
@@ -35,6 +35,7 @@ impl FunctionState {
         use common_base::AffectedRows;
         use common_meta::rpc::procedure::{MigrateRegionRequest, ProcedureStateResponse};
         use common_query::error::Result;
+        use common_query::Output;
         use session::context::QueryContextRef;
         use store_api::storage::RegionId;
         use table::requests::{
@@ -70,8 +71,8 @@ impl FunctionState {
                 &self,
                 _request: InsertRequest,
                 _ctx: QueryContextRef,
-            ) -> Result<AffectedRows> {
-                Ok(ROWS)
+            ) -> Result<Output> {
+                Ok(Output::new_with_affected_rows(ROWS))
             }
 
             async fn delete(

--- a/src/common/plugins/src/consts.rs
+++ b/src/common/plugins/src/consts.rs
@@ -16,4 +16,5 @@
 pub const GREPTIME_EXEC_PREFIX: &str = "greptime_exec_";
 
 /// Execution cost metrics key
-pub const GREPTIME_EXEC_COST: &str = "greptime_exec_cost";
+pub const GREPTIME_EXEC_READ_COST: &str = "greptime_exec_read_cost";
+pub const GREPTIME_EXEC_WRITE_COST: &str = "greptime_exec_write_cost";

--- a/src/common/plugins/src/lib.rs
+++ b/src/common/plugins/src/lib.rs
@@ -17,4 +17,4 @@
 /// since `plugins` crate is at the top depending on crates like `frontend` and `datanode`
 mod consts;
 
-pub use consts::{GREPTIME_EXEC_COST, GREPTIME_EXEC_PREFIX};
+pub use consts::{GREPTIME_EXEC_PREFIX, GREPTIME_EXEC_READ_COST, GREPTIME_EXEC_WRITE_COST};

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -40,7 +40,7 @@ pub struct Output {
 /// Original Output struct
 /// carrying result data to response/client/user interface
 pub enum OutputData {
-    AffectedRows(usize),
+    AffectedRows(OutputRows),
     RecordBatches(RecordBatches),
     Stream(SendableRecordBatchStream),
 }
@@ -50,11 +50,11 @@ pub enum OutputData {
 pub struct OutputMeta {
     /// May exist for query output. One can retrieve execution metrics from this plan.
     pub plan: Option<Arc<dyn PhysicalPlan>>,
-    pub cost: usize,
+    pub cost: OutputCost,
 }
 
 impl Output {
-    pub fn new_with_affected_rows(affected_rows: usize) -> Self {
+    pub fn new_with_affected_rows(affected_rows: OutputRows) -> Self {
         Self {
             data: OutputData::AffectedRows(affected_rows),
             meta: Default::default(),
@@ -79,7 +79,7 @@ impl Output {
         Self { data, meta }
     }
 
-    pub fn extract_rows_and_cost(&self) -> (usize, usize) {
+    pub fn extract_rows_and_cost(&self) -> (OutputRows, OutputCost) {
         match self.data {
             OutputData::AffectedRows(rows) => (rows, self.meta.cost),
             _ => (0, self.meta.cost),
@@ -140,3 +140,6 @@ impl From<&AddColumnLocation> for Location {
         }
     }
 }
+
+pub type OutputRows = usize;
+pub type OutputCost = usize;

--- a/src/common/query/src/lib.rs
+++ b/src/common/query/src/lib.rs
@@ -78,6 +78,13 @@ impl Output {
     pub fn new(data: OutputData, meta: OutputMeta) -> Self {
         Self { data, meta }
     }
+
+    pub fn extract_rows_and_cost(&self) -> (usize, usize) {
+        match self.data {
+            OutputData::AffectedRows(rows) => (rows, self.meta.cost),
+            _ => (0, self.meta.cost),
+        }
+    }
 }
 
 impl Debug for OutputData {

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -26,7 +26,7 @@ use common_error::ext::BoxedError;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
-use common_telemetry::{logging, tracing, warn};
+use common_telemetry::{logging, tracing};
 use operator::insert::InserterRef;
 use operator::statement::StatementExecutor;
 use prost::Message;

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -31,7 +31,7 @@ use operator::insert::InserterRef;
 use operator::statement::StatementExecutor;
 use prost::Message;
 use servers::error::{self, AuthSnafu, Result as ServerResult};
-use servers::http::header::collect_plan_metrics;
+use servers::http::header::{collect_plan_metrics, CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF};
 use servers::http::prom_store::PHYSICAL_TABLE_PARAM;
 use servers::interceptor::{PromStoreProtocolInterceptor, PromStoreProtocolInterceptorRef};
 use servers::prom_store::{self, Metrics};
@@ -273,8 +273,8 @@ impl PromStoreProtocolHandler for Instance {
 
                 // TODO(dennis): may consume too much memory, adds flow control
                 Ok(PromStoreResponse {
-                    content_type: "application/x-protobuf".to_string(),
-                    content_encoding: "snappy".to_string(),
+                    content_type: CONTENT_TYPE_PROTOBUF.clone(),
+                    content_encoding: CONTENT_ENCODING_SNAPPY.clone(),
                     resp_metrics,
                     body: prom_store::snappy_compress(&response.encode_to_vec())?,
                 })

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -26,7 +26,7 @@ use common_error::ext::BoxedError;
 use common_query::prelude::GREPTIME_PHYSICAL_TABLE;
 use common_query::Output;
 use common_recordbatch::RecordBatches;
-use common_telemetry::{logging, tracing};
+use common_telemetry::{logging, tracing, warn};
 use operator::insert::InserterRef;
 use operator::statement::StatementExecutor;
 use prost::Message;
@@ -255,6 +255,7 @@ impl PromStoreProtocolHandler for Instance {
                 let mut query_results = Vec::with_capacity(results.len());
                 let mut map = HashMap::new();
                 for (table_name, output) in results {
+                    warn!("[DEBUG]output: {:?}", output);
                     if let Some(ref plan) = output.meta.plan {
                         collect_plan_metrics(plan.clone(), &mut [&mut map]);
                     }

--- a/src/frontend/src/instance/prom_store.rs
+++ b/src/frontend/src/instance/prom_store.rs
@@ -255,11 +255,11 @@ impl PromStoreProtocolHandler for Instance {
                 let mut query_results = Vec::with_capacity(results.len());
                 let mut map = HashMap::new();
                 for (table_name, output) in results {
-                    warn!("[DEBUG]output: {:?}", output);
-                    if let Some(ref plan) = output.meta.plan {
+                    let plan = output.meta.plan.clone();
+                    query_results.push(to_query_result(&table_name, output).await?);
+                    if let Some(ref plan) = plan {
                         collect_plan_metrics(plan.clone(), &mut [&mut map]);
                     }
-                    query_results.push(to_query_result(&table_name, output).await?);
                 }
 
                 let response = ReadResponse {

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -124,10 +124,7 @@ impl StatementExecutor {
                         .copy_table_to(req, query_ctx)
                         .await
                         .map(Output::new_with_affected_rows),
-                    CopyDirection::Import => self
-                        .copy_table_from(req, query_ctx)
-                        .await
-                        .map(Output::new_with_affected_rows),
+                    CopyDirection::Import => self.copy_table_from(req, query_ctx).await,
                 }
             }
 

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use client::Output;
+use client::{Output, OutputData, OutputMeta};
 use common_datasource::file_format::Format;
 use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::build_backend;
@@ -129,7 +129,9 @@ impl StatementExecutor {
             .get(CONTINUE_ON_ERROR_KEY)
             .and_then(|v| bool::from_str(v).ok())
             .unwrap_or(false);
+
         let mut rows_inserted = 0;
+        let mut insert_cost = 0;
 
         for e in entries {
             let table_name = match parse_file_name_to_copy(&e) {
@@ -156,8 +158,13 @@ impl StatementExecutor {
             };
             debug!("Copy table, arg: {:?}", req);
             match self.copy_table_from(req, ctx.clone()).await {
-                Ok(rows) => {
-                    rows_inserted += rows;
+                Ok(o) => {
+                    rows_inserted += if let OutputData::AffectedRows(r) = o.data {
+                        r
+                    } else {
+                        0
+                    };
+                    insert_cost += o.meta.cost;
                 }
                 Err(err) => {
                     if continue_on_error {
@@ -169,7 +176,10 @@ impl StatementExecutor {
                 }
             }
         }
-        Ok(Output::new_with_affected_rows(rows_inserted))
+        Ok(Output::new(
+            OutputData::AffectedRows(rows_inserted),
+            OutputMeta::new_with_cost(insert_cost),
+        ))
     }
 }
 

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -159,12 +159,9 @@ impl StatementExecutor {
             debug!("Copy table, arg: {:?}", req);
             match self.copy_table_from(req, ctx.clone()).await {
                 Ok(o) => {
-                    rows_inserted += if let OutputData::AffectedRows(r) = o.data {
-                        r
-                    } else {
-                        0
-                    };
-                    insert_cost += o.meta.cost;
+                    let (rows, cost) = o.extract_rows_and_cost();
+                    rows_inserted += rows;
+                    insert_cost += cost;
                 }
                 Err(err) => {
                     if continue_on_error {

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -451,15 +451,7 @@ async fn batch_insert(
     let result = futures::future::try_join_all(batch)
         .await?
         .iter()
-        .map(|o| {
-            let rows = if let OutputData::AffectedRows(r) = o.data {
-                r
-            } else {
-                0
-            };
-            let cost = o.meta.cost;
-            (rows, cost)
-        })
+        .map(|o| o.extract_rows_and_cost())
         .reduce(|(a, b), (c, d)| (a + c, b + d))
         .unwrap_or((0, 0));
     *pending_bytes = 0;

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -15,7 +15,9 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::usize;
 
+use client::{Output, OutputData, OutputMeta};
 use common_base::readable_size::ReadableSize;
 use common_datasource::file_format::csv::{CsvConfigBuilder, CsvFormat, CsvOpener};
 use common_datasource::file_format::json::{JsonFormat, JsonOpener};
@@ -328,7 +330,7 @@ impl StatementExecutor {
         &self,
         req: CopyTableRequest,
         query_ctx: QueryContextRef,
-    ) -> Result<usize> {
+    ) -> Result<Output> {
         let table_ref = TableReference {
             catalog: &req.catalog_name,
             schema: &req.schema_name,
@@ -373,6 +375,7 @@ impl StatementExecutor {
         }
 
         let mut rows_inserted = 0;
+        let mut insert_cost = 0;
         for (compat_schema, file_schema_projection, projected_table_schema, file_metadata) in files
         {
             let mut stream = self
@@ -419,28 +422,48 @@ impl StatementExecutor {
                 ));
 
                 if pending_mem_size as u64 >= pending_mem_threshold {
-                    rows_inserted += batch_insert(&mut pending, &mut pending_mem_size).await?;
+                    let (rows, cost) = batch_insert(&mut pending, &mut pending_mem_size).await?;
+                    rows_inserted += rows;
+                    insert_cost += cost;
                 }
             }
 
             if !pending.is_empty() {
-                rows_inserted += batch_insert(&mut pending, &mut pending_mem_size).await?;
+                let (rows, cost) = batch_insert(&mut pending, &mut pending_mem_size).await?;
+                rows_inserted += rows;
+                insert_cost += cost;
             }
         }
 
-        Ok(rows_inserted)
+        Ok(Output::new(
+            OutputData::AffectedRows(rows_inserted),
+            OutputMeta::new_with_cost(insert_cost),
+        ))
     }
 }
 
 /// Executes all pending inserts all at once, drain pending requests and reset pending bytes.
 async fn batch_insert(
-    pending: &mut Vec<impl Future<Output = Result<usize>>>,
+    pending: &mut Vec<impl Future<Output = Result<Output>>>,
     pending_bytes: &mut usize,
-) -> Result<usize> {
+) -> Result<(usize, usize)> {
     let batch = pending.drain(..);
-    let res: usize = futures::future::try_join_all(batch).await?.iter().sum();
+    let result = futures::future::try_join_all(batch)
+        .await?
+        .iter()
+        .map(|o| {
+            let rows = if let OutputData::AffectedRows(r) = o.data {
+                r
+            } else {
+                0
+            };
+            let cost = o.meta.cost;
+            (rows, cost)
+        })
+        .reduce(|(a, b), (c, d)| (a + c, b + d))
+        .unwrap_or((0, 0));
     *pending_bytes = 0;
-    Ok(res)
+    Ok(result)
 }
 
 fn ensure_schema_compatible(from: &SchemaRef, to: &SchemaRef) -> Result<()> {

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -26,6 +26,7 @@ use common_datasource::file_format::{FileFormat, Format};
 use common_datasource::lister::{Lister, Source};
 use common_datasource::object_store::{build_backend, parse_url};
 use common_datasource::util::find_dir_and_filename;
+use common_query::{OutputCost, OutputRows};
 use common_recordbatch::adapter::RecordBatchStreamTypeAdapter;
 use common_recordbatch::DfSendableRecordBatchStream;
 use common_telemetry::{debug, tracing};
@@ -446,7 +447,7 @@ impl StatementExecutor {
 async fn batch_insert(
     pending: &mut Vec<impl Future<Output = Result<Output>>>,
     pending_bytes: &mut usize,
-) -> Result<(usize, usize)> {
+) -> Result<(OutputRows, OutputCost)> {
     let batch = pending.drain(..);
     let result = futures::future::try_join_all(batch)
         .await?

--- a/src/operator/src/table.rs
+++ b/src/operator/src/table.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use client::Output;
 use common_base::AffectedRows;
 use common_error::ext::BoxedError;
 use common_function::handlers::TableMutationHandler;
@@ -52,7 +53,7 @@ impl TableMutationHandler for TableMutationOperator {
         &self,
         request: TableInsertRequest,
         ctx: QueryContextRef,
-    ) -> QueryResult<AffectedRows> {
+    ) -> QueryResult<Output> {
         self.inserter
             .handle_table_insert(request, ctx)
             .await

--- a/src/query/src/datafusion.rs
+++ b/src/query/src/datafusion.rs
@@ -142,12 +142,9 @@ impl DatafusionQueryEngine {
                     let output = self
                         .insert(&table_name, column_vectors, query_ctx.clone())
                         .await?;
-                    affected_rows += if let OutputData::AffectedRows(r) = output.data {
-                        r
-                    } else {
-                        0
-                    };
-                    insert_cost += output.meta.cost;
+                    let (rows, cost) = output.extract_rows_and_cost();
+                    affected_rows += rows;
+                    insert_cost += cost;
                 }
                 WriteOp::Delete => {
                     affected_rows += self

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -22,7 +22,7 @@ use common_base::bytes::Bytes;
 use common_catalog::parse_catalog_and_schema_from_db_string;
 use common_error::ext::BoxedError;
 use common_meta::table_name::TableName;
-use common_plugins::GREPTIME_EXEC_COST;
+use common_plugins::GREPTIME_EXEC_READ_COST;
 use common_query::physical_plan::TaskContext;
 use common_recordbatch::adapter::DfRecordBatchStreamAdapter;
 use common_recordbatch::error::ExternalSnafu;
@@ -338,7 +338,7 @@ impl MergeScanMetric {
             first_consume_time: MetricBuilder::new(metric).subset_time("first_consume_time", 1),
             finish_time: MetricBuilder::new(metric).subset_time("finish_time", 1),
             output_rows: MetricBuilder::new(metric).output_rows(1),
-            greptime_exec_cost: MetricBuilder::new(metric).gauge(GREPTIME_EXEC_COST, 1),
+            greptime_exec_cost: MetricBuilder::new(metric).gauge(GREPTIME_EXEC_READ_COST, 1),
         }
     }
 

--- a/src/servers/src/grpc/otlp.rs
+++ b/src/servers/src/grpc/otlp.rs
@@ -52,9 +52,11 @@ impl TraceService for OtlpService {
             .cloned()
             .context(error::MissingQueryContextSnafu)?;
 
-        let res = self.handler.traces(req, ctx).await?;
+        let _ = self.handler.traces(req, ctx).await?;
 
-        Ok(Response::new(res))
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
     }
 }
 
@@ -71,8 +73,10 @@ impl MetricsService for OtlpService {
             .cloned()
             .context(error::MissingQueryContextSnafu)?;
 
-        let res = self.handler.metrics(req, ctx).await?;
+        let _ = self.handler.metrics(req, ctx).await?;
 
-        Ok(Response::new(res))
+        Ok(Response::new(ExportMetricsServiceResponse {
+            partial_success: None,
+        }))
     }
 }

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -61,6 +61,9 @@ pub static GREPTIME_DB_HEADER_NAME: HeaderName =
 pub static GREPTIME_TIMEZONE_HEADER_NAME: HeaderName =
     HeaderName::from_static(constants::GREPTIME_TIMEZONE_HEADER_NAME);
 
+pub static CONTENT_TYPE_PROTOBUF: HeaderValue = HeaderValue::from_static("application/x-protobuf");
+pub static CONTENT_ENCODING_SNAPPY: HeaderValue = HeaderValue::from_static("snappy");
+
 pub struct GreptimeDbName(Option<String>);
 
 impl Header for GreptimeDbName {

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common_plugins::GREPTIME_EXEC_PREFIX;
+use common_query::physical_plan::PhysicalPlan;
+use datafusion::physical_plan::metrics::MetricValue;
 use headers::{Header, HeaderName, HeaderValue};
+use hyper::HeaderMap;
+use serde_json::Value;
 
 pub mod constants {
     // New HTTP headers would better distinguish use cases among:
@@ -85,5 +93,57 @@ impl Header for GreptimeDbName {
 impl GreptimeDbName {
     pub fn value(&self) -> Option<&String> {
         self.0.as_ref()
+    }
+}
+
+pub fn write_cost_header_map(cost: usize) -> HeaderMap {
+    let mut header_map = HeaderMap::new();
+    if cost > 0 {
+        let mut map: HashMap<String, Value> = HashMap::new();
+        map.insert(
+            common_plugins::GREPTIME_EXEC_WRITE_COST.to_string(),
+            Value::from(cost),
+        );
+        let _ = serde_json::to_string(&map)
+            .ok()
+            .and_then(|s| HeaderValue::from_str(&s).ok())
+            .and_then(|v| header_map.insert(&GREPTIME_DB_HEADER_METRICS, v));
+    }
+    header_map
+}
+
+fn collect_into_maps(name: &str, value: u64, maps: &mut [&mut HashMap<String, u64>]) {
+    if name.starts_with(GREPTIME_EXEC_PREFIX) && value > 0 {
+        maps.iter_mut().for_each(|map| {
+            map.entry(name.to_string())
+                .and_modify(|v| *v += value)
+                .or_insert(value);
+        });
+    }
+}
+
+pub fn collect_plan_metrics(plan: Arc<dyn PhysicalPlan>, maps: &mut [&mut HashMap<String, u64>]) {
+    if let Some(m) = plan.metrics() {
+        m.iter().for_each(|m| match m.value() {
+            MetricValue::Count { name, count } => {
+                collect_into_maps(name, count.value() as u64, maps);
+            }
+            MetricValue::Gauge { name, gauge } => {
+                collect_into_maps(name, gauge.value() as u64, maps);
+            }
+            MetricValue::Time { name, time } => {
+                if name.starts_with(GREPTIME_EXEC_PREFIX) {
+                    // override
+                    maps.iter_mut().for_each(|map| {
+                        map.insert(name.to_string(), time.value() as u64);
+                    });
+                }
+            }
+            _ => {}
+        });
+    }
+
+    for c in plan.children() {
+        collect_plan_metrics(c, maps);
     }
 }

--- a/src/servers/src/http/header.rs
+++ b/src/servers/src/http/header.rs
@@ -99,6 +99,7 @@ impl GreptimeDbName {
     }
 }
 
+// collect write
 pub fn write_cost_header_map(cost: usize) -> HeaderMap {
     let mut header_map = HeaderMap::new();
     if cost > 0 {

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -15,17 +15,15 @@
 use std::collections::HashMap;
 
 use axum::extract::{Query, State};
-use axum::http::{HeaderValue, StatusCode};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Extension;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_grpc::writer::Precision;
 use common_telemetry::tracing;
-use hyper::HeaderMap;
-use serde_json::Value;
 use session::context::QueryContextRef;
 
-use super::header::GREPTIME_DB_HEADER_METRICS;
+use super::header::write_cost_header_map;
 use crate::error::{Result, TimePrecisionSnafu};
 use crate::influxdb::InfluxdbRequest;
 use crate::query_handler::InfluxdbLineProtocolHandlerRef;
@@ -98,20 +96,10 @@ pub async fn influxdb_write(
     let request = InfluxdbRequest { precision, lines };
     let output = handler.exec(request, ctx).await?;
 
-    let mut header_map = HeaderMap::new();
-    if output.meta.cost > 0 {
-        let mut map: HashMap<String, Value> = HashMap::new();
-        map.insert(
-            common_plugins::GREPTIME_EXEC_WRITE_COST.to_string(),
-            Value::from(output.meta.cost),
-        );
-        let _ = serde_json::to_string(&map)
-            .ok()
-            .and_then(|s| HeaderValue::from_str(&s).ok())
-            .and_then(|v| header_map.insert(&GREPTIME_DB_HEADER_METRICS, v));
-    }
-
-    Ok((StatusCode::NO_CONTENT, header_map))
+    Ok((
+        StatusCode::NO_CONTENT,
+        write_cost_header_map(output.meta.cost),
+    ))
 }
 
 fn parse_time_precision(value: &str) -> Result<Precision> {

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use axum::extract::{RawBody, State};
-use axum::http::header;
+use axum::http::{header, HeaderValue};
 use axum::response::IntoResponse;
 use axum::Extension;
 use common_telemetry::tracing;
@@ -28,6 +28,7 @@ use prost::Message;
 use session::context::QueryContextRef;
 use snafu::prelude::*;
 
+use super::header::write_cost_header_map;
 use crate::error::{self, Result};
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 
@@ -43,10 +44,16 @@ pub async fn metrics(
         .with_label_values(&[db.as_str()])
         .start_timer();
     let request = parse_metrics_body(body).await?;
+
     handler
         .metrics(request, query_ctx)
         .await
-        .map(OtlpMetricsResponse)
+        .map(|o| OtlpMetricsResponse {
+            resp_body: ExportMetricsServiceResponse {
+                partial_success: None,
+            },
+            write_cost: o.meta.cost,
+        })
 }
 
 async fn parse_metrics_body(body: Body) -> Result<ExportMetricsServiceRequest> {
@@ -58,15 +65,20 @@ async fn parse_metrics_body(body: Body) -> Result<ExportMetricsServiceRequest> {
         })
 }
 
-pub struct OtlpMetricsResponse(ExportMetricsServiceResponse);
+pub struct OtlpMetricsResponse {
+    resp_body: ExportMetricsServiceResponse,
+    write_cost: usize,
+}
 
 impl IntoResponse for OtlpMetricsResponse {
     fn into_response(self) -> axum::response::Response {
-        (
-            [(header::CONTENT_TYPE, "application/x-protobuf")],
-            self.0.encode_to_vec(),
-        )
-            .into_response()
+        let mut header_map = write_cost_header_map(self.write_cost);
+        header_map.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str("application/x-protobuf").unwrap(),
+        );
+
+        (header_map, self.resp_body.encode_to_vec()).into_response()
     }
 }
 
@@ -85,7 +97,12 @@ pub async fn traces(
     handler
         .traces(request, query_ctx)
         .await
-        .map(OtlpTracesResponse)
+        .map(|o| OtlpTracesResponse {
+            resp_body: ExportTraceServiceResponse {
+                partial_success: None,
+            },
+            write_cost: o.meta.cost,
+        })
 }
 
 async fn parse_traces_body(body: Body) -> Result<ExportTraceServiceRequest> {
@@ -97,14 +114,19 @@ async fn parse_traces_body(body: Body) -> Result<ExportTraceServiceRequest> {
         })
 }
 
-pub struct OtlpTracesResponse(ExportTraceServiceResponse);
+pub struct OtlpTracesResponse {
+    resp_body: ExportTraceServiceResponse,
+    write_cost: usize,
+}
 
 impl IntoResponse for OtlpTracesResponse {
     fn into_response(self) -> axum::response::Response {
-        (
-            [(header::CONTENT_TYPE, "application/x-protobuf")],
-            self.0.encode_to_vec(),
-        )
-            .into_response()
+        let mut header_map = write_cost_header_map(self.write_cost);
+        header_map.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_str("application/x-protobuf").unwrap(),
+        );
+
+        (header_map, self.resp_body.encode_to_vec()).into_response()
     }
 }

--- a/src/servers/src/http/otlp.rs
+++ b/src/servers/src/http/otlp.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use axum::extract::{RawBody, State};
-use axum::http::{header, HeaderValue};
+use axum::http::header;
 use axum::response::IntoResponse;
 use axum::Extension;
 use common_telemetry::tracing;
@@ -28,7 +28,7 @@ use prost::Message;
 use session::context::QueryContextRef;
 use snafu::prelude::*;
 
-use super::header::write_cost_header_map;
+use super::header::{write_cost_header_map, CONTENT_TYPE_PROTOBUF};
 use crate::error::{self, Result};
 use crate::query_handler::OpenTelemetryProtocolHandlerRef;
 
@@ -73,10 +73,7 @@ pub struct OtlpMetricsResponse {
 impl IntoResponse for OtlpMetricsResponse {
     fn into_response(self) -> axum::response::Response {
         let mut header_map = write_cost_header_map(self.write_cost);
-        header_map.insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_str("application/x-protobuf").unwrap(),
-        );
+        header_map.insert(header::CONTENT_TYPE, CONTENT_TYPE_PROTOBUF.clone());
 
         (header_map, self.resp_body.encode_to_vec()).into_response()
     }
@@ -122,10 +119,7 @@ pub struct OtlpTracesResponse {
 impl IntoResponse for OtlpTracesResponse {
     fn into_response(self) -> axum::response::Response {
         let mut header_map = write_cost_header_map(self.write_cost);
-        header_map.insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_str("application/x-protobuf").unwrap(),
-        );
+        header_map.insert(header::CONTENT_TYPE, CONTENT_TYPE_PROTOBUF.clone());
 
         (header_map, self.resp_body.encode_to_vec()).into_response()
     }

--- a/src/servers/src/http/prom_store.rs
+++ b/src/servers/src/http/prom_store.rs
@@ -122,14 +122,8 @@ pub async fn remote_write(
 impl IntoResponse for PromStoreResponse {
     fn into_response(self) -> axum::response::Response {
         let mut header_map = HeaderMap::new();
-        header_map.insert(
-            &header::CONTENT_TYPE,
-            HeaderValue::from_str(&self.content_type).unwrap(),
-        );
-        header_map.insert(
-            &header::CONTENT_ENCODING,
-            HeaderValue::from_str(&self.content_encoding).unwrap(),
-        );
+        header_map.insert(&header::CONTENT_TYPE, self.content_type);
+        header_map.insert(&header::CONTENT_ENCODING, self.content_encoding);
 
         let metrics = if self.resp_metrics.is_empty() {
             None

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -39,9 +39,11 @@ use query::parser::{PromQuery, DEFAULT_LOOKBACK_STRING};
 use schemars::JsonSchema;
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use session::context::QueryContextRef;
 use snafu::{Location, ResultExt};
 
+use super::header::collect_plan_metrics;
 pub use super::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
     CollectRecordbatchSnafu, Error, InvalidQuerySnafu, Result, UnexpectedResultSnafu,
@@ -275,6 +277,7 @@ pub async fn labels_query(
     let mut labels = HashSet::new();
     let _ = labels.insert(METRIC_NAME.to_string());
 
+    let mut merge_map = HashMap::new();
     for query in queries {
         let prom_query = PromQuery {
             query,
@@ -285,17 +288,27 @@ pub async fn labels_query(
 
         let result = handler.do_query(&prom_query, query_ctx.clone()).await;
 
-        let response = retrieve_labels_name_from_query_result(result, &mut labels).await;
-
-        if let Err(err) = response {
-            // Prometheus won't report error if querying nonexist label and metric
-            if err.status_code() != StatusCode::TableNotFound
-                && err.status_code() != StatusCode::TableColumnNotFound
-            {
-                return PrometheusJsonResponse::error(
-                    err.status_code().to_string(),
-                    err.output_msg(),
-                );
+        match retrieve_labels_name_from_query_result(result, &mut labels).await {
+            Err(err) => {
+                // Prometheus won't report error if querying nonexist label and metric
+                if err.status_code() != StatusCode::TableNotFound
+                    && err.status_code() != StatusCode::TableColumnNotFound
+                {
+                    return PrometheusJsonResponse::error(
+                        err.status_code().to_string(),
+                        err.output_msg(),
+                    );
+                }
+            }
+            Ok(map) => {
+                for (k, v) in map.into_iter() {
+                    merge_map
+                        .entry(k)
+                        .and_modify(|existing| {
+                            *existing += v;
+                        })
+                        .or_insert(v);
+                }
             }
         }
     }
@@ -305,7 +318,13 @@ pub async fn labels_query(
 
     let mut sorted_labels: Vec<String> = labels.into_iter().collect();
     sorted_labels.sort();
-    PrometheusJsonResponse::success(PrometheusResponse::Labels(sorted_labels))
+    let merge_map = merge_map
+        .into_iter()
+        .map(|(k, v)| (k, Value::from(v)))
+        .collect();
+    let mut resp = PrometheusJsonResponse::success(PrometheusResponse::Labels(sorted_labels));
+    resp.resp_metrics = merge_map;
+    resp
 }
 
 async fn get_all_column_names(
@@ -335,48 +354,53 @@ async fn retrieve_series_from_query_result(
     result: Result<Output>,
     series: &mut Vec<HashMap<String, String>>,
     table_name: &str,
-) -> Result<()> {
-    match result?.data {
-        OutputData::RecordBatches(batches) => {
-            record_batches_to_series(batches, series, table_name)?;
-            Ok(())
-        }
+) -> Result<HashMap<String, u64>> {
+    let result = result?;
+    match result.data {
+        OutputData::RecordBatches(batches) => record_batches_to_series(batches, series, table_name),
         OutputData::Stream(stream) => {
             let batches = RecordBatches::try_collect(stream)
                 .await
                 .context(CollectRecordbatchSnafu)?;
-            record_batches_to_series(batches, series, table_name)?;
-            Ok(())
+            record_batches_to_series(batches, series, table_name)
         }
         OutputData::AffectedRows(_) => Err(Error::UnexpectedResult {
             reason: "expected data result, but got affected rows".to_string(),
             location: Location::default(),
         }),
+    }?;
+
+    let mut map = HashMap::new();
+    if let Some(ref plan) = result.meta.plan {
+        collect_plan_metrics(plan.clone(), &mut [&mut map]);
     }
+    Ok(map)
 }
 
 /// Retrieve labels name from query result
 async fn retrieve_labels_name_from_query_result(
     result: Result<Output>,
     labels: &mut HashSet<String>,
-) -> Result<()> {
-    match result?.data {
-        OutputData::RecordBatches(batches) => {
-            record_batches_to_labels_name(batches, labels)?;
-            Ok(())
-        }
+) -> Result<HashMap<String, u64>> {
+    let result = result?;
+    match result.data {
+        OutputData::RecordBatches(batches) => record_batches_to_labels_name(batches, labels),
         OutputData::Stream(stream) => {
             let batches = RecordBatches::try_collect(stream)
                 .await
                 .context(CollectRecordbatchSnafu)?;
-            record_batches_to_labels_name(batches, labels)?;
-            Ok(())
+            record_batches_to_labels_name(batches, labels)
         }
         OutputData::AffectedRows(_) => UnexpectedResultSnafu {
             reason: "expected data result, but got affected rows".to_string(),
         }
         .fail(),
+    }?;
+    let mut map = HashMap::new();
+    if let Some(ref plan) = result.meta.plan {
+        collect_plan_metrics(plan.clone(), &mut [&mut map]);
     }
+    Ok(map)
 }
 
 fn record_batches_to_series(
@@ -537,6 +561,7 @@ pub async fn label_values_query(
 
     let mut label_values = HashSet::new();
 
+    let mut merge_map = HashMap::new();
     for query in queries {
         let prom_query = PromQuery {
             query,
@@ -546,30 +571,51 @@ pub async fn label_values_query(
         };
         let result = handler.do_query(&prom_query, query_ctx.clone()).await;
         let result = retrieve_label_values(result, &label_name, &mut label_values).await;
-        if let Err(err) = result {
-            // Prometheus won't report error if querying nonexist label and metric
-            if err.status_code() != StatusCode::TableNotFound
-                && err.status_code() != StatusCode::TableColumnNotFound
-            {
-                return PrometheusJsonResponse::error(
-                    err.status_code().to_string(),
-                    err.output_msg(),
-                );
+
+        match result {
+            Err(err) => {
+                // Prometheus won't report error if querying nonexist label and metric
+                if err.status_code() != StatusCode::TableNotFound
+                    && err.status_code() != StatusCode::TableColumnNotFound
+                {
+                    return PrometheusJsonResponse::error(
+                        err.status_code().to_string(),
+                        err.output_msg(),
+                    );
+                }
+            }
+            Ok(map) => {
+                for (k, v) in map.into_iter() {
+                    merge_map
+                        .entry(k)
+                        .and_modify(|existing| {
+                            *existing += v;
+                        })
+                        .or_insert(v);
+                }
             }
         }
     }
 
+    let merge_map = merge_map
+        .into_iter()
+        .map(|(k, v)| (k, Value::from(v)))
+        .collect();
+
     let mut label_values: Vec<_> = label_values.into_iter().collect();
     label_values.sort();
-    PrometheusJsonResponse::success(PrometheusResponse::LabelValues(label_values))
+    let mut resp = PrometheusJsonResponse::success(PrometheusResponse::LabelValues(label_values));
+    resp.resp_metrics = merge_map;
+    resp
 }
 
 async fn retrieve_label_values(
     result: Result<Output>,
     label_name: &str,
     labels_values: &mut HashSet<String>,
-) -> Result<()> {
-    match result?.data {
+) -> Result<HashMap<String, u64>> {
+    let result = result?;
+    match result.data {
         OutputData::RecordBatches(batches) => {
             retrieve_label_values_from_record_batch(batches, label_name, labels_values).await
         }
@@ -583,7 +629,13 @@ async fn retrieve_label_values(
             reason: "expected data result, but got affected rows".to_string(),
         }
         .fail(),
+    }?;
+    let mut map = HashMap::new();
+    if let Some(ref plan) = result.meta.plan {
+        collect_plan_metrics(plan.clone(), &mut [&mut map]);
     }
+
+    Ok(map)
 }
 
 async fn retrieve_label_values_from_record_batch(
@@ -658,6 +710,7 @@ pub async fn series_query(
         .unwrap_or_else(current_time_rfc3339);
 
     let mut series = Vec::new();
+    let mut merge_map = HashMap::new();
     for query in queries {
         let table_name = query.clone();
         let prom_query = PromQuery {
@@ -668,10 +721,31 @@ pub async fn series_query(
             step: DEFAULT_LOOKBACK_STRING.to_string(),
         };
         let result = handler.do_query(&prom_query, query_ctx.clone()).await;
-        if let Err(err) = retrieve_series_from_query_result(result, &mut series, &table_name).await
-        {
-            return PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg());
+
+        match retrieve_series_from_query_result(result, &mut series, &table_name).await {
+            Err(err) => {
+                return PrometheusJsonResponse::error(
+                    err.status_code().to_string(),
+                    err.output_msg(),
+                );
+            }
+            Ok(map) => {
+                for (k, v) in map.into_iter() {
+                    merge_map
+                        .entry(k)
+                        .and_modify(|existing| {
+                            *existing += v;
+                        })
+                        .or_insert(v);
+                }
+            }
         }
     }
-    PrometheusJsonResponse::success(PrometheusResponse::Series(series))
+    let merge_map = merge_map
+        .into_iter()
+        .map(|(k, v)| (k, Value::from(v)))
+        .collect();
+    let mut resp = PrometheusJsonResponse::success(PrometheusResponse::Series(series));
+    resp.resp_metrics = merge_map;
+    resp
 }

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -43,11 +43,11 @@ use serde_json::Value;
 use session::context::QueryContextRef;
 use snafu::{Location, ResultExt};
 
-use super::header::collect_plan_metrics;
 pub use super::prometheus_resp::PrometheusJsonResponse;
 use crate::error::{
     CollectRecordbatchSnafu, Error, InvalidQuerySnafu, Result, UnexpectedResultSnafu,
 };
+use crate::http::header::collect_plan_metrics;
 use crate::prom_store::METRIC_NAME_LABEL;
 use crate::prometheus_handler::PrometheusHandlerRef;
 

--- a/src/servers/src/http/prometheus_resp.rs
+++ b/src/servers/src/http/prometheus_resp.rs
@@ -32,8 +32,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use snafu::{OptionExt, ResultExt};
 
-use super::handler::collect_plan_metrics;
-use super::header::GREPTIME_DB_HEADER_METRICS;
+use super::header::{collect_plan_metrics, GREPTIME_DB_HEADER_METRICS};
 use super::prometheus::{PromData, PromSeries, PrometheusResponse};
 use crate::error::{CollectRecordbatchSnafu, InternalSnafu, Result};
 

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -38,6 +38,7 @@ use opentelemetry_proto::tonic::collector::metrics::v1::{
 use opentelemetry_proto::tonic::collector::trace::v1::{
     ExportTraceServiceRequest, ExportTraceServiceResponse,
 };
+use serde_json::Value;
 use session::context::QueryContextRef;
 
 use crate::error::Result;
@@ -84,6 +85,7 @@ pub trait OpentsdbProtocolHandler {
 pub struct PromStoreResponse {
     pub content_type: String,
     pub content_encoding: String,
+    pub resp_metrics: HashMap<String, Value>,
     pub body: Vec<u8>,
 }
 
@@ -95,7 +97,7 @@ pub trait PromStoreProtocolHandler {
         request: WriteRequest,
         ctx: QueryContextRef,
         with_metric_engine: bool,
-    ) -> Result<()>;
+    ) -> Result<Output>;
 
     /// Handling prometheus remote write requests
     async fn write_fast(
@@ -103,7 +105,7 @@ pub trait PromStoreProtocolHandler {
         request: RowInsertRequests,
         ctx: QueryContextRef,
         with_metric_engine: bool,
-    ) -> Result<()>;
+    ) -> Result<Output>;
 
     /// Handling prometheus remote read requests
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse>;

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -32,6 +32,7 @@ use api::prom_store::remote::{ReadRequest, WriteRequest};
 use api::v1::RowInsertRequests;
 use async_trait::async_trait;
 use common_query::Output;
+use headers::HeaderValue;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use serde_json::Value;
@@ -79,8 +80,8 @@ pub trait OpentsdbProtocolHandler {
 }
 
 pub struct PromStoreResponse {
-    pub content_type: String,
-    pub content_encoding: String,
+    pub content_type: HeaderValue,
+    pub content_encoding: HeaderValue,
     pub resp_metrics: HashMap<String, Value>,
     pub body: Vec<u8>,
 }

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -32,12 +32,8 @@ use api::prom_store::remote::{ReadRequest, WriteRequest};
 use api::v1::RowInsertRequests;
 use async_trait::async_trait;
 use common_query::Output;
-use opentelemetry_proto::tonic::collector::metrics::v1::{
-    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
-};
-use opentelemetry_proto::tonic::collector::trace::v1::{
-    ExportTraceServiceRequest, ExportTraceServiceResponse,
-};
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
 use serde_json::Value;
 use session::context::QueryContextRef;
 
@@ -120,12 +116,12 @@ pub trait OpenTelemetryProtocolHandler {
         &self,
         request: ExportMetricsServiceRequest,
         ctx: QueryContextRef,
-    ) -> Result<ExportMetricsServiceResponse>;
+    ) -> Result<Output>;
 
     /// Handling opentelemetry traces request
     async fn traces(
         &self,
         request: ExportTraceServiceRequest,
         ctx: QueryContextRef,
-    ) -> Result<ExportTraceServiceResponse>;
+    ) -> Result<Output>;
 }

--- a/src/servers/src/query_handler.rs
+++ b/src/servers/src/query_handler.rs
@@ -71,7 +71,7 @@ pub trait ScriptHandler {
 pub trait InfluxdbLineProtocolHandler {
     /// A successful request will not return a response.
     /// Only on error will the socket return a line of data.
-    async fn exec(&self, request: InfluxdbRequest, ctx: QueryContextRef) -> Result<()>;
+    async fn exec(&self, request: InfluxdbRequest, ctx: QueryContextRef) -> Result<Output>;
 }
 
 #[async_trait]

--- a/src/servers/tests/http/influxdb_test.rs
+++ b/src/servers/tests/http/influxdb_test.rs
@@ -55,7 +55,7 @@ impl GrpcQueryHandler for DummyInstance {
 
 #[async_trait]
 impl InfluxdbLineProtocolHandler for DummyInstance {
-    async fn exec(&self, request: InfluxdbRequest, ctx: QueryContextRef) -> Result<()> {
+    async fn exec(&self, request: InfluxdbRequest, ctx: QueryContextRef) -> Result<Output> {
         let requests: RowInsertRequests = request.try_into()?;
         for expr in requests.inserts {
             let _ = self
@@ -64,7 +64,7 @@ impl InfluxdbLineProtocolHandler for DummyInstance {
                 .await;
         }
 
-        Ok(())
+        Ok(Output::new_with_affected_rows(0))
     }
 }
 

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -29,6 +29,7 @@ use query::parser::PromQuery;
 use query::plan::LogicalPlan;
 use query::query_engine::DescribeResult;
 use servers::error::{Error, Result};
+use servers::http::header::{CONTENT_ENCODING_SNAPPY, CONTENT_TYPE_PROTOBUF};
 use servers::http::{HttpOptions, HttpServerBuilder};
 use servers::prom_store;
 use servers::prom_store::{snappy_compress, Metrics};
@@ -88,8 +89,8 @@ impl PromStoreProtocolHandler for DummyInstance {
         };
 
         Ok(PromStoreResponse {
-            content_type: "application/x-protobuf".to_string(),
-            content_encoding: "snappy".to_string(),
+            content_type: CONTENT_TYPE_PROTOBUF.clone(),
+            content_encoding: CONTENT_ENCODING_SNAPPY.clone(),
             resp_metrics: Default::default(),
             body: response.encode_to_vec(),
         })

--- a/src/servers/tests/http/prom_store_test.rs
+++ b/src/servers/tests/http/prom_store_test.rs
@@ -57,13 +57,13 @@ impl GrpcQueryHandler for DummyInstance {
 
 #[async_trait]
 impl PromStoreProtocolHandler for DummyInstance {
-    async fn write(&self, request: WriteRequest, ctx: QueryContextRef, _: bool) -> Result<()> {
+    async fn write(&self, request: WriteRequest, ctx: QueryContextRef, _: bool) -> Result<Output> {
         let _ = self
             .tx
             .send((ctx.current_schema().to_owned(), request.encode_to_vec()))
             .await;
 
-        Ok(())
+        Ok(Output::new_with_affected_rows(0))
     }
 
     async fn write_fast(
@@ -71,8 +71,8 @@ impl PromStoreProtocolHandler for DummyInstance {
         _request: RowInsertRequests,
         _ctx: QueryContextRef,
         _with_metric_engine: bool,
-    ) -> Result<()> {
-        Ok(())
+    ) -> Result<Output> {
+        Ok(Output::new_with_affected_rows(0))
     }
 
     async fn read(&self, request: ReadRequest, ctx: QueryContextRef) -> Result<PromStoreResponse> {
@@ -90,6 +90,7 @@ impl PromStoreProtocolHandler for DummyInstance {
         Ok(PromStoreResponse {
             content_type: "application/x-protobuf".to_string(),
             content_encoding: "snappy".to_string(),
+            resp_metrics: Default::default(),
             body: response.encode_to_vec(),
         })
     }

--- a/tests-integration/src/otlp.rs
+++ b/tests-integration/src/otlp.rs
@@ -64,8 +64,8 @@ mod test {
         .unwrap()
         .is_ok());
 
-        let resp = instance.metrics(req, ctx.clone()).await.unwrap();
-        assert!(resp.partial_success.is_none());
+        let resp = instance.metrics(req, ctx.clone()).await;
+        assert!(resp.is_ok());
 
         let mut output = instance
             .do_query(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr is a follow-up of https://github.com/GreptimeTeam/greptimedb/pull/3466. 
Now that we have `OutputMeta`, we can easily bring metrics from execution level up to the HTTP interface and put them into HTTP header. 
This pr covers basically every HTTP entry with read or write request, returning a HTTP header indicating the cost of the request.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
