### PR TITLE
build: strip sqlness binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,3 +241,7 @@ strip = true
 lto = "thin"
 debug = false
 incremental = false
+
+[profile.dev.package.sqlness-runner]
+debug = false
+strip = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Debug info is unnecessary to `sqlness-runner`. Omit it to save space for CI (https://github.com/GreptimeTeam/greptimedb/actions/runs/8980727729/job/24665718225)

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
