### PR TITLE
fix: dynamically get python udf from scripts table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8842,6 +8842,7 @@ dependencies = [
  "common-error",
  "common-function",
  "common-macro",
+ "common-meta",
  "common-query",
  "common-recordbatch",
  "common-runtime",

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -275,11 +275,12 @@ impl StartCommand {
             cached_meta_backend.clone(),
             catalog_manager,
             Arc::new(DatanodeClients::default()),
-            meta_client,
+            meta_client.clone(),
         )
         .with_plugin(plugins.clone())
         .with_cache_invalidator(multi_cache_invalidator)
         .with_heartbeat_task(heartbeat_task)
+        .with_meta_client(meta_client.clone())
         .try_build()
         .await
         .context(StartFrontendSnafu)?;

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -151,6 +151,7 @@ impl Instance {
             .enable_heartbeat()
             .enable_procedure()
             .enable_access_cluster_info()
+            .enable_lock()
             .channel_manager(channel_manager)
             .ddl_channel_manager(ddl_channel_manager)
             .build();

--- a/src/meta-client/src/client.rs
+++ b/src/meta-client/src/client.rs
@@ -22,6 +22,8 @@ mod cluster;
 mod store;
 mod util;
 
+use std::sync::Arc;
+
 use api::v1::meta::Role;
 use cluster::Client as ClusterClient;
 use common_error::ext::BoxedError;
@@ -206,6 +208,8 @@ pub struct MetaClient {
     procedure: Option<ProcedureClient>,
     cluster: Option<ClusterClient>,
 }
+
+pub type MetaClientRef = Arc<MetaClient>;
 
 #[async_trait::async_trait]
 impl ProcedureExecutor for MetaClient {

--- a/src/meta-srv/src/mocks.rs
+++ b/src/meta-srv/src/mocks.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use api::v1::meta::heartbeat_server::HeartbeatServer;
+use api::v1::meta::lock_server::LockServer;
 use api::v1::meta::procedure_service_server::ProcedureServiceServer;
 use api::v1::meta::store_server::StoreServer;
 use client::client_manager::DatanodeClients;
@@ -84,6 +85,7 @@ pub async fn mock(
             .add_service(HeartbeatServer::new(service.clone()))
             .add_service(StoreServer::new(service.clone()))
             .add_service(ProcedureServiceServer::new(service.clone()))
+            .add_service(LockServer::new(service.clone()))
             .serve_with_incoming(futures::stream::iter(vec![Ok::<_, std::io::Error>(server)]))
             .await
     });

--- a/src/script/Cargo.toml
+++ b/src/script/Cargo.toml
@@ -36,6 +36,7 @@ common-catalog.workspace = true
 common-error.workspace = true
 common-function.workspace = true
 common-macro.workspace = true
+common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
 common-runtime.workspace = true

--- a/src/script/src/error.rs
+++ b/src/script/src/error.rs
@@ -74,6 +74,18 @@ pub enum Error {
         source: query::error::Error,
         location: Location,
     },
+
+    #[snafu(display("General catalog error"))]
+    Catalog {
+        location: Location,
+        source: catalog::error::Error,
+    },
+
+    #[snafu(display("Failed to query by grpc"))]
+    GrpcQuery {
+        location: Location,
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -90,6 +102,8 @@ impl ErrorExt for Error {
             ScriptNotFound { .. } => StatusCode::InvalidArguments,
             BuildDfLogicalPlan { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
+            Catalog { source, .. } => source.status_code(),
+            GrpcQuery { source, .. } => source.status_code(),
         }
     }
 

--- a/src/script/src/manager.rs
+++ b/src/script/src/manager.rs
@@ -16,29 +16,43 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use api::v1::CreateTableExpr;
+use api::v1::ddl_request::Expr;
+use api::v1::greptime_request::Request;
+use api::v1::{CreateTableExpr, DdlRequest};
 use arc_swap::ArcSwap;
-use catalog::{OpenSystemTableHook, RegisterSystemTableRequest};
+use catalog::{CatalogManagerRef, RegisterSystemTableRequest};
 use common_catalog::consts::{default_engine, DEFAULT_SCHEMA_NAME};
-use common_error::ext::ErrorExt;
+use common_error::ext::{BoxedError, ErrorExt};
+use common_function::function::FunctionRef;
+use common_function::function_registry::{FunctionProvider, FUNCTION_REGISTRY};
+use common_meta::table_name::TableName;
 use common_query::Output;
 use common_telemetry::logging;
-use futures::future::FutureExt;
 use query::QueryEngineRef;
 use servers::query_handler::grpc::GrpcQueryHandlerRef;
+use session::context::{QueryContext, QueryContextRef};
 use snafu::{OptionExt, ResultExt};
 use table::TableRef;
 
 use crate::engine::{CompileContext, EvalContext, Script, ScriptEngine};
 use crate::error::{
-    CompilePythonSnafu, ExecutePythonSnafu, Result, ScriptNotFoundSnafu, ScriptsTableNotFoundSnafu,
+    CatalogSnafu, CompilePythonSnafu, Error, ExecutePythonSnafu, GrpcQuerySnafu, Result,
+    ScriptNotFoundSnafu, ScriptsTableNotFoundSnafu,
 };
+use crate::python::utils::block_on_async;
 use crate::python::{PyEngine, PyScript};
 use crate::table::{build_scripts_schema, ScriptsTable, ScriptsTableRef, SCRIPTS_TABLE_NAME};
 
+#[derive(Clone)]
+struct ScriptWithVersion {
+    script: Arc<PyScript>,
+    version: u64,
+}
+
 pub struct ScriptManager<E: ErrorExt + Send + Sync + 'static> {
-    compiled: RwLock<HashMap<String, Arc<PyScript>>>,
+    compiled: RwLock<HashMap<String, ScriptWithVersion>>,
     py_engine: PyEngine,
+    catalog_manager: CatalogManagerRef,
     grpc_handler: ArcSwap<GrpcQueryHandlerRef<E>>,
     //  Catalog name -> `[ScriptsTable]`
     tables: RwLock<HashMap<String, ScriptsTableRef<E>>>,
@@ -47,16 +61,22 @@ pub struct ScriptManager<E: ErrorExt + Send + Sync + 'static> {
 
 impl<E: ErrorExt + Send + Sync + 'static> ScriptManager<E> {
     pub async fn new(
+        catalog_manager: CatalogManagerRef,
         grpc_handler: GrpcQueryHandlerRef<E>,
         query_engine: QueryEngineRef,
     ) -> Result<Self> {
         Ok(Self {
             compiled: RwLock::new(HashMap::default()),
             py_engine: PyEngine::new(query_engine.clone()),
+            catalog_manager,
             query_engine,
             grpc_handler: ArcSwap::new(Arc::new(grpc_handler)),
             tables: RwLock::new(HashMap::default()),
         })
+    }
+
+    pub fn register_as_function_provider(s: Arc<Self>) {
+        FUNCTION_REGISTRY.register_provider(s);
     }
 
     pub fn start(&self, grpc_handler: GrpcQueryHandlerRef<E>) -> Result<()> {
@@ -84,35 +104,93 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptManager<E> {
             engine: default_engine().to_string(),
         };
 
-        let query_engine = self.query_engine.clone();
-
-        let hook: OpenSystemTableHook = Box::new(move |table: TableRef| {
-            let query_engine = query_engine.clone();
-            async move { ScriptsTable::<E>::recompile_register_udf(table, query_engine.clone()).await }
-                .boxed()
-        });
-
         RegisterSystemTableRequest {
             create_table_expr,
-            open_hook: Some(hook),
+            open_hook: None,
         }
     }
 
+    /// Create scripts table for the specific catalog if it's not exists.
+    /// The function is idempotent and safe to be called more than once for the same catalog
+    pub async fn create_table_if_need(&self, catalog: &str) -> Result<()> {
+        let scripts_table = self.get_scripts_table(catalog);
+        if scripts_table.is_some() {
+            return Ok(());
+        }
+        let RegisterSystemTableRequest {
+            create_table_expr: expr,
+            open_hook,
+        } = self.create_table_request(catalog);
+
+        if let Some(table) = self
+            .catalog_manager
+            .table(&expr.catalog_name, &expr.schema_name, &expr.table_name)
+            .await
+            .context(CatalogSnafu)?
+        {
+            if let Some(open_hook) = open_hook {
+                (open_hook)(table.clone()).await.context(CatalogSnafu)?;
+            }
+
+            self.insert_scripts_table(catalog, table);
+
+            return Ok(());
+        }
+
+        let table_name = TableName::new(&expr.catalog_name, &expr.schema_name, &expr.table_name);
+
+        let _ = self
+            .grpc_handler
+            .load()
+            .do_query(
+                Request::Ddl(DdlRequest {
+                    expr: Some(Expr::CreateTable(expr)),
+                }),
+                QueryContext::arc(),
+            )
+            .await
+            .map_err(|e| BoxedError::new(e))
+            .context(GrpcQuerySnafu)?;
+
+        let table = self
+            .catalog_manager
+            .table(
+                &table_name.catalog_name,
+                &table_name.schema_name,
+                &table_name.table_name,
+            )
+            .await
+            .context(CatalogSnafu)?
+            .with_context(|| ScriptsTableNotFoundSnafu {})?;
+
+        if let Some(open_hook) = open_hook {
+            (open_hook)(table.clone()).await.context(CatalogSnafu)?;
+        }
+
+        logging::info!(
+            "Created scripts table {}.",
+            table.table_info().full_table_name()
+        );
+
+        self.insert_scripts_table(catalog, table);
+
+        Ok(())
+    }
+
     /// compile script, and register them to the query engine and UDF registry
-    async fn compile(&self, name: &str, script: &str) -> Result<Arc<PyScript>> {
-        let script = Arc::new(Self::compile_without_cache(&self.py_engine, name, script).await?);
+    async fn compile(&self, name: &str, script: &str, version: u64) -> Result<ScriptWithVersion> {
+        let compiled_script = ScriptWithVersion {
+            script: Arc::new(Self::compile_without_cache(&self.py_engine, name, script).await?),
+            version,
+        };
 
         {
             let mut compiled = self.compiled.write().unwrap();
-            let _ = compiled.insert(name.to_string(), script.clone());
+            let _ = compiled.insert(name.to_string(), compiled_script.clone());
         }
         logging::info!("Compiled and cached script: {}", name);
 
-        script.as_ref().register_udf().await;
-
-        logging::info!("Script register as UDF: {}", name);
-
-        Ok(script)
+        Ok(compiled_script)
     }
 
     /// compile script to PyScript, but not register them to the query engine and UDF registry nor caching in `compiled`
@@ -156,14 +234,15 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptManager<E> {
         schema: &str,
         name: &str,
         script: &str,
+        version: u64,
     ) -> Result<Arc<PyScript>> {
-        let compiled_script = self.compile(name, script).await?;
+        let compiled_script = self.compile(name, script, version).await?;
         self.get_scripts_table(catalog)
             .context(ScriptsTableNotFoundSnafu)?
-            .insert(schema, name, script)
+            .insert(schema, name, script, version)
             .await?;
 
-        Ok(compiled_script)
+        Ok(compiled_script.script)
     }
 
     pub async fn execute(
@@ -173,38 +252,81 @@ impl<E: ErrorExt + Send + Sync + 'static> ScriptManager<E> {
         name: &str,
         params: HashMap<String, String>,
     ) -> Result<Output> {
-        let script = {
-            let s = self.compiled.read().unwrap().get(name).cloned();
+        let compiled_script = self
+            .try_find_script_and_update_cache(catalog, schema, name)
+            .await?
+            .with_context(|| ScriptNotFoundSnafu { name })?;
 
-            if s.is_some() {
-                s
-            } else {
-                self.try_find_script_and_compile(catalog, schema, name)
-                    .await?
-            }
-        };
-
-        let script = script.context(ScriptNotFoundSnafu { name })?;
-
-        script
+        compiled_script
+            .script
             .execute(params, EvalContext::default())
             .await
             .context(ExecutePythonSnafu { name })
     }
 
-    async fn try_find_script_and_compile(
+    pub async fn try_find_script(
         &self,
         catalog: &str,
         schema: &str,
         name: &str,
-    ) -> Result<Option<Arc<PyScript>>> {
-        let script = self
+    ) -> Result<Option<(String, u64)>> {
+        let script_and_version = self
             .get_scripts_table(catalog)
             .context(ScriptsTableNotFoundSnafu)?
-            .find_script_by_name(schema, name)
-            .await?;
+            .find_script_and_version_by_name(schema, name)
+            .await;
+        if let Err(Error::ScriptNotFound { .. }) = script_and_version {
+            return Ok(None);
+        }
 
-        Ok(Some(self.compile(name, &script).await?))
+        Ok(Some(script_and_version?))
+    }
+
+    async fn try_find_script_and_update_cache(
+        &self,
+        catalog: &str,
+        schema: &str,
+        name: &str,
+    ) -> Result<Option<ScriptWithVersion>> {
+        let (script, version) = self
+            .try_find_script(catalog, schema, name)
+            .await?
+            .with_context(|| ScriptNotFoundSnafu { name })?;
+
+        if let Some(s) = self.compiled.read().unwrap().get(name).cloned() {
+            if s.version >= version {
+                return Ok(Some(s));
+            }
+        }
+
+        Ok(Some(self.compile(name, &script, version).await?))
+    }
+}
+
+impl<E: ErrorExt + Send + Sync + 'static> FunctionProvider for ScriptManager<E> {
+    fn get_function(&self, name: &str, query_ctx: QueryContextRef) -> Option<FunctionRef> {
+        let compiled_script = block_on_async(async {
+            self.create_table_if_need(query_ctx.current_catalog())
+                .await?;
+
+            self.try_find_script_and_update_cache(
+                query_ctx.current_catalog(),
+                query_ctx.current_schema(),
+                name,
+            )
+            .await
+        });
+
+        compiled_script
+            .unwrap_or_else(|e| {
+                logging::error!("Thread error: {:?}", e);
+                Ok(None)
+            })
+            .unwrap_or_else(|e| {
+                logging::error!("Failed to find script: {:?}", e);
+                None
+            })
+            .map(|s| s.script.udf() as FunctionRef)
     }
 }
 
@@ -227,26 +349,28 @@ mod tests {
 def test() -> vector[str]:
     return 'hello';
 "#;
+        let version = 1;
 
-        let mgr = setup_scripts_manager(catalog, schema, name, script).await;
+        let mgr = setup_scripts_manager(catalog, schema, name, script, version).await;
 
         {
             let cached = mgr.compiled.read().unwrap();
             assert!(cached.get(name).is_none());
         }
 
-        mgr.insert_and_compile(catalog, schema, name, script)
+        mgr.insert_and_compile(catalog, schema, name, script, version)
             .await
             .unwrap();
 
         {
             let cached = mgr.compiled.read().unwrap();
             assert!(cached.get(name).is_some());
+            assert_eq!(cached.get(name).unwrap().version, 1);
         }
 
         // try to find and compile
         let script = mgr
-            .try_find_script_and_compile(catalog, schema, name)
+            .try_find_script_and_update_cache(catalog, schema, name)
             .await
             .unwrap();
         let _ = script.unwrap();

--- a/src/script/src/python/engine.rs
+++ b/src/script/src/python/engine.rs
@@ -209,6 +209,10 @@ impl PyScript {
         PyUDF::register_as_udf(udf.clone());
         PyUDF::register_to_query_engine(udf, self.query_engine.clone());
     }
+
+    pub fn udf(&self) -> Arc<PyUDF> {
+        PyUDF::from_copr(self.copr.clone())
+    }
 }
 
 pub struct CoprStream {

--- a/src/servers/tests/py_script/mod.rs
+++ b/src/servers/tests/py_script/mod.rs
@@ -19,7 +19,7 @@ use common_query::OutputData;
 use common_recordbatch::RecordBatch;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::{ColumnSchema, Schema};
-use datatypes::vectors::{StringVector, VectorRef};
+use datatypes::vectors::{StringVector, UInt64Vector, VectorRef};
 use servers::error::Result;
 use servers::query_handler::sql::SqlQueryHandler;
 use servers::query_handler::ScriptHandler;
@@ -38,17 +38,20 @@ async fn test_insert_py_udf_and_query() -> Result<()> {
 def hello() -> vector[str]:
     return 'hello';
 "#;
+    let version = 1;
 
     let column_schemas = vec![
         ColumnSchema::new("script", ConcreteDataType::string_datatype(), false),
         ColumnSchema::new("schema", ConcreteDataType::string_datatype(), false),
         ColumnSchema::new("name", ConcreteDataType::string_datatype(), false),
+        ColumnSchema::new("version", ConcreteDataType::uint64_datatype(), false),
     ];
 
     let columns: Vec<VectorRef> = vec![
         Arc::new(StringVector::from(vec![script])),
         Arc::new(StringVector::from(vec![schema])),
         Arc::new(StringVector::from(vec![name])),
+        Arc::new(UInt64Vector::from_values(vec![version])),
     ];
 
     let raw_schema = Arc::new(Schema::new(column_schemas));

--- a/tests-integration/src/tests.rs
+++ b/tests-integration/src/tests.rs
@@ -30,7 +30,7 @@ pub struct MockDistributedInstance(GreptimeDbCluster);
 
 impl MockDistributedInstance {
     pub fn frontend(&self) -> Arc<Instance> {
-        self.0.frontend.clone()
+        self.0.frontend_instances.first().unwrap().clone()
     }
 
     pub fn datanodes(&self) -> &HashMap<u64, Datanode> {

--- a/tests-integration/src/tests/test_util.rs
+++ b/tests-integration/src/tests/test_util.rs
@@ -78,7 +78,9 @@ impl MockInstance for MockInstanceImpl {
     fn frontend(&self) -> Arc<Instance> {
         match self {
             MockInstanceImpl::Standalone(instance) => instance.frontend(),
-            MockInstanceImpl::Distributed(instance) => instance.frontend.clone(),
+            MockInstanceImpl::Distributed(instance) => {
+                instance.frontend_instances.first().unwrap().clone()
+            }
         }
     }
 

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -98,7 +98,7 @@ pub async fn test_region_failover(store_type: StorageType) {
         .build()
         .await;
 
-    let frontend = cluster.frontend.clone();
+    let frontend = cluster.frontend();
 
     let table_id = prepare_testing_table(&cluster).await;
 
@@ -142,7 +142,7 @@ pub async fn test_region_failover(store_type: StorageType) {
     assert!(!has_route_cache(&frontend, table_id).await);
 
     // Inserts data to each datanode after failover
-    let frontend = cluster.frontend.clone();
+    let frontend = cluster.frontend();
     let results = insert_values(&frontend, logical_timer).await;
     for result in results {
         assert!(matches!(result.unwrap().data, OutputData::AffectedRows(1)));
@@ -241,11 +241,11 @@ CREATE TABLE my_table (
     PARTITION r2 VALUES LESS THAN (50),
     PARTITION r3 VALUES LESS THAN (MAXVALUE),
 )";
-    let result = cluster.frontend.do_query(sql, QueryContext::arc()).await;
+    let frontend = cluster.frontend();
+    let result = frontend.do_query(sql, QueryContext::arc()).await;
     result.first().unwrap().as_ref().unwrap();
 
-    let table = cluster
-        .frontend
+    let table = frontend
         .catalog_manager()
         .table(DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME, "my_table")
         .await


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/2434
https://github.com/GreptimeTeam/greptimedb/issues/2532

## What's changed and what's your intention?

Add a `version` column to the scripts table and retrieve the latest script from the database before each script execution. If it is newer than the one in the local cache, recompile it.

This solves the problem where a script updated on one frontend in a cluster with multiple frontends does not take effect on the other frontends(because the script compilation cache cannot be updated, or the script is not registered).

**BREAKING CHANGE:**
Since the scripts are now obtained through scripts table, when executing via UDF in SQL, the script name must be used instead of the function name. This fixes the issue mentioned in https://github.com/GreptimeTeam/greptimedb/issues/2532. However, in cases where the script name and function name are different, if the program is using the function name, it will no longer work.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
