### PR TITLE
fix: performance degradation caused by config change

### DIFF
--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -45,7 +45,7 @@ use crate::memtable::{
 };
 
 /// Use `1/DICTIONARY_SIZE_FACTOR` of OS memory as dictionary size.
-const DICTIONARY_SIZE_FACTOR: u64 = 8;
+pub(crate) const DICTIONARY_SIZE_FACTOR: u64 = 8;
 pub(crate) const DEFAULT_MAX_KEYS_PER_SHARD: usize = 8192;
 pub(crate) const DEFAULT_FREEZE_THRESHOLD: usize = 131072;
 
@@ -84,7 +84,7 @@ pub struct PartitionTreeConfig {
 
 impl Default for PartitionTreeConfig {
     fn default() -> Self {
-        let mut fork_dictionary_bytes = ReadableSize::gb(1);
+        let mut fork_dictionary_bytes = ReadableSize::mb(512);
         if let Some(sys_memory) = common_config::utils::get_sys_total_memory() {
             let adjust_dictionary_bytes =
                 std::cmp::min(sys_memory / DICTIONARY_SIZE_FACTOR, fork_dictionary_bytes);

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -248,10 +248,20 @@ pub struct PartitionTreeOptions {
 
 impl Default for PartitionTreeOptions {
     fn default() -> Self {
+        let mut fork_dictionary_bytes = ReadableSize::mb(512);
+        if let Some(sys_memory) = common_config::utils::get_sys_total_memory() {
+            let adjust_dictionary_bytes = std::cmp::min(
+                sys_memory / crate::memtable::partition_tree::DICTIONARY_SIZE_FACTOR,
+                fork_dictionary_bytes,
+            );
+            if adjust_dictionary_bytes.0 > 0 {
+                fork_dictionary_bytes = adjust_dictionary_bytes;
+            }
+        }
         Self {
             index_max_keys_per_shard: DEFAULT_MAX_KEYS_PER_SHARD,
             data_freeze_threshold: DEFAULT_FREEZE_THRESHOLD,
-            fork_dictionary_bytes: ReadableSize::mb(64),
+            fork_dictionary_bytes,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes #3555

## What's changed and what's your intention?
Change the default `fork_dictionary_bytes` config in `PartitionTreeMemtable` to mitigate performance issue.

Ingestion rate
<img width="1249" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/6406592/df53be62-7965-44ed-9c07-1075d7568a43">


Memory usage
<img width="1281" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/6406592/bd09424e-e2b0-40bd-91f0-8b18a1ff41ec">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
