### PR TITLE
fix: update pk_cache in compat reader 

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -191,6 +191,9 @@ impl Batch {
     }
 
     /// Replaces the primary key of the batch.
+    ///
+    /// Notice that this [Batch] also contains a maybe-exist `pk_values`.
+    /// Be sure to update that field as well.
     pub fn set_primary_key(&mut self, primary_key: Vec<u8>) {
         self.primary_key = primary_key;
     }

--- a/src/mito2/src/read/compat.rs
+++ b/src/mito2/src/read/compat.rs
@@ -119,6 +119,14 @@ impl CompatPrimaryKey {
         )?;
 
         batch.set_primary_key(buffer);
+
+        // update cache
+        if let Some(pk_values) = &mut batch.pk_values {
+            for value in &self.values {
+                pk_values.push(value.clone());
+            }
+        }
+
         Ok(batch)
     }
 }

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -16,7 +16,9 @@ INSERT INTO test_alt_table VALUES (1, 1, 0), (2, 2, 1);
 
 Affected Rows: 2
 
-ALTER TABLE test_alt_table ADD COLUMN k INTEGER PRIMARY KEY;
+-- TODO: It may result in an error if `k` is with type INTEGER.
+-- Error: 3001(EngineExecuteQuery), Invalid argument error: column types must match schema types, expected Int32 but found Utf8 at column index 3
+ALTER TABLE test_alt_table ADD COLUMN k STRING PRIMARY KEY;
 
 Affected Rows: 0
 
@@ -28,7 +30,7 @@ DESC TABLE test_alt_table;
 | h      | Int32                | PRI | YES  |         | TAG           |
 | i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
-| k      | Int32                | PRI | YES  |         | TAG           |
+| k      | String               | PRI | YES  |         | TAG           |
 +--------+----------------------+-----+------+---------+---------------+
 
 SELECT * FROM test_alt_table;
@@ -61,7 +63,7 @@ DESC TABLE test_alt_table;
 | h      | Int32                | PRI | YES  |         | TAG           |
 | i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
-| k      | Int32                | PRI | YES  |         | TAG           |
+| k      | String               | PRI | YES  |         | TAG           |
 | m      | Int32                |     | YES  |         | FIELD         |
 +--------+----------------------+-----+------+---------+---------------+
 

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -1,4 +1,4 @@
-CREATE TABLE test_alt_table(i INTEGER, j TIMESTAMP TIME INDEX);
+CREATE TABLE test_alt_table(h INTEGER, i INTEGER, j TIMESTAMP TIME INDEX, PRIMARY KEY (h, i));
 
 Affected Rows: 0
 
@@ -7,15 +7,16 @@ DESC TABLE test_alt_table;
 +--------+----------------------+-----+------+---------+---------------+
 | Column | Type                 | Key | Null | Default | Semantic Type |
 +--------+----------------------+-----+------+---------+---------------+
-| i      | Int32                |     | YES  |         | FIELD         |
+| h      | Int32                | PRI | YES  |         | TAG           |
+| i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 +--------+----------------------+-----+------+---------+---------------+
 
-INSERT INTO test_alt_table VALUES (1, 0), (2, 1);
+INSERT INTO test_alt_table VALUES (1, 1, 0), (2, 2, 1);
 
 Affected Rows: 2
 
-ALTER TABLE test_alt_table ADD COLUMN k INTEGER;
+ALTER TABLE test_alt_table ADD COLUMN k INTEGER PRIMARY KEY;
 
 Affected Rows: 0
 
@@ -24,36 +25,28 @@ DESC TABLE test_alt_table;
 +--------+----------------------+-----+------+---------+---------------+
 | Column | Type                 | Key | Null | Default | Semantic Type |
 +--------+----------------------+-----+------+---------+---------------+
-| i      | Int32                |     | YES  |         | FIELD         |
+| h      | Int32                | PRI | YES  |         | TAG           |
+| i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
-| k      | Int32                |     | YES  |         | FIELD         |
+| k      | Int32                | PRI | YES  |         | TAG           |
 +--------+----------------------+-----+------+---------+---------------+
 
 SELECT * FROM test_alt_table;
 
-+---+-------------------------+---+
-| i | j                       | k |
-+---+-------------------------+---+
-| 1 | 1970-01-01T00:00:00     |   |
-| 2 | 1970-01-01T00:00:00.001 |   |
-+---+-------------------------+---+
-
-SELECT * FROM test_alt_table WHERE k IS NULL;
-
-+---+-------------------------+---+
-| i | j                       | k |
-+---+-------------------------+---+
-| 1 | 1970-01-01T00:00:00     |   |
-| 2 | 1970-01-01T00:00:00.001 |   |
-+---+-------------------------+---+
++---+---+-------------------------+---+
+| h | i | j                       | k |
++---+---+-------------------------+---+
+| 1 | 1 | 1970-01-01T00:00:00     |   |
+| 2 | 2 | 1970-01-01T00:00:00.001 |   |
++---+---+-------------------------+---+
 
 SELECT * FROM test_alt_table WHERE i = 1;
 
