### PR TITLE
docs: add style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ GreptimeDB uses the [Apache 2.0 license](https://github.com/GreptimeTeam/greptim
 
 - To ensure that community is free and confident in its ability to use your contributions, please sign the Contributor License Agreement (CLA) which will be incorporated in the pull request process.
 - Make sure all files have proper license header (running `docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 format` from the project root).
-- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/).
+- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/) and [style guide](http://github.com/greptimeTeam/docs/style-guide.md).
 - Make sure all unit tests are passed (using `cargo test --workspace` or [nextest](https://nexte.st/index.html) `cargo nextest run`).
 - Make sure all clippy warnings are fixed (you can check it locally by running `cargo clippy --workspace --all-targets -- -D warnings`).
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -39,4 +39,8 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 
 - Define a custom error type for the module if needed.
 - Prefer `with_context()` over `context()` when allocation is needed to construct an error.
-  
+- Use `error!()` or `warn!()` macros in the `common_telemetry` crate to log errors. E.g.:
+
+```rust
+error!(e; "Failed to do something");
+```

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -8,11 +8,13 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 
 - Formatting
 - Modules
+- Comments
 
 ## Formatting
 
 - Place all `mod` declaration before any `use`.
 - Use `unimplemented!()` instead of `todo!()` for things that aren't likely to be implemented.
+- Add an empty line before and after declaration blocks.
 
 ## Modules
 
@@ -25,3 +27,9 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 │  └── write_cache.rs
 └── cache.rs
 ```
+
+## Comments
+
+- Add comments for public functions and structs.
+- Prefer document comment (`///`) over normal comment (`//`) for structs, fields, functions etc.
+- Add link (`[]`) to struct, method, or any other reference. And make sure that link works.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -15,6 +15,7 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 - Place all `mod` declaration before any `use`.
 - Use `unimplemented!()` instead of `todo!()` for things that aren't likely to be implemented.
 - Add an empty line before and after declaration blocks.
+- Place comment before attributes (`#[]`) and derive (`#[derive]`).
 
 ## Modules
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -34,3 +34,9 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 - Add comments for public functions and structs.
 - Prefer document comment (`///`) over normal comment (`//`) for structs, fields, functions etc.
 - Add link (`[]`) to struct, method, or any other reference. And make sure that link works.
+
+## Error handling
+
+- Define a custom error type for the module if needed.
+- Prefer `with_context()` over `context()` when allocation is needed to construct an error.
+  

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,27 @@
+# GreptimeDB Style Guide
+
+This style guide is intended to help contributors to GreptimeDB write code that is consistent with the rest of the codebase. It is a living document and will be updated as the codebase evolves.
+
+It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/style-guide/rust/).
+
+## Table of Contents
+
+- Formatting
+- Modules
+
+## Formatting
+
+- Place all `mod` declaration before any `use`.
+- Use `unimplemented!()` instead of `todo!()` for things that aren't likely to be implemented.
+
+## Modules
+
+- Use the file with same name instead of `mod.rs` to define a module. E.g.:
+
+```
+.
+├── cache
+│  ├── cache_size.rs
+│  └── write_cache.rs
+└── cache.rs
+```


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Add GreptimeDB specific style guide.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
