### PR TITLE
feat: create regions persist true

### DIFF
--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -195,9 +195,8 @@ impl CreateTableProcedure {
         // Safety: the table route must be allocated.
         match self.table_route()?.clone() {
             TableRouteValue::Physical(x) => {
-                let region_routes = x.region_routes.clone();
                 let request_builder = self.new_region_request_builder(None)?;
-                self.create_regions(&region_routes, request_builder).await
+                self.create_regions(&x.region_routes, request_builder).await
             }
             TableRouteValue::Logical(x) => {
                 let physical_table_id = x.physical_table_id();

--- a/src/common/meta/src/ddl/create_table.rs
+++ b/src/common/meta/src/ddl/create_table.rs
@@ -288,9 +288,8 @@ impl CreateTableProcedure {
 
         self.creator.data.state = CreateTableState::CreateMetadata;
 
-        // Ensures the procedures after the crash start from the `DatanodeCreateRegions` stage.
         // TODO(weny): Add more tests.
-        Ok(Status::executing(false))
+        Ok(Status::executing(true))
     }
 
     /// Creates table metadata

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -237,7 +237,7 @@ async fn test_on_datanode_create_regions() {
     });
 
     let status = procedure.on_datanode_create_regions().await.unwrap();
-    assert!(matches!(status, Status::Executing { persist: false }));
+    assert!(matches!(status, Status::Executing { persist: true }));
     assert!(matches!(
         procedure.creator.data.state,
         CreateTableState::CreateMetadata


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

__!!! DO NOT LEAVE THIS BLOCK EMPTY !!!__

When creating table, the step of `create region` should persist its's status.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
