### PR TITLE
feat: get metasrv clusterinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,7 +3775,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=3edba4e6342d8926e427a1a2f12973420d06991c#3edba4e6342d8926e427a1a2f12973420d06991c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=8da84a04b137c4104262459807eab1c04b92f3cc#8da84a04b137c4104262459807eab1c04b92f3cc"
 dependencies = [
  "prost 0.12.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,7 +3775,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b97efbf92a0bf9abcfa1d8fe0ffe8741a2e7309e#b97efbf92a0bf9abcfa1d8fe0ffe8741a2e7309e"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=3edba4e6342d8926e427a1a2f12973420d06991c#3edba4e6342d8926e427a1a2f12973420d06991c"
 dependencies = [
  "prost 0.12.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ etcd-client = "0.12"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "3edba4e6342d8926e427a1a2f12973420d06991c" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "8da84a04b137c4104262459807eab1c04b92f3cc" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ etcd-client = "0.12"
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b97efbf92a0bf9abcfa1d8fe0ffe8741a2e7309e" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "3edba4e6342d8926e427a1a2f12973420d06991c" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/src/common/meta/src/cluster.rs
+++ b/src/common/meta/src/cluster.rs
@@ -56,7 +56,7 @@ pub trait ClusterInfo {
 pub struct NodeInfoKey {
     /// The cluster id.
     pub cluster_id: u64,
-    /// The role of the node. It can be [Role::Datanode] or [Role::Frontend].
+    /// The role of the node. It can be `[Role::Datanode]` or `[Role::Frontend]`.
     pub role: Role,
     /// The node id.
     pub node_id: u64,

--- a/src/common/meta/src/cluster.rs
+++ b/src/common/meta/src/cluster.rs
@@ -27,24 +27,12 @@ use crate::error::{
 use crate::peer::Peer;
 
 const CLUSTER_NODE_INFO_PREFIX: &str = "__meta_cluster_node_info";
-const CLUSTER_METASRV_INFO_PREFIX: &str = "__meta_cluster_metasrv_info";
 
 lazy_static! {
     static ref CLUSTER_NODE_INFO_PREFIX_PATTERN: Regex = Regex::new(&format!(
         "^{CLUSTER_NODE_INFO_PREFIX}-([0-9]+)-([0-9]+)-([0-9]+)$"
     ))
     .unwrap();
-}
-
-pub fn metasrv_node_key(target: &str) -> Vec<u8> {
-    format!("{}-{}", CLUSTER_METASRV_INFO_PREFIX, target).into_bytes()
-}
-
-pub fn metasrv_node_info(target: &str, is_leader: bool) -> (Vec<u8>, NodeStatus) {
-    (
-        metasrv_node_key(target),
-        NodeStatus::Metasrv(MetasrvStatus { is_leader }),
-    )
 }
 
 /// [ClusterInfo] provides information about the cluster.
@@ -62,11 +50,13 @@ pub trait ClusterInfo {
 }
 
 /// The key of [NodeInfo] in the storage. The format is `__meta_cluster_node_info-{cluster_id}-{role}-{node_id}`.
+/// This key cannot be used to describe the `Metasrv` because the `Metasrv` does not have
+/// a `cluster_id`, it serves multiple clusters.
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct NodeInfoKey {
     /// The cluster id.
     pub cluster_id: u64,
-    /// The role of the node. It can be [Role::Datanode], [Role::Frontend], or [Role::Metasrv].
+    /// The role of the node. It can be [Role::Datanode] or [Role::Frontend].
     pub role: Role,
     /// The node id.
     pub node_id: u64,

--- a/src/common/meta/src/cluster.rs
+++ b/src/common/meta/src/cluster.rs
@@ -27,12 +27,24 @@ use crate::error::{
 use crate::peer::Peer;
 
 const CLUSTER_NODE_INFO_PREFIX: &str = "__meta_cluster_node_info";
+const CLUSTER_METASRV_INFO_PREFIX: &str = "__meta_cluster_metasrv_info";
 
 lazy_static! {
     static ref CLUSTER_NODE_INFO_PREFIX_PATTERN: Regex = Regex::new(&format!(
         "^{CLUSTER_NODE_INFO_PREFIX}-([0-9]+)-([0-9]+)-([0-9]+)$"
     ))
     .unwrap();
+}
+
+pub fn metasrv_node_key(target: &str) -> Vec<u8> {
+    format!("{}-{}", CLUSTER_METASRV_INFO_PREFIX, target).into_bytes()
+}
+
+pub fn metasrv_node_info(target: &str, is_leader: bool) -> (Vec<u8>, NodeStatus) {
+    (
+        metasrv_node_key(target),
+        NodeStatus::Metasrv(MetasrvStatus { is_leader }),
+    )
 }
 
 /// [ClusterInfo] provides information about the cluster.

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -493,7 +493,7 @@ impl MetaClient {
     pub fn procedure_client(&self) -> Result<ProcedureClient> {
         self.procedure
             .clone()
-            .context(NotStartedSnafu { name: "ddl_client" })
+            .context(NotStartedSnafu { name: "procedure_client" })
     }
 
     #[inline]

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -491,9 +491,9 @@ impl MetaClient {
 
     #[inline]
     pub fn procedure_client(&self) -> Result<ProcedureClient> {
-        self.procedure
-            .clone()
-            .context(NotStartedSnafu { name: "procedure_client" })
+        self.procedure.clone().context(NotStartedSnafu {
+            name: "procedure_client",
+        })
     }
 
     #[inline]

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -496,7 +496,6 @@ impl MetaClient {
         })
     }
 
-    #[inline]
     pub fn cluster_client(&self) -> Result<ClusterClient> {
         self.cluster.clone().context(NotStartedSnafu {
             name: "cluster_client",

--- a/src/meta-srv/src/election.rs
+++ b/src/meta-srv/src/election.rs
@@ -21,8 +21,10 @@ use etcd_client::LeaderKey;
 use tokio::sync::broadcast::Receiver;
 
 use crate::error::Result;
+use crate::metasrv::LeaderValue;
 
 pub const ELECTION_KEY: &str = "__metasrv_election";
+pub const CANDIDATES_ROOT: &str = "__metasrv_election_candidates/";
 
 #[derive(Debug, Clone)]
 pub enum LeaderChangeMessage {
@@ -64,6 +66,12 @@ pub trait Election: Send + Sync {
     ///
     /// note: a new leader will only return true on the first call.
     fn in_infancy(&self) -> bool;
+
+    /// Registers a candidate for the election.
+    async fn register_candidate(&self) -> Result<()>;
+
+    /// Gets all candidates in the election.
+    async fn all_candidates(&self) -> Result<Vec<LeaderValue>>;
 
     /// Campaign waits to acquire leadership in an election.
     ///

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -105,19 +105,11 @@ impl EtcdElection {
     }
 
     fn election_key(&self) -> String {
-        if self.store_key_prefix.is_empty() {
-            ELECTION_KEY.to_string()
-        } else {
-            format!("{}{}", self.store_key_prefix, ELECTION_KEY)
-        }
+        format!("{}{}", self.store_key_prefix, ELECTION_KEY)
     }
 
     fn candidate_root(&self) -> String {
-        if self.store_key_prefix.is_empty() {
-            CANDIDATES_ROOT.to_string()
-        } else {
-            format!("{}{}", self.store_key_prefix, CANDIDATES_ROOT)
-        }
+        format!("{}{}", self.store_key_prefix, CANDIDATES_ROOT)
     }
 
     fn candidate_key(&self) -> String {

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -18,13 +18,13 @@ use std::time::Duration;
 
 use common_meta::distributed_time_constants::{META_KEEP_ALIVE_INTERVAL_SECS, META_LEASE_SECS};
 use common_telemetry::{error, info, warn};
-use etcd_client::Client;
+use etcd_client::{Client, GetOptions, PutOptions};
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
 
-use crate::election::{Election, LeaderChangeMessage, ELECTION_KEY};
+use crate::election::{Election, LeaderChangeMessage, CANDIDATES_ROOT, ELECTION_KEY};
 use crate::error;
 use crate::error::Result;
 use crate::metasrv::{ElectionRef, LeaderValue};
@@ -111,6 +111,18 @@ impl EtcdElection {
             format!("{}{}", self.store_key_prefix, ELECTION_KEY)
         }
     }
+
+    fn candidate_root(&self) -> String {
+        if self.store_key_prefix.is_empty() {
+            CANDIDATES_ROOT.to_string()
+        } else {
+            format!("{}{}", self.store_key_prefix, CANDIDATES_ROOT)
+        }
+    }
+
+    fn candidate_key(&self) -> String {
+        format!("{}{}", self.candidate_root(), self.leader_value)
+    }
 }
 
 #[async_trait::async_trait]
@@ -125,6 +137,65 @@ impl Election for EtcdElection {
         self.infancy
             .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
+    }
+
+    async fn register_candidate(&self) -> Result<()> {
+        const CANDIDATE_LEASE_SECS: u64 = 600;
+        const KEEP_ALIVE_INTERVAL_SECS: u64 = CANDIDATE_LEASE_SECS / 2;
+
+        let mut lease_client = self.client.lease_client();
+        let res = lease_client
+            .grant(CANDIDATE_LEASE_SECS as i64, None)
+            .await
+            .context(error::EtcdFailedSnafu)?;
+        let lease_id = res.id();
+
+        // The register info: key is the candidate key, value is its leader value.
+        let key = self.candidate_key().into_bytes();
+        let value = self.leader_value.clone().into_bytes();
+        // Puts with the lease id
+        self.client
+            .kv_client()
+            .put(key, value, Some(PutOptions::new().with_lease(lease_id)))
+            .await
+            .context(error::EtcdFailedSnafu)?;
+
+        let (mut keeper, mut receiver) = lease_client
+            .keep_alive(lease_id)
+            .await
+            .context(error::EtcdFailedSnafu)?;
+
+        let mut keep_alive_interval =
+            tokio::time::interval(Duration::from_secs(KEEP_ALIVE_INTERVAL_SECS));
+
+        loop {
+            let _ = keep_alive_interval.tick().await;
+            keeper.keep_alive().await.context(error::EtcdFailedSnafu)?;
+
+            if let Some(res) = receiver.message().await.context(error::EtcdFailedSnafu)? {
+                if res.ttl() <= 0 {
+                    // Failed to keep alive, just break the loop.
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn all_candidates(&self) -> Result<Vec<LeaderValue>> {
+        let key = self.candidate_root().into_bytes();
+        let res = self
+            .client
+            .kv_client()
+            .get(key, Some(GetOptions::new().with_prefix()))
+            .await
+            .context(error::EtcdFailedSnafu)?;
+
+        res.kvs()
+            .iter()
+            .map(|kv| Ok(LeaderValue(String::from_utf8_lossy(kv.value()).to_string())))
+            .collect()
     }
 
     async fn campaign(&self) -> Result<()> {

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -208,6 +208,13 @@ impl Context {
 
 pub struct LeaderValue(pub String);
 
+impl<T: AsRef<[u8]>> From<T> for LeaderValue {
+    fn from(value: T) -> Self {
+        let string = String::from_utf8_lossy(value.as_ref());
+        Self(string.to_string())
+    }
+}
+
 #[derive(Clone)]
 pub struct SelectorContext {
     pub server_addr: String,

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -64,21 +64,38 @@ pub const METASRV_HOME: &str = "/tmp/metasrv";
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct MetasrvOptions {
+    /// The address the server listens on.
     pub bind_addr: String,
+    /// The address the server advertises to the clients.
     pub server_addr: String,
+    /// The address of the store, e.g., etcd.
     pub store_addr: String,
+    /// The type of selector.
     pub selector: SelectorType,
+    /// Whether to use the memory store.
     pub use_memory_store: bool,
+    /// Whether to enable region failover.
     pub enable_region_failover: bool,
+    /// The HTTP server options.
     pub http: HttpOptions,
+    /// The logging options.
     pub logging: LoggingOptions,
+    /// The procedure options.
     pub procedure: ProcedureConfig,
+    /// The failure detector options.
     pub failure_detector: PhiAccrualFailureDetectorOptions,
+    /// The datanode options.
     pub datanode: DatanodeOptions,
+    /// Whether to enable telemetry.
     pub enable_telemetry: bool,
+    /// The data home directory.
     pub data_home: String,
+    /// The WAL options.
     pub wal: MetasrvWalConfig,
+    /// The metrics export options.
     pub export_metrics: ExportMetricsOption,
+    /// The store key prefix. If it is not empty, all keys in the store will be prefixed with it.
+    /// This is useful when multiple metasrv clusters share the same store.
     pub store_key_prefix: String,
     /// The max operations per txn
     ///


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

As the title said, provide a way to get the metasrvs info:
1. Make that each Metasrv node registers candidate information upon startup, sets the key (`__metasrv_election_candidates/{address}`), and keeps it alive every 300 seconds. The key will be delete when no keep lease.
2. Let the cluster client can get this information via gRPC service

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
