### PR TITLE
feat: add `filter_deleted` option to avoid removing deletion markers

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -31,6 +31,8 @@ mod create_test;
 #[cfg(test)]
 mod drop_test;
 #[cfg(test)]
+mod filter_deleted_test;
+#[cfg(test)]
 mod flush_test;
 #[cfg(any(test, feature = "test"))]
 pub mod listener;

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -193,7 +193,7 @@ async fn test_append_mode_compaction() {
 }
 
 /// Sorts `batches` by column `names`.
-fn sort_batches_and_print(batches: &RecordBatches, names: &[&str]) -> String {
+pub(crate) fn sort_batches_and_print(batches: &RecordBatches, names: &[&str]) -> String {
     let schema = batches.schema();
     let record_batches = batches.iter().map(|batch| batch.df_record_batch());
     let record_batch = compute::concat_batches(schema.arrow_schema(), record_batches).unwrap();

--- a/src/mito2/src/engine/filter_deleted_test.rs
+++ b/src/mito2/src/engine/filter_deleted_test.rs
@@ -19,6 +19,7 @@ use store_api::region_request::RegionRequest;
 use store_api::storage::{RegionId, ScanRequest};
 
 use crate::config::MitoConfig;
+use crate::test_util::batch_util::sort_batches_and_print;
 use crate::test_util::{
     build_rows, delete_rows, flush_region, put_rows, rows_schema, CreateRequestBuilder, TestEnv,
 };
@@ -77,10 +78,7 @@ async fn test_scan_without_filtering_deleted() {
 | 1     | 1.0     | 1970-01-01T00:00:01 |
 | 4     | 4.0     | 1970-01-01T00:00:04 |
 +-------+---------+---------------------+";
-    assert_eq!(
-        expected,
-        crate::engine::append_mode_test::sort_batches_and_print(&batches, &["tag_0", "ts"])
-    );
+    assert_eq!(expected, sort_batches_and_print(&batches, &["tag_0", "ts"]));
 
     // Tries to use seq scan to test it under append mode.
     let scan = engine

--- a/src/mito2/src/engine/filter_deleted_test.rs
+++ b/src/mito2/src/engine/filter_deleted_test.rs
@@ -1,0 +1,104 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use api::v1::Rows;
+use common_recordbatch::RecordBatches;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::RegionRequest;
+use store_api::storage::{RegionId, ScanRequest};
+
+use crate::config::MitoConfig;
+use crate::test_util::{
+    build_rows, delete_rows, flush_region, put_rows, rows_schema, CreateRequestBuilder, TestEnv,
+};
+
+#[tokio::test]
+async fn test_scan_without_filtering_deleted() {
+    common_telemetry::init_default_ut_logging();
+
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.max_active_window_files", "10")
+        .build();
+
+    let column_schemas = rows_schema(&request);
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+
+    // put 1, 2, 3, 4 and flush
+    put_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(1, 5),
+        },
+    )
+    .await;
+    flush_region(&engine, region_id, None).await;
+
+    // delete 2, 3 and flush
+    delete_rows(
+        &engine,
+        region_id,
+        Rows {
+            schema: column_schemas.clone(),
+            rows: build_rows(2, 4),
+        },
+    )
+    .await;
+    flush_region(&engine, region_id, None).await;
+
+    // scan
+    let request = ScanRequest::default();
+    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let expected = "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 1     | 1.0     | 1970-01-01T00:00:01 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
++-------+---------+---------------------+";
+    assert_eq!(
+        expected,
+        crate::engine::append_mode_test::sort_batches_and_print(&batches, &["tag_0", "ts"])
+    );
+
+    // Tries to use seq scan to test it under append mode.
+    let scan = engine
+        .scan_region(region_id, ScanRequest::default())
+        .unwrap();
+
+    let seq_scan = scan.scan_without_filter_deleted().unwrap();
+
+    let stream = seq_scan.build_stream().await.unwrap();
+    let batches = RecordBatches::try_collect(stream).await.unwrap();
+    let expected = "\
++-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 1     | 1.0     | 1970-01-01T00:00:01 |
+| 2     | 2.0     | 1970-01-01T00:00:02 |
+| 3     | 3.0     | 1970-01-01T00:00:03 |
+| 4     | 4.0     | 1970-01-01T00:00:04 |
++-------+---------+---------------------+";
+    assert_eq!(expected, batches.pretty_print().unwrap());
+}

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -105,7 +105,8 @@ impl SeqScan {
         // Scans all memtables and SSTs. Builds a merge reader to merge results.
         let sources = self.input.build_sources().await?;
         let dedup = !self.input.append_mode;
-        let mut builder = MergeReaderBuilder::from_sources(sources, dedup);
+        let mut builder =
+            MergeReaderBuilder::from_sources(sources, dedup, self.input.filter_deleted);
         let reader = builder.build().await?;
         Ok(Box::new(reader))
     }
@@ -114,7 +115,8 @@ impl SeqScan {
     async fn build_parallel_reader(&self) -> Result<BoxedBatchReader> {
         let sources = self.input.build_parallel_sources().await?;
         let dedup = !self.input.append_mode;
-        let mut builder = MergeReaderBuilder::from_sources(sources, dedup);
+        let mut builder =
+            MergeReaderBuilder::from_sources(sources, dedup, self.input.filter_deleted);
         let reader = builder.build().await?;
         Ok(Box::new(reader))
     }

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -14,6 +14,7 @@
 
 //! Utilities for testing.
 
+pub mod batch_util;
 pub mod memtable_util;
 pub mod meta_util;
 pub mod scheduler_util;

--- a/src/mito2/src/test_util/batch_util.rs
+++ b/src/mito2/src/test_util/batch_util.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_recordbatch::RecordBatches;
+use datatypes::arrow::array::RecordBatch;
+use datatypes::arrow::compute;
+use datatypes::arrow::compute::SortColumn;
+use datatypes::arrow::util::pretty;
+
+/// Sorts `batches` by column `names`.
+pub fn sort_batches_and_print(batches: &RecordBatches, names: &[&str]) -> String {
+    let schema = batches.schema();
+    let record_batches = batches.iter().map(|batch| batch.df_record_batch());
+    let record_batch = compute::concat_batches(schema.arrow_schema(), record_batches).unwrap();
+    let columns: Vec<_> = names
+        .iter()
+        .map(|name| {
+            let array = record_batch.column_by_name(name).unwrap();
+            SortColumn {
+                values: array.clone(),
+                options: None,
+            }
+        })
+        .collect();
+    let indices = compute::lexsort_to_indices(&columns, None).unwrap();
+    let columns = record_batch
+        .columns()
+        .iter()
+        .map(|array| compute::take(&array, &indices, None).unwrap())
+        .collect();
+    let record_batch = RecordBatch::try_new(record_batch.schema(), columns).unwrap();
+
+    pretty::pretty_format_batches(&[record_batch])
+        .unwrap()
+        .to_string()
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #3416

## What's changed and what's your intention?

This PR adds an `filter_deleted` option to `MergeReader` so that it will not remove deletion markers (or tombstones) during merging.

`filter_deleted` is different from `dedup` in that:
- If `dedup` is set to false, then `filter_deleted` will always be false since deletion markers are not expected to present.
- If `dedup` is set to true, then `filter_deleted` decides whether deletion markers should be removed. 

This PR is the predecessor work of #3702. 


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
