### PR TITLE
chore: respect axum test client's origin

### DIFF
--- a/licenserc.toml
+++ b/licenserc.toml
@@ -23,6 +23,7 @@ excludes = [
     # copied sources
     "src/common/base/src/readable_size.rs",
     "src/servers/src/repeated_field.rs",
+    "src/servers/src/http/test_helpers.rs",
 ]
 
 [properties]

--- a/src/servers/src/http/test_helpers.rs
+++ b/src/servers/src/http/test_helpers.rs
@@ -1,16 +1,4 @@
-// Copyright 2023 Greptime Team
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// This file is copied from https://github.com/tokio-rs/axum/blob/axum-v0.6.20/axum/src/test_helpers/test_client.rs
 
 //! Axum Test Client
 //!


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

TRIVIAL AS IS.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
