### PR TITLE
refactor(meta): Ensure all moving values remain unchanged between two transactions

### DIFF
--- a/src/common/meta/src/ddl/drop_table/executor.rs
+++ b/src/common/meta/src/ddl/drop_table/executor.rs
@@ -106,19 +106,6 @@ impl DropTableExecutor {
         ctx: &DdlContext,
         table_route_value: &TableRouteValue,
     ) -> Result<()> {
-        let table_name_key = TableNameKey::new(
-            &self.table.catalog_name,
-            &self.table.schema_name,
-            &self.table.table_name,
-        );
-        if !ctx
-            .table_metadata_manager
-            .table_name_manager()
-            .exists(table_name_key)
-            .await?
-        {
-            return Ok(());
-        }
         ctx.table_metadata_manager
             .delete_table_metadata(self.table_id, &self.table, table_route_value)
             .await
@@ -152,19 +139,6 @@ impl DropTableExecutor {
         ctx: &DdlContext,
         table_route_value: &TableRouteValue,
     ) -> Result<()> {
-        let table_name_key = TableNameKey::new(
-            &self.table.catalog_name,
-            &self.table.schema_name,
-            &self.table.table_name,
-        );
-        if ctx
-            .table_metadata_manager
-            .table_name_manager()
-            .exists(table_name_key)
-            .await?
-        {
-            return Ok(());
-        }
         ctx.table_metadata_manager
             .restore_table_metadata(self.table_id, &self.table, table_route_value)
             .await

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -421,9 +421,6 @@ pub enum Error {
     #[snafu(display("Invalid role: {}", role))]
     InvalidRole { role: i32, location: Location },
 
-    #[snafu(display("Atomic key changed: {err_msg}"))]
-    CasKeyChanged { err_msg: String, location: Location },
-
     #[snafu(display("Failed to move values: {err_msg}"))]
     MoveValues { err_msg: String, location: Location },
 
@@ -447,7 +444,6 @@ impl ErrorExt for Error {
             | EtcdFailed { .. }
             | EtcdTxnFailed { .. }
             | ConnectEtcd { .. }
-            | CasKeyChanged { .. }
             | MoveValues { .. } => StatusCode::Internal,
 
             SerdeJson { .. }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -424,6 +424,9 @@ pub enum Error {
     #[snafu(display("Atomic key changed: {err_msg}"))]
     CasKeyChanged { err_msg: String, location: Location },
 
+    #[snafu(display("Failed to move values: {err_msg}"))]
+    MoveValues { err_msg: String, location: Location },
+
     #[snafu(display("Failed to parse {} from utf8", name))]
     FromUtf8 {
         name: String,
@@ -444,7 +447,8 @@ impl ErrorExt for Error {
             | EtcdFailed { .. }
             | EtcdTxnFailed { .. }
             | ConnectEtcd { .. }
-            | CasKeyChanged { .. } => StatusCode::Internal,
+            | CasKeyChanged { .. }
+            | MoveValues { .. } => StatusCode::Internal,
 
             SerdeJson { .. }
             | ParseOption { .. }

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -1332,14 +1332,17 @@ mod tests {
             .delete_table_metadata(table_id, &table_name, table_route_value)
             .await
             .unwrap();
-
+        // Should be ignored.
+        table_metadata_manager
+            .delete_table_metadata(table_id, &table_name, table_route_value)
+            .await
+            .unwrap();
         assert!(table_metadata_manager
             .table_info_manager()
             .get(table_id)
             .await
             .unwrap()
             .is_none());
-
         assert!(table_metadata_manager
             .table_route_manager()
             .table_route_storage()
@@ -1347,7 +1350,6 @@ mod tests {
             .await
             .unwrap()
             .is_none());
-
         assert!(table_metadata_manager
             .datanode_table_manager()
             .tables(datanode_id)
@@ -1362,7 +1364,6 @@ mod tests {
             .await
             .unwrap();
         assert!(table_info.is_none());
-
         let table_route = table_metadata_manager
             .table_route_manager()
             .table_route_storage()
@@ -1832,6 +1833,13 @@ mod tests {
             .delete_table_metadata(table_id, &table_name, &table_route_value)
             .await
             .unwrap();
+        table_metadata_manager
+            .restore_table_metadata(table_id, &table_name, &table_route_value)
+            .await
+            .unwrap();
+        let kvs = mem_kv.dump();
+        assert_eq!(kvs, expected_result);
+        // Should be ignored.
         table_metadata_manager
             .restore_table_metadata(table_id, &table_name, &table_route_value)
             .await

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -51,7 +51,7 @@ impl TombstoneManager {
     /// - the value of `src_key` equals `value`.
     /// - the `dest_key` is vacant.
     ///
-    /// Otherwise retrieves the values of `src_key`, `dest_key`.
+    /// Otherwise retrieves the value of `src_key`.
     fn build_move_value_txn(
         &self,
         src_key: Vec<u8>,
@@ -127,7 +127,6 @@ impl TombstoneManager {
     /// Moves values to `dest_key` if:
     ///
     /// - All `dest_key` are vacant.
-    /// - All origin values remain unchanged.
     async fn move_values(&self, keys: Vec<Vec<u8>>, dest_keys: Vec<Vec<u8>>) -> Result<()> {
         let chunk_size = self.kv_backend.max_txn_ops() / 2;
         if keys.len() > chunk_size {

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -38,35 +38,6 @@ fn to_tombstone(key: &[u8]) -> Vec<u8> {
     [TOMBSTONE_PREFIX.as_bytes(), key].concat()
 }
 
-fn format_move_value_error(
-    unexpected_items: Vec<(MoveValue, Option<Vec<u8>>, Option<Vec<u8>>)>,
-) -> String {
-    unexpected_items
-        .into_iter()
-        .map(
-            |(
-                MoveValue {
-                    key,
-                    dest_key,
-                    value,
-                },
-                src_value,
-                dest_value,
-            )| {
-                format!(
-                    "Moving key: '{}' to dest: '{}' with value: '{}'\nSrc value: {:?}\nDest value: {:?}",
-                    String::from_utf8_lossy(&key),
-                    String::from_utf8_lossy(&dest_key),
-                    String::from_utf8_lossy(&value),
-                    src_value.map(|value| String::from_utf8_lossy(&value).to_string()),
-                    dest_value.map(|value| String::from_utf8_lossy(&value).to_string()),
-                )
-            },
-        )
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 #[derive(Debug, Clone)]
 struct MoveValue {
     key: Vec<u8>,
@@ -215,7 +186,30 @@ impl TombstoneManager {
             ensure!(
                 comparison_result.into_iter().all(Into::into),
                 error::MoveValuesSnafu {
-                    err_msg: format_move_value_error(unexpected_items)
+                    err_msg: unexpected_items
+                    .into_iter()
+                    .map(
+                        |(
+                            MoveValue {
+                                key,
+                                dest_key,
+                                value,
+                            },
+                            src_value,
+                            dest_value,
+                        )| {
+                            format!(
+                                "Moving key: '{}' to dest: '{}' with value: '{}'\nSrc value: {:?}\nDest value: {:?}",
+                                String::from_utf8_lossy(&key),
+                                String::from_utf8_lossy(&dest_key),
+                                String::from_utf8_lossy(&value),
+                                src_value.map(|value| String::from_utf8_lossy(&value).to_string()),
+                                dest_value.map(|value| String::from_utf8_lossy(&value).to_string()),
+                            )
+                        },
+                    )
+                    .collect::<Vec<_>>()
+                    .join("\n")
                 }
             )
         }

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -122,9 +122,7 @@ impl TombstoneManager {
         .fail()
     }
 
-    /// Moves values to `dest_key` if:
-    ///
-    /// - All `dest_key` are vacant.
+    /// Moves values to `dest_key`.
     async fn move_values(&self, keys: Vec<Vec<u8>>, dest_keys: Vec<Vec<u8>>) -> Result<()> {
         let chunk_size = self.kv_backend.max_txn_ops() / 2;
         if keys.len() > chunk_size {

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -14,6 +14,8 @@
 
 use std::collections::HashMap;
 
+use snafu::ensure;
+
 use crate::error::{self, Result};
 use crate::key::txn_helper::TxnOpGetResponseSet;
 use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp};
@@ -72,6 +74,12 @@ impl TombstoneManager {
     }
 
     async fn move_values_inner(&self, keys: &[Vec<u8>], dest_keys: &[Vec<u8>]) -> Result<()> {
+        ensure!(
+            keys.len() == dest_keys.len(),
+            error::UnexpectedSnafu {
+                err_msg: "The length of keys does not match the length of dest_keys."
+            }
+        );
         // The key -> dest key mapping.
         let lookup_table = keys.iter().zip(dest_keys.iter()).collect::<HashMap<_, _>>();
 

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use snafu::{ensure, OptionExt};
+use snafu::ensure;
 
 use super::TableMetaKeyGetTxnOp;
 use crate::error::{self, Result};
@@ -29,80 +29,14 @@ pub(crate) struct TombstoneManager {
 
 const TOMBSTONE_PREFIX: &str = "__tombstone/";
 
-pub(crate) struct TombstoneKey<T>(T);
+pub(crate) struct TombstoneKeyValue {
+    pub(crate) origin_key: Vec<u8>,
+    pub(crate) tombstone_key: Vec<u8>,
+    pub(crate) value: Vec<u8>,
+}
 
 fn to_tombstone(key: &[u8]) -> Vec<u8> {
     [TOMBSTONE_PREFIX.as_bytes(), key].concat()
-}
-
-impl TombstoneKey<&Vec<u8>> {
-    /// Returns the origin key and tombstone key.
-    fn to_keys(&self) -> (Vec<u8>, Vec<u8>) {
-        let key = self.0;
-        let tombstone_key = to_tombstone(key);
-        (key.clone(), tombstone_key)
-    }
-
-    /// Returns the origin key and tombstone key.
-    fn into_keys(self) -> (Vec<u8>, Vec<u8>) {
-        self.to_keys()
-    }
-
-    /// Returns the tombstone key.
-    fn to_tombstone_key(&self) -> Vec<u8> {
-        let key = self.0;
-        to_tombstone(key)
-    }
-}
-
-impl TableMetaKeyGetTxnOp for TombstoneKey<&Vec<u8>> {
-    fn build_get_op(
-        &self,
-    ) -> (
-        TxnOp,
-        impl FnMut(&'_ mut TxnOpGetResponseSet) -> Option<Vec<u8>>,
-    ) {
-        TxnOpGetResponseSet::build_get_op(to_tombstone(self.0))
-    }
-}
-
-/// The key used in the [TombstoneManager].
-pub(crate) struct Key {
-    bytes: Vec<u8>,
-    // Atomic Key:
-    // The value corresponding to the key remains consistent between two transactions.
-    atomic: bool,
-}
-
-impl Key {
-    /// Returns a new atomic key.
-    pub(crate) fn compare_and_swap<T: Into<Vec<u8>>>(key: T) -> Self {
-        Self {
-            bytes: key.into(),
-            atomic: true,
-        }
-    }
-
-    /// Returns a new normal key.
-    pub(crate) fn new<T: Into<Vec<u8>>>(key: T) -> Self {
-        Self {
-            bytes: key.into(),
-            atomic: false,
-        }
-    }
-
-    /// Into bytes
-    pub(crate) fn into_bytes(self) -> Vec<u8> {
-        self.bytes
-    }
-
-    fn get_inner(&self) -> &Vec<u8> {
-        &self.bytes
-    }
-
-    fn is_atomic(&self) -> bool {
-        self.atomic
-    }
 }
 
 fn format_move_value_error(
@@ -151,18 +85,6 @@ impl From<(Vec<u8>, Vec<u8>, Vec<u8>)> for MoveValue {
     }
 }
 
-impl TableMetaKeyGetTxnOp for Key {
-    fn build_get_op(
-        &self,
-    ) -> (
-        TxnOp,
-        impl FnMut(&'_ mut TxnOpGetResponseSet) -> Option<Vec<u8>>,
-    ) {
-        let key = self.get_inner().clone();
-        (TxnOp::Get(key.clone()), TxnOpGetResponseSet::filter(key))
-    }
-}
-
 fn format_on_failure_error_message<F: FnMut(&mut TxnOpGetResponseSet) -> Option<Vec<u8>>>(
     mut set: TxnOpGetResponseSet,
     on_failure_kv_and_filters: Vec<(Vec<u8>, Vec<u8>, F)>,
@@ -192,13 +114,6 @@ fn format_on_failure_error_message<F: FnMut(&mut TxnOpGetResponseSet) -> Option<
         })
         .collect::<Vec<_>>()
         .join("; ")
-}
-
-fn format_keys(keys: &[Key]) -> String {
-    keys.iter()
-        .map(|key| String::from_utf8_lossy(&key.bytes))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 impl TombstoneManager {
@@ -245,6 +160,10 @@ impl TombstoneManager {
         )
     }
 
+    /// Moves values to `dest_key` if:
+    ///
+    /// - All `dest_key` are vacant.
+    /// - All origin values remain unchanged.
     async fn move_values(&self, kvs: Vec<MoveValue>) -> Result<()> {
         let mut txns = Vec::with_capacity(kvs.len());
         let mut src_key_filters = Vec::with_capacity(kvs.len());
@@ -307,172 +226,76 @@ impl TombstoneManager {
     /// Creates tombstones for keys.
     ///
     /// Preforms to:
-    /// - retrieve all values corresponding `keys`.
+    /// - deletes origin values.
     /// - stores tombstone values.
-    pub(crate) async fn create(&self, keys: Vec<Key>) -> Result<()> {
-        // Builds transaction to retrieve all values
-        let (operations, mut filters): (Vec<_>, Vec<_>) =
-            keys.iter().map(|key| key.build_get_op()).unzip();
+    pub(crate) async fn create(&self, kvs: Vec<(Vec<u8>, Vec<u8>)>) -> Result<()> {
+        let move_values = kvs
+            .into_iter()
+            .map(|(key, value)| {
+                let dest_key = to_tombstone(&key);
+                MoveValue {
+                    key,
+                    dest_key,
+                    value,
+                }
+            })
+            .collect();
 
-        let txn = Txn::new().and_then(operations);
-        let mut resp = self.kv_backend.txn(txn).await?;
-        ensure!(
-            resp.succeeded,
-            error::UnexpectedSnafu {
-                err_msg: format!(
-                    "Failed to retrieves the metadata, keys: {}",
-                    format_keys(&keys)
-                ),
-            }
-        );
-
-        let mut set = TxnOpGetResponseSet::from(&mut resp.responses);
-        // Builds the create tombstone transaction.
-        let mut tombstone_operations = Vec::with_capacity(keys.len() * 2);
-        let mut tombstone_comparison = vec![];
-        let mut on_failure_operations = vec![];
-        let mut on_failure_kv_and_filters = vec![];
-        for (idx, key) in keys.iter().enumerate() {
-            let filter = &mut filters[idx];
-            let value = filter(&mut set).with_context(|| error::UnexpectedSnafu {
-                err_msg: format!(
-                    "Missing value, key: {}",
-                    String::from_utf8_lossy(key.get_inner())
-                ),
-            })?;
-            let (origin_key, tombstone_key) = TombstoneKey(key.get_inner()).into_keys();
-            // Compares the atomic key.
-            if key.is_atomic() {
-                tombstone_comparison.push(Compare::with_not_exist_value(
-                    tombstone_key.clone(),
-                    CompareOp::Equal,
-                ));
-                tombstone_comparison.push(Compare::with_value(
-                    origin_key.clone(),
-                    CompareOp::Equal,
-                    value.clone(),
-                ));
-                let (op, filter) = TxnOpGetResponseSet::build_get_op(origin_key.clone());
-                on_failure_operations.push(op);
-                on_failure_kv_and_filters.push((origin_key.clone(), value.clone(), filter));
-            }
-            tombstone_operations.push(TxnOp::Delete(origin_key));
-            tombstone_operations.push(TxnOp::Put(tombstone_key, value));
-        }
-
-        let txn = if !tombstone_comparison.is_empty() {
-            Txn::new().when(tombstone_comparison)
-        } else {
-            Txn::new()
-        }
-        .and_then(tombstone_operations);
-
-        let txn = if !on_failure_operations.is_empty() {
-            txn.or_else(on_failure_operations)
-        } else {
-            txn
-        };
-
-        let mut resp = self.kv_backend.txn(txn).await?;
-        // TODO(weny): add tests for atomic key changed.
-        if !resp.succeeded {
-            let set = TxnOpGetResponseSet::from(&mut resp.responses);
-            let err_msg = format_on_failure_error_message(set, on_failure_kv_and_filters);
-            return error::CasKeyChangedSnafu { err_msg }.fail();
-        }
-        Ok(())
+        self.move_values(move_values).await
     }
 
     /// Restores tombstones for keys.
     ///
     /// Preforms to:
-    /// - retrieve all tombstone values corresponding `keys`.
-    /// - stores tombstone values.
-    pub(crate) async fn restore(&self, keys: Vec<Key>) -> Result<()> {
-        // Builds transaction to retrieve all tombstone values
-        let tombstone_keys = keys
-            .iter()
-            .map(|key| TombstoneKey(key.get_inner()))
-            .collect::<Vec<_>>();
-        let (operations, mut filters): (Vec<_>, Vec<_>) =
-            tombstone_keys.iter().map(|key| key.build_get_op()).unzip();
+    /// - restore origin value.
+    /// - deletes tombstone values.
+    pub(crate) async fn restore(&self, kvs: Vec<(Vec<u8>, Vec<u8>)>) -> Result<()> {
+        let move_values = kvs
+            .into_iter()
+            .map(|(key, value)| {
+                let tombstone_key = to_tombstone(&key);
+                MoveValue {
+                    key: tombstone_key,
+                    dest_key: key,
+                    value,
+                }
+            })
+            .collect();
 
-        let txn = Txn::new().and_then(operations);
-        let mut resp = self.kv_backend.txn(txn).await?;
-        ensure!(
-            resp.succeeded,
-            error::UnexpectedSnafu {
-                err_msg: format!(
-                    "Failed to retrieves the metadata, keys: {}",
-                    format_keys(&keys)
-                ),
-            }
-        );
-
-        let mut set = TxnOpGetResponseSet::from(&mut resp.responses);
-
-        // Builds the restore tombstone transaction.
-        let mut tombstone_operations = Vec::with_capacity(keys.len() * 2);
-        let mut tombstone_comparison = vec![];
-        let mut on_failure_operations = vec![];
-        let mut on_failure_kv_and_filters = vec![];
-        for (idx, key) in keys.iter().enumerate() {
-            let filter = &mut filters[idx];
-            let value = filter(&mut set).with_context(|| error::UnexpectedSnafu {
-                err_msg: format!(
-                    "Missing value, key: {}",
-                    String::from_utf8_lossy(key.get_inner())
-                ),
-            })?;
-            let (origin_key, tombstone_key) = tombstone_keys[idx].to_keys();
-            // Compares the atomic key.
-            if key.is_atomic() {
-                tombstone_comparison.push(Compare::with_not_exist_value(
-                    origin_key.clone(),
-                    CompareOp::Equal,
-                ));
-                tombstone_comparison.push(Compare::with_value(
-                    tombstone_key.clone(),
-                    CompareOp::Equal,
-                    value.clone(),
-                ));
-                let (op, filter) = tombstone_keys[idx].build_get_op();
-                on_failure_operations.push(op);
-                on_failure_kv_and_filters.push((tombstone_key.clone(), value.clone(), filter));
-            }
-            tombstone_operations.push(TxnOp::Delete(tombstone_key));
-            tombstone_operations.push(TxnOp::Put(origin_key, value));
-        }
-
-        let txn = if !tombstone_comparison.is_empty() {
-            Txn::new().when(tombstone_comparison)
-        } else {
-            Txn::new()
-        }
-        .and_then(tombstone_operations);
-
-        let txn = if !on_failure_operations.is_empty() {
-            txn.or_else(on_failure_operations)
-        } else {
-            txn
-        };
-
-        let mut resp = self.kv_backend.txn(txn).await?;
-        // TODO(weny): add tests for atomic key changed.
-        if !resp.succeeded {
-            let set = TxnOpGetResponseSet::from(&mut resp.responses);
-            let err_msg = format_on_failure_error_message(set, on_failure_kv_and_filters);
-            return error::CasKeyChangedSnafu { err_msg }.fail();
-        }
-
-        Ok(())
+        self.move_values(move_values).await
     }
 
-    /// Deletes tombstones for keys.
+    /// Retrieves a batch of tombstone values for the specified `keys`.
+    pub(crate) async fn batch_get(&self, keys: Vec<Vec<u8>>) -> Result<Vec<TombstoneKeyValue>> {
+        let (ops, mut filters): (Vec<_>, Vec<_>) = keys
+            .iter()
+            .map(|key| TxnOpGetResponseSet::build_get_op(to_tombstone(key)))
+            .unzip();
+
+        let txn = Txn::new().and_then(ops);
+        let mut resp = self.kv_backend.txn(txn).await?;
+        let mut set = TxnOpGetResponseSet::from(&mut resp.responses);
+        let mut result = Vec::with_capacity(keys.len());
+        for (idx, key) in keys.into_iter().enumerate() {
+            let value = filters[idx](&mut set);
+            if let Some(value) = value {
+                let tombstone_key = to_tombstone(&key);
+                result.push(TombstoneKeyValue {
+                    origin_key: key,
+                    tombstone_key,
+                    value,
+                })
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Deletes tombstones values for the specified `keys`.
     pub(crate) async fn delete(&self, keys: Vec<Vec<u8>>) -> Result<()> {
         let operations = keys
             .iter()
-            .map(|key| TxnOp::Delete(TombstoneKey(key).to_tombstone_key()))
+            .map(|key| TxnOp::Delete(to_tombstone(key)))
             .collect::<Vec<_>>();
 
         let txn = Txn::new().and_then(operations);
@@ -491,7 +314,7 @@ mod tests {
 
     use super::to_tombstone;
     use crate::error::{self, Error};
-    use crate::key::tombstone::{Key, MoveValue, TombstoneKey, TombstoneManager};
+    use crate::key::tombstone::{MoveValue, TombstoneKeyValue, TombstoneManager};
     use crate::kv_backend::memory::MemoryKvBackend;
     use crate::kv_backend::KvBackend;
     use crate::rpc::store::PutRequest;
@@ -509,14 +332,17 @@ mod tests {
             .await
             .unwrap();
         tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("foo")])
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap();
         assert!(!kv_backend.exists(b"bar").await.unwrap());
         assert!(!kv_backend.exists(b"foo").await.unwrap());
         assert_eq!(
             kv_backend
-                .get(&TombstoneKey(&"bar".into()).to_tombstone_key())
+                .get(&to_tombstone(b"bar"))
                 .await
                 .unwrap()
                 .unwrap()
@@ -525,46 +351,7 @@ mod tests {
         );
         assert_eq!(
             kv_backend
-                .get(&TombstoneKey(&"foo".into()).to_tombstone_key())
-                .await
-                .unwrap()
-                .unwrap()
-                .value,
-            b"hi"
-        );
-        assert_eq!(kv_backend.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_create_tombstone_without_atomic_key() {
-        let kv_backend = Arc::new(MemoryKvBackend::default());
-        let tombstone_manager = TombstoneManager::new(kv_backend.clone());
-        kv_backend
-            .put(PutRequest::new().with_key("bar").with_value("baz"))
-            .await
-            .unwrap();
-        kv_backend
-            .put(PutRequest::new().with_key("foo").with_value("hi"))
-            .await
-            .unwrap();
-        tombstone_manager
-            .create(vec![Key::new("bar"), Key::new("foo")])
-            .await
-            .unwrap();
-        assert!(!kv_backend.exists(b"bar").await.unwrap());
-        assert!(!kv_backend.exists(b"foo").await.unwrap());
-        assert_eq!(
-            kv_backend
-                .get(&TombstoneKey(&"bar".into()).to_tombstone_key())
-                .await
-                .unwrap()
-                .unwrap()
-                .value,
-            b"baz"
-        );
-        assert_eq!(
-            kv_backend
-                .get(&TombstoneKey(&"foo".into()).to_tombstone_key())
+                .get(&to_tombstone(b"foo"))
                 .await
                 .unwrap()
                 .unwrap()
@@ -589,10 +376,13 @@ mod tests {
             .unwrap();
 
         let err = tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("baz")])
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"baz".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("Missing value"));
+        assert_matches!(err, error::Error::MoveValues { .. });
     }
 
     #[tokio::test]
@@ -609,35 +399,17 @@ mod tests {
             .unwrap();
         let expected_kvs = kv_backend.dump();
         tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("foo")])
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap();
         tombstone_manager
-            .restore(vec![Key::compare_and_swap("bar"), Key::new("foo")])
-            .await
-            .unwrap();
-        assert_eq!(expected_kvs, kv_backend.dump());
-    }
-
-    #[tokio::test]
-    async fn test_restore_tombstone_without_atomic_key() {
-        let kv_backend = Arc::new(MemoryKvBackend::default());
-        let tombstone_manager = TombstoneManager::new(kv_backend.clone());
-        kv_backend
-            .put(PutRequest::new().with_key("bar").with_value("baz"))
-            .await
-            .unwrap();
-        kv_backend
-            .put(PutRequest::new().with_key("foo").with_value("hi"))
-            .await
-            .unwrap();
-        let expected_kvs = kv_backend.dump();
-        tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("foo")])
-            .await
-            .unwrap();
-        tombstone_manager
-            .restore(vec![Key::new("bar"), Key::new("foo")])
+            .restore(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap();
         assert_eq!(expected_kvs, kv_backend.dump());
@@ -656,14 +428,20 @@ mod tests {
             .await
             .unwrap();
         tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("foo")])
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap();
         let err = tombstone_manager
-            .restore(vec![Key::new("bar"), Key::new("baz")])
+            .restore(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"baz".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("Missing value"));
+        assert_matches!(err, error::Error::MoveValues { .. });
     }
 
     #[tokio::test]
@@ -679,7 +457,10 @@ mod tests {
             .await
             .unwrap();
         tombstone_manager
-            .create(vec![Key::compare_and_swap("bar"), Key::new("foo")])
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
             .await
             .unwrap();
         tombstone_manager
@@ -785,5 +566,47 @@ mod tests {
             .await
             .unwrap_err();
         assert_matches!(err, error::Error::MoveValues { .. });
+    }
+
+    #[tokio::test]
+    async fn test_batch_get() {
+        let kv_backend = Arc::new(MemoryKvBackend::default());
+        let tombstone_manager = TombstoneManager::new(kv_backend.clone());
+        let kvs = HashMap::from([
+            (b"bar".to_vec(), b"baz".to_vec()),
+            (b"foo".to_vec(), b"hi".to_vec()),
+            (b"baz".to_vec(), b"hello".to_vec()),
+        ]);
+        for (key, value) in &kvs {
+            kv_backend
+                .put(
+                    PutRequest::new()
+                        .with_key(key.clone())
+                        .with_value(value.clone()),
+                )
+                .await
+                .unwrap();
+        }
+        tombstone_manager
+            .create(vec![
+                (b"bar".to_vec(), b"baz".to_vec()),
+                (b"foo".to_vec(), b"hi".to_vec()),
+            ])
+            .await
+            .unwrap();
+
+        let values = tombstone_manager
+            .batch_get(vec![b"bar".to_vec(), b"foo".to_vec(), b"hi".to_vec()])
+            .await
+            .unwrap();
+        assert_eq!(values.len(), 2);
+        for TombstoneKeyValue {
+            origin_key,
+            tombstone_key,
+            ..
+        } in values
+        {
+            assert_eq!(to_tombstone(&origin_key), tombstone_key)
+        }
     }
 }

--- a/src/common/meta/src/key/tombstone.rs
+++ b/src/common/meta/src/key/tombstone.rs
@@ -14,7 +14,6 @@
 
 use snafu::ensure;
 
-use super::TableMetaKeyGetTxnOp;
 use crate::error::{self, Result};
 use crate::key::txn_helper::TxnOpGetResponseSet;
 use crate::kv_backend::txn::{Compare, CompareOp, Txn, TxnOp};

--- a/src/common/meta/src/key/txn_helper.rs
+++ b/src/common/meta/src/key/txn_helper.rs
@@ -24,18 +24,6 @@ use crate::rpc::KeyValue;
 pub(crate) struct TxnOpGetResponseSet(Vec<KeyValue>);
 
 impl TxnOpGetResponseSet {
-    /// Returns a [TxnOp] to retrieve the value corresponding `key` and
-    /// a filter to consume corresponding [KeyValue] from [TxnOpGetResponseSet].
-    pub(crate) fn build_get_op<T: Into<Vec<u8>>>(
-        key: T,
-    ) -> (
-        TxnOp,
-        impl FnMut(&'_ mut TxnOpGetResponseSet) -> Option<Vec<u8>>,
-    ) {
-        let key = key.into();
-        (TxnOp::Get(key.clone()), TxnOpGetResponseSet::filter(key))
-    }
-
     /// Returns a filter to consume a [KeyValue] where the key equals `key`.
     pub(crate) fn filter(key: Vec<u8>) -> impl FnMut(&mut TxnOpGetResponseSet) -> Option<Vec<u8>> {
         move |set| {

--- a/src/common/meta/src/rpc/store.rs
+++ b/src/common/meta/src/rpc/store.rs
@@ -97,7 +97,6 @@ impl Display for RangeRequest {
 }
 
 impl RangeRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             key: vec![],
@@ -114,7 +113,6 @@ impl RangeRequest {
 
     /// key is the first key for the range, If range_end is not given, the
     /// request only looks up key.
-    #[inline]
     pub fn with_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self
@@ -129,7 +127,6 @@ impl RangeRequest {
     /// then the range request gets all keys prefixed with key.
     /// If both key and range_end are '\0', then the range request returns all
     /// keys.
-    #[inline]
     pub fn with_range(mut self, key: impl Into<Vec<u8>>, range_end: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self.range_end = range_end.into();
@@ -138,7 +135,6 @@ impl RangeRequest {
 
     /// Gets all keys prefixed with key.
     /// range_end is the key plus one (e.g., "aa"+1 == "ab", "a\xff"+1 == "b"),
-    #[inline]
     pub fn with_prefix(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self.range_end = util::get_prefix_end_key(&self.key);
@@ -147,14 +143,12 @@ impl RangeRequest {
 
     /// limit is a limit on the number of keys returned for the request. When
     /// limit is set to 0, it is treated as no limit.
-    #[inline]
     pub fn with_limit(mut self, limit: i64) -> Self {
         self.limit = limit;
         self
     }
 
     /// keys_only when set returns only the keys and not the values.
-    #[inline]
     pub fn with_keys_only(mut self) -> Self {
         self.keys_only = true;
         self
@@ -204,7 +198,6 @@ impl RangeResponse {
         }
     }
 
-    #[inline]
     pub fn take_kvs(&mut self) -> Vec<KeyValue> {
         self.kvs.drain(..).collect()
     }
@@ -244,7 +237,6 @@ impl From<PbPutRequest> for PutRequest {
 }
 
 impl PutRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             key: vec![],
@@ -254,7 +246,6 @@ impl PutRequest {
     }
 
     /// key is the key, in bytes, to put into the key-value store.
-    #[inline]
     pub fn with_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self
@@ -262,7 +253,6 @@ impl PutRequest {
 
     /// value is the value, in bytes, to associate with the key in the
     /// key-value store.
-    #[inline]
     pub fn with_value(mut self, value: impl Into<Vec<u8>>) -> Self {
         self.value = value.into();
         self
@@ -270,7 +260,6 @@ impl PutRequest {
 
     /// If prev_kv is set, gets the previous key-value pair before changing it.
     /// The previous key-value pair will be returned in the put response.
-    #[inline]
     pub fn with_prev_kv(mut self) -> Self {
         self.prev_kv = true;
         self
@@ -330,18 +319,15 @@ impl Default for BatchGetRequest {
 }
 
 impl BatchGetRequest {
-    #[inline]
     pub fn new() -> Self {
         Self { keys: vec![] }
     }
 
-    #[inline]
     pub fn with_keys(mut self, keys: Vec<Vec<u8>>) -> Self {
         self.keys = keys;
         self
     }
 
-    #[inline]
     pub fn add_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.keys.push(key.into());
         self
@@ -416,7 +402,6 @@ impl From<PbBatchPutRequest> for BatchPutRequest {
 }
 
 impl BatchPutRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             kvs: vec![],
@@ -424,7 +409,6 @@ impl BatchPutRequest {
         }
     }
 
-    #[inline]
     pub fn add_kv(mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Self {
         self.kvs.push(KeyValue {
             key: key.into(),
@@ -435,7 +419,6 @@ impl BatchPutRequest {
 
     /// If prev_kv is set, gets the previous key-value pair before changing it.
     /// The previous key-value pair will be returned in the put response.
-    #[inline]
     pub fn with_prev_kv(mut self) -> Self {
         self.prev_kv = true;
         self
@@ -467,7 +450,6 @@ impl BatchPutResponse {
         }
     }
 
-    #[inline]
     pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
         self.prev_kvs.drain(..).collect()
     }
@@ -501,7 +483,6 @@ impl From<PbBatchDeleteRequest> for BatchDeleteRequest {
 }
 
 impl BatchDeleteRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             keys: vec![],
@@ -515,7 +496,6 @@ impl BatchDeleteRequest {
         self
     }
 
-    #[inline]
     pub fn add_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.keys.push(key.into());
         self
@@ -523,7 +503,6 @@ impl BatchDeleteRequest {
 
     /// If prev_kv is set, gets the previous key-value pair before deleting it.
     /// The previous key-value pair will be returned in the batch delete response.
-    #[inline]
     pub fn with_prev_kv(mut self) -> Self {
         self.prev_kv = true;
         self
@@ -588,7 +567,6 @@ impl From<PbCompareAndPutRequest> for CompareAndPutRequest {
 }
 
 impl CompareAndPutRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             key: vec![],
@@ -598,14 +576,12 @@ impl CompareAndPutRequest {
     }
 
     /// key is the key, in bytes, to put into the key-value store.
-    #[inline]
     pub fn with_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self
     }
 
     /// expect is the previous value, in bytes
-    #[inline]
     pub fn with_expect(mut self, expect: impl Into<Vec<u8>>) -> Self {
         self.expect = expect.into();
         self
@@ -613,7 +589,6 @@ impl CompareAndPutRequest {
 
     /// value is the value, in bytes, to associate with the key in the
     /// key-value store.
-    #[inline]
     pub fn with_value(mut self, value: impl Into<Vec<u8>>) -> Self {
         self.value = value.into();
         self
@@ -655,12 +630,10 @@ impl CompareAndPutResponse {
         }
     }
 
-    #[inline]
     pub fn is_success(&self) -> bool {
         self.success
     }
 
-    #[inline]
     pub fn take_prev_kv(&mut self) -> Option<KeyValue> {
         self.prev_kv.take()
     }
@@ -709,7 +682,6 @@ impl From<PbDeleteRangeRequest> for DeleteRangeRequest {
 }
 
 impl DeleteRangeRequest {
-    #[inline]
     pub fn new() -> Self {
         Self {
             key: vec![],
@@ -725,7 +697,6 @@ impl DeleteRangeRequest {
 
     /// key is the first key to delete in the range. If range_end is not given,
     /// the range is defined to contain only the key argument.
-    #[inline]
     pub fn with_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self
@@ -741,7 +712,6 @@ impl DeleteRangeRequest {
     /// the keys with the prefix (the given key).
     /// If range_end is '\0', the range is all keys greater than or equal to the
     /// key argument.
-    #[inline]
     pub fn with_range(mut self, key: impl Into<Vec<u8>>, range_end: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self.range_end = range_end.into();
@@ -750,7 +720,6 @@ impl DeleteRangeRequest {
 
     /// Deletes all keys prefixed with key.
     /// range_end is one bit larger than the given key.
-    #[inline]
     pub fn with_prefix(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.key = key.into();
         self.range_end = util::get_prefix_end_key(&self.key);
@@ -759,7 +728,6 @@ impl DeleteRangeRequest {
 
     /// If prev_kv is set, gets the previous key-value pairs before deleting it.
     /// The previous key-value pairs will be returned in the delete response.
-    #[inline]
     pub fn with_prev_kv(mut self) -> Self {
         self.prev_kv = true;
         self
@@ -794,12 +762,10 @@ impl DeleteRangeResponse {
         }
     }
 
-    #[inline]
     pub fn deleted(&self) -> i64 {
         self.deleted
     }
 
-    #[inline]
     pub fn take_prev_kvs(&mut self) -> Vec<KeyValue> {
         self.prev_kvs.drain(..).collect()
     }

--- a/src/common/meta/src/rpc/store.rs
+++ b/src/common/meta/src/rpc/store.rs
@@ -509,7 +509,6 @@ impl BatchDeleteRequest {
         }
     }
 
-    #[inline]
     /// Sets `keys`.
     pub fn with_keys(mut self, keys: Vec<Vec<u8>>) -> Self {
         self.keys = keys;

--- a/src/common/meta/src/rpc/store.rs
+++ b/src/common/meta/src/rpc/store.rs
@@ -510,6 +510,13 @@ impl BatchDeleteRequest {
     }
 
     #[inline]
+    /// Sets `keys`.
+    pub fn with_keys(mut self, keys: Vec<Vec<u8>>) -> Self {
+        self.keys = keys;
+        self
+    }
+
+    #[inline]
     pub fn add_key(mut self, key: impl Into<Vec<u8>>) -> Self {
         self.keys.push(key.into());
         self


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your 

1. Introduce `move_values` in `TombstoneManager`
2. Ensure all moving values remain unchanged between two transactions
3. Make `delete_table_metadata` and `restore_table_metadata` to be Idempotent.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
