### PR TITLE
fix: set is_time_index properly on updating physical table's schema

### DIFF
--- a/src/common/meta/src/ddl/physical_table_metadata.rs
+++ b/src/common/meta/src/ddl/physical_table_metadata.rs
@@ -52,5 +52,9 @@ pub(crate) fn build_new_physical_table_info(
         columns.push(col.column_schema.clone());
     }
 
+    if let Some(time_index) = *time_index {
+        raw_table_info.meta.schema.column_schemas[time_index].set_time_index();
+    }
+
     raw_table_info
 }

--- a/src/datatypes/src/schema/column_schema.rs
+++ b/src/datatypes/src/schema/column_schema.rs
@@ -54,6 +54,10 @@ impl fmt::Debug for ColumnSchema {
             if self.is_nullable { "null" } else { "not null" },
         )?;
 
+        if self.is_time_index {
+            write!(f, " time_index")?;
+        }
+
         // Add default constraint if present
         if let Some(default_constraint) = &self.default_constraint {
             write!(f, " default={:?}", default_constraint)?;
@@ -157,6 +161,14 @@ impl ColumnSchema {
     /// [with_nullable_set]: Self::with_nullable_set
     pub fn set_nullable(&mut self) {
         self.is_nullable = true;
+    }
+
+    /// Set the `is_time_index` to `true` of the column.
+    /// Similar to [with_time_index] but don't take the ownership.
+    ///
+    /// [with_time_index]: Self::with_time_index
+    pub fn set_time_index(&mut self) {
+        self.is_time_index = true;
     }
 
     /// Creates a new [`ColumnSchema`] with given metadata.

--- a/tests/cases/standalone/common/alter/alter_metric_table.result
+++ b/tests/cases/standalone/common/alter/alter_metric_table.result
@@ -11,6 +11,15 @@ SHOW TABLES;
 | phy     |
 +---------+
 
+DESC TABLE phy;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| ts     | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| val    | Float64              |     | YES  |         | FIELD         |
++--------+----------------------+-----+------+---------+---------------+
+
 CREATE TABLE t1 (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
 
 Affected Rows: 0
@@ -44,7 +53,7 @@ DESC TABLE phy;
 +------------+----------------------+-----+------+---------+---------------+
 | Column     | Type                 | Key | Null | Default | Semantic Type |
 +------------+----------------------+-----+------+---------+---------------+
-| ts         | TimestampMillisecond |     | NO   |         | FIELD         |
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |
@@ -87,7 +96,7 @@ DESC TABLE phy;
 +------------+----------------------+-----+------+---------+---------------+
 | Column     | Type                 | Key | Null | Default | Semantic Type |
 +------------+----------------------+-----+------+---------+---------------+
-| ts         | TimestampMillisecond |     | NO   |         | FIELD         |
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |

--- a/tests/cases/standalone/common/alter/alter_metric_table.sql
+++ b/tests/cases/standalone/common/alter/alter_metric_table.sql
@@ -2,6 +2,8 @@ CREATE TABLE phy (ts timestamp time index, val double) engine=metric with ("phys
 
 SHOW TABLES;
 
+DESC TABLE phy;
+
 CREATE TABLE t1 (ts timestamp time index, val double, host string primary key) engine = metric with ("on_physical_table" = "phy");
 
 CREATE TABLE t2 (ts timestamp time index, job string primary key, val double) engine = metric with ("on_physical_table" = "phy");

--- a/tests/cases/standalone/common/create/create_metric_table.result
+++ b/tests/cases/standalone/common/create/create_metric_table.result
@@ -43,7 +43,7 @@ DESC TABLE phy;
 +------------+----------------------+-----+------+---------+---------------+
 | Column     | Type                 | Key | Null | Default | Semantic Type |
 +------------+----------------------+-----+------+---------+---------------+
-| ts         | TimestampMillisecond |     | NO   |         | FIELD         |
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |
@@ -83,7 +83,7 @@ DESC TABLE phy;
 +------------+----------------------+-----+------+---------+---------------+
 | Column     | Type                 | Key | Null | Default | Semantic Type |
 +------------+----------------------+-----+------+---------+---------------+
-| ts         | TimestampMillisecond |     | NO   |         | FIELD         |
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |

--- a/tests/cases/standalone/common/insert/logical_metric_table.result
+++ b/tests/cases/standalone/common/insert/logical_metric_table.result
@@ -54,7 +54,7 @@ DESC TABLE phy;
 +------------+----------------------+-----+------+---------+---------------+
 | Column     | Type                 | Key | Null | Default | Semantic Type |
 +------------+----------------------+-----+------+---------+---------------+
-| ts         | TimestampMillisecond |     | NO   |         | FIELD         |
+| ts         | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
 | val        | Float64              |     | YES  |         | FIELD         |
 | __table_id | UInt32               | PRI | NO   |         | TAG           |
 | __tsid     | UInt64               | PRI | NO   |         | TAG           |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes https://github.com/GreptimeTeam/greptimedb/issues/3758

## What's changed and what's your intention?


Related to this ticket: https://github.com/GreptimeTeam/greptimedb/issues/2798

Only `time_index` in schema is set before, but forget to set this on column_schema

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
