### PR TITLE
fix: push down order hint of the query again

### DIFF
--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -436,7 +436,8 @@ dir = "/tmp/greptimedb/logs"
 
 ## The log level. Can be `info`/`debug`/`warn`/`error`.
 ## +toml2docs:none-default
-level = "info"
+level = "debug"
+# level = "info"
 
 ## Enable OTLP tracing.
 enable_otlp_tracing = false

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -436,8 +436,7 @@ dir = "/tmp/greptimedb/logs"
 
 ## The log level. Can be `info`/`debug`/`warn`/`error`.
 ## +toml2docs:none-default
-level = "debug"
-# level = "info"
+level = "info"
 
 ## Enable OTLP tracing.
 enable_otlp_tracing = false

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -248,6 +248,7 @@ pub enum Error {
         location: Location,
     },
 
+    // TODO(yingwen): remove it.
     #[snafu(display(
         "Failed to get metadata from engine {} for region_id {}",
         engine,

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -248,19 +248,6 @@ pub enum Error {
         location: Location,
     },
 
-    // TODO(yingwen): remove it.
-    #[snafu(display(
-        "Failed to get metadata from engine {} for region_id {}",
-        engine,
-        region_id,
-    ))]
-    GetRegionMetadata {
-        engine: String,
-        region_id: RegionId,
-        location: Location,
-        source: BoxedError,
-    },
-
     #[snafu(display("Failed to build region requests"))]
     BuildRegionRequests {
         location: Location,
@@ -338,8 +325,7 @@ impl ErrorExt for Error {
             | IncorrectInternalState { .. }
             | ShutdownInstance { .. }
             | RegionEngineNotFound { .. }
-            | UnsupportedOutput { .. }
-            | GetRegionMetadata { .. } => StatusCode::Internal,
+            | UnsupportedOutput { .. } => StatusCode::Internal,
 
             RegionNotFound { .. } => StatusCode::RegionNotFound,
             RegionNotReady { .. } => StatusCode::RegionNotReady,

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Dummy catalog for region servers.
+//! Dummy catalog for region server.
 
 use std::any::Any;
 use std::sync::{Arc, Mutex};
@@ -127,7 +127,7 @@ impl SchemaProvider for DummySchemaProvider {
     }
 }
 
-/// For [TableProvider](TableProvider) and [DummyCatalogList]
+/// For [TableProvider] and [DummyCatalogList]
 #[derive(Clone)]
 pub struct DummyTableProvider {
     region_id: RegionId,

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -1,0 +1,214 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Dummy catalog for region servers.
+
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use common_query::physical_plan::DfPhysicalPlanAdapter;
+use common_query::DfPhysicalPlan;
+use datafusion::catalog::schema::SchemaProvider;
+use datafusion::catalog::{CatalogList, CatalogProvider};
+use datafusion::datasource::TableProvider;
+use datafusion::error::Result;
+use datafusion::execution::context::SessionState;
+use datafusion_common::DataFusionError;
+use datafusion_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datatypes::arrow::datatypes::SchemaRef;
+use store_api::metadata::RegionMetadataRef;
+use store_api::region_engine::RegionEngineRef;
+use store_api::storage::{RegionId, ScanRequest};
+use table::table::scan::StreamScanAdapter;
+
+/// Resolve to the given region (specified by [RegionId]) unconditionally.
+#[derive(Clone)]
+struct DummyCatalogList {
+    catalog: DummyCatalogProvider,
+}
+
+impl DummyCatalogList {
+    fn with_table_provider(table_provider: Arc<dyn TableProvider>) -> Self {
+        let schema_provider = DummySchemaProvider {
+            table: table_provider,
+        };
+        let catalog_provider = DummyCatalogProvider {
+            schema: schema_provider,
+        };
+        Self {
+            catalog: catalog_provider,
+        }
+    }
+}
+
+impl CatalogList for DummyCatalogList {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn register_catalog(
+        &self,
+        _name: String,
+        _catalog: Arc<dyn CatalogProvider>,
+    ) -> Option<Arc<dyn CatalogProvider>> {
+        None
+    }
+
+    fn catalog_names(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn catalog(&self, _name: &str) -> Option<Arc<dyn CatalogProvider>> {
+        Some(Arc::new(self.catalog.clone()))
+    }
+}
+
+/// For [DummyCatalogList].
+#[derive(Clone)]
+struct DummyCatalogProvider {
+    schema: DummySchemaProvider,
+}
+
+impl CatalogProvider for DummyCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        vec![]
+    }
+
+    fn schema(&self, _name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        Some(Arc::new(self.schema.clone()))
+    }
+}
+
+/// For [DummyCatalogList].
+#[derive(Clone)]
+struct DummySchemaProvider {
+    table: Arc<dyn TableProvider>,
+}
+
+#[async_trait]
+impl SchemaProvider for DummySchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        vec![]
+    }
+
+    async fn table(&self, _name: &str) -> Option<Arc<dyn TableProvider>> {
+        Some(self.table.clone())
+    }
+
+    fn table_exist(&self, _name: &str) -> bool {
+        true
+    }
+}
+
+/// For [TableProvider](TableProvider) and [DummyCatalogList]
+#[derive(Clone)]
+struct DummyTableProvider {
+    region_id: RegionId,
+    engine: RegionEngineRef,
+    metadata: RegionMetadataRef,
+    /// Keeping a mutable request makes it possible to change in the optimize phase.
+    scan_request: Arc<Mutex<ScanRequest>>,
+}
+
+#[async_trait]
+impl TableProvider for DummyTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        common_telemetry::info!("DummyTableProvider as any");
+
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.metadata.schema.arrow_schema().clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn DfPhysicalPlan>> {
+        common_telemetry::info!("DummyTableProvider scan");
+        let mut request = self.scan_request.lock().unwrap().clone();
+        request.projection = projection.cloned();
+        request.filters = filters
+            .iter()
+            .map(|e| common_query::logical_plan::Expr::from(e.clone()))
+            .collect();
+        request.limit = limit;
+
+        let stream = self
+            .engine
+            .handle_query(self.region_id, request)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(Arc::new(DfPhysicalPlanAdapter(Arc::new(
+            StreamScanAdapter::new(stream),
+        ))))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+    }
+}
+
+pub struct DummyTableProviderFactory;
+
+#[async_trait]
+impl TableProviderFactory for DummyTableProviderFactory {
+    async fn create(
+        &self,
+        region_id: RegionId,
+        engine: RegionEngineRef,
+    ) -> Result<Arc<dyn TableProvider>> {
+        let metadata = engine
+            .get_metadata(region_id)
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        Ok(Arc::new(DummyTableProvider {
+            region_id,
+            engine,
+            metadata,
+            scan_request: Default::default(),
+        }))
+    }
+}
+
+#[async_trait]
+pub trait TableProviderFactory: Send + Sync {
+    async fn create(
+        &self,
+        region_id: RegionId,
+        engine: RegionEngineRef,
+    ) -> Result<Arc<dyn TableProvider>>;
+}
+
+pub type TableProviderFactoryRef = Arc<dyn TableProviderFactory>;

