### PR TITLE
feat: Parquet reader builder supports building multiple ranges to read

### DIFF
--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -14,11 +14,11 @@
 
 //! SST in parquet format.
 
+pub(crate) mod file_range;
 mod format;
 pub(crate) mod helper;
 pub(crate) mod metadata;
 mod page_reader;
-pub(crate) mod partition;
 pub mod reader;
 pub mod row_group;
 mod row_selection;

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -18,6 +18,7 @@ mod format;
 pub(crate) mod helper;
 pub(crate) mod metadata;
 mod page_reader;
+pub(crate) mod partition;
 pub mod reader;
 pub mod row_group;
 mod row_selection;

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -121,16 +121,16 @@ pub(crate) struct ReadFormat {
     /// Field column id to its index in `schema` (SST schema).
     /// In SST schema, fields are stored in the front of the schema.
     field_id_to_index: HashMap<ColumnId, usize>,
+    /// Indices of columns to read from the SST. It contains all internal columns.
+    projection_indices: Vec<usize>,
     /// Field column id to their index in the projected schema (
     /// the schema of [Batch]).
-    ///
-    /// This field is set at the first call to [convert_record_batch](Self::convert_record_batch).
-    field_id_to_projected_index: Option<HashMap<ColumnId, usize>>,
+    field_id_to_projected_index: HashMap<ColumnId, usize>,
 }
 
 impl ReadFormat {
-    /// Creates a helper with existing `metadata`.
-    pub(crate) fn new(metadata: RegionMetadataRef) -> ReadFormat {
+    /// Creates a helper with existing `metadata` and `column_ids` to read.
+    pub(crate) fn new(metadata: RegionMetadataRef, column_ids: &[ColumnId]) -> ReadFormat {
         let field_id_to_index: HashMap<_, _> = metadata
             .field_columns()
             .enumerate()
@@ -138,11 +138,43 @@ impl ReadFormat {
             .collect();
         let arrow_schema = to_sst_arrow_schema(&metadata);
 
+        // Maps column id of a projected field to its index in SST.
+        let mut projected_field_id_index: Vec<_> = column_ids
+            .into_iter()
+            .filter_map(|column_id| {
+                // Only apply projection to fields.
+                field_id_to_index
+                    .get(column_id)
+                    .copied()
+                    .map(|index| (*column_id, index))
+            })
+            .collect();
+        let mut projection_indices: Vec<_> = projected_field_id_index
+            .iter()
+            .map(|(_column_id, index)| *index)
+            // We need to add all fixed position columns.
+            .chain(arrow_schema.fields.len() - FIXED_POS_COLUMN_NUM..arrow_schema.fields.len())
+            .collect();
+        projection_indices.sort_unstable();
+
+        // Sort fields by their indices in the SST. Then the order of fields is their order
+        // in the Batch.
+        projected_field_id_index.sort_unstable_by_key(|x| x.1);
+        // Because the SST put fields before other columns, we don't need to consider other
+        // columns.
+        let field_id_to_projected_index = projected_field_id_index
+            .into_iter()
+            .map(|(column_id, _)| column_id)
+            .enumerate()
+            .map(|(index, column_id)| (column_id, index))
+            .collect();
+
         ReadFormat {
             metadata,
             arrow_schema,
             field_id_to_index,
-            field_id_to_projected_index: None,
+            projection_indices,
+            field_id_to_projected_index,
         }
     }
 
@@ -159,35 +191,16 @@ impl ReadFormat {
         &self.metadata
     }
 
-    /// Gets sorted projection indices to read `columns` from parquet files.
-    ///
-    /// This function ignores columns not in `metadata` to for compatibility between
-    /// different schemas.
-    pub(crate) fn projection_indices(
-        &self,
-        columns: impl IntoIterator<Item = ColumnId>,
-    ) -> Vec<usize> {
-        let mut indices: Vec<_> = columns
-            .into_iter()
-            .filter_map(|column_id| {
-                // Only apply projection to fields.
-                self.field_id_to_index.get(&column_id).copied()
-            })
-            // We need to add all fixed position columns.
-            .chain(
-                self.arrow_schema.fields.len() - FIXED_POS_COLUMN_NUM
-                    ..self.arrow_schema.fields.len(),
-            )
-            .collect();
-        indices.sort_unstable();
-        indices
+    /// Gets sorted projection indices to read.
+    pub(crate) fn projection_indices(&self) -> &[usize] {
+        &self.projection_indices
     }
 
     /// Convert a arrow record batch into `batches`.
     ///
     /// Note that the `record_batch` may only contains a subset of columns if it is projected.
     pub(crate) fn convert_record_batch(
-        &mut self,
+        &self,
         record_batch: &RecordBatch,
         batches: &mut VecDeque<Batch>,
     ) -> Result<()> {
@@ -203,10 +216,6 @@ impl ReadFormat {
                 ),
             }
         );
-
-        if self.field_id_to_projected_index.is_none() {
-            self.init_id_to_projected_index(record_batch);
-        }
 
         let mut fixed_pos_columns = record_batch
             .columns()
@@ -268,19 +277,6 @@ impl ReadFormat {
         }
 
         Ok(())
-    }
-
-    fn init_id_to_projected_index(&mut self, record_batch: &RecordBatch) {
-        let mut name_to_projected_index = HashMap::new();
-        for (index, field) in record_batch.schema().fields().iter().enumerate() {
-            let Some(column) = self.metadata.column_by_name(field.name()) else {
-                continue;
-            };
-            if column.semantic_type == SemanticType::Field {
-                name_to_projected_index.insert(column.column_id, index);
-            }
-        }
-        self.field_id_to_projected_index = Some(name_to_projected_index);
     }
 
     /// Returns min values of specific column in row groups.
@@ -513,13 +509,8 @@ impl ReadFormat {
     }
 
     /// Index of a field column by its column id.
-    /// This function is only available after the first call to
-    /// [convert_record_batch](Self::convert_record_batch). Otherwise
-    /// it always return `None`
     pub fn field_index_by_id(&self, column_id: ColumnId) -> Option<usize> {
-        self.field_id_to_projected_index
-            .as_ref()
-            .and_then(|m| m.get(&column_id).copied())
+        self.field_id_to_projected_index.get(&column_id).copied()
     }
 }
 
@@ -753,18 +744,18 @@ mod tests {
     #[test]
     fn test_projection_indices() {
         let metadata = build_test_region_metadata();
-        let read_format = ReadFormat::new(metadata);
         // Only read tag1
-        assert_eq!(vec![2, 3, 4, 5], read_format.projection_indices([3]));
+        let read_format = ReadFormat::new(metadata.clone(), &[3]);
+        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
         // Only read field1
-        assert_eq!(vec![0, 2, 3, 4, 5], read_format.projection_indices([4]));
+        let read_format = ReadFormat::new(metadata.clone(), &[4]);
+        assert_eq!(&[0, 2, 3, 4, 5], read_format.projection_indices());
         // Only read ts
-        assert_eq!(vec![2, 3, 4, 5], read_format.projection_indices([5]));
+        let read_format = ReadFormat::new(metadata.clone(), &[5]);
+        assert_eq!(&[2, 3, 4, 5], read_format.projection_indices());
         // Read field0, tag0, ts
-        assert_eq!(
-            vec![1, 2, 3, 4, 5],
-            read_format.projection_indices([2, 1, 5])
-        );
+        let read_format = ReadFormat::new(metadata, &[2, 1, 5]);
+        assert_eq!(&[1, 2, 3, 4, 5], read_format.projection_indices());
     }
 
     #[test]
@@ -805,7 +796,12 @@ mod tests {
     fn test_convert_empty_record_batch() {
         let metadata = build_test_region_metadata();
         let arrow_schema = build_test_arrow_schema();
-        let mut read_format = ReadFormat::new(metadata);
+        let column_ids: Vec<_> = metadata
+            .column_metadatas
+            .iter()
+            .map(|col| col.column_id)
+            .collect();
+        let read_format = ReadFormat::new(metadata, &column_ids);
         assert_eq!(arrow_schema, *read_format.arrow_schema());
 
         let record_batch = RecordBatch::new_empty(arrow_schema);
@@ -819,7 +815,12 @@ mod tests {
     #[test]
     fn test_convert_record_batch() {
         let metadata = build_test_region_metadata();
-        let mut read_format = ReadFormat::new(metadata);
+        let column_ids: Vec<_> = metadata
+            .column_metadatas
+            .iter()
+            .map(|col| col.column_id)
+            .collect();
+        let read_format = ReadFormat::new(metadata, &column_ids);
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(Int64Array::from(vec![1, 1, 10, 10])), // field1

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -140,7 +140,7 @@ impl ReadFormat {
 
         // Maps column id of a projected field to its index in SST.
         let mut projected_field_id_index: Vec<_> = column_ids
-            .into_iter()
+            .iter()
             .filter_map(|column_id| {
                 // Only apply projection to fields.
                 field_id_to_index

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -1,0 +1,85 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs and functions for reading partitions from a parquet file. A partition
+//! is usually a row group in a parquet file.
+
+use std::sync::Arc;
+
+use common_recordbatch::filter::SimpleFilterEvaluator;
+use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, RowSelection};
+
+use crate::error::Result;
+use crate::sst::parquet::format::ReadFormat;
+use crate::sst::parquet::reader::RowGroupReaderBuilder;
+
+/// A partition of a parquet SST. Now it is a row group.
+pub(crate) struct Partition {
+    /// Shared context.
+    context: PartitionContextRef,
+    /// Index of the row group in the SST.
+    row_group_idx: usize,
+    /// Row selection for the row group. `None` means all rows.
+    row_selection: Option<RowSelection>,
+}
+
+impl Partition {
+    /// Creates a new partition.
+    pub(crate) fn new(
+        context: PartitionContextRef,
+        row_group_idx: usize,
+        row_selection: Option<RowSelection>,
+    ) -> Self {
+        Self {
+            context,
+            row_group_idx,
+            row_selection,
+        }
+    }
+
+    /// Returns a reader to read the partition.
+    pub(crate) async fn reader(&self) -> Result<ParquetRecordBatchReader> {
+        self.context
+            .reader_builder
+            .build(self.row_group_idx, self.row_selection.clone())
+            .await
+    }
+}
+
+/// Context shared by partitions of the same parquet SST.
+pub(crate) struct PartitionContext {
+    // Row group reader builder for the file.
+    reader_builder: RowGroupReaderBuilder,
+    /// Filters pushed down.
+    filters: Vec<SimpleFilterEvaluator>,
+    /// Helper to read the SST.
+    format: ReadFormat,
+}
+
+pub(crate) type PartitionContextRef = Arc<PartitionContext>;
+
+impl PartitionContext {
+    /// Creates a new partition context.
+    pub(crate) fn new(
+        reader_builder: RowGroupReaderBuilder,
+        filters: Vec<SimpleFilterEvaluator>,
+        format: ReadFormat,
+    ) -> Self {
+        Self {
+            reader_builder,
+            filters,
+            format,
+        }
+    }
+}

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -15,12 +15,19 @@
 //! Structs and functions for reading partitions from a parquet file. A partition
 //! is usually a row group in a parquet file.
 
+use std::ops::BitAnd;
 use std::sync::Arc;
 
+use api::v1::SemanticType;
 use common_recordbatch::filter::SimpleFilterEvaluator;
+use datatypes::arrow::array::BooleanArray;
+use datatypes::arrow::buffer::BooleanBuffer;
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, RowSelection};
+use snafu::ResultExt;
 
-use crate::error::Result;
+use crate::error::{FieldTypeMismatchSnafu, FilterRecordBatchSnafu, Result};
+use crate::read::Batch;
+use crate::row_converter::{McmpRowCodec, RowCodec};
 use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::reader::RowGroupReaderBuilder;
 
@@ -64,7 +71,9 @@ pub(crate) struct PartitionContext {
     /// Filters pushed down.
     filters: Vec<SimpleFilterEvaluator>,
     /// Helper to read the SST.
-    format: ReadFormat,
+    read_format: ReadFormat,
+    /// Decoder for primary keys
+    codec: McmpRowCodec,
 }
 
 pub(crate) type PartitionContextRef = Arc<PartitionContext>;
@@ -74,12 +83,101 @@ impl PartitionContext {
     pub(crate) fn new(
         reader_builder: RowGroupReaderBuilder,
         filters: Vec<SimpleFilterEvaluator>,
-        format: ReadFormat,
+        read_format: ReadFormat,
+        codec: McmpRowCodec,
     ) -> Self {
         Self {
             reader_builder,
             filters,
-            format,
+            read_format,
+            codec,
         }
+    }
+
+    /// Returns the path of the file to read.
+    pub(crate) fn file_path(&self) -> &str {
+        self.reader_builder.file_path()
+    }
+
+    /// Returns filters pushed down.
+    pub(crate) fn filters(&self) -> &[SimpleFilterEvaluator] {
+        &self.filters
+    }
+
+    /// Returns the format helper.
+    pub(crate) fn read_format(&self) -> &ReadFormat {
+        &self.read_format
+    }
+
+    /// TRY THE BEST to perform pushed down predicate precisely on the input batch.
+    /// Return the filtered batch. If the entire batch is filtered out, return None.
+    ///
+    /// Supported filter expr type is defined in [SimpleFilterEvaluator].
+    ///
+    /// When a filter is referencing primary key column, this method will decode
+    /// the primary key and put it into the batch.
+    pub(crate) fn precise_filter(&self, mut input: Batch) -> Result<Option<Batch>> {
+        let mut mask = BooleanBuffer::new_set(input.num_rows());
+
+        // Run filter one by one and combine them result
+        // TODO(ruihang): run primary key filter first. It may short circuit other filters
+        for filter in &self.filters {
+            let column_name = filter.column_name();
+            let Some(column_metadata) = self.read_format.metadata().column_by_name(column_name)
+            else {
+                // column not found, skip
+                // in situation like an column is added later
+                continue;
+            };
+            let result = match column_metadata.semantic_type {
+                SemanticType::Tag => {
+                    let pk_values = if let Some(pk_values) = input.pk_values() {
+                        pk_values
+                    } else {
+                        input.set_pk_values(self.codec.decode(input.primary_key())?);
+                        input.pk_values().unwrap()
+                    };
+                    // Safety: this is a primary key
+                    let pk_index = self
+                        .read_format
+                        .metadata()
+                        .primary_key_index(column_metadata.column_id)
+                        .unwrap();
+                    let pk_value = pk_values[pk_index]
+                        .try_to_scalar_value(&column_metadata.column_schema.data_type)
+                        .context(FieldTypeMismatchSnafu)?;
+                    if filter
+                        .evaluate_scalar(&pk_value)
+                        .context(FilterRecordBatchSnafu)?
+                    {
+                        continue;
+                    } else {
+                        // PK not match means the entire batch is filtered out.
+                        return Ok(None);
+                    }
+                }
+                SemanticType::Field => {
+                    let Some(field_index) = self
+                        .read_format
+                        .field_index_by_id(column_metadata.column_id)
+                    else {
+                        continue;
+                    };
+                    let field_col = &input.fields()[field_index].data;
+                    filter
+                        .evaluate_vector(field_col)
+                        .context(FilterRecordBatchSnafu)?
+                }
+                SemanticType::Timestamp => filter
+                    .evaluate_vector(input.timestamps())
+                    .context(FilterRecordBatchSnafu)?,
+            };
+
+            mask = mask.bitand(&result);
+        }
+
+        input.filter(&BooleanArray::from(mask).into())?;
+
+        Ok(Some(input))
     }
 }

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -119,6 +119,7 @@ impl PartitionContext {
     pub(crate) fn precise_filter(&self, mut input: Batch) -> Result<Option<Batch>> {
         let mut mask = BooleanBuffer::new_set(input.num_rows());
 
+        // FIXME(yingwen): We should use expected metadata to get the column id.
         // Run filter one by one and combine them result
         // TODO(ruihang): run primary key filter first. It may short circuit other filters
         for filter in &self.filters {

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -19,19 +19,19 @@ use std::ops::BitAnd;
 use std::sync::Arc;
 
 use api::v1::SemanticType;
-use common_recordbatch::filter::SimpleFilterEvaluator;
 use datatypes::arrow::array::BooleanArray;
 use datatypes::arrow::buffer::BooleanBuffer;
-use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, RowSelection};
+use parquet::arrow::arrow_reader::RowSelection;
 use snafu::ResultExt;
 
 use crate::error::{FieldTypeMismatchSnafu, FilterRecordBatchSnafu, Result};
 use crate::read::Batch;
 use crate::row_converter::{McmpRowCodec, RowCodec};
 use crate::sst::parquet::format::ReadFormat;
-use crate::sst::parquet::reader::{RowGroupReaderBuilder, SimpleFilterContext};
+use crate::sst::parquet::reader::{RowGroupReader, RowGroupReaderBuilder, SimpleFilterContext};
 
 /// A partition of a parquet SST. Now it is a row group.
+#[allow(dead_code)]
 pub(crate) struct Partition {
     /// Shared context.
     context: PartitionContextRef,
@@ -43,6 +43,7 @@ pub(crate) struct Partition {
 
 impl Partition {
     /// Creates a new partition.
+    #[allow(dead_code)]
     pub(crate) fn new(
         context: PartitionContextRef,
         row_group_idx: usize,
@@ -56,11 +57,15 @@ impl Partition {
     }
 
     /// Returns a reader to read the partition.
-    pub(crate) async fn reader(&self) -> Result<ParquetRecordBatchReader> {
-        self.context
+    #[allow(dead_code)]
+    pub(crate) async fn reader(&self) -> Result<RowGroupReader> {
+        let parquet_reader = self
+            .context
             .reader_builder
             .build(self.row_group_idx, self.row_selection.clone())
-            .await
+            .await?;
+
+        Ok(RowGroupReader::new(self.context.clone(), parquet_reader))
     }
 }
 

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -31,6 +31,7 @@ use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::reader::{RowGroupReader, RowGroupReaderBuilder, SimpleFilterContext};
 
 /// A partition of a parquet SST. Now it is a row group.
+/// We can read different partitions in parallel.
 pub struct Partition {
     /// Shared context.
     context: PartitionContextRef,

--- a/src/mito2/src/sst/parquet/partition.rs
+++ b/src/mito2/src/sst/parquet/partition.rs
@@ -31,8 +31,7 @@ use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::reader::{RowGroupReader, RowGroupReaderBuilder, SimpleFilterContext};
 
 /// A partition of a parquet SST. Now it is a row group.
-#[allow(dead_code)]
-pub(crate) struct Partition {
+pub struct Partition {
     /// Shared context.
     context: PartitionContextRef,
     /// Index of the row group in the SST.
@@ -43,7 +42,6 @@ pub(crate) struct Partition {
 
 impl Partition {
     /// Creates a new partition.
-    #[allow(dead_code)]
     pub(crate) fn new(
         context: PartitionContextRef,
         row_group_idx: usize,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -478,7 +478,7 @@ impl RowGroupReaderBuilder {
 
     /// Builds a [ParquetRecordBatchReader] to read the row group at `row_group_idx`.
     async fn build(
-        &mut self,
+        &self,
         row_group_idx: usize,
         row_selection: Option<RowSelection>,
     ) -> Result<ParquetRecordBatchReader> {

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -181,16 +181,17 @@ impl ParquetReaderBuilder {
         // Gets the metadata stored in the SST.
         let region_meta = Arc::new(Self::get_region_metadata(&file_path, key_value_meta)?);
         let read_format = if let Some(column_ids) = &self.projection {
-            ReadFormat::new(region_meta.clone(), column_ids)
+            ReadFormat::new(region_meta.clone(), column_ids.iter().copied())
         } else {
             // Lists all column ids to read, we always use the expected metadata if possible.
             let expected_meta = self.expected_metadata.as_ref().unwrap_or(&region_meta);
-            let column_ids: Vec<_> = expected_meta
-                .column_metadatas
-                .iter()
-                .map(|col| col.column_id)
-                .collect();
-            ReadFormat::new(region_meta.clone(), &column_ids)
+            ReadFormat::new(
+                region_meta.clone(),
+                expected_meta
+                    .column_metadatas
+                    .iter()
+                    .map(|col| col.column_id),
+            )
         };
 
         // Computes the projection mask.

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -15,17 +15,13 @@
 //! Parquet reader.
 
 use std::collections::{BTreeMap, VecDeque};
-use std::ops::BitAnd;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use api::v1::SemanticType;
 use async_trait::async_trait;
 use common_recordbatch::filter::SimpleFilterEvaluator;
 use common_telemetry::{debug, warn};
 use common_time::range::TimestampRange;
-use datafusion_common::arrow::array::BooleanArray;
-use datafusion_common::arrow::buffer::BooleanBuffer;
 use datatypes::arrow::record_batch::RecordBatch;
 use itertools::Itertools;
 use object_store::ObjectStore;
@@ -40,20 +36,19 @@ use table::predicate::Predicate;
 
 use crate::cache::CacheManagerRef;
 use crate::error::{
-    ArrowReaderSnafu, FieldTypeMismatchSnafu, FilterRecordBatchSnafu, InvalidMetadataSnafu,
-    InvalidParquetSnafu, ReadParquetSnafu, Result,
+    ArrowReaderSnafu, InvalidMetadataSnafu, InvalidParquetSnafu, ReadParquetSnafu, Result,
 };
 use crate::metrics::{
     PRECISE_FILTER_ROWS_TOTAL, READ_ROWS_IN_ROW_GROUP_TOTAL, READ_ROWS_TOTAL,
     READ_ROW_GROUPS_TOTAL, READ_STAGE_ELAPSED,
 };
 use crate::read::{Batch, BatchReader};
-use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
+use crate::row_converter::{McmpRowCodec, SortField};
 use crate::sst::file::FileHandle;
 use crate::sst::index::applier::SstIndexApplierRef;
 use crate::sst::parquet::format::ReadFormat;
 use crate::sst::parquet::metadata::MetadataLoader;
-use crate::sst::parquet::partition::PartitionContextRef;
+use crate::sst::parquet::partition::{PartitionContext, PartitionContextRef};
 use crate::sst::parquet::row_group::InMemoryRowGroup;
 use crate::sst::parquet::row_selection::row_selection_from_row_ranges;
 use crate::sst::parquet::stats::RowGroupPruningStats;
@@ -205,7 +200,7 @@ impl ParquetReaderBuilder {
 
         metrics.build_cost = start.elapsed();
 
-        let predicate = if let Some(predicate) = &self.predicate {
+        let filters = if let Some(predicate) = &self.predicate {
             predicate
                 .exprs()
                 .iter()
@@ -214,7 +209,6 @@ impl ParquetReaderBuilder {
         } else {
             vec![]
         };
-
         let codec = McmpRowCodec::new(
             read_format
                 .metadata()
@@ -223,16 +217,8 @@ impl ParquetReaderBuilder {
                 .collect(),
         );
 
-        Ok(ParquetReader {
-            row_groups,
-            read_format,
-            reader_builder,
-            predicate,
-            current_reader: None,
-            batches: VecDeque::new(),
-            codec,
-            metrics,
-        })
+        let context = PartitionContext::new(reader_builder, filters, read_format, codec);
+        ParquetReader::new(Arc::new(context), row_groups).await
     }
 
     /// Decodes region metadata from key value.
@@ -522,280 +508,182 @@ impl RowGroupReaderBuilder {
     }
 }
 
+/// The state of a [ParquetReader].
+enum ReaderState {
+    /// The reader is reading a row group.
+    Readable(RowGroupReader),
+    /// The reader is exhausted.
+    Exhausted(Metrics),
+}
+
+impl ReaderState {
+    /// Returns the metrics of the reader.
+    fn metrics(&self) -> &Metrics {
+        match self {
+            ReaderState::Readable(reader) => &reader.metrics,
+            ReaderState::Exhausted(m) => &m,
+        }
+    }
+}
+
 /// Parquet batch reader to read our SST format.
 pub struct ParquetReader {
+    /// Partition context.
+    context: PartitionContextRef,
     /// Indices of row groups to read, along with their respective row selections.
     row_groups: BTreeMap<usize, Option<RowSelection>>,
-    /// Helper to read record batches.
-    ///
-    /// Not `None` if [ParquetReader::stream] is not `None`.
-    read_format: ReadFormat,
-    /// Builder to build row group readers.
-    ///
-    /// The builder contains the file handle, so don't drop the builder while using
-    /// the [ParquetReader].
-    reader_builder: RowGroupReaderBuilder,
-    /// Predicate pushed down to this reader.
-    predicate: Vec<SimpleFilterEvaluator>,
     /// Reader of current row group.
-    current_reader: Option<ParquetRecordBatchReader>,
-    /// Buffered batches to return.
-    batches: VecDeque<Batch>,
-    /// Decoder for primary keys
-    codec: McmpRowCodec,
-    /// Local metrics.
-    metrics: Metrics,
+    reader_state: ReaderState,
 }
 
 #[async_trait]
 impl BatchReader for ParquetReader {
     async fn next_batch(&mut self) -> Result<Option<Batch>> {
+        let ReaderState::Readable(reader) = &mut self.reader_state else {
+            return Ok(None);
+        };
+
         let start = Instant::now();
-        if let Some(batch) = self.batches.pop_front() {
-            self.metrics.scan_cost += start.elapsed();
-            self.metrics.num_rows += batch.num_rows();
+        // We don't collect the elapsed time if the reader returns an error.
+        if let Some(batch) = reader.next_batch().await? {
+            reader.metrics.scan_cost += start.elapsed();
             return Ok(Some(batch));
         }
 
-        // We need to fetch next record batch and convert it to batches.
-        while self.batches.is_empty() {
-            let Some(record_batch) = self.fetch_next_record_batch().await? else {
-                self.metrics.scan_cost += start.elapsed();
-                return Ok(None);
-            };
-            self.metrics.num_record_batches += 1;
-
-            self.read_format
-                .convert_record_batch(&record_batch, &mut self.batches)?;
-            self.prune_batches()?;
-            self.metrics.num_batches += self.batches.len();
+        // No more items in current row group, reads next row group.
+        while let Some((row_group_idx, row_selection)) = self.row_groups.pop_first() {
+            let parquet_reader = self
+                .context
+                .reader_builder()
+                .build(row_group_idx, row_selection)
+                .await?;
+            // Resets the parquet reader.
+            reader.reset_reader(parquet_reader);
+            if let Some(batch) = reader.next_batch().await? {
+                reader.metrics.scan_cost += start.elapsed();
+                return Ok(Some(batch));
+            }
         }
-        let batch = self.batches.pop_front();
-        self.metrics.scan_cost += start.elapsed();
-        self.metrics.num_rows += batch.as_ref().map(|b| b.num_rows()).unwrap_or(0);
-        Ok(batch)
+
+        // The reader is exhaused.
+        reader.metrics.scan_cost += start.elapsed();
+        self.reader_state = ReaderState::Exhausted(std::mem::take(&mut reader.metrics));
+        Ok(None)
     }
 }
 
 impl Drop for ParquetReader {
     fn drop(&mut self) {
+        let metrics = self.reader_state.metrics();
         debug!(
             "Read parquet {} {}, range: {:?}, {}/{} row groups, metrics: {:?}",
-            self.reader_builder.file_handle.region_id(),
-            self.reader_builder.file_handle.file_id(),
-            self.reader_builder.file_handle.time_range(),
-            self.metrics.num_row_groups_before_filtering
-                - self.metrics.num_row_groups_inverted_index_filtered
-                - self.metrics.num_row_groups_min_max_filtered,
-            self.metrics.num_row_groups_before_filtering,
-            self.metrics
+            self.context.reader_builder().file_handle.region_id(),
+            self.context.reader_builder().file_handle.file_id(),
+            self.context.reader_builder().file_handle.time_range(),
+            metrics.num_row_groups_before_filtering
+                - metrics.num_row_groups_inverted_index_filtered
+                - metrics.num_row_groups_min_max_filtered,
+            metrics.num_row_groups_before_filtering,
+            metrics
         );
 
         // Report metrics.
         READ_STAGE_ELAPSED
             .with_label_values(&["build_parquet_reader"])
-            .observe(self.metrics.build_cost.as_secs_f64());
+            .observe(metrics.build_cost.as_secs_f64());
         READ_STAGE_ELAPSED
             .with_label_values(&["scan_row_groups"])
-            .observe(self.metrics.scan_cost.as_secs_f64());
+            .observe(metrics.scan_cost.as_secs_f64());
         READ_ROWS_TOTAL
             .with_label_values(&["parquet"])
-            .inc_by(self.metrics.num_rows as u64);
+            .inc_by(metrics.num_rows as u64);
         READ_ROW_GROUPS_TOTAL
             .with_label_values(&["before_filtering"])
-            .inc_by(self.metrics.num_row_groups_before_filtering as u64);
+            .inc_by(metrics.num_row_groups_before_filtering as u64);
         READ_ROW_GROUPS_TOTAL
             .with_label_values(&["inverted_index_filtered"])
-            .inc_by(self.metrics.num_row_groups_inverted_index_filtered as u64);
+            .inc_by(metrics.num_row_groups_inverted_index_filtered as u64);
         READ_ROW_GROUPS_TOTAL
             .with_label_values(&["minmax_index_filtered"])
-            .inc_by(self.metrics.num_row_groups_min_max_filtered as u64);
+            .inc_by(metrics.num_row_groups_min_max_filtered as u64);
         PRECISE_FILTER_ROWS_TOTAL
             .with_label_values(&["parquet"])
-            .inc_by(self.metrics.num_rows_precise_filtered as u64);
+            .inc_by(metrics.num_rows_precise_filtered as u64);
         READ_ROWS_IN_ROW_GROUP_TOTAL
             .with_label_values(&["before_filtering"])
-            .inc_by(self.metrics.num_rows_in_row_group_before_filtering as u64);
+            .inc_by(metrics.num_rows_in_row_group_before_filtering as u64);
         READ_ROWS_IN_ROW_GROUP_TOTAL
             .with_label_values(&["inverted_index_filtered"])
-            .inc_by(self.metrics.num_rows_in_row_group_inverted_index_filtered as u64);
+            .inc_by(metrics.num_rows_in_row_group_inverted_index_filtered as u64);
     }
 }
 
 impl ParquetReader {
-    /// Returns the metadata of the SST.
-    pub fn metadata(&self) -> &RegionMetadataRef {
-        self.read_format.metadata()
-    }
-
-    /// Tries to fetch next [RecordBatch] from the reader.
-    ///
-    /// If the reader is exhausted, reads next row group.
-    async fn fetch_next_record_batch(&mut self) -> Result<Option<RecordBatch>> {
-        if let Some(row_group_reader) = &mut self.current_reader {
-            if let Some(record_batch) =
-                row_group_reader
-                    .next()
-                    .transpose()
-                    .context(ArrowReaderSnafu {
-                        path: self.reader_builder.file_path(),
-                    })?
-            {
-                return Ok(Some(record_batch));
-            }
-        }
-
+    /// Creates a new reader.
+    async fn new(
+        context: PartitionContextRef,
+        mut row_groups: BTreeMap<usize, Option<RowSelection>>,
+    ) -> Result<Self> {
         // No more items in current row group, reads next row group.
-        while let Some((row_group_idx, row_selection)) = self.row_groups.pop_first() {
-            let mut row_group_reader = self
-                .reader_builder
+        let reader_state = if let Some((row_group_idx, row_selection)) = row_groups.pop_first() {
+            let parquet_reader = context
+                .reader_builder()
                 .build(row_group_idx, row_selection)
                 .await?;
-            let Some(record_batch) =
-                row_group_reader
-                    .next()
-                    .transpose()
-                    .context(ArrowReaderSnafu {
-                        path: self.reader_builder.file_path(),
-                    })?
-            else {
-                continue;
-            };
+            ReaderState::Readable(RowGroupReader::new(context.clone(), parquet_reader))
+        } else {
+            ReaderState::Exhausted(Metrics::default())
+        };
 
-            // Sets current reader to this reader.
-            self.current_reader = Some(row_group_reader);
-            return Ok(Some(record_batch));
-        }
-
-        Ok(None)
+        Ok(ParquetReader {
+            context,
+            row_groups,
+            reader_state,
+        })
     }
 
-    /// Prunes batches by the pushed down predicate.
-    fn prune_batches(&mut self) -> Result<()> {
-        // fast path
-        if self.predicate.is_empty() {
-            return Ok(());
-        }
-
-        let mut new_batches = VecDeque::new();
-        let batches = std::mem::take(&mut self.batches);
-        for batch in batches {
-            let num_rows_before_filter = batch.num_rows();
-            let Some(batch_filtered) = self.precise_filter(batch)? else {
-                // the entire batch is filtered out
-                self.metrics.num_rows_precise_filtered += num_rows_before_filter;
-                continue;
-            };
-
-            // update metric
-            let filtered_rows = num_rows_before_filter - batch_filtered.num_rows();
-            self.metrics.num_rows_precise_filtered += filtered_rows;
-
-            if !batch_filtered.is_empty() {
-                new_batches.push_back(batch_filtered);
-            }
-        }
-        self.batches = new_batches;
-
-        Ok(())
-    }
-
-    /// TRY THE BEST to perform pushed down predicate precisely on the input batch.
-    /// Return the filtered batch. If the entire batch is filtered out, return None.
-    ///
-    /// Supported filter expr type is defined in [SimpleFilterEvaluator].
-    ///
-    /// When a filter is referencing primary key column, this method will decode
-    /// the primary key and put it into the batch.
-    fn precise_filter(&self, mut input: Batch) -> Result<Option<Batch>> {
-        let mut mask = BooleanBuffer::new_set(input.num_rows());
-
-        // Run filter one by one and combine them result
-        // TODO(ruihang): run primary key filter first. It may short circuit other filters
-        for filter in &self.predicate {
-            let column_name = filter.column_name();
-            let Some(column_metadata) = self.read_format.metadata().column_by_name(column_name)
-            else {
-                // column not found, skip
-                // in situation like an column is added later
-                continue;
-            };
-            let result = match column_metadata.semantic_type {
-                SemanticType::Tag => {
-                    let pk_values = if let Some(pk_values) = input.pk_values() {
-                        pk_values
-                    } else {
-                        input.set_pk_values(self.codec.decode(input.primary_key())?);
-                        input.pk_values().unwrap()
-                    };
-                    // Safety: this is a primary key
-                    let pk_index = self
-                        .read_format
-                        .metadata()
-                        .primary_key_index(column_metadata.column_id)
-                        .unwrap();
-                    let pk_value = pk_values[pk_index]
-                        .try_to_scalar_value(&column_metadata.column_schema.data_type)
-                        .context(FieldTypeMismatchSnafu)?;
-                    if filter
-                        .evaluate_scalar(&pk_value)
-                        .context(FilterRecordBatchSnafu)?
-                    {
-                        continue;
-                    } else {
-                        // PK not match means the entire batch is filtered out.
-                        return Ok(None);
-                    }
-                }
-                SemanticType::Field => {
-                    let Some(field_index) = self
-                        .read_format
-                        .field_index_by_id(column_metadata.column_id)
-                    else {
-                        continue;
-                    };
-                    let field_col = &input.fields()[field_index].data;
-                    filter
-                        .evaluate_vector(field_col)
-                        .context(FilterRecordBatchSnafu)?
-                }
-                SemanticType::Timestamp => filter
-                    .evaluate_vector(input.timestamps())
-                    .context(FilterRecordBatchSnafu)?,
-            };
-
-            mask = mask.bitand(&result);
-        }
-
-        input.filter(&BooleanArray::from(mask).into())?;
-
-        Ok(Some(input))
+    /// Returns the metadata of the SST.
+    pub fn metadata(&self) -> &RegionMetadataRef {
+        self.context.read_format().metadata()
     }
 
     #[cfg(test)]
     pub fn parquet_metadata(&self) -> Arc<ParquetMetaData> {
-        self.reader_builder.parquet_meta.clone()
+        self.context.reader_builder().parquet_meta.clone()
     }
 }
 
 /// Reader to read a row group of a parquet file.
-pub(crate) struct ParquetRowGroupReader {
-    /// Inner parquet reader.
-    reader: ParquetRecordBatchReader,
+pub(crate) struct RowGroupReader {
     /// Context of partitions.
     context: PartitionContextRef,
+    /// Inner parquet reader.
+    reader: ParquetRecordBatchReader,
     /// Buffered batches to return.
     batches: VecDeque<Batch>,
-    /// Scan metrics.
+    /// Local scan metrics.
     metrics: Metrics,
 }
 
-impl ParquetRowGroupReader {
+impl RowGroupReader {
+    /// Creates a new reader.
+    fn new(context: PartitionContextRef, reader: ParquetRecordBatchReader) -> Self {
+        Self {
+            context,
+            reader,
+            batches: VecDeque::new(),
+            metrics: Metrics::default(),
+        }
+    }
+
+    /// Resets the parquet reader.
+    fn reset_reader(&mut self, reader: ParquetRecordBatchReader) {
+        self.reader = reader;
+    }
+
     /// Tries to fetch next [Batch] from the reader.
     async fn next_batch(&mut self) -> Result<Option<Batch>> {
-        let start = Instant::now();
         if let Some(batch) = self.batches.pop_front() {
-            self.metrics.scan_cost += start.elapsed();
             self.metrics.num_rows += batch.num_rows();
             return Ok(Some(batch));
         }
@@ -803,7 +691,6 @@ impl ParquetRowGroupReader {
         // We need to fetch next record batch and convert it to batches.
         while self.batches.is_empty() {
             let Some(record_batch) = self.fetch_next_record_batch()? else {
-                self.metrics.scan_cost += start.elapsed();
                 return Ok(None);
             };
             self.metrics.num_record_batches += 1;
@@ -815,7 +702,6 @@ impl ParquetRowGroupReader {
             self.metrics.num_batches += self.batches.len();
         }
         let batch = self.batches.pop_front();
-        self.metrics.scan_cost += start.elapsed();
         self.metrics.num_rows += batch.as_ref().map(|b| b.num_rows()).unwrap_or(0);
         Ok(batch)
     }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -743,7 +743,7 @@ pub(crate) struct RowGroupReader {
 
 impl RowGroupReader {
     /// Creates a new reader.
-    fn new(context: PartitionContextRef, reader: ParquetRecordBatchReader) -> Self {
+    pub(crate) fn new(context: PartitionContextRef, reader: ParquetRecordBatchReader) -> Self {
         Self {
             context,
             reader,

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -162,10 +162,7 @@ impl ParquetReaderBuilder {
         let region_meta = Arc::new(Self::get_region_metadata(&file_path, key_value_meta)?);
         // Lists all column ids to read, we always use the expected metadata if possible.
         let column_ids = self.projection.clone().unwrap_or_else(|| {
-            let expected_meta = self
-                .expected_metadata
-                .as_ref()
-                .unwrap_or_else(|| &region_meta);
+            let expected_meta = self.expected_metadata.as_ref().unwrap_or(&region_meta);
             expected_meta
                 .column_metadatas
                 .iter()
@@ -531,7 +528,7 @@ impl ReaderState {
     fn metrics(&self) -> &Metrics {
         match self {
             ReaderState::Readable(reader) => &reader.metrics,
-            ReaderState::Exhausted(m) => &m,
+            ReaderState::Exhausted(m) => m,
         }
     }
 }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -451,7 +451,7 @@ struct Metrics {
 }
 
 /// Builder to build a [ParquetRecordBatchReader] for a row group.
-struct RowGroupReaderBuilder {
+pub(crate) struct RowGroupReaderBuilder {
     /// SST file to read.
     ///
     /// Holds the file handle to avoid the file purge purge it.
@@ -477,7 +477,7 @@ impl RowGroupReaderBuilder {
     }
 
     /// Builds a [ParquetRecordBatchReader] to read the row group at `row_group_idx`.
-    async fn build(
+    pub(crate) async fn build(
         &self,
         row_group_idx: usize,
         row_selection: Option<RowSelection>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2806

## What's changed and what's your intention?
This PR defines the `FileRange` struct for parquet files and implements a method `build_file_ranges()` to build ranges from a parquet file. A `FileRange` contains a range of rows to read from a parquet file. We can read different ranges in parallel later. Now a `FileRange` is a row group exactly.

```rust
pub struct FileRange {}

impl FileRange {
    pub(crate) async fn reader(&self) -> Result<RowGroupReader> {}
}
```

To reuse code, this PR
- Refactors the `ParquetReader`. Now it adds a `RowGroupReader` to read `Batches` from a row group. The `ParquetReader` invokes the `RowGroupReader` to read the parquet file.
- Defines a struct `FileRangeContext` for all ranges of the same parquet file. This PR also moves the `precise_filter()` method to the context as the context contains all inputs the method needs.


Now the builder uses a method `build_reader_input()` to construct the `FileRangeContext` and row groups to read. Both `build()` and `build_file_ranges` can reuse this method.

```rust
impl ParquetReaderBuilder {
    pub async fn build(&self) -> Result<ParquetReader> {
        let (context, row_groups) = self.build_reader_input().await?;
        ParquetReader::new(context, row_groups).await
    }

    pub async fn build_file_ranges(&self, file_ranges: &mut Vec<FileRange>) -> Result<()> {}

    async fn build_reader_input(&self) -> Result<(FileRangeContextRef, RowGroupMap)> {}
}
```


This PR also fixes some remaining issues and improves the `ReadFormat` helper struct.
- It passes the projection while constructing the struct so it could
  - compute the `projection_indices` in advance
  - compute the `field_id_to_projected_index` in advance. Then `convert_record_batch()` doesn't require `&mut self`. This is necessary for the `FileRangeContext` as we have to share the `ReadFormat`
- It wraps the `SimpleFilterEvaluator` into a `SimpleFilterContext`. The context gets the column info in advance,  from the expected region metadata. This ensures the context can use the correct column id to find the column in the `ReadFormat`

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
