### PR TITLE
docs: run fuzz tests in dev mode & disable sanitizer

### DIFF
--- a/tests-fuzz/README.md
+++ b/tests-fuzz/README.md
@@ -33,7 +33,7 @@ cargo fuzz list --fuzz-dir tests-fuzz
 
 2. Run a fuzz target.
 ```bash
-cargo fuzz run fuzz_create_table --fuzz-dir tests-fuzz
+cargo fuzz run fuzz_create_table --fuzz-dir tests-fuzz -D -s none
 ```
 
 ## Crash Reproduction
@@ -47,11 +47,11 @@ echo "Base64" > .crash
 Print the `std::fmt::Debug` output for an input.
 
 ```bash
-cargo fuzz fmt fuzz_target .crash --fuzz-dir tests-fuzz  
+cargo fuzz fmt fuzz_target .crash --fuzz-dir tests-fuzz -D -s none
 ```
 Rerun the fuzz test with the input.
 
 ```bash
-cargo fuzz run fuzz_target .crash --fuzz-dir tests-fuzz
+cargo fuzz run fuzz_target .crash --fuzz-dir tests-fuzz -D -s none
 ```
 For more details, visit [cargo fuzz](https://rust-fuzz.github.io/book/cargo-fuzz/tutorial.html) or run the command `cargo fuzz --help`.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Update the fuzz tests document. Run fuzz tests in dev mode with sanitizer disabled to reduce compile time.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