--- a/src/query/src/error.rs
+++ b/src/query/src/error.rs
@@ -22,6 +22,7 @@ use datafusion::error::DataFusionError;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::Value;
 use snafu::{Location, Snafu};
+use store_api::storage::RegionId;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
@@ -244,6 +245,18 @@ pub enum Error {
 
     #[snafu(display("Range Query: {}", msg))]
     RangeQuery { msg: String, location: Location },
+
+    #[snafu(display(
+        "Failed to get metadata from engine {} for region_id {}",
+        engine,
+        region_id,
+    ))]
+    GetRegionMetadata {
+        engine: String,
+        region_id: RegionId,
+        location: Location,
+        source: BoxedError,
+    },
 }
 
 impl ErrorExt for Error {
@@ -296,6 +309,7 @@ impl ErrorExt for Error {
             RegionQuery { source, .. } => source.status_code(),
             TableMutation { source, .. } => source.status_code(),
             MissingTableMutationHandler { .. } => StatusCode::Unexpected,
+            GetRegionMetadata { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/query/src/lib.rs
+++ b/src/query/src/lib.rs
@@ -35,10 +35,10 @@ mod range_select;
 pub mod region_query;
 pub mod sql;
 
+#[cfg(test)]
+mod tests;
+
 pub use crate::datafusion::DfContextProviderAdapter;
 pub use crate::query_engine::{
     QueryEngine, QueryEngineContext, QueryEngineFactory, QueryEngineRef,
 };
-
-#[cfg(test)]
-mod tests;

--- a/src/query/src/lib.rs
+++ b/src/query/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod dataframe;
 pub mod datafusion;
 pub mod dist_plan;
+pub mod dummy_catalog;
 pub mod error;
 pub mod executor;
 pub mod logical_optimizer;

--- a/src/query/src/optimizer.rs
+++ b/src/query/src/optimizer.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod order_hint;
+pub mod string_normalization;
+#[cfg(test)]
+mod test_util;
+pub mod type_conversion;
+
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::Result;
 use datafusion_expr::LogicalPlan;
@@ -30,7 +36,3 @@ pub trait ExtensionAnalyzerRule {
         config: &ConfigOptions,
     ) -> Result<LogicalPlan>;
 }
-
-pub mod order_hint;
-pub mod string_normalization;
-pub mod type_conversion;

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -1,0 +1,144 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utils for testing the optimizer.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use api::region::RegionResponse;
+use api::v1::SemanticType;
+use async_trait::async_trait;
+use common_error::ext::{BoxedError, PlainError};
+use common_error::status_code::StatusCode;
+use common_recordbatch::SendableRecordBatchStream;
+use datatypes::schema::ColumnSchema;
+use store_api::metadata::{
+    ColumnMetadata, RegionMetadata, RegionMetadataBuilder, RegionMetadataRef,
+};
+use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_request::RegionRequest;
+use store_api::storage::{ConcreteDataType, RegionId, ScanRequest};
+
+use crate::dummy_catalog::DummyTableProvider;
+
+/// A mock region engine that can be used for testing the optimizer.
+pub(crate) struct MetaRegionEngine {
+    metadatas: HashMap<RegionId, RegionMetadataRef>,
+}
+
+impl MetaRegionEngine {
+    /// Creates a engine with the given metadata.
+    pub(crate) fn with_metadata(metadata: RegionMetadataRef) -> Self {
+        let mut metadatas = HashMap::new();
+        metadatas.insert(metadata.region_id, metadata);
+
+        Self { metadatas }
+    }
+}
+
+#[async_trait]
+impl RegionEngine for MetaRegionEngine {
+    fn name(&self) -> &str {
+        "MetaRegionEngine"
+    }
+
+    async fn handle_request(
+        &self,
+        _region_id: RegionId,
+        _request: RegionRequest,
+    ) -> Result<RegionResponse, BoxedError> {
+        unimplemented!()
+    }
+
+    async fn handle_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<SendableRecordBatchStream, BoxedError> {
+        unimplemented!()
+    }
+
+    async fn get_metadata(&self, region_id: RegionId) -> Result<RegionMetadataRef, BoxedError> {
+        self.metadatas.get(&region_id).cloned().ok_or_else(|| {
+            BoxedError::new(PlainError::new(
+                "Region not found".to_string(),
+                StatusCode::RegionNotFound,
+            ))
+        })
+    }
+
+    async fn region_disk_usage(&self, _region_id: RegionId) -> Option<i64> {
+        None
+    }
+
+    async fn stop(&self) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn set_writable(&self, _region_id: RegionId, _writable: bool) -> Result<(), BoxedError> {
+        unimplemented!()
+    }
+
+    async fn set_readonly_gracefully(
+        &self,
+        _region_id: RegionId,
+    ) -> Result<SetReadonlyResponse, BoxedError> {
+        unimplemented!()
+    }
+
+    fn role(&self, _region_id: RegionId) -> Option<RegionRole> {
+        None
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Mock a [DummyTableProvider] with a single region.
+pub(crate) fn mock_table_provider(region_id: RegionId) -> DummyTableProvider {
+    let metadata = Arc::new(mock_region_metadata(region_id));
+    let engine = Arc::new(MetaRegionEngine::with_metadata(metadata.clone()));
+    DummyTableProvider::new(region_id, engine, metadata)
+}
+
+/// Returns a mock region metadata.
+/// The schema is: `k0: string, ts: timestamp, v0: float64`
+fn mock_region_metadata(region_id: RegionId) -> RegionMetadata {
+    let mut builder = RegionMetadataBuilder::new(region_id);
+    builder
+        .push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new("k0", ConcreteDataType::string_datatype(), true),
+            semantic_type: SemanticType::Tag,
+            column_id: 1,
+        })
+        .push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new(
+                "ts",
+                ConcreteDataType::timestamp_millisecond_datatype(),
+                false,
+            ),
+            semantic_type: SemanticType::Timestamp,
+            column_id: 2,
+        })
+        .push_column_metadata(ColumnMetadata {
+            column_schema: ColumnSchema::new("v0", ConcreteDataType::float64_datatype(), false),
+            semantic_type: SemanticType::Field,
+            column_id: 3,
+        })
+        .primary_key(vec![1]);
+    builder.build().unwrap()
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3274

## What's changed and what's your intention?
This PR fixes the issue that the region server doesn't push down the order hint of the query to the mito engine. This is the first step to optimize `order by ts` and `order by ts limit` statements.

It moves the `DummyTableProvider` to the `common-query` mod so the `OptimizeRule` can correctly downcast the table provider and attach the `OrderOption` to the provider.

Now we can get the order hint in the mito engine:
```sql
create table order_hint(a int primary key, ts timestamp time index);

select * from order_hint order by ts;
```

Then the debug log shows the hint
```
Scan region 4398046511104(1024, 0), request: ScanRequest { projection: Some([0, 1]), filters: [], output_ordering: Some([OrderOption { name: "ts", options: SortOptions { descending: false, nulls_first: false } }]), limit: None },
```

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
