### PR TITLE
feat: support time range in copy table

### DIFF
--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -360,6 +360,8 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
             .map_err(BoxedError::new)
             .context(ExternalSnafu)?;
 
+    let timestamp_range = timestamp_range_from_option_map(&with, &query_ctx)?;
+
     let pattern = with
         .get(common_datasource::file_format::FILE_PATTERN)
         .cloned();
@@ -373,8 +375,7 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
         connection: connection.map,
         pattern,
         direction,
-        // we copy the whole table by default.
-        timestamp_range: None,
+        timestamp_range,
     })
 }
 
@@ -387,16 +388,7 @@ fn to_copy_database_request(
     let (catalog_name, database_name) = idents_to_full_database_name(&arg.database_name, query_ctx)
         .map_err(BoxedError::new)
         .context(ExternalSnafu)?;
-
-    let start_timestamp = extract_timestamp(&arg.with, COPY_DATABASE_TIME_START_KEY, query_ctx)?;
-    let end_timestamp = extract_timestamp(&arg.with, COPY_DATABASE_TIME_END_KEY, query_ctx)?;
-
-    let time_range = match (start_timestamp, end_timestamp) {
-        (Some(start), Some(end)) => TimestampRange::new(start, end),
-        (Some(start), None) => Some(TimestampRange::from_start(start)),
-        (None, Some(end)) => Some(TimestampRange::until_end(end, false)), // exclusive end
-        (None, None) => None,
-    };
+    let time_range = timestamp_range_from_option_map(&arg.with, query_ctx)?;
 
     Ok(CopyDatabaseRequest {
         catalog_name,
@@ -406,6 +398,24 @@ fn to_copy_database_request(
         connection: arg.connection.map,
         time_range,
     })
+}
+
+/// Extracts timestamp range from OptionMap with keys `start_time` and `end_time`.
+/// The timestamp ranges should be a valid timestamp string as defined in [Timestamp::from_str].
+/// The timezone used for conversion will respect that inside `query_ctx`.
+fn timestamp_range_from_option_map(
+    options: &OptionMap,
+    query_ctx: &QueryContextRef,
+) -> Result<Option<TimestampRange>> {
+    let start_timestamp = extract_timestamp(options, COPY_DATABASE_TIME_START_KEY, query_ctx)?;
+    let end_timestamp = extract_timestamp(options, COPY_DATABASE_TIME_END_KEY, query_ctx)?;
+    let time_range = match (start_timestamp, end_timestamp) {
+        (Some(start), Some(end)) => TimestampRange::new(start, end),
+        (Some(start), None) => Some(TimestampRange::from_start(start)),
+        (None, Some(end)) => Some(TimestampRange::until_end(end, false)), // exclusive end
+        (None, None) => None,
+    };
+    Ok(time_range)
 }
 
 /// Extracts timestamp from a [HashMap<String, String>] with given key.
@@ -438,5 +448,46 @@ fn idents_to_full_database_name(
             ),
         }
         .fail(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use common_time::{Timestamp, Timezone};
+    use session::context::QueryContextBuilder;
+    use sql::statements::OptionMap;
+
+    use crate::statement::copy_database::{
+        COPY_DATABASE_TIME_END_KEY, COPY_DATABASE_TIME_START_KEY,
+    };
+    use crate::statement::timestamp_range_from_option_map;
+
+    #[test]
+    fn test_timestamp_range_from_option_map() {
+        let query_ctx = QueryContextBuilder::default()
+            .timezone(Arc::new(Timezone::from_tz_string("Asia/Shanghai").unwrap()))
+            .build();
+        let map = OptionMap::from(
+            [
+                (
+                    COPY_DATABASE_TIME_START_KEY.to_string(),
+                    "2022-04-11 08:00:00".to_string(),
+                ),
+                (
+                    COPY_DATABASE_TIME_END_KEY.to_string(),
+                    "2022-04-11 16:00:00".to_string(),
+                ),
+            ]
+            .into_iter()
+            .collect::<HashMap<_, _>>(),
+        );
+        let range = timestamp_range_from_option_map(&map, &query_ctx)
+            .unwrap()
+            .unwrap();
+        assert_eq!(Timestamp::new_second(1649635200), range.start().unwrap());
+        assert_eq!(Timestamp::new_second(1649664000), range.end().unwrap());
     }
 }

