### PR TITLE
docs: correct v0.7 benchmark report

### DIFF
--- a/docs/benchmarks/tsbs/v0.7.0.md
+++ b/docs/benchmarks/tsbs/v0.7.0.md
@@ -23,28 +23,28 @@
 
 ## Write performance
 
-| Environment        | Ingest rate (rows/s)  |
-| ------------------ | --------------------- |
-| Local              | 3695814.64            |
-| EC2 c5d.2xlarge    | 2987166.64            |
+| Environment     | Ingest rate (rows/s) |
+| --------------- | -------------------- |
+| Local           | 369581.464           |
+| EC2 c5d.2xlarge | 298716.664           |
 
 
 ## Query performance
 
-| Query type            | Local (ms) | EC2 c5d.2xlarge (ms)   |
-| --------------------- | ---------- | ---------------------- |
-| cpu-max-all-1         | 30.56      | 54.74                  |
-| cpu-max-all-8         | 52.69      | 70.50                  |
-| double-groupby-1      | 664.30     | 1366.63                |
-| double-groupby-5      | 1391.26    | 2141.71                |
-| double-groupby-all    | 2828.94    | 3389.59                |
-| groupby-orderby-limit | 718.92     | 1213.90                |
-| high-cpu-1            | 29.21      | 52.98                  |
-| high-cpu-all          | 5514.12    | 7194.91                |
-| lastpoint             | 7571.40    | 9423.41                |
-| single-groupby-1-1-1  | 19.09      | 7.77                   |
-| single-groupby-1-1-12 | 27.28      | 51.64                  |
-| single-groupby-1-8-1  | 31.85      | 11.64                  |
-| single-groupby-5-1-1  | 16.14      | 9.67                   |
-| single-groupby-5-1-12 | 27.21      | 53.62                  |
-| single-groupby-5-8-1  | 39.62      | 14.96                  |
+| Query type            | Local (ms) | EC2 c5d.2xlarge (ms) |
+| --------------------- | ---------- | -------------------- |
+| cpu-max-all-1         | 30.56      | 54.74                |
+| cpu-max-all-8         | 52.69      | 70.50                |
+| double-groupby-1      | 664.30     | 1366.63              |
+| double-groupby-5      | 1391.26    | 2141.71              |
+| double-groupby-all    | 2828.94    | 3389.59              |
+| groupby-orderby-limit | 718.92     | 1213.90              |
+| high-cpu-1            | 29.21      | 52.98                |
+| high-cpu-all          | 5514.12    | 7194.91              |
+| lastpoint             | 7571.40    | 9423.41              |
+| single-groupby-1-1-1  | 19.09      | 7.77                 |
+| single-groupby-1-1-12 | 27.28      | 51.64                |
+| single-groupby-1-8-1  | 31.85      | 11.64                |
+| single-groupby-5-1-1  | 16.14      | 9.67                 |
+| single-groupby-5-1-12 | 27.21      | 53.62                |
+| single-groupby-5-8-1  | 39.62      | 14.96                |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


The previous data is "metrics/sec", not "rows/sec" 🥵

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
