### PR TITLE
build: run cargo gc to build binaries

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -114,9 +114,12 @@ jobs:
         with:
           # Shares across multiple jobs
           shared-key: "build-binaries"
+      - name: Install cargo-gc-bin
+        shell: bash
+        run: cargo install cargo-gc-bin
       - name: Build greptime binaries
         shell: bash
-        run: cargo build --bin greptime --bin sqlness-runner
+        run: cargo gc -- --bin greptime --bin sqlness-runner
       - name: Pack greptime binaries
         shell: bash
         run: |

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -119,6 +119,7 @@ jobs:
         run: cargo install cargo-gc-bin
       - name: Build greptime binaries
         shell: bash
+        # `cargo gc` will invoke `cargo build` with specified args
         run: cargo gc -- --bin greptime --bin sqlness-runner
       - name: Pack greptime binaries
         shell: bash


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Introduce `cargo-gc-bin` to our CI. I've triggered it manually and it looks good

<img width="809" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/15380403/89254218-d27e-45f3-bcb0-8b828b3c4c46">

Example run: https://github.com/GreptimeTeam/greptimedb/actions/runs/8982051140/job/24668825435

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
