### PR TITLE
ci: use single commit on the deployment branch

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -40,3 +40,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: target/doc
+        single-commit: true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3579

## What's changed and what's your intention?
This PR sets `single-commit` to `true` for the `gh-pages` branch. It should reduce the branch size.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
