### PR TITLE
refactor(logstore): remove Entry::namemspace

### DIFF
--- a/src/log-store/src/kafka.rs
+++ b/src/log-store/src/kafka.rs
@@ -57,7 +57,6 @@ pub struct EntryImpl {
 
 impl Entry for EntryImpl {
     type Error = Error;
-    type Namespace = NamespaceImpl;
 
     fn data(&self) -> &[u8] {
         &self.data
@@ -65,10 +64,6 @@ impl Entry for EntryImpl {
 
     fn id(&self) -> EntryId {
         self.id
-    }
-
-    fn namespace(&self) -> Self::Namespace {
-        self.ns.clone()
     }
 
     fn estimated_size(&self) -> usize {

--- a/src/log-store/src/noop.rs
+++ b/src/log-store/src/noop.rs
@@ -37,7 +37,6 @@ impl Namespace for NamespaceImpl {
 
 impl Entry for EntryImpl {
     type Error = Error;
-    type Namespace = NamespaceImpl;
 
     fn data(&self) -> &[u8] {
         &[]
@@ -45,10 +44,6 @@ impl Entry for EntryImpl {
 
     fn id(&self) -> EntryId {
         0
-    }
-
-    fn namespace(&self) -> Self::Namespace {
-        Default::default()
     }
 
     fn estimated_size(&self) -> usize {

--- a/src/log-store/src/raft_engine.rs
+++ b/src/log-store/src/raft_engine.rs
@@ -68,7 +68,6 @@ impl Namespace for NamespaceImpl {
 
 impl Entry for EntryImpl {
     type Error = Error;
-    type Namespace = NamespaceImpl;
 
     fn data(&self) -> &[u8] {
         self.data.as_slice()
@@ -78,31 +77,20 @@ impl Entry for EntryImpl {
         self.id
     }
 
-    fn namespace(&self) -> Self::Namespace {
-        NamespaceImpl {
-            id: self.namespace_id,
-            ..Default::default()
-        }
-    }
-
     fn estimated_size(&self) -> usize {
-        size_of::<Self>() + self.data.capacity() * size_of::<u8>()
+        self.data.len() + size_of::<u64>() + size_of::<u64>()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
     use store_api::logstore::entry::Entry;
 
     use crate::raft_engine::protos::logstore::EntryImpl;
 
     #[test]
     fn test_estimated_size() {
-        let entry = EntryImpl::create(1, 1, Vec::with_capacity(100));
-        let expected = size_of::<EntryImpl>() + 100;
-        let got = entry.estimated_size();
-        assert_eq!(expected, got);
+        let entry = EntryImpl::create(1, 1, b"hello, world".to_vec());
+        assert_eq!(28, entry.estimated_size());
     }
 }

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -14,8 +14,6 @@
 
 use common_error::ext::ErrorExt;
 
-use crate::logstore::namespace::Namespace;
-
 /// An entry's id.
 /// Different log store implementations may interpret the id to different meanings.
 pub type Id = u64;
@@ -24,7 +22,6 @@ pub type Id = u64;
 /// The log store implementation may have larger or smaller data storage unit than an entry.
 pub trait Entry: Send + Sync {
     type Error: ErrorExt + Send + Sync;
-    type Namespace: Namespace;
 
     /// Returns the contained data of the entry.
     fn data(&self) -> &[u8];
@@ -33,9 +30,6 @@ pub trait Entry: Send + Sync {
     /// Usually the namespace id is identical with the region id.
     fn id(&self) -> Id;
 
-    /// Returns the namespace of the entry.
-    fn namespace(&self) -> Self::Namespace;
-
-    /// Computes the estimated size in bytes of the entry.
+    /// Computes the estimated encoded size.
     fn estimated_size(&self) -> usize;
 }

--- a/src/store-api/src/logstore/entry_stream.rs
+++ b/src/store-api/src/logstore/entry_stream.rs
@@ -31,7 +31,6 @@ pub type SendableEntryStream<'a, I, E> = Pin<Box<dyn Stream<Item = Result<Vec<I>
 #[cfg(test)]
 mod tests {
     use std::any::Any;
-    use std::mem::size_of;
     use std::task::{Context, Poll};
 
     use common_error::ext::StackError;
@@ -50,15 +49,6 @@ mod tests {
     #[snafu(visibility(pub))]
     pub struct Error {}
 
-    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-    pub struct Namespace {}
-
-    impl crate::logstore::Namespace for Namespace {
-        fn id(&self) -> crate::logstore::namespace::Id {
-            0
-        }
-    }
-
     impl ErrorExt for Error {
         fn as_any(&self) -> &dyn Any {
             self
@@ -75,7 +65,6 @@ mod tests {
 
     impl Entry for SimpleEntry {
         type Error = Error;
-        type Namespace = Namespace;
 
         fn data(&self) -> &[u8] {
             &self.data
@@ -85,12 +74,8 @@ mod tests {
             0u64
         }
 
-        fn namespace(&self) -> Self::Namespace {
-            Namespace {}
-        }
-
         fn estimated_size(&self) -> usize {
-            self.data.capacity() * size_of::<u8>()
+            self.data.len()
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Remove `Entry::namespace` method and related asscoiated type.
- Fix the estimated size logic to computing the encoded length of entries.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
