### PR TITLE
refactor: add the main cli entry point struct `Command{}` and simplify `main()`

### DIFF
--- a/src/cmd/src/cli.rs
+++ b/src/cmd/src/cli.rs
@@ -36,7 +36,7 @@ use upgrade::UpgradeCommand;
 
 use self::export::ExportCommand;
 use crate::error::Result;
-use crate::options::{CliOptions, Options};
+use crate::options::{GlobalOptions, Options};
 use crate::App;
 
 #[async_trait]
@@ -80,14 +80,14 @@ impl Command {
         self.cmd.build().await
     }
 
-    pub fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
+    pub fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
         let mut logging_opts = LoggingOptions::default();
 
-        if let Some(dir) = &cli_options.log_dir {
+        if let Some(dir) = &global_options.log_dir {
             logging_opts.dir.clone_from(dir);
         }
 
-        logging_opts.level.clone_from(&cli_options.log_level);
+        logging_opts.level.clone_from(&global_options.log_level);
 
         Ok(Options::Cli(Box::new(logging_opts)))
     }

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -28,7 +28,7 @@ use servers::Mode;
 use snafu::{OptionExt, ResultExt};
 
 use crate::error::{MissingConfigSnafu, Result, ShutdownDatanodeSnafu, StartDatanodeSnafu};
-use crate::options::{CliOptions, Options};
+use crate::options::{GlobalOptions, Options};
 use crate::App;
 
 pub struct Instance {
@@ -82,8 +82,8 @@ impl Command {
         self.subcmd.build(opts).await
     }
 
-    pub fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
-        self.subcmd.load_options(cli_options)
+    pub fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
+        self.subcmd.load_options(global_options)
     }
 }
 
@@ -99,9 +99,9 @@ impl SubCommand {
         }
     }
 
-    fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
+    fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
         match self {
-            SubCommand::Start(cmd) => cmd.load_options(cli_options),
+            SubCommand::Start(cmd) => cmd.load_options(global_options),
         }
     }
 }
