### PR TITLE
feat(fuzz): add create logical table target

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ "fuzz_create_table", "fuzz_alter_table", "fuzz_create_database" ]
+        target: [ "fuzz_create_table", "fuzz_alter_table", "fuzz_create_database", "fuzz_create_logical_table" ]
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/setup-protoc@v3

--- a/tests-fuzz/Cargo.toml
+++ b/tests-fuzz/Cargo.toml
@@ -51,6 +51,13 @@ bench = false
 doc = false
 
 [[bin]]
+name = "fuzz_create_logical_table"
+path = "targets/fuzz_create_logical_table.rs"
+test = false
+bench = false
+doc = false
+
+[[bin]]
 name = "fuzz_insert"
 path = "targets/fuzz_insert.rs"
 test = false

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -277,6 +277,9 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateLogicalTableExprG
             .unwrap();
 
         let mut table = table_generator.generate(rng)?;
+        while table.table_name.value == physical_table_name {
+            table.table_name = table_generator.name_generator.gen(rng);
+        }
         let logical_ts = table.columns.iter().position(|column| {
             column
                 .options
@@ -290,8 +293,8 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateLogicalTableExprG
                 .options
                 .retain(|option| option == &ColumnOption::PrimaryKey);
             // Ensures the column name is unique.
-            while column.name == self.table_ctx.columns[0].name
-                || column.name == self.table_ctx.columns[1].name
+            while column.name.value == self.table_ctx.columns[0].name.value
+                || column.name.value == self.table_ctx.columns[1].name.value
             {
                 column.name = table_generator.name_generator.gen(rng);
             }

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -30,9 +30,9 @@ use crate::generator::{ColumnOptionGenerator, ConcreteDataTypeGenerator, Random}
 use crate::ir::create_expr::{ColumnOption, CreateDatabaseExprBuilder, CreateTableExprBuilder};
 use crate::ir::{
     column_options_generator, generate_columns, generate_random_value,
-    partible_column_options_generator, primary_key_and_not_null_column_options_generator,
-    ts_column_options_generator, Column, ColumnTypeGenerator, CreateDatabaseExpr, CreateTableExpr,
-    Ident, PartibleColumnTypeGenerator, StringColumnTypeGenerator, TsColumnTypeGenerator,
+    partible_column_options_generator, primary_key_options_generator, ts_column_options_generator,
+    Column, ColumnTypeGenerator, CreateDatabaseExpr, CreateTableExpr, Ident,
+    PartibleColumnTypeGenerator, StringColumnTypeGenerator, TsColumnTypeGenerator,
 };
 
 #[derive(Builder)]
@@ -286,16 +286,8 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateLogicalTableExprG
             rng,
             column_names,
             &StringColumnTypeGenerator,
-            Box::new(primary_key_and_not_null_column_options_generator),
+            Box::new(primary_key_options_generator),
         ));
-
-        logical_table.columns.iter_mut().for_each(|column| {
-            if column.column_type == ConcreteDataType::string_datatype() {
-                column
-                    .options
-                    .retain(|option| option == &ColumnOption::PrimaryKey);
-            }
-        });
 
         // Currently only the `primary key` option is kept in physical table,
         // so we only keep the `primary key` option in the logical table for fuzz test.

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -206,7 +206,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
     }
 }
 
-/// Generates a physical table.
+/// Generate a physical table with 2 columns: time index and value.
 #[derive(Builder)]
 #[builder(pattern = "owned")]
 pub struct CreatePhysicalTableExprGenerator<R: Rng + 'static> {
