### PR TITLE
fix: fix compiler warnings on Windows

### DIFF
--- a/src/common/datasource/src/object_store.rs
+++ b/src/common/datasource/src/object_store.rs
@@ -35,7 +35,7 @@ pub fn parse_url(url: &str) -> Result<(String, Option<String>, String)> {
     #[cfg(windows)]
     {
         // On Windows, the url may start with `C:/`.
-        if let Some(_) = handle_windows_path(url) {
+        if handle_windows_path(url).is_some() {
             return Ok((FS_SCHEMA.to_string(), None, url.to_string()));
         }
     }

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -310,12 +310,12 @@ mod test {
 
         let region_dir = "test_metric_region";
         // assert metadata region's dir
-        let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
+        let metadata_region_dir = join_dir(region_dir, METADATA_REGION_SUBDIR);
         let exist = object_store.is_exist(&metadata_region_dir).await.unwrap();
         assert!(exist);
 
         // assert data region's dir
-        let data_region_dir = join_dir(&region_dir, DATA_REGION_SUBDIR);
+        let data_region_dir = join_dir(region_dir, DATA_REGION_SUBDIR);
         let exist = object_store.is_exist(&data_region_dir).await.unwrap();
         assert!(exist);
 

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -291,6 +291,10 @@ pub fn build_rows(num_tags: usize, num_rows: usize) -> Vec<Row> {
 
 #[cfg(test)]
 mod test {
+    use object_store::services::Fs;
+    use object_store::ObjectStore;
+    use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
+
     use super::*;
     use crate::utils::{self, to_metadata_region_id};
 
@@ -300,22 +304,20 @@ mod test {
         env.init_metric_region().await;
         let region_id = to_metadata_region_id(env.default_physical_region_id());
 
-        // `join_dir` doesn't suit windows path
-        #[cfg(not(target_os = "windows"))]
-        {
-            use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
+        let mut builder = Fs::default();
+        builder.root(&env.data_home());
+        let object_store = ObjectStore::new(builder).unwrap().finish();
 
-            let region_dir = join_dir(&env.data_home(), "test_metric_region");
-            // assert metadata region's dir
-            let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
-            let exist = tokio::fs::try_exists(metadata_region_dir).await.unwrap();
-            assert!(exist);
+        let region_dir = "test_metric_region";
+        // assert metadata region's dir
+        let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
+        let exist = object_store.is_exist(&metadata_region_dir).await.unwrap();
+        assert!(exist);
 
-            // assert data region's dir
-            let data_region_dir = join_dir(&region_dir, DATA_REGION_SUBDIR);
-            let exist = tokio::fs::try_exists(data_region_dir).await.unwrap();
-            assert!(exist);
-        }
+        // assert data region's dir
+        let data_region_dir = join_dir(&region_dir, DATA_REGION_SUBDIR);
+        let exist = object_store.is_exist(&data_region_dir).await.unwrap();
+        assert!(exist);
 
         // check mito engine
         let metadata_region_id = utils::to_metadata_region_id(region_id);

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -291,9 +291,6 @@ pub fn build_rows(num_tags: usize, num_rows: usize) -> Vec<Row> {
 
 #[cfg(test)]
 mod test {
-
-    use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
-
     use super::*;
     use crate::utils::{self, to_metadata_region_id};
 
@@ -302,11 +299,13 @@ mod test {
         let env = TestEnv::new().await;
         env.init_metric_region().await;
         let region_id = to_metadata_region_id(env.default_physical_region_id());
-        let region_dir = join_dir(&env.data_home(), "test_metric_region");
 
         // `join_dir` doesn't suit windows path
         #[cfg(not(target_os = "windows"))]
         {
+            use store_api::metric_engine_consts::{DATA_REGION_SUBDIR, METADATA_REGION_SUBDIR};
+
+            let region_dir = join_dir(&env.data_home(), "test_metric_region");
             // assert metadata region's dir
             let metadata_region_dir = join_dir(&region_dir, METADATA_REGION_SUBDIR);
             let exist = tokio::fs::try_exists(metadata_region_dir).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR fixes compiler warnings on Windows. It also fixes the test `create_metadata_region()` on Windows.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
