### PR TITLE
fix: count_wildcard_to_time_index_rule doesn't handle table reference properly

### DIFF
--- a/src/query/src/optimizer/count_wildcard.rs
+++ b/src/query/src/optimizer/count_wildcard.rs
@@ -81,6 +81,21 @@ impl CountWildcardToTimeIndexRule {
         let mut finder = TimeIndexFinder::default();
         // Safety: `TimeIndexFinder` won't throw error.
         plan.visit(&mut finder).unwrap();
+
+        // check if the time index is a valid column as for current plan
+        if let Some(col) = &finder.time_index {
+            let mut is_valid = false;
+            for input in plan.inputs() {
+                if input.schema().has_column_with_unqualified_name(col) {
+                    is_valid = true;
+                    break;
+                }
+            }
+            if !is_valid {
+                return None;
+            }
+        }
+
         finder.time_index
     }
 }

--- a/tests/cases/standalone/common/aggregate/count.result
+++ b/tests/cases/standalone/common/aggregate/count.result
@@ -14,10 +14,6 @@ select count(*) from "HelloWorld";
 | 2        |
 +----------+
 
-drop table "HelloWorld";
-
-Affected Rows: 0
-
 create table test (a string, "BbB" timestamp time index);
 
 Affected Rows: 0
@@ -41,6 +37,18 @@ select count(*) from (select count(*) from test where a = 'a');
 +----------+
 | 1        |
 +----------+
+
+select count(*) from (select * from test cross join "HelloWorld");
+
++----------+
+| COUNT(*) |
++----------+
+| 2        |
++----------+
+
+drop table "HelloWorld";
+
+Affected Rows: 0
 
 drop table test;
 

--- a/tests/cases/standalone/common/aggregate/count.result
+++ b/tests/cases/standalone/common/aggregate/count.result
@@ -1,0 +1,48 @@
+create table "HelloWorld" (a string, b timestamp time index);
+
+Affected Rows: 0
+
+insert into "HelloWorld" values ("a", 1) ,("b", 2);
+
+Affected Rows: 2
+
+select count(*) from "HelloWorld";
+
++----------+
+| COUNT(*) |
++----------+
+| 2        |
++----------+
+
+drop table "HelloWorld";
+
+Affected Rows: 0
+
+create table test (a string, "BbB" timestamp time index);
+
+Affected Rows: 0
+
+insert into test values ("c", 1) ;
+
+Affected Rows: 1
+
+select count(*) from test;
+
++----------+
+| COUNT(*) |
++----------+
+| 1        |
++----------+
+
+select count(*) from (select count(*) from test where a = 'a');
+
++----------+
+| COUNT(*) |
++----------+
+| 1        |
++----------+
+
+drop table test;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/aggregate/count.sql
+++ b/tests/cases/standalone/common/aggregate/count.sql
@@ -1,0 +1,17 @@
+create table "HelloWorld" (a string, b timestamp time index);
+
+insert into "HelloWorld" values ("a", 1) ,("b", 2);
+
+select count(*) from "HelloWorld";
+
+drop table "HelloWorld";
+
+create table test (a string, "BbB" timestamp time index);
+
+insert into test values ("c", 1) ;
+
+select count(*) from test;
+
+select count(*) from (select count(*) from test where a = 'a');
+
+drop table test;

--- a/tests/cases/standalone/common/aggregate/count.sql
+++ b/tests/cases/standalone/common/aggregate/count.sql
@@ -4,8 +4,6 @@ insert into "HelloWorld" values ("a", 1) ,("b", 2);
 
 select count(*) from "HelloWorld";
 
-drop table "HelloWorld";
-
 create table test (a string, "BbB" timestamp time index);
 
 insert into test values ("c", 1) ;
@@ -13,5 +11,9 @@ insert into test values ("c", 1) ;
 select count(*) from test;
 
 select count(*) from (select count(*) from test where a = 'a');
+
+select count(*) from (select * from test cross join "HelloWorld");
+
+drop table "HelloWorld";
 
 drop table test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fix regressions from https://github.com/GreptimeTeam/greptimedb/pull/3845

## What's changed and what's your intention?


Use `TableReference` to avoid unexpected canonicalization. And check if the time index column is valid at the plan to use it.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
