### PR TITLE
feat: add preserve arg to sqlness runner

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -184,13 +184,13 @@ jobs:
       - name: Unzip binaries
         run: tar -xvf ./bins.tar.gz
       - name: Run sqlness
-        run: RUST_BACKTRACE=1 ./bins/sqlness-runner -c ./tests/cases --bins-dir ./bins
+        run: RUST_BACKTRACE=1 ./bins/sqlness-runner -c ./tests/cases --bins-dir ./bins --preserve-state
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sqlness-logs
-          path: /tmp/greptime-*.log
+          path: /tmp/sqlness-*
           retention-days: 3
 
   sqlness-kafka-wal:
@@ -214,13 +214,13 @@ jobs:
         working-directory: tests-integration/fixtures/kafka
         run: docker compose -f docker-compose-standalone.yml up -d --wait
       - name: Run sqlness
-        run: RUST_BACKTRACE=1 ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases --bins-dir ./bins
+        run: RUST_BACKTRACE=1 ./bins/sqlness-runner -w kafka -k 127.0.0.1:9092 -c ./tests/cases --bins-dir ./bins --preserve-state
       - name: Upload sqlness logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sqlness-logs-with-kafka-wal
-          path: /tmp/greptime-*.log
+          path: /tmp/sqlness-*
           retention-days: 3
 
   fmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
  "num_cpus",
  "parquet",
  "prometheus",
- "rand 0.8.5",
+ "rand",
  "rskafka",
  "serde",
  "store-api",
@@ -1544,7 +1544,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "prost 0.12.3",
- "rand 0.8.5",
+ "rand",
  "serde_json",
  "snafu",
  "substrait 0.17.1",
