### PR TITLE
refactor: add `etcd_connect_options` for metasrv

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -263,6 +263,9 @@
 | `export_metrics.remote_write` | -- | -- | -- |
 | `export_metrics.remote_write.url` | String | `""` | The url the metrics send to. The url example can be: `http://127.0.0.1:4000/v1/prometheus/write?db=information_schema`. |
 | `export_metrics.remote_write.headers` | InlineTable | -- | HTTP headers of Prometheus remote-write carry. |
+| `etcd_connect_options` | -- | -- | The options for connecting etcd. |
+| `etcd_connect_options.timeout` | String | `None` | Apply a timeout to each gRPC request. |
+| `etcd_connect_options.connect_timeout` | String | `None` | Apply a timeout to connecting to the endpoint. |
 
 
 ### Datanode

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -141,3 +141,12 @@ url = ""
 
 ## HTTP headers of Prometheus remote-write carry.
 headers = { }
+
+## The options for connecting etcd.
+[etcd_connect_options]
+## Apply a timeout to each gRPC request.
+## +toml2docs:none-default
+timeout = "5s"
+## Apply a timeout to connecting to the endpoint.
+## +toml2docs:none-default
+connect_timeout = "5s"

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -246,7 +246,11 @@ async fn create_etcd_client(opts: &MetasrvOptions) -> Result<Client> {
         .map(|x| x.trim())
         .filter(|x| !x.is_empty())
         .collect::<Vec<_>>();
-    Client::connect(&etcd_endpoints, None)
-        .await
-        .context(error::ConnectEtcdSnafu)
+
+    Client::connect(
+        &etcd_endpoints,
+        Some(opts.etcd_connect_options.clone().into()),
+    )
+    .await
+    .context(error::ConnectEtcdSnafu)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The original `create_etcd_client()` uses `None` for [`ConnectOptions`](https://docs.rs/etcd-client/latest/etcd_client/struct.ConnectOptions.html) and can't configure some important arguments for connecting etcd.

In this PR, I created the `EtcdConnectOptions`, a subset of `ConnectOptions`, in the `MetasrvOptions`. I also added the covert function to let `EtcdConnectOptions` convert `ConnectOptions` easily.

btw, it's convenient to add TLS configurations in the future in the same structure(I will add it in the next PR). 

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