@@ -219,7 +219,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreatePhysicalTableExpr
 
     fn generate(&self, rng: &mut R) -> Result<CreateTableExpr> {
         let if_not_exists = rng.gen_bool(0.5);
-        // Simply generates a physical table with two columns.
+
         let create_physical_table_generator = CreateTableExprGeneratorBuilder::default()
             .name_generator(Box::new(MappedGenerator::new(
                 WordGenerator,
@@ -236,7 +236,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreatePhysicalTableExpr
     }
 }
 
-/// Generates a logical table based on an existing physical table.
+/// Generate a logical table based on an existing physical table.
 #[derive(Builder)]
 #[builder(pattern = "owned")]
 pub struct CreateLogicalTableExprGenerator<R: Rng + 'static> {
@@ -250,7 +250,7 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateLogicalTableExprG
     type Error = Error;
 
     fn generate(&self, rng: &mut R) -> Result<CreateTableExpr> {
-        // Currently we mock the usage of GreptimeDB as Prometheu's backend, the physical table must have two columns.
+        // Currently we mock the usage of GreptimeDB as Prometheus' backend, the physical table must have two columns.
         ensure!(
             self.table_ctx.columns.len() == 2,
             error::UnexpectedSnafu {

--- a/tests-fuzz/src/generator/create_expr.rs
+++ b/tests-fuzz/src/generator/create_expr.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::marker::PhantomData;
 
 use datatypes::data_type::ConcreteDataType;
 use datatypes::value::Value;
@@ -213,8 +212,6 @@ impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateTableExprGenerato
 pub struct CreatePhysicalTableExprGenerator<R: Rng + 'static> {
     #[builder(default = "Box::new(WordGenerator)")]
     name_generator: Box<dyn Random<Ident, R>>,
-    #[builder(default)]
-    _phantom: PhantomData<R>,
 }
 
 impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreatePhysicalTableExprGenerator<R> {
@@ -254,8 +251,6 @@ pub struct CreateLogicalTableExprGenerator<R: Rng + 'static> {
     #[builder(default = "Box::new(WordGenerator)")]
     name_generator: Box<dyn Random<Ident, R>>,
     labels: usize,
-    #[builder(default)]
-    _phantom: PhantomData<R>,
 }
 
 impl<R: Rng + 'static> Generator<CreateTableExpr, R> for CreateLogicalTableExprGenerator<R> {

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -63,6 +63,8 @@ lazy_static! {
         ConcreteDataType::date_datatype(),
         ConcreteDataType::datetime_datatype(),
     ];
+    pub static ref STRING_DATA_TYPES: Vec<ConcreteDataType> =
+        vec![ConcreteDataType::string_datatype(),];
 }
 
 impl_random!(ConcreteDataType, ColumnTypeGenerator, DATA_TYPES);
@@ -72,10 +74,16 @@ impl_random!(
     PartibleColumnTypeGenerator,
     PARTIBLE_DATA_TYPES
 );
+impl_random!(
+    ConcreteDataType,
+    StringColumnTypeGenerator,
+    STRING_DATA_TYPES
+);
 
 pub struct ColumnTypeGenerator;
 pub struct TsColumnTypeGenerator;
 pub struct PartibleColumnTypeGenerator;
+pub struct StringColumnTypeGenerator;
 
 /// Generates a random [Value].
 pub fn generate_random_value<R: Rng>(
@@ -316,6 +324,13 @@ pub fn ts_column_options_generator<R: Rng + 'static>(
     _: &ConcreteDataType,
 ) -> Vec<ColumnOption> {
     vec![ColumnOption::TimeIndex]
+}
+
+pub fn primary_key_column_options_generator<R: Rng + 'static>(
+    _: &mut R,
+    _: &ConcreteDataType,
+) -> Vec<ColumnOption> {
+    vec![ColumnOption::PrimaryKey, ColumnOption::NotNull]
 }
 
 /// Generates columns with given `names`.

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -64,7 +64,7 @@ lazy_static! {
         ConcreteDataType::datetime_datatype(),
     ];
     pub static ref STRING_DATA_TYPES: Vec<ConcreteDataType> =
-        vec![ConcreteDataType::string_datatype(),];
+        vec![ConcreteDataType::string_datatype()];
 }
 
 impl_random!(ConcreteDataType, ColumnTypeGenerator, DATA_TYPES);
@@ -326,7 +326,7 @@ pub fn ts_column_options_generator<R: Rng + 'static>(
     vec![ColumnOption::TimeIndex]
 }
 
-pub fn primary_key_column_options_generator<R: Rng + 'static>(
+pub fn primary_key_and_not_null_column_options_generator<R: Rng + 'static>(
     _: &mut R,
     _: &ConcreteDataType,
 ) -> Vec<ColumnOption> {

--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -333,6 +333,13 @@ pub fn primary_key_and_not_null_column_options_generator<R: Rng + 'static>(
     vec![ColumnOption::PrimaryKey, ColumnOption::NotNull]
 }
 
+pub fn primary_key_options_generator<R: Rng + 'static>(
+    _: &mut R,
+    _: &ConcreteDataType,
+) -> Vec<ColumnOption> {
+    vec![ColumnOption::PrimaryKey]
+}
+
 /// Generates columns with given `names`.
 pub fn generate_columns<R: Rng + 'static>(
     rng: &mut R,

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -88,6 +88,10 @@ fn generate_create_logical_table_expr<R: Rng + 'static>(
     let if_not_exists = rng.gen_bool(0.5);
     let columns = rng.gen_range(2..30);
     let overlapped_columns = rng.gen_range(0..table_ctx.columns.len() - 1);