@@ -1619,7 +1619,7 @@ dependencies = [
  "prometheus",
  "prost 0.12.3",
  "query",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rexpect",
  "rustyline 10.1.1",
@@ -1829,7 +1829,7 @@ dependencies = [
  "flatbuffers",
  "lazy_static",
  "prost 0.12.3",
- "rand 0.8.5",
+ "rand",
  "snafu",
  "tokio",
  "tonic 0.10.2",
@@ -1914,7 +1914,7 @@ dependencies = [
  "lazy_static",
  "prometheus",
  "prost 0.12.3",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rskafka",
  "serde",
@@ -2063,7 +2063,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "tempfile",
 ]
 
@@ -2077,7 +2077,7 @@ dependencies = [
  "common-error",
  "common-macro",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "snafu",
@@ -2568,7 +2568,7 @@ dependencies = [
  "parquet",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sqlparser 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
@@ -2612,7 +2612,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "tempfile",
  "url",
 ]
@@ -2674,7 +2674,7 @@ dependencies = [
  "md-5",
  "paste",
  "petgraph",
- "rand 0.8.5",
+ "rand",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -2706,7 +2706,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "tokio",
  "uuid",
 ]
@@ -3242,7 +3242,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -3580,12 +3580,6 @@ name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -4281,7 +4275,7 @@ dependencies = [
  "mockall",
  "pin-project",
  "prost 0.12.3",
- "rand 0.8.5",
+ "rand",
  "regex",
  "regex-automata 0.4.3",
  "snafu",
@@ -4865,7 +4859,7 @@ dependencies = [
  "protobuf",
  "protobuf-build",
  "raft-engine",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "rskafka",
  "serde",
@@ -5142,7 +5136,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "meta-srv",
- "rand 0.8.5",
+ "rand",
  "serde",
  "snafu",
  "tokio",
@@ -5189,7 +5183,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "prost 0.12.3",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -5344,7 +5338,7 @@ dependencies = [
  "prometheus",
  "prost 0.12.3",
  "puffin",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -5418,7 +5412,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ca7f22ed370d5991a9caec16a83187e865bc8a532f889670337d5a5689e3a1"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5490,7 +5484,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rustls 0.21.10",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -5529,7 +5523,7 @@ dependencies = [
  "mysql-common-derive 0.30.2",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "saturating",
@@ -5569,7 +5563,7 @@ dependencies = [
  "mysql-common-derive 0.31.0",
  "num-bigint",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rust_decimal",
  "saturating",
@@ -5597,7 +5591,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rand_distr",
  "simba",
  "typenum",
@@ -5766,7 +5760,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -6121,7 +6115,7 @@ dependencies = [
  "opentelemetry 0.21.0 (git+https://github.com/waynexia/opentelemetry-rust.git?rev=33841b38dda79b15f2024952be5f32533325ca02)",
  "ordered-float 4.2.0",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "thiserror",
 ]
 
@@ -6141,7 +6135,7 @@ dependencies = [
  "opentelemetry 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 4.2.0",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6243,7 +6237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -6590,7 +6584,7 @@ dependencies = [
  "log",
  "md5",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "ring 0.17.7",
  "stringprep",
  "thiserror",
@@ -6627,7 +6621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -6736,7 +6730,7 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
  "pkcs5",
- "rand_core 0.6.4",
+ "rand_core",
  "spki 0.7.3",
 ]
 
@@ -6816,7 +6810,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "stringprep",
 ]
@@ -7422,7 +7416,7 @@ dependencies = [
  "prometheus",
  "promql",
  "promql-parser",
- "rand 0.8.5",
+ "rand",
  "regex",
  "session",
  "snafu",
@@ -7516,26 +7510,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
 ]
 
@@ -7546,23 +7527,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7581,7 +7547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -7623,15 +7589,6 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7744,15 +7701,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7782,7 +7730,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "quick-xml 0.31.0",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "rsa 0.9.6",
  "rust-ini 0.20.0",
@@ -7962,7 +7910,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.3.3",
  "pkcs8 0.8.0",
- "rand_core 0.6.4",
+ "rand_core",
  "smallvec",
  "subtle",
  "zeroize",
@@ -7981,7 +7929,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.7.5",
  "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2",
  "signature",
  "spki 0.7.3",
@@ -8005,7 +7953,7 @@ dependencies = [
  "lz4",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "snap",
  "thiserror",
  "tokio",
@@ -8046,7 +7994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
- "rand 0.8.5",
+ "rand",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -8164,7 +8112,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rkyv",
  "serde",
  "serde_json",
@@ -8359,7 +8307,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "radium",
- "rand 0.8.5",
+ "rand",
  "siphasher",
  "unic-ucd-category",
  "volatile",
@@ -8499,8 +8447,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "puruspe",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand",
+ "rand_core",
  "rustpython-common",
  "rustpython-derive",
  "rustpython-vm",
@@ -8564,7 +8512,7 @@ dependencies = [
  "optional",
  "parking_lot 0.12.1",
  "paste",
- "rand 0.8.5",
+ "rand",
  "result-like",
  "rustc_version",
  "rustpython-ast",
@@ -9131,7 +9079,7 @@ dependencies = [
  "promql-parser",
  "prost 0.12.3",
  "query",
- "rand 0.8.5",
+ "rand",
  "regex",
  "reqwest",
  "rust-embed",
@@ -9256,7 +9204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -9507,7 +9455,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlness",
- "tempdir",
+ "tempfile",
  "tinytemplate",
  "tokio",
 ]
@@ -9604,7 +9552,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand 0.8.5",
+ "rand",
  "rsa 0.6.1",
  "rustls 0.20.9",
  "rustls-pemfile 1.0.4",
@@ -9686,7 +9634,7 @@ dependencies = [
  "lazy_static",
  "nalgebra",
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -10067,16 +10015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10142,7 +10080,7 @@ dependencies = [
  "lazy_static",
  "libfuzzer-sys",
  "partition",
- "rand 0.8.5",
+ "rand",
  "rand_chacha",
  "serde",
  "serde_json",
@@ -10197,7 +10135,7 @@ dependencies = [
  "paste",
  "prost 0.12.3",
  "query",
- "rand 0.8.5",
+ "rand",
  "rstest",
  "rstest_reuse",
  "script",
@@ -10489,7 +10427,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.8.5",
+ "rand",
  "socket2 0.5.5",
  "tokio",
  "tokio-util",
@@ -10757,7 +10695,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-util",
@@ -11050,7 +10988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -11394,7 +11332,7 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "atomic",
  "getrandom",
- "rand 0.8.5",
+ "rand",
  "serde",
  "uuid-macro-internal",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
  "num_cpus",
  "parquet",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "rskafka",
  "serde",
  "store-api",
@@ -1544,7 +1544,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "prost 0.12.3",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "snafu",
  "substrait 0.17.1",
@@ -1619,7 +1619,7 @@ dependencies = [
  "prometheus",
  "prost 0.12.3",
  "query",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rexpect",
  "rustyline 10.1.1",
@@ -1829,7 +1829,7 @@ dependencies = [
  "flatbuffers",
  "lazy_static",
  "prost 0.12.3",
- "rand",
+ "rand 0.8.5",
  "snafu",
  "tokio",
  "tonic 0.10.2",
@@ -1914,7 +1914,7 @@ dependencies = [
  "lazy_static",
  "prometheus",
  "prost 0.12.3",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rskafka",
  "serde",
@@ -2063,7 +2063,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "tempfile",
 ]
 
@@ -2077,7 +2077,7 @@ dependencies = [
  "common-error",
  "common-macro",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "snafu",
@@ -2568,7 +2568,7 @@ dependencies = [
  "parquet",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sqlparser 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "tokio",
@@ -2612,7 +2612,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot 0.12.1",
- "rand",
+ "rand 0.8.5",
  "tempfile",
  "url",
 ]
@@ -2674,7 +2674,7 @@ dependencies = [
  "md-5",
  "paste",
  "petgraph",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -2706,7 +2706,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "uuid",
 ]
@@ -3242,7 +3242,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3580,6 +3580,12 @@ name = "fst"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "funty"
@@ -4275,7 +4281,7 @@ dependencies = [
  "mockall",
  "pin-project",
  "prost 0.12.3",
- "rand",
+ "rand 0.8.5",
  "regex",
  "regex-automata 0.4.3",
  "snafu",
@@ -4859,7 +4865,7 @@ dependencies = [
  "protobuf",
  "protobuf-build",
  "raft-engine",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rskafka",
  "serde",
@@ -5136,7 +5142,7 @@ dependencies = [
  "futures",
  "humantime-serde",
  "meta-srv",
- "rand",
+ "rand 0.8.5",
  "serde",
  "snafu",
  "tokio",
@@ -5183,7 +5189,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prometheus",
  "prost 0.12.3",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -5338,7 +5344,7 @@ dependencies = [
  "prometheus",
  "prost 0.12.3",
  "puffin",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -5412,7 +5418,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ca7f22ed370d5991a9caec16a83187e865bc8a532f889670337d5a5689e3a1"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5484,7 +5490,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustls 0.21.10",
  "rustls-pemfile 1.0.4",
  "serde",
@@ -5523,7 +5529,7 @@ dependencies = [
  "mysql-common-derive 0.30.2",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rust_decimal",
  "saturating",
@@ -5563,7 +5569,7 @@ dependencies = [
  "mysql-common-derive 0.31.0",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rust_decimal",
  "saturating",
@@ -5591,7 +5597,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "simba",
  "typenum",
@@ -5760,7 +5766,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -6115,7 +6121,7 @@ dependencies = [
  "opentelemetry 0.21.0 (git+https://github.com/waynexia/opentelemetry-rust.git?rev=33841b38dda79b15f2024952be5f32533325ca02)",
  "ordered-float 4.2.0",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -6135,7 +6141,7 @@ dependencies = [
  "opentelemetry 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 4.2.0",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6237,7 +6243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -6584,7 +6590,7 @@ dependencies = [
  "log",
  "md5",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.7",
  "stringprep",
  "thiserror",
@@ -6621,7 +6627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -6730,7 +6736,7 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.8",
  "pkcs5",
- "rand_core",
+ "rand_core 0.6.4",
  "spki 0.7.3",
 ]
 
@@ -6810,7 +6816,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.8.5",
  "sha2",
  "stringprep",
 ]
@@ -7416,7 +7422,7 @@ dependencies = [
  "prometheus",
  "promql",
  "promql-parser",
- "rand",
+ "rand 0.8.5",
  "regex",
  "session",
  "snafu",
@@ -7510,13 +7516,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
 ]
 
@@ -7527,8 +7546,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7547,7 +7581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7589,6 +7623,15 @@ checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7701,6 +7744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rend"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7730,7 +7782,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "quick-xml 0.31.0",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "rsa 0.9.6",
  "rust-ini 0.20.0",
@@ -7910,7 +7962,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.3.3",
  "pkcs8 0.8.0",
- "rand_core",
+ "rand_core 0.6.4",
  "smallvec",
  "subtle",
  "zeroize",
@@ -7929,7 +7981,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.7.5",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2",
  "signature",
  "spki 0.7.3",
@@ -7953,7 +8005,7 @@ dependencies = [
  "lz4",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "snap",
  "thiserror",
  "tokio",
@@ -7994,7 +8046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f80dcc84beab3a327bbe161f77db25f336a1452428176787c8c79ac79d7073"
 dependencies = [
  "quote",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -8112,7 +8164,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -8307,7 +8359,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "radium",
- "rand",
+ "rand 0.8.5",
  "siphasher",
  "unic-ucd-category",
  "volatile",
@@ -8447,8 +8499,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "puruspe",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "rustpython-common",
  "rustpython-derive",
  "rustpython-vm",
@@ -8512,7 +8564,7 @@ dependencies = [
  "optional",
  "parking_lot 0.12.1",
  "paste",
- "rand",
+ "rand 0.8.5",
  "result-like",
  "rustc_version",
  "rustpython-ast",
@@ -9079,7 +9131,7 @@ dependencies = [
  "promql-parser",
  "prost 0.12.3",
  "query",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest",
  "rust-embed",
@@ -9204,7 +9256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9455,6 +9507,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlness",
+ "tempdir",
  "tinytemplate",
  "tokio",
 ]
@@ -9551,7 +9604,7 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa 0.6.1",
  "rustls 0.20.9",
  "rustls-pemfile 1.0.4",
@@ -9633,7 +9686,7 @@ dependencies = [
  "lazy_static",
  "nalgebra",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10014,6 +10067,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10079,7 +10142,7 @@ dependencies = [
  "lazy_static",
  "libfuzzer-sys",
  "partition",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "serde",
  "serde_json",
@@ -10134,7 +10197,7 @@ dependencies = [
  "paste",
  "prost 0.12.3",
  "query",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "rstest_reuse",
  "script",
@@ -10426,7 +10489,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "socket2 0.5.5",
  "tokio",
  "tokio-util",
@@ -10694,7 +10757,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -10987,7 +11050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -11331,7 +11394,7 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "atomic",
  "getrandom",
- "rand",
+ "rand 0.8.5",
  "serde",
  "uuid-macro-internal",
 ]

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -18,5 +18,6 @@ common-time.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlness = { version = "0.5" }
+tempdir = "0.3"
 tinytemplate = "1.2"
 tokio.workspace = true

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -18,6 +18,6 @@ common-time.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlness = { version = "0.5" }
-tempdir = "0.3"
+tempfile.workspace = true
 tinytemplate = "1.2"
 tokio.workspace = true

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -19,7 +19,6 @@ use std::path::PathBuf;
 use clap::{Parser, ValueEnum};
 use env::{Env, WalConfig};
 use sqlness::{ConfigBuilder, Runner};
-use tempdir::TempDir;
 
 mod env;
 mod util;
@@ -79,7 +78,10 @@ struct Args {
 async fn main() {
     let args = Args::parse();
 
-    let temp_dir = TempDir::new("sqlness").unwrap();
+    let temp_dir = tempfile::Builder::new()
+        .prefix("sqlness")
+        .tempdir()
+        .unwrap();
     let data_home = temp_dir.path().to_path_buf();
 
     let config = ConfigBuilder::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Add `--preserve-state` CLI arg to prevent temp dir from cleaning on exit. Sqlness runner in CI will use it to preserve logs and state.

~~Use `tempdir` because `tempfile` cannot set a prefix on temp dir.~~

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