--- a/tests/cases/standalone/common/copy/copy_to_fs.result
+++ b/tests/cases/standalone/common/copy/copy_to_fs.result
@@ -1,4 +1,9 @@
-CREATE TABLE demo(host string, cpu double, memory double, ts TIMESTAMP time index);
+--- Set time zone ---
+set time_zone='Asia/Shanghai';
+
+Affected Rows: 0
+
+CREATE TABLE demo(host string, cpu DOUBLE, memory DOUBLE, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
 
@@ -6,17 +11,17 @@ insert into demo(host, cpu, memory, ts) values ('host1', 66.6, 1024, 16552765570
 
 Affected Rows: 2
 
-Copy demo TO '/tmp/export/demo.parquet';
+COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
-Affected Rows: 2
+Affected Rows: 1
 
-Copy demo TO '/tmp/export/demo.csv' with (format='csv');
+COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
-Affected Rows: 2
+Affected Rows: 1
 
-Copy demo TO '/tmp/export/demo.json' with (format='json');
+COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
-Affected Rows: 2
+Affected Rows: 1
 
 drop table demo;
 

--- a/tests/cases/standalone/common/copy/copy_to_fs.result
+++ b/tests/cases/standalone/common/copy/copy_to_fs.result
@@ -1,8 +1,3 @@
---- Set time zone ---
-set time_zone='Asia/Shanghai';
-
-Affected Rows: 0
-
 CREATE TABLE demo(host string, cpu DOUBLE, memory DOUBLE, ts TIMESTAMP TIME INDEX);
 
 Affected Rows: 0
@@ -11,15 +6,15 @@ insert into demo(host, cpu, memory, ts) values ('host1', 66.6, 1024, 16552765570
 
 Affected Rows: 2
 
-COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
 Affected Rows: 1
 
-COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
 Affected Rows: 1
 
-COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
 Affected Rows: 1
 

--- a/tests/cases/standalone/common/copy/copy_to_fs.sql
+++ b/tests/cases/standalone/common/copy/copy_to_fs.sql
@@ -1,11 +1,14 @@
-CREATE TABLE demo(host string, cpu double, memory double, ts TIMESTAMP time index);
+--- Set time zone ---
+set time_zone='Asia/Shanghai';
+
+CREATE TABLE demo(host string, cpu DOUBLE, memory DOUBLE, ts TIMESTAMP TIME INDEX);
 
 insert into demo(host, cpu, memory, ts) values ('host1', 66.6, 1024, 1655276557000), ('host2', 88.8,  333.3, 1655276558000);
 
-Copy demo TO '/tmp/export/demo.parquet';
+COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
-Copy demo TO '/tmp/export/demo.csv' with (format='csv');
+COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
-Copy demo TO '/tmp/export/demo.json' with (format='json');
+COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
 
 drop table demo;

--- a/tests/cases/standalone/common/copy/copy_to_fs.sql
+++ b/tests/cases/standalone/common/copy/copy_to_fs.sql
@@ -1,14 +1,11 @@
---- Set time zone ---
-set time_zone='Asia/Shanghai';
-
 CREATE TABLE demo(host string, cpu DOUBLE, memory DOUBLE, ts TIMESTAMP TIME INDEX);
 
 insert into demo(host, cpu, memory, ts) values ('host1', 66.6, 1024, 1655276557000), ('host2', 88.8,  333.3, 1655276558000);
 
-COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.parquet' WITH (start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
-COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.csv' WITH (format='csv', start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
-COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 15:02:37', end_time='2022-06-15 15:02:38');
+COPY demo TO '/tmp/export/demo.json' WITH (format='json', start_time='2022-06-15 07:02:37', end_time='2022-06-15 07:02:38');
 
 drop table demo;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds support for specifying time range to export when executing `COPY <TABLE> TO` statement.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