+
+    // Sometimes the name of the table is like `table_name` with backticks, we need to remove them in the with clause
+    let physical_table_name = table_ctx.name.to_string().replace('`', "");
+
     let create_table_generator = CreateTableExprGeneratorBuilder::default()
         .name_generator(Box::new(MappedGenerator::new(
             WordGenerator,
@@ -96,7 +100,7 @@ fn generate_create_logical_table_expr<R: Rng + 'static>(
         .columns(columns)
         .engine("metric")
         .if_not_exists(if_not_exists)
-        .with_clause([("on_physical_table".to_string(), table_ctx.name.to_string())])
+        .with_clause([("on_physical_table".to_string(), physical_table_name)])
         .build()
         .unwrap();
 

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -17,23 +17,20 @@
 use std::sync::Arc;
 
 use common_telemetry::info;
+use datatypes::data_type::ConcreteDataType;
 use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use snafu::ResultExt;
 use sqlx::{MySql, Pool};
-use tests_fuzz::context::{TableContext, TableContextRef};
+use tests_fuzz::context::TableContext;
 use tests_fuzz::error::{self, Result};
-use tests_fuzz::fake::{
-    merge_two_word_map_fn, random_capitalize_map, uppercase_and_keyword_backtick_map,
-    MappedGenerator, WordGenerator,
-};
 use tests_fuzz::generator::create_expr::{
-    CreateLogicalTableExprGeneratorBuilder, CreateTableExprGeneratorBuilder,
+    CreateLogicalTableExprGeneratorBuilder, CreatePhysicalTableExprGeneratorBuilder,
 };
 use tests_fuzz::generator::Generator;
-use tests_fuzz::ir::CreateTableExpr;
+use tests_fuzz::ir::{primary_key_column_options_generator, Column};
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::DslTranslator;
 use tests_fuzz::utils::{init_greptime_connections, Connections};
@@ -64,61 +61,15 @@ impl Arbitrary<'_> for FuzzInput {
     }
 }
 
-fn generate_create_physical_table_expr<R: Rng + 'static>(rng: &mut R) -> Result<CreateTableExpr> {
-    let if_not_exists = rng.gen_bool(0.5);
-    let columns = rng.gen_range(2..30);
-    let create_physical_table_generator = CreateTableExprGeneratorBuilder::default()
-        .name_generator(Box::new(MappedGenerator::new(
-            WordGenerator,
-            merge_two_word_map_fn(random_capitalize_map, uppercase_and_keyword_backtick_map),
-        )))
-        .columns(columns)
-        .engine("metric")
-        .if_not_exists(if_not_exists)
-        .with_clause([("physical_metric_table".to_string(), "".to_string())])
-        .build()
-        .unwrap();
-    create_physical_table_generator.generate(rng)
-}
-
-fn generate_create_logical_table_expr<R: Rng + 'static>(
-    table_ctx: TableContextRef,
-    rng: &mut R,
-) -> Result<CreateTableExpr> {
-    let if_not_exists = rng.gen_bool(0.5);
-    let columns = rng.gen_range(2..30);
-    let overlapped_columns = rng.gen_range(0..table_ctx.columns.len() - 1);
-
-    // Sometimes the name of the table is like `table_name` with backticks, we need to remove them in the with clause
-    let physical_table_name = table_ctx.name.to_string().replace('`', "");
-
-    let create_table_generator = CreateTableExprGeneratorBuilder::default()
-        .name_generator(Box::new(MappedGenerator::new(
-            WordGenerator,
-            merge_two_word_map_fn(random_capitalize_map, uppercase_and_keyword_backtick_map),
-        )))
-        .columns(columns)
-        .engine("metric")
-        .if_not_exists(if_not_exists)
-        .with_clause([("on_physical_table".to_string(), physical_table_name)])
-        .build()
-        .unwrap();
-
-    let create_logical_table_generator = CreateLogicalTableExprGeneratorBuilder::default()
-        .table_ctx(table_ctx)
-        .table_generator(create_table_generator)
-        .overlapped_columns(overlapped_columns)
-        .build()
-        .unwrap();
-    create_logical_table_generator.generate(rng)
-}
-
 async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
     info!("input: {input:?}");
     let mut rng = ChaChaRng::seed_from_u64(input.seed);
 
     // Create physical table
