### PR TITLE
refactor: avoid unnecessary alloc by using unwrap_or_else

### DIFF
--- a/src/operator/src/statement/tql.rs
+++ b/src/operator/src/statement/tql.rs
@@ -37,7 +37,9 @@ impl StatementExecutor {
                     end: eval.end,
                     step: eval.step,
                     query: eval.query,
-                    lookback: eval.lookback.unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+                    lookback: eval
+                        .lookback
+                        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
                 };
                 QueryLanguageParser::parse_promql(&promql, &query_ctx).context(ParseQuerySnafu)?
             }
@@ -46,7 +48,7 @@ impl StatementExecutor {
                     query: explain.query,
                     lookback: explain
                         .lookback
-                        .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+                        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
                     ..PromQuery::default()
                 };
                 let explain_node_name = if explain.is_verbose {
@@ -69,7 +71,7 @@ impl StatementExecutor {
                     query: analyze.query,
                     lookback: analyze
                         .lookback
-                        .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+                        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
                 };
                 let analyze_node_name = if analyze.is_verbose {
                     ANALYZE_VERBOSE_NODE_NAME

--- a/src/servers/src/http/handler.rs
+++ b/src/servers/src/http/handler.rs
@@ -218,7 +218,7 @@ impl From<PromqlQuery> for PromQuery {
             step: query.step,
             lookback: query
                 .lookback
-                .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+                .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
         }
     }
 }

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -182,7 +182,7 @@ pub async fn instant_query(
         lookback: params
             .lookback
             .or(form_params.lookback)
-            .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+            .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
     };
 
     let result = handler.do_query(&prom_query, query_ctx).await;
@@ -225,7 +225,7 @@ pub async fn range_query(
         lookback: params
             .lookback
             .or(form_params.lookback)
-            .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string()),
+            .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string()),
     };
 
     let result = handler.do_query(&prom_query, query_ctx).await;
@@ -324,7 +324,7 @@ pub async fn labels_query(
     let lookback = params
         .lookback
         .or(form_params.lookback)
-        .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string());
+        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
 
     let mut labels = HashSet::new();
     let _ = labels.insert(METRIC_NAME.to_string());
@@ -607,7 +607,7 @@ pub async fn label_values_query(
     let end = params.end.unwrap_or_else(current_time_rfc3339);
     let lookback = params
         .lookback
-        .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string());
+        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
 
     let mut label_values = HashSet::new();
 
@@ -752,7 +752,7 @@ pub async fn series_query(
     let lookback = params
         .lookback
         .or(form_params.lookback)
-        .unwrap_or(DEFAULT_LOOKBACK_STRING.to_string());
+        .unwrap_or_else(|| DEFAULT_LOOKBACK_STRING.to_string());
 
     let mut series = Vec::new();
     let mut merge_map = HashMap::new();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/3453
https://github.com/GreptimeTeam/greptimedb/pull/3630

## What's changed and what's your intention?
improve the implementation by avoid an allocation if the lookback value is provided.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
