### PR TITLE
chore: bump version to 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,7 @@ checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
 name = "api"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arrow",
@@ -1254,7 +1254,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arrow",
@@ -1536,7 +1536,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1565,7 +1565,7 @@ dependencies = [
  "serde_json",
  "snafu",
  "substrait 0.17.1",
- "substrait 0.7.1",
+ "substrait 0.7.2",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "auth",
@@ -1646,7 +1646,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.7.1",
+ "substrait 0.7.2",
  "table",
  "temp-env",
  "tikv-jemallocator",
@@ -1689,7 +1689,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "common-error",
@@ -1715,7 +1715,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "common-base",
  "num_cpus",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bigdecimal",
  "common-error",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "snafu",
  "strum 0.25.0",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "common-base",
@@ -1871,7 +1871,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-recursion",
@@ -1948,11 +1948,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "common-procedure"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "atty",
  "backtrace",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "client",
  "common-query",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "build-data",
  "schemars",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2806,7 +2806,7 @@ dependencies = [
  "session",
  "snafu",
  "store-api",
- "substrait 0.7.1",
+ "substrait 0.7.2",
  "table",
  "tokio",
  "toml 0.8.8",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3301,7 +3301,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "common-decimal",
@@ -3456,7 +3456,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4848,7 +4848,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log-store"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5134,7 +5134,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -5914,7 +5914,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6428,7 +6428,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "auth",
  "common-base",
@@ -7047,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash 0.8.6",
  "async-recursion",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bitflags 2.4.1",
@@ -7379,7 +7379,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "ahash 0.8.6",
  "api",
@@ -7436,7 +7436,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.7.1",
+ "substrait 0.7.2",
  "table",
  "tokio",
  "tokio-stream",
@@ -8742,7 +8742,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aide",
  "api",
@@ -9126,7 +9126,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -9398,7 +9398,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "chrono",
@@ -9454,7 +9454,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "clap 4.4.11",
@@ -9659,7 +9659,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -9797,7 +9797,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -9964,7 +9964,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10074,7 +10074,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -10103,7 +10103,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -10157,7 +10157,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.7.1",
+ "substrait 0.7.2",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Bump version

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