@@ -131,19 +131,19 @@ struct StartCommand {
 }
 
 impl StartCommand {
-    fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
+    fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
         let mut opts: DatanodeOptions = Options::load_layered_options(
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
             DatanodeOptions::env_list_keys(),
         )?;
 
-        if let Some(dir) = &cli_options.log_dir {
+        if let Some(dir) = &global_options.log_dir {
             opts.logging.dir.clone_from(dir);
         }
 
-        if cli_options.log_level.is_some() {
-            opts.logging.level.clone_from(&cli_options.log_level);
+        if global_options.log_level.is_some() {
+            opts.logging.level.clone_from(&global_options.log_level);
         }
 
         if let Some(addr) = &self.rpc_addr {
@@ -259,7 +259,7 @@ mod tests {
     use servers::Mode;
 
     use super::*;
-    use crate::options::{CliOptions, ENV_VAR_SEP};
+    use crate::options::{GlobalOptions, ENV_VAR_SEP};
 
     #[test]
     fn test_read_from_config_file() {
@@ -315,7 +315,8 @@ mod tests {
             ..Default::default()
         };
 
-        let Options::Datanode(options) = cmd.load_options(&CliOptions::default()).unwrap() else {
+        let Options::Datanode(options) = cmd.load_options(&GlobalOptions::default()).unwrap()
+        else {
             unreachable!()
         };
 
@@ -377,7 +378,7 @@ mod tests {
     #[test]
     fn test_try_from_cmd() {
         if let Options::Datanode(opt) = StartCommand::default()
-            .load_options(&CliOptions::default())
+            .load_options(&GlobalOptions::default())
             .unwrap()
         {
             assert_eq!(Mode::Standalone, opt.mode)
@@ -388,7 +389,7 @@ mod tests {
             metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
-        .load_options(&CliOptions::default())
+        .load_options(&GlobalOptions::default())
         .unwrap()
         {
             assert_eq!(Mode::Distributed, opt.mode)
@@ -398,7 +399,7 @@ mod tests {
             metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
-        .load_options(&CliOptions::default())
+        .load_options(&GlobalOptions::default())
         .is_err());
 
         // Providing node_id but leave metasrv_addr absent is ok since metasrv_addr has default value
@@ -406,7 +407,7 @@ mod tests {
             node_id: Some(42),
             ..Default::default()
         })
-        .load_options(&CliOptions::default())
+        .load_options(&GlobalOptions::default())
         .is_ok());
     }
 
@@ -415,7 +416,7 @@ mod tests {
         let cmd = StartCommand::default();
 
         let options = cmd
-            .load_options(&CliOptions {
+            .load_options(&GlobalOptions {
                 log_dir: Some("/tmp/greptimedb/test/logs".to_string()),
                 log_level: Some("debug".to_string()),
 
@@ -504,7 +505,8 @@ mod tests {
                     ..Default::default()
                 };
 
-                let Options::Datanode(opts) = command.load_options(&CliOptions::default()).unwrap()
+                let Options::Datanode(opts) =
+                    command.load_options(&GlobalOptions::default()).unwrap()
                 else {
                     unreachable!()
                 };

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(assert_matches, let_chains)]
 
 use async_trait::async_trait;
-use clap::arg;
 use common_telemetry::{error, info};
 
 pub mod cli;
@@ -77,15 +76,6 @@ pub fn log_versions(version_string: &str, app_version: &str) {
     info!("GreptimeDB version: {}", version_string);
 
     log_env_flags();
-}
-
-pub fn greptimedb_cli() -> clap::Command {
-    let cmd = clap::Command::new("greptimedb").subcommand_required(true);
-
-    #[cfg(feature = "tokio-console")]
-    let cmd = cmd.arg(arg!(--"tokio-console-addr"[TOKIO_CONSOLE_ADDR]));
-
-    cmd.args([arg!(--"log-dir"[LOG_DIR]), arg!(--"log-level"[LOG_LEVEL])])
 }
 
 fn log_env_flags() {

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -22,7 +22,7 @@ use meta_srv::metasrv::MetasrvOptions;
 use snafu::ResultExt;
 
 use crate::error::{self, Result, StartMetaServerSnafu};
-use crate::options::{CliOptions, Options};
+use crate::options::{GlobalOptions, Options};
 use crate::App;
 
 pub struct Instance {
@@ -68,8 +68,8 @@ impl Command {
         self.subcmd.build(opts).await
     }
 
-    pub fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
-        self.subcmd.load_options(cli_options)
+    pub fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
+        self.subcmd.load_options(global_options)
     }
 }
 
@@ -85,9 +85,9 @@ impl SubCommand {
         }
     }
 
-    fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
+    fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
         match self {
-            SubCommand::Start(cmd) => cmd.load_options(cli_options),
+            SubCommand::Start(cmd) => cmd.load_options(global_options),
         }
     }
 }
@@ -126,19 +126,19 @@ struct StartCommand {
 }
 
 impl StartCommand {
-    fn load_options(&self, cli_options: &CliOptions) -> Result<Options> {
+    fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
         let mut opts: MetasrvOptions = Options::load_layered_options(
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
             MetasrvOptions::env_list_keys(),
         )?;
 
-        if let Some(dir) = &cli_options.log_dir {
+        if let Some(dir) = &global_options.log_dir {
             opts.logging.dir.clone_from(dir);
         }
 
-        if cli_options.log_level.is_some() {
-            opts.logging.level.clone_from(&cli_options.log_level);
+        if global_options.log_level.is_some() {
+            opts.logging.level.clone_from(&global_options.log_level);
         }
 
         if let Some(addr) = &self.bind_addr {
@@ -235,7 +235,7 @@ mod tests {
             ..Default::default()
         };
 
-        let Options::Metasrv(options) = cmd.load_options(&CliOptions::default()).unwrap() else {
+        let Options::Metasrv(options) = cmd.load_options(&GlobalOptions::default()).unwrap() else {
             unreachable!()
         };
         assert_eq!("127.0.0.1:3002".to_string(), options.bind_addr);
@@ -270,7 +270,7 @@ mod tests {
             ..Default::default()
         };
 
-        let Options::Metasrv(options) = cmd.load_options(&CliOptions::default()).unwrap() else {
+        let Options::Metasrv(options) = cmd.load_options(&GlobalOptions::default()).unwrap() else {
             unreachable!()
         };
         assert_eq!("127.0.0.1:3002".to_string(), options.bind_addr);
@@ -315,7 +315,7 @@ mod tests {
         };
 
         let options = cmd
-            .load_options(&CliOptions {
+            .load_options(&GlobalOptions {
                 log_dir: Some("/tmp/greptimedb/test/logs".to_string()),
                 log_level: Some("debug".to_string()),
 
@@ -379,7 +379,8 @@ mod tests {
                     ..Default::default()
                 };
 
-                let Options::Metasrv(opts) = command.load_options(&CliOptions::default()).unwrap()
+                let Options::Metasrv(opts) =
+                    command.load_options(&GlobalOptions::default()).unwrap()
                 else {
                     unreachable!()
                 };

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::ArgMatches;
+use clap::Parser;
 use common_config::KvBackendConfig;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use common_wal::config::MetasrvWalConfig;
@@ -61,26 +61,23 @@ pub enum Options {
     Cli(Box<LoggingOptions>),
 }
 
-#[derive(Default)]
-pub struct CliOptions {
+#[derive(Parser, Default, Debug, Clone)]
+pub struct GlobalOptions {
+    #[clap(long, value_name = "LOG_DIR")]
+    #[arg(global = true)]
     pub log_dir: Option<String>,
+
+    #[clap(long, value_name = "LOG_LEVEL")]
+    #[arg(global = true)]
     pub log_level: Option<String>,
 
     #[cfg(feature = "tokio-console")]
+    #[clap(long, value_name = "TOKIO_CONSOLE_ADDR")]
+    #[arg(global = true)]
     pub tokio_console_addr: Option<String>,
 }
 
-impl CliOptions {
-    pub fn new(args: &ArgMatches) -> Self {
-        Self {
-            log_dir: args.get_one::<String>("log-dir").cloned(),
-            log_level: args.get_one::<String>("log-level").cloned(),
-
-            #[cfg(feature = "tokio-console")]
-            tokio_console_addr: args.get_one::<String>("tokio-console-addr").cloned(),
-        }
-    }
-
+impl GlobalOptions {
     pub fn tracing_options(&self) -> TracingOptions {
         TracingOptions {
             #[cfg(feature = "tokio-console")]

--- a/tests-integration/src/database.rs
+++ b/tests-integration/src/database.rs
@@ -274,7 +274,7 @@ mod tests {
     use clap::Parser;
     use client::Client;
     use cmd::error::Result as CmdResult;
-    use cmd::options::{CliOptions, Options};
+    use cmd::options::{GlobalOptions, Options};
     use cmd::{cli, standalone, App};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
 
@@ -313,7 +313,7 @@ mod tests {
             &*output_dir.path().to_string_lossy(),
         ]);
         let Options::Standalone(standalone_opts) =
-            standalone.load_options(&CliOptions::default())?
+            standalone.load_options(&GlobalOptions::default())?
         else {
             unreachable!()
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The parsing entry of the current command line is a bit messy and I think we need a cleaner and more unified entry. 

- Add the `Command{}` struct: Unify all the cli options, including subcommand and global options. When we load the cli option, use `Command::parse()`;

- Make the `main()` cleaner by using the following sub-functions:

  - Add `setup_human_panic()`;
  - Add `start()` to load the options and start the service;

- Rename `CliOptions` to `GlobalOptions`;

Reference: [`uv`](https://github.com/astral-sh/uv/blob/main/crates/uv/src/cli.rs#L21-L43) has a clean entry point.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