-+---+---------------------+---+
-| i | j                   | k |
-+---+---------------------+---+
-| 1 | 1970-01-01T00:00:00 |   |
-+---+---------------------+---+
++---+---+---------------------+---+
+| h | i | j                   | k |
++---+---+---------------------+---+
+| 1 | 1 | 1970-01-01T00:00:00 |   |
++---+---+---------------------+---+
 
 -- SQLNESS ARG restart=true
 ALTER TABLE test_alt_table ADD COLUMN m INTEGER;
@@ -65,9 +58,10 @@ DESC TABLE test_alt_table;
 +--------+----------------------+-----+------+---------+---------------+
 | Column | Type                 | Key | Null | Default | Semantic Type |
 +--------+----------------------+-----+------+---------+---------------+
-| i      | Int32                |     | YES  |         | FIELD         |
+| h      | Int32                | PRI | YES  |         | TAG           |
+| i      | Int32                | PRI | YES  |         | TAG           |
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
-| k      | Int32                |     | YES  |         | FIELD         |
+| k      | Int32                | PRI | YES  |         | TAG           |
 | m      | Int32                |     | YES  |         | FIELD         |
 +--------+----------------------+-----+------+---------+---------------+
 

--- a/tests/cases/standalone/common/alter/alter_table.result
+++ b/tests/cases/standalone/common/alter/alter_table.result
@@ -11,6 +11,10 @@ DESC TABLE test_alt_table;
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 +--------+----------------------+-----+------+---------+---------------+
 
+INSERT INTO test_alt_table VALUES (1, 0), (2, 1);
+
+Affected Rows: 2
+
 ALTER TABLE test_alt_table ADD COLUMN k INTEGER;
 
 Affected Rows: 0
@@ -24,6 +28,32 @@ DESC TABLE test_alt_table;
 | j      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | k      | Int32                |     | YES  |         | FIELD         |
 +--------+----------------------+-----+------+---------+---------------+
+
+SELECT * FROM test_alt_table;
+
++---+-------------------------+---+
+| i | j                       | k |
++---+-------------------------+---+
+| 1 | 1970-01-01T00:00:00     |   |
+| 2 | 1970-01-01T00:00:00.001 |   |
++---+-------------------------+---+
+
+SELECT * FROM test_alt_table WHERE k IS NULL;
+
++---+-------------------------+---+
+| i | j                       | k |
++---+-------------------------+---+
+| 1 | 1970-01-01T00:00:00     |   |
+| 2 | 1970-01-01T00:00:00.001 |   |
++---+-------------------------+---+
+
+SELECT * FROM test_alt_table WHERE i = 1;
+
++---+---------------------+---+
+| i | j                   | k |
++---+---------------------+---+
+| 1 | 1970-01-01T00:00:00 |   |
++---+---------------------+---+
 
 -- SQLNESS ARG restart=true
 ALTER TABLE test_alt_table ADD COLUMN m INTEGER;

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -2,9 +2,17 @@ CREATE TABLE test_alt_table(i INTEGER, j TIMESTAMP TIME INDEX);
 
 DESC TABLE test_alt_table;
 
+INSERT INTO test_alt_table VALUES (1, 0), (2, 1);
+
 ALTER TABLE test_alt_table ADD COLUMN k INTEGER;
 
 DESC TABLE test_alt_table;
+
+SELECT * FROM test_alt_table;
+
+SELECT * FROM test_alt_table WHERE k IS NULL;
+
+SELECT * FROM test_alt_table WHERE i = 1;
 
 -- SQLNESS ARG restart=true
 ALTER TABLE test_alt_table ADD COLUMN m INTEGER;

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -4,7 +4,9 @@ DESC TABLE test_alt_table;
 
 INSERT INTO test_alt_table VALUES (1, 1, 0), (2, 2, 1);
 
-ALTER TABLE test_alt_table ADD COLUMN k INTEGER PRIMARY KEY;
+-- TODO: It may result in an error if `k` is with type INTEGER.
+-- Error: 3001(EngineExecuteQuery), Invalid argument error: column types must match schema types, expected Int32 but found Utf8 at column index 3
+ALTER TABLE test_alt_table ADD COLUMN k STRING PRIMARY KEY;
 
 DESC TABLE test_alt_table;
 

--- a/tests/cases/standalone/common/alter/alter_table.sql
+++ b/tests/cases/standalone/common/alter/alter_table.sql
@@ -1,16 +1,14 @@
-CREATE TABLE test_alt_table(i INTEGER, j TIMESTAMP TIME INDEX);
+CREATE TABLE test_alt_table(h INTEGER, i INTEGER, j TIMESTAMP TIME INDEX, PRIMARY KEY (h, i));
 
 DESC TABLE test_alt_table;
 
-INSERT INTO test_alt_table VALUES (1, 0), (2, 1);
+INSERT INTO test_alt_table VALUES (1, 1, 0), (2, 2, 1);
 
-ALTER TABLE test_alt_table ADD COLUMN k INTEGER;
+ALTER TABLE test_alt_table ADD COLUMN k INTEGER PRIMARY KEY;
 
 DESC TABLE test_alt_table;
 
 SELECT * FROM test_alt_table;
-
-SELECT * FROM test_alt_table WHERE k IS NULL;
 
 SELECT * FROM test_alt_table WHERE i = 1;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


SELECT with a filter will decode the primary key in advance, before compat reader. And compat reader doesn't handle the cache which leads to this error.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
