### PR TITLE
fix: broken link in contributing guide 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ GreptimeDB uses the [Apache 2.0 license](https://github.com/GreptimeTeam/greptim
 
 - To ensure that community is free and confident in its ability to use your contributions, please sign the Contributor License Agreement (CLA) which will be incorporated in the pull request process.
 - Make sure all files have proper license header (running `docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 format` from the project root).
-- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/) and [style guide](http://github.com/greptimeTeam/docs/style-guide.md).
+- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/) and [style guide](https://github.com/GreptimeTeam/greptimedb/blob/main/docs/style-guide.md).
 - Make sure all unit tests are passed (using `cargo test --workspace` or [nextest](https://nexte.st/index.html) `cargo nextest run`).
 - Make sure all clippy warnings are fixed (you can check it locally by running `cargo clippy --workspace --all-targets -- -D warnings`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ GreptimeDB uses the [Apache 2.0 license](https://github.com/GreptimeTeam/greptim
 
 - To ensure that community is free and confident in its ability to use your contributions, please sign the Contributor License Agreement (CLA) which will be incorporated in the pull request process.
 - Make sure all files have proper license header (running `docker run --rm -v $(pwd):/github/workspace ghcr.io/korandoru/hawkeye-native:v3 format` from the project root).
-- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/) and [style guide](https://github.com/GreptimeTeam/greptimedb/blob/main/docs/style-guide.md).
+- Make sure all your codes are formatted and follow the [coding style](https://pingcap.github.io/style-guide/rust/) and [style guide](docs/style-guide.md).
 - Make sure all unit tests are passed (using `cargo test --workspace` or [nextest](https://nexte.st/index.html) `cargo nextest run`).
 - Make sure all clippy warnings are fixed (you can check it locally by running `cargo clippy --workspace --all-targets -- -D warnings`).
 

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -12,7 +12,7 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 
 ## Formatting
 
-- Place all `mod` declaration before any `use` (except the test mod).
+- Place all `mod` declaration before any `use`.
 - Use `unimplemented!()` instead of `todo!()` for things that aren't likely to be implemented.
 - Add an empty line before and after declaration blocks.
 - Place comment before attributes (`#[]`) and derive (`#[derive]`).

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -12,7 +12,7 @@ It's mainly an complement to the [Rust Style Guide](https://pingcap.github.io/st
 
 ## Formatting
 
-- Place all `mod` declaration before any `use`.
+- Place all `mod` declaration before any `use` (except the test mod).
 - Use `unimplemented!()` instead of `todo!()` for things that aren't likely to be implemented.
 - Add an empty line before and after declaration blocks.
 - Place comment before attributes (`#[]`) and derive (`#[derive]`).


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Fix the wrong link to style guide in `CONTRIBUTING.md`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
