### PR TITLE
feat: reload user provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,6 +7514,7 @@ dependencies = [
  "async-recursion",
  "async-stream",
  "async-trait",
+ "auth",
  "catalog",
  "chrono",
  "client",

--- a/src/auth/src/common.rs
+++ b/src/auth/src/common.rs
@@ -40,7 +40,7 @@ pub fn user_provider_from_option(opt: &String) -> Result<UserProviderRef> {
     match name {
         STATIC_USER_PROVIDER => {
             let provider =
-                StaticUserProvider::try_from(content).map(|p| Arc::new(p) as UserProviderRef)?;
+                StaticUserProvider::new(content.into()).map(|p| Arc::new(p) as UserProviderRef)?;
             Ok(provider)
         }
         _ => InvalidConfigSnafu {

--- a/src/auth/src/user_provider.rs
+++ b/src/auth/src/user_provider.rs
@@ -22,6 +22,10 @@ use crate::UserInfoRef;
 pub trait UserProvider: Send + Sync {
     fn name(&self) -> &str;
 
+    fn reload(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Checks whether a user is valid and allowed to access the database.
     async fn authenticate(&self, id: Identity<'_>, password: Password<'_>) -> Result<UserInfoRef>;
 

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -83,6 +83,11 @@ impl QueryEngine for MockQueryEngine {
         unimplemented!()
     }
 
+    fn reload_user_provider(&self) -> query::error::Result<()> {
+        Ok(())
+    }
+
+
     fn engine_context(&self, _query_ctx: QueryContextRef) -> QueryEngineContext {
         unimplemented!()
     }

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -476,8 +476,10 @@ pub fn check_permission(
         Statement::CreateDatabase(_) | Statement::ShowDatabases(_) | Statement::DropDatabase(_) => {
         }
         // show create table and alter are not supported yet
-        Statement::ShowCreateTable(_) | Statement::CreateExternalTable(_) | Statement::Alter(_) => {
-        }
+        Statement::ShowCreateTable(_)
+        | Statement::CreateExternalTable(_)
+        | Statement::Alter(_)
+        | Statement::AlterReload(_) => {}
         // set/show variable now only alter/show variable in session
         Statement::SetVariables(_) | Statement::ShowVariables(_) => {}
 

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -47,6 +47,7 @@ use sql::statements::statement::Statement;
 use sql::statements::OptionMap;
 use sql::util::format_raw_object_name;
 use sqlparser::ast::{Expr, Ident, ObjectName, Value};
+use sql::statements::reload::ReloadTarget;
 use table::requests::{CopyDatabaseRequest, CopyDirection, CopyTableRequest};
 use table::table_reference::TableReference;
 use table::TableRef;
@@ -160,6 +161,13 @@ impl StatementExecutor {
                 Ok(Output::new_with_affected_rows(0))
             }
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
+            Statement::AlterReload(target) => {
+                match target {
+                    ReloadTarget::UserProvider => {
+                        Ok(Output::new_with_affected_rows(0))
+                    }
+                }
+            }
             Statement::DropTable(stmt) => {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(stmt.table_name(), &query_ctx)

--- a/src/query/Cargo.toml
+++ b/src/query/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 ahash.workspace = true
 api.workspace = true
+auth.workspace = true
 arc-swap = "1.0"
 arrow.workspace = true
 arrow-schema.workspace = true

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -39,6 +39,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to reload user provider"))]
+    ReloadUserProvider {
+        #[snafu(source)]
+        source: auth::error::Error,
+        location: Location,
+    },
+
     #[snafu(display("General catalog error"))]
     Catalog {
         source: catalog::error::Error,
@@ -296,6 +303,7 @@ impl ErrorExt for Error {
             RegionQuery { source, .. } => source.status_code(),
             TableMutation { source, .. } => source.status_code(),
             MissingTableMutationHandler { .. } => StatusCode::Unexpected,
+            ReloadUserProvider { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/query/src/query_engine.rs
+++ b/src/query/src/query_engine.rs
@@ -88,6 +88,9 @@ pub trait QueryEngine: Send + Sync {
     /// Create a DataFrame from a table.
     fn read_table(&self, table: TableRef) -> Result<DataFrame>;
 
+    /// Create a DataFrame from a table.
+    fn reload_user_provider(&self) -> Result<()>;
+
     /// Create a [`QueryEngineContext`].
     fn engine_context(&self, query_ctx: QueryContextRef) -> QueryEngineContext;
 }

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
+use auth::{UserProvider, UserProviderRef};
 use catalog::CatalogManagerRef;
 use common_base::Plugins;
 use common_function::function::FunctionRef;
@@ -229,6 +230,11 @@ impl QueryEngineState {
             .map::<QueryOptions, _, _>(|x| x.disallow_cross_catalog_query)
             .unwrap_or(false)
     }
+
+    // pub(crate) fn reload_user_provider(&self) -> DfResult<()> {
+    //     self.plugins.map_mut::<UserProviderRef, _, _>(|x| ());
+    //     Ok(())
+    // }
 
     pub(crate) fn session_state(&self) -> SessionState {
         self.df_context.state()

--- a/src/query/src/query_engine/state.rs
+++ b/src/query/src/query_engine/state.rs
@@ -231,11 +231,6 @@ impl QueryEngineState {
             .unwrap_or(false)
     }
 
-    // pub(crate) fn reload_user_provider(&self) -> DfResult<()> {
-    //     self.plugins.map_mut::<UserProviderRef, _, _>(|x| ());
-    //     Ok(())
-    // }
-
     pub(crate) fn session_state(&self) -> SessionState {
         self.df_context.state()
     }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -28,6 +28,7 @@ pub mod statement;
 pub mod tql;
 mod transform;
 pub mod truncate;
+pub mod reload;
 
 use std::str::FromStr;
 

--- a/src/sql/src/statements/reload.rs
+++ b/src/sql/src/statements/reload.rs
@@ -1,0 +1,20 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sqlparser_derive::{Visit, VisitMut};
+
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
+pub enum ReloadTarget {
+    UserProvider,
+}

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -29,6 +29,7 @@ use crate::statements::drop::DropTable;
 use crate::statements::explain::Explain;
 use crate::statements::insert::Insert;
 use crate::statements::query::Query;
+use crate::statements::reload::ReloadTarget;
 use crate::statements::set_variables::SetVariables;
 use crate::statements::show::{ShowCreateTable, ShowDatabases, ShowTables};
 use crate::statements::tql::Tql;
@@ -56,8 +57,10 @@ pub enum Statement {
     DropDatabase(DropDatabase),
     // CREATE DATABASE
     CreateDatabase(CreateDatabase),
-    /// ALTER TABLE
+    // ALTER TABLE
     Alter(AlterTable),
+    // ALTER SYSTEM RELOAD
+    AlterReload(ReloadTarget),
     // Databases.
     ShowDatabases(ShowDatabases),
     // SHOW TABLES


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This is a draft related to #1862.

But I found an issue -

`UserProvider` is immutable and hard to access in Query/Execute context.

Shall we even make it mutable? Where we should implement this mutation and access to the provider?

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
