### PR TITLE
feat: add strict mode to validate protocol strings

### DIFF
--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -101,7 +101,11 @@ where
 
         if opts.prom_store.enable {
             builder = builder
-                .with_prom_handler(self.instance.clone(), opts.prom_store.with_metric_engine)
+                .with_prom_handler(
+                    self.instance.clone(),
+                    opts.prom_store.with_metric_engine,
+                    opts.http.strict_mode,
+                )
                 .with_prometheus_handler(self.instance.clone());
         }
 

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -127,6 +127,8 @@ pub struct HttpOptions {
     pub disable_dashboard: bool,
 
     pub body_limit: ReadableSize,
+
+    pub strict_mode: bool,
 }
 
 impl Default for HttpOptions {
@@ -136,6 +138,7 @@ impl Default for HttpOptions {
             timeout: Duration::from_secs(30),
             disable_dashboard: false,
             body_limit: DEFAULT_BODY_LIMIT,
+            strict_mode: false,
         }
     }
 }
@@ -502,11 +505,12 @@ impl HttpServerBuilder {
         self,
         handler: PromStoreProtocolHandlerRef,
         prom_store_with_metric_engine: bool,
+        strict_mode: bool,
     ) -> Self {
         Self {
             router: self.router.nest(
                 &format!("/{HTTP_API_VERSION}/prometheus"),
-                HttpServer::route_prom(handler, prom_store_with_metric_engine),
+                HttpServer::route_prom(handler, prom_store_with_metric_engine, strict_mode),
             ),
             ..self
         }
@@ -698,14 +702,25 @@ impl HttpServer {
     fn route_prom<S>(
         prom_handler: PromStoreProtocolHandlerRef,
         prom_store_with_metric_engine: bool,
+        strict_mode: bool,
     ) -> Router<S> {
         let mut router = Router::new().route("/read", routing::post(prom_store::remote_read));
-        if prom_store_with_metric_engine {
+        if prom_store_with_metric_engine && strict_mode {
             router = router.route("/write", routing::post(prom_store::remote_write));
-        } else {
+        } else if prom_store_with_metric_engine && !strict_mode {
+            router = router.route(
+                "/write",
+                routing::post(prom_store::remote_write_without_strict_mode),
+            );
+        } else if !prom_store_with_metric_engine && strict_mode {
             router = router.route(
                 "/write",
                 routing::post(prom_store::route_write_without_metric_engine),
+            );
+        } else {
+            router = router.route(
+                "/write",
+                routing::post(prom_store::route_write_without_metric_engine_and_strict_mode),
             );
         }
         router.with_state(prom_handler)

--- a/src/servers/src/proto.rs
+++ b/src/servers/src/proto.rs
@@ -150,6 +150,7 @@ impl PromTimeSeries {
         tag: u32,
         wire_type: WireType,
         buf: &mut Bytes,
+        strict_mode: bool,
     ) -> Result<(), DecodeError> {
         const STRUCT_NAME: &str = "PromTimeSeries";
         match tag {
@@ -175,8 +176,14 @@ impl PromTimeSeries {
                     return Err(DecodeError::new("delimited length exceeded"));
                 }
                 if label.name.deref() == METRIC_NAME_LABEL_BYTES {
-                    // safety: we expect all labels are UTF-8 encoded strings.
-                    let table_name = unsafe { String::from_utf8_unchecked(label.value.to_vec()) };
+                    let table_name = if strict_mode {
+                        match String::from_utf8(label.value.to_vec()) {
+                            Ok(s) => s,
+                            Err(_) => return Err(DecodeError::new("invalid utf-8")),
+                        }
+                    } else {
+                        unsafe { String::from_utf8_unchecked(label.value.to_vec()) }
+                    };
                     self.table_name = table_name;
                     self.labels.truncate(self.labels.len() - 1); // remove last label
                 }
@@ -198,7 +205,7 @@ impl PromTimeSeries {
         }
     }
 
-    fn add_to_table_data(&mut self, table_builders: &mut TablesBuilder) {
+    fn add_to_table_data(&mut self, table_builders: &mut TablesBuilder, strict_mode: bool) {
         let label_num = self.labels.len();
         let row_num = self.samples.len();
         let table_data = table_builders.get_or_create_table_builder(
@@ -206,7 +213,11 @@ impl PromTimeSeries {
             label_num,
             row_num,
         );
-        table_data.add_labels_and_samples(self.labels.as_slice(), self.samples.as_slice());
+        let _ = table_data.add_labels_and_samples(
+            self.labels.as_slice(),
+            self.samples.as_slice(),
+            strict_mode,
+        );
         self.labels.clear();
         self.samples.clear();
     }
@@ -230,7 +241,7 @@ impl PromWriteRequest {
     }
 
     // todo(hl): maybe use &[u8] can reduce the overhead introduced with Bytes.
-    pub fn merge(&mut self, mut buf: Bytes) -> Result<(), DecodeError> {
+    pub fn merge(&mut self, mut buf: Bytes, strict_mode: bool) -> Result<(), DecodeError> {
         const STRUCT_NAME: &str = "PromWriteRequest";
         while buf.has_remaining() {
             let (tag, wire_type) = decode_key(&mut buf)?;
@@ -250,12 +261,14 @@ impl PromWriteRequest {
                     let limit = remaining - len as usize;
                     while buf.remaining() > limit {
                         let (tag, wire_type) = decode_key(&mut buf)?;
-                        self.series.merge_field(tag, wire_type, &mut buf)?;
+                        self.series
+                            .merge_field(tag, wire_type, &mut buf, strict_mode)?;
                     }
                     if buf.remaining() != limit {
                         return Err(DecodeError::new("delimited length exceeded"));
                     }
-                    self.series.add_to_table_data(&mut self.table_data);
+                    self.series
+                        .add_to_table_data(&mut self.table_data, strict_mode);
                 }
                 3u32 => {
                     // todo(hl): metadata are skipped.

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -462,7 +462,7 @@ pub async fn setup_test_prom_app_with_frontend(
             ServerSqlQueryHandlerAdapter::arc(frontend_ref.clone()),
             Some(frontend_ref.clone()),
         )
-        .with_prom_handler(frontend_ref.clone(), true)
+        .with_prom_handler(frontend_ref.clone(), true, true)
         .with_prometheus_handler(frontend_ref)
         .with_greptime_config_options(instance.mix_options.datanode.to_toml_string())
         .build();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#3435
## What's changed and what's your intention?

provide a strict mode to perform UTF-8 validation

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
