### PR TITLE
feat: support `2+2` and `/status/buildinfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,8 @@ name = "common-version"
 version = "0.7.1"
 dependencies = [
  "build-data",
+ "schemars",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 rskafka = "0.5"
 rust_decimal = "1.33"
+schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_with = "3"

--- a/src/common/version/Cargo.toml
+++ b/src/common/version/Cargo.toml
@@ -7,5 +7,10 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+codec = ["dep:serde", "dep:schemars"]
+
 [dependencies]
 build-data = "0.1.4"
+schemars = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }

--- a/src/common/version/src/lib.rs
+++ b/src/common/version/src/lib.rs
@@ -18,6 +18,11 @@ use std::sync::OnceLock;
 
 const UNKNOWN: &str = "unknown";
 
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "codec",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)
+)]
 pub struct BuildInfo {
     pub branch: Cow<'static, str>,
     pub commit: Cow<'static, str>,

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -41,7 +41,7 @@ common-recordbatch.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
-common-version = { workspace = true, features=["codec"] }
+common-version = { workspace = true, features = ["codec"] }
 dashmap.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -41,6 +41,7 @@ common-recordbatch.workspace = true
 common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
+common-version = { workspace = true, features=["codec"] }
 dashmap.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true
@@ -83,7 +84,7 @@ rust-embed = { version = "6.6", features = ["debug-embed"] }
 rustls = "0.22"
 rustls-pemfile = "2.0"
 rustls-pki-types = "1.0"
-schemars = "0.8"
+schemars.workspace = true
 secrecy = { version = "0.8", features = ["serde", "alloc"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -59,7 +59,8 @@ use crate::http::greptime_result_v1::GreptimedbV1Response;
 use crate::http::influxdb::{influxdb_health, influxdb_ping, influxdb_write_v1, influxdb_write_v2};
 use crate::http::influxdb_result_v1::InfluxdbV1Response;
 use crate::http::prometheus::{
-    format_query, instant_query, label_values_query, labels_query, range_query, series_query,
+    build_info_query, format_query, instant_query, label_values_query, labels_query, range_query,
+    series_query,
 };
 use crate::metrics::http_metrics_layer;
 use crate::metrics_handler::MetricsHandler;
@@ -682,6 +683,7 @@ impl HttpServer {
                 "/format_query",
                 routing::post(format_query).get(format_query),
             )
+            .route("/status/buildinfo", routing::get(build_info_query))
             .route("/query", routing::post(instant_query).get(instant_query))
             .route("/query_range", routing::post(range_query).get(range_query))
             .route("/labels", routing::post(labels_query).get(labels_query))

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -27,6 +27,7 @@ use common_query::{Output, OutputData};
 use common_recordbatch::RecordBatches;
 use common_telemetry::tracing;
 use common_time::util::{current_time_rfc3339, yesterday_rfc3339};
+use common_version::BuildInfo;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::scalars::ScalarVector;
 use datatypes::vectors::{Float64Vector, StringVector};
@@ -76,6 +77,7 @@ pub enum PrometheusResponse {
     Series(Vec<HashMap<String, String>>),
     LabelValues(Vec<String>),
     FormatQuery(String),
+    BuildInfo(BuildInfo),
 }
 
 impl Default for PrometheusResponse {
@@ -111,6 +113,19 @@ pub async fn format_query(
             PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg())
         }
     }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct BuildInfoQuery {}
+
+#[axum_macros::debug_handler]
+#[tracing::instrument(
+    skip_all,
+    fields(protocol = "prometheus", request_type = "build_info_query")
+)]
+pub async fn build_info_query() -> PrometheusJsonResponse {
+    let build_info = common_version::build_info().clone();
+    PrometheusJsonResponse::success(PrometheusResponse::BuildInfo(build_info))
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -52,21 +52,42 @@ use crate::http::header::collect_plan_metrics;
 use crate::prom_store::METRIC_NAME_LABEL;
 use crate::prometheus_handler::PrometheusHandlerRef;
 
+/// For [ValueType::Vector] result type
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct PromSeries {
+pub struct PromSeriesVector {
     pub metric: HashMap<String, String>,
-    /// For [ValueType::Matrix] result type
-    pub values: Vec<(f64, String)>,
-    /// For [ValueType::Vector] result type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<(f64, String)>,
+}
+
+/// For [ValueType::Matrix] result type
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct PromSeriesMatrix {
+    pub metric: HashMap<String, String>,
+    pub values: Vec<(f64, String)>,
+}
+
+/// Variants corresponding to [ValueType]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(untagged)]
+pub enum PromQueryResult {
+    Matrix(Vec<PromSeriesMatrix>),
+    Vector(Vec<PromSeriesVector>),
+    Scalar(#[serde(skip_serializing_if = "Option::is_none")] Option<(f64, String)>),
+    String(#[serde(skip_serializing_if = "Option::is_none")] Option<(f64, String)>),
+}
+
+impl Default for PromQueryResult {
+    fn default() -> Self {
+        PromQueryResult::Matrix(Default::default())
+    }
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct PromData {
     #[serde(rename = "resultType")]
     pub result_type: String,
-    pub result: Vec<PromSeries>,
+    pub result: PromQueryResult,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq)]

--- a/src/servers/src/http/prometheus_resp.rs
+++ b/src/servers/src/http/prometheus_resp.rs
@@ -283,7 +283,7 @@ impl PrometheusJsonResponse {
                     *v = values.pop();
                 }
                 PromQueryResult::String(ref mut _v) => {
-                    // Not supported yet
+                    // TODO(ruihang): Not supported yet
                 }
             }
         });

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -403,6 +403,22 @@ pub async fn test_prom_http_api(store_type: StorageType) {
         .await;
     assert_eq!(res.status(), StatusCode::OK);
 
+    // instant query 1+1
+    let res = client
+        .get("/v1/prometheus/api/v1/query?query=1%2B1&time=1")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = serde_json::from_str::<PrometheusJsonResponse>(&res.text().await).unwrap();
+    assert_eq!(body.status, "success");
+    assert_eq!(
+        body.data,
+        serde_json::from_value::<PrometheusResponse>(
+            json!({"resultType":"scalar","result":[1.0,"2"]})
+        )
+        .unwrap()
+    );
+
     // range query
     let res = client
         .get("/v1/prometheus/api/v1/query_range?query=up&start=1&end=100&step=5")
@@ -538,6 +554,15 @@ pub async fn test_prom_http_api(store_type: StorageType) {
     assert_eq!(prom_resp.status, "success");
     assert!(prom_resp.error.is_none());
     assert!(prom_resp.error_type.is_none());
+
+    // buildinfo
+    let res = client
+        .get("/v1/prometheus/api/v1/status/buildinfo")
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body = serde_json::from_str::<PrometheusJsonResponse>(&res.text().await).unwrap();
+    assert_eq!(body.status, "success");
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
Closes https://github.com/GreptimeTeam/greptimedb/issues/3496

## What's changed and what's your intention?


When adding GreptimeDB to Grafana (v9.0) datasource using Prometheus extension, it will send two queries:
```
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on docker0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
15:55:50.899080 IP 172.17.0.3.54034 > 172.17.0.1.4000: Flags [P.], seq 3048369435:3048369718, ack 3792103051, win 251, options [nop,nop,TS val 2511689527 ecr 2125370641], length 283
E..O..@.@.................m.........Yh.....
..W7~...POST /v1/prometheus/api/v1/query HTTP/1.1
Host: 172.17.0.1:4000
User-Agent: Grafana/10.2.3
Content-Length: 18
Content-Type: application/x-www-form-urlencoded
X-Datasource-Uid: c91e98f4-01ea-4ffd-890a-eef523983c78
X-Grafana-Org-Id: 1
Accept-Encoding: gzip

query=1%2B1&time=4
15:55:50.901986 IP 172.17.0.3.54034 > 172.17.0.1.4000: Flags [P.], seq 283:489, ack 229, win 250, options [nop,nop,TS val 2511689530 ecr 2125370644], length 206
E.....@.@.................n6...o....Y......
..W:~...GET /v1/prometheus/api/v1/status/buildinfo HTTP/1.1
Host: 172.17.0.1:4000
User-Agent: Grafana/10.2.3
X-Datasource-Uid: c91e98f4-01ea-4ffd-890a-eef523983c78
X-Grafana-Org-Id: 1
Accept-Encoding: gzip
```

This patch supports these two requests. Now GreptimeDB can be add to Grafana data source via Prometheus extension without error:

<img width="976" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/813c69da-b361-4146-9bd9-17b833477031">


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
