### PR TITLE
feat(procedure): enable auto split large value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,6 +1937,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "backon",
+ "common-base",
  "common-error",
  "common-macro",
  "common-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,7 @@ dependencies = [
  "object-store",
  "serde",
  "serde_json",
+ "serde_with",
  "smallvec",
  "snafu",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,7 +1949,6 @@ dependencies = [
  "object-store",
  "serde",
  "serde_json",
- "serde_with",
  "smallvec",
  "snafu",
  "tokio",

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -29,6 +29,11 @@ store_key_prefix = ""
 max_retry_times = 12
 # Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
+# Auto split large value
+# The etcd the maximum size of any request is 1.5 MiB
+# 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
+# If it's empty, it stands for no limit.
+max_value_size = "1535KiB"
 
 # Failure detectors options.
 [failure_detector]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -33,7 +33,7 @@ retry_delay = "500ms"
 # GreptimeDB procedure uses etcd as the default metadata storage backend.
 # The etcd the maximum size of any request is 1.5 MiB
 # 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
-# If it's empty, it stands for no limit.
+# Comments out the `max_metadata_value_size`, for don't split large value (no limit).
 max_metadata_value_size = "1535KiB"
 
 # Failure detectors options.

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -30,10 +30,11 @@ max_retry_times = 12
 # Initial retry delay of procedures, increases exponentially
 retry_delay = "500ms"
 # Auto split large value
+# GreptimeDB procedure uses etcd as the default metadata storage backend.
 # The etcd the maximum size of any request is 1.5 MiB
 # 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
 # If it's empty, it stands for no limit.
-max_value_size = "1535KiB"
+max_metadata_value_size = "1535KiB"
 
 # Failure detectors options.
 [failure_detector]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -32,9 +32,9 @@ retry_delay = "500ms"
 # Auto split large value
 # GreptimeDB procedure uses etcd as the default metadata storage backend.
 # The etcd the maximum size of any request is 1.5 MiB
-# 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
+# 1500KiB = 1536KiB (1.5MiB) - 36KiB (reserved size of key)
 # Comments out the `max_metadata_value_size`, for don't split large value (no limit).
-max_metadata_value_size = "1535KiB"
+max_metadata_value_size = "1500KiB"
 
 # Failure detectors options.
 [failure_detector]

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -218,6 +218,7 @@ impl StartCommand {
 mod tests {
     use std::io::Write;
 
+    use common_base::readable_size::ReadableSize;
     use common_test_util::temp_dir::create_named_temp_file;
     use meta_srv::selector::SelectorType;
 
@@ -296,6 +297,10 @@ mod tests {
                 .failure_detector
                 .first_heartbeat_estimate
                 .as_millis()
+        );
+        assert_eq!(
+            options.procedure.max_value_size,
+            Some(ReadableSize::kb(1535))
         );
     }
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -300,7 +300,7 @@ mod tests {
         );
         assert_eq!(
             options.procedure.max_metadata_value_size,
-            Some(ReadableSize::kb(1535))
+            Some(ReadableSize::kb(1500))
         );
     }
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -299,7 +299,7 @@ mod tests {
                 .as_millis()
         );
         assert_eq!(
-            options.procedure.max_value_size,
+            options.procedure.max_metadata_value_size,
             Some(ReadableSize::kb(1535))
         );
     }

--- a/src/common/meta/src/state_store.rs
+++ b/src/common/meta/src/state_store.rs
@@ -366,11 +366,11 @@ mod tests {
             Arc::new(ChrootKvBackend::new(chroot.into(), backend))
         };
 
-        let key_preserve_size = 1024;
+        let key_size = 1024;
         // The etcd default size limit of any requests is 1.5MiB.
         // However, some KvBackends, the `ChrootKvBackend`, will add the prefix to `key`;
         // we don't know the exact size of the key.
