### PR TITLE
chore: bump proto to 219b24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,7 +3895,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=65c1364d8ee190a8d05cad5758d478b11eff2d35"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=219b2409bb701f75b43fc0ba64967d2ed8e75491#219b2409bb701f75b43fc0ba64967d2ed8e75491"
 dependencies = [
  "prost 0.12.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev 
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "65c1364d8ee190a8d05cad5758d478b11eff2d35" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "219b2409bb701f75b43fc0ba64967d2ed8e75491" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

 bump proto to 219b24

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