-    let create_physical_table_expr = generate_create_physical_table_expr(&mut rng)?;
+    let create_physical_table_expr = CreatePhysicalTableExprGeneratorBuilder::default()
+        .build()
+        .unwrap()
+        .generate(&mut rng)?;
     let translator = CreateTableExprTranslator;
     let sql = translator.translate(&create_physical_table_expr)?;
     let result = sqlx::query(&sql)
@@ -127,12 +78,37 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
         .context(error::ExecuteQuerySnafu { sql: &sql })?;
     info!("Create physical table: {sql}, result: {result:?}");
 
+    let mut physical_table_columns = create_physical_table_expr.columns.clone();
+    physical_table_columns.push({
+        let column_type = ConcreteDataType::uint64_datatype();
+        let options = primary_key_column_options_generator(&mut rng, &column_type);
+        Column {
+            name: "__tsid".into(),
+            column_type,
+            options,
+        }
+    });
+    physical_table_columns.push({
+        let column_type = ConcreteDataType::uint32_datatype();
+        let options = primary_key_column_options_generator(&mut rng, &column_type);
+        Column {
+            name: "__table_id".into(),
+            column_type,
+            options,
+        }
+    });
+
     // Create logical table
     let table_ctx = Arc::new(TableContext::from(&create_physical_table_expr));
     for _ in 0..input.actions {
-        let create_logical_table_expr =
-            generate_create_logical_table_expr(table_ctx.clone(), &mut rng)?;
-        let translator = CreateTableExprTranslator;
+        let labels = rng.gen_range(1..=5);
+
+        let create_logical_table_expr = CreateLogicalTableExprGeneratorBuilder::default()
+            .table_ctx(table_ctx.clone())
+            .labels(labels)
+            .build()
+            .unwrap()
+            .generate(&mut rng)?;
         let sql = translator.translate(&create_logical_table_expr)?;
         let result = sqlx::query(&sql)
             .execute(&ctx.greptime)
@@ -140,7 +116,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
             .context(error::ExecuteQuerySnafu { sql: &sql })?;
         info!("Create logical table: {sql}, result: {result:?}");
 
-        // Validate columns
+        // Validate columns in logical table
         let mut column_entries = validator::column::fetch_columns(
             &ctx.greptime,
             "public".into(),
@@ -152,7 +128,21 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
         columns.sort_by(|a, b| a.name.value.cmp(&b.name.value));
         validator::column::assert_eq(&column_entries, &columns)?;
 
-        // Cleans up logical table
+        // Validate columns in physical table
+        columns.retain(|column| column.column_type == ConcreteDataType::string_datatype());
+        physical_table_columns.append(&mut columns);
+        physical_table_columns.sort_by(|a, b| a.name.value.cmp(&b.name.value));
+
+        let mut column_entries = validator::column::fetch_columns(
+            &ctx.greptime,
+            "public".into(),
+            create_physical_table_expr.table_name.clone(),
+        )
+        .await?;
+        column_entries.sort_by(|a, b| a.column_name.cmp(&b.column_name));
+        validator::column::assert_eq(&column_entries, &physical_table_columns)?;
+
+        // Clean up logical table
         let sql = format!("DROP TABLE {}", create_logical_table_expr.table_name);
         let result = sqlx::query(&sql)
             .execute(&ctx.greptime)
@@ -164,7 +154,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
         );
     }
 
