### PR TITLE
feat: write manifests in background tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,6 +5319,7 @@ dependencies = [
  "common-wal",
  "crc32fast",
  "criterion",
+ "crossbeam-utils",
  "datafusion",
  "datafusion-common",
  "datafusion-expr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ bytemuck = "1.12"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
+crossbeam-utils = "0.8"
 dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }
 datafusion-common = { git = "https://github.com/apache/arrow-datafusion.git", rev = "26e43acac3a96cec8dd4c8365f22dfb1a84306e9" }

--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -59,6 +59,7 @@ pub enum StatusCode {
     RegionNotFound = 4005,
     RegionAlreadyExists = 4006,
     RegionReadonly = 4007,
+    /// Region is not in a proper state to handle specific request.
     RegionNotReady = 4008,
     // If mutually exclusive operations are reached at the same time,
     // only one can be executed, another one will get region busy.

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -31,8 +31,8 @@ common-telemetry.workspace = true
 common-test-util = { workspace = true, optional = true }
 common-time.workspace = true
 common-wal.workspace = true
-crossbeam-utils.workspace = true
 crc32fast = "1"
+crossbeam-utils.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -31,6 +31,7 @@ common-telemetry.workspace = true
 common-test-util = { workspace = true, optional = true }
 common-time.workspace = true
 common-wal.workspace = true
+crossbeam-utils.workspace = true
 crc32fast = "1"
 datafusion.workspace = true
 datafusion-common.workspace = true

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -41,7 +41,7 @@ use crate::read::seq_scan::SeqScan;
 use crate::read::{BoxedBatchReader, Source};
 use crate::region::options::IndexOptions;
 use crate::region::version::VersionControlRef;
-use crate::region::ManifestContextRef;
+use crate::region::{ManifestContextRef, REGION_STATE_WRITABLE};
 use crate::request::{
     BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
 };
@@ -450,7 +450,7 @@ impl TwcsCompactionTask {
         // We might leak files if we fail to update manifest. We can add a cleanup task to
         // remove them later.
         self.manifest_ctx
-            .update_manifest(action_list, || {
+            .update_manifest(REGION_STATE_WRITABLE, action_list, || {
                 self.version_control
                     .apply_edit(edit, &[], self.file_purger.clone());
             })

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -439,9 +439,7 @@ impl TwcsCompactionTask {
             merge_time,
         );
 
-        self.listener
-            .on_handle_compaction_finished(self.region_id)
-            .await;
+        self.listener.on_merge_ssts_finished(self.region_id).await;
 
         let _manifest_timer = COMPACTION_STAGE_ELAPSED
             .with_label_values(&["write_manifest"])

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -41,7 +41,7 @@ use crate::read::seq_scan::SeqScan;
 use crate::read::{BoxedBatchReader, Source};
 use crate::region::options::IndexOptions;
 use crate::region::version::VersionControlRef;
-use crate::region::{ManifestContextRef, REGION_STATE_WRITABLE};
+use crate::region::{ManifestContextRef, RegionState};
 use crate::request::{
     BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
 };
@@ -458,7 +458,7 @@ impl TwcsCompactionTask {
         // We might leak files if we fail to update manifest. We can add a cleanup task to
         // remove them later.
         self.manifest_ctx
-            .update_manifest(REGION_STATE_WRITABLE, action_list, || {
+            .update_manifest(RegionState::Writable, action_list, || {
                 self.version_control
                     .apply_edit(edit, &[], self.file_purger.clone());
             })

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -33,12 +33,15 @@ use crate::compaction::picker::{CompactionTask, Picker};
 use crate::compaction::CompactionRequest;
 use crate::config::MitoConfig;
 use crate::error::{self, CompactRegionSnafu};
+use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
 use crate::metrics::{COMPACTION_FAILURE_COUNT, COMPACTION_STAGE_ELAPSED};
 use crate::read::projection::ProjectionMapper;
 use crate::read::scan_region::ScanInput;
 use crate::read::seq_scan::SeqScan;
 use crate::read::{BoxedBatchReader, Source};
 use crate::region::options::IndexOptions;
+use crate::region::version::VersionControlRef;
+use crate::region::ManifestContextRef;
 use crate::request::{
     BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
 };
@@ -133,6 +136,8 @@ impl Picker for TwcsPicker {
             file_purger,
             start_time,
             cache_manager,
+            manifest_ctx,
+            version_control,
         } = req;
 
         let region_metadata = current_version.metadata.clone();
@@ -190,6 +195,8 @@ impl Picker for TwcsPicker {
             storage: current_version.options.storage.clone(),
             index_options: current_version.options.index_options.clone(),
             append_mode: current_version.options.append_mode,
+            manifest_ctx,
+            version_control,
         };
         Some(Box::new(task))
     }
@@ -259,6 +266,10 @@ pub(crate) struct TwcsCompactionTask {
     pub(crate) index_options: IndexOptions,
     /// The region is using append mode.
     pub(crate) append_mode: bool,
+    /// Manifest context.
+    pub(crate) manifest_ctx: ManifestContextRef,
+    /// Version control to update.
+    pub(crate) version_control: VersionControlRef,
 }
 
 impl Debug for TwcsCompactionTask {
@@ -398,18 +409,52 @@ impl TwcsCompactionTask {
         Ok((output_files, inputs))
     }
 
-    async fn handle_compaction(&mut self) -> error::Result<(Vec<FileMeta>, Vec<FileMeta>)> {
+    async fn handle_compaction(&mut self) -> error::Result<()> {
         self.mark_files_compacting(true);
         let merge_timer = COMPACTION_STAGE_ELAPSED
             .with_label_values(&["merge"])
             .start_timer();
-        let (output, mut compacted) = self.merge_ssts().await.map_err(|e| {
-            error!(e; "Failed to compact region: {}", self.region_id);
-            merge_timer.stop_and_discard();
-            e
-        })?;
-        compacted.extend(self.expired_ssts.iter().map(FileHandle::meta));
-        Ok((output, compacted))
+        let (added, mut deleted) = match self.merge_ssts().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!(e; "Failed to compact region: {}", self.region_id);
+                merge_timer.stop_and_discard();
+                return Err(e);
+            }
+        };
+        deleted.extend(self.expired_ssts.iter().map(FileHandle::meta));
+        let merge_time = merge_timer.stop_and_record();
+        info!(
+            "Compacted SST files, input: {:?}, output: {:?}, window: {:?}, waiter_num: {}, merge_time: {}s",
+            deleted,
+            added,
+            self.compaction_time_window,
+            self.waiters.len(),
+            merge_time,
+        );
+
+        let _manifest_timer = COMPACTION_STAGE_ELAPSED
+            .with_label_values(&["write_manifest"])
+            .start_timer();
+        // Write region edit to manifest.
+        let edit = RegionEdit {
+            files_to_add: added,
+            files_to_remove: deleted,
+            compaction_time_window: self
+                .compaction_time_window
+                .map(|seconds| Duration::from_secs(seconds as u64)),
+            flushed_entry_id: None,
+            flushed_sequence: None,
+        };
+        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
+        // We might leak files if we fail to update manifest. We can add a cleanup task to
+        // remove them later.
+        self.manifest_ctx
+            .update_manifest(action_list, || {
+                self.version_control
+                    .apply_edit(edit, &[], self.file_purger.clone());
+            })
+            .await
     }
 
     /// Handles compaction failure, notifies all waiters.
@@ -437,27 +482,11 @@ impl TwcsCompactionTask {
 impl CompactionTask for TwcsCompactionTask {
     async fn run(&mut self) {
         let notify = match self.handle_compaction().await {
-            Ok((added, deleted)) => {
-                info!(
-                    "Compacted SST files, input: {:?}, output: {:?}, window: {:?}, waiter_num: {}",
-                    deleted,
-                    added,
-                    self.compaction_time_window,
-                    self.waiters.len(),
-                );
-
-                BackgroundNotify::CompactionFinished(CompactionFinished {
-                    region_id: self.region_id,
-                    compaction_outputs: added,
-                    compacted_files: deleted,
-                    senders: std::mem::take(&mut self.waiters),
-                    file_purger: self.file_purger.clone(),
-                    compaction_time_window: self
-                        .compaction_time_window
-                        .map(|seconds| Duration::from_secs(seconds as u64)),
-                    start_time: self.start_time,
-                })
-            }
+            Ok(()) => BackgroundNotify::CompactionFinished(CompactionFinished {
+                region_id: self.region_id,
+                senders: std::mem::take(&mut self.waiters),
+                start_time: self.start_time,
+            }),
             Err(e) => {
                 error!(e; "Failed to compact region, region id: {}", self.region_id);
                 let err = Arc::new(e);

--- a/src/mito2/src/engine/catchup_test.rs
+++ b/src/mito2/src/engine/catchup_test.rs
@@ -345,7 +345,7 @@ async fn test_catchup_with_manifest_update() {
     // Ensures the mutable is empty.
     assert!(region.version().memtables.mutable.is_empty());
 
-    let manifest = region.manifest_manager.read().await.manifest();
+    let manifest = region.manifest_ctx.manifest().await;
     assert_eq!(manifest.manifest_version, 0);
 
     let resp = follower_engine
@@ -361,7 +361,7 @@ async fn test_catchup_with_manifest_update() {
 
     // The inner region was replaced. We must get it again.
     let region = follower_engine.get_region(region_id).unwrap();
-    let manifest = region.manifest_manager.read().await.manifest();
+    let manifest = region.manifest_ctx.manifest().await;
     assert_eq!(manifest.manifest_version, 2);
     assert!(!region.is_writable());
 

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -187,6 +187,7 @@ async fn test_readonly_during_compaction() {
     put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
 
     // Waits until the engine receives compaction finished request.
+    // TODO(yingwen): We need to wait in the background job.
     listener.wait_handle_finished().await;
 
     // Sets the region to read only mode.

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -187,7 +187,6 @@ async fn test_readonly_during_compaction() {
     put_and_flush(&engine, region_id, &column_schemas, 10..20).await;
 
     // Waits until the engine receives compaction finished request.
-    // TODO(yingwen): We need to wait in the background job.
     listener.wait_handle_finished().await;
 
     // Sets the region to read only mode.

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -51,9 +51,9 @@ pub trait EventListener: Send + Sync {
         let _ = removed;
     }
 
-    /// Notifies the listener that the region is going to handle the compaction
-    /// finished request.
-    async fn on_handle_compaction_finished(&self, region_id: RegionId) {
+    /// Notifies the listener that ssts has been merged and the region
+    /// is going to update its manifest.
+    async fn on_merge_ssts_finished(&self, region_id: RegionId) {
         let _ = region_id;
     }
 }
@@ -201,7 +201,7 @@ impl CompactionListener {
 
 #[async_trait]
 impl EventListener for CompactionListener {
-    async fn on_handle_compaction_finished(&self, region_id: RegionId) {
+    async fn on_merge_ssts_finished(&self, region_id: RegionId) {
         info!("Handle compaction finished request, region {region_id}");
 
         self.handle_finished_notify.notify_one();

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -127,7 +127,7 @@ async fn test_engine_open_readonly() {
         )
         .await
         .unwrap_err();
-    assert_eq!(StatusCode::RegionReadonly, err.status_code());
+    assert_eq!(StatusCode::RegionNotReady, err.status_code());
 
     assert_eq!(Some(RegionRole::Follower), engine.role(region_id));
     // Set writable and write.

--- a/src/mito2/src/engine/set_readonly_test.rs
+++ b/src/mito2/src/engine/set_readonly_test.rs
@@ -66,7 +66,7 @@ async fn test_set_readonly_gracefully() {
         .await
         .unwrap_err();
 
-    assert_eq!(error.status_code(), StatusCode::RegionReadonly);
+    assert_eq!(error.status_code(), StatusCode::RegionNotReady);
 
     engine.set_writable(region_id, true).unwrap();
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -672,7 +672,7 @@ impl ErrorExt for Error {
             CompactRegion { source, .. } => source.status_code(),
             CompatReader { .. } => StatusCode::Unexpected,
             InvalidRegionRequest { source, .. } => source.status_code(),
-            RegionState { .. } => StatusCode::RegionBusy,
+            RegionState { .. } => StatusCode::RegionNotReady,
             JsonOptions { .. } => StatusCode::InvalidArguments,
             EmptyRegionDir { .. } | EmptyManifestDir { .. } => StatusCode::RegionNotFound,
             ArrowReader { .. } => StatusCode::StorageUnavailable,

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -29,6 +29,7 @@ use store_api::manifest::ManifestVersion;
 use store_api::storage::RegionId;
 
 use crate::cache::file_cache::FileType;
+use crate::region::region_state_to_str;
 use crate::sst::file::FileId;
 use crate::worker::WorkerId;
 
@@ -395,9 +396,10 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} is read only", region_id))]
-    RegionReadonly {
+    #[snafu(display("Region {} is in {} state", region_id, region_state_to_str(*state)))]
+    RegionState {
         region_id: RegionId,
+        state: u8,
         location: Location,
     },
 
@@ -669,7 +671,7 @@ impl ErrorExt for Error {
             CompactRegion { source, .. } => source.status_code(),
             CompatReader { .. } => StatusCode::Unexpected,
             InvalidRegionRequest { source, .. } => source.status_code(),
-            RegionReadonly { .. } => StatusCode::RegionReadonly,
+            RegionState { .. } => StatusCode::RegionReadonly,
             JsonOptions { .. } => StatusCode::InvalidArguments,
             EmptyRegionDir { .. } | EmptyManifestDir { .. } => StatusCode::RegionNotFound,
             ArrowReader { .. } => StatusCode::StorageUnavailable,

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -29,7 +29,7 @@ use store_api::manifest::ManifestVersion;
 use store_api::storage::RegionId;
 
 use crate::cache::file_cache::FileType;
-use crate::region::region_state_to_str;
+use crate::region::RegionState;
 use crate::sst::file::FileId;
 use crate::worker::WorkerId;
 
@@ -396,10 +396,10 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} is in {} state", region_id, region_state_to_str(*state)))]
+    #[snafu(display("Region {} is in {:?} state", region_id, state))]
     RegionState {
         region_id: RegionId,
-        state: u8,
+        state: RegionState,
         location: Location,
     },
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -396,10 +396,11 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Region {} is in {:?} state", region_id, state))]
+    #[snafu(display("Region {} is in {:?} state, expect: {:?}", region_id, state, expect))]
     RegionState {
         region_id: RegionId,
         state: RegionState,
+        expect: RegionState,
         location: Location,
     },
 
@@ -671,7 +672,7 @@ impl ErrorExt for Error {
             CompactRegion { source, .. } => source.status_code(),
             CompatReader { .. } => StatusCode::Unexpected,
             InvalidRegionRequest { source, .. } => source.status_code(),
-            RegionState { .. } => StatusCode::RegionReadonly,
+            RegionState { .. } => StatusCode::RegionBusy,
             JsonOptions { .. } => StatusCode::InvalidArguments,
             EmptyRegionDir { .. } | EmptyManifestDir { .. } => StatusCode::RegionNotFound,
             ArrowReader { .. } => StatusCode::StorageUnavailable,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -35,6 +35,7 @@ use crate::metrics::{FLUSH_BYTES_TOTAL, FLUSH_ELAPSED, FLUSH_ERRORS_TOTAL, FLUSH
 use crate::read::Source;
 use crate::region::options::IndexOptions;
 use crate::region::version::{VersionControlData, VersionControlRef, VersionRef};
+use crate::region::ManifestContextRef;
 use crate::request::{
     BackgroundNotify, FlushFailed, FlushFinished, OptionOutputTx, OutputTx, SenderDdlRequest,
     SenderWriteRequest, WorkerRequest,
@@ -204,6 +205,7 @@ pub(crate) struct RegionFlushTask {
     pub(crate) engine_config: Arc<MitoConfig>,
     pub(crate) row_group_size: Option<usize>,
     pub(crate) cache_manager: CacheManagerRef,
+    pub(crate) manifest_ctx: ManifestContextRef,
 
     /// Index options for the region.
     pub(crate) index_options: IndexOptions,

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -36,7 +36,7 @@ use crate::metrics::{FLUSH_BYTES_TOTAL, FLUSH_ELAPSED, FLUSH_ERRORS_TOTAL, FLUSH
 use crate::read::Source;
 use crate::region::options::IndexOptions;
 use crate::region::version::{VersionControlData, VersionControlRef};
-use crate::region::{ManifestContextRef, REGION_STATE_WRITABLE};
+use crate::region::{ManifestContextRef, RegionState};
 use crate::request::{
     BackgroundNotify, FlushFailed, FlushFinished, OptionOutputTx, OutputTx, SenderDdlRequest,
     SenderWriteRequest, WorkerRequest,
@@ -405,7 +405,7 @@ impl RegionFlushTask {
         // We will leak files if the manifest update fails, but we ignore them for simplicity. We can
         // add a cleanup job to remove them later.
         self.manifest_ctx
-            .update_manifest(REGION_STATE_WRITABLE, action_list, || {
+            .update_manifest(RegionState::Writable, action_list, || {
                 version_control.apply_edit(edit, &memtables_to_remove, self.file_purger.clone());
             })
             .await

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -723,13 +723,10 @@ impl FlushStatus {
 
 #[cfg(test)]
 mod tests {
-    use common_datasource::compression::CompressionType;
     use tokio::sync::oneshot;
 
     use super::*;
     use crate::cache::CacheManager;
-    use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
-    use crate::region::{ManifestContext, REGION_STATE_WRITABLE};
     use crate::test_util::scheduler_util::SchedulerEnv;
     use crate::test_util::version_util::VersionControlBuilder;
 
@@ -806,20 +803,9 @@ mod tests {
             engine_config: Arc::new(MitoConfig::default()),
             row_group_size: None,
             cache_manager: Arc::new(CacheManager::default()),
-            manifest_ctx: Arc::new(ManifestContext::new(
-                RegionManifestManager::new(
-                    version_control.current().version.metadata.clone(),
-                    RegionManifestOptions {
-                        manifest_dir: "".to_string(),
-                        object_store: env.access_layer.object_store().clone(),
-                        compress_type: CompressionType::Uncompressed,
-                        checkpoint_distance: 10,
-                    },
-                )
-                .await
-                .unwrap(),
-                REGION_STATE_WRITABLE,
-            )),
+            manifest_ctx: env
+                .mock_manifest_context(version_control.current().version.metadata.clone())
+                .await,
             index_options: IndexOptions::default(),
         };
         task.push_sender(OptionOutputTx::from(output_tx));

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -699,10 +699,13 @@ impl FlushStatus {
 
 #[cfg(test)]
 mod tests {
+    use common_datasource::compression::CompressionType;
     use tokio::sync::oneshot;
 
     use super::*;
     use crate::cache::CacheManager;
+    use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
+    use crate::region::{ManifestContext, REGION_STATE_WRITABLE};
     use crate::test_util::scheduler_util::SchedulerEnv;
     use crate::test_util::version_util::VersionControlBuilder;
 
@@ -779,6 +782,20 @@ mod tests {
             engine_config: Arc::new(MitoConfig::default()),
             row_group_size: None,
             cache_manager: Arc::new(CacheManager::default()),
+            manifest_ctx: Arc::new(ManifestContext::new(
+                RegionManifestManager::new(
+                    version_control.current().version.metadata.clone(),
+                    RegionManifestOptions {
+                        manifest_dir: "".to_string(),
+                        object_store: env.access_layer.object_store().clone(),
+                        compress_type: CompressionType::Uncompressed,
+                        checkpoint_distance: 10,
+                    },
+                )
+                .await
+                .unwrap(),
+                REGION_STATE_WRITABLE,
+            )),
             index_options: IndexOptions::default(),
         };
         task.push_sender(OptionOutputTx::from(output_tx));

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -36,7 +36,7 @@ use crate::metrics::{FLUSH_BYTES_TOTAL, FLUSH_ELAPSED, FLUSH_ERRORS_TOTAL, FLUSH
 use crate::read::Source;
 use crate::region::options::IndexOptions;
 use crate::region::version::{VersionControlData, VersionControlRef};
-use crate::region::ManifestContextRef;
+use crate::region::{ManifestContextRef, REGION_STATE_WRITABLE};
 use crate::request::{
     BackgroundNotify, FlushFailed, FlushFinished, OptionOutputTx, OutputTx, SenderDdlRequest,
     SenderWriteRequest, WorkerRequest,
@@ -405,7 +405,7 @@ impl RegionFlushTask {
         // We will leak files if the manifest update fails, but we ignore them for simplicity. We can
         // add a cleanup job to remove them later.
         self.manifest_ctx
-            .update_manifest(action_list, || {
+            .update_manifest(REGION_STATE_WRITABLE, action_list, || {
                 version_control.apply_edit(edit, &memtables_to_remove, self.file_purger.clone());
             })
             .await

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -119,9 +119,6 @@ pub struct RegionManifestManager {
     stopped: bool,
 }
 
-/// Ref-counted pointer to a [RegionManifestManager] guarded by a lock.
-pub type RegionManifestManagerRef = Arc<tokio::sync::RwLock<RegionManifestManager>>;
-
 impl RegionManifestManager {
     /// Constructs a region's manifest and persist it.
     pub async fn new(metadata: RegionMetadataRef, options: RegionManifestOptions) -> Result<Self> {

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -119,6 +119,9 @@ pub struct RegionManifestManager {
     stopped: bool,
 }
 
+/// Ref-counted pointer to a [RegionManifestManager] guarded by a lock.
+pub type RegionManifestManagerRef = Arc<tokio::sync::RwLock<RegionManifestManager>>;
+
 impl RegionManifestManager {
     /// Constructs a region's manifest and persist it.
     pub async fn new(metadata: RegionMetadataRef, options: RegionManifestOptions) -> Result<Self> {

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -257,9 +257,8 @@ impl RegionManifestManager {
     }
 
     /// Stops the manager.
-    pub async fn stop(&mut self) -> Result<()> {
+    pub async fn stop(&mut self) {
         self.stopped = true;
-        Ok(())
     }
 
     /// Updates the manifest. Returns the current manifest version number.
@@ -524,7 +523,7 @@ mod test {
             .unwrap()
             .unwrap();
         // Stops it.
-        manager.stop().await.unwrap();
+        manager.stop().await;
 
         // Open it.
         let manager = env
@@ -564,7 +563,7 @@ mod test {
         manager.validate_manifest(&new_metadata, 1);
 
         // Reopen the manager.
-        manager.stop().await.unwrap();
+        manager.stop().await;
         let manager = env
             .create_manifest_manager(CompressionType::Uncompressed, 10, None)
             .await
@@ -651,7 +650,7 @@ mod test {
 
         // Reopen the manager,
         // we just calculate the size from the latest checkpoint file
-        manager.stop().await.unwrap();
+        manager.stop().await;
         let manager = env
             .create_manifest_manager(CompressionType::Uncompressed, 10, None)
             .await

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -152,7 +152,7 @@ async fn manager_with_checkpoint_distance_1() {
     assert_eq!(expected_json, raw_json);
 
     // reopen the manager
-    manager.stop().await.unwrap();
+    manager.stop().await;
     let manager = reopen_manager(&env, 1, CompressionType::Uncompressed).await;
     assert_eq!(10, manager.manifest().manifest_version);
 }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -336,7 +336,9 @@ impl ManifestContext {
         }
 
         // Now we can update the manifest.
-        manager.update(action_list).await?;
+        manager.update(action_list).await.inspect_err(
+            |e| error!(e; "Failed to update manifest, region_id: {}", manifest.metadata.region_id),
+        )?;
 
         // Executes the applier. We MUST holds the write lock.
         applier();

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 
-use common_telemetry::{error, info};
+use common_telemetry::{error, info, warn};
 use common_wal::options::WalOptions;
 use crossbeam_utils::atomic::AtomicCell;
 use snafu::{ensure, OptionExt};
@@ -356,6 +356,13 @@ impl ManifestContext {
 
         // Executes the applier. We MUST holds the write lock.
         applier();
+
+        if self.state.load() == RegionState::ReadOnly {
+            warn!(
+                "Region {} becomes read-only while updating manifest which may cause inconsistency",
+                manifest.metadata.region_id
+            );
+        }
 
         Ok(())
     }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -111,20 +111,18 @@ pub(crate) type MitoRegionRef = Arc<MitoRegion>;
 
 impl MitoRegion {
     /// Stop background managers for this region.
-    pub(crate) async fn stop(&self) -> Result<()> {
+    pub(crate) async fn stop(&self) {
         self.manifest_ctx
             .manifest_manager
             .write()
             .await
             .stop()
-            .await?;
+            .await;
 
         info!(
             "Stopped region manifest manager, region_id: {}",
             self.region_id
         );
-
-        Ok(())
     }
 
     /// Returns current metadata of the region.
@@ -262,6 +260,7 @@ impl MitoRegion {
                 RegionStateSnafu {
                     region_id: self.region_id,
                     state: actual,
+                    expect,
                 }
                 .build()
             })?;
@@ -311,6 +310,7 @@ impl ManifestContext {
             RegionStateSnafu {
                 region_id: manifest.metadata.region_id,
                 state: current_state,
+                expect: expect_state,
             }
         );
 
@@ -413,7 +413,8 @@ impl RegionMap {
             region.is_writable(),
             RegionStateSnafu {
                 region_id,
-                state: region.state()
+                state: region.state(),
+                expect: RegionState::Writable,
             }
         );
         Ok(region)

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -355,6 +355,7 @@ impl ManifestContext {
         )?;
 
         // Executes the applier. We MUST hold the write lock.
+        applier();
 
         if self.state.load() == RegionState::ReadOnly {
             warn!(

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -27,12 +27,11 @@ use common_wal::options::WalOptions;
 use snafu::{ensure, OptionExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::RegionId;
-use tokio::sync::RwLock as TokioRwLock;
 
 use crate::access_layer::AccessLayerRef;
 use crate::error::{RegionNotFoundSnafu, RegionReadonlySnafu, Result};
 use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
-use crate::manifest::manager::RegionManifestManager;
+use crate::manifest::manager::RegionManifestManagerRef;
 use crate::memtable::{MemtableBuilderRef, MemtableId};
 use crate::region::version::{VersionControlRef, VersionRef};
 use crate::request::OnFailure;
@@ -71,11 +70,13 @@ pub(crate) struct MitoRegion {
     pub(crate) region_id: RegionId,
 
     /// Version controller for this region.
+    ///
+    /// We MUST update the version control inside the write lock of the region manifest manager.
     pub(crate) version_control: VersionControlRef,
     /// SSTs accessor for this region.
     pub(crate) access_layer: AccessLayerRef,
     /// Manager to maintain manifest for this region.
-    pub(crate) manifest_manager: TokioRwLock<RegionManifestManager>,
+    pub(crate) manifest_manager: RegionManifestManagerRef,
     /// SST file purger.
     pub(crate) file_purger: FilePurgerRef,
     /// Wal options of this region.

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -354,8 +354,7 @@ impl ManifestContext {
             |e| error!(e; "Failed to update manifest, region_id: {}", manifest.metadata.region_id),
         )?;
 
-        // Executes the applier. We MUST holds the write lock.
-        applier();
+        // Executes the applier. We MUST hold the write lock.
 
         if self.state.load() == RegionState::ReadOnly {
             warn!(

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -364,6 +364,7 @@ impl ManifestContext {
 
 pub(crate) type ManifestContextRef = Arc<ManifestContext>;
 
+/// Switches the region state to `REGION_STATE_WRITABLE` if the current state is `expect`.
 pub(crate) fn switch_state_to_writable(region: &MitoRegionRef, expect: u8) {
     if let Err(e) = region.compare_exchange_state(expect, REGION_STATE_WRITABLE) {
         error!(e; "failed to switch region state to writable, expect state is {}", region_state_to_str(expect));

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -203,7 +203,7 @@ impl RegionOpener {
             region_id,
             version_control,
             access_layer: access_layer.clone(),
-            manifest_manager: RwLock::new(manifest_manager),
+            manifest_manager: Arc::new(RwLock::new(manifest_manager)),
             file_purger: Arc::new(LocalFilePurger::new(
                 self.purge_scheduler,
                 access_layer,
@@ -331,7 +331,7 @@ impl RegionOpener {
             region_id: self.region_id,
             version_control,
             access_layer,
-            manifest_manager: RwLock::new(manifest_manager),
+            manifest_manager: Arc::new(RwLock::new(manifest_manager)),
             file_purger,
             wal_options,
             last_flush_millis: AtomicI64::new(time_provider.current_time_millis()),

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -40,7 +40,7 @@ use crate::memtable::time_partition::TimePartitions;
 use crate::memtable::MemtableBuilderProvider;
 use crate::region::options::RegionOptions;
 use crate::region::version::{VersionBuilder, VersionControl, VersionControlRef};
-use crate::region::{ManifestContext, MitoRegion, REGION_STATE_READ_ONLY, REGION_STATE_WRITABLE};
+use crate::region::{ManifestContext, MitoRegion, RegionState};
 use crate::region_write_ctx::RegionWriteCtx;
 use crate::request::OptionOutputTx;
 use crate::schedule::scheduler::SchedulerRef;
@@ -205,7 +205,7 @@ impl RegionOpener {
             // Region is writable after it is created.
             manifest_ctx: Arc::new(ManifestContext::new(
                 manifest_manager,
-                REGION_STATE_WRITABLE,
+                RegionState::Writable,
             )),
             file_purger: Arc::new(LocalFilePurger::new(
                 self.purge_scheduler,
@@ -335,7 +335,7 @@ impl RegionOpener {
             // Region is always opened in read only mode.
             manifest_ctx: Arc::new(ManifestContext::new(
                 manifest_manager,
-                REGION_STATE_READ_ONLY,
+                RegionState::ReadOnly,
             )),
             file_purger,
             wal_options,

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -15,7 +15,7 @@
 //! Region opener.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64};
+use std::sync::atomic::{AtomicI64, AtomicU8};
 use std::sync::Arc;
 
 use common_telemetry::{debug, error, info, warn};
@@ -41,7 +41,7 @@ use crate::memtable::time_partition::TimePartitions;
 use crate::memtable::MemtableBuilderProvider;
 use crate::region::options::RegionOptions;
 use crate::region::version::{VersionBuilder, VersionControl, VersionControlRef};
-use crate::region::MitoRegion;
+use crate::region::{MitoRegion, REGION_STATE_READ_ONLY, REGION_STATE_WRITABLE};
 use crate::region_write_ctx::RegionWriteCtx;
 use crate::request::OptionOutputTx;
 use crate::schedule::scheduler::SchedulerRef;
@@ -212,7 +212,7 @@ impl RegionOpener {
             wal_options,
             last_flush_millis: AtomicI64::new(time_provider.current_time_millis()),
             // Region is writable after it is created.
-            writable: AtomicBool::new(true),
+            state: AtomicU8::new(REGION_STATE_WRITABLE),
             time_provider,
             memtable_builder,
         })
@@ -336,7 +336,7 @@ impl RegionOpener {
             wal_options,
             last_flush_millis: AtomicI64::new(time_provider.current_time_millis()),
             // Region is always opened in read only mode.
-            writable: AtomicBool::new(false),
+            state: AtomicU8::new(REGION_STATE_READ_ONLY),
             time_provider,
             memtable_builder,
         };

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -620,6 +620,8 @@ pub(crate) enum BackgroundNotify {
     CompactionFinished(CompactionFinished),
     /// Compaction has failed.
     CompactionFailed(CompactionFailed),
+    /// Truncate result.
+    Truncate(TruncateResult),
 }
 
 /// Notifies a flush job is finished.
@@ -735,6 +737,21 @@ pub(crate) struct CompactionFailed {
     pub(crate) region_id: RegionId,
     /// The error source of the failure.
     pub(crate) err: Arc<Error>,
+}
+
+/// Notifies the truncate result of a region.
+#[derive(Debug)]
+pub(crate) struct TruncateResult {
+    /// Region id.
+    pub(crate) region_id: RegionId,
+    /// Result sender.
+    pub(crate) sender: OptionOutputTx,
+    /// Truncate result.
+    pub(crate) result: Result<()>,
+    /// Truncated entry id.
+    pub(crate) truncated_entry_id: EntryId,
+    /// Truncated sequence.
+    pub(crate) truncated_sequence: SequenceNumber,
 }
 
 #[cfg(test)]

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -34,6 +34,7 @@ use crate::region::{ManifestContext, ManifestContextRef, REGION_STATE_WRITABLE};
 use crate::request::WorkerRequest;
 use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
 use crate::sst::index::intermediate::IntermediateManager;
+use crate::worker::WorkerListener;
 
 /// Scheduler mocker.
 pub(crate) struct SchedulerEnv {
@@ -83,6 +84,7 @@ impl SchedulerEnv {
             request_sender,
             Arc::new(CacheManager::default()),
             Arc::new(MitoConfig::default()),
+            WorkerListener::default(),
         )
     }
 

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -16,16 +16,21 @@
 
 use std::sync::Arc;
 
+use common_datasource::compression::CompressionType;
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use object_store::services::Fs;
 use object_store::util::join_dir;
 use object_store::ObjectStore;
+use store_api::metadata::RegionMetadataRef;
 use tokio::sync::mpsc::Sender;
 
 use crate::access_layer::{AccessLayer, AccessLayerRef};
 use crate::cache::CacheManager;
 use crate::compaction::CompactionScheduler;
+use crate::config::MitoConfig;
 use crate::flush::FlushScheduler;
+use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
+use crate::region::{ManifestContext, ManifestContextRef, REGION_STATE_WRITABLE};
 use crate::request::WorkerRequest;
 use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
 use crate::sst::index::intermediate::IntermediateManager;
@@ -73,7 +78,12 @@ impl SchedulerEnv {
     ) -> CompactionScheduler {
         let scheduler = self.get_scheduler();
 
-        CompactionScheduler::new(scheduler, request_sender, Arc::new(CacheManager::default()))
+        CompactionScheduler::new(
+            scheduler,
+            request_sender,
+            Arc::new(CacheManager::default()),
+            Arc::new(MitoConfig::default()),
+        )
     }
 
     /// Creates a new flush scheduler.
@@ -81,6 +91,27 @@ impl SchedulerEnv {
         let scheduler = self.get_scheduler();
 
         FlushScheduler::new(scheduler)
+    }
+
+    /// Creates a new manifest context.
+    pub(crate) async fn mock_manifest_context(
+        &self,
+        metadata: RegionMetadataRef,
+    ) -> ManifestContextRef {
+        Arc::new(ManifestContext::new(
+            RegionManifestManager::new(
+                metadata,
+                RegionManifestOptions {
+                    manifest_dir: "".to_string(),
+                    object_store: self.access_layer.object_store().clone(),
+                    compress_type: CompressionType::Uncompressed,
+                    checkpoint_distance: 10,
+                },
+            )
+            .await
+            .unwrap(),
+            REGION_STATE_WRITABLE,
+        ))
     }
 
     fn get_scheduler(&self) -> SchedulerRef {

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -30,7 +30,7 @@ use crate::compaction::CompactionScheduler;
 use crate::config::MitoConfig;
 use crate::flush::FlushScheduler;
 use crate::manifest::manager::{RegionManifestManager, RegionManifestOptions};
-use crate::region::{ManifestContext, ManifestContextRef, REGION_STATE_WRITABLE};
+use crate::region::{ManifestContext, ManifestContextRef, RegionState};
 use crate::request::WorkerRequest;
 use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
 use crate::sst::index::intermediate::IntermediateManager;
@@ -112,7 +112,7 @@ impl SchedulerEnv {
             )
             .await
             .unwrap(),
-            REGION_STATE_WRITABLE,
+            RegionState::Writable,
         ))
     }
 

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -739,9 +739,7 @@ impl<S> RegionWorkerLoop<S> {
         // Closes remaining regions.
         let regions = self.regions.list_regions();
         for region in regions {
-            if let Err(e) = region.stop().await {
-                error!(e; "Failed to stop region {}", region.region_id);
-            }
+            region.stop().await;
         }
 
         self.regions.clear();

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -811,10 +811,10 @@ impl WorkerListener {
         let _ = removed;
     }
 
-    pub(crate) async fn on_handle_compaction_finished(&self, region_id: RegionId) {
+    pub(crate) async fn on_merge_ssts_finished(&self, region_id: RegionId) {
         #[cfg(any(test, feature = "test"))]
         if let Some(listener) = &self.listener {
-            listener.on_handle_compaction_finished(region_id).await;
+            listener.on_merge_ssts_finished(region_id).await;
         }
         // Avoid compiler warning.
         let _ = region_id;

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -367,7 +367,7 @@ impl<S: LogStore> WorkerStarter<S> {
             running: running.clone(),
             memtable_builder_provider: MemtableBuilderProvider::new(
                 Some(self.write_buffer_manager.clone()),
-                self.config,
+                self.config.clone(),
             ),
             purge_scheduler: self.purge_scheduler.clone(),
             write_buffer_manager: self.write_buffer_manager,
@@ -376,6 +376,7 @@ impl<S: LogStore> WorkerStarter<S> {
                 self.scheduler,
                 sender.clone(),
                 self.cache_manager.clone(),
+                self.config,
             ),
             stalled_requests: StalledRequests::default(),
             listener: self.listener,

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -377,6 +377,7 @@ impl<S: LogStore> WorkerStarter<S> {
                 sender.clone(),
                 self.cache_manager.clone(),
                 self.config,
+                self.listener.clone(),
             ),
             stalled_requests: StalledRequests::default(),
             listener: self.listener,

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use common_telemetry::{debug, error, info};
+use common_telemetry::{debug, info};
 use snafu::ResultExt;
 use store_api::metadata::{RegionMetadata, RegionMetadataBuilder, RegionMetadataRef};
 use store_api::region_request::RegionAlterRequest;
@@ -26,9 +26,7 @@ use crate::error::{
     InvalidMetadataSnafu, InvalidRegionRequestSchemaVersionSnafu, InvalidRegionRequestSnafu, Result,
 };
 use crate::flush::FlushReason;
-use crate::manifest::action::{RegionChange, RegionMetaAction, RegionMetaActionList};
-use crate::region::version::Version;
-use crate::region::MitoRegionRef;
+use crate::manifest::action::RegionChange;
 use crate::request::{DdlRequest, OptionOutputTx, SenderDdlRequest};
 use crate::worker::RegionWorkerLoop;
 

--- a/src/mito2/src/worker/handle_alter.rs
+++ b/src/mito2/src/worker/handle_alter.rs
@@ -138,18 +138,16 @@ async fn alter_region_schema(
         metadata: new_meta.clone(),
     };
     let action_list = RegionMetaActionList::with_action(RegionMetaAction::Change(change));
-    region
-        .manifest_manager
-        .write()
-        .await
-        .update(action_list)
-        .await?;
 
-    // Apply the metadata to region's version.
     region
-        .version_control
-        .alter_schema(new_meta, &region.memtable_builder);
-    Ok(())
+        .manifest_ctx
+        .update_manifest(action_list, || {
+            // Apply the metadata to region's version.
+            region
+                .version_control
+                .alter_schema(new_meta, &region.memtable_builder);
+        })
+        .await
 }
 
 /// Creates a metadata after applying the alter `request` to the old `metadata`.

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -33,7 +33,7 @@ impl<S> RegionWorkerLoop<S> {
 
         info!("Try to close region {}", region_id);
 
-        region.stop().await?;
+        region.stop().await;
         self.regions.remove_region(region_id);
         // Clean flush status.
         self.flush_scheduler.on_region_closed(region_id);

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -16,9 +16,8 @@ use common_telemetry::{error, info, warn};
 use store_api::logstore::LogStore;
 use store_api::storage::RegionId;
 
-use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
-use crate::metrics::{COMPACTION_REQUEST_COUNT, COMPACTION_STAGE_ELAPSED};
-use crate::request::{CompactionFailed, CompactionFinished, OnFailure, OptionOutputTx};
+use crate::metrics::COMPACTION_REQUEST_COUNT;
+use crate::request::{CompactionFailed, CompactionFinished, OptionOutputTx};
 use crate::worker::RegionWorkerLoop;
 
 impl<S: LogStore> RegionWorkerLoop<S> {
@@ -38,7 +37,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             &region.access_layer,
             &region.file_purger,
             sender,
-            self.config.clone(),
+            &region.manifest_ctx,
         ) {
             error!(e; "Failed to schedule compaction task for region: {}", region_id);
         } else {
@@ -65,42 +64,12 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             return;
         };
 
-        {
-            let manifest_timer = COMPACTION_STAGE_ELAPSED
-                .with_label_values(&["write_manifest"])
-                .start_timer();
-            // Write region edit to manifest.
-            let edit = RegionEdit {
-                files_to_add: std::mem::take(&mut request.compaction_outputs),
-                files_to_remove: std::mem::take(&mut request.compacted_files),
-                compaction_time_window: request.compaction_time_window,
-                flushed_entry_id: None,
-                flushed_sequence: None,
-            };
-            let action_list =
-                RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
-            let res = region
-                .manifest_ctx
-                .update_manifest(action_list, || {
-                    // Apply edit to region's version.
-                    region
-                        .version_control
-                        .apply_edit(edit, &[], region.file_purger.clone());
-                })
-                .await;
-            if let Err(e) = res {
-                error!(e; "Failed to update manifest, region: {}", region_id);
-                manifest_timer.stop_and_discard();
-                request.on_failure(e);
-                return;
-            }
-        }
         // compaction finished.
         request.on_success();
 
         // Schedule next compaction if necessary.
         self.compaction_scheduler
-            .on_compaction_finished(region_id, self.config.clone());
+            .on_compaction_finished(region_id, &region.manifest_ctx);
     }
 
     /// When compaction fails, we simply log the error.

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -54,8 +54,6 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         region_id: RegionId,
         mut request: CompactionFinished,
     ) {
-        self.listener.on_handle_compaction_finished(region_id).await;
-
         let Some(region) = self.regions.writable_region_or(region_id, &mut request) else {
             warn!(
                 "Unable to finish the compaction task for a read only region {}",

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -42,7 +42,11 @@ impl<S> RegionWorkerLoop<S> {
 
         info!("Try to drop region: {}", region_id);
 
-        // write dropping marker
+        // Marks the region as dropping.
+        region.set_dropping()?;
+
+        // Writes dropping marker
+        // We rarely drop a region so we still operate in the worker loop.
         let marker_path = join_path(region.access_layer.region_dir(), DROPPING_MARKER_FILE);
         region
             .access_layer
@@ -52,7 +56,7 @@ impl<S> RegionWorkerLoop<S> {
             .context(OpenDalSnafu)?;
 
         region.stop().await?;
-        // remove this region from region map to prevent other requests from accessing this region
+        // Removes this region from region map to prevent other requests from accessing this region
         self.regions.remove_region(region_id);
         self.dropping_regions.insert_region(region.clone());
         // Notifies flush scheduler.
@@ -60,7 +64,7 @@ impl<S> RegionWorkerLoop<S> {
         // Notifies compaction scheduler.
         self.compaction_scheduler.on_region_dropped(region_id);
 
-        // mark region version as dropped
+        // Marks region version as dropped
         region
             .version_control
             .mark_dropped(&region.memtable_builder);
@@ -71,7 +75,7 @@ impl<S> RegionWorkerLoop<S> {
 
         REGION_COUNT.dec();
 
-        // detach a background task to delete the region dir
+        // Detaches a background task to delete the region dir
         let region_dir = region.access_layer.region_dir().to_owned();
         let object_store = region.access_layer.object_store().clone();
         let dropping_regions = self.dropping_regions.clone();

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -27,7 +27,7 @@ use tokio::time::sleep;
 
 use crate::error::{OpenDalSnafu, Result};
 use crate::metrics::REGION_COUNT;
-use crate::region::{switch_state_to_writable, MitoRegionRef, RegionMapRef, REGION_STATE_DROPPING};
+use crate::region::{MitoRegionRef, RegionMapRef, RegionState};
 use crate::worker::{RegionWorkerLoop, DROPPING_MARKER_FILE};
 
 const GC_TASK_INTERVAL_SEC: u64 = 5 * 60; // 5 minutes
@@ -53,7 +53,7 @@ impl<S> RegionWorkerLoop<S> {
         impl<'a> Drop for ResetState<'a> {
             fn drop(&mut self) {
                 if !self.discard {
-                    switch_state_to_writable(&self.region, REGION_STATE_DROPPING);
+                    self.region.switch_state_to_writable(RegionState::Dropping);
                 }
             }
         }

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -178,6 +178,7 @@ impl<S> RegionWorkerLoop<S> {
             engine_config,
             row_group_size,
             cache_manager: self.cache_manager.clone(),
+            manifest_ctx: region.manifest_ctx.clone(),
             index_options: region.version().options.index_options.clone(),
         }
     }

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -240,7 +240,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             &region.access_layer,
             &region.file_purger,
             OptionOutputTx::none(),
-            self.config.clone(),
+            &region.manifest_ctx,
         ) {
             warn!(
                 "Failed to schedule compaction after flush, region: {}, err: {}",

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -1,0 +1,93 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Handles manifest.
+//!
+//! It updates the manifest and applies the changes to the region in background.
+
+use snafu::ensure;
+use store_api::storage::RegionId;
+use tokio::sync::oneshot::Sender;
+
+use crate::error::{InvalidRequestSnafu, Result};
+use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList, RegionTruncate};
+use crate::manifest::manager::RegionManifestManagerRef;
+use crate::region::version::VersionControlRef;
+use crate::region::MitoRegionRef;
+use crate::worker::RegionWorkerLoop;
+
+impl<S> RegionWorkerLoop<S> {
+    /// Handles region edit request.
+    pub(crate) async fn handle_region_edit(
+        &self,
+        region_id: RegionId,
+        edit: RegionEdit,
+        sender: Sender<Result<()>>,
+    ) {
+        todo!()
+    }
+
+    /// Writes truncate action to the manifest and then applies it to the region in background.
+    pub(crate) fn handle_manifest_truncate_action(
+        &self,
+        region: MitoRegionRef,
+        truncate: RegionTruncate,
+        sender: Sender<Result<()>>,
+    ) -> Result<()> {
+        let request_sender = self.sender.clone();
+        let manifest_manager = region.manifest_manager.clone();
+        let version_control = region.version_control.clone();
+
+        // Updates manifest in background.
+        common_runtime::spawn_bg(async move {
+            //
+        });
+
+        todo!()
+    }
+
+    /// Checks the region edit, writes it to the manifest and then applies it to the region.
+    async fn edit_region(&self, region_id: RegionId, edit: RegionEdit) -> Result<()> {
+        let region = self.regions.writable_region(region_id)?;
+
+        for file_meta in &edit.files_to_add {
+            let is_exist = region.access_layer.is_exist(file_meta).await?;
+            ensure!(
+                is_exist,
+                InvalidRequestSnafu {
+                    region_id,
+                    reason: format!(
+                        "trying to add a not exist file '{}' when editing region",
+                        file_meta.file_id
+                    )
+                }
+            );
+        }
+
+        // Applying region edit directly has nothing to do with memtables (at least for now).
+        region.apply_edit(edit, &[]).await
+    }
+}
+
+async fn write_and_apply_truncate_action(manifest_manager: RegionManifestManagerRef, version_control: VersionControlRef, truncate: RegionTruncate, sender: ) -> Result<()> {
+    // Write region truncated to manifest.
+    let action_list =
+        RegionMetaActionList::with_action(RegionMetaAction::Truncate(truncate.clone()));
+
+    // Acquires the write lock of the manifest manager.
+    let mut manifest_manager = manifest_manager.write().await;
+    manifest_manager.update(action_list).await?;
+
+    todo!()
+}

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -56,7 +56,12 @@ impl<S> RegionWorkerLoop<S> {
         common_runtime::spawn_bg(async move {
             let result = edit_region(&region, edit).await;
 
-            let _ = sender.send(result);
+            if let Err(res) = sender.send(result) {
+                warn!(
+                    "Failed to send result back to the worker, region_id: {}, res: {:?}",
+                    region_id, res
+                );
+            }
 
             // Sets the region as writable. For simplicity, we don't send the result
             // back to the worker.

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -25,7 +25,7 @@ use crate::error::{InvalidRequestSnafu, Result};
 use crate::manifest::action::{
     RegionChange, RegionEdit, RegionMetaAction, RegionMetaActionList, RegionTruncate,
 };
-use crate::memtable::{MemtableBuilderRef, MemtableId};
+use crate::memtable::MemtableId;
 use crate::region::version::VersionControlRef;
 use crate::region::{
     switch_state_to_writable, ManifestContextRef, MitoRegionRef, REGION_STATE_ALTERING,

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -27,6 +27,7 @@ use crate::manifest::action::{
 };
 use crate::region::{
     switch_state_to_writable, MitoRegionRef, REGION_STATE_ALTERING, REGION_STATE_EDITING,
+    REGION_STATE_TRUNCATING,
 };
 use crate::request::{BackgroundNotify, OptionOutputTx, TruncateResult, WorkerRequest};
 use crate::worker::RegionWorkerLoop;
@@ -93,7 +94,7 @@ impl<S> RegionWorkerLoop<S> {
                 RegionMetaActionList::with_action(RegionMetaAction::Truncate(truncate.clone()));
 
             let result = manifest_ctx
-                .update_manifest(action_list, || {
+                .update_manifest(REGION_STATE_TRUNCATING, action_list, || {
                     // Applies the truncate action to the region.
                     version_control.truncate(
                         truncate.truncated_entry_id,
@@ -141,7 +142,7 @@ impl<S> RegionWorkerLoop<S> {
 
             let result = region
                 .manifest_ctx
-                .update_manifest(action_list, || {
+                .update_manifest(REGION_STATE_ALTERING, action_list, || {
                     // Apply the metadata to region's version.
                     region
                         .version_control
@@ -187,7 +188,7 @@ async fn edit_region(region: &MitoRegionRef, edit: RegionEdit) -> Result<()> {
     let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
     region
         .manifest_ctx
-        .update_manifest(action_list, || {
+        .update_manifest(REGION_STATE_EDITING, action_list, || {
             // Applies the edit to the region.
             region
                 .version_control

--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -74,7 +74,7 @@ impl<S> RegionWorkerLoop<S> {
         // Marks the region as truncating.
         // This prevents the region from being accessed by other write requests.
         if let Err(e) = region.set_truncating() {
-            let _ = sender.send(Err(e));
+            sender.send(Err(e));
             return;
         }
         // Now the region is in truncating state.
@@ -128,7 +128,7 @@ impl<S> RegionWorkerLoop<S> {
     ) {
         // Marks the region as altering.
         if let Err(e) = region.set_altering() {
-            let _ = sender.send(Err(e));
+            sender.send(Err(e));
             return;
         }
 

--- a/src/mito2/src/worker/handle_truncate.rs
+++ b/src/mito2/src/worker/handle_truncate.rs
@@ -16,19 +16,23 @@
 
 use common_telemetry::info;
 use store_api::logstore::LogStore;
-use store_api::region_request::AffectedRows;
 use store_api::storage::RegionId;
 
-use crate::error::Result;
-use crate::manifest::action::{RegionMetaAction, RegionMetaActionList, RegionTruncate};
+use crate::error::RegionNotFoundSnafu;
+use crate::manifest::action::RegionTruncate;
+use crate::region::{switch_state_to_writable, REGION_STATE_TRUNCATING};
+use crate::request::{OptionOutputTx, TruncateResult};
 use crate::worker::RegionWorkerLoop;
 
 impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) async fn handle_truncate_request(
         &mut self,
         region_id: RegionId,
-    ) -> Result<AffectedRows> {
-        let region = self.regions.writable_region(region_id)?;
+        mut sender: OptionOutputTx,
+    ) {
+        let Some(region) = self.regions.writable_region_or(region_id, &mut sender) else {
+            return;
+        };
 
         info!("Try to truncate region {}", region_id);
 
@@ -42,36 +46,55 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             truncated_entry_id,
             truncated_sequence,
         };
-        let action_list =
-            RegionMetaActionList::with_action(RegionMetaAction::Truncate(truncate.clone()));
-        region
-            .manifest_manager
-            .write()
-            .await
-            .update(action_list)
-            .await?;
+        self.handle_manifest_truncate_action(region, truncate, sender);
+    }
+
+    /// Handles truncate result.
+    pub(crate) async fn handle_truncate_result(&mut self, truncate_result: TruncateResult) {
+        let region_id = truncate_result.region_id;
+        let Some(region) = self.regions.get_region(region_id) else {
+            truncate_result.sender.send(
+                RegionNotFoundSnafu {
+                    region_id: truncate_result.region_id,
+                }
+                .fail(),
+            );
+            return;
+        };
+
+        // We are already in the worker loop so we can set the state first.
+        switch_state_to_writable(&region, REGION_STATE_TRUNCATING);
+
+        if let Err(e) = truncate_result.result {
+            // Unable to truncate the region.
+            truncate_result.sender.send(Err(e));
+            return;
+        }
 
         // Notifies flush scheduler.
         self.flush_scheduler.on_region_truncated(region_id);
         // Notifies compaction scheduler.
         self.compaction_scheduler.on_region_truncated(region_id);
 
-        // Reset region's version and mark all SSTs deleted.
-        region.version_control.truncate(
-            truncated_entry_id,
-            truncated_sequence,
-            &region.memtable_builder,
-        );
-
         // Make all data obsolete.
-        self.wal
-            .obsolete(region_id, truncated_entry_id, &region.wal_options)
-            .await?;
+        if let Err(e) = self
+            .wal
+            .obsolete(
+                region_id,
+                truncate_result.truncated_entry_id,
+                &region.wal_options,
+            )
+            .await
+        {
+            truncate_result.sender.send(Err(e));
+            return;
+        }
+
         info!(
             "Complete truncating region: {}, entry id: {} and sequence: {}.",
-            region_id, truncated_entry_id, truncated_sequence
+            region_id, truncate_result.truncated_entry_id, truncate_result.truncated_sequence
         );
 
-        Ok(0)
+        truncate_result.sender.send(Ok(0));
     }
 }

--- a/src/mito2/src/worker/handle_truncate.rs
+++ b/src/mito2/src/worker/handle_truncate.rs
@@ -20,7 +20,7 @@ use store_api::storage::RegionId;
 
 use crate::error::RegionNotFoundSnafu;
 use crate::manifest::action::RegionTruncate;
-use crate::region::{switch_state_to_writable, REGION_STATE_TRUNCATING};
+use crate::region::RegionState;
 use crate::request::{OptionOutputTx, TruncateResult};
 use crate::worker::RegionWorkerLoop;
 
@@ -63,7 +63,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         };
 
         // We are already in the worker loop so we can set the state first.
-        switch_state_to_writable(&region, REGION_STATE_TRUNCATING);
+        region.switch_state_to_writable(RegionState::Truncating);
 
         if let Err(e) = truncate_result.result {
             // Unable to truncate the region.

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -41,7 +41,7 @@ common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
 console = "0.15"
-crossbeam-utils = "0.8.14"
+crossbeam-utils.workspace = true
 datafusion = { workspace = true, optional = true }
 datafusion-common = { workspace = true, optional = true }
 datafusion-expr = { workspace = true, optional = true }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3456

## What's changed and what's your intention?
This PR spawns a background task to write the manifest file.

It replaces the `writable` flag with `RegionState` to represent the state of the region.
```rust
/// State of the region.
#[derive(Debug, Clone, Copy, PartialEq, Eq)]
enum RegionState {
    /// The region is opened but is still read-only.
    ReadOnly,
    /// The region is opened and is writable.
    Writable,
    /// The region is altering.
    Altering,
    /// The region is dropping.
    Dropping,
    /// The region is truncating.
    Truncating,
    /// The region is handling a region edit.
    Editing,
}
```

The region rejects write requests while it is not in the writable state. This avoids the region handling other requests while updating the manifest in the background.

It wraps the manifest manager and the region state into a new struct `ManifestContext`. Before updating the manifest, the context will also check the region state.
```rust
struct ManifestContext {
    /// Manager to maintain manifest for this region.
    manifest_manager: tokio::sync::RwLock<RegionManifestManager>,
    /// The state of the region. The region checks the state before updating
    /// manifest.
    state: AtomicCell<RegionState>,
}
```

We need to ensure the region version is updated while holding the write lock of the manifest manager. So the context provides a method `update_manifest()` to update the manifest and apply the update to the region version.

### Flush and Compaction
Since the region flushes and compacts files in the background job, it can update the manifest in the background directly.

### Truncate
It rewrites the implementation of truncate to spawn a background job to write the manifest (See `handle_manifest_truncate_action()`). After the manifest is updated, the background job sends the `TruncateResult` back to the worker loop.

As the manifest action created by the flush/compaction job before truncation should be ignored, the method `ManifestContext::update_manifest()` needs to handle it correctly.

### Alter
It sets the state and then spawns a background job to write the manifest.

### Regoin Edit
Similar to alteration, the worker spawns a background job to do this.

### Drop
Drop doesn't update the manifest so we still write the marker file in the worker loop to avoid this PR getting to large. But it still sets the region state.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
