### PR TITLE
refactor: remove `TableMetaKey` trait

### DIFF
--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -22,7 +22,7 @@ use crate::key::schema_name::SchemaNameKey;
 use crate::key::table_info::TableInfoKey;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteKey;
-use crate::key::TableMetaKey;
+use crate::key::MetaKey;
 
 /// KvBackend cache invalidator
 #[async_trait::async_trait]
@@ -99,18 +99,18 @@ where
             match cache {
                 CacheIdent::TableId(table_id) => {
                     let key = TableInfoKey::new(table_id);
-                    self.invalidate_key(&key.as_raw_key()).await;
+                    self.invalidate_key(&key.to_bytes()).await;
 
                     let key = &TableRouteKey { table_id };
-                    self.invalidate_key(&key.as_raw_key()).await;
+                    self.invalidate_key(&key.to_bytes()).await;
                 }
                 CacheIdent::TableName(table_name) => {
                     let key: TableNameKey = (&table_name).into();
-                    self.invalidate_key(&key.as_raw_key()).await
+                    self.invalidate_key(&key.to_bytes()).await
                 }
                 CacheIdent::SchemaName(schema_name) => {
                     let key: SchemaNameKey = (&schema_name).into();
-                    self.invalidate_key(&key.as_raw_key()).await;
+                    self.invalidate_key(&key.to_bytes()).await;
                 }
             }
         }

--- a/src/common/meta/src/key/catalog_name.rs
+++ b/src/common/meta/src/key/catalog_name.rs
@@ -21,12 +21,15 @@ use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 
 use crate::error::{self, Error, InvalidTableMetadataSnafu, Result};
-use crate::key::{TableMetaKey, CATALOG_NAME_KEY_PATTERN, CATALOG_NAME_KEY_PREFIX};
+use crate::key::{MetaKey, CATALOG_NAME_KEY_PATTERN, CATALOG_NAME_KEY_PREFIX};
 use crate::kv_backend::KvBackendRef;
 use crate::range_stream::{PaginationStream, DEFAULT_PAGE_SIZE};
 use crate::rpc::store::RangeRequest;
 use crate::rpc::KeyValue;
 
+/// The catalog name key, indices all catalog names
+///
+/// The layout: `__catalog_name/{catalog_name}`
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CatalogNameKey<'a> {
     pub catalog: &'a str,
@@ -53,15 +56,28 @@ impl<'a> CatalogNameKey<'a> {
     }
 }
 
-impl Display for CatalogNameKey<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", CATALOG_NAME_KEY_PREFIX, self.catalog)
+impl<'a> MetaKey<'a, CatalogNameKey<'a>> for CatalogNameKey<'_> {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_string().into_bytes()
+    }
+
+    fn from_bytes(bytes: &'a [u8]) -> Result<CatalogNameKey<'a>> {
+        let key = std::str::from_utf8(bytes).map_err(|e| {
+            InvalidTableMetadataSnafu {
+                err_msg: format!(
+                    "CatalogNameKey '{}' is not a valid UTF8 string: {e}",
+                    String::from_utf8_lossy(bytes)
+                ),
+            }
+            .build()
+        })?;
+        CatalogNameKey::try_from(key)
     }
 }
 
-impl TableMetaKey for CatalogNameKey<'_> {
-    fn as_raw_key(&self) -> Vec<u8> {
-        self.to_string().into_bytes()
+impl Display for CatalogNameKey<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", CATALOG_NAME_KEY_PREFIX, self.catalog)
     }
 }
 
