### PR TITLE
ci: secrets.GITHUB_TOKEN not exist on self-hosted runner

### DIFF
--- a/.github/actions/build-windows-artifacts/action.yml
+++ b/.github/actions/build-windows-artifacts/action.yml
@@ -26,8 +26,6 @@ runs:
   using: composite
   steps:
     - uses: arduino/setup-protoc@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install rust toolchain
       uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

```
Error: C:\a\greptimedb\greptimedb\./.github/actions/build-windows-artifacts\action.yml (Line: 30, Col: 21): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

This default secrets doesn't exist on self-hosted runner. The TOKEN is mainly for avoid rate limitation, but that may not be quite an issue for self-hosted daily cronjob. Remove firstly to unlock the workflow. We can revisit this topic if the rate limit comes back to be an issue.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