-        let size_limit = 1536 * 1024 - key_preserve_size;
+        let size_limit = 1536 * 1024 - key_size;
         let page_size = rand::thread_rng().gen_range(1..10);
         test_meta_state_store_split_value_with_size_limit(
             kv_backend,

--- a/src/common/meta/src/state_store.rs
+++ b/src/common/meta/src/state_store.rs
@@ -60,6 +60,15 @@ impl KvStateStore {
             max_size_per_value: None,
         }
     }
+
+    /// Sets the `max_size_per_value`.
+    ///
+    /// If a value is larger than the `max_size_per_value`,
+    /// the [`KvStateStore`] will automatically split the large value into multiple values.
+    pub fn with_max_size_per_value(mut self, max_size_per_value: usize) -> Self {
+        self.max_num_per_range = Some(max_size_per_value);
+        self
+    }
 }
 
 fn decode_kv(kv: KeyValue) -> Result<(String, Vec<u8>)> {

--- a/src/common/meta/src/state_store.rs
+++ b/src/common/meta/src/state_store.rs
@@ -45,28 +45,28 @@ fn strip_prefix(key: &str) -> String {
 pub struct KvStateStore {
     kv_backend: KvBackendRef,
     // The max num of keys to be returned in a range scan request
-    // `None` stands no limit.
-    max_num_per_range: Option<usize>,
+    // `None` stands for no limit.
+    max_num_per_range_request: Option<usize>,
     // The max bytes of value.
-    // `None` stands no limit.
-    max_size_per_value: Option<usize>,
+    // `None` stands for no limit.
+    max_value_size: Option<usize>,
 }
 
 impl KvStateStore {
     pub fn new(kv_backend: KvBackendRef) -> Self {
         Self {
             kv_backend,
-            max_num_per_range: None,
-            max_size_per_value: None,
+            max_num_per_range_request: None,
+            max_value_size: None,
         }
     }
 
-    /// Sets the `max_size_per_value`.
+    /// Sets the `max_value_size`. `None` stands for no limit.
     ///
-    /// If a value is larger than the `max_size_per_value`,
+    /// If a value is larger than the `max_value_size`,
     /// the [`KvStateStore`] will automatically split the large value into multiple values.
-    pub fn with_max_size_per_value(mut self, max_size_per_value: usize) -> Self {
-        self.max_num_per_range = Some(max_size_per_value);
+    pub fn with_max_value_size(mut self, max_value_size: Option<usize>) -> Self {
+        self.max_value_size = max_value_size;
         self
     }
 }
@@ -84,12 +84,12 @@ enum SplitValue<'a> {
     Multiple(Vec<&'a [u8]>),
 }
 
-fn split_value(value: &[u8], max_size_per_value: Option<usize>) -> SplitValue<'_> {
-    if let Some(max_size_per_value) = max_size_per_value {
-        if value.len() <= max_size_per_value {
+fn split_value(value: &[u8], max_value_size: Option<usize>) -> SplitValue<'_> {
+    if let Some(max_value_size) = max_value_size {
+        if value.len() <= max_value_size {
             SplitValue::Single(value)
         } else {
-            SplitValue::Multiple(value.chunks(max_size_per_value).collect::<Vec<_>>())
+            SplitValue::Multiple(value.chunks(max_value_size).collect::<Vec<_>>())
         }
     } else {
         SplitValue::Single(value)
@@ -99,7 +99,7 @@ fn split_value(value: &[u8], max_size_per_value: Option<usize>) -> SplitValue<'_
 #[async_trait]
 impl StateStore for KvStateStore {
     async fn put(&self, key: &str, value: Vec<u8>) -> ProcedureResult<()> {
-        let split = split_value(&value, self.max_size_per_value);
+        let split = split_value(&value, self.max_value_size);
         let key = with_prefix(key);
         match split {
             SplitValue::Single(_) => {
@@ -165,7 +165,7 @@ impl StateStore for KvStateStore {
         let stream = PaginationStream::new(
             self.kv_backend.clone(),
             req,
-            self.max_num_per_range.unwrap_or_default(),
+            self.max_num_per_range_request.unwrap_or_default(),
             Arc::new(decode_kv),
         );
 
@@ -223,8 +223,8 @@ mod tests {
     async fn test_meta_state_store() {
         let store = &KvStateStore {
             kv_backend: Arc::new(MemoryKvBackend::new()),
-            max_num_per_range: Some(1), // for testing "more" in range
-            max_size_per_value: None,
+            max_num_per_range_request: Some(1), // for testing "more" in range
+            max_value_size: None,
         };
 
         let walk_top_down = async move |path: &str| -> Vec<KeyValue> {
@@ -303,8 +303,8 @@ mod tests {
         }
         let store = &KvStateStore {
             kv_backend: kv_backend.clone(),
-            max_num_per_range: Some(num_per_range as usize), // for testing "more" in range
-            max_size_per_value: Some(size_limit as usize),
+            max_num_per_range_request: Some(num_per_range as usize), // for testing "more" in range
+            max_value_size: Some(size_limit as usize),
         };
         let walk_top_down = async move |path: &str| -> Vec<KeyValue> {
             let mut data = store

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
 backon = "0.4"
+common-base.workspace = true
 common-error.workspace = true
 common-macro.workspace = true
 common-runtime.workspace = true

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -24,6 +24,7 @@ humantime-serde.workspace = true
 object-store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_with.workspace = true
 smallvec.workspace = true
 snafu.workspace = true
 tokio.workspace = true

--- a/src/common/procedure/Cargo.toml
+++ b/src/common/procedure/Cargo.toml
@@ -24,7 +24,6 @@ humantime-serde.workspace = true
 object-store.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-serde_with.workspace = true
 smallvec.workspace = true
 snafu.workspace = true
 tokio.workspace = true

--- a/src/common/procedure/src/options.rs
+++ b/src/common/procedure/src/options.rs
@@ -18,9 +18,7 @@ use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, NoneAsEmptyString};
 
-#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ProcedureConfig {
@@ -30,7 +28,6 @@ pub struct ProcedureConfig {
     #[serde(with = "humantime_serde")]
     pub retry_delay: Duration,
     /// `None` stands for no limit.
-    #[serde_as(as = "NoneAsEmptyString")]
     pub max_metadata_value_size: Option<ReadableSize>,
 }
 

--- a/src/common/procedure/src/options.rs
+++ b/src/common/procedure/src/options.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, NoneAsEmptyString};
 
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ProcedureConfig {
@@ -28,6 +30,7 @@ pub struct ProcedureConfig {
     #[serde(with = "humantime_serde")]
     pub retry_delay: Duration,
     /// `None` stands for no limit.
+    #[serde_as(as = "NoneAsEmptyString")]
     pub max_value_size: Option<ReadableSize>,
 }
 

--- a/src/common/procedure/src/options.rs
+++ b/src/common/procedure/src/options.rs
@@ -16,6 +16,7 @@
 
 use std::time::Duration;
 
+use common_base::readable_size::ReadableSize;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -26,6 +27,8 @@ pub struct ProcedureConfig {
     /// Initial retry delay of procedures, increases exponentially.
     #[serde(with = "humantime_serde")]
     pub retry_delay: Duration,
+    /// `None` stands for no limit.
+    pub max_value_size: Option<ReadableSize>,
 }
 
 impl Default for ProcedureConfig {
@@ -33,6 +36,7 @@ impl Default for ProcedureConfig {
         ProcedureConfig {
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
+            max_value_size: None,
         }
     }
 }

--- a/src/common/procedure/src/options.rs
+++ b/src/common/procedure/src/options.rs
@@ -31,7 +31,7 @@ pub struct ProcedureConfig {
     pub retry_delay: Duration,
     /// `None` stands for no limit.
     #[serde_as(as = "NoneAsEmptyString")]
-    pub max_value_size: Option<ReadableSize>,
+    pub max_metadata_value_size: Option<ReadableSize>,
 }
 
 impl Default for ProcedureConfig {
@@ -39,7 +39,7 @@ impl Default for ProcedureConfig {
         ProcedureConfig {
             max_retry_times: 3,
             retry_delay: Duration::from_millis(500),
-            max_value_size: None,
+            max_metadata_value_size: None,
         }
     }
 }

--- a/src/common/procedure/src/store/util.rs
+++ b/src/common/procedure/src/store/util.rs
@@ -40,11 +40,11 @@ fn parse_segments(segments: Vec<(String, Vec<u8>)>, prefix: &str) -> Result<Vec<
         .collect::<Result<Vec<_>>>()
 }
 
-/// Collects multiple values into a single key-value pair.
+/// Merges multiple values into a single key-value pair.
 /// Returns an error if:
 /// - Part values are lost.
 /// - Failed to parse the key of segment.
-fn multiple_values_collector(
+fn merge_multiple_values(
     CollectingState { mut pairs }: CollectingState,
 ) -> Result<(KeySet, Vec<u8>)> {
     if pairs.len() == 1 {
@@ -119,14 +119,14 @@ pub fn multiple_value_stream(
                     } else {
                         // Starts to collect next key value pair.
                         collecting = Some(CollectingState::new(key, value));
-                        yield multiple_values_collector(current)?;
+                        yield merge_multiple_values(current)?;
                     }
                 }
                 None => collecting = Some(CollectingState::new(key, value)),
             }
         }
         if let Some(current) = collecting.take() {
-            yield multiple_values_collector(current)?
+            yield merge_multiple_values(current)?
         }
     }
 }
@@ -151,7 +151,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_multiple_values_collector() {
+    async fn test_merge_multiple_values() {
         let upstream = stream::iter(vec![
             Ok(("foo".to_string(), vec![0, 1, 2, 3])),
             Ok(("foo/0002".to_string(), vec![6, 7])),
@@ -194,7 +194,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_multiple_values_collector_err() {
+    async fn test_multiple_values_stream_err() {
         let upstream = stream::iter(vec![
             Err(error::UnexpectedSnafu { err_msg: "mock" }.build()),
             Ok(("foo".to_string(), vec![0, 1, 2, 3])),

--- a/src/common/procedure/src/store/util.rs
+++ b/src/common/procedure/src/store/util.rs
@@ -22,7 +22,7 @@ use super::state_store::KeySet;
 use crate::error;
 use crate::error::Result;
 
-pub struct CollectingState {
+struct CollectingState {
     pairs: Vec<(String, Vec<u8>)>,
 }
 
@@ -100,7 +100,7 @@ impl CollectingState {
     }
 }
 
-pub type Upstream = dyn Stream<Item = Result<(String, Vec<u8>)>> + Send;
+type Upstream = dyn Stream<Item = Result<(String, Vec<u8>)>> + Send;
 
 /// Merges multiple values that have the same prefix of the key
 /// from `upstream` into a single value.

--- a/src/common/procedure/src/store/util.rs
+++ b/src/common/procedure/src/store/util.rs
@@ -102,6 +102,8 @@ impl CollectingState {
 
 pub type Upstream = dyn Stream<Item = Result<(String, Vec<u8>)>> + Send;
 
+/// Merges multiple values that have the same prefix of the key
+/// from `upstream` into a single value.
 pub fn multiple_value_stream(
     mut upstream: Pin<Box<Upstream>>,
 ) -> impl Stream<Item = Result<(KeySet, Vec<u8>)>> {

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -18,6 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use common_base::readable_size::ReadableSize;
 use common_base::Plugins;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
 use common_grpc::channel_manager;
@@ -115,6 +116,9 @@ impl Default for MetaSrvOptions {
             procedure: ProcedureConfig {
                 max_retry_times: 12,
                 retry_delay: Duration::from_millis(500),
+                // The etcd the maximum size of any request is 1.5 MiB
+                // 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
+                max_value_size: Some(ReadableSize::kb(1535)),
             },
             failure_detector: PhiAccrualFailureDetectorOptions::default(),
             datanode: DatanodeOptions::default(),

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -117,8 +117,8 @@ impl Default for MetaSrvOptions {
                 max_retry_times: 12,
                 retry_delay: Duration::from_millis(500),
                 // The etcd the maximum size of any request is 1.5 MiB
-                // 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
-                max_metadata_value_size: Some(ReadableSize::kb(1535)),
+                // 1500KiB = 1536KiB (1.5MiB) - 36KiB (reserved size of key)
+                max_metadata_value_size: Some(ReadableSize::kb(1500)),
             },
             failure_detector: PhiAccrualFailureDetectorOptions::default(),
             datanode: DatanodeOptions::default(),

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -118,7 +118,7 @@ impl Default for MetaSrvOptions {
                 retry_delay: Duration::from_millis(500),
                 // The etcd the maximum size of any request is 1.5 MiB
                 // 1535KiB = 1536KiB (1.5MiB) - 1KiB (reserved size of key)
-                max_value_size: Some(ReadableSize::kb(1535)),
+                max_metadata_value_size: Some(ReadableSize::kb(1535)),
             },
             failure_detector: PhiAccrualFailureDetectorOptions::default(),
             datanode: DatanodeOptions::default(),

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -376,10 +376,12 @@ fn build_procedure_manager(
         retry_delay: options.procedure.retry_delay,
         ..Default::default()
     };
-    let mut state_store = KvStateStore::new(kv_backend.clone());
-    if let Some(max_value_size) = options.procedure.max_value_size {
-        state_store = state_store.with_max_size_per_value(max_value_size.as_bytes() as usize);
-    }
+    let state_store = KvStateStore::new(kv_backend.clone()).with_max_value_size(
+        options
+            .procedure
+            .max_value_size
+            .map(|v| v.as_bytes() as usize),
+    );
     Arc::new(LocalManager::new(manager_config, Arc::new(state_store)))
 }
 

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -379,7 +379,7 @@ fn build_procedure_manager(
     let state_store = KvStateStore::new(kv_backend.clone()).with_max_value_size(
         options
             .procedure
-            .max_value_size
+            .max_metadata_value_size
             .map(|v| v.as_bytes() as usize),
     );
     Arc::new(LocalManager::new(manager_config, Arc::new(state_store)))

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -376,8 +376,11 @@ fn build_procedure_manager(
         retry_delay: options.procedure.retry_delay,
         ..Default::default()
     };
-    let state_store = Arc::new(KvStateStore::new(kv_backend.clone()));
-    Arc::new(LocalManager::new(manager_config, state_store))
+    let mut state_store = KvStateStore::new(kv_backend.clone());
+    if let Some(max_value_size) = options.procedure.max_value_size {
+        state_store = state_store.with_max_size_per_value(max_value_size.as_bytes() as usize);
+    }
+    Arc::new(LocalManager::new(manager_config, Arc::new(state_store)))
 }
 
 fn build_ddl_manager(

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -174,6 +174,7 @@ impl GreptimeDbClusterBuilder {
                 // We only make max_retry_times and retry_delay large than the default in tests.
                 max_retry_times: 5,
                 retry_delay: Duration::from_secs(1),
+                max_value_size: None,
             },
             wal: self.metasrv_wal_config.clone(),
             ..Default::default()

--- a/tests-integration/src/cluster.rs
+++ b/tests-integration/src/cluster.rs
@@ -174,7 +174,7 @@ impl GreptimeDbClusterBuilder {
                 // We only make max_retry_times and retry_delay large than the default in tests.
                 max_retry_times: 5,
                 retry_delay: Duration::from_secs(1),
-                max_value_size: None,
+                max_metadata_value_size: None,
             },
             wal: self.metasrv_wal_config.clone(),
             ..Default::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Enable auto split large value
2. Add `max_value_size` configuration to `[procedure]` section in `metasrv.example.toml`, with default value `1535KiB`.
3. Add `max_value_size` to `ProcedureConfig`, type of `Option<size>` the default value is None(no max size limit).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
