### PR TITLE
fix: set http response chartset to utf-8 when using table format

### DIFF
--- a/src/servers/src/http/table_result.rs
+++ b/src/servers/src/http/table_result.rs
@@ -135,7 +135,7 @@ impl IntoResponse for TableResponse {
         let mut resp = (
             [(
                 header::CONTENT_TYPE,
-                HeaderValue::from_static(mime::PLAIN.as_ref()),
+                HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
             )],
             self.to_string(),
         )


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixed the problem mentioned in this PR: https://github.com/GreptimeTeam/greptimedb/pull/3539

## What's changed and what's your intention?

The table format contains non-ASCII characters, and the content-type does not specify a character set. Although most clients will try to using UTF-8, but we cannot make this assumption and need to explicitly set it.

before:
<img width="653" alt="before" src="https://github.com/GreptimeTeam/greptimedb/assets/31284445/c9209ad2-a9d1-458e-9aad-be2a3acef6d6">

after:
<img width="705" alt="after" src="https://github.com/GreptimeTeam/greptimedb/assets/31284445/a81106c2-eea9-4163-ba0d-4ab8e035c676">

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
