### PR TITLE
feat!: reduce sorted runs during compaction

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod run;
 mod buckets;
 pub mod compactor;
 pub mod picker;
+mod run;
 mod task;
 #[cfg(test)]
 mod test_util;

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod run;
 mod buckets;
 pub mod compactor;
 pub mod picker;

--- a/src/mito2/src/compaction/picker.rs
+++ b/src/mito2/src/compaction/picker.rs
@@ -132,8 +132,8 @@ pub fn new_picker(
     } else {
         match compaction_options {
             CompactionOptions::Twcs(twcs_opts) => Arc::new(TwcsPicker::new(
-                twcs_opts.max_active_window_files,
-                twcs_opts.max_inactive_window_files,
+                twcs_opts.max_active_window_runs,
+                twcs_opts.max_inactive_window_runs,
                 twcs_opts.time_window_seconds(),
             )) as Arc<_>,
         }

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -1,0 +1,688 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_base::BitVec;
+
+use crate::sst::file::FileHandle;
+
+pub(crate) trait Item: Clone {
+    type BoundType: Ord + Copy;
+
+    fn range(&self) -> (Self::BoundType, Self::BoundType);
+
+    fn size(&self) -> usize;
+
+    fn merge(&self, other: &Self) -> Self;
+
+    fn overlap(&self, other: &Self) -> bool {
+        let (lhs_start, lhs_end) = self.range();
+        let (rhs_start, rhs_end) = other.range();
+        if lhs_start < rhs_start {
+            lhs_end >= rhs_start
+        } else if lhs_start > rhs_start {
+            lhs_start <= rhs_end
+        } else {
+            true
+        }
+    }
+}
+
+struct FileHandlesItem {
+    files: Vec<FileHandle>,
+}
+
+/// A set of files with non-overlapping time ranges.
+#[derive(Debug, Clone)]
+pub(crate) struct SortedRun<T: Item> {
+    pub(crate) items: Vec<T>,
+    penalty: usize,
+    start: Option<T::BoundType>,
+    end: Option<T::BoundType>,
+}
+
+impl<T: Item> SortedRun<T> {
+    pub(crate) fn new(items: &[T]) -> Self {
+        let mut res = Self {
+            items: Vec::with_capacity(items.len()),
+            penalty: 0,
+            start: None,
+            end: None,
+        };
+        for i in items {
+            res.push_item(i);
+        }
+        res
+    }
+}
+
+impl<T> Default for SortedRun<T>
+where
+    T: Item,
+{
+    fn default() -> Self {
+        Self {
+            items: vec![],
+            penalty: 0,
+            start: None,
+            end: None,
+        }
+    }
+}
+
+impl<T> SortedRun<T>
+where
+    T: Item,
+{
+    /// Adds a file to current run and updates timestamps.
+    fn push_item(&mut self, t: &T) {
+        let (file_start, file_end) = t.range();
+        self.items.push(t.clone());
+        self.start = Some(self.start.map_or(file_start, |v| v.min(file_start)));
+        self.end = Some(self.end.map_or(file_end, |v| v.max(file_end)));
+    }
+
+    fn merge(self, other: Self) -> Self {
+        let (lhs, rhs) = if self.start < other.start {
+            (self, other)
+        } else {
+            (other, self)
+        };
+
+        let mut overlapping_item: Option<T> = None;
+
+        let mut lhs_selection = BitVec::repeat(false, lhs.items.len());
+        let mut lhs_start_offset = None;
+
+        for rhs_idx in 0..rhs.items.len() {
+            for lhs_idx in lhs_start_offset.unwrap_or(0)..lhs.items.len() {
+                let rhs_item = &rhs.items[rhs_idx];
+                let lhs_item = &lhs.items[lhs_idx];
+
+                if !lhs_item.overlap(rhs_item) {
+                    continue;
+                }
+                lhs_start_offset.get_or_insert(lhs_idx);
+                lhs_selection.set(lhs_idx, true);
+            }
+        }
+
+        let mut lhs_remain = SortedRun::default();
+        let mut penalty = 0;
+        for (f, selected) in lhs.items.iter().zip(lhs_selection.iter().by_vals()) {
+            if selected {
+                penalty += f.size();
+                overlapping_item =
+                    Some(overlapping_item.map_or(f.clone(), |existing| existing.merge(f)));
+            } else {
+                lhs_remain.push_item(f);
+            }
+        }
+
+        for rhs in &rhs.items {
+            penalty += rhs.size();
+            overlapping_item =
+                Some(overlapping_item.map_or(rhs.clone(), |existing| existing.merge(rhs)));
+        }
+        lhs_remain.push_item(&overlapping_item.unwrap());
+        lhs_remain.items.sort_unstable_by(|l, r| {
+            let (l_start, l_end) = l.range();
+            let (r_start, r_end) = r.range();
+            l_start.cmp(&r_start).then(r_end.cmp(&l_end))
+        });
+        lhs_remain.penalty = penalty;
+        lhs_remain
+    }
+}
+
+pub(crate) fn find_sorted_runs<T>(mut files: Vec<T>) -> Vec<SortedRun<T>>
+where
+    T: Item,
+{
+    if files.is_empty() {
+        return vec![];
+    }
+    // sort files
+    files.sort_unstable_by(|l, r| {
+        let (l_start, l_end) = l.range();
+        let (r_start, r_end) = r.range();
+        l_start.cmp(&r_start).then(r_end.cmp(&l_end))
+    });
+
+    let mut current_run = SortedRun::default();
+    let mut runs = vec![];
+
+    while !files.is_empty() {
+        let mut selection = BitVec::repeat(false, files.len());
+        for idx in 0..files.len() {
+            let current = &files[idx];
+            match current_run.items.last() {
+                None => {
+                    selection.set(idx, true);
+                    current_run.push_item(current);
+                }
+                Some(last) => {
+                    if !last.overlap(current) {
+                        // does not overlap, push to current run
+                        selection.set(idx, true);
+                        current_run.push_item(current);
+                    } else {
+                        selection.set(idx, false);
+                    }
+                }
+            }
+        }
+        runs.push(std::mem::take(&mut current_run));
+        files = files
+            .into_iter()
+            .zip(selection.iter().by_vals())
+            .filter_map(|(f, selected)| if selected { None } else { Some(f) })
+            .collect::<Vec<_>>();
+    }
+    runs
+}
+
+fn merge_all_runs<T: Item>(mut runs: Vec<SortedRun<T>>) -> SortedRun<T> {
+    assert!(!runs.is_empty());
+    if runs.len() == 1 {
+        return runs.pop().unwrap();
+    }
+    let mut res = runs.pop().unwrap();
+    while let Some(next) = runs.pop() {
+        res = res.merge(next);
+    }
+    res
+}
+
+/// Finds out the overlapping items between two adjacent runs.
+/// For two adjacent runs, all items in the latter (with larger start bound) should overlap
+/// with some item in previous run.
+/// # Return
+/// Returns the remaining lhs run and overlapping files.
+fn find_overlapping_items<T: Item>(
+    lhs: &SortedRun<T>,
+    rhs: &SortedRun<T>,
+) -> (SortedRun<T>, Vec<T>) {
+    assert!(lhs.start <= rhs.start);
+    assert!(!lhs.items.is_empty());
+    assert!(!rhs.items.is_empty());
+    // todo: empty handling
+    let mut overlapping_items = vec![];
+
+    let mut lhs_selection = BitVec::repeat(false, lhs.items.len());
+
+    let mut lhs_start_offset = None;
+    for rhs_idx in 0..rhs.items.len() {
+        for lhs_idx in lhs_start_offset.unwrap_or(0)..lhs.items.len() {
+            let rhs_item = &rhs.items[rhs_idx];
+            let lhs_item = &lhs.items[lhs_idx];
+
+            if !lhs_item.overlap(rhs_item) {
+                continue;
+            }
+            lhs_start_offset.get_or_insert(lhs_idx);
+            lhs_selection.set(lhs_idx, true);
+        }
+    }
+
+    let mut lhs_remain = SortedRun::default();
+    for (f, selected) in lhs.items.iter().zip(lhs_selection.iter().by_vals()) {
+        if selected {
+            overlapping_items.push(f.clone());
+        } else {
+            lhs_remain.push_item(f);
+        }
+    }
+    overlapping_items.extend(rhs.items.iter().cloned());
+
+    (lhs_remain, overlapping_items)
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+    use itertools::Itertools;
+
+    use super::*;
+
+    #[derive(Clone, Debug)]
+    struct MockFile {
+        start: i64,
+        end: i64,
+        size: usize,
+    }
+
+    #[derive(Clone, Debug)]
+    struct MockFileItem {
+        files: Vec<MockFile>,
+        start: i64,
+        end: i64,
+        size: usize,
+    }
+
+    impl MockFileItem {
+        fn new(file: MockFile) -> Self {
+            let start = file.start;
+            let end = file.end;
+            let size = file.size;
+            let files = vec![file];
+            Self {
+                files,
+                start,
+                end,
+                size,
+            }
+        }
+    }
+
+    impl Item for MockFileItem {
+        type BoundType = i64;
+
+        fn range(&self) -> (Self::BoundType, Self::BoundType) {
+            (self.start, self.end)
+        }
+
+        fn size(&self) -> usize {
+            self.size
+        }
+
+        fn merge(&self, other: &Self) -> Self {
+            let start = self.start.min(other.start);
+            let end = self.end.max(other.end);
+            let size = self.size + other.size;
+            let mut files = Vec::with_capacity(self.files.len() + other.files.len());
+            files.extend(self.files.iter().cloned());
+            files.extend(other.files.iter().cloned());
+
+            Self {
+                start,
+                end,
+                size,
+                files,
+            }
+        }
+    }
+
+    impl MockFile {
+        fn new(start: i64, end: i64) -> Self {
+            Self {
+                start,
+                end,
+                size: 1,
+            }
+        }
+    }
+
+    fn build_items(ranges: &[(i64, i64)]) -> Vec<MockFileItem> {
+        ranges
+            .iter()
+            .map(|(start, end)| {
+                MockFileItem::new(MockFile {
+                    start: *start,
+                    end: *end,
+                    size: 1,
+                })
+            })
+            .collect()
+    }
+
+    fn check_sorted_runs(
+        ranges: &[(i64, i64)],
+        expected_runs: &[Vec<(i64, i64)>],
+    ) -> Vec<SortedRun<MockFileItem>> {
+        let files = build_items(ranges);
+        let runs = find_sorted_runs(files);
+
+        let result_file_ranges: Vec<Vec<_>> = runs
+            .iter()
+            .map(|r| r.items.iter().map(|f| f.range()).collect())
+            .collect();
+        assert_eq!(&expected_runs, &result_file_ranges);
+        runs
+    }
+
+    #[test]
+    fn test_find_sorted_runs() {
+        check_sorted_runs(&[], &[]);
+        check_sorted_runs(&[(1, 1), (2, 2)], &[vec![(1, 1), (2, 2)]]);
+        check_sorted_runs(&[(1, 2)], &[vec![(1, 2)]]);
+        check_sorted_runs(&[(1, 2), (2, 3)], &[vec![(1, 2)], vec![(2, 3)]]);
+        check_sorted_runs(&[(1, 2), (3, 4)], &[vec![(1, 2), (3, 4)]]);
+        check_sorted_runs(&[(2, 4), (1, 3)], &[vec![(1, 3)], vec![(2, 4)]]);
+        check_sorted_runs(
+            &[(1, 3), (2, 4), (4, 5)],
+            &[vec![(1, 3), (4, 5)], vec![(2, 4)]],
+        );
+
+        check_sorted_runs(
+            &[(1, 2), (3, 4), (3, 5)],
+            &[vec![(1, 2), (3, 5)], vec![(3, 4)]],
+        );
+
+        check_sorted_runs(
+            &[(1, 3), (2, 4), (5, 6)],
+            &[vec![(1, 3), (5, 6)], vec![(2, 4)]],
+        );
+
+        check_sorted_runs(
+            &[(1, 2), (3, 5), (4, 6)],
+            &[vec![(1, 2), (3, 5)], vec![(4, 6)]],
+        );
+
+        check_sorted_runs(
+            &[(1, 2), (3, 4), (4, 6), (7, 8)],
+            &[vec![(1, 2), (3, 4), (7, 8)], vec![(4, 6)]],
+        );
+        check_sorted_runs(
+            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
+            &[vec![(1, 2), (3, 6), (7, 8)], vec![(3, 4), (5, 6), (8, 9)]],
+        );
+
+        check_sorted_runs(
+            &[(10, 19), (20, 21), (20, 29), (30, 39)],
+            &[vec![(10, 19), (20, 29), (30, 39)], vec![(20, 21)]],
+        );
+
+        check_sorted_runs(
+            &[(10, 19), (20, 29), (21, 22), (30, 39), (31, 32), (32, 42)],
+            &[
+                vec![(10, 19), (20, 29), (30, 39)],
+                vec![(21, 22), (31, 32)],
+                vec![(32, 42)],
+            ],
+        );
+    }
+
+    fn check_find_overlapping(ranges: &[(i64, i64)], expected: &[Vec<(i64, i64)>]) {
+        let runs = find_sorted_runs(build_items(ranges));
+        for run_idx in 0..runs.len() - 1 {
+            let (_, files) = find_overlapping_items(&runs[run_idx], &runs[run_idx + 1]);
+            let mut range = files.iter().map(|f| f.range()).collect::<Vec<_>>();
+            range.sort_unstable_by(|(l_start, l_end), (r_start, r_end)| {
+                l_start.cmp(&r_start).then(l_end.cmp(&r_end))
+            });
+            assert_eq!(expected[run_idx], range);
+        }
+    }
+
+    #[test]
+    fn test_find_overlapping() {
+        check_find_overlapping(&[(1, 2), (2, 3)], &[vec![(1, 2), (2, 3)]]);
+        check_find_overlapping(&[(1, 3), (2, 4), (4, 5)], &[vec![(1, 3), (2, 4), (4, 5)]]);
+        check_find_overlapping(&[(1, 2), (3, 4), (4, 6), (7, 8)], &[vec![(3, 4), (4, 6)]]);
+        check_find_overlapping(
+            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
+            &[vec![(3, 4), (3, 6), (5, 6), (7, 8), (8, 9)]],
+        );
+
+        check_find_overlapping(
+            &[(10, 19), (20, 29), (21, 22), (30, 39), (31, 32), (32, 42)],
+            &[
+                vec![(20, 29), (21, 22), (30, 39), (31, 32)],
+                vec![(31, 32), (32, 42)],
+            ],
+        );
+
+        check_find_overlapping(
+            &[
+                (0, 9),
+                (10, 19),
+                (20, 29),
+                (30, 39), // run1
+                (11, 18),
+                (35, 40), // run2
+                (15, 19), // run3
+            ],
+            &[
+                vec![(10, 19), (11, 18), (30, 39), (35, 40)],
+                vec![(11, 18), (15, 19)],
+            ],
+        );
+    }
+
+    /// files: file arrangement with two sorted runs.
+    fn check_merge_sorted_runs(
+        files: &[(i64, i64)],
+        expected_penalty: usize,
+        expected: &[Vec<(i64, i64)>],
+    ) {
+        let files = build_items(files);
+        let runs = find_sorted_runs(files);
+        let result = merge_all_runs(runs);
+        assert_eq!(expected_penalty, result.penalty);
+        assert_eq!(expected.len(), result.items.len());
+        let res = result
+            .items
+            .iter()
+            .map(|i| {
+                let mut res = i.files.iter().map(|f| (f.start, f.end)).collect::<Vec<_>>();
+                res.sort_unstable_by(|l, r| l.0.cmp(&r.0));
+                res
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(expected, &res);
+    }
+
+    #[test]
+    fn test_merge_sorted_runs() {
+        // [1..2][3..4]
+        //          [4..10]
+        check_merge_sorted_runs(
+            &[(1, 2), (3, 4), (4, 10)],
+            2,
+            &[vec![(1, 2)], vec![(3, 4), (4, 10)]],
+        );
+
+        // [1..2] [3..4] [5..6]
+        //           [4..........10]
+        check_merge_sorted_runs(
+            &[(1, 2), (3, 4), (5, 6), (4, 10)],
+            3,
+            &[vec![(1, 2)], vec![(3, 4), (4, 10), (5, 6)]],
+        );
+
+        // [10..20] [30..40] [50....60]
+        //             [35........55]
+        //                     [51..61]
+        check_merge_sorted_runs(
+            &[(10, 20), (30, 40), (50, 60), (35, 55), (51, 61)],
+            4,
+            &[vec![(10, 20)], vec![(30, 40), (35, 55), (50, 60), (51, 61)]],
+        );
+    }
+
+    #[test]
+    fn test_sorted_runs_time_range() {
+        let files = build_items(&[(1, 2), (3, 4), (4, 10)]);
+        let runs = find_sorted_runs(files);
+        assert_eq!(2, runs.len());
+        let SortedRun { start, end, .. } = &runs[0];
+        assert_eq!(Some(1), *start);
+        assert_eq!(Some(4), *end);
+
+        let SortedRun { start, end, .. } = &runs[1];
+        assert_eq!(Some(4), *start);
+        assert_eq!(Some(10), *end);
+    }
+
+    fn reduce_runs(runs: Vec<SortedRun<MockFileItem>>, target: usize) -> Vec<MockFile> {
+        assert_ne!(target, 0);
+        //todo: check run length
+        let k = runs.len() + 1 - target;
+
+        let run = runs
+            .into_iter()
+            .combinations(k)
+            .into_iter()
+            .map(|runs_to_merge| merge_all_runs(runs_to_merge))
+            .min_by(|p, r| p.penalty.cmp(&r.penalty))
+            .unwrap();
+
+        let mut files_to_merge = vec![];
+
+        for file_item in run.items {
+            if file_item.files.len() > 1 {
+                // todo: do we have better way to find merged runs.
+                files_to_merge.extend(file_item.files);
+            }
+        }
+        files_to_merge
+    }
+
+    fn check_reduce_runs(
+        files: &[(i64, i64)],
+        expected_runs: &[Vec<(i64, i64)>],
+        target: usize,
+        expected: &[(i64, i64)],
+    ) {
+        let runs = check_sorted_runs(files, expected_runs);
+        let mut files_to_merge = reduce_runs(runs, target);
+        files_to_merge.sort_unstable_by(|l, r| l.start.cmp(&r.start));
+        let file_timestamps = files_to_merge
+            .into_iter()
+            .map(|f| (f.start, f.end))
+            .collect::<Vec<_>>();
+        assert_eq!(expected, &file_timestamps);
+    }
+
+    #[test]
+    fn test_minimize_runs() {
+        check_reduce_runs(
+            &[(1, 3), (2, 4), (5, 6)],
+            &[vec![(1, 3), (5, 6)], vec![(2, 4)]],
+            1,
+            &[(1, 3), (2, 4)],
+        );
+
+        check_reduce_runs(
+            &[(1, 2), (3, 5), (4, 6)],
+            &[vec![(1, 2), (3, 5)], vec![(4, 6)]],
+            1,
+            &[(3, 5), (4, 6)],
+        );
+
+        check_reduce_runs(
+            &[(1, 4), (2, 5), (3, 6)],
+            &[vec![(1, 4)], vec![(2, 5)], vec![(3, 6)]],
+            1,
+            &[(1, 4), (2, 5), (3, 6)],
+        );
+
+        check_reduce_runs(
+            &[(1, 4), (2, 5), (3, 6)],
+            &[vec![(1, 4)], vec![(2, 5)], vec![(3, 6)]],
+            2,
+            &[(1, 4), (2, 5)],
+        );
+
+        // [1..2][3..4]    [7..8]
+        //          [4..6]
+        check_reduce_runs(
+            &[(1, 2), (3, 4), (4, 6), (7, 8)],
+            &[vec![(1, 2), (3, 4), (7, 8)], vec![(4, 6)]],
+            1,
+            &[(3, 4), (4, 6)],
+        );
+
+        // [1..2][3........6][7..8]
+        //       [3..4][5..6]   [8..9]
+        check_reduce_runs(
+            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
+            &[vec![(1, 2), (3, 6), (7, 8)], vec![(3, 4), (5, 6), (8, 9)]],
+            2,
+            &[], // already satisfied
+        );
+
+        // [1..2][3........6][7..8]
+        //       [3..4][5..6]   [8..9]
+        check_reduce_runs(
+            &[(1, 2), (3, 4), (5, 6), (3, 6), (7, 8), (8, 9)],
+            &[vec![(1, 2), (3, 6), (7, 8)], vec![(3, 4), (5, 6), (8, 9)]],
+            1,
+            &[(3, 6), (3, 4), (5, 6), (7, 8), (8, 9)], // already satisfied
+        );
+
+        // [10..20] [30..40] [50........80]     [100..110]
+        //                   [50..60]  [80.......100]
+        //                             [80..90]
+        check_reduce_runs(
+            &[
+                (10, 20),
+                (30, 40),
+                (50, 60),
+                (50, 80),
+                (80, 90),
+                (80, 100),
+                (100, 110),
+            ],
+            &[
+                vec![(10, 20), (30, 40), (50, 80), (100, 110)],
+                vec![(50, 60), (80, 100)],
+                vec![(80, 90)],
+            ],
+            2,
+            &[(50, 80), (80, 90)],
+        );
+
+        // [10..20] [30..40] [50........80]     [100..110]
+        //                   [50..60]  [80.......100]
+        //                             [80..90]
+        check_reduce_runs(
+            &[
+                (10, 20),
+                (30, 40),
+                (50, 60),
+                (50, 80),
+                (80, 90),
+                (80, 100),
+                (100, 110),
+            ],
+            &[
+                vec![(10, 20), (30, 40), (50, 80), (100, 110)],
+                vec![(50, 60), (80, 100)],
+                vec![(80, 90)],
+            ],
+            1,
+            &[(50, 80), (50, 60), (80, 100), (80, 90), (100, 110)],
+        );
+
+        // corner case
+        check_reduce_runs(
+            &[(0, 10), (0, 11), (0, 12), (0, 13)],
+            &[vec![(0, 13)], vec![(0, 12)], vec![(0, 11)], vec![(0, 10)]],
+            4,
+            &[],
+        );
+
+        check_reduce_runs(
+            &[(0, 10), (0, 11), (0, 12), (0, 13)],
+            &[vec![(0, 13)], vec![(0, 12)], vec![(0, 11)], vec![(0, 10)]],
+            3,
+            &[(0, 13), (0, 12)],
+        );
+
+        check_reduce_runs(
+            &[(0, 10), (0, 11), (0, 12), (0, 13)],
+            &[vec![(0, 13)], vec![(0, 12)], vec![(0, 11)], vec![(0, 10)]],
+            2,
+            &[(0, 13), (0, 12), (0, 11)],
+        );
+
+        check_reduce_runs(
+            &[(0, 10), (0, 11), (0, 12), (0, 13)],
+            &[vec![(0, 13)], vec![(0, 12)], vec![(0, 11)], vec![(0, 10)]],
+            1,
+            &[(0, 13), (0, 12), (0, 11), (0, 10)],
+        );
+    }
+}

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -36,6 +36,14 @@ pub(crate) trait Ranged {
     }
 }
 
+fn sort_ranged_items<T: Ranged>(values: &mut Vec<T>) {
+    values.sort_unstable_by(|l, r| {
+        let (l_start, l_end) = l.range();
+        let (r_start, r_end) = r.range();
+        l_start.cmp(&r_start).then(r_end.cmp(&l_end))
+    });
+}
+
 pub(crate) trait Item: Ranged + Clone {
     fn size(&self) -> usize;
 }
@@ -260,11 +268,7 @@ where
             }
         }
 
