### PR TITLE
fix: move object store read/write timer into inner

### DIFF
--- a/src/object-store/src/layers/prometheus.rs
+++ b/src/object-store/src/layers/prometheus.rs
@@ -433,16 +433,12 @@ pub struct PrometheusMetricWrapper<R> {
 
     op: Operation,
     bytes_counter: Histogram,
-    requests_duration_timer: Option<HistogramTimer>,
-
+    _requests_duration_timer: HistogramTimer,
     bytes: u64,
 }
 
 impl<R> Drop for PrometheusMetricWrapper<R> {
     fn drop(&mut self) {
-        if let Some(timer) = self.requests_duration_timer.take() {
-            timer.observe_duration();
-        }
         self.bytes_counter.observe(self.bytes as f64);
     }
 }
@@ -458,7 +454,7 @@ impl<R> PrometheusMetricWrapper<R> {
             inner,
             op,
             bytes_counter,
-            requests_duration_timer: Some(requests_duration_timer),
+            _requests_duration_timer: requests_duration_timer,
             bytes: 0,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#3622

## What's changed and what's your intention?

Move timer from read/write function into `PrometheusMetricWrapper` and update data when dropping to get accurate metric.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
