### PR TITLE
chore: add manifest related metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3793,9 +3793,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -10996,7 +10996,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand",
  "static_assertions",
 ]
@@ -11445,12 +11445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11605,12 +11599,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 dependencies = [
- "redox_syscall 0.4.1",
- "wasite",
+ "wasm-bindgen",
  "web-sys",
 ]
 

--- a/src/mito2/src/manifest/action.rs
+++ b/src/mito2/src/manifest/action.rs
@@ -22,13 +22,14 @@ use snafu::{OptionExt, ResultExt};
 use store_api::manifest::ManifestVersion;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::{RegionId, SequenceNumber};
+use strum::Display;
 
 use crate::error::{RegionMetadataNotFoundSnafu, Result, SerdeJsonSnafu, Utf8Snafu};
 use crate::sst::file::{FileId, FileMeta};
 use crate::wal::EntryId;
 
 /// Actions that can be applied to region manifest.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Display)]
 pub enum RegionMetaAction {
     /// Change region's metadata for request like ALTER
     Change(RegionChange),

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -400,7 +400,7 @@ impl RegionManifestManagerInner {
 
     /// Makes a new checkpoint. Return the fresh one if there are some actions to compact.
     async fn do_checkpoint(&mut self) -> Result<Option<RegionCheckpoint>> {
-        let _ = MANIFEST_CHECKPOINT_ELAPSED.start_timer();
+        let _timer = MANIFEST_CHECKPOINT_ELAPSED.start_timer();
 
         let last_checkpoint = Self::last_checkpoint(&mut self.store).await?;
         let current_version = self.last_version;

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -297,4 +297,20 @@ lazy_static! {
     .unwrap();
 
     // ------- End of partition tree memtable metrics.
+
+
+    // Manifest related metrics:
+
+    /// Elapsed time of manifest update. Labeled with "action".
+    pub static ref MANIFEST_UPDATE_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_manifest_update_elapsed",
+        "mito manifest update elapsed",
+        &["action"]
+    ).unwrap();
+
+    /// Elapsed time of checkpointing manifest.
+    pub static ref MANIFEST_CHECKPOINT_ELAPSED: Histogram = register_histogram!(
+        "greptime_manifest_checkpoint_elapsed",
+        "mito manifest checkpoint elapsed",
+    ).unwrap();
 }

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -301,16 +301,10 @@ lazy_static! {
 
     // Manifest related metrics:
 
-    /// Elapsed time of manifest update. Labeled with "action".
-    pub static ref MANIFEST_UPDATE_ELAPSED: HistogramVec = register_histogram_vec!(
-        "greptime_manifest_update_elapsed",
-        "mito manifest update elapsed",
-        &["action"]
-    ).unwrap();
-
-    /// Elapsed time of checkpointing manifest.
-    pub static ref MANIFEST_CHECKPOINT_ELAPSED: Histogram = register_histogram!(
-        "greptime_manifest_checkpoint_elapsed",
-        "mito manifest checkpoint elapsed",
+    /// Elapsed time of manifest operation. Labeled with "op".
+    pub static ref MANIFEST_OP_ELAPSED: HistogramVec = register_histogram_vec!(
+        "greptime_manifest_op_elapsed",
+        "mito manifest operation elapsed",
+        &["op"]
     ).unwrap();
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb-enterprise/issues/39

## What's changed and what's your intention?

The metrics of the time to operate the manifest, labeled with "op". Label values are "update", "open" and "checkpoint", each represent the corresponding manifest operation.

Screenshot of "/metrics" output:

![image](https://github.com/GreptimeTeam/greptimedb/assets/990479/40838f1e-1dfb-48b5-82cf-4252f976c71a)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
