### PR TITLE
fix: add data type to vector cache key

### DIFF
--- a/src/mito2/src/read/projection.rs
+++ b/src/mito2/src/read/projection.rs
@@ -241,7 +241,7 @@ fn repeated_vector_with_cache(
     num_rows: usize,
     cache_manager: &CacheManager,
 ) -> common_recordbatch::error::Result<VectorRef> {
-    if let Some(vector) = cache_manager.get_repeated_vector(value) {
+    if let Some(vector) = cache_manager.get_repeated_vector(data_type, value) {
         // Tries to get the vector from cache manager. If the vector doesn't
         // have enough length, creates a new one.
         match vector.len().cmp(&num_rows) {
@@ -366,9 +366,15 @@ mod tests {
 +---------------------+----+----+----+----+";
         assert_eq!(expect, print_record_batch(record_batch));
 
-        assert!(cache.get_repeated_vector(&Value::Int64(1)).is_some());
-        assert!(cache.get_repeated_vector(&Value::Int64(2)).is_some());
-        assert!(cache.get_repeated_vector(&Value::Int64(3)).is_none());
+        assert!(cache
+            .get_repeated_vector(&ConcreteDataType::int64_datatype(), &Value::Int64(1))
+            .is_some());
+        assert!(cache
+            .get_repeated_vector(&ConcreteDataType::int64_datatype(), &Value::Int64(2))
+            .is_some());
+        assert!(cache
+            .get_repeated_vector(&ConcreteDataType::int64_datatype(), &Value::Int64(3))
+            .is_none());
         let record_batch = mapper.convert(&batch, Some(&cache)).unwrap();
         assert_eq!(expect, print_record_batch(record_batch));
     }

--- a/tests/cases/standalone/common/insert/nullable_tag.result
+++ b/tests/cases/standalone/common/insert/nullable_tag.result
@@ -41,7 +41,12 @@ Affected Rows: 2
 
 SELECT * FROM `esT` order by `eT` desc;
 
-Error: 3001(EngineExecuteQuery), Invalid argument error: column types must match schema types, expected Utf8 but found Int32 at column index 3
++----------------------------+-------+---------+-------------+-------+-------------+------------+------+-------------+------+
+| eT                         | eAque | DoLOruM | repudiAndae | ULLaM | COnSECTeTuR | DOLOrIBUS  | QUiS | consEquatuR | vERO |
++----------------------------+-------+---------+-------------+-------+-------------+------------+------+-------------+------+
+| +234049-06-04T01:11:41.163 | false |         | hello       |       | -31852      | 0.97377783 |      | false       |      |
+| -19578-12-20T11:45:59.875  | true  |         |             |       | -31852      | 0.3535998  |      | false       |      |
++----------------------------+-------+---------+-------------+-------+-------------+------------+------+-------------+------+
 
 DROP TABLE `esT`;
 

--- a/tests/cases/standalone/common/insert/nullable_tag.result
+++ b/tests/cases/standalone/common/insert/nullable_tag.result
@@ -1,0 +1,49 @@
+CREATE TABLE `esT`(
+  `eT` TIMESTAMP(3) TIME INDEX,
+  `eAque` BOOLEAN,
+  `DoLOruM` INT,
+  `repudiAndae` STRING,
+  `ULLaM` BOOLEAN,
+  `COnSECTeTuR` SMALLINT DEFAULT -31852,
+  `DOLOrIBUS` FLOAT NOT NULL,
+  `QUiS` SMALLINT NULL,
+  `consEquatuR` BOOLEAN NOT NULL,
+  `vERO` BOOLEAN,
+  PRIMARY KEY(`repudiAndae`, `ULLaM`, `DoLOruM`)
+);
+
+Affected Rows: 0
+
+INSERT INTO `esT` (
+  `consEquatuR`,
+  `eAque`,
+  `eT`,
+  `repudiAndae`,
+  `DOLOrIBUS`
+)
+VALUES
+(
+  false,
+  false,
+  '+234049-06-04 01:11:41.163+0000',
+  'hello',
+  0.97377783
+),
+(
+  false,
+  true,
+  '-19578-12-20 11:45:59.875+0000',
+  NULL,
+  0.3535998
+);
+
+Affected Rows: 2
+
+SELECT * FROM `esT` order by `eT` desc;
+
+Error: 3001(EngineExecuteQuery), Invalid argument error: column types must match schema types, expected Utf8 but found Int32 at column index 3
+
+DROP TABLE `esT`;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/insert/nullable_tag.sql
+++ b/tests/cases/standalone/common/insert/nullable_tag.sql
@@ -1,0 +1,40 @@
+CREATE TABLE `esT`(
+  `eT` TIMESTAMP(3) TIME INDEX,
+  `eAque` BOOLEAN,
+  `DoLOruM` INT,
+  `repudiAndae` STRING,
+  `ULLaM` BOOLEAN,
+  `COnSECTeTuR` SMALLINT DEFAULT -31852,
+  `DOLOrIBUS` FLOAT NOT NULL,
+  `QUiS` SMALLINT NULL,
+  `consEquatuR` BOOLEAN NOT NULL,
+  `vERO` BOOLEAN,
+  PRIMARY KEY(`repudiAndae`, `ULLaM`, `DoLOruM`)
+);
+
+INSERT INTO `esT` (
+  `consEquatuR`,
+  `eAque`,
+  `eT`,
+  `repudiAndae`,
+  `DOLOrIBUS`
+)
+VALUES
+(
+  false,
+  false,
+  '+234049-06-04 01:11:41.163+0000',
+  'hello',
+  0.97377783
+),
+(
+  false,
+  true,
+  '-19578-12-20 11:45:59.875+0000',
+  NULL,
+  0.3535998
+);
+
+SELECT * FROM `esT` order by `eT` desc;
+
+DROP TABLE `esT`;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- fixes https://github.com/GreptimeTeam/greptimedb/issues/3869

## What's changed and what's your intention?
This PR adds data type to the cache key for repeated vectors. It fixes the issue that different data types use the same null vector in the cache. When the reader gets a null vector from the cache, the data type of the vector might not be the expected type and result in the following error: `column types must match schema types`.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
