### PR TITLE
feat: add tinytext, mediumtext and longtext data types

### DIFF
--- a/src/sql/src/statements/transform/type_alias.rs
+++ b/src/sql/src/statements/transform/type_alias.rs
@@ -35,6 +35,7 @@ use crate::statements::{sql_data_type_to_concrete_data_type, TimezoneInfo};
 ///  - `INT32` for `int`
 ///  - `INT64` for `bigint`
 ///  -  And `UINT8`, `UINT16` etc. for `UnsignedTinyint` etc.
+///  -  TinyText, MediumText, LongText for `Text`.
 pub(crate) struct TypeAliasTransformRule;
 
 impl TransformRule for TypeAliasTransformRule {
@@ -158,6 +159,8 @@ pub fn get_data_type_by_alias_name(name: &str) -> Option<DataType> {
         "UINT64" => Some(DataType::UnsignedBigInt(None)),
         "FLOAT32" => Some(DataType::Float(None)),
         "FLOAT64" => Some(DataType::Double),
+        // String type alias
+        "TINYTEXT" | "MEDIUMTEXT" | "LONGTEXT" => Some(DataType::Text),
         _ => None,
     }
 }
@@ -261,6 +264,18 @@ mod tests {
             get_data_type_by_alias_name("Timestamp_ns"),
             Some(DataType::Timestamp(Some(9), TimezoneInfo::None))
         );
+        assert_eq!(
+            get_data_type_by_alias_name("TinyText"),
+            Some(DataType::Text)
+        );
+        assert_eq!(
+            get_data_type_by_alias_name("MediumText"),
+            Some(DataType::Text)
+        );
+        assert_eq!(
+            get_data_type_by_alias_name("LongText"),
+            Some(DataType::Text)
+        );
     }
 
     fn test_timestamp_alias(alias: &str, expected: &str) {
@@ -303,6 +318,9 @@ mod tests {
         let sql = r#"
 CREATE TABLE data_types (
   s string,
+  tt tinytext,
+  mt mediumtext,
+  lt longtext,
   tint int8,
   sint int16,
   i int32,
@@ -329,6 +347,9 @@ CREATE TABLE data_types (
             Statement::CreateTable(c) => {
                 let expected = r#"CREATE TABLE  data_types (
   s STRING,
+  tt TEXT,
+  mt TEXT,
+  lt TEXT,
   tint INT8,
   sint SMALLINT,
   i INT,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #3703 

## What's changed and what's your intention?

Add `TINYTEXT`, `MEDIUMTEXT` and `LONGTEXT` as alias of `TEXT` for compatibility with MYSQL.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
