### PR TITLE
fix(alter_table): ignore request outdated error

### DIFF
--- a/src/common/meta/src/ddl/alter_table.rs
+++ b/src/common/meta/src/ddl/alter_table.rs
@@ -22,6 +22,8 @@ use std::vec;
 use api::v1::alter_expr::Kind;
 use api::v1::RenameTable;
 use async_trait::async_trait;
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
 use common_procedure::error::{FromJsonSnafu, Result as ProcedureResult, ToJsonSnafu};
 use common_procedure::{
     Context as ProcedureContext, Error as ProcedureError, LockKey, Procedure, Status, StringKey,
@@ -115,10 +117,16 @@ impl AlterTableProcedure {
                 let requester = requester.clone();
 
                 alter_region_tasks.push(async move {
-                    requester
-                        .handle(request)
-                        .await
-                        .map_err(add_peer_context_if_needed(datanode))
+                    if let Err(err) = requester.handle(request).await {
+                        if err.status_code() != StatusCode::RequestOutdated {
+                            // Treat request outdated as success.
+                            // The engine will throw this code when the schema version not match.
+                            // As this procedure has locked the table, the only reason for this error
+                            // is procedure is succeeded before and is retrying.
+                            return Err(add_peer_context_if_needed(datanode)(err));
+                        }
+                    }
+                    Ok(())
                 });
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Ignore request outdated error

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
