### PR TITLE
fix: avoid unused_variables under Windows

### DIFF
--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -292,8 +292,6 @@ pub fn build_rows(num_tags: usize, num_rows: usize) -> Vec<Row> {
 #[cfg(test)]
 mod test {
 
-    use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
-
     use super::*;
     use crate::utils::{self, to_metadata_region_id};
 
@@ -302,11 +300,12 @@ mod test {
         let env = TestEnv::new().await;
         env.init_metric_region().await;
         let region_id = to_metadata_region_id(env.default_physical_region_id());
-        let region_dir = join_dir(&env.data_home(), "test_metric_region");
 
         // `join_dir` doesn't suit windows path
         #[cfg(not(target_os = "windows"))]
         {
+            let region_dir = join_dir(&env.data_home(), "test_metric_region");
+            use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
             // assert metadata region's dir
             let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
             let exist = tokio::fs::try_exists(metadata_region_dir).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fixes https://github.com/GreptimeTeam/greptimedb/actions/runs/8808344307

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
