### PR TITLE
fix: clone data instead of moving it - homemade future is dangerous

### DIFF
--- a/src/promql/src/extension_plan/series_divide.rs
+++ b/src/promql/src/extension_plan/series_divide.rs
@@ -255,18 +255,20 @@ impl Stream for SeriesDivideStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            if let Some(batch) = self.buffer.take() {
+            if let Some(batch) = self.buffer.clone() {
                 let same_length = self.find_first_diff_row(&batch) + 1;
                 if same_length >= batch.num_rows() {
                     let next_batch = match ready!(self.as_mut().fetch_next_batch(cx)) {
-                        Some(Ok(next_batch)) => next_batch,
+                        Some(Ok(batch)) => batch,
                         None => {
+                            self.buffer = None;
                             self.num_series += 1;
                             return Poll::Ready(Some(Ok(batch)));
                         }
                         error => return Poll::Ready(error),
                     };
-                    let new_batch = compute::concat_batches(&batch.schema(), &[batch, next_batch])?;
+                    let new_batch =
+                        compute::concat_batches(&batch.schema(), &[batch.clone(), next_batch])?;
                     self.buffer = Some(new_batch);
                     continue;
                 } else {

--- a/src/promql/src/extension_plan/series_divide.rs
+++ b/src/promql/src/extension_plan/series_divide.rs
@@ -255,6 +255,7 @@ impl Stream for SeriesDivideStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
+            // It has to be cloned here, otherwise the later ready! will mess things up
             if let Some(batch) = self.buffer.clone() {
                 let same_length = self.find_first_diff_row(&batch) + 1;
                 if same_length >= batch.num_rows() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fix the change in #3537. Since `RecordBatch` is all wrapped by `Arc`, cloning it is not that unacceptable.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
