### PR TITLE
fix: incorrect version info in

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -13,5 +13,8 @@
 // limitations under the License.
 
 fn main() {
+    // Trigger this script if the git branch/commit changes
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+
     common_version::setup_build_info();
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The build script in `cmd` won't rerun if the current git HEAD is changed, and will likely produce an incorrect result in `--version`.

<img width="451" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/80b3af8a-3ba8-4632-a019-6d31aae881a4">


But our release is not affected as the environment is clear for each release build.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
