### PR TITLE
feat(procedure): support to rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,7 +3781,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=1bd2398b686e5ac6c1eef6daf615867ce27f75c1#1bd2398b686e5ac6c1eef6daf615867ce27f75c1"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=224bf7c0059ebe7b1634303ea62a05292a2259c5#224bf7c0059ebe7b1634303ea62a05292a2259c5"
 dependencies = [
  "prost 0.12.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,7 +3781,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=224bf7c0059ebe7b1634303ea62a05292a2259c5#224bf7c0059ebe7b1634303ea62a05292a2259c5"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=c00c73b76ed20a603e4d29fb96cb4e6ef987bba7#c00c73b76ed20a603e4d29fb96cb4e6ef987bba7"
 dependencies = [
  "prost 0.12.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ etcd-client = "0.12"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "1bd2398b686e5ac6c1eef6daf615867ce27f75c1" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "224bf7c0059ebe7b1634303ea62a05292a2259c5" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ etcd-client = "0.12"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "224bf7c0059ebe7b1634303ea62a05292a2259c5" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "c00c73b76ed20a603e4d29fb96cb4e6ef987bba7" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/src/common/meta/src/rpc/procedure.rs
+++ b/src/common/meta/src/rpc/procedure.rs
@@ -56,6 +56,9 @@ pub fn procedure_state_to_pb_response(state: &ProcedureState) -> PbProcedureStat
         ProcedureState::Done { .. } => (PbProcedureStatus::Done, String::default()),
         ProcedureState::Retrying { error } => (PbProcedureStatus::Retrying, error.to_string()),
         ProcedureState::Failed { error } => (PbProcedureStatus::Failed, error.to_string()),
+        // TODO(weny): implement it
+        ProcedureState::CommitRollback { .. } => todo!(),
+        ProcedureState::RollingBack { .. } => todo!(),
     };
 
     PbProcedureStateResponse {

--- a/src/common/meta/src/rpc/procedure.rs
+++ b/src/common/meta/src/rpc/procedure.rs
@@ -56,8 +56,8 @@ pub fn procedure_state_to_pb_response(state: &ProcedureState) -> PbProcedureStat
         ProcedureState::Done { .. } => (PbProcedureStatus::Done, String::default()),
         ProcedureState::Retrying { error } => (PbProcedureStatus::Retrying, error.to_string()),
         ProcedureState::Failed { error } => (PbProcedureStatus::Failed, error.to_string()),
-        ProcedureState::CommitRollback { error } => {
-            (PbProcedureStatus::CommitRollback, error.to_string())
+        ProcedureState::PrepareRollback { error } => {
+            (PbProcedureStatus::PrepareRollback, error.to_string())
         }
         ProcedureState::RollingBack { error } => {
             (PbProcedureStatus::RollingBack, error.to_string())

--- a/src/common/meta/src/rpc/procedure.rs
+++ b/src/common/meta/src/rpc/procedure.rs
@@ -56,9 +56,12 @@ pub fn procedure_state_to_pb_response(state: &ProcedureState) -> PbProcedureStat
         ProcedureState::Done { .. } => (PbProcedureStatus::Done, String::default()),
         ProcedureState::Retrying { error } => (PbProcedureStatus::Retrying, error.to_string()),
         ProcedureState::Failed { error } => (PbProcedureStatus::Failed, error.to_string()),
-        // TODO(weny): implement it
-        ProcedureState::CommitRollback { .. } => todo!(),
-        ProcedureState::RollingBack { .. } => todo!(),
+        ProcedureState::CommitRollback { error } => {
+            (PbProcedureStatus::CommitRollback, error.to_string())
+        }
+        ProcedureState::RollingBack { error } => {
+            (PbProcedureStatus::RollingBack, error.to_string())
+        }
     };
 
     PbProcedureStateResponse {

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -104,8 +104,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Procedure recovered after the system fails"))]
-    ProcedureRecoveredAfterFails { location: Location },
+    #[snafu(display("Procedure recovered after the system fails: {error}"))]
+    ProcedureRecoveredAfterFails { error: String, location: Location },
 
     #[snafu(display("Procedure retry exceeded max times, procedure_id: {}", procedure_id))]
     RetryTimesExceeded {

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -110,6 +110,15 @@ pub enum Error {
         procedure_id: ProcedureId,
     },
 
+    #[snafu(display(
+        "Procedure rollback exceeded max times, procedure_id: {}",
+        procedure_id
+    ))]
+    RollbackTimesExceeded {
+        source: Arc<Error>,
+        procedure_id: ProcedureId,
+    },
+
     #[snafu(display("Corrupted data, error: "))]
     CorruptedData {
         #[snafu(source)]
@@ -161,6 +170,7 @@ impl ErrorExt for Error {
             | Error::DeleteState { .. }
             | Error::FromJson { .. }
             | Error::RetryTimesExceeded { .. }
+            | Error::RollbackTimesExceeded { .. }
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
             | Error::ManagerNotStart { .. } => StatusCode::Internal,

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -104,8 +104,8 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Procedure recovered after the system fails: {error}"))]
-    ProcedureRecoveredAfterFails { error: String, location: Location },
+    #[snafu(display("Rollback Procedure recovered: {error}"))]
+    RollbackProcedureRecovered { error: String, location: Location },
 
     #[snafu(display("Procedure retry exceeded max times, procedure_id: {}", procedure_id))]
     RetryTimesExceeded {
@@ -180,7 +180,7 @@ impl ErrorExt for Error {
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
             | Error::ManagerNotStart { .. }
-            | Error::ProcedureRecoveredAfterFails { .. }
+            | Error::RollbackProcedureRecovered { .. }
             | Error::RollbackNotSupported { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -157,6 +157,9 @@ pub enum Error {
 
     #[snafu(display("Unexpected: {err_msg}"))]
     Unexpected { location: Location, err_msg: String },
+
+    #[snafu(display("Not support to rollback the procedure"))]
+    RollbackNotSupported { location: Location },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -177,7 +180,8 @@ impl ErrorExt for Error {
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
             | Error::ManagerNotStart { .. }
-            | Error::ProcedureRecoveredAfterFails { .. } => StatusCode::Internal,
+            | Error::ProcedureRecoveredAfterFails { .. }
+            | Error::RollbackNotSupported { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/error.rs
+++ b/src/common/procedure/src/error.rs
@@ -104,6 +104,9 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Procedure recovered after the system fails"))]
+    ProcedureRecoveredAfterFails { location: Location },
+
     #[snafu(display("Procedure retry exceeded max times, procedure_id: {}", procedure_id))]
     RetryTimesExceeded {
         source: Arc<Error>,
@@ -173,7 +176,8 @@ impl ErrorExt for Error {
             | Error::RollbackTimesExceeded { .. }
             | Error::RetryLater { .. }
             | Error::WaitWatcher { .. }
-            | Error::ManagerNotStart { .. } => StatusCode::Internal,
+            | Error::ManagerNotStart { .. }
+            | Error::ProcedureRecoveredAfterFails { .. } => StatusCode::Internal,
             Error::LoaderConflict { .. } | Error::DuplicateProcedure { .. } => {
                 StatusCode::InvalidArguments
             }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -962,7 +962,7 @@ mod tests {
                 Ok(())
             }
 
-            fn is_support_rollback(&self) -> bool {
+            fn rollback_supported(&self) -> bool {
                 true
             }
 

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -952,6 +952,14 @@ mod tests {
                 }
             }
 
+            async fn rollback(&mut self, _: &Context) -> Result<()> {
+                Ok(())
+            }
+
+            fn is_support_rollback(&self) -> bool {
+                true
+            }
+
             fn dump(&self) -> Result<String> {
                 Ok(String::new())
             }

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -969,7 +969,7 @@ mod tests {
         let mut watcher = check_procedure(MockProcedure { panic: false }).await;
         // Wait for the notification.
         watcher.changed().await.unwrap();
-        assert!(watcher.borrow().is_commit_rollback());
+        assert!(watcher.borrow().is_prepare_rollback());
         watcher.changed().await.unwrap();
         assert!(watcher.borrow().is_rolling_back());
         watcher.changed().await.unwrap();

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -506,7 +506,7 @@ impl LocalManager {
                 let procedure_state = match init_state {
                     InitProcedureState::RollingBack => ProcedureState::RollingBack {
                         error: Arc::new(
-                            error::ProcedureRecoveredAfterFailsSnafu {
+                            error::RollbackProcedureRecoveredSnafu {
                                 error: message.error.clone().unwrap_or("Unknown error".to_string()),
                             }
                             .build(),

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -241,7 +241,7 @@ impl Runner {
     }
 
     async fn prepare_rollback(&mut self, err: Arc<Error>) {
-        if let Err(e) = self.write_procedure_state().await {
+        if let Err(e) = self.write_procedure_state(err.to_string()).await {
             self.meta
                 .set_state(ProcedureState::prepare_rollback(Arc::new(e)));
             return;
@@ -475,7 +475,7 @@ impl Runner {
         Ok(())
     }
 
-    async fn write_procedure_state(&mut self) -> Result<()> {
+    async fn write_procedure_state(&mut self, error: String) -> Result<()> {
         // Persists procedure state
         let type_name = self.procedure.type_name().to_string();
         let data = self.procedure.dump()?;
@@ -484,6 +484,7 @@ impl Runner {
             data,
             parent_id: self.meta.parent_id,
             step: self.step,
+            error: Some(error),
         };
         self.store
             .rollback_procedure(self.meta.id, message)

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -466,8 +466,18 @@ impl Runner {
     }
 
     async fn rollback_procedure(&mut self) -> Result<()> {
+        // Persists procedure state
+        let type_name = self.procedure.type_name().to_string();
+        let data = self.procedure.dump()?;
+
         self.store
-            .rollback_procedure(self.meta.id, self.step)
+            .rollback_procedure(
+                self.meta.id,
+                self.step,
+                type_name,
+                data,
+                self.meta.parent_id,
+            )
             .await
             .map_err(|e| {
                 logging::error!(

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -22,7 +22,7 @@ use tokio::time;
 use super::rwlock::OwnedKeyRwLockGuard;
 use crate::error::{self, ProcedurePanicSnafu, Result};
 use crate::local::{ManagerContext, ProcedureMeta, ProcedureMetaRef};
-use crate::procedure::{InitProcedureState, Output, StringKey};
+use crate::procedure::{Output, StringKey};
 use crate::store::{ProcedureMessage, ProcedureStore};
 use crate::{BoxedProcedure, Context, Error, ProcedureId, ProcedureState, ProcedureWithId, Status};
 
@@ -335,7 +335,7 @@ impl Runner {
     fn submit_subprocedure(
         &self,
         procedure_id: ProcedureId,
-        init_state: InitProcedureState,
+        procedure_state: ProcedureState,
         mut procedure: BoxedProcedure,
     ) {
         if self.manager_ctx.contains_procedure(procedure_id) {
@@ -357,7 +357,7 @@ impl Runner {
 
         let meta = Arc::new(ProcedureMeta::new(
             procedure_id,
-            init_state,
+            procedure_state,
             Some(self.meta.id),
             procedure.lock_key(),
         ));
@@ -417,7 +417,7 @@ impl Runner {
 
             self.submit_subprocedure(
                 subprocedure.id,
-                InitProcedureState::Running,
+                ProcedureState::Running,
                 subprocedure.procedure,
             );
         }

--- a/src/common/procedure/src/local/runner.rs
+++ b/src/common/procedure/src/local/runner.rs
@@ -232,7 +232,7 @@ impl Runner {
     }
 
     async fn rollback(&mut self, ctx: &Context, err: Arc<Error>) {
-        if self.procedure.is_support_rollback() {
+        if self.procedure.rollback_supported() {
             if let Err(e) = self.procedure.rollback(ctx).await {
                 self.meta
                     .set_state(ProcedureState::rolling_back(Arc::new(e)));
@@ -248,7 +248,7 @@ impl Runner {
                 .set_state(ProcedureState::prepare_rollback(Arc::new(e)));
             return;
         }
-        if self.procedure.is_support_rollback() {
+        if self.procedure.rollback_supported() {
             self.meta.set_state(ProcedureState::rolling_back(err));
         } else {
             self.meta.set_state(ProcedureState::failed(err));
@@ -629,7 +629,7 @@ mod tests {
             Ok(())
         }
 
-        fn is_support_rollback(&self) -> bool {
+        fn rollback_supported(&self) -> bool {
             self.rollback_fn.is_some()
         }
 

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -132,7 +132,7 @@ pub trait Procedure: Send {
         error::RollbackNotSupportedSnafu {}.fail()
     }
 
-    /// Indices whether support to rollback the procedure.
+    /// Indicates whether it supports rolling back the procedure.
     fn is_support_rollback(&self) -> bool {
         false
     }
@@ -371,22 +371,11 @@ impl ProcedureState {
     }
 }
 
-impl From<InitProcedureState> for ProcedureState {
-    fn from(value: InitProcedureState) -> Self {
-        match value {
-            InitProcedureState::Running => ProcedureState::Running,
-            InitProcedureState::RollingBack(error) => ProcedureState::RollingBack {
-                error: Arc::new(error::ProcedureRecoveredAfterFailsSnafu { error }.build()),
-            },
-        }
-    }
-}
-
 /// The initial procedure state.
 #[derive(Debug, Clone)]
 pub enum InitProcedureState {
     Running,
-    RollingBack(String),
+    RollingBack,
 }
 
 // TODO(yingwen): Shutdown

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -371,18 +371,18 @@ impl From<InitProcedureState> for ProcedureState {
     fn from(value: InitProcedureState) -> Self {
         match value {
             InitProcedureState::Running => ProcedureState::Running,
-            InitProcedureState::RollingBack => ProcedureState::RollingBack {
-                error: Arc::new(error::ProcedureRecoveredAfterFailsSnafu {}.build()),
+            InitProcedureState::RollingBack(error) => ProcedureState::RollingBack {
+                error: Arc::new(error::ProcedureRecoveredAfterFailsSnafu { error }.build()),
             },
         }
     }
 }
 
 /// The initial procedure state.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum InitProcedureState {
     Running,
-    RollingBack,
+    RollingBack(String),
 }
 
 // TODO(yingwen): Shutdown

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -133,7 +133,7 @@ pub trait Procedure: Send {
     }
 
     /// Indicates whether it supports rolling back the procedure.
-    fn is_support_rollback(&self) -> bool {
+    fn rollback_supported(&self) -> bool {
         false
     }
 

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -128,9 +128,13 @@ pub trait Procedure: Send {
     /// Rollback the failed procedure.
     ///
     /// The implementation must be idempotent.
-    async fn rollback(&mut self, ctx: &Context) -> Result<()> {
-        let _ = ctx;
-        Ok(())
+    async fn rollback(&mut self, _: &Context) -> Result<()> {
+        error::RollbackNotSupportedSnafu {}.fail()
+    }
+
+    /// Indices whether support to rollback the procedure.
+    fn is_support_rollback(&self) -> bool {
+        false
     }
 
     /// Dump the state of the procedure to a string.

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -23,7 +23,7 @@ use smallvec::{smallvec, SmallVec};
 use snafu::{ResultExt, Snafu};
 use uuid::Uuid;
 
-use crate::error::{Error, Result};
+use crate::error::{self, Error, Result};
 use crate::watcher::Watcher;
 
 pub type Output = Arc<dyn Any + Send + Sync>;
@@ -364,6 +364,24 @@ impl ProcedureState {
             _ => None,
         }
     }
+}
+
+impl From<InitProcedureState> for ProcedureState {
+    fn from(value: InitProcedureState) -> Self {
+        match value {
+            InitProcedureState::Running => ProcedureState::Running,
+            InitProcedureState::RollingBack => ProcedureState::RollingBack {
+                error: Arc::new(error::ProcedureRecoveredAfterFailsSnafu {}.build()),
+            },
+        }
+    }
+}
+
+/// The initial procedure state.
+#[derive(Debug, Clone, Copy)]
+pub enum InitProcedureState {
+    Running,
+    RollingBack,
 }
 
 // TODO(yingwen): Shutdown

--- a/src/common/procedure/src/procedure.rs
+++ b/src/common/procedure/src/procedure.rs
@@ -125,6 +125,13 @@ pub trait Procedure: Send {
     /// The implementation must be idempotent.
     async fn execute(&mut self, ctx: &Context) -> Result<Status>;
 
+    /// Rollback the failed procedure.
+    ///
+    /// The implementation must be idempotent.
+    async fn rollback(&mut self, _: &Context) -> Result<()> {
+        Ok(())
+    }
+
     /// Dump the state of the procedure to a string.
     fn dump(&self) -> Result<String>;
 

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -50,6 +50,9 @@ pub struct ProcedureMessage {
     pub parent_id: Option<ProcedureId>,
     /// Current step.
     pub step: u32,
+    /// Errors raised during the procedure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Procedure storage layer.
@@ -85,6 +88,7 @@ impl ProcedureStore {
             data,
             parent_id,
             step,
+            error: None,
         };
         let key = ParsedKey {
             prefix: &self.proc_path,
@@ -452,6 +456,7 @@ mod tests {
             data: "no parent id".to_string(),
             parent_id: None,
             step: 4,
+            error: None,
         };
 
         let json = serde_json::to_string(&message).unwrap();
@@ -522,6 +527,7 @@ mod tests {
             data: "test store procedure".to_string(),
             parent_id: None,
             step: 0,
+            error: None,
         };
         assert_eq!(expect, *msg);
     }
@@ -571,6 +577,7 @@ mod tests {
             data,
             parent_id: None,
             step: 1,
+            error: None,
         };
         store
             .rollback_procedure(procedure_id, message)

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -122,24 +122,16 @@ impl ProcedureStore {
     pub(crate) async fn rollback_procedure(
         &self,
         procedure_id: ProcedureId,
-        step: u32,
-        type_name: String,
-        data: String,
-        parent_id: Option<ProcedureId>,
+        message: ProcedureMessage,
     ) -> Result<()> {
         let key = ParsedKey {
             prefix: &self.proc_path,
             procedure_id,
-            step,
+            step: message.step,
             key_type: KeyType::Rollback,
         }
         .to_string();
-        let message = ProcedureMessage {
-            type_name,
-            data,
-            parent_id,
-            step,
-        };
+
         self.store
             .put(&key, serde_json::to_vec(&message).context(ToJsonSnafu)?)
             .await?;
@@ -574,8 +566,14 @@ mod tests {
             )
             .await
             .unwrap();
+        let message = ProcedureMessage {
+            type_name,
+            data,
+            parent_id: None,
+            step: 1,
+        };
         store
-            .rollback_procedure(procedure_id, 1, type_name, data, None)
+            .rollback_procedure(procedure_id, message)
             .await
             .unwrap();
 

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -32,7 +32,7 @@ pub async fn wait(watcher: &mut Watcher) -> Result<Option<Output>> {
                 return Ok(output.clone());
             }
             ProcedureState::Failed { error } => {
-                return Err(error.clone()).context(ProcedureExecSnafu)
+                return Err(error.clone()).context(ProcedureExecSnafu);
             }
             ProcedureState::Retrying { error } => {
                 debug!("retrying, source: {}", error)
@@ -40,7 +40,7 @@ pub async fn wait(watcher: &mut Watcher) -> Result<Option<Output>> {
             ProcedureState::RollingBack { error } => {
                 debug!("rolling back, source: {:?}", error)
             }
-            ProcedureState::CommitRollback { error } => {
+            ProcedureState::PrepareRollback { error } => {
                 debug!("commit rollback, source: {}", error)
             }
         }

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -37,6 +37,12 @@ pub async fn wait(watcher: &mut Watcher) -> Result<Option<Output>> {
             ProcedureState::Retrying { error } => {
                 debug!("retrying, source: {}", error)
             }
+            ProcedureState::RollingBack { error } => {
+                debug!("rolling back, source: {}", error)
+            }
+            ProcedureState::CommitRollback { error } => {
+                debug!("commit rollback, source: {}", error)
+            }
         }
     }
 }

--- a/src/common/procedure/src/watcher.rs
+++ b/src/common/procedure/src/watcher.rs
@@ -32,13 +32,13 @@ pub async fn wait(watcher: &mut Watcher) -> Result<Option<Output>> {
                 return Ok(output.clone());
             }
             ProcedureState::Failed { error } => {
-                return Err(error.clone()).context(ProcedureExecSnafu);
+                return Err(error.clone()).context(ProcedureExecSnafu)
             }
             ProcedureState::Retrying { error } => {
                 debug!("retrying, source: {}", error)
             }
             ProcedureState::RollingBack { error } => {
-                debug!("rolling back, source: {}", error)
+                debug!("rolling back, source: {:?}", error)
             }
             ProcedureState::CommitRollback { error } => {
                 debug!("commit rollback, source: {}", error)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Support to rollback failed procedures
1. Add the `rollback` method to the `Procedure` trait, the method requires an idempotent implementation.
2. Add `CommitRollback`, `RollingBack` states to `ProcedureState`.
3. Rollback procedures during the recovering.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
