### PR TITLE
build: only build amd64 for CentOS

### DIFF
--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -22,15 +22,15 @@ inputs:
   build-dev-builder-ubuntu:
     description: Build dev-builder-ubuntu image
     required: false
-    default: 'true'
+    default: "true"
   build-dev-builder-centos:
     description: Build dev-builder-centos image
     required: false
-    default: 'true'
+    default: "true"
   build-dev-builder-android:
     description: Build dev-builder-android image
     required: false
-    default: 'true'
+    default: "true"
 runs:
   using: composite
   steps:
@@ -47,7 +47,7 @@ runs:
       run: |
         make dev-builder \
           BASE_IMAGE=ubuntu \
-          BUILDX_MULTI_PLATFORM_BUILD=true \
+          BUILDX_MULTI_PLATFORM_BUILD=all \
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }}
@@ -58,7 +58,7 @@ runs:
       run: |
         make dev-builder \
           BASE_IMAGE=centos \
-          BUILDX_MULTI_PLATFORM_BUILD=true \
+          BUILDX_MULTI_PLATFORM_BUILD=amd64 \
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }}
@@ -72,5 +72,5 @@ runs:
           IMAGE_REGISTRY=${{ inputs.dockerhub-image-registry }} \
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }} && \
-        
+
         docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/actions/build-linux-artifacts/action.yml
+++ b/.github/actions/build-linux-artifacts/action.yml
@@ -16,7 +16,7 @@ inputs:
   dev-mode:
     description: Enable dev mode, only build standard greptime
     required: false
-    default: 'false'
+    default: "false"
   working-dir:
     description: Working directory to build the artifacts
     required: false
@@ -68,7 +68,7 @@ runs:
 
     - name: Build greptime on centos base image
       uses: ./.github/actions/build-greptime-binary
-      if: ${{ inputs.arch == 'amd64' && inputs.dev-mode == 'false' }} # Only build centos7 base image for amd64.
+      if: ${{ inputs.arch == 'amd64' && inputs.dev-mode == 'false' }} # Builds greptime for centos if the host machine is amd64.
       with:
         base-image: centos
         features: servers/dashboard
@@ -79,7 +79,7 @@ runs:
 
     - name: Build greptime on android base image
       uses: ./.github/actions/build-greptime-binary
-      if: ${{ inputs.arch == 'amd64' && inputs.dev-mode == 'false' }} # Only build android base image on amd64.
+      if: ${{ inputs.arch == 'amd64' && inputs.dev-mode == 'false' }} # Builds arm64 greptime binary for android if the host machine amd64.
       with:
         base-image: android
         artifacts-dir: greptime-android-arm64-${{ inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,10 @@ ifneq ($(strip $(RELEASE)),)
 	CARGO_BUILD_OPTS += --release
 endif
 
-ifeq ($(BUILDX_MULTI_PLATFORM_BUILD), true)
+ifeq ($(BUILDX_MULTI_PLATFORM_BUILD), all)
 	BUILDX_MULTI_PLATFORM_BUILD_OPTS := --platform linux/amd64,linux/arm64 --push
+else ifeq ($(BUILDX_MULTI_PLATFORM_BUILD), amd64)
+	BUILDX_MULTI_PLATFORM_BUILD_OPTS := --platform linux/amd64 --push
 else
 	BUILDX_MULTI_PLATFORM_BUILD_OPTS := -o type=docker
 endif


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/briansmith/ring/issues/1728

## What's changed and what's your intention?

https://github.com/GreptimeTeam/greptimedb/actions/runs/8778537946/job/24085145007

While building dev builder image on CentOS we got the following error
```
error: failed to run custom build command for `ring v0.17.8`

cargo:warning=include/ring-core/arm_arch.h:82:2: error: #error "ARM assembler must define __ARM_ARCH"
```

Version 0.17 of ring doesn't support CentOS arm64. Since we don't provide arm64 binary for CentOS, I removed the arm64 image for CentOS in this PR.

`BUILDX_MULTI_PLATFORM_BUILD` now has three possible value
- all: builds images for both amd64 and arm64 platform
- amd64: builds amd64 image only
- false: builds image for current platform

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
