### PR TITLE
ci: use a PAT to list all writers

### DIFF
--- a/.github/workflows/unassign.yml
+++ b/.github/workflows/unassign.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Auto Unassign
         uses: tisonspieces/auto-unassign@main
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Default GitHub token cannot access members set their org status as private.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
