### PR TITLE
chore: remove global_ttl config

### DIFF
--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -62,8 +62,6 @@ sync_write = false
 data_home = "/tmp/greptimedb/"
 # Storage type.
 type = "File"
-# TTL for all tables. Disabled by default.
-# global_ttl = "7d"
 
 # Cache configuration for object storage such as 'S3' etc.
 # The local file cache directory

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -170,8 +170,6 @@ retry_delay = "500ms"
 data_home = "/tmp/greptimedb/"
 # Storage type.
 type = "File"
-# TTL for all tables. Disabled by default.
-# global_ttl = "7d"
 # Cache configuration for object storage such as 'S3' etc.
 # cache_path = "/path/local_cache"
 # The local file cache capacity in bytes.

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -14,8 +14,6 @@
 
 //! Datanode configurations
 
-use std::time::Duration;
-
 use common_base::readable_size::ReadableSize;
 use common_grpc::channel_manager::{
     DEFAULT_MAX_GRPC_RECV_MESSAGE_SIZE, DEFAULT_MAX_GRPC_SEND_MESSAGE_SIZE,

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -65,13 +65,6 @@ impl ObjectStoreConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct StorageConfig {
-    /// Retention period for all tables.
-    ///
-    /// Default value is `None`, which means no TTL.
-    ///
-    /// The precedence order is: ttl in table options > global ttl.
-    #[serde(with = "humantime_serde")]
-    pub global_ttl: Option<Duration>,
     /// The working directory of database
     pub data_home: String,
     #[serde(flatten)]
@@ -82,7 +75,6 @@ pub struct StorageConfig {
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            global_ttl: None,
             data_home: DEFAULT_DATA_HOME.to_string(),
             store: ObjectStoreConfig::default(),
             providers: vec![],

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -346,7 +346,6 @@ pub(crate) fn create_datanode_opts(
             data_home: home_dir,
             providers,
             store: default_store,
-            ..Default::default()
         },
         mode,
         wal: wal_config,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR removes the `global_ttl` config item since its no longer used.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
