### PR TITLE
fix: do not remove deletion markers when window time range overlaps

### DIFF
--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -197,6 +197,54 @@ async fn test_compaction_region_with_overlapping() {
     assert_eq!((3600..10800).map(|i| { i * 1000 }).collect::<Vec<_>>(), vec);
 }
 
+#[tokio::test]
+async fn test_compaction_region_with_overlapping_delete_all() {
+    common_telemetry::init_default_ut_logging();
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.max_active_window_files", "2")
+        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .insert_option("compaction.twcs.time_window", "1h")
+        .build();
+
+    let column_schemas = request
+        .column_metadatas
+        .iter()
+        .map(column_metadata_to_column_schema)
+        .collect::<Vec<_>>();
+    engine
+        .handle_request(region_id, RegionRequest::Create(request))
+        .await
+        .unwrap();
+    // Flush 4 SSTs for compaction.
+    put_and_flush(&engine, region_id, &column_schemas, 0..1200).await; // window 3600
+    put_and_flush(&engine, region_id, &column_schemas, 0..2400).await; // window 3600
+    put_and_flush(&engine, region_id, &column_schemas, 0..3600).await; // window 3600
+    delete_and_flush(&engine, region_id, &column_schemas, 0..10800).await; // window 10800
+
+    let result = engine
+        .handle_request(region_id, RegionRequest::Compact(RegionCompactRequest {}))
+        .await
+        .unwrap();
+    assert_eq!(result.affected_rows, 0);
+
+    let scanner = engine.scanner(region_id, ScanRequest::default()).unwrap();
+    assert_eq!(
+        4,
+        scanner.num_files(),
+        "unexpected files: {:?}",
+        scanner.file_ids()
+    );
+    let stream = scanner.scan().await.unwrap();
+
+    let vec = collect_stream_ts(stream).await;
+    assert!(vec.is_empty());
+}
+
 // For issue https://github.com/GreptimeTeam/greptimedb/issues/3633
 #[tokio::test]
 async fn test_readonly_during_compaction() {

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -396,6 +396,7 @@ pub struct CreateRequestBuilder {
     primary_key: Option<Vec<ColumnId>>,
     all_not_null: bool,
     engine: String,
+    ts_type: ConcreteDataType,
 }
 
 impl Default for CreateRequestBuilder {
@@ -408,6 +409,7 @@ impl Default for CreateRequestBuilder {
             primary_key: None,
             all_not_null: false,
             engine: MITO_ENGINE_NAME.to_string(),
+            ts_type: ConcreteDataType::timestamp_millisecond_datatype(),
         }
     }
 }
@@ -454,6 +456,12 @@ impl CreateRequestBuilder {
         self
     }
 
+    #[must_use]
+    pub fn with_ts_type(mut self, ty: ConcreteDataType) -> Self {
+        self.ts_type = ty;
+        self
+    }
+
     pub fn build(&self) -> RegionCreateRequest {
         let mut column_id = 0;
         let mut column_metadatas = Vec::with_capacity(self.tag_num + self.field_num + 1);
@@ -487,7 +495,7 @@ impl CreateRequestBuilder {
         column_metadatas.push(ColumnMetadata {
             column_schema: ColumnSchema::new(
                 "ts",
-                ConcreteDataType::timestamp_millisecond_datatype(),
+                self.ts_type.clone(),
                 // Time index is always not null.
                 false,
             ),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR disables deletion marker removal when some window's time range overlaps with another window, so that deletion markers will not be removed, which may cause deleted rows appear again.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
