### PR TITLE
ci: avoid trying to send slack notification in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,7 +436,7 @@ jobs:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
 
   notification:
-    if: ${{ always() }} # Not requiring successful dependent jobs, always run.
+    if: ${{ always() || github.repository == 'GreptimeTeam/greptimedb' }}
     name: Send notification to Greptime team
     needs: [
       release-images-to-dockerhub,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Although forks can disable this workflow at all, let's try to skip this step because forks doesn't have the secrets: https://github.com/tisonkun/greptimedb/actions/runs/8962181455/job/24610696840

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
