### PR TITLE
fix: `DeserializedValueWithBytes::from_inner` misusing

### DIFF
--- a/src/common/meta/src/ddl/alter_logical_tables.rs
+++ b/src/common/meta/src/ddl/alter_logical_tables.rs
@@ -35,6 +35,7 @@ use crate::ddl::DdlContext;
 use crate::error::{DecodeJsonSnafu, Error, MetadataCorruptionSnafu, Result};
 use crate::key::table_info::TableInfoValue;
 use crate::key::table_route::PhysicalTableRouteValue;
+use crate::key::DeserializedValueWithBytes;
 use crate::lock_key::{CatalogLock, SchemaLock, TableLock};
 use crate::rpc::ddl::AlterTableTask;
 use crate::rpc::router::find_leaders;
@@ -245,10 +246,10 @@ pub struct AlterTablesData {
     tasks: Vec<AlterTableTask>,
     /// Table info values before the alter operation.
     /// Corresponding one-to-one with the AlterTableTask in tasks.
-    table_info_values: Vec<TableInfoValue>,
+    table_info_values: Vec<DeserializedValueWithBytes<TableInfoValue>>,
     /// Physical table info
     physical_table_id: TableId,
-    physical_table_info: Option<TableInfoValue>,
+    physical_table_info: Option<DeserializedValueWithBytes<TableInfoValue>>,
     physical_table_route: Option<PhysicalTableRouteValue>,
     physical_columns: Vec<ColumnMetadata>,
 }

--- a/src/common/meta/src/ddl_manager.rs
+++ b/src/common/meta/src/ddl_manager.rs
@@ -489,15 +489,13 @@ async fn handle_drop_table_task(
         .await?;
     let (_, table_route_value) = table_metadata_manager
         .table_route_manager()
-        .get_physical_table_route(table_id)
+        .table_route_storage()
+        .get_raw_physical_table_route(table_id)
         .await?;
 
     let table_info_value = table_info_value.with_context(|| TableInfoNotFoundSnafu {
         table: table_ref.to_string(),
     })?;
-
-    let table_route_value =
-        DeserializedValueWithBytes::from_inner(TableRouteValue::Physical(table_route_value));
 
     let (id, _) = ddl_manager
         .submit_drop_table_task(

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -284,6 +284,7 @@ impl<T: Serialize + DeserializeOwned + TableMetaValue> DeserializedValueWithByte
     }
 
     /// Notes: used for test purpose.
+    #[cfg(any(test, feature = "testing"))]
     pub fn from_inner(inner: T) -> Self {
         let bytes = serde_json::to_vec(&inner).unwrap();
 
@@ -687,7 +688,7 @@ impl TableMetadataManager {
 
     pub async fn batch_update_table_info_values(
         &self,
-        table_info_value_pairs: Vec<(TableInfoValue, RawTableInfo)>,
+        table_info_value_pairs: Vec<(DeserializedValueWithBytes<TableInfoValue>, RawTableInfo)>,
     ) -> Result<()> {
         let len = table_info_value_pairs.len();
         let mut txns = Vec::with_capacity(len);
@@ -708,7 +709,7 @@ impl TableMetadataManager {
             let (update_table_info_txn, on_update_table_info_failure) =
                 self.table_info_manager().build_update_txn(
                     table_id,
-                    &DeserializedValueWithBytes::from_inner(table_info_value),
+                    &table_info_value,
                     &new_table_info_value,
                 )?;
 

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -283,7 +283,6 @@ impl<T: Serialize + DeserializeOwned + TableMetaValue> DeserializedValueWithByte
         self.bytes.to_vec()
     }
 
-    /// Notes: used for test purpose.
     #[cfg(any(test, feature = "testing"))]
     pub fn from_inner(inner: T) -> Self {
         let bytes = serde_json::to_vec(&inner).unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

We shouldn't use the `DeserializedValueWithBytes::from_inner` for non-test purposes.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