@@ -103,7 +119,7 @@ impl CatalogManager {
     pub async fn create(&self, catalog: CatalogNameKey<'_>, if_not_exists: bool) -> Result<()> {
         let _timer = crate::metrics::METRIC_META_CREATE_CATALOG.start_timer();
 
-        let raw_key = catalog.as_raw_key();
+        let raw_key = catalog.to_bytes();
         let raw_value = CatalogNameValue.try_as_raw_value()?;
         if self
             .kv_backend
@@ -117,7 +133,7 @@ impl CatalogManager {
     }
 
     pub async fn exists(&self, catalog: CatalogNameKey<'_>) -> Result<bool> {
-        let raw_key = catalog.as_raw_key();
+        let raw_key = catalog.to_bytes();
 
         self.kv_backend.exists(&raw_key).await
     }

--- a/src/common/meta/src/key/catalog_name.rs
+++ b/src/common/meta/src/key/catalog_name.rs
@@ -164,7 +164,7 @@ mod tests {
 
         assert_eq!(key.to_string(), "__catalog_name/my-catalog");
 
-        let parsed: CatalogNameKey = "__catalog_name/my-catalog".try_into().unwrap();
+        let parsed = CatalogNameKey::from_bytes(b"__catalog_name/my-catalog").unwrap();
 
         assert_eq!(key, parsed);
     }

--- a/src/common/meta/src/key/flow.rs
+++ b/src/common/meta/src/key/flow.rs
@@ -58,7 +58,7 @@ impl<T> FlowScoped<T> {
     }
 }
 
-impl<T: MetaKey<T>> MetaKey<FlowScoped<T>> for FlowScoped<T> {
+impl<'a, T: MetaKey<'a, T>> MetaKey<'a, FlowScoped<T>> for FlowScoped<T> {
     fn to_bytes(&self) -> Vec<u8> {
         let prefix = FlowScoped::<T>::PREFIX.as_bytes();
         let inner = self.inner.to_bytes();
@@ -68,7 +68,7 @@ impl<T: MetaKey<T>> MetaKey<FlowScoped<T>> for FlowScoped<T> {
         bytes
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlowScoped<T>> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowScoped<T>> {
         let prefix = FlowScoped::<T>::PREFIX.as_bytes();
         ensure!(
             bytes.starts_with(prefix),
@@ -224,12 +224,12 @@ mod tests {
         inner: Vec<u8>,
     }
 
-    impl MetaKey<MockKey> for MockKey {
+    impl<'a> MetaKey<'a, MockKey> for MockKey {
         fn to_bytes(&self) -> Vec<u8> {
             self.inner.clone()
         }
 
-        fn from_bytes(bytes: &[u8]) -> Result<MockKey> {
+        fn from_bytes(bytes: &'a [u8]) -> Result<MockKey> {
             Ok(MockKey {
                 inner: bytes.to_vec(),
             })

--- a/src/common/meta/src/key/flow/flow_info.rs
+++ b/src/common/meta/src/key/flow/flow_info.rs
@@ -43,12 +43,12 @@ lazy_static! {
 /// The layout: `__flow/info/{flow_id}`.
 pub struct FlowInfoKey(FlowScoped<FlowInfoKeyInner>);
 
-impl MetaKey<FlowInfoKey> for FlowInfoKey {
+impl<'a> MetaKey<'a, FlowInfoKey> for FlowInfoKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlowInfoKey> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowInfoKey> {
         Ok(FlowInfoKey(FlowScoped::<FlowInfoKeyInner>::from_bytes(
             bytes,
         )?))
@@ -81,12 +81,12 @@ impl FlowInfoKeyInner {
     }
 }
 
-impl MetaKey<FlowInfoKeyInner> for FlowInfoKeyInner {
+impl<'a> MetaKey<'a, FlowInfoKeyInner> for FlowInfoKeyInner {
     fn to_bytes(&self) -> Vec<u8> {
         format!("{FLOW_INFO_KEY_PREFIX}/{}", self.flow_id).into_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlowInfoKeyInner> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowInfoKeyInner> {
         let key = std::str::from_utf8(bytes).map_err(|e| {
             error::InvalidTableMetadataSnafu {
                 err_msg: format!(

--- a/src/common/meta/src/key/flow/flow_name.rs
+++ b/src/common/meta/src/key/flow/flow_name.rs
@@ -59,12 +59,12 @@ impl FlowNameKey {
     }
 }
 
-impl MetaKey<FlowNameKey> for FlowNameKey {
+impl<'a> MetaKey<'a, FlowNameKey> for FlowNameKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlowNameKey> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowNameKey> {
         Ok(FlowNameKey(FlowScoped::<FlowNameKeyInner>::from_bytes(
             bytes,
         )?))
@@ -78,7 +78,7 @@ pub struct FlowNameKeyInner {
     pub flow_name: String,
 }
 
-impl MetaKey<FlowNameKeyInner> for FlowNameKeyInner {
+impl<'a> MetaKey<'a, FlowNameKeyInner> for FlowNameKeyInner {
     fn to_bytes(&self) -> Vec<u8> {
         format!(
             "{FLOW_NAME_KEY_PREFIX}/{}/{}",
@@ -87,7 +87,7 @@ impl MetaKey<FlowNameKeyInner> for FlowNameKeyInner {
         .into_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlowNameKeyInner> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowNameKeyInner> {
         let key = std::str::from_utf8(bytes).map_err(|e| {
             error::InvalidTableMetadataSnafu {
                 err_msg: format!(

--- a/src/common/meta/src/key/flow/flow_name.rs
+++ b/src/common/meta/src/key/flow/flow_name.rs
@@ -39,32 +39,32 @@ lazy_static! {
 /// The key of mapping {flow_name} to [FlowId].
 ///
 /// The layout: `__flow/name/{catalog_name}/{flow_name}`.
-pub struct FlowNameKey(FlowScoped<FlowNameKeyInner>);
+pub struct FlowNameKey<'a>(FlowScoped<FlowNameKeyInner<'a>>);
 
-impl FlowNameKey {
+impl<'a> FlowNameKey<'a> {
     /// Returns the [FlowNameKey]
-    pub fn new(catalog: String, flow_name: String) -> FlowNameKey {
+    pub fn new(catalog: &'a str, flow_name: &'a str) -> FlowNameKey<'a> {
         let inner = FlowNameKeyInner::new(catalog, flow_name);
         FlowNameKey(FlowScoped::new(inner))
     }
 
     /// Returns the catalog.
     pub fn catalog(&self) -> &str {
-        &self.0.catalog_name
+        self.0.catalog_name
     }
 
     /// Return the `flow_name`
     pub fn flow_name(&self) -> &str {
-        &self.0.flow_name
+        self.0.flow_name
     }
 }
 
-impl<'a> MetaKey<'a, FlowNameKey> for FlowNameKey {
+impl<'a> MetaKey<'a, FlowNameKey<'a>> for FlowNameKey<'a> {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &'a [u8]) -> Result<FlowNameKey> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlowNameKey<'a>> {
         Ok(FlowNameKey(FlowScoped::<FlowNameKeyInner>::from_bytes(
             bytes,
         )?))
@@ -73,12 +73,12 @@ impl<'a> MetaKey<'a, FlowNameKey> for FlowNameKey {
 
 /// The key of mapping name to [FlowId]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FlowNameKeyInner {
-    pub catalog_name: String,
-    pub flow_name: String,
+pub struct FlowNameKeyInner<'a> {
+    pub catalog_name: &'a str,
+    pub flow_name: &'a str,
 }
 
-impl<'a> MetaKey<'a, FlowNameKeyInner> for FlowNameKeyInner {
+impl<'a> MetaKey<'a, FlowNameKeyInner<'a>> for FlowNameKeyInner<'_> {
     fn to_bytes(&self) -> Vec<u8> {
         format!(
             "{FLOW_NAME_KEY_PREFIX}/{}/{}",
@@ -104,8 +104,8 @@ impl<'a> MetaKey<'a, FlowNameKeyInner> for FlowNameKeyInner {
                     err_msg: format!("Invalid FlowNameKeyInner '{key}'"),
                 })?;
         // Safety: pass the regex check above
-        let catalog_name = captures[1].to_string();
-        let flow_name = captures[2].to_string();
+        let catalog_name = captures.get(1).unwrap().as_str();
+        let flow_name = captures.get(2).unwrap().as_str();
         Ok(FlowNameKeyInner {
             catalog_name,
             flow_name,
@@ -113,9 +113,9 @@ impl<'a> MetaKey<'a, FlowNameKeyInner> for FlowNameKeyInner {
     }
 }
 
-impl FlowNameKeyInner {
+impl<'a> FlowNameKeyInner<'a> {
     /// Returns a [FlowNameKeyInner].
-    pub fn new(catalog_name: String, flow_name: String) -> Self {
+    pub fn new(catalog_name: &'a str, flow_name: &'a str) -> Self {
         Self {
             catalog_name,
             flow_name,
@@ -154,7 +154,7 @@ impl FlowNameManager {
 
     /// Returns the [FlowNameValue] of specified `catalog.flow`.
     pub async fn get(&self, catalog: &str, flow: &str) -> Result<Option<FlowNameValue>> {
-        let key = FlowNameKey::new(catalog.to_string(), flow.to_string());
+        let key = FlowNameKey::new(catalog, flow);
         let raw_key = key.to_bytes();
         self.kv_backend
             .get(&raw_key)
@@ -165,7 +165,7 @@ impl FlowNameManager {
 
     /// Returns true if the `flow` exists.
     pub async fn exists(&self, catalog: &str, flow: &str) -> Result<bool> {
-        let key = FlowNameKey::new(catalog.to_string(), flow.to_string());
+        let key = FlowNameKey::new(catalog, flow);
         let raw_key = key.to_bytes();
         self.kv_backend.exists(&raw_key).await
     }
@@ -184,7 +184,7 @@ impl FlowNameManager {
             &mut TxnOpGetResponseSet,
         ) -> Result<Option<DeserializedValueWithBytes<FlowNameValue>>>,
     )> {
-        let key = FlowNameKey::new(catalog_name.to_string(), flow_name.to_string());
+        let key = FlowNameKey::new(catalog_name, flow_name);
         let raw_key = key.to_bytes();
         let flow_flow_name_value = FlowNameValue::new(flow_id);
         let txn = txn_helper::build_put_if_absent_txn(
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_key_serialization() {
-        let key = FlowNameKey::new("my_catalog".to_string(), "my_task".to_string());
+        let key = FlowNameKey::new("my_catalog", "my_task");
         assert_eq!(b"__flow/name/my_catalog/my_task".to_vec(), key.to_bytes(),);
     }
 

--- a/src/common/meta/src/key/flow/flownode_flow.rs
+++ b/src/common/meta/src/key/flow/flownode_flow.rs
@@ -44,12 +44,12 @@ const FLOWNODE_FLOW_KEY_PREFIX: &str = "flownode";
 /// The layout `__flow/flownode/{flownode_id}/{flow_id}/{partition_id}`
 pub struct FlownodeFlowKey(FlowScoped<FlownodeFlowKeyInner>);
 
-impl MetaKey<FlownodeFlowKey> for FlownodeFlowKey {
+impl<'a> MetaKey<'a, FlownodeFlowKey> for FlownodeFlowKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlownodeFlowKey> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlownodeFlowKey> {
         Ok(FlownodeFlowKey(
             FlowScoped::<FlownodeFlowKeyInner>::from_bytes(bytes)?,
         ))
@@ -118,7 +118,7 @@ impl FlownodeFlowKeyInner {
     }
 }
 
-impl MetaKey<FlownodeFlowKeyInner> for FlownodeFlowKeyInner {
+impl<'a> MetaKey<'a, FlownodeFlowKeyInner> for FlownodeFlowKeyInner {
     fn to_bytes(&self) -> Vec<u8> {
         format!(
             "{FLOWNODE_FLOW_KEY_PREFIX}/{}/{}/{}",
@@ -127,7 +127,7 @@ impl MetaKey<FlownodeFlowKeyInner> for FlownodeFlowKeyInner {
         .into_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<FlownodeFlowKeyInner> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<FlownodeFlowKeyInner> {
         let key = std::str::from_utf8(bytes).map_err(|e| {
             error::InvalidTableMetadataSnafu {
                 err_msg: format!(

--- a/src/common/meta/src/key/flow/table_flow.rs
+++ b/src/common/meta/src/key/flow/table_flow.rs
@@ -54,12 +54,12 @@ struct TableFlowKeyInner {
 #[derive(Debug, PartialEq)]
 pub struct TableFlowKey(FlowScoped<TableFlowKeyInner>);
 
-impl MetaKey<TableFlowKey> for TableFlowKey {
+impl<'a> MetaKey<'a, TableFlowKey> for TableFlowKey {
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<TableFlowKey> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<TableFlowKey> {
         Ok(TableFlowKey(FlowScoped::<TableFlowKeyInner>::from_bytes(
             bytes,
         )?))
@@ -132,7 +132,7 @@ impl TableFlowKeyInner {
     }
 }
 
-impl MetaKey<TableFlowKeyInner> for TableFlowKeyInner {
+impl<'a> MetaKey<'a, TableFlowKeyInner> for TableFlowKeyInner {
     fn to_bytes(&self) -> Vec<u8> {
         format!(
             "{TABLE_FLOW_KEY_PREFIX}/{}/{}/{}/{}",
@@ -141,7 +141,7 @@ impl MetaKey<TableFlowKeyInner> for TableFlowKeyInner {
         .into_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<TableFlowKeyInner> {
+    fn from_bytes(bytes: &'a [u8]) -> Result<TableFlowKeyInner> {
         let key = std::str::from_utf8(bytes).map_err(|e| {
             error::InvalidTableMetadataSnafu {
                 err_msg: format!(

--- a/src/common/meta/src/key/schema_name.rs
+++ b/src/common/meta/src/key/schema_name.rs
@@ -238,7 +238,8 @@ mod tests {
         let key = SchemaNameKey::new("my-catalog", "my-schema");
         assert_eq!(key.to_string(), "__schema_name/my-catalog/my-schema");
 
-        let parsed: SchemaNameKey<'_> = "__schema_name/my-catalog/my-schema".try_into().unwrap();
+        let parsed = SchemaNameKey::from_bytes(b"__schema_name/my-catalog/my-schema").unwrap();
+
         assert_eq!(key, parsed);
 
         let value = SchemaNameValue {

--- a/src/common/meta/src/key/table_info.rs
+++ b/src/common/meta/src/key/table_info.rs
@@ -34,6 +34,7 @@ use crate::table_name::TableName;
 /// The key stores the metadata of the table.
 ///
 /// The layout: `__table_info/{table_id}`.
+#[derive(Debug, PartialEq)]
 pub struct TableInfoKey {
     table_id: TableId,
 }
@@ -281,14 +282,21 @@ mod tests {
     }
 
     #[test]
-    fn test_key_serde() {
+    fn test_key_serialization() {
         let key = TableInfoKey::new(42);
         let raw_key = key.to_bytes();
         assert_eq!(raw_key, b"__table_info/42");
     }
 
     #[test]
-    fn test_value_serde() {
+    fn test_key_deserialization() {
+        let expected = TableInfoKey::new(42);
+        let key = TableInfoKey::from_bytes(b"__table_info/42").unwrap();
+        assert_eq!(key, expected);
+    }
+
+    #[test]
+    fn test_value_serialization() {
         let value = TableInfoValue {
             table_info: new_table_info(42),
             version: 1,

--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -303,13 +303,18 @@ mod tests {
     }
 
     #[test]
-    fn test_serde() {
+    fn test_serialization() {
         let key = TableNameKey::new("my_catalog", "my_schema", "my_table");
         let raw_key = key.to_bytes();
         assert_eq!(
             b"__table_name/my_catalog/my_schema/my_table",
             raw_key.as_slice()
         );
+        let table_name_key =
+            TableNameKey::from_bytes(b"__table_name/my_catalog/my_schema/my_table").unwrap();
+        assert_eq!(table_name_key.catalog, "my_catalog");
+        assert_eq!(table_name_key.schema, "my_schema");
+        assert_eq!(table_name_key.table, "my_table");
 
         let value = TableNameValue::new(1);
         let literal = br#"{"table_id":1}"#;

--- a/src/common/meta/src/key/table_region.rs
+++ b/src/common/meta/src/key/table_region.rs
@@ -13,16 +13,18 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::fmt::Display;
 
+use lazy_static::lazy_static;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
+use snafu::{OptionExt, ResultExt};
 use store_api::storage::RegionNumber;
 use table::metadata::TableId;
 
-use super::TABLE_REGION_KEY_PREFIX;
-use crate::error::{Result, SerdeJsonSnafu};
-use crate::key::TableMetaKey;
-use crate::{impl_table_meta_key, impl_table_meta_value, DatanodeId};
+use super::{MetaKey, TABLE_REGION_KEY_PREFIX};
+use crate::error::{InvalidTableMetadataSnafu, Result, SerdeJsonSnafu};
+use crate::{impl_table_meta_value, DatanodeId};
 
 pub type RegionDistribution = BTreeMap<DatanodeId, Vec<RegionNumber>>;
 
@@ -34,19 +36,49 @@ pub struct TableRegionKey {
     table_id: TableId,
 }
 
+lazy_static! {
+    static ref TABLE_REGION_KEY_PATTERN: Regex =
+        Regex::new(&format!("^{TABLE_REGION_KEY_PREFIX}/([0-9]+)$")).unwrap();
+}
+
 impl TableRegionKey {
     pub fn new(table_id: TableId) -> Self {
         Self { table_id }
     }
 }
 
-impl TableMetaKey for TableRegionKey {
-    fn as_raw_key(&self) -> Vec<u8> {
-        format!("{}/{}", TABLE_REGION_KEY_PREFIX, self.table_id).into_bytes()
+impl Display for TableRegionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", TABLE_REGION_KEY_PREFIX, self.table_id)
     }
 }
 
-impl_table_meta_key! {TableRegionKey}
+impl<'a> MetaKey<'a, TableRegionKey> for TableRegionKey {
+    fn to_bytes(&self) -> Vec<u8> {
+        self.to_string().into_bytes()
+    }
+
+    fn from_bytes(bytes: &'a [u8]) -> Result<TableRegionKey> {
+        let key = std::str::from_utf8(bytes).map_err(|e| {
+            InvalidTableMetadataSnafu {
+                err_msg: format!(
+                    "TableRegionKey '{}' is not a valid UTF8 string: {e}",
+                    String::from_utf8_lossy(bytes)
+                ),
+            }
+            .build()
+        })?;
+        let captures =
+            TABLE_REGION_KEY_PATTERN
+                .captures(key)
+                .context(InvalidTableMetadataSnafu {
+                    err_msg: format!("Invalid TableRegionKey '{key}'"),
+                })?;
+        // Safety: pass the regex check above
+        let table_id = captures[1].parse::<TableId>().unwrap();
+        Ok(TableRegionKey { table_id })
+    }
+}
 
 #[deprecated(
     since = "0.4.0",
@@ -77,7 +109,7 @@ mod tests {
     #[test]
     fn test_serde() {
         let key = TableRegionKey::new(1);
-        let raw_key = key.as_raw_key();
+        let raw_key = key.to_bytes();
         assert_eq!(raw_key, b"__table_region/1");
 
         let value = TableRegionValue {

--- a/src/common/meta/src/key/table_region.rs
+++ b/src/common/meta/src/key/table_region.rs
@@ -32,6 +32,7 @@ pub type RegionDistribution = BTreeMap<DatanodeId, Vec<RegionNumber>>;
     since = "0.4.0",
     note = "Please use the TableRouteManager's get_region_distribution method instead"
 )]
+#[derive(Debug, PartialEq)]
 pub struct TableRegionKey {
     table_id: TableId,
 }
@@ -107,10 +108,12 @@ mod tests {
     use crate::key::TableMetaValue;
 
     #[test]
-    fn test_serde() {
-        let key = TableRegionKey::new(1);
+    fn test_serialization() {
+        let key = TableRegionKey::new(24);
         let raw_key = key.to_bytes();
-        assert_eq!(raw_key, b"__table_region/1");
+        assert_eq!(raw_key, b"__table_region/24");
+        let deserialized = TableRegionKey::from_bytes(b"__table_region/24").unwrap();
+        assert_eq!(key, deserialized);
 
         let value = TableRegionValue {
             region_distribution: RegionDistribution::from([(1, vec![1, 2, 3]), (2, vec![4, 5, 6])]),

--- a/src/common/meta/src/key/table_route.rs
+++ b/src/common/meta/src/key/table_route.rs
@@ -37,6 +37,7 @@ use crate::rpc::store::BatchGetRequest;
 /// The key stores table routes
 ///
 /// The layout: `__table_route/{table_id}`.
+#[derive(Debug, PartialEq)]
 pub struct TableRouteKey {
     pub table_id: TableId,
 }
@@ -626,6 +627,20 @@ mod tests {
             new_raw_v,
             r#"Physical(PhysicalTableRouteValue { region_routes: [RegionRoute { region: Region { id: 1(0, 1), name: "r1", partition: None, attrs: {} }, leader_peer: Some(Peer { id: 2, addr: "a2" }), follower_peers: [], leader_status: None, leader_down_since: None }, RegionRoute { region: Region { id: 1(0, 1), name: "r1", partition: None, attrs: {} }, leader_peer: Some(Peer { id: 2, addr: "a2" }), follower_peers: [], leader_status: None, leader_down_since: None }], version: 0 })"#
         );
+    }
+
+    #[test]
+    fn test_key_serialization() {
+        let key = TableRouteKey::new(42);
+        let raw_key = key.to_bytes();
+        assert_eq!(raw_key, b"__table_route/42");
+    }
+
+    #[test]
+    fn test_key_deserialization() {
+        let expected = TableRouteKey::new(42);
+        let key = TableRouteKey::from_bytes(b"__table_route/42").unwrap();
+        assert_eq!(key, expected);
     }
 
     #[tokio::test]

--- a/src/frontend/src/heartbeat/handler/tests.rs
+++ b/src/frontend/src/heartbeat/handler/tests.rs
@@ -24,7 +24,7 @@ use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MessageMeta};
 use common_meta::instruction::{CacheIdent, Instruction};
 use common_meta::key::schema_name::{SchemaName, SchemaNameKey};
 use common_meta::key::table_info::TableInfoKey;
-use common_meta::key::TableMetaKey;
+use common_meta::key::MetaKey;
 use partition::manager::TableRouteCacheInvalidator;
 use table::metadata::TableId;
 use tokio::sync::mpsc;
@@ -79,7 +79,7 @@ async fn handle_instruction(
 async fn test_invalidate_table_cache_handler() {
     let table_id = 1;
     let table_info_key = TableInfoKey::new(table_id);
-    let inner = HashMap::from([(table_info_key.as_raw_key(), 1)]);
+    let inner = HashMap::from([(table_info_key.to_bytes(), 1)]);
     let backend = Arc::new(MockKvCacheInvalidator {
         inner: Mutex::new(inner),
     });
@@ -103,7 +103,7 @@ async fn test_invalidate_table_cache_handler() {
         .inner
         .lock()
         .unwrap()
-        .contains_key(&table_info_key.as_raw_key()));
+        .contains_key(&table_info_key.to_bytes()));
 
     // removes a invalid key
     handle_instruction(
@@ -118,7 +118,7 @@ async fn test_invalidate_table_cache_handler() {
 async fn test_invalidate_schema_key_handler() {
     let (catalog, schema) = ("foo", "bar");
     let schema_key = SchemaNameKey { catalog, schema };
-    let inner = HashMap::from([(schema_key.as_raw_key(), 1)]);
+    let inner = HashMap::from([(schema_key.to_bytes(), 1)]);
     let backend = Arc::new(MockKvCacheInvalidator {
         inner: Mutex::new(inner),
     });
@@ -146,7 +146,7 @@ async fn test_invalidate_schema_key_handler() {
         .inner
         .lock()
         .unwrap()
-        .contains_key(&schema_key.as_raw_key()));
+        .contains_key(&schema_key.to_bytes()));
 
     // removes a invalid key
     handle_instruction(

--- a/tests-integration/tests/region_failover.rs
+++ b/tests-integration/tests/region_failover.rs
@@ -19,7 +19,7 @@ use catalog::kvbackend::{CachedMetaKvBackend, KvBackendCatalogManager};
 use client::OutputData;
 use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 use common_meta::key::table_route::TableRouteKey;
-use common_meta::key::{RegionDistribution, TableMetaKey};
+use common_meta::key::{MetaKey, RegionDistribution};
 use common_meta::peer::Peer;
 use common_meta::{distributed_time_constants, RegionIdent};
 use common_procedure::{watcher, ProcedureWithId};
@@ -176,7 +176,7 @@ async fn has_route_cache(instance: &Arc<Instance>, table_id: TableId) -> bool {
         .cache();
 
     cache
-        .get(TableRouteKey::new(table_id).as_raw_key().as_slice())
+        .get(TableRouteKey::new(table_id).to_bytes().as_slice())
         .await
         .is_some()
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Wait for #3835

use `MetaKey` trait instead of `TableMetaKey`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
