### PR TITLE
chore: remove one slice copy in wal encoding

### DIFF
--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -59,14 +59,9 @@ impl LogStore for KafkaLogStore {
     type Namespace = NamespaceImpl;
 
     /// Creates an entry of the associated Entry type.
-    fn entry<D: AsRef<[u8]>>(
-        &self,
-        data: D,
-        entry_id: EntryId,
-        ns: Self::Namespace,
-    ) -> Self::Entry {
+    fn entry(&self, data: &mut Vec<u8>, entry_id: EntryId, ns: Self::Namespace) -> Self::Entry {
         EntryImpl {
-            data: data.as_ref().to_vec(),
+            data: std::mem::take(data),
             id: entry_id,
             ns,
         }

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -135,7 +135,7 @@ mod tests {
     #[tokio::test]
     async fn test_noop_logstore() {
         let store = NoopLogStore;
-        let e = store.entry(&mut "".as_bytes().to_vec(), 1, NamespaceImpl);
+        let e = store.entry(&mut vec![], 1, NamespaceImpl);
         let _ = store.append(e.clone()).await.unwrap();
         assert!(store.append_batch(vec![e]).await.is_ok());
         store.create_namespace(&NamespaceImpl).await.unwrap();

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -97,12 +97,7 @@ impl LogStore for NoopLogStore {
         Ok(vec![])
     }
 
-    fn entry<D: AsRef<[u8]>>(
-        &self,
-        data: D,
-        entry_id: EntryId,
-        ns: Self::Namespace,
-    ) -> Self::Entry {
+    fn entry(&self, data: &mut Vec<u8>, entry_id: EntryId, ns: Self::Namespace) -> Self::Entry {
         let _ = data;
         let _ = entry_id;
         let _ = ns;
@@ -140,7 +135,7 @@ mod tests {
     #[tokio::test]
     async fn test_noop_logstore() {
         let store = NoopLogStore;
-        let e = store.entry("".as_bytes(), 1, NamespaceImpl);
+        let e = store.entry(&mut "".as_bytes().to_vec(), 1, NamespaceImpl);
         let _ = store.append(e.clone()).await.unwrap();
         assert!(store.append_batch(vec![e]).await.is_ok());
         store.create_namespace(&NamespaceImpl).await.unwrap();

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -402,15 +402,10 @@ impl LogStore for RaftEngineLogStore {
         Ok(namespaces)
     }
 
-    fn entry<D: AsRef<[u8]>>(
-        &self,
-        data: D,
-        entry_id: EntryId,
-        ns: Self::Namespace,
-    ) -> Self::Entry {
+    fn entry(&self, data: &mut Vec<u8>, entry_id: EntryId, ns: Self::Namespace) -> Self::Entry {
         EntryImpl {
             id: entry_id,
-            data: data.as_ref().to_vec(),
+            data: std::mem::take(data),
             namespace_id: ns.id(),
             ..Default::default()
         }

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -135,7 +135,7 @@ pub struct WalWriter<S: LogStore> {
 }
 
 impl<S: LogStore> WalWriter<S> {
-    /// Add an wal entry for specific region to the writer's buffer.
+    /// Add a wal entry for specific region to the writer's buffer.
     pub fn add_entry(
         &mut self,
         region_id: RegionId,
@@ -157,7 +157,7 @@ impl<S: LogStore> WalWriter<S> {
             .context(EncodeWalSnafu { region_id })?;
         let entry = self
             .store
-            .entry(&self.entry_encode_buf, entry_id, namespace);
+            .entry(&mut self.entry_encode_buf, entry_id, namespace);
 
         self.entries.push(entry);
 

--- a/src/store-api/src/logstore.rs
+++ b/src/store-api/src/logstore.rs
@@ -72,8 +72,7 @@ pub trait LogStore: Send + Sync + 'static + std::fmt::Debug {
     async fn obsolete(&self, ns: Self::Namespace, entry_id: EntryId) -> Result<(), Self::Error>;
 
     /// Makes an entry instance of the associated Entry type
-    fn entry<D: AsRef<[u8]>>(&self, data: D, entry_id: EntryId, ns: Self::Namespace)
-        -> Self::Entry;
+    fn entry(&self, data: &mut Vec<u8>, entry_id: EntryId, ns: Self::Namespace) -> Self::Entry;
 
     /// Makes a namespace instance of the associated Namespace type
     fn namespace(&self, ns_id: NamespaceId, wal_options: &WalOptions) -> Self::Namespace;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR removes one slice copy in wal encoding.

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
