### PR TITLE
fix: promql scalar when input empty batch

### DIFF
--- a/tests/cases/standalone/common/promql/scalar.result
+++ b/tests/cases/standalone/common/promql/scalar.result
@@ -301,6 +301,35 @@ TQL EVAL (0, 15, '5s') scalar(host{host="host1"} + scalar(host));
 | 1970-01-01T00:00:15 | NaN                               |
 +---------------------+-----------------------------------+
 
+-- No data input in scalar
+TQL EVAL (350, 360, '5s') scalar(host{host="host1"});
+
++---------------------+-------------+
+| ts                  | scalar(val) |
++---------------------+-------------+
+| 1970-01-01T00:05:50 | NaN         |
+| 1970-01-01T00:05:55 | NaN         |
+| 1970-01-01T00:06:00 | NaN         |
++---------------------+-------------+
+
+DELETE from host where ts = 0;
+
+Affected Rows: 2
+
+-- Under this case, InstantManipulate will input a valid record batch but output a empty record batch (because no data will be selected in this batch)
+-- Test input a empty record batch to ScalarCalculate plan
+TQL EVAL (0, 1600, '6m40s') scalar(host{host="host1"});
+
++---------------------+-------------+
+| ts                  | scalar(val) |
++---------------------+-------------+
+| 1970-01-01T00:00:00 | NaN         |
+| 1970-01-01T00:06:40 | NaN         |
+| 1970-01-01T00:13:20 | NaN         |
+| 1970-01-01T00:20:00 | NaN         |
+| 1970-01-01T00:26:40 | NaN         |
++---------------------+-------------+
+
 -- error case
 TQL EVAL (0, 15, '5s') scalar(1 + scalar(host{host="host2"}));
 

--- a/tests/cases/standalone/common/promql/scalar.sql
+++ b/tests/cases/standalone/common/promql/scalar.sql
@@ -84,6 +84,15 @@ TQL EVAL (0, 15, '5s') scalar(host) + host{host="host2"};
 -- SQLNESS SORT_RESULT 3 1
 TQL EVAL (0, 15, '5s') scalar(host{host="host1"} + scalar(host));
 
+-- No data input in scalar
+TQL EVAL (350, 360, '5s') scalar(host{host="host1"});
+
+DELETE from host where ts = 0;
+
+-- Under this case, InstantManipulate will input a valid record batch but output a empty record batch (because no data will be selected in this batch)
+-- Test input a empty record batch to ScalarCalculate plan
+TQL EVAL (0, 1600, '6m40s') scalar(host{host="host1"});
+
 -- error case
 
 TQL EVAL (0, 15, '5s') scalar(1 + scalar(host{host="host2"}));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Follow up of https://github.com/GreptimeTeam/greptimedb/pull/3693

## What's changed and what's your intention?

ScalarCalculate don't check whether the record batch is empty. When input a empty record batch in ScalarCalculate, it may lead crash of DB.

https://github.com/GreptimeTeam/greptimedb/blob/778e195f07c576a01562f74f9e44bd31088a422b/src/promql/src/extension_plan/scalar_calculate.rs#L414

Please explain IN DETAIL what the changes are in this PR and why they are needed:

check the input record batch is empty

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
