### PR TITLE
feat: adds metric engine to information_schema engines table

### DIFF
--- a/src/catalog/src/information_schema/memory_table/tables.rs
+++ b/src/catalog/src/information_schema/memory_table/tables.rs
@@ -14,12 +14,14 @@
 
 use std::sync::Arc;
 
-use common_catalog::consts::MITO_ENGINE;
+use common_catalog::consts::{METRIC_ENGINE, MITO_ENGINE};
 use datatypes::prelude::{ConcreteDataType, VectorRef};
 use datatypes::schema::{ColumnSchema, Schema, SchemaRef};
 use datatypes::vectors::{Int64Vector, StringVector};
 
 use crate::information_schema::table_names::*;
+
+const NO_VALUE: &str = "NO";
 
 /// Find the schema and columns by the table_name, only valid for memory tables.
 /// Safety: the user MUST ensure the table schema exists, panic otherwise.
@@ -59,14 +61,15 @@ pub fn get_schema_columns(table_name: &str) -> (SchemaRef, Vec<VectorRef>) {
                 "SAVEPOINTS",
             ]),
             vec![
-                Arc::new(StringVector::from(vec![MITO_ENGINE])),
-                Arc::new(StringVector::from(vec!["DEFAULT"])),
+                Arc::new(StringVector::from(vec![MITO_ENGINE, METRIC_ENGINE])),
+                Arc::new(StringVector::from(vec!["DEFAULT", "DEFAULT"])),
                 Arc::new(StringVector::from(vec![
                     "Storage engine for time-series data",
+                    "Storage engine for observability scenarios, which is adept at handling a large number of small tables, making it particularly suitable for cloud-native monitoring",
                 ])),
-                Arc::new(StringVector::from(vec!["NO"])),
-                Arc::new(StringVector::from(vec!["NO"])),
-                Arc::new(StringVector::from(vec!["NO"])),
+                Arc::new(StringVector::from(vec![NO_VALUE, NO_VALUE])),
+                Arc::new(StringVector::from(vec![NO_VALUE, NO_VALUE])),
+                Arc::new(StringVector::from(vec![NO_VALUE, NO_VALUE])),
             ],
         ),
 

--- a/src/catalog/src/information_schema/memory_table/tables.rs
+++ b/src/catalog/src/information_schema/memory_table/tables.rs
@@ -62,7 +62,7 @@ pub fn get_schema_columns(table_name: &str) -> (SchemaRef, Vec<VectorRef>) {
             ]),
             vec![
                 Arc::new(StringVector::from(vec![MITO_ENGINE, METRIC_ENGINE])),
-                Arc::new(StringVector::from(vec!["DEFAULT", "DEFAULT"])),
+                Arc::new(StringVector::from(vec!["DEFAULT", "YES"])),
                 Arc::new(StringVector::from(vec![
                     "Storage engine for time-series data",
                     "Storage engine for observability scenarios, which is adept at handling a large number of small tables, making it particularly suitable for cloud-native monitoring",

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -516,7 +516,7 @@ select * from engines;
 | engine | support | comment                                                                                                                                                            | transactions | xa | savepoints |
 +--------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----+------------+
 | mito   | DEFAULT | Storage engine for time-series data                                                                                                                                | NO           | NO | NO         |
-| metric | DEFAULT | Storage engine for observability scenarios, which is adept at handling a large number of small tables, making it particularly suitable for cloud-native monitoring | NO           | NO | NO         |
+| metric | YES     | Storage engine for observability scenarios, which is adept at handling a large number of small tables, making it particularly suitable for cloud-native monitoring | NO           | NO | NO         |
 +--------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----+------------+
 
 desc table build_info;

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -512,11 +512,12 @@ select * from schemata where catalog_name = 'greptime' and schema_name != 'publi
 -- test engines
 select * from engines;
 
-+--------+---------+-------------------------------------+--------------+----+------------+
-| engine | support | comment                             | transactions | xa | savepoints |
-+--------+---------+-------------------------------------+--------------+----+------------+
-| mito   | DEFAULT | Storage engine for time-series data | NO           | NO | NO         |
-+--------+---------+-------------------------------------+--------------+----+------------+
++--------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----+------------+
+| engine | support | comment                                                                                                                                                            | transactions | xa | savepoints |
++--------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----+------------+
+| mito   | DEFAULT | Storage engine for time-series data                                                                                                                                | NO           | NO | NO         |
+| metric | DEFAULT | Storage engine for observability scenarios, which is adept at handling a large number of small tables, making it particularly suitable for cloud-native monitoring | NO           | NO | NO         |
++--------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+----+------------+
 
 desc table build_info;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Adds `metric` engine to `information_schema` engines table.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
