### PR TITLE
feat: limit total rows copied in COPY TABLE FROM with LIMIT segment

### DIFF
--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -302,6 +302,7 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
         connection,
         with,
         table_name,
+        limit,
         ..
     } = match stmt {
         CopyTable::To(arg) => arg,
@@ -328,6 +329,7 @@ fn to_copy_table_request(stmt: CopyTable, query_ctx: QueryContextRef) -> Result<
         pattern,
         direction,
         timestamp_range,
+        limit,
     })
 }
 

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -90,6 +90,7 @@ impl StatementExecutor {
                         pattern: None,
                         direction: CopyDirection::Export,
                         timestamp_range: req.time_range,
+                        limit: None,
                     },
                     ctx.clone(),
                 )
@@ -155,6 +156,7 @@ impl StatementExecutor {
                 pattern: None,
                 direction: CopyDirection::Import,
                 timestamp_range: None,
+                limit: None,
             };
             debug!("Copy table, arg: {:?}", req);
             match self.copy_table_from(req, ctx.clone()).await {

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -379,11 +379,14 @@ impl StatementExecutor {
 
         let mut rows_inserted = 0;
         let mut insert_cost = 0;
-        let max_insert_rows = req
-            .with
-            .get(MAX_INSERT_ROWS)
-            .and_then(|val| val.parse::<usize>().ok())
-            .unwrap_or(DEFAULT_MAX_INSERT_ROWS);
+        let max_insert_rows = if let Some(num) = req.limit {
+            num as usize
+        } else {
+            req.with
+                .get(MAX_INSERT_ROWS)
+                .and_then(|val| val.parse::<usize>().ok())
+                .unwrap_or(DEFAULT_MAX_INSERT_ROWS)
+        };
         for (compat_schema, file_schema_projection, projected_table_schema, file_metadata) in files
         {
             let mut stream = self

--- a/src/operator/src/statement/copy_table_from.rs
+++ b/src/operator/src/statement/copy_table_from.rs
@@ -377,7 +377,7 @@ impl StatementExecutor {
 
         let mut rows_inserted = 0;
         let mut insert_cost = 0;
-        let max_insert_rows = req.limit;
+        let max_insert_rows = req.limit.map(|n| n as usize);
         for (compat_schema, file_schema_projection, projected_table_schema, file_metadata) in files
         {
             let mut stream = self
@@ -430,7 +430,7 @@ impl StatementExecutor {
                 }
 
                 if let Some(max_insert_rows) = max_insert_rows {
-                    if rows_inserted >= max_insert_rows as usize {
+                    if rows_inserted >= max_insert_rows {
                         return Ok(gen_insert_output(rows_inserted, insert_cost));
                     }
                 }

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -151,7 +151,7 @@ pub enum Error {
 
     #[snafu(display("Unrecognized database option key: {}, value: {}", key, value))]
     InvalidDatabaseOptionValue {
-        key: Ident,
+        key: String,
         value: u64,
         location: Location,
     },

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -146,13 +146,13 @@ pub enum Error {
     InvalidTableOptionValue {
         key: Ident,
         value: Expr,
+        location: Location,
     },
 
     #[snafu(display("Unrecognized database option key: {}, value: {}", key, value))]
     InvalidDatabaseOptionValue {
         key: Ident,
         value: u64,
-        location: Location,
     },
 
     #[snafu(display("Failed to serialize column default constraint"))]

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -146,12 +146,11 @@ pub enum Error {
     InvalidTableOptionValue {
         key: Ident,
         value: Expr,
-        location: Location,
     },
 
     #[snafu(display("Unrecognized database option key: {}, value: {}", key, value))]
     InvalidDatabaseOptionValue {
-        key: String,
+        key: Ident,
         value: u64,
         location: Location,
     },

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -149,14 +149,6 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Unrecognized database option key: {}, value: {}", key, value))]
-    InvalidDatabaseOptionValue {
-        key: Ident,
-        value: u64,
-        #[snafu(implicit)]
-        location: Location,
-    },
-
     #[snafu(display("Failed to serialize column default constraint"))]
     SerializeColumnDefaultConstraint {
         location: Location,
@@ -218,7 +210,6 @@ impl ErrorExt for Error {
 
             InvalidColumnOption { .. }
             | InvalidTableOptionValue { .. }
-            | InvalidDatabaseOptionValue { .. }
             | InvalidDatabaseName { .. }
             | ColumnTypeMismatch { .. }
             | InvalidTableName { .. }

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -153,6 +153,8 @@ pub enum Error {
     InvalidDatabaseOptionValue {
         key: Ident,
         value: u64,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Failed to serialize column default constraint"))]

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -149,6 +149,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Unrecognized database option key: {}, value: {}", key, value))]
+    InvalidDatabaseOptionValue {
+        key: Ident,
+        value: u64,
+        location: Location,
+    },
+
     #[snafu(display("Failed to serialize column default constraint"))]
     SerializeColumnDefaultConstraint {
         location: Location,
@@ -210,6 +217,7 @@ impl ErrorExt for Error {
 
             InvalidColumnOption { .. }
             | InvalidTableOptionValue { .. }
+            | InvalidDatabaseOptionValue { .. }
             | InvalidDatabaseName { .. }
             | ColumnTypeMismatch { .. }
             | InvalidTableName { .. }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -58,11 +58,11 @@ impl<'a> ParserContext<'a> {
         let req = if self.parser.parse_keyword(Keyword::TO) {
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if let Some(num) = limit {
-                return Err(error::InvalidDatabaseOptionValueSnafu {
+                return error::InvalidDatabaseOptionValueSnafu {
                     key: "LIMIT",
                     value: num,
                 }
-                .build());
+                .fail();
             }
 
             let argument = CopyDatabaseArgument {

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -56,7 +56,15 @@ impl<'a> ParserContext<'a> {
             })?;
 
         let req = if self.parser.parse_keyword(Keyword::TO) {
-            let (with, connection, location, _) = self.parse_copy_parameters()?;
+            let (with, connection, location, limit) = self.parse_copy_parameters()?;
+            if let Some(num) = limit {
+                return Err(error::InvalidDatabaseOptionValueSnafu {
+                    key: "LIMIT",
+                    value: num,
+                }
+                .build());
+            }
+
             let argument = CopyDatabaseArgument {
                 database_name,
                 with: with.into(),
@@ -68,7 +76,15 @@ impl<'a> ParserContext<'a> {
             self.parser
                 .expect_keyword(Keyword::FROM)
                 .context(error::SyntaxSnafu)?;
-            let (with, connection, location, _) = self.parse_copy_parameters()?;
+            let (with, connection, location, limit) = self.parse_copy_parameters()?;
+            if let Some(num) = limit {
+                return Err(error::InvalidDatabaseOptionValueSnafu {
+                    key: "LIMIT",
+                    value: num,
+                }
+                .build());
+            }
+
             let argument = CopyDatabaseArgument {
                 database_name,
                 with: with.into(),

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -57,7 +57,7 @@ impl<'a> ParserContext<'a> {
 
         let req = if self.parser.parse_keyword(Keyword::TO) {
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
-            if let Some(num) = limit {
+            if limit.is_some() {
                 return error::InvalidSqlSnafu {
                     msg: "limit xxx is not supported",
                 }
@@ -76,7 +76,7 @@ impl<'a> ParserContext<'a> {
                 .expect_keyword(Keyword::FROM)
                 .context(error::SyntaxSnafu)?;
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
-            if let Some(num) = limit {
+            if limit.is_some() {
                 return error::InvalidSqlSnafu {
                     msg: "limit xxx is not supported",
                 }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -164,7 +164,7 @@ impl<'a> ParserContext<'a> {
                     .parse_literal_uint()
                     .with_context(|_| error::UnexpectedSnafu {
                         sql: self.sql,
-                        expected: "maximum rows",
+                        expected: "the number of maximum rows",
                         actual: self.peek_token_as_string(),
                     })?,
             )

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -78,7 +78,7 @@ impl<'a> ParserContext<'a> {
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if limit.is_some() {
                 return error::InvalidSqlSnafu {
-                    msg: "limit xxx is not supported",
+                    msg: "limit is not supported",
                 }
                 .fail();
             }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -78,11 +78,11 @@ impl<'a> ParserContext<'a> {
                 .context(error::SyntaxSnafu)?;
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if let Some(num) = limit {
-                return Err(error::InvalidDatabaseOptionValueSnafu {
+                return error::InvalidDatabaseOptionValueSnafu {
                     key: "LIMIT",
                     value: num,
                 }
-                .build());
+                .fail();
             }
 
             let argument = CopyDatabaseArgument {

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -59,7 +59,7 @@ impl<'a> ParserContext<'a> {
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if limit.is_some() {
                 return error::InvalidSqlSnafu {
-                    msg: "limit xxx is not supported",
+                    msg: "limit is not supported",
                 }
                 .fail();
             }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -58,9 +58,8 @@ impl<'a> ParserContext<'a> {
         let req = if self.parser.parse_keyword(Keyword::TO) {
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if let Some(num) = limit {
-                return error::InvalidDatabaseOptionValueSnafu {
-                    key: "LIMIT",
-                    value: num,
+                return error::InvalidSqlSnafu {
+                    msg: "limit xxx is not supported",
                 }
                 .fail();
             }
@@ -78,9 +77,8 @@ impl<'a> ParserContext<'a> {
                 .context(error::SyntaxSnafu)?;
             let (with, connection, location, limit) = self.parse_copy_parameters()?;
             if let Some(num) = limit {
-                return error::InvalidDatabaseOptionValueSnafu {
-                    key: "LIMIT",
-                    value: num,
+                return error::InvalidSqlSnafu {
+                    msg: "limit xxx is not supported",
                 }
                 .fail();
             }

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -145,11 +145,15 @@ impl<'a> ParserContext<'a> {
             .collect::<Result<Connection>>()?;
 
         let limit = if self.parser.parse_keyword(Keyword::LIMIT) {
-            Some(self.parser.parse_literal_uint().with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
-                    expected: "maximum rows",
-                    actual: self.peek_token_as_string(),
-            })?)
+            Some(
+                self.parser
+                    .parse_literal_uint()
+                    .with_context(|_| error::UnexpectedSnafu {
+                        sql: self.sql,
+                        expected: "maximum rows",
+                        actual: self.peek_token_as_string(),
+                    })?,
+            )
         } else {
             None
         };

--- a/src/sql/src/statements/copy.rs
+++ b/src/sql/src/statements/copy.rs
@@ -111,6 +111,7 @@ pub struct CopyTableArgument {
     pub connection: OptionMap,
     /// Copy tbl [To|From] 'location'.
     pub location: String,
+    pub limit: Option<u64>,
 }
 
 #[cfg(test)]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -228,6 +228,7 @@ pub struct CopyTableRequest {
     pub pattern: Option<String>,
     pub direction: CopyDirection,
     pub timestamp_range: Option<TimestampRange>,
+    pub limit: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
@@ -52,6 +52,14 @@ SELECT * FROM demo ORDER BY ts;
 | host1 | 66.6 | 1024.0 | 2022-06-15T07:02:37 |
 +-------+------+--------+---------------------+
 
+DELETE FROM demo;
+
+Affected Rows: 1
+
+COPY DATABASE public FROM '/tmp/demo/export/parquet_range/' LIMIT 2;
+
+Error: 1004(InvalidArguments), Unrecognized database option key: LIMIT, value: 2
+
 DROP TABLE demo;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
@@ -58,7 +58,7 @@ Affected Rows: 1
 
 COPY DATABASE public FROM '/tmp/demo/export/parquet_range/' LIMIT 2;
 
-Error: 2000(InvalidSyntax), Invalid SQL, error: limit xxx is not supported
+Error: 2000(InvalidSyntax), Invalid SQL, error: limit is not supported
 
 DROP TABLE demo;
 

--- a/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.result
@@ -58,7 +58,7 @@ Affected Rows: 1
 
 COPY DATABASE public FROM '/tmp/demo/export/parquet_range/' LIMIT 2;
 
-Error: 1004(InvalidArguments), Unrecognized database option key: LIMIT, value: 2
+Error: 2000(InvalidSyntax), Invalid SQL, error: limit xxx is not supported
 
 DROP TABLE demo;
 

--- a/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_database_from_fs_parquet.sql
@@ -20,4 +20,8 @@ COPY DATABASE public FROM '/tmp/demo/export/parquet_range/';
 
 SELECT * FROM demo ORDER BY ts;
 
+DELETE FROM demo;
+
+COPY DATABASE public FROM '/tmp/demo/export/parquet_range/' LIMIT 2;
+
 DROP TABLE demo;

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -109,9 +109,9 @@ select count(*) from with_limit_rows_segment;
 | 2        |
 +----------+
 
-Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT hello;
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;, expected: 'maximum rows', found: 1: sql parser error: Expected literal int, found: - at Line: 1, Column 75
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT hello;, expected: 'the number of maximum rows', found: ;: sql parser error: Expected literal int, found: hello at Line: 1, Column 75
 
 drop table demo;
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -109,6 +109,22 @@ select count(*) from with_limit_rows;
 | 2        |
 +----------+
 
+CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts timestamp time index);
+
+Affected Rows: 0
+
+Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
+
+Affected Rows: 2
+
+select count(*) from with_limit_rows_segment;
+
++----------+
+| COUNT(*) |
++----------+
+| 0        |
++----------+
+
 drop table demo;
 
 Affected Rows: 0
@@ -134,6 +150,10 @@ drop table without_limit_rows;
 Affected Rows: 0
 
 drop table with_limit_rows;
+
+Affected Rows: 0
+
+drop table with_limit_rows_segment;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -93,22 +93,6 @@ select count(*) from without_limit_rows;
 | 4        |
 +----------+
 
-CREATE TABLE with_limit_rows(host string, cpu double, memory double, ts timestamp time index);
-
-Affected Rows: 0
-
-Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' WITH (MAX_INSERT_ROWS = 2);
-
-Affected Rows: 2
-
-select count(*) from with_limit_rows;
-
-+----------+
-| COUNT(*) |
-+----------+
-| 2        |
-+----------+
-
 CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts timestamp time index);
 
 Affected Rows: 0
@@ -150,10 +134,6 @@ drop table with_pattern;
 Affected Rows: 0
 
 drop table without_limit_rows;
-
-Affected Rows: 0
-
-drop table with_limit_rows;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -113,7 +113,7 @@ CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts 
 
 Affected Rows: 0
 
-Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
 
 Affected Rows: 2
 
@@ -122,8 +122,12 @@ select count(*) from with_limit_rows_segment;
 +----------+
 | COUNT(*) |
 +----------+
-| 0        |
+| 2        |
 +----------+
+
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;
+
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;, expected: 'maximum rows', found: 1: sql parser error: Expected literal int, found: - at Line: 1, Column 75
 
 drop table demo;
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -42,9 +42,11 @@ select count(*) from with_limit_rows;
 
 CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts timestamp time index);
 
-Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
 
 select count(*) from with_limit_rows_segment;
+
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;
 
 drop table demo;
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -34,12 +34,6 @@ Copy without_limit_rows FROM '/tmp/demo/export/parquet_files/';
 
 select count(*) from without_limit_rows;
 
-CREATE TABLE with_limit_rows(host string, cpu double, memory double, ts timestamp time index);
-
-Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' WITH (MAX_INSERT_ROWS = 2);
-
-select count(*) from with_limit_rows;
-
 CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts timestamp time index);
 
 Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
@@ -59,7 +53,5 @@ drop table with_path;
 drop table with_pattern;
 
 drop table without_limit_rows;
-
-drop table with_limit_rows;
 
 drop table with_limit_rows_segment;

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -40,7 +40,7 @@ Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
 
 select count(*) from with_limit_rows_segment;
 
-Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT -1;
+Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT hello;
 
 drop table demo;
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.sql
@@ -40,6 +40,12 @@ Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' WITH (MAX_INSERT_ROW
 
 select count(*) from with_limit_rows;
 
+CREATE TABLE with_limit_rows_segment(host string, cpu double, memory double, ts timestamp time index);
+
+Copy with_limit_rows FROM '/tmp/demo/export/parquet_files/' LIMIT 2;
+
+select count(*) from with_limit_rows_segment;
+
 drop table demo;
 
 drop table demo_2;
@@ -53,3 +59,5 @@ drop table with_pattern;
 drop table without_limit_rows;
 
 drop table with_limit_rows;
+
+drop table with_limit_rows_segment;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close: #3889

## What's changed and what's your intention?

limit total rows copied in COPY TABLE FROM with LIMIT segment

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [ ]  This PR does not require documentation updates.
