### PR TITLE
chore: generate release notes with git-cliff

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,116 @@
+# https://git-cliff.org/docs/configuration
+
+[remote.github]
+owner = "GreptimeTeam"
+repo = "greptimedb"
+
+[changelog]
+header = ""
+footer = ""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+# {{ version }}
+
+Release date: {{ timestamp | date(format="%B %d, %Y") }}
+
+{%- set breakings = commits | filter(attribute="breaking", value=true) -%}
+{%- if breakings | length > 0 %}
+
+## Breaking changes
+    {% for commit in breakings %}
+      * {{ commit.github.pr_title }}\
+        {% if commit.github.username %} by \
+          {% set author = commit.github.username -%}
+          [@{{ author }}](https://github.com/{{ author }})
+        {%- endif -%}
+        {% if commit.github.pr_number %} in \
+          {% set number = commit.github.pr_number -%}
+          [#{{ number }}]({{ self::remote_url() }}/pull/{{ number }})
+        {%- endif %}
+    {%- endfor %}
+{%- endif -%}
+
+{%- set grouped_commits = commits | filter(attribute="breaking", value=false) | group_by(attribute="group") -%}
+{% for group, commits in grouped_commits %}
+
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        * {{ commit.github.pr_title }}\
+            {% if commit.github.username %} by \
+              {% set author = commit.github.username -%}
+              [@{{ author }}](https://github.com/{{ author }})
+            {%- endif -%}
+            {% if commit.github.pr_number %} in \
+              {% set number = commit.github.pr_number -%}
+              [#{{ number }}]({{ self::remote_url() }}/pull/{{ number }})
+            {%- endif %}
+    {%- endfor -%}
+{% endfor %}
+
+{%- if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+  {% raw %}\n{% endraw -%}
+  ## New Contributors
+{% endif -%}
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  * @{{ contributor.username }} made their first contribution
+    {%- if contributor.pr_number %} in \
+      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
+    {%- endif %}
+{%- endfor -%}
+
+{% if github.contributors | length != 0 %}
+  {% raw %}\n{% endraw -%}
+## All Contributors
+
+We would like to thank the following contributors from the GreptimeDB community:
+
+{{ github.contributors | map(attribute="username") | join(sep=", ") }}
+{%- endif %}\
+
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+"""
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+  { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+  { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+  { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+  { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+  { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+  { message = "^chore\\(release\\): prepare for", skip = true },
+  { message = "^chore\\(deps.*\\)", skip = true },
+  { message = "^chore\\(pr\\)", skip = true },
+  { message = "^chore\\(pull\\)", skip = true },
+  { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+  { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+  { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# regex for matching git tags
+# tag_pattern = "v[0-9].*"
+# regex for skipping tags
+# skip_tags = ""
+# regex for ignoring tags
+ignore_tags = ".*-nightly-.*"
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"
+# limit the number of commits included in the changelog.
+# limit_commits = 42

--- a/cliff.toml
+++ b/cliff.toml
@@ -66,7 +66,8 @@ Release date: {{ timestamp | date(format="%B %d, %Y") }}
 We would like to thank the following contributors from the GreptimeDB community:
 
 {{ github.contributors | map(attribute="username") | join(sep=", ") }}
-{%- endif %}\
+{%- endif %}
+{% raw %}\n{% endraw %}
 
 {%- macro remote_url() -%}
   https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This refers to #3609 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Result

Install `cargo install git-cliff`

Running `GITHUB_TOKEN=*** git cliff v0.6.0..v0.7.0` gives:

(We can then manually add highlights and/or fine-tuning the notes)

```markdown
# v0.7.0

Release date: March 05, 2024

## Breaking changes

* feat!: switch prom remote write to metric engine by [@waynexia](https://github.com/waynexia) in [#3198](https://github.com/GreptimeTeam/greptimedb/pull/3198)
* refactor!: rename initialize_region_in_background to init_regions_in_background by [@WenyXu](https://github.com/WenyXu) in [#3216](https://github.com/GreptimeTeam/greptimedb/pull/3216)
* feat!: new partition grammar - parser part by [@waynexia](https://github.com/waynexia) in [#3347](https://github.com/GreptimeTeam/greptimedb/pull/3347)

### 🚀 Features

* feat: add modulo function by [@etolbakov](https://github.com/etolbakov) in [#3147](https://github.com/GreptimeTeam/greptimedb/pull/3147)
* feat: support HTTP&gRPC&pg set timezone by [@Taylor-lagrange](https://github.com/Taylor-lagrange) in [#3125](https://github.com/GreptimeTeam/greptimedb/pull/3125)
* feat(mito): enable inverted index by [@zhongzc](https://github.com/zhongzc) in [#3158](https://github.com/GreptimeTeam/greptimedb/pull/3158)
* feat: upgrade pgwire to 0.19 by [@sunng87](https://github.com/sunng87) in [#3157](https://github.com/GreptimeTeam/greptimedb/pull/3157)
* feat: let tables API return a stream by [@fengjiachun](https://github.com/fengjiachun) in [#3170](https://github.com/GreptimeTeam/greptimedb/pull/3170)
* feat: add tests-fuzz crate by [@WenyXu](https://github.com/WenyXu) in [#3173](https://github.com/GreptimeTeam/greptimedb/pull/3173)
* feat: tables stream with CatalogManager by [@fengjiachun](https://github.com/fengjiachun) in [#3180](https://github.com/GreptimeTeam/greptimedb/pull/3180)
* feat: adds date_format function by [@killme2008](https://github.com/killme2008) in [#3167](https://github.com/GreptimeTeam/greptimedb/pull/3167)
* feat: auto config cache size according to memory size by [@QuenKar](https://github.com/QuenKar) in [#3165](https://github.com/GreptimeTeam/greptimedb/pull/3165)
* feat: precise filter for mito parquet reader by [@waynexia](https://github.com/waynexia) in [#3178](https://github.com/GreptimeTeam/greptimedb/pull/3178)
* feat: adds parse options for SQL parser by [@killme2008](https://github.com/killme2008) in [#3193](https://github.com/GreptimeTeam/greptimedb/pull/3193)
* feat(tests-fuzz): add CreateTableExprGenerator & AlterTableExprGenerator by [@WenyXu](https://github.com/WenyXu) in [#3182](https://github.com/GreptimeTeam/greptimedb/pull/3182)
* feat: make procedure able to return output by [@WenyXu](https://github.com/WenyXu) in [#3201](https://github.com/GreptimeTeam/greptimedb/pull/3201)
* feat: copy database from by [@v0y4g3r](https://github.com/v0y4g3r) in [#3164](https://github.com/GreptimeTeam/greptimedb/pull/3164)
* feat: introduce information schema provider cache by [@WenyXu](https://github.com/WenyXu) in [#3208](https://github.com/GreptimeTeam/greptimedb/pull/3208)
* feat: lazy initialize vector builder on write by [@waynexia](https://github.com/waynexia) in [#3210](https://github.com/GreptimeTeam/greptimedb/pull/3210)
* feat: make query be aware of timezone setting by [@killme2008](https://github.com/killme2008) in [#3175](https://github.com/GreptimeTeam/greptimedb/pull/3175)
* feat: add create alter table expr translator by [@WenyXu](https://github.com/WenyXu) in [#3203](https://github.com/GreptimeTeam/greptimedb/pull/3203)
* feat: read column and region info from state cache by [@waynexia](https://github.com/waynexia) in [#3222](https://github.com/GreptimeTeam/greptimedb/pull/3222)
* feat: enable concurrent write by [@WenyXu](https://github.com/WenyXu) in [#3214](https://github.com/GreptimeTeam/greptimedb/pull/3214)
* feat: add Arrow IPC output format for http rest api by [@sunng87](https://github.com/sunng87) in [#3177](https://github.com/GreptimeTeam/greptimedb/pull/3177)
* feat: change Range Query’s default align behavior aware of timezone by [@killme2008](https://github.com/killme2008) in [#3219](https://github.com/GreptimeTeam/greptimedb/pull/3219)
* feat: update dashboard to v0.4.7 by [@ZonaHex](https://github.com/ZonaHex) in [#3229](https://github.com/GreptimeTeam/greptimedb/pull/3229)
* feat: http sql api return schema on empty resultset by [@sunng87](https://github.com/sunng87) in [#3237](https://github.com/GreptimeTeam/greptimedb/pull/3237)
* feat: add pg create alter table expr translator by [@WenyXu](https://github.com/WenyXu) in [#3206](https://github.com/GreptimeTeam/greptimedb/pull/3206)
* feat: read metadata from write cache by [@QuenKar](https://github.com/QuenKar) in [#3224](https://github.com/GreptimeTeam/greptimedb/pull/3224)
* feat: batch create ddl by [@fengjiachun](https://github.com/fengjiachun) in [#3194](https://github.com/GreptimeTeam/greptimedb/pull/3194)
* feat: add insert/select generator & translator by [@WenyXu](https://github.com/WenyXu) in [#3240](https://github.com/GreptimeTeam/greptimedb/pull/3240)
* feat: return request outdated error on handling alter by [@waynexia](https://github.com/waynexia) in [#3239](https://github.com/GreptimeTeam/greptimedb/pull/3239)
* feat: don't map semantic type in metric engine by [@waynexia](https://github.com/waynexia) in [#3243](https://github.com/GreptimeTeam/greptimedb/pull/3243)
* feat: create tables in batch on prom write by [@fengjiachun](https://github.com/fengjiachun) in [#3246](https://github.com/GreptimeTeam/greptimedb/pull/3246)
* feat: Only allow inserts and deletes operations to be executed in parallel by [@fengjiachun](https://github.com/fengjiachun) in [#3257](https://github.com/GreptimeTeam/greptimedb/pull/3257)
* feat: basic types for Dataflow Framework by [@discord9](https://github.com/discord9) in [#3186](https://github.com/GreptimeTeam/greptimedb/pull/3186)
* feat: initial configuration for grafana dashboard by [@waynexia](https://github.com/waynexia) in [#3263](https://github.com/GreptimeTeam/greptimedb/pull/3263)
* feat: support fraction part in timestamp by [@discord9](https://github.com/discord9) in [#3272](https://github.com/GreptimeTeam/greptimedb/pull/3272)
* feat: use simple filter to prune memtable  by [@waynexia](https://github.com/waynexia) in [#3269](https://github.com/GreptimeTeam/greptimedb/pull/3269)
* feat: Basic Definitions for Expression&Functions for Dataflow by [@discord9](https://github.com/discord9) in [#3267](https://github.com/GreptimeTeam/greptimedb/pull/3267)
* feat: support cache for batch_get in CachedMetaKvBackend by [@fengys1996](https://github.com/fengys1996) in [#3277](https://github.com/GreptimeTeam/greptimedb/pull/3277)
* feat: put all filter exprs in a filter plan separately by [@waynexia](https://github.com/waynexia) in [#3288](https://github.com/GreptimeTeam/greptimedb/pull/3288)
* feat: administration functions by [@killme2008](https://github.com/killme2008) in [#3236](https://github.com/GreptimeTeam/greptimedb/pull/3236)
* feat(mito): adjust seg size of inverted index to finer granularity instead of row group level by [@zhongzc](https://github.com/zhongzc) in [#3289](https://github.com/GreptimeTeam/greptimedb/pull/3289)
* feat(mito): add options to ignore building index for specific column ids by [@zhongzc](https://github.com/zhongzc) in [#3295](https://github.com/GreptimeTeam/greptimedb/pull/3295)
* feat: organize tracing on query path by [@waynexia](https://github.com/waynexia) in [#3310](https://github.com/GreptimeTeam/greptimedb/pull/3310)
* feat: impl partitions and region_peers information schema by [@killme2008](https://github.com/killme2008) in [#3278](https://github.com/GreptimeTeam/greptimedb/pull/3278)
* feat: batch get physical table routes by [@fengjiachun](https://github.com/fengjiachun) in [#3319](https://github.com/GreptimeTeam/greptimedb/pull/3319)
* feat: Defines structs in the merge tree memtable by [@evenyag](https://github.com/evenyag) in [#3326](https://github.com/GreptimeTeam/greptimedb/pull/3326)
* feat(metric-engine): set index options for data region by [@zhongzc](https://github.com/zhongzc) in [#3330](https://github.com/GreptimeTeam/greptimedb/pull/3330)
* feat: data buffer and related structs by [@v0y4g3r](https://github.com/v0y4g3r) in [#3329](https://github.com/GreptimeTeam/greptimedb/pull/3329)
* feat: Implement KeyDictBuilder for the merge tree memtable by [@evenyag](https://github.com/evenyag) in [#3334](https://github.com/GreptimeTeam/greptimedb/pull/3334)
* feat: replace pk index with pk_weight during freeze by [@v0y4g3r](https://github.com/v0y4g3r) in [#3343](https://github.com/GreptimeTeam/greptimedb/pull/3343)
* feat: merge tree data parts  by [@v0y4g3r](https://github.com/v0y4g3r) in [#3346](https://github.com/GreptimeTeam/greptimedb/pull/3346)
* feat(flow): impl ScalarExpr&Scalar Function by [@discord9](https://github.com/discord9) in [#3283](https://github.com/GreptimeTeam/greptimedb/pull/3283)
* feat: impl migrate_region and procedure_state SQL function by [@killme2008](https://github.com/killme2008) in [#3325](https://github.com/GreptimeTeam/greptimedb/pull/3325)
* feat: add isnull function by [@KKould](https://github.com/KKould) in [#3360](https://github.com/GreptimeTeam/greptimedb/pull/3360)
* feat: skip filling NULL for put and delete requests by [@waynexia](https://github.com/waynexia) in [#3364](https://github.com/GreptimeTeam/greptimedb/pull/3364)
* feat: impl merge reader for DataParts by [@v0y4g3r](https://github.com/v0y4g3r) in [#3361](https://github.com/GreptimeTeam/greptimedb/pull/3361)
* feat: Implement write and fork for the new memtable by [@evenyag](https://github.com/evenyag) in [#3357](https://github.com/GreptimeTeam/greptimedb/pull/3357)
* feat: distinguish between different read paths by [@v0y4g3r](https://github.com/v0y4g3r) in [#3369](https://github.com/GreptimeTeam/greptimedb/pull/3369)
* feat: Add freeze and fork method to the memtable by [@evenyag](https://github.com/evenyag) in [#3374](https://github.com/GreptimeTeam/greptimedb/pull/3374)
* feat: merge tree dedup reader by [@v0y4g3r](https://github.com/v0y4g3r) in [#3375](https://github.com/GreptimeTeam/greptimedb/pull/3375)
* feat: Implement iter for the new memtable by [@evenyag](https://github.com/evenyag) in [#3373](https://github.com/GreptimeTeam/greptimedb/pull/3373)
* feat: Implement dedup for the new memtable and expose the config by [@evenyag](https://github.com/evenyag) in [#3377](https://github.com/GreptimeTeam/greptimedb/pull/3377)
* feat: change how region id maps to region worker by [@waynexia](https://github.com/waynexia) in [#3384](https://github.com/GreptimeTeam/greptimedb/pull/3384)
* feat: make tls certificates/keys reloadable (part 1) by [@sunng87](https://github.com/sunng87) in [#3335](https://github.com/GreptimeTeam/greptimedb/pull/3335)
* feat(grafana): enable shared tooltip, add raft engine throughput by [@waynexia](https://github.com/waynexia) in [#3387](https://github.com/GreptimeTeam/greptimedb/pull/3387)
* feat: Implement partition eviction and only add value size to write buffer size by [@evenyag](https://github.com/evenyag) in [#3393](https://github.com/GreptimeTeam/greptimedb/pull/3393)
* feat: enable zstd compression and encodings in merge tree data part by [@v0y4g3r](https://github.com/v0y4g3r) in [#3380](https://github.com/GreptimeTeam/greptimedb/pull/3380)
* feat(flow): impl for MapFilterProject by [@discord9](https://github.com/discord9) in [#3359](https://github.com/GreptimeTeam/greptimedb/pull/3359)
* feat: flush or compact table and region functions by [@killme2008](https://github.com/killme2008) in [#3363](https://github.com/GreptimeTeam/greptimedb/pull/3363)
* feat: Use a partition level map to look up pk index by [@evenyag](https://github.com/evenyag) in [#3400](https://github.com/GreptimeTeam/greptimedb/pull/3400)
* feat(index): measure memory usage in global instead of single-column and add metrics by [@zhongzc](https://github.com/zhongzc) in [#3383](https://github.com/GreptimeTeam/greptimedb/pull/3383)
* feat: enable ArrowFlight compression by [@tisonkun](https://github.com/tisonkun) in [#3403](https://github.com/GreptimeTeam/greptimedb/pull/3403)
* feat: zero copy on split rows by [@fengjiachun](https://github.com/fengjiachun) in [#3407](https://github.com/GreptimeTeam/greptimedb/pull/3407)
* feat: Support automatic DNS lookup for kafka bootstrap servers by [@J0HN50N133](https://github.com/J0HN50N133) in [#3379](https://github.com/GreptimeTeam/greptimedb/pull/3379)
* feat: add configuration for tls watch option by [@sunng87](https://github.com/sunng87) in [#3395](https://github.com/GreptimeTeam/greptimedb/pull/3395)
* feat: employ sparse key encoding for shard lookup by [@v0y4g3r](https://github.com/v0y4g3r) in [#3410](https://github.com/GreptimeTeam/greptimedb/pull/3410)
* feat: support `Create Table ... Like` by [@KKould](https://github.com/KKould) in [#3372](https://github.com/GreptimeTeam/greptimedb/pull/3372)
* feat: tableref cache by [@fengjiachun](https://github.com/fengjiachun) in [#3420](https://github.com/GreptimeTeam/greptimedb/pull/3420)
* feat: add verbose support for tql explain/analyze by [@etolbakov](https://github.com/etolbakov) in [#3390](https://github.com/GreptimeTeam/greptimedb/pull/3390)
* feat: reduce a clone of string by [@fengjiachun](https://github.com/fengjiachun) in [#3422](https://github.com/GreptimeTeam/greptimedb/pull/3422)
* feat: Correct server metrics and add more metrics for scan by [@evenyag](https://github.com/evenyag) in [#3426](https://github.com/GreptimeTeam/greptimedb/pull/3426)
* feat: support tracing rule sampler by [@Taylor-lagrange](https://github.com/Taylor-lagrange) in [#3405](https://github.com/GreptimeTeam/greptimedb/pull/3405)
* feat: decode prom requests to grpc by [@v0y4g3r](https://github.com/v0y4g3r) in [#3425](https://github.com/GreptimeTeam/greptimedb/pull/3425)
* feat: implement multi-dim partition rule by [@waynexia](https://github.com/waynexia) in [#3409](https://github.com/GreptimeTeam/greptimedb/pull/3409)

### 🐛 Bug Fixes

* fix: change back `GREPTIME_DB_HEADER_NAME` header key name by [@shuiyisong](https://github.com/shuiyisong) in [#3184](https://github.com/GreptimeTeam/greptimedb/pull/3184)
* fix(index): S3 `EntityTooSmall` error by [@zhongzc](https://github.com/zhongzc) in [#3192](https://github.com/GreptimeTeam/greptimedb/pull/3192)
* fix: remove __name__ matcher from processed matcher list by [@waynexia](https://github.com/waynexia) in [#3213](https://github.com/GreptimeTeam/greptimedb/pull/3213)
* fix: fix default value cannot accept negative number by [@WenyXu](https://github.com/WenyXu) in [#3217](https://github.com/GreptimeTeam/greptimedb/pull/3217)
* fix: only register region keeper while creating physical table by [@WenyXu](https://github.com/WenyXu) in [#3223](https://github.com/GreptimeTeam/greptimedb/pull/3223)
* fix: fix MockInstance rebuild issue by [@WenyXu](https://github.com/WenyXu) in [#3218](https://github.com/GreptimeTeam/greptimedb/pull/3218)
* fix: security update for shlex and h2 by [@sunng87](https://github.com/sunng87) in [#3227](https://github.com/GreptimeTeam/greptimedb/pull/3227)
* fix: fix create table ddl return incorrect table id by [@WenyXu](https://github.com/WenyXu) in [#3232](https://github.com/GreptimeTeam/greptimedb/pull/3232)
* fix: init parquet reader metrics twice by [@evenyag](https://github.com/evenyag) in [#3242](https://github.com/GreptimeTeam/greptimedb/pull/3242)
* fix: IntermediateWriter closes underlying writer twice by [@waynexia](https://github.com/waynexia) in [#3248](https://github.com/GreptimeTeam/greptimedb/pull/3248)
* fix: decouple columns in projection and prune by [@waynexia](https://github.com/waynexia) in [#3253](https://github.com/GreptimeTeam/greptimedb/pull/3253)
* fix(Copy From): fix incorrect type casts by [@WenyXu](https://github.com/WenyXu) in [#3264](https://github.com/GreptimeTeam/greptimedb/pull/3264)
* fix: SQL insertion and column default constraint aware of timezone by [@killme2008](https://github.com/killme2008) in [#3266](https://github.com/GreptimeTeam/greptimedb/pull/3266)
* fix: cli export database default value by [@tisonkun](https://github.com/tisonkun) in [#3259](https://github.com/GreptimeTeam/greptimedb/pull/3259)
* fix: use `fe_opts` after `setup_frontend_plugins` in standalone by [@shuiyisong](https://github.com/shuiyisong) in [#3275](https://github.com/GreptimeTeam/greptimedb/pull/3275)
* fix: fix incorrect StatusCode parsing by [@WenyXu](https://github.com/WenyXu) in [#3281](https://github.com/GreptimeTeam/greptimedb/pull/3281)
* fix(util): join_path function should not trim leading `/` by [@dalprahcd](https://github.com/dalprahcd) in [#3280](https://github.com/GreptimeTeam/greptimedb/pull/3280)
* fix: correct the case sensitivity behavior for PromQL by [@waynexia](https://github.com/waynexia) in [#3296](https://github.com/GreptimeTeam/greptimedb/pull/3296)
* fix: $TARGET_BIN not found when docker run the image  by [@daviderli614](https://github.com/daviderli614) in [#3297](https://github.com/GreptimeTeam/greptimedb/pull/3297)
* fix(index): sanitize S3 upload buffer size by [@zhongzc](https://github.com/zhongzc) in [#3300](https://github.com/GreptimeTeam/greptimedb/pull/3300)
* fix: commit_short sqlness test case  by [@tisonkun](https://github.com/tisonkun) in [#3313](https://github.com/GreptimeTeam/greptimedb/pull/3313)
* fix: bump libgit2-sys from 0.16.1+1.7.1 to 0.16.2+1.7.2 by [@dependabot[bot]](https://github.com/dependabot[bot]) in [#3316](https://github.com/GreptimeTeam/greptimedb/pull/3316)
* fix: split write metadata request by [@fengjiachun](https://github.com/fengjiachun) in [#3311](https://github.com/GreptimeTeam/greptimedb/pull/3311)
* fix(index): encode string type to original data to enable fst regex to work by [@zhongzc](https://github.com/zhongzc) in [#3324](https://github.com/GreptimeTeam/greptimedb/pull/3324)
* fix: disable ansi contorl char when stdout is redirected by [@waynexia](https://github.com/waynexia) in [#3332](https://github.com/GreptimeTeam/greptimedb/pull/3332)
* fix: typo in lint config by [@waynexia](https://github.com/waynexia) in [#3358](https://github.com/GreptimeTeam/greptimedb/pull/3358)
* fix: treat "0" and "1" as valid boolean values. by [@MichaelScofield](https://github.com/MichaelScofield) in [#3370](https://github.com/GreptimeTeam/greptimedb/pull/3370)
* fix: remove unused imports in memtable_util.rs by [@v0y4g3r](https://github.com/v0y4g3r) in [#3376](https://github.com/GreptimeTeam/greptimedb/pull/3376)
* fix: resets dict builder keys counter and avoid unnecessary pruning by [@evenyag](https://github.com/evenyag) in [#3386](https://github.com/GreptimeTeam/greptimedb/pull/3386)
* test: range fix in modulo function tests by [@dimbtp](https://github.com/dimbtp) in [#3389](https://github.com/GreptimeTeam/greptimedb/pull/3389)
* fix: throw errors instead of panic by [@WenyXu](https://github.com/WenyXu) in [#3391](https://github.com/GreptimeTeam/greptimedb/pull/3391)
* fix: some read metrics by [@v0y4g3r](https://github.com/v0y4g3r) in [#3404](https://github.com/GreptimeTeam/greptimedb/pull/3404)
* fix: partition region id by [@fengjiachun](https://github.com/fengjiachun) in [#3414](https://github.com/GreptimeTeam/greptimedb/pull/3414)
* fix: show table names not complete from information_schema by [@killme2008](https://github.com/killme2008) in [#3417](https://github.com/GreptimeTeam/greptimedb/pull/3417)
* fix: mitigate memory spike during startup by [@niebayes](https://github.com/niebayes) in [#3418](https://github.com/GreptimeTeam/greptimedb/pull/3418)
* fix: complete interceptors for all frontend entry by [@shuiyisong](https://github.com/shuiyisong) in [#3428](https://github.com/GreptimeTeam/greptimedb/pull/3428)

### 🚜 Refactor

* refactor: make grpc service able to be added dynamically by [@MichaelScofield](https://github.com/MichaelScofield) in [#3160](https://github.com/GreptimeTeam/greptimedb/pull/3160)
* refactor: remove TableEngine by [@waynexia](https://github.com/waynexia) in [#3181](https://github.com/GreptimeTeam/greptimedb/pull/3181)
* refactor: expose region edit in mito engine by [@MichaelScofield](https://github.com/MichaelScofield) in [#3179](https://github.com/GreptimeTeam/greptimedb/pull/3179)
* refactor: introduce common-wal to aggregate wal stuff by [@niebayes](https://github.com/niebayes) in [#3171](https://github.com/GreptimeTeam/greptimedb/pull/3171)
* refactor: reduce number of parquet metadata reads and enable reader buffer by [@WenyXu](https://github.com/WenyXu) in [#3197](https://github.com/GreptimeTeam/greptimedb/pull/3197)
* refactor: read parquet metadata by [@QuenKar](https://github.com/QuenKar) in [#3199](https://github.com/GreptimeTeam/greptimedb/pull/3199)
* refactor: make http server built flexibly by [@MichaelScofield](https://github.com/MichaelScofield) in [#3225](https://github.com/GreptimeTeam/greptimedb/pull/3225)
* refactor: add same SST files by [@MichaelScofield](https://github.com/MichaelScofield) in [#3270](https://github.com/GreptimeTeam/greptimedb/pull/3270)
* refactor(index): move option `segment_row_count` from WriteOptions to IndexOptions by [@zhongzc](https://github.com/zhongzc) in [#3307](https://github.com/GreptimeTeam/greptimedb/pull/3307)
* refactor: bring metrics to http output by [@shuiyisong](https://github.com/shuiyisong) in [#3247](https://github.com/GreptimeTeam/greptimedb/pull/3247)
* refactor: allocate table id in the procedure by [@WenyXu](https://github.com/WenyXu) in [#3271](https://github.com/GreptimeTeam/greptimedb/pull/3271)
* refactor: put together HTTP headers by [@tisonkun](https://github.com/tisonkun) in [#3337](https://github.com/GreptimeTeam/greptimedb/pull/3337)
* refactor: allocate table ids in the procedure by [@WenyXu](https://github.com/WenyXu) in [#3293](https://github.com/GreptimeTeam/greptimedb/pull/3293)
* refactor: set the actual bound port in server handler by [@MichaelScofield](https://github.com/MichaelScofield) in [#3353](https://github.com/GreptimeTeam/greptimedb/pull/3353)
* refactor: Remove Item from merger's Node trait by [@evenyag](https://github.com/evenyag) in [#3371](https://github.com/GreptimeTeam/greptimedb/pull/3371)
* refactor: change the receivers of merge tree components by [@v0y4g3r](https://github.com/v0y4g3r) in [#3378](https://github.com/GreptimeTeam/greptimedb/pull/3378)
* refactor: refactor TableRouteManager by [@WenyXu](https://github.com/WenyXu) in [#3392](https://github.com/GreptimeTeam/greptimedb/pull/3392)
* refactor: move some costly methods in DataBuffer::read out of read lock by [@v0y4g3r](https://github.com/v0y4g3r) in [#3406](https://github.com/GreptimeTeam/greptimedb/pull/3406)
* refactor: show tables and show databases by [@killme2008](https://github.com/killme2008) in [#3423](https://github.com/GreptimeTeam/greptimedb/pull/3423)
* refactor: make MergeTreeMemtable the default choice by [@v0y4g3r](https://github.com/v0y4g3r) in [#3430](https://github.com/GreptimeTeam/greptimedb/pull/3430)

### 📚 Documentation

* docs: add tracking issue for inverted-index RFC by [@tisonkun](https://github.com/tisonkun) in [#3169](https://github.com/GreptimeTeam/greptimedb/pull/3169)
* docs: Update README.md by [@tisonkun](https://github.com/tisonkun) in [#3168](https://github.com/GreptimeTeam/greptimedb/pull/3168)
* docs: update SDK links in README.md by [@nicecui](https://github.com/nicecui) in [#3156](https://github.com/GreptimeTeam/greptimedb/pull/3156)
* docs: RFC of Dataflow Framework by [@discord9](https://github.com/discord9) in [#3185](https://github.com/GreptimeTeam/greptimedb/pull/3185)
* docs: update pull_request_template.md by [@tisonkun](https://github.com/tisonkun) in [#3421](https://github.com/GreptimeTeam/greptimedb/pull/3421)
* docs(rfcs): multi-dimension partition rule by [@waynexia](https://github.com/waynexia) in [#3350](https://github.com/GreptimeTeam/greptimedb/pull/3350)

### 🧪 Testing

* test: engine with write cache by [@QuenKar](https://github.com/QuenKar) in [#3163](https://github.com/GreptimeTeam/greptimedb/pull/3163)
* test: align chrono and some forked test deps to upstream by [@sunng87](https://github.com/sunng87) in [#3245](https://github.com/GreptimeTeam/greptimedb/pull/3245)
* test: add data compatibility test by [@MichaelScofield](https://github.com/MichaelScofield) in [#3109](https://github.com/GreptimeTeam/greptimedb/pull/3109)
* test: fix list_files_and_parse_table_name path issue on windows by [@evenyag](https://github.com/evenyag) in [#3349](https://github.com/GreptimeTeam/greptimedb/pull/3349)

### ⚙️ Miscellaneous Tasks

* chore: expose promql test to distributed instance by [@niebayes](https://github.com/niebayes) in [#3176](https://github.com/GreptimeTeam/greptimedb/pull/3176)
* chore: carry metrics in flight metadata from datanode to frontend by [@shuiyisong](https://github.com/shuiyisong) in [#3113](https://github.com/GreptimeTeam/greptimedb/pull/3113)
* chore: bump opendal to v0.44.2 by [@WenyXu](https://github.com/WenyXu) in [#3209](https://github.com/GreptimeTeam/greptimedb/pull/3209)
* chore: change default factor to compute memory size by [@shuiyisong](https://github.com/shuiyisong) in [#3211](https://github.com/GreptimeTeam/greptimedb/pull/3211)
* ci: make git's "safe.directory" accept all by [@MichaelScofield](https://github.com/MichaelScofield) in [#3234](https://github.com/GreptimeTeam/greptimedb/pull/3234)
* ci: adding `DOCKER_BUILD_ROOT` docker arg for dev build by [@MichaelScofield](https://github.com/MichaelScofield) in [#3241](https://github.com/GreptimeTeam/greptimedb/pull/3241)
* chore: adjust MySQL connection log by [@shuiyisong](https://github.com/shuiyisong) in [#3251](https://github.com/GreptimeTeam/greptimedb/pull/3251)
* ci: merge doc label actor and checker tasks by [@sunng87](https://github.com/sunng87) in [#3252](https://github.com/GreptimeTeam/greptimedb/pull/3252)
* chore: switch to free machine by [@WenyXu](https://github.com/WenyXu) in [#3256](https://github.com/GreptimeTeam/greptimedb/pull/3256)
* chore: adjust storage engine related metrics by [@waynexia](https://github.com/waynexia) in [#3261](https://github.com/GreptimeTeam/greptimedb/pull/3261)
* ci: build GreptimeDB binary for later use by [@MichaelScofield](https://github.com/MichaelScofield) in [#3244](https://github.com/GreptimeTeam/greptimedb/pull/3244)
* ci: fix nightly build by [@MichaelScofield](https://github.com/MichaelScofield) in [#3276](https://github.com/GreptimeTeam/greptimedb/pull/3276)
* chore: share cache corss jobs by [@WenyXu](https://github.com/WenyXu) in [#3284](https://github.com/GreptimeTeam/greptimedb/pull/3284)
* chore: start plugins during standalone startup & comply with current catalog while changing database by [@shuiyisong](https://github.com/shuiyisong) in [#3282](https://github.com/GreptimeTeam/greptimedb/pull/3282)
* chore(index): add BiError to fulfil the requirement of returning two errors by [@zhongzc](https://github.com/zhongzc) in [#3291](https://github.com/GreptimeTeam/greptimedb/pull/3291)
* chore: update link to official website link by [@caicancai](https://github.com/caicancai) in [#3299](https://github.com/GreptimeTeam/greptimedb/pull/3299)
* ci: add release result send to slack by [@daviderli614](https://github.com/daviderli614) in [#3312](https://github.com/GreptimeTeam/greptimedb/pull/3312)
* ci: run CI jobs in draft PR by [@waynexia](https://github.com/waynexia) in [#3314](https://github.com/GreptimeTeam/greptimedb/pull/3314)
* ci: upgrade actions to avoid node16 deprecation warning by [@tisonkun](https://github.com/tisonkun) in [#3317](https://github.com/GreptimeTeam/greptimedb/pull/3317)
* ci: add build artifacts needs in notification by [@daviderli614](https://github.com/daviderli614) in [#3320](https://github.com/GreptimeTeam/greptimedb/pull/3320)
* chore: check dirs before create RaftEngine store by [@tisonkun](https://github.com/tisonkun) in [#3327](https://github.com/GreptimeTeam/greptimedb/pull/3327)
* chore: support configure GITHUB_PROXY_URL when fetch dashboard assets by [@tisonkun](https://github.com/tisonkun) in [#3340](https://github.com/GreptimeTeam/greptimedb/pull/3340)
* ci: try fix log location by [@tisonkun](https://github.com/tisonkun) in [#3342](https://github.com/GreptimeTeam/greptimedb/pull/3342)
* ci: upgrade actions to node20-based version by [@tisonkun](https://github.com/tisonkun) in [#3345](https://github.com/GreptimeTeam/greptimedb/pull/3345)
* chore: remove unused deprecated table_dir_with_catalog_and_schema by [@tisonkun](https://github.com/tisonkun) in [#3341](https://github.com/GreptimeTeam/greptimedb/pull/3341)
* chore: use workspace-wide lints by [@SteveLauC](https://github.com/SteveLauC) in [#3352](https://github.com/GreptimeTeam/greptimedb/pull/3352)
* ci: align docs workflow jobs with develop.yml by [@waynexia](https://github.com/waynexia) in [#3356](https://github.com/GreptimeTeam/greptimedb/pull/3356)
* chore: skip reorder workspace tables in taplo by [@waynexia](https://github.com/waynexia) in [#3388](https://github.com/GreptimeTeam/greptimedb/pull/3388)
* ci: add builder result outputs in release action by [@daviderli614](https://github.com/daviderli614) in [#3381](https://github.com/GreptimeTeam/greptimedb/pull/3381)
* chore: retry fetch dashboard assets by [@tisonkun](https://github.com/tisonkun) in [#3394](https://github.com/GreptimeTeam/greptimedb/pull/3394)
* chore: add metris for memtable read path by [@v0y4g3r](https://github.com/v0y4g3r) in [#3397](https://github.com/GreptimeTeam/greptimedb/pull/3397)
* ci: refine windows output env by [@daviderli614](https://github.com/daviderli614) in [#3431](https://github.com/GreptimeTeam/greptimedb/pull/3431)
* chore: bump version to v0.7.0 by [@evenyag](https://github.com/evenyag) in [#3433](https://github.com/GreptimeTeam/greptimedb/pull/3433)

### Build

* build: make binary name a Dockerfile "ARG" by [@MichaelScofield](https://github.com/MichaelScofield) in [#3254](https://github.com/GreptimeTeam/greptimedb/pull/3254)
* build(deps): Upgrade raft-engine dependency cascading by [@tisonkun](https://github.com/tisonkun) in [#3305](https://github.com/GreptimeTeam/greptimedb/pull/3305)
* build: support build without git by [@tisonkun](https://github.com/tisonkun) in [#3309](https://github.com/GreptimeTeam/greptimedb/pull/3309)
* build(deps): axum-tets-helper has included patch-1 by [@tisonkun](https://github.com/tisonkun) in [#3333](https://github.com/GreptimeTeam/greptimedb/pull/3333)
* build(deps): Upgrade opensrv to 0.7.0 by [@tisonkun](https://github.com/tisonkun) in [#3362](https://github.com/GreptimeTeam/greptimedb/pull/3362)
* build(deps): bump libgit2-sys from 0.16.1+1.7.1 to 0.16.2+1.7.2 by [@dependabot[bot]](https://github.com/dependabot[bot]) in [#3367](https://github.com/GreptimeTeam/greptimedb/pull/3367)
* build: do not retry for connrefused by [@tisonkun](https://github.com/tisonkun) in [#3402](https://github.com/GreptimeTeam/greptimedb/pull/3402)
* build(deps): bump mio from 0.8.10 to 0.8.11 by [@dependabot[bot]](https://github.com/dependabot[bot]) in [#3434](https://github.com/GreptimeTeam/greptimedb/pull/3434)

## New Contributors

* @KKould made their first contribution in [#3372](https://github.com/GreptimeTeam/greptimedb/pull/3372)
* @SteveLauC made their first contribution in [#3352](https://github.com/GreptimeTeam/greptimedb/pull/3352)
* @caicancai made their first contribution in [#3299](https://github.com/GreptimeTeam/greptimedb/pull/3299)
* @dalprahcd made their first contribution in [#3280](https://github.com/GreptimeTeam/greptimedb/pull/3280)

## All Contributors

We would like to thank the following contributors from the GreptimeDB community:

evenyag, waynexia, dependabot[bot], v0y4g3r, shuiyisong, daviderli614, Taylor-lagrange, killme2008, tisonkun, fengjiachun, etolbakov, KKould, niebayes, sunng87, J0HN50N133, zhongzc, WenyXu, discord9, dimbtp, MichaelScofield, SteveLauC, caicancai, dalprahcd, fengys1996, QuenKar, ZonaHex, nicecui
```