### PR TITLE
fix: cli export "create table" with quoted names

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -303,6 +303,13 @@ jobs:
       - name: Setup kafka server
         working-directory: tests-integration/fixtures/kafka
         run: docker compose -f docker-compose-standalone.yml up -d --wait
+      - name: Download pre-built binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: bins
+          path: .
+      - name: Unzip binaries
+        run: tar -xvf ./bins.tar.gz
       - name: Run nextest cases
         run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
         env:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -262,6 +262,7 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   coverage:
+    needs: build
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04-8-cores
     timeout-minutes: 60

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -262,7 +262,6 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   coverage:
-    needs: build
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04-8-cores
     timeout-minutes: 60
@@ -304,13 +303,6 @@ jobs:
       - name: Setup kafka server
         working-directory: tests-integration/fixtures/kafka
         run: docker compose -f docker-compose-standalone.yml up -d --wait
-      - name: Download pre-built binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: bins
-          path: .
-      - name: Unzip binaries
-        run: tar -xvf ./bins.tar.gz
       - name: Run nextest cases
         run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info -F pyo3_backend -F dashboard
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,7 @@ dependencies = [
  "substrait 0.7.2",
  "table",
  "temp-env",
+ "tempfile",
  "tikv-jemallocator",
  "tokio",
  "toml 0.8.8",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -76,6 +76,7 @@ tikv-jemallocator = "0.5"
 common-test-util.workspace = true
 serde.workspace = true
 temp-env = "0.3"
+tempfile.workspace = true
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rexpect = "0.5"

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -226,7 +226,7 @@ impl Export {
     }
 
     async fn show_create_table(&self, catalog: &str, schema: &str, table: &str) -> Result<String> {
-        let sql = format!("show create table {}.{}.{}", catalog, schema, table);
+        let sql = format!("show create table '{}'.'{}'.'{}'", catalog, schema, table);
         let mut client = self.client.clone();
         client.set_catalog(catalog);
         client.set_schema(schema);
@@ -273,7 +273,7 @@ impl Export {
                 for (c, s, t) in table_list {
                     match self.show_create_table(&c, &s, &t).await {
                         Err(e) => {
-                            error!(e; "Failed to export table {}.{}.{}", c, s, t)
+                            error!(e; "Failed to export table '{}'.'{}'.'{}'", c, s, t)
                         }
                         Ok(create_table) => {
                             file.write_all(create_table.as_bytes())

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -447,12 +447,9 @@ mod tests {
                 .output()
                 .expect("failed to build greptime binary");
             if !output.status.success() {
-                eprintln!("Failed to build GreptimeDB, {}", output.status);
-                eprintln!("Cargo build stdout:");
                 io::stdout().write_all(&output.stdout).unwrap();
-                eprintln!("Cargo build stderr:");
                 io::stderr().write_all(&output.stderr).unwrap();
-                panic!();
+                panic!("failed to build greptime binary");
             }
         }
 

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -435,26 +435,26 @@ mod tests {
         let mut bin_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         bin_path.pop();
         bin_path.pop();
+        let path = bin_path.clone();
+        bin_path.push("target");
+        bin_path.push("debug");
+        bin_path.push("greptime");
 
-        if !bin_path.join("target").exists() {
-            println!("need to build greptime binary");
+        if !bin_path.exists() {
             let output = Command::new("cargo")
-                .current_dir(&bin_path)
+                .current_dir(path)
                 .args(["build", "--bin", "greptime"])
                 .output()
                 .expect("failed to build greptime binary");
             if !output.status.success() {
-                println!("Failed to build GreptimeDB, {}", output.status);
-                println!("Cargo build stdout:");
+                eprintln!("Failed to build GreptimeDB, {}", output.status);
+                eprintln!("Cargo build stdout:");
                 io::stdout().write_all(&output.stdout).unwrap();
-                println!("Cargo build stderr:");
+                eprintln!("Cargo build stderr:");
                 io::stderr().write_all(&output.stderr).unwrap();
                 panic!();
             }
         }
-        bin_path.push("target");
-        bin_path.push("debug");
-        bin_path.push("greptime");
 
         let mut standalone = Command::new(&bin_path)
             .args(["standalone", "start"])

--- a/src/cmd/src/cli/export.rs
+++ b/src/cmd/src/cli/export.rs
@@ -423,7 +423,6 @@ fn split_database(database: &str) -> Result<(String, Option<String>)> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{self, Write};
     use std::path::PathBuf;
     use std::process::{Command, Stdio};
     use std::time::Duration;
@@ -435,22 +434,17 @@ mod tests {
         let mut bin_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         bin_path.pop();
         bin_path.pop();
-        let path = bin_path.clone();
-        bin_path.push("target");
-        bin_path.push("debug");
-        bin_path.push("greptime");
 
+        // github ci
+        bin_path.push("bins");
+        bin_path.push("greptime");
         if !bin_path.exists() {
-            let output = Command::new("cargo")
-                .current_dir(path)
-                .args(["build", "--bin", "greptime"])
-                .output()
-                .expect("failed to build greptime binary");
-            if !output.status.success() {
-                io::stdout().write_all(&output.stdout).unwrap();
-                io::stderr().write_all(&output.stderr).unwrap();
-                panic!("failed to build greptime binary");
-            }
+            // local test
+            bin_path.pop();
+            bin_path.pop();
+            bin_path.push("target");
+            bin_path.push("debug");
+            bin_path.push("greptime");
         }
 
         let mut standalone = Command::new(&bin_path)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #3681

## What's changed and what's your intention?

Solve the problem that running `cli export` with `--target create-table` fails when the `catalog/schema/table` names contain `.` (e.g. `a.b.c`).

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
