### PR TITLE
refactor: move the version string to common

### DIFF
--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -36,6 +36,7 @@ common-telemetry = { workspace = true, features = [
     "deadlock_detection",
 ] }
 common-time.workspace = true
+common-version.workspace = true
 common-wal.workspace = true
 config = "0.13"
 datanode.workspace = true

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -22,6 +22,7 @@ use cmd::options::{CliOptions, Options};
 use cmd::{
     cli, datanode, frontend, greptimedb_cli, log_versions, metasrv, standalone, start_app, App,
 };
+use common_version::{short_version, version};
 
 #[derive(Parser)]
 enum SubCommand {
@@ -105,7 +106,8 @@ async fn main() -> Result<()> {
 
     common_telemetry::set_panic_hook();
 
-    let cli = greptimedb_cli();
+    let version = version!();
+    let cli = greptimedb_cli().version(version);
 
     let cli = SubCommand::augment_subcommands(cli);
 
@@ -129,7 +131,7 @@ async fn main() -> Result<()> {
         opts.node_id(),
     );
 
-    log_versions();
+    log_versions(version, short_version!());
 
     let app = subcmd.build(opts).await?;
 

--- a/src/common/version/src/lib.rs
+++ b/src/common/version/src/lib.rs
@@ -103,3 +103,28 @@ pub fn setup_build_info() {
     println!("cargo:rustc-env=RUSTC_VERSION={}", build_info.rustc);
     println!("cargo:rustc-env=SOURCE_TIMESTAMP={}", build_info.timestamp);
 }
+
+/// Get the string for the output of cli "--version".
+#[macro_export]
+macro_rules! version {
+    () => {
+        concat!(
+            "\nbranch: ",
+            env!("GIT_BRANCH"),
+            "\ncommit: ",
+            env!("GIT_COMMIT"),
+            "\ndirty: ",
+            env!("GIT_DIRTY"),
+            "\nversion: ",
+            env!("CARGO_PKG_VERSION")
+        )
+    };
+}
+
+/// Short version for reporting metrics.
+#[macro_export]
+macro_rules! short_version {
+    () => {
+        concat!(env!("GIT_BRANCH"), "-", env!("GIT_COMMIT_SHORT"))
+    };
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

To make the cli "--version" prints the correct version string. Previously, in a project that embeds greptimedb as a submodule, the project's bins always print the git info of greptimedb, instead of the project's. After this PR, that can be fixed.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
