### PR TITLE
feat: add append mode to table options

### DIFF
--- a/src/mito2/src/worker/handle_write.rs
+++ b/src/mito2/src/worker/handle_write.rs
@@ -239,7 +239,7 @@ fn check_op_type(append_mode: bool, request: &WriteRequest) -> Result<()> {
             request.op_type == OpType::Put,
             InvalidRequestSnafu {
                 region_id: request.region_id,
-                reason: "Only put is allowed under append mode",
+                reason: "DELETE is not allowed under append mode",
             }
         );
     }

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -33,6 +33,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
         "memtable.partition_tree.index_max_keys_per_shard",
         "memtable.partition_tree.data_freeze_threshold",
         "memtable.partition_tree.fork_dictionary_bytes",
+        "append_mode",
     ]
     .contains(&key)
 }
@@ -70,6 +71,7 @@ mod tests {
         assert!(is_mito_engine_option_key(
             "memtable.partition_tree.fork_dictionary_bytes"
         ));
+        assert!(is_mito_engine_option_key("append_mode"));
         assert!(!is_mito_engine_option_key("foo"));
     }
 }

--- a/tests/cases/standalone/common/insert/append_mode.result
+++ b/tests/cases/standalone/common/insert/append_mode.result
@@ -1,0 +1,68 @@
+create table if not exists append_mode1(
+    host string,
+    ts timestamp,
+    cpu double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('append_mode'='true');
+
+Affected Rows: 0
+
+INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+Affected Rows: 2
+
+INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+Affected Rows: 2
+
+SELECT * from append_mode1 ORDER BY host, ts;
+
++-------+-------------------------+-----+
+| host  | ts                      | cpu |
++-------+-------------------------+-----+
+| host1 | 1970-01-01T00:00:00     | 0.0 |
+| host1 | 1970-01-01T00:00:00     | 0.0 |
+| host2 | 1970-01-01T00:00:00.001 | 1.0 |
+| host2 | 1970-01-01T00:00:00.001 | 1.0 |
++-------+-------------------------+-----+
+
+create table if not exists append_mode2(
+    host string,
+    ts timestamp,
+    cpu double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('append_mode'='false');
+
+Affected Rows: 0
+
+INSERT INTO append_mode2 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+Affected Rows: 2
+
+INSERT INTO append_mode2 VALUES ('host1',0, 10), ('host2', 1, 11,);
+
+Affected Rows: 2
+
+SELECT * from append_mode2 ORDER BY host, ts;
+
++-------+-------------------------+------+
+| host  | ts                      | cpu  |
++-------+-------------------------+------+
+| host1 | 1970-01-01T00:00:00     | 10.0 |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 |
++-------+-------------------------+------+
+
+DROP TABLE append_mode1;
+
+Affected Rows: 0
+
+DROP TABLE append_mode2;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/insert/append_mode.result
+++ b/tests/cases/standalone/common/insert/append_mode.result
@@ -1,4 +1,4 @@
-create table if not exists append_mode1(
+create table if not exists append_mode_on(
     host string,
     ts timestamp,
     cpu double,
@@ -10,15 +10,15 @@ with('append_mode'='true');
 
 Affected Rows: 0
 
-INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_on VALUES ('host1',0, 0), ('host2', 1, 1,);
 
 Affected Rows: 2
 
-INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_on VALUES ('host1',0, 0), ('host2', 1, 1,);
 
 Affected Rows: 2
 
-SELECT * from append_mode1 ORDER BY host, ts;
+SELECT * from append_mode_on ORDER BY host, ts;
 
 +-------+-------------------------+-----+
 | host  | ts                      | cpu |
@@ -29,7 +29,7 @@ SELECT * from append_mode1 ORDER BY host, ts;
 | host2 | 1970-01-01T00:00:00.001 | 1.0 |
 +-------+-------------------------+-----+
 
-create table if not exists append_mode2(
+create table if not exists append_mode_off(
     host string,
     ts timestamp,
     cpu double,
@@ -41,15 +41,15 @@ with('append_mode'='false');
 
 Affected Rows: 0
 
-INSERT INTO append_mode2 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_off VALUES ('host1',0, 0), ('host2', 1, 1,);
 
 Affected Rows: 2
 
-INSERT INTO append_mode2 VALUES ('host1',0, 10), ('host2', 1, 11,);
+INSERT INTO append_mode_off VALUES ('host1',0, 10), ('host2', 1, 11,);
 
 Affected Rows: 2
 
-SELECT * from append_mode2 ORDER BY host, ts;
+SELECT * from append_mode_off ORDER BY host, ts;
 
 +-------+-------------------------+------+
 | host  | ts                      | cpu  |
@@ -58,11 +58,11 @@ SELECT * from append_mode2 ORDER BY host, ts;
 | host2 | 1970-01-01T00:00:00.001 | 11.0 |
 +-------+-------------------------+------+
 
-DROP TABLE append_mode1;
+DROP TABLE append_mode_on;
 
 Affected Rows: 0
 
-DROP TABLE append_mode2;
+DROP TABLE append_mode_off;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/insert/append_mode.result
+++ b/tests/cases/standalone/common/insert/append_mode.result
@@ -29,6 +29,11 @@ SELECT * from append_mode_on ORDER BY host, ts;
 | host2 | 1970-01-01T00:00:00.001 | 1.0 |
 +-------+-------------------------+-----+
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
+DELETE FROM append_mode_on WHERE host = 'host1';
+
+Error: 1004(InvalidArguments), Invalid request to region, reason: DELETE is not allowed under append mode
+
 create table if not exists append_mode_off(
     host string,
     ts timestamp,

--- a/tests/cases/standalone/common/insert/append_mode.sql
+++ b/tests/cases/standalone/common/insert/append_mode.sql
@@ -1,0 +1,35 @@
+create table if not exists append_mode1(
+    host string,
+    ts timestamp,
+    cpu double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('append_mode'='true');
+
+INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+SELECT * from append_mode1 ORDER BY host, ts;
+
+create table if not exists append_mode2(
+    host string,
+    ts timestamp,
+    cpu double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('append_mode'='false');
+
+INSERT INTO append_mode2 VALUES ('host1',0, 0), ('host2', 1, 1,);
+
+INSERT INTO append_mode2 VALUES ('host1',0, 10), ('host2', 1, 11,);
+
+SELECT * from append_mode2 ORDER BY host, ts;
+
+DROP TABLE append_mode1;
+
+DROP TABLE append_mode2;

--- a/tests/cases/standalone/common/insert/append_mode.sql
+++ b/tests/cases/standalone/common/insert/append_mode.sql
@@ -14,6 +14,9 @@ INSERT INTO append_mode_on VALUES ('host1',0, 0), ('host2', 1, 1,);
 
 SELECT * from append_mode_on ORDER BY host, ts;
 
+-- SQLNESS REPLACE (region\s\d+\(\d+\,\s\d+\)) region
+DELETE FROM append_mode_on WHERE host = 'host1';
+
 create table if not exists append_mode_off(
     host string,
     ts timestamp,

--- a/tests/cases/standalone/common/insert/append_mode.sql
+++ b/tests/cases/standalone/common/insert/append_mode.sql
@@ -1,4 +1,4 @@
-create table if not exists append_mode1(
+create table if not exists append_mode_on(
     host string,
     ts timestamp,
     cpu double,
@@ -8,13 +8,13 @@ create table if not exists append_mode1(
 engine=mito
 with('append_mode'='true');
 
-INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_on VALUES ('host1',0, 0), ('host2', 1, 1,);
 
-INSERT INTO append_mode1 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_on VALUES ('host1',0, 0), ('host2', 1, 1,);
 
-SELECT * from append_mode1 ORDER BY host, ts;
+SELECT * from append_mode_on ORDER BY host, ts;
 
-create table if not exists append_mode2(
+create table if not exists append_mode_off(
     host string,
     ts timestamp,
     cpu double,
@@ -24,12 +24,12 @@ create table if not exists append_mode2(
 engine=mito
 with('append_mode'='false');
 
-INSERT INTO append_mode2 VALUES ('host1',0, 0), ('host2', 1, 1,);
+INSERT INTO append_mode_off VALUES ('host1',0, 0), ('host2', 1, 1,);
 
-INSERT INTO append_mode2 VALUES ('host1',0, 10), ('host2', 1, 11,);
+INSERT INTO append_mode_off VALUES ('host1',0, 10), ('host2', 1, 11,);
 
-SELECT * from append_mode2 ORDER BY host, ts;
+SELECT * from append_mode_off ORDER BY host, ts;
 
-DROP TABLE append_mode1;
+DROP TABLE append_mode_on;
 
-DROP TABLE append_mode2;
+DROP TABLE append_mode_off;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #3480

## What's changed and what's your intention?
This PR adds `append_mode` to mito engine's table options. It also adds a sqlness test for append mode.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
