### PR TITLE
chore: limit OpenDAL's feature gates

### DIFF
--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -20,7 +20,14 @@ md5 = "0.7"
 moka = { workspace = true, features = ["future"] }
 opendal = { version = "0.45", features = [
     "layers-tracing",
-] }
+    "rustls",
+    "services-azblob",
+    "services-fs",
+    "services-gcs",
+    "services-http",
+    "services-oss",
+    "services-s3",
+], default-features = false }
 prometheus.workspace = true
 snafu.workspace = true
 uuid.workspace = true
@@ -29,4 +36,5 @@ uuid.workspace = true
 anyhow = "1.0"
 common-telemetry.workspace = true
 common-test-util.workspace = true
+opendal = { version = "0.45", features = ["services-memory"] }
 tokio.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Topic from https://github.com/GreptimeTeam/greptimedb/pull/3582

## What's changed and what's your intention?

OpenDAL's default features contain many services that aren't used in our system. Opt them out can reduce the compile time of OpenDAL by half (from 29.31s to 15.07s) and speed up the overall compile time by 2s (out of 151s in total).

This is because OpenDAL lies in the critical path of the entire compile progress, and long compile time would lead to a small hang:

| - | - |
|:-:|:-:|
| Before | <img width="1813" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/42cdaaa1-b4e2-4b0f-86d9-49315aa20333"> |
| After | <img width="1744" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/b004e9ed-4493-4579-8976-654269027581">  |


P.S.:

The following big hang is from DataFusion...

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