-    // Cleans up physical table
+    // Clean up physical table
     let sql = format!("DROP TABLE {}", create_physical_table_expr.table_name);
     let result = sqlx::query(&sql)
         .execute(&ctx.greptime)

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -1,0 +1,178 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use std::sync::Arc;
+
+use common_telemetry::info;
+use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaChaRng;
+use snafu::ResultExt;
+use sqlx::{MySql, Pool};
+use tests_fuzz::context::{TableContext, TableContextRef};
+use tests_fuzz::error::{self, Result};
+use tests_fuzz::fake::{
+    merge_two_word_map_fn, random_capitalize_map, uppercase_and_keyword_backtick_map,
+    MappedGenerator, WordGenerator,
+};
+use tests_fuzz::generator::create_expr::{
+    CreateLogicalTableExprGeneratorBuilder, CreateTableExprGeneratorBuilder,
+};
+use tests_fuzz::generator::Generator;
+use tests_fuzz::ir::CreateTableExpr;
+use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
+use tests_fuzz::translator::DslTranslator;
+use tests_fuzz::utils::{init_greptime_connections, Connections};
+use tests_fuzz::validator;
+
+struct FuzzContext {
+    greptime: Pool<MySql>,
+}
+
+impl FuzzContext {
+    async fn close(self) {
+        self.greptime.close().await;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct FuzzInput {
+    seed: u64,
+    actions: usize,
+}
+
+impl Arbitrary<'_> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let seed = u.int_in_range(u64::MIN..=u64::MAX)?;
+        let mut rng = ChaChaRng::seed_from_u64(seed);
+        let actions = rng.gen_range(2..30);
+        Ok(FuzzInput { actions, seed })
+    }
+}
+
+fn generate_create_physical_table_expr<R: Rng + 'static>(rng: &mut R) -> Result<CreateTableExpr> {
+    let if_not_exists = rng.gen_bool(0.5);
+    let columns = rng.gen_range(2..30);
+    let create_physical_table_generator = CreateTableExprGeneratorBuilder::default()
+        .name_generator(Box::new(MappedGenerator::new(
+            WordGenerator,
+            merge_two_word_map_fn(random_capitalize_map, uppercase_and_keyword_backtick_map),
+        )))
+        .columns(columns)
+        .engine("metric")
+        .if_not_exists(if_not_exists)
+        .with_clause([("physical_metric_table".to_string(), "".to_string())])
+        .build()
+        .unwrap();
+    create_physical_table_generator.generate(rng)
+}
+
+fn generate_create_logical_table_expr<R: Rng + 'static>(
+    table_ctx: TableContextRef,
+    rng: &mut R,
+) -> Result<CreateTableExpr> {
+    let if_not_exists = rng.gen_bool(0.5);
+    let columns = rng.gen_range(2..30);
+    let overlapped_columns = rng.gen_range(0..table_ctx.columns.len() - 1);
+    let create_table_generator = CreateTableExprGeneratorBuilder::default()
+        .name_generator(Box::new(MappedGenerator::new(
+            WordGenerator,
+            merge_two_word_map_fn(random_capitalize_map, uppercase_and_keyword_backtick_map),
+        )))
+        .columns(columns)
+        .engine("metric")
+        .if_not_exists(if_not_exists)
+        .with_clause([("on_physical_table".to_string(), table_ctx.name.to_string())])
+        .build()
+        .unwrap();
+
+    let create_logical_table_generator = CreateLogicalTableExprGeneratorBuilder::default()
+        .table_ctx(table_ctx)
+        .table_generator(create_table_generator)
+        .overlapped_columns(overlapped_columns)
+        .build()
+        .unwrap();
+    create_logical_table_generator.generate(rng)
+}
+
+async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
+    info!("input: {input:?}");
+    let mut rng = ChaChaRng::seed_from_u64(input.seed);
+
+    // Create physical table
+    let create_physical_table_expr = generate_create_physical_table_expr(&mut rng)?;
+    let translator = CreateTableExprTranslator;
+    let sql = translator.translate(&create_physical_table_expr)?;
+    let result = sqlx::query(&sql)
+        .execute(&ctx.greptime)
+        .await
+        .context(error::ExecuteQuerySnafu { sql: &sql })?;
+    info!("Create physical table: {sql}, result: {result:?}");
+
+    // Create logical table
+    let table_ctx = Arc::new(TableContext::from(&create_physical_table_expr));
+    for _ in 0..input.actions {
+        let create_logical_table_expr =
+            generate_create_logical_table_expr(table_ctx.clone(), &mut rng)?;
+        let translator = CreateTableExprTranslator;
+        let sql = translator.translate(&create_logical_table_expr)?;
+        let result = sqlx::query(&sql)
+            .execute(&ctx.greptime)
+            .await
+            .context(error::ExecuteQuerySnafu { sql: &sql })?;
+        info!("Create logical table: {sql}, result: {result:?}");
+
+        // Validate columns
+        let mut column_entries = validator::column::fetch_columns(
+            &ctx.greptime,
+            "public".into(),
+            create_logical_table_expr.table_name.clone(),
+        )
+        .await?;
+        column_entries.sort_by(|a, b| a.column_name.cmp(&b.column_name));
+        let mut columns = create_logical_table_expr.columns.clone();
+        columns.sort_by(|a, b| a.name.value.cmp(&b.name.value));
+        validator::column::assert_eq(&column_entries, &columns)?;
+
+        // Cleans up
+        let sql = format!("DROP TABLE {}", create_logical_table_expr.table_name);
+        let result = sqlx::query(&sql)
+            .execute(&ctx.greptime)
+            .await
+            .context(error::ExecuteQuerySnafu { sql: &sql })?;
+        info!(
+            "Drop table: {}, result: {result:?}",
+            create_logical_table_expr.table_name
+        );
+    }
+    ctx.close().await;
+
+    Ok(())
+}
+
+fuzz_target!(|input: FuzzInput| {
+    common_telemetry::init_default_ut_logging();
+    common_runtime::block_on_write(async {
+        let Connections { mysql } = init_greptime_connections().await;
+        let ctx = FuzzContext {
+            greptime: mysql.expect("mysql connection init must be succeed"),
+        };
+        execute_create_logic_table(ctx, input)
+            .await
+            .unwrap_or_else(|err| panic!("fuzz test must be succeed: {err:?}"));
+    })
+});

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -148,7 +148,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
         columns.sort_by(|a, b| a.name.value.cmp(&b.name.value));
         validator::column::assert_eq(&column_entries, &columns)?;
 
