### PR TITLE
feat: let alter table procedure can only alter physical table

### DIFF
--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -356,7 +356,6 @@ impl TableMetadataManager {
         &self.kv_backend
     }
 
-    // TODO(ruihang): deprecate this
     pub async fn get_full_table_info(
         &self,
         table_id: TableId,
@@ -368,17 +367,14 @@ impl TableMetadataManager {
             .table_route_manager
             .table_route_storage()
             .build_get_txn(table_id);
-
         let (get_table_info_txn, table_info_decoder) =
             self.table_info_manager.build_get_txn(table_id);
 
         let txn = Txn::merge_all(vec![get_table_route_txn, get_table_info_txn]);
+        let res = self.kv_backend.txn(txn).await?;
 
-        let r = self.kv_backend.txn(txn).await?;
-
-        let table_info_value = table_info_decoder(&r.responses)?;
-
-        let table_route_value = table_route_decoder(&r.responses)?;
+        let table_info_value = table_info_decoder(&res.responses)?;
+        let table_route_value = table_route_decoder(&res.responses)?;
 
         Ok((table_info_value, table_route_value))
     }

--- a/src/meta-srv/src/procedure/tests.rs
+++ b/src/meta-srv/src/procedure/tests.rs
@@ -407,7 +407,6 @@ fn test_create_alter_region_request() {
         1,
         alter_table_task,
         DeserializedValueWithBytes::from_inner(TableInfoValue::new(test_data::new_table_info())),
-        None,
         test_data::new_ddl_context(Arc::new(DatanodeClients::default())),
     )
     .unwrap();
@@ -478,7 +477,6 @@ async fn test_submit_alter_region_requests() {
         1,
         alter_table_task,
         DeserializedValueWithBytes::from_inner(TableInfoValue::new(table_info)),
-        None,
         context,
     )
     .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title said, we already have the `AlterLogicalTablesProcedure` for logical tables.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
