### PR TITLE
feat: Add timers to more mito methods

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -127,6 +127,10 @@ impl MitoEngine {
     /// Other region editing intention will result in an "invalid request" error.
     /// Also note that if a region is to be edited directly, we MUST not write data to it thereafter.
     pub async fn edit_region(&self, region_id: RegionId, edit: RegionEdit) -> Result<()> {
+        let _timer = HANDLE_REQUEST_ELAPSED
+            .with_label_values(&["edit_region"])
+            .start_timer();
+
         ensure!(
             is_valid_region_edit(&edit),
             InvalidRequestSnafu {
@@ -215,10 +219,6 @@ impl EngineInner {
         region_id: RegionId,
         request: RegionRequest,
     ) -> Result<AffectedRows> {
-        let _timer = HANDLE_REQUEST_ELAPSED
-            .with_label_values(&[request.type_name()])
-            .start_timer();
-
         let (request, receiver) = WorkerRequest::try_from_region_request(region_id, request)?;
         self.workers.submit_to_worker(region_id, request).await?;
 
@@ -298,6 +298,10 @@ impl RegionEngine for MitoEngine {
         region_id: RegionId,
         request: RegionRequest,
     ) -> Result<RegionHandleResult, BoxedError> {
+        let _timer = HANDLE_REQUEST_ELAPSED
+            .with_label_values(&[request.type_name()])
+            .start_timer();
+
         self.inner
             .handle_request(region_id, request)
             .await
@@ -355,6 +359,10 @@ impl RegionEngine for MitoEngine {
         &self,
         region_id: RegionId,
     ) -> Result<SetReadonlyResponse, BoxedError> {
+        let _timer = HANDLE_REQUEST_ELAPSED
+            .with_label_values(&["set_readonly_gracefully"])
+            .start_timer();
+
         self.inner
             .set_readonly_gracefully(region_id)
             .await

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -299,7 +299,7 @@ impl RegionEngine for MitoEngine {
         request: RegionRequest,
     ) -> Result<RegionHandleResult, BoxedError> {
         let _timer = HANDLE_REQUEST_ELAPSED
-            .with_label_values(&[request.type_name()])
+            .with_label_values(&[request.request_type()])
             .start_timer();
 
         self.inner

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -50,24 +50,6 @@ pub enum RegionRequest {
 }
 
 impl RegionRequest {
-    /// Returns the type name of the [RegionRequest].
-    #[inline]
-    pub fn request_type(&self) -> &'static str {
-        match &self {
-            RegionRequest::Put(_) => "put",
-            RegionRequest::Delete(_) => "delete",
-            RegionRequest::Create(_) => "create",
-            RegionRequest::Drop(_) => "drop",
-            RegionRequest::Open(_) => "open",
-            RegionRequest::Close(_) => "close",
-            RegionRequest::Alter(_) => "alter",
-            RegionRequest::Flush(_) => "flush",
-            RegionRequest::Compact(_) => "compact",
-            RegionRequest::Truncate(_) => "truncate",
-            RegionRequest::Catchup(_) => "catchup",
-        }
-    }
-
     /// Convert [Body](region_request::Body) to a group of [RegionRequest] with region id.
     /// Inserts/Deletes request might become multiple requests. Others are one-to-one.
     pub fn try_from_request_body(body: region_request::Body) -> Result<Vec<(RegionId, Self)>> {
@@ -89,7 +71,7 @@ impl RegionRequest {
     }
 
     /// Returns the type name of the request.
-    pub fn type_name(&self) -> &'static str {
+    pub fn request_type(&self) -> &'static str {
         self.into()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR adds timers to more mito methods
- edit_region
- set_readonly_gracefully

It also combines `RegionRequest::request_type()` and `RegionRequest::type_name()` into one method.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
