### PR TITLE
fix: return metric name instead of query in Prometheus /series API

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -312,10 +312,25 @@ pub enum Error {
     },
 
     #[snafu(display("Error accessing catalog"))]
-    CatalogError { source: catalog::error::Error },
+    CatalogError {
+        source: catalog::error::Error,
+        location: Location,
+    },
 
     #[snafu(display("Cannot find requested database: {}-{}", catalog, schema))]
-    DatabaseNotFound { catalog: String, schema: String },
+    DatabaseNotFound {
+        catalog: String,
+        schema: String,
+        location: Location,
+    },
+
+    #[snafu(display("Cannot find requested table: {}-{}-{}", catalog, schema, table))]
+    TableNotFound {
+        catalog: String,
+        schema: String,
+        table: String,
+        location: Location,
+    },
 
     #[cfg(feature = "mem-prof")]
     #[snafu(display("Failed to dump profile data"))]
@@ -325,10 +340,10 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid prepare statement: {}", err_msg))]
-    InvalidPrepareStatement { err_msg: String },
+    InvalidPrepareStatement { err_msg: String, location: Location },
 
     #[snafu(display("Invalid flush argument: {}", err_msg))]
-    InvalidFlushArgument { err_msg: String },
+    InvalidFlushArgument { err_msg: String, location: Location },
 
     #[snafu(display("Failed to build gRPC reflection service"))]
     GrpcReflectionService {
@@ -546,6 +561,9 @@ impl ErrorExt for Error {
             | InvalidAuthHeaderInvalidUtf8Value { .. } => StatusCode::InvalidAuthHeader,
 
             DatabaseNotFound { .. } => StatusCode::DatabaseNotFound,
+
+            TableNotFound { .. } => StatusCode::TableNotFound,
+
             #[cfg(feature = "mem-prof")]
             DumpProfileData { source, .. } => source.status_code(),
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -499,7 +499,7 @@ fn record_batches_to_series(
         let projection = batch
             .schema
             .column_schemas()
-            .into_iter()
+            .iter()
             .enumerate()
             .filter_map(|(idx, col)| {
                 if tag_columns.contains(&col.name) {

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -508,10 +508,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
         .collect::<BTreeMap<String, String>>();
     let expected = BTreeMap::from([
         ("__name__".to_string(), "demo".to_string()),
-        ("ts".to_string(), "1970-01-01 00:00:00+0000".to_string()),
-        ("cpu".to_string(), "1.1".to_string()),
         ("host".to_string(), "host1".to_string()),
-        ("memory".to_string(), "2.2".to_string()),
     ]);
     assert_eq!(actual, expected);
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -492,7 +492,7 @@ pub async fn test_prom_http_api(store_type: StorageType) {
 
     // series
     let res = client
-        .get("/v1/prometheus/api/v1/series?match[]=demo&start=0&end=0")
+        .get("/v1/prometheus/api/v1/series?match[]=demo{}&start=0&end=0")
         .send()
         .await;
     assert_eq!(res.status(), StatusCode::OK);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The previous implement returns the whole query instead of metric name in result. This patch fixes this behavior

![image](https://github.com/GreptimeTeam/greptimedb/assets/15380403/489bbbc2-1ffe-4b18-919d-ead61ed16032)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
