### PR TITLE
refactor: reduce one clone by carefully pass ready boundary

### DIFF
--- a/src/promql/src/extension_plan/series_divide.rs
+++ b/src/promql/src/extension_plan/series_divide.rs
@@ -266,16 +266,13 @@ impl Stream for SeriesDivideStream {
                         }
                         error => return Poll::Ready(error),
                     };
-                    match self.buffer.take() {
-                        None => {
-                            self.buffer = Some(next_batch);
-                        }
-                        Some(batch) => {
-                            let new_batch =
-                                compute::concat_batches(&batch.schema(), &[batch, next_batch])?;
-                            self.buffer = Some(new_batch);
-                        }
-                    }
+                    self.buffer = match self.buffer.take() {
+                        None => Some(next_batch),
+                        Some(batch) => Some(compute::concat_batches(
+                            &batch.schema(),
+                            &[batch, next_batch],
+                        )?),
+                    };
                     continue;
                 } else {
                     let result_batch = batch.slice(0, same_length);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This follows up #3542. Hopefully I don't introduce new subtle issues 🥵

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