-        // Cleans up
+        // Cleans up logical table
         let sql = format!("DROP TABLE {}", create_logical_table_expr.table_name);
         let result = sqlx::query(&sql)
             .execute(&ctx.greptime)
@@ -159,6 +159,18 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
             create_logical_table_expr.table_name
         );
     }
+
+    // Cleans up physical table
+    let sql = format!("DROP TABLE {}", create_physical_table_expr.table_name);
+    let result = sqlx::query(&sql)
+        .execute(&ctx.greptime)
+        .await
+        .context(error::ExecuteQuerySnafu { sql })?;
+    info!(
+        "Drop table: {}, result: {result:?}",
+        create_physical_table_expr.table_name
+    );
+
     ctx.close().await;
 
     Ok(())

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -67,11 +67,13 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
     let mut rng = ChaChaRng::seed_from_u64(input.seed);
 
     // Create physical table
+    let physical_table_if_not_exists = rng.gen_bool(0.5);
     let create_physical_table_expr = CreatePhysicalTableExprGeneratorBuilder::default()
         .name_generator(Box::new(MappedGenerator::new(
             WordGenerator,
             merge_two_word_map_fn(random_capitalize_map, uppercase_and_keyword_backtick_map),
         )))
+        .if_not_exists(physical_table_if_not_exists)
         .build()
         .unwrap()
         .generate(&mut rng)?;
@@ -106,6 +108,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
     // Create logical table
     let physical_table_ctx = Arc::new(TableContext::from(&create_physical_table_expr));
     let labels = rng.gen_range(1..=5);
+    let logical_table_if_not_exists = rng.gen_bool(0.5);
 
     let create_logical_table_expr = CreateLogicalTableExprGeneratorBuilder::default()
         .name_generator(Box::new(MappedGenerator::new(
@@ -114,6 +117,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
         )))
         .physical_table_ctx(physical_table_ctx)
         .labels(labels)
+        .if_not_exists(logical_table_if_not_exists)
         .build()
         .unwrap()
         .generate(&mut rng)?;

--- a/tests-fuzz/targets/fuzz_create_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_create_logical_table.rs
@@ -34,7 +34,7 @@ use tests_fuzz::generator::create_expr::{
     CreateLogicalTableExprGeneratorBuilder, CreatePhysicalTableExprGeneratorBuilder,
 };
 use tests_fuzz::generator::Generator;
-use tests_fuzz::ir::{primary_key_column_options_generator, Column};
+use tests_fuzz::ir::{primary_key_and_not_null_column_options_generator, Column};
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::DslTranslator;
 use tests_fuzz::utils::{init_greptime_connections, Connections};
@@ -88,7 +88,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
     let mut physical_table_columns = create_physical_table_expr.columns.clone();
     physical_table_columns.push({
         let column_type = ConcreteDataType::uint64_datatype();
-        let options = primary_key_column_options_generator(&mut rng, &column_type);
+        let options = primary_key_and_not_null_column_options_generator(&mut rng, &column_type);
         Column {
             name: "__tsid".into(),
             column_type,
@@ -97,7 +97,7 @@ async fn execute_create_logic_table(ctx: FuzzContext, input: FuzzInput) -> Resul
     });
     physical_table_columns.push({
         let column_type = ConcreteDataType::uint32_datatype();
-        let options = primary_key_column_options_generator(&mut rng, &column_type);
+        let options = primary_key_and_not_null_column_options_generator(&mut rng, &column_type);
         Column {
             name: "__table_id".into(),
             column_type,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#3741 and #3174

## What's changed and what's your intention?

Fuzz test for metric engine. Create some logical tables on the same physical table.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
