### PR TITLE
chore(pprof): import `common_telemetry::info`

### DIFF
--- a/src/servers/src/http/pprof.rs
+++ b/src/servers/src/http/pprof.rs
@@ -23,6 +23,7 @@ pub mod handler {
     use axum::extract::Query;
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
+    use common_telemetry::info;
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
     use snafu::ResultExt;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#3865

## What's changed and what's your intention?

Missing items while executing `cargo build --bin greptime   --features=pprof`

```
   Compiling cmd v0.7.2 (/home/weny/Projects/greptimedb/src/cmd)
   Compiling servers v0.7.2 (/home/weny/Projects/greptimedb/src/servers)
error: cannot find macro `info` in this scope
  --> src/servers/src/http/pprof.rs:66:9
   |
66 |         info!("start pprof, request: {:?}", req);
   |         ^^^^
   |
help: consider importing one of these items
   |
20 +     use common_telemetry::info;
   |
20 +     use crate::http::info;
   |
```

Import `common_telemetry::info` for `pprof.rs`


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