-        res.items.sort_unstable_by(|l, r| {
-            let (l_start, l_end) = l.range();
-            let (r_start, r_end) = r.range();
-            l_start.cmp(&r_start).then(r_end.cmp(&l_end))
-        });
+        sort_ranged_items(&mut res.items);
         res.penalty = penalty;
         res
     }
@@ -289,11 +293,7 @@ where
         return vec![];
     }
     // sort files
-    items.sort_unstable_by(|l, r| {
-        let (l_start, l_end) = l.range();
-        let (r_start, r_end) = r.range();
-        l_start.cmp(&r_start).then(r_end.cmp(&l_end))
-    });
+    sort_ranged_items(&mut items);
 
     let mut current_run = SortedRun::default();
     let mut runs = vec![];

--- a/src/mito2/src/compaction/run.rs
+++ b/src/mito2/src/compaction/run.rs
@@ -226,16 +226,19 @@ fn merge_all_runs<T: Item>(runs: Vec<SortedRun<T>>) -> SortedRun<T> {
         .flat_map(|r| r.items.into_iter())
         .collect::<Vec<_>>();
 
-    all_items.sort_unstable_by(|l, r| l.start.cmp(&r.start).then(l.end.cmp(&r.end).reverse()));
+    sort_ranged_items(&mut all_items);
 
     let mut res = SortedRun::default();
-    let mut current_item = all_items[0].clone();
+    let mut iter = all_items.into_iter();
+    // safety: all_items is not empty
+    let mut current_item = iter.next().unwrap();
 
-    for item in all_items.into_iter().skip(1) {
+    for item in iter {
         if current_item.overlap(&item) {
             current_item = current_item.merge(item);
         } else {
-            res.push_item(std::mem::replace(&mut current_item, item));
+            res.push_item(current_item);
+            current_item = item;
         }
     }
     res.push_item(current_item);

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -24,7 +24,7 @@ use common_time::Timestamp;
 use crate::compaction::buckets::infer_time_bucket;
 use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::picker::{Picker, PickerOutput};
-use crate::compaction::run::find_sorted_runs;
+use crate::compaction::run::{find_sorted_runs, reduce_runs};
 use crate::compaction::{get_expired_ssts, CompactionOutput};
 use crate::sst::file::{overlaps, FileHandle, FileId};
 use crate::sst::version::LevelMeta;
@@ -88,7 +88,7 @@ impl TwcsPicker {
                         output_time_range: None, // we do not enforce output time range in twcs compactions.
                     });
                 } else {
-                    debug!("Active window not present or no enough files in active window {:?}, window: {}", active_window, *window);
+                    debug!("Active window not present or no enough sorted runs in active window {:?}, window: {}, current run: {}", active_window, *window, sorted_runs.len());
                 }
             } else {
                 // not active writing window

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -73,10 +73,15 @@ impl TwcsPicker {
         let mut output = vec![];
         for (window, files) in time_windows {
             let files_in_window = &files.files;
-            // we only remove deletion markers once no file in current window overlaps with any other window.
-            let filter_deleted = !files.overlapping;
             let sorted_runs = find_sorted_runs(files_in_window.clone());
-
+            // we only remove deletion markers once no file in current window overlaps with any other window.
+            let filter_deleted = !files.overlapping && sorted_runs.len() == 1;
+            debug!(
+                "Window {}, found run: {}, filter deleted: {}",
+                *window,
+                sorted_runs.len(),
+                filter_deleted
+            );
             if let Some(active_window) = active_window
                 && *window == active_window
             {

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -28,6 +28,9 @@ use crate::compaction::{get_expired_ssts, CompactionOutput};
 use crate::sst::file::{overlaps, FileHandle, FileId};
 use crate::sst::version::LevelMeta;
 
+// const LEVEL_UNCOMPACTED: Level = 0;
+const LEVEL_COMPACTED: Level = 1;
+
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
 pub struct TwcsPicker {
@@ -78,7 +81,7 @@ impl TwcsPicker {
                 if files_in_window.len() > self.max_active_window_files {
                     output.push(CompactionOutput {
                         output_file_id: FileId::random(),
-                        output_level: 1, // we only have two levels and always compact to l1
+                        output_level: LEVEL_COMPACTED, // we only have two levels and always compact to l1
                         inputs: files_in_window.clone(),
                         filter_deleted,
                         output_time_range: None, // we do not enforce output time range in twcs compactions.
@@ -91,7 +94,7 @@ impl TwcsPicker {
                 if files_in_window.len() > self.max_inactive_window_files {
                     output.push(CompactionOutput {
                         output_file_id: FileId::random(),
-                        output_level: 1,
+                        output_level: LEVEL_COMPACTED,
                         inputs: files_in_window.clone(),
                         filter_deleted,
                         output_time_range: None,

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -26,7 +26,7 @@ use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::picker::{Picker, PickerOutput};
 use crate::compaction::run::{find_sorted_runs, reduce_runs};
 use crate::compaction::{get_expired_ssts, CompactionOutput};
-use crate::sst::file::{overlaps, FileHandle, FileId};
+use crate::sst::file::{overlaps, FileHandle, FileId, Level};
 use crate::sst::version::LevelMeta;
 
 const LEVEL_COMPACTED: Level = 1;
@@ -94,7 +94,8 @@ impl TwcsPicker {
                         output_level: LEVEL_COMPACTED, // always compact to l1
                         inputs,
                         filter_deleted,
-                    output_time_range: None, // we do not enforce output time range in twcs compactions.});
+                        output_time_range: None, // we do not enforce output time range in twcs compactions.});
+                    });
                 }
             } else {
                 debug!("Skip building compaction output, active window: {:?}, current window: {}, max runs: {}, found runs: {}, ", active_window, *window, max_runs, found_runs);

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -100,7 +100,7 @@ async fn test_append_mode_compaction() {
 
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "2")
+        .insert_option("compaction.twcs.max_active_window_runs", "2")
         .insert_option("compaction.twcs.max_inactive_window_files", "2")
         .insert_option("append_mode", "true")
         .build();

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -167,7 +167,7 @@ async fn test_append_mode_compaction() {
 +-------+---------+---------------------+";
     // Scans in parallel.
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
-    assert_eq!(1, scanner.num_files());
+    assert_eq!(2, scanner.num_files());
     assert_eq!(1, scanner.num_memtables());
     let stream = scanner.scan().await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -101,7 +101,7 @@ async fn test_append_mode_compaction() {
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
         .insert_option("compaction.twcs.max_active_window_runs", "2")
-        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "2")
         .insert_option("append_mode", "true")
         .build();
     let region_dir = request.region_dir.clone();

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -140,13 +140,18 @@ async fn test_compaction_region() {
     assert_eq!(result.affected_rows, 0);
 
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    // Input:
     // [0..9]
     //       [10...19]
     //                [20....29]
     //          -[15.........29]-
     //           [15.....24]
+    // Output:
+    // [0..9]
+    //     [10..14]
+    //            [15..24]
     assert_eq!(
-        2,
+        3,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -171,7 +171,7 @@ async fn test_compaction_region_with_overlapping() {
     let region_id = RegionId::new(1, 1);
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "2")
+        .insert_option("compaction.twcs.max_active_window_runs", "2")
         .insert_option("compaction.twcs.max_inactive_window_runs", "2")
         .insert_option("compaction.twcs.time_window", "1h")
         .build();
@@ -277,7 +277,7 @@ async fn test_readonly_during_compaction() {
     let region_id = RegionId::new(1, 1);
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "1")
+        .insert_option("compaction.twcs.max_active_window_runs", "1")
         .build();
 
     let column_schemas = request

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -140,8 +140,13 @@ async fn test_compaction_region() {
     assert_eq!(result.affected_rows, 0);
 
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    // [0..9]
+    //       [10...19]
+    //                [20....29]
+    //          -[15.........29]-
+    //           [15.....24]
     assert_eq!(
-        1,
+        3,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -289,7 +294,7 @@ async fn test_readonly_during_compaction() {
         .unwrap();
     // Flush 2 SSTs for compaction.
     put_and_flush(&engine, region_id, &column_schemas, 0..10).await;
-    put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
+    put_and_flush(&engine, region_id, &column_schemas, 5..20).await;
 
     // Waits until the engine receives compaction finished request.
     listener.wait_handle_finished().await;

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -146,7 +146,7 @@ async fn test_compaction_region() {
     //          -[15.........29]-
     //           [15.....24]
     assert_eq!(
-        3,
+        2,
         scanner.num_files(),
         "unexpected files: {:?}",
         scanner.file_ids()
@@ -167,7 +167,7 @@ async fn test_compaction_region_with_overlapping() {
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
         .insert_option("compaction.twcs.max_active_window_files", "2")
-        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "2")
         .insert_option("compaction.twcs.time_window", "1h")
         .build();
 
@@ -210,8 +210,8 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     let region_id = RegionId::new(1, 1);
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "2")
-        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .insert_option("compaction.twcs.max_active_window_runs", "2")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "2")
         .insert_option("compaction.twcs.time_window", "1h")
         .build();
 
@@ -240,6 +240,12 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     assert_eq!(result.affected_rows, 0);
 
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    assert_eq!(
+        4,
+        scanner.num_files(),
+        "unexpected files: {:?}",
+        scanner.file_ids()
+    );
     let stream = scanner.scan().await.unwrap();
     let vec = collect_stream_ts(stream).await;
     assert!(vec.is_empty());

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -196,14 +196,7 @@ async fn test_compaction_region_with_overlapping() {
     assert_eq!(result.affected_rows, 0);
 
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
-    assert_eq!(
-        2,
-        scanner.num_files(),
-        "unexpected files: {:?}",
-        scanner.file_ids()
-    );
     let stream = scanner.scan().await.unwrap();
-
     let vec = collect_stream_ts(stream).await;
     assert_eq!((3600..10800).map(|i| { i * 1000 }).collect::<Vec<_>>(), vec);
 }
@@ -247,14 +240,7 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     assert_eq!(result.affected_rows, 0);
 
     let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
-    assert_eq!(
-        4,
-        scanner.num_files(),
-        "unexpected files: {:?}",
-        scanner.file_ids()
-    );
     let stream = scanner.scan().await.unwrap();
-
     let vec = collect_stream_ts(stream).await;
     assert!(vec.is_empty());
 }

--- a/src/mito2/src/engine/filter_deleted_test.rs
+++ b/src/mito2/src/engine/filter_deleted_test.rs
@@ -34,7 +34,7 @@ async fn test_scan_without_filtering_deleted() {
     let region_id = RegionId::new(1, 1);
     let request = CreateRequestBuilder::new()
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "10")
+        .insert_option("compaction.twcs.max_active_window_runs", "10")
         .build();
 
     let column_schemas = rows_schema(&request);

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -160,7 +160,7 @@ impl TwcsOptions {
 impl Default for TwcsOptions {
     fn default() -> Self {
         Self {
-            max_active_window_runs: 4,
+            max_active_window_runs: 1,
             max_inactive_window_files: 1,
             time_window: None,
         }

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -130,9 +130,9 @@ impl Default for CompactionOptions {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TwcsOptions {
-    /// Max num of files that can be kept in active writing time window.
+    /// Max num of sorted runs that can be kept in active writing time window.
     #[serde_as(as = "DisplayFromStr")]
-    pub max_active_window_files: usize,
+    pub max_active_window_runs: usize,
     /// Max num of files that can be kept in inactive time window.
     #[serde_as(as = "DisplayFromStr")]
     pub max_inactive_window_files: usize,
@@ -160,7 +160,7 @@ impl TwcsOptions {
 impl Default for TwcsOptions {
     fn default() -> Self {
         Self {
-            max_active_window_files: 4,
+            max_active_window_runs: 4,
             max_inactive_window_files: 1,
             time_window: None,
         }
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn test_without_compaction_type() {
         let map = make_map(&[
-            ("compaction.twcs.max_active_window_files", "8"),
+            ("compaction.twcs.max_active_window_runs", "8"),
             ("compaction.twcs.time_window", "2h"),
         ]);
         let err = RegionOptions::try_from(&map).unwrap_err();
@@ -391,14 +391,14 @@ mod tests {
     #[test]
     fn test_with_compaction_type() {
         let map = make_map(&[
-            ("compaction.twcs.max_active_window_files", "8"),
+            ("compaction.twcs.max_active_window_runs", "8"),
             ("compaction.twcs.time_window", "2h"),
             ("compaction.type", "twcs"),
         ]);
         let options = RegionOptions::try_from(&map).unwrap();
         let expect = RegionOptions {
             compaction: CompactionOptions::Twcs(TwcsOptions {
-                max_active_window_files: 8,
+                max_active_window_runs: 8,
                 time_window: Some(Duration::from_secs(3600 * 2)),
                 ..Default::default()
             }),
@@ -484,7 +484,7 @@ mod tests {
         });
         let map = make_map(&[
             ("ttl", "7d"),
-            ("compaction.twcs.max_active_window_files", "8"),
+            ("compaction.twcs.max_active_window_runs", "8"),
             ("compaction.twcs.max_inactive_window_files", "2"),
             ("compaction.twcs.time_window", "2h"),
             ("compaction.type", "twcs"),
@@ -505,7 +505,7 @@ mod tests {
         let expect = RegionOptions {
             ttl: Some(Duration::from_secs(3600 * 24 * 7)),
             compaction: CompactionOptions::Twcs(TwcsOptions {
-                max_active_window_files: 8,
+                max_active_window_runs: 8,
                 max_inactive_window_files: 2,
                 time_window: Some(Duration::from_secs(3600 * 2)),
             }),

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -135,7 +135,7 @@ pub struct TwcsOptions {
     pub max_active_window_runs: usize,
     /// Max num of files that can be kept in inactive time window.
     #[serde_as(as = "DisplayFromStr")]
-    pub max_inactive_window_files: usize,
+    pub max_inactive_window_runs: usize,
     /// Compaction time window defined when creating tables.
     #[serde(with = "humantime_serde")]
     pub time_window: Option<Duration>,
@@ -161,7 +161,7 @@ impl Default for TwcsOptions {
     fn default() -> Self {
         Self {
             max_active_window_runs: 1,
-            max_inactive_window_files: 1,
+            max_inactive_window_runs: 1,
             time_window: None,
         }
     }
@@ -485,7 +485,7 @@ mod tests {
         let map = make_map(&[
             ("ttl", "7d"),
             ("compaction.twcs.max_active_window_runs", "8"),
-            ("compaction.twcs.max_inactive_window_files", "2"),
+            ("compaction.twcs.max_inactive_window_runs", "2"),
             ("compaction.twcs.time_window", "2h"),
             ("compaction.type", "twcs"),
             ("storage", "S3"),
@@ -506,7 +506,7 @@ mod tests {
             ttl: Some(Duration::from_secs(3600 * 24 * 7)),
             compaction: CompactionOptions::Twcs(TwcsOptions {
                 max_active_window_runs: 8,
-                max_inactive_window_files: 2,
+                max_inactive_window_runs: 2,
                 time_window: Some(Duration::from_secs(3600 * 2)),
             }),
             storage: Some("S3".to_string()),

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -200,6 +200,10 @@ impl FileHandle {
     pub fn meta_ref(&self) -> &FileMeta {
         &self.inner.meta
     }
+
+    pub fn size(&self) -> u64 {
+        self.inner.meta.file_size
+    }
 }
 
 /// Inner data of [FileHandle].

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -22,7 +22,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
     [
         "ttl",
         "compaction.type",
-        "compaction.twcs.max_active_window_files",
+        "compaction.twcs.max_active_window_runs",
         "compaction.twcs.max_inactive_window_files",
         "compaction.twcs.time_window",
         "storage",
@@ -47,7 +47,7 @@ mod tests {
         assert!(is_mito_engine_option_key("ttl"));
         assert!(is_mito_engine_option_key("compaction.type"));
         assert!(is_mito_engine_option_key(
-            "compaction.twcs.max_active_window_files"
+            "compaction.twcs.max_active_window_runs"
         ));
         assert!(is_mito_engine_option_key(
             "compaction.twcs.max_inactive_window_files"

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -23,7 +23,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
         "ttl",
         "compaction.type",
         "compaction.twcs.max_active_window_runs",
-        "compaction.twcs.max_inactive_window_files",
+        "compaction.twcs.max_inactive_window_runs",
         "compaction.twcs.time_window",
         "storage",
         "index.inverted_index.ignore_column_ids",
@@ -50,7 +50,7 @@ mod tests {
             "compaction.twcs.max_active_window_runs"
         ));
         assert!(is_mito_engine_option_key(
-            "compaction.twcs.max_inactive_window_files"
+            "compaction.twcs.max_inactive_window_runs"
         ));
         assert!(is_mito_engine_option_key("compaction.twcs.time_window"));
         assert!(is_mito_engine_option_key("storage"));

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -68,7 +68,7 @@ with(
     'ttl'='7d',
     'compaction.type'='twcs',
     'compaction.twcs.max_active_window_runs'='2',
-    'compaction.twcs.max_inactive_window_files'='2',
+    'compaction.twcs.max_inactive_window_runs'='2',
     'compaction.twcs.time_window'='1d',
     'index.inverted_index.ignore_column_ids'='1,2,3',
     'index.inverted_index.segment_row_count'='512',

--- a/tests/cases/standalone/common/create/create_with_options.result
+++ b/tests/cases/standalone/common/create/create_with_options.result
@@ -67,7 +67,7 @@ engine=mito
 with(
     'ttl'='7d',
     'compaction.type'='twcs',
-    'compaction.twcs.max_active_window_files'='8',
+    'compaction.twcs.max_active_window_runs'='2',
     'compaction.twcs.max_inactive_window_files'='2',
     'compaction.twcs.time_window'='1d',
     'index.inverted_index.ignore_column_ids'='1,2,3',
@@ -90,7 +90,7 @@ create table if not exists invalid_compaction(
     PRIMARY KEY(host)
 )
 engine=mito
-with('compaction.type'='twcs', 'compaction.twcs.max_active_window_files'='8d');
+with('compaction.type'='twcs', 'compaction.twcs.max_active_window_runs'='8d');
 
 Error: 1004(InvalidArguments), Invalid options: invalid digit found in string
 

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -57,7 +57,7 @@ engine=mito
 with(
     'ttl'='7d',
     'compaction.type'='twcs',
-    'compaction.twcs.max_active_window_runs'='8',
+    'compaction.twcs.max_active_window_runs'='2',
     'compaction.twcs.max_inactive_window_files'='2',
     'compaction.twcs.time_window'='1d',
     'index.inverted_index.ignore_column_ids'='1,2,3',

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -58,7 +58,7 @@ with(
     'ttl'='7d',
     'compaction.type'='twcs',
     'compaction.twcs.max_active_window_runs'='2',
-    'compaction.twcs.max_inactive_window_files'='2',
+    'compaction.twcs.max_inactive_window_runs'='2',
     'compaction.twcs.time_window'='1d',
     'index.inverted_index.ignore_column_ids'='1,2,3',
     'index.inverted_index.segment_row_count'='512',

--- a/tests/cases/standalone/common/create/create_with_options.sql
+++ b/tests/cases/standalone/common/create/create_with_options.sql
@@ -57,7 +57,7 @@ engine=mito
 with(
     'ttl'='7d',
     'compaction.type'='twcs',
-    'compaction.twcs.max_active_window_files'='8',
+    'compaction.twcs.max_active_window_runs'='8',
     'compaction.twcs.max_inactive_window_files'='2',
     'compaction.twcs.time_window'='1d',
     'index.inverted_index.ignore_column_ids'='1,2,3',
@@ -76,4 +76,4 @@ create table if not exists invalid_compaction(
     PRIMARY KEY(host)
 )
 engine=mito
-with('compaction.type'='twcs', 'compaction.twcs.max_active_window_files'='8d');
+with('compaction.type'='twcs', 'compaction.twcs.max_active_window_runs'='8d');


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #3416

## What's changed and what's your intention?

This PR changes the behavior during compaction from reduce file nums to sorted runs.

A sorted run in GreptimeDB is defined as a sequence of non-overlapping SST files. If multiple sorted runs exist in some time window, even a simple query with explicit time ranges may invole multiple files. Before this PR, GreptimeDB merges all files in active window into one single file if the total num of files exceeds `max_active_window_files`, of which the write amplification is rather severe. In this PR, we only enforce a `max_active_window_runs` in active window to reduce read amplication. If num of sorted runs exceeds that threshold, it only merges the overlapping files on demand.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to merge ranged items efficiently and manage sorted runs in the new `run` module.

- **Improvements**
  - Renamed compaction parameters from `max_active_window_files` and `max_inactive_window_files` to `max_active_window_runs` and `max_inactive_window_runs` for clarity.
  - Updated logic in compaction-related modules to handle runs instead of files.

- **Bug Fixes**
  - Corrected configurations and assertions in tests to align with the updated compaction parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->