### PR TITLE
refactor: add `Configurable` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,9 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -1624,7 +1627,6 @@ dependencies = [
  "common-time",
  "common-version",
  "common-wal",
- "config",
  "datanode",
  "datatypes",
  "either",
@@ -1728,9 +1730,22 @@ name = "common-config"
 version = "0.7.2"
 dependencies = [
  "common-base",
+ "common-error",
+ "common-macro",
+ "common-telemetry",
+ "common-test-util",
+ "common-wal",
+ "config",
+ "datanode",
+ "meta-client",
  "num_cpus",
  "serde",
+ "serde_json",
+ "snafu 0.8.2",
  "sysinfo",
+ "temp-env",
+ "tempfile",
+ "toml 0.8.12",
 ]
 
 [[package]]
@@ -1824,7 +1839,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "ron",
+ "ron 0.7.1",
  "serde",
  "serde_json",
  "session",
@@ -2168,20 +2183,21 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
 dependencies = [
  "async-trait",
+ "convert_case",
  "json5",
  "lazy_static",
  "nom",
  "pathdiff",
- "ron",
- "rust-ini 0.18.0",
+ "ron 0.8.1",
+ "rust-ini 0.19.0",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml 0.8.12",
  "yaml-rust",
 ]
 
@@ -2271,6 +2287,15 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -3149,6 +3174,7 @@ dependencies = [
  "catalog",
  "client",
  "common-base",
+ "common-config",
  "common-error",
  "common-function",
  "common-greptimedb-telemetry",
@@ -3434,12 +3460,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dlv-list"
@@ -5601,6 +5621,7 @@ dependencies = [
  "client",
  "common-base",
  "common-catalog",
+ "common-config",
  "common-error",
  "common-greptimedb-telemetry",
  "common-grpc",
@@ -6727,12 +6748,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
 dependencies = [
- "dlv-list 0.3.0",
- "hashbrown 0.12.3",
+ "dlv-list",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -6741,7 +6762,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
- "dlv-list 0.5.2",
+ "dlv-list",
  "hashbrown 0.14.5",
 ]
 
@@ -8392,6 +8413,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.5.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rsa"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8530,12 +8563,12 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
 dependencies = [
  "cfg-if 1.0.0",
- "ordered-multimap 0.4.3",
+ "ordered-multimap 0.6.0",
 ]
 
 [[package]]
@@ -9248,7 +9281,7 @@ dependencies = [
  "pyo3",
  "query",
  "rayon",
- "ron",
+ "ron 0.7.1",
  "rustpython-codegen",
  "rustpython-compiler",
  "rustpython-compiler-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,6 @@ name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -1839,7 +1836,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "paste",
- "ron 0.7.1",
+ "ron",
  "serde",
  "serde_json",
  "session",
@@ -2183,21 +2180,20 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.14.0"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
 dependencies = [
  "async-trait",
- "convert_case",
  "json5",
  "lazy_static",
  "nom",
  "pathdiff",
- "ron 0.8.1",
- "rust-ini 0.19.0",
+ "ron",
+ "rust-ini 0.18.0",
  "serde",
  "serde_json",
- "toml 0.8.12",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -2287,15 +2283,6 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -3460,6 +3447,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dlv-list"
@@ -6748,12 +6741,12 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.6.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
- "dlv-list",
- "hashbrown 0.13.2",
+ "dlv-list 0.3.0",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -6762,7 +6755,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
- "dlv-list",
+ "dlv-list 0.5.2",
  "hashbrown 0.14.5",
 ]
 
@@ -8413,18 +8406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
-dependencies = [
- "base64 0.21.7",
- "bitflags 2.5.0",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "rsa"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8563,12 +8544,12 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.19.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if 1.0.0",
- "ordered-multimap 0.6.0",
+ "ordered-multimap 0.4.3",
 ]
 
 [[package]]
@@ -9281,7 +9262,7 @@ dependencies = [
  "pyo3",
  "query",
  "rayon",
- "ron 0.7.1",
+ "ron",
  "rustpython-codegen",
  "rustpython-compiler",
  "rustpython-compiler-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ bytemuck = "1.12"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
+config = "0.14.0"
 crossbeam-utils = "0.8"
 dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ bytemuck = "1.12"
 bytes = { version = "1.5", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.4", features = ["derive"] }
-config = "0.14.0"
+config = "0.13.0"
 crossbeam-utils = "0.8"
 dashmap = "5.4"
 datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -40,7 +40,6 @@ common-telemetry = { workspace = true, features = [
 common-time.workspace = true
 common-version.workspace = true
 common-wal.workspace = true
-config = "0.13"
 datanode.workspace = true
 datatypes.workspace = true
 either = "1.8"

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -143,6 +143,7 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
+                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -143,7 +143,6 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
-                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -209,7 +209,7 @@ pub enum Error {
     #[snafu(display("Failed to load layered config"))]
     LoadLayeredConfig {
         #[snafu(source)]
-        source: common_config::error::Error,
+        source: Box<common_config::error::Error>,
         #[snafu(implicit)]
         location: Location,
     },

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -17,7 +17,6 @@ use std::any::Any;
 use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
-use config::ConfigError;
 use rustyline::error::ReadlineError;
 use snafu::{Location, Snafu};
 
@@ -210,7 +209,7 @@ pub enum Error {
     #[snafu(display("Failed to load layered config"))]
     LoadLayeredConfig {
         #[snafu(source)]
-        error: ConfigError,
+        source: common_config::error::Error,
         #[snafu(implicit)]
         location: Location,
     },

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -208,7 +208,7 @@ pub enum Error {
 
     #[snafu(display("Failed to load layered config"))]
     LoadLayeredConfig {
-        #[snafu(source)]
+        #[snafu(source(from(common_config::error::Error, Box::new)))]
         source: Box<common_config::error::Error>,
         #[snafu(implicit)]
         location: Location,

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -163,7 +163,6 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
-                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -163,6 +163,7 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
+                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -136,7 +136,6 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
-                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -16,13 +16,14 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use clap::Parser;
+use common_config::Configurable;
 use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
 use meta_srv::bootstrap::MetasrvInstance;
 use meta_srv::metasrv::MetasrvOptions;
 use snafu::ResultExt;
 
-use crate::error::{self, Result, StartMetaServerSnafu};
+use crate::error::{self, LoadLayeredConfigSnafu, Result, StartMetaServerSnafu};
 use crate::options::{GlobalOptions, Options};
 use crate::App;
 
@@ -128,11 +129,11 @@ struct StartCommand {
 
 impl StartCommand {
     fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
-        let mut opts: MetasrvOptions = Options::load_layered_options(
+        let mut opts: MetasrvOptions = MetasrvOptions::load_layered_options(
             self.config_file.as_deref(),
             self.env_prefix.as_ref(),
-            MetasrvOptions::env_list_keys(),
-        )?;
+        )
+        .context(LoadLayeredConfigSnafu)?;
 
         if let Some(dir) = &global_options.log_dir {
             opts.logging.dir.clone_from(dir);
@@ -225,11 +226,11 @@ mod tests {
     use std::io::Write;
 
     use common_base::readable_size::ReadableSize;
+    use common_config::ENV_VAR_SEP;
     use common_test_util::temp_dir::create_named_temp_file;
     use meta_srv::selector::SelectorType;
 
     use super::*;
-    use crate::options::ENV_VAR_SEP;
 
     #[test]
     fn test_read_from_cmd() {

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -136,6 +136,7 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
+                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -14,18 +14,11 @@
 
 use clap::Parser;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
-use config::{Config, Environment, File, FileFormat};
 use datanode::config::DatanodeOptions;
 use frontend::frontend::FrontendOptions;
 use meta_srv::metasrv::MetasrvOptions;
-use serde::{Deserialize, Serialize};
-use snafu::ResultExt;
 
-use crate::error::{LoadLayeredConfigSnafu, Result, SerdeJsonSnafu};
 use crate::standalone::StandaloneOptions;
-
-pub const ENV_VAR_SEP: &str = "__";
-pub const ENV_LIST_SEP: &str = ",";
 
 pub enum Options {
     Datanode(Box<DatanodeOptions>),
@@ -71,194 +64,11 @@ impl Options {
         }
     }
 
-    /// Load the configuration from multiple sources and merge them.
-    /// The precedence order is: config file > environment variables > default values.
-    /// `env_prefix` is the prefix of environment variables, e.g. "FRONTEND__xxx".
-    /// The function will use dunder(double underscore) `__` as the separator for environment variables, for example:
-    /// `DATANODE__STORAGE__MANIFEST__CHECKPOINT_MARGIN` will be mapped to `DatanodeOptions.storage.manifest.checkpoint_margin` field in the configuration.
-    /// `list_keys` is the list of keys that should be parsed as a list, for example, you can pass `Some(&["meta_client_options.metasrv_addrs"]` to parse `GREPTIMEDB_METASRV__META_CLIENT_OPTIONS__METASRV_ADDRS` as a list.
-    /// The function will use comma `,` as the separator for list values, for example: `127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003`.
-    pub fn load_layered_options<'de, T: Serialize + Deserialize<'de> + Default>(
-        config_file: Option<&str>,
-        env_prefix: &str,
-        list_keys: Option<&[&str]>,
-    ) -> Result<T> {
-        let default_opts = T::default();
-
-        let env_source = {
-            let mut env = Environment::default();
-
-            if !env_prefix.is_empty() {
-                env = env.prefix(env_prefix);
-            }
-
-            if let Some(list_keys) = list_keys {
-                env = env.list_separator(ENV_LIST_SEP);
-                for key in list_keys {
-                    env = env.with_list_parse_key(key);
-                }
-            }
-
-            env.try_parsing(true)
-                .separator(ENV_VAR_SEP)
-                .ignore_empty(true)
-        };
-
-        // Workaround: Replacement for `Config::try_from(&default_opts)` due to
-        // `ConfigSerializer` cannot handle the case of an empty struct contained
-        // within an iterative structure.
-        // See: https://github.com/mehcode/config-rs/issues/461
-        let json_str = serde_json::to_string(&default_opts).context(SerdeJsonSnafu)?;
-        let default_config = File::from_str(&json_str, FileFormat::Json);
-
-        // Add default values and environment variables as the sources of the configuration.
-        let mut layered_config = Config::builder()
-            .add_source(default_config)
-            .add_source(env_source);
-
-        // Add config file as the source of the configuration if it is specified.
-        if let Some(config_file) = config_file {
-            layered_config = layered_config.add_source(File::new(config_file, FileFormat::Toml));
-        }
-
-        let opts = layered_config
-            .build()
-            .context(LoadLayeredConfigSnafu)?
-            .try_deserialize()
-            .context(LoadLayeredConfigSnafu)?;
-
-        Ok(opts)
-    }
-
     pub fn node_id(&self) -> Option<String> {
         match self {
             Options::Metasrv(_) | Options::Cli(_) | Options::Standalone(_) => None,
             Options::Datanode(opt) => opt.node_id.map(|x| x.to_string()),
             Options::Frontend(opt) => opt.node_id.clone(),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::io::Write;
-
-    use common_test_util::temp_dir::create_named_temp_file;
-    use common_wal::config::DatanodeWalConfig;
-    use datanode::config::{DatanodeOptions, ObjectStoreConfig};
-
-    use super::*;
-
-    #[test]
-    fn test_load_layered_options() {
-        let mut file = create_named_temp_file();
-        let toml_str = r#"
-            mode = "distributed"
-            enable_memory_catalog = false
-            rpc_addr = "127.0.0.1:3001"
-            rpc_hostname = "127.0.0.1"
-            rpc_runtime_size = 8
-            mysql_addr = "127.0.0.1:4406"
-            mysql_runtime_size = 2
-
-            [meta_client]
-            timeout = "3s"
-            connect_timeout = "5s"
-            tcp_nodelay = true
-
-            [wal]
-            provider = "raft_engine"
-            dir = "/tmp/greptimedb/wal"
-            file_size = "1GB"
-            purge_threshold = "50GB"
-            purge_interval = "10m"
-            read_batch_size = 128
-            sync_write = false
-
-            [logging]
-            level = "debug"
-            dir = "/tmp/greptimedb/test/logs"
-        "#;
-        write!(file, "{}", toml_str).unwrap();
-
-        let env_prefix = "DATANODE_UT";
-        temp_env::with_vars(
-            // The following environment variables will be used to override the values in the config file.
-            [
-                (
-                    // storage.type = S3
-                    [
-                        env_prefix.to_string(),
-                        "storage".to_uppercase(),
-                        "type".to_uppercase(),
-                    ]
-                    .join(ENV_VAR_SEP),
-                    Some("S3"),
-                ),
-                (
-                    // storage.bucket = mybucket
-                    [
-                        env_prefix.to_string(),
-                        "storage".to_uppercase(),
-                        "bucket".to_uppercase(),
-                    ]
-                    .join(ENV_VAR_SEP),
-                    Some("mybucket"),
-                ),
-                (
-                    // wal.dir = /other/wal/dir
-                    [
-                        env_prefix.to_string(),
-                        "wal".to_uppercase(),
-                        "dir".to_uppercase(),
-                    ]
-                    .join(ENV_VAR_SEP),
-                    Some("/other/wal/dir"),
-                ),
-                (
-                    // meta_client.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
-                    [
-                        env_prefix.to_string(),
-                        "meta_client".to_uppercase(),
-                        "metasrv_addrs".to_uppercase(),
-                    ]
-                    .join(ENV_VAR_SEP),
-                    Some("127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003"),
-                ),
-            ],
-            || {
-                let opts: DatanodeOptions = Options::load_layered_options(
-                    Some(file.path().to_str().unwrap()),
-                    env_prefix,
-                    DatanodeOptions::env_list_keys(),
-                )
-                .unwrap();
-
-                // Check the configs from environment variables.
-                match &opts.storage.store {
-                    ObjectStoreConfig::S3(s3_config) => {
-                        assert_eq!(s3_config.bucket, "mybucket".to_string());
-                    }
-                    _ => panic!("unexpected store type"),
-                }
-                assert_eq!(
-                    opts.meta_client.unwrap().metasrv_addrs,
-                    vec![
-                        "127.0.0.1:3001".to_string(),
-                        "127.0.0.1:3002".to_string(),
-                        "127.0.0.1:3003".to_string()
-                    ]
-                );
-
-                // Should be the values from config file, not environment variables.
-                let DatanodeWalConfig::RaftEngine(raft_engine_config) = opts.wal else {
-                    unreachable!()
-                };
-                assert_eq!(raft_engine_config.dir.unwrap(), "/tmp/greptimedb/wal");
-
-                // Should be default values.
-                assert_eq!(opts.node_id, None);
-            },
-        );
     }
 }

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -295,6 +295,7 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
+                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -22,9 +22,8 @@ use cache::{
 };
 use catalog::kvbackend::KvBackendCatalogManager;
 use clap::Parser;
-use common_config::Configurable;
 use common_catalog::consts::{MIN_USER_FLOW_ID, MIN_USER_TABLE_ID};
-use common_config::{metadata_store_dir, KvBackendConfig};
+use common_config::{metadata_store_dir, Configurable, KvBackendConfig};
 use common_meta::cache::LayeredCacheRegistryBuilder;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::ddl::flow_meta::{FlowMetadataAllocator, FlowMetadataAllocatorRef};
@@ -64,9 +63,9 @@ use snafu::{OptionExt, ResultExt};
 
 use crate::error::{
     BuildCacheRegistrySnafu, CacheRequiredSnafu, CreateDirSnafu, IllegalConfigSnafu,
-    InitDdlManagerSnafu, InitMetadataSnafu, InitTimezoneSnafu, Result, ShutdownDatanodeSnafu,
-    ShutdownFrontendSnafu, StartDatanodeSnafu, StartFrontendSnafu, StartProcedureManagerSnafu,
-    StartWalOptionsAllocatorSnafu, StopProcedureManagerSnafu,LoadLayeredConfigSnafu
+    InitDdlManagerSnafu, InitMetadataSnafu, InitTimezoneSnafu, LoadLayeredConfigSnafu, Result,
+    ShutdownDatanodeSnafu, ShutdownFrontendSnafu, StartDatanodeSnafu, StartFrontendSnafu,
+    StartProcedureManagerSnafu, StartWalOptionsAllocatorSnafu, StopProcedureManagerSnafu,
 };
 use crate::options::{GlobalOptions, Options};
 use crate::App;
@@ -295,7 +294,6 @@ impl StartCommand {
                     self.config_file.as_deref(),
                     self.env_prefix.as_ref(),
                 )
-                .map_err(Box::new)
                 .context(LoadLayeredConfigSnafu)?,
             )?,
         )))

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -9,6 +9,22 @@ workspace = true
 
 [dependencies]
 common-base.workspace = true
+common-error.workspace = true
+common-macro.workspace = true
+config.workspace = true
 num_cpus.workspace = true
 serde.workspace = true
 sysinfo.workspace = true
+snafu.workspace = true
+serde_json.workspace = true
+toml.workspace = true
+
+[dev-dependencies]
+common-test-util.workspace = true
+serde.workspace = true
+common-wal.workspace = true
+common-telemetry.workspace = true
+datanode.workspace = true
+tempfile.workspace = true
+meta-client.workspace = true
+temp-env = "0.3"

--- a/src/common/config/Cargo.toml
+++ b/src/common/config/Cargo.toml
@@ -14,17 +14,17 @@ common-macro.workspace = true
 config.workspace = true
 num_cpus.workspace = true
 serde.workspace = true
-sysinfo.workspace = true
-snafu.workspace = true
 serde_json.workspace = true
+snafu.workspace = true
+sysinfo.workspace = true
 toml.workspace = true
 
 [dev-dependencies]
-common-test-util.workspace = true
-serde.workspace = true
-common-wal.workspace = true
 common-telemetry.workspace = true
+common-test-util.workspace = true
+common-wal.workspace = true
 datanode.workspace = true
-tempfile.workspace = true
 meta-client.workspace = true
+serde.workspace = true
 temp-env = "0.3"
+tempfile.workspace = true

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -18,9 +18,13 @@ use snafu::ResultExt;
 
 use crate::error::{LoadLayeredConfigSnafu, Result, SerdeJsonSnafu, TomlFormatSnafu};
 
+/// Separator for environment variables. For example, `DATANODE__STORAGE__MANIFEST__CHECKPOINT_MARGIN`.
 pub const ENV_VAR_SEP: &str = "__";
+
+/// Separator for list values in environment variables. For example, `localhost:3001,localhost:3002,localhost:3003`.
 pub const ENV_LIST_SEP: &str = ",";
 
+/// Configuration trait defines the common interface for configuration that can be loaded from multiple sources and serialized to TOML.
 pub trait Configurable<'de>: Serialize + Deserialize<'de> + Default + Sized {
     /// Load the configuration from multiple sources and merge them.
     /// The precedence order is: config file > environment variables > default values.
@@ -77,10 +81,12 @@ pub trait Configurable<'de>: Serialize + Deserialize<'de> + Default + Sized {
         Ok(opts)
     }
 
+    /// List of toml keys that should be parsed as a list.
     fn env_list_keys() -> Option<&'static [&'static str]> {
         None
     }
 
+    /// Serialize the configuration to a TOML string.
     fn to_toml(&self) -> Result<String> {
         toml::to_string(&self).context(TomlFormatSnafu)
     }

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -74,8 +74,7 @@ pub trait Configurable<'de>: Serialize + Deserialize<'de> + Default + Sized {
 
         let opts = layered_config
             .build()
-            .context(LoadLayeredConfigSnafu)?
-            .try_deserialize()
+            .and_then(|x| x.try_deserialize())
             .context(LoadLayeredConfigSnafu)?;
 
         Ok(opts)

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -1,0 +1,249 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use config::{Environment, File, FileFormat};
+use serde::{Deserialize, Serialize};
+use snafu::ResultExt;
+
+use crate::error::{LoadLayeredConfigSnafu, Result, SerdeJsonSnafu, TomlFormatSnafu};
+
+pub const ENV_VAR_SEP: &str = "__";
+pub const ENV_LIST_SEP: &str = ",";
+
+pub trait Configurable<'de>: Serialize + Deserialize<'de> + Default + Sized {
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    /// Load the configuration from multiple sources and merge them.
+    /// The precedence order is: config file > environment variables > default values.
+    /// `env_prefix` is the prefix of environment variables, e.g. "FRONTEND__xxx".
+    /// The function will use dunder(double underscore) `__` as the separator for environment variables, for example:
+    /// `DATANODE__STORAGE__MANIFEST__CHECKPOINT_MARGIN` will be mapped to `DatanodeOptions.storage.manifest.checkpoint_margin` field in the configuration.
+    /// `list_keys` is the list of keys that should be parsed as a list, for example, you can pass `Some(&["meta_client_options.metasrv_addrs"]` to parse `GREPTIMEDB_METASRV__META_CLIENT_OPTIONS__METASRV_ADDRS` as a list.
+    /// The function will use comma `,` as the separator for list values, for example: `127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003`.
+    fn load_layered_options(config_file: Option<&str>, env_prefix: &str) -> Result<Self> {
+        let default_opts = Self::default();
+
+        let env_source = {
+            let mut env = Environment::default();
+
+            if !env_prefix.is_empty() {
+                env = env.prefix(env_prefix);
+            }
+
+            if let Some(list_keys) = Self::env_list_keys() {
+                env = env.list_separator(ENV_LIST_SEP);
+                for key in list_keys {
+                    env = env.with_list_parse_key(key);
+                }
+            }
+
+            env.try_parsing(true)
+                .separator(ENV_VAR_SEP)
+                .ignore_empty(true)
+        };
+
+        // Workaround: Replacement for `Config::try_from(&default_opts)` due to
+        // `ConfigSerializer` cannot handle the case of an empty struct contained
+        // within an iterative structure.
+        // See: https://github.com/mehcode/config-rs/issues/461
+        let json_str = serde_json::to_string(&default_opts).context(SerdeJsonSnafu)?;
+        let default_config = File::from_str(&json_str, FileFormat::Json);
+
+        // Add default values and environment variables as the sources of the configuration.
+        let mut layered_config = config::Config::builder()
+            .add_source(default_config)
+            .add_source(env_source);
+
+        // Add config file as the source of the configuration if it is specified.
+        if let Some(config_file) = config_file {
+            layered_config = layered_config.add_source(File::new(config_file, FileFormat::Toml));
+        }
+
+        let opts = layered_config
+            .build()
+            .context(LoadLayeredConfigSnafu)?
+            .try_deserialize()
+            .context(LoadLayeredConfigSnafu)?;
+
+        Ok(opts)
+    }
+
+    fn env_list_keys() -> Option<&'static [&'static str]> {
+        None
+    }
+
+    fn to_toml(&self) -> Result<String> {
+        toml::to_string(&self).context(TomlFormatSnafu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use common_telemetry::logging::LoggingOptions;
+    use common_test_util::temp_dir::create_named_temp_file;
+    use common_wal::config::DatanodeWalConfig;
+    use datanode::config::{ObjectStoreConfig, StorageConfig};
+    use meta_client::MetaClientOptions;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::Mode;
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestDatanodeConfig {
+        mode: Mode,
+        node_id: Option<u64>,
+        logging: LoggingOptions,
+        meta_client: Option<MetaClientOptions>,
+        wal: DatanodeWalConfig,
+        storage: StorageConfig,
+    }
+
+    impl Default for TestDatanodeConfig {
+        fn default() -> Self {
+            Self {
+                mode: Mode::Distributed,
+                node_id: None,
+                logging: LoggingOptions::default(),
+                meta_client: None,
+                wal: DatanodeWalConfig::default(),
+                storage: StorageConfig::default(),
+            }
+        }
+    }
+
+    impl Configurable<'_> for TestDatanodeConfig {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn env_list_keys() -> Option<&'static [&'static str]> {
+            Some(&["meta_client.metasrv_addrs"])
+        }
+    }
+
+    #[test]
+    fn test_load_layered_options() {
+        let mut file = create_named_temp_file();
+        let toml_str = r#"
+            mode = "distributed"
+            enable_memory_catalog = false
+            rpc_addr = "127.0.0.1:3001"
+            rpc_hostname = "127.0.0.1"
+            rpc_runtime_size = 8
+            mysql_addr = "127.0.0.1:4406"
+            mysql_runtime_size = 2
+
+            [meta_client]
+            timeout = "3s"
+            connect_timeout = "5s"
+            tcp_nodelay = true
+
+            [wal]
+            provider = "raft_engine"
+            dir = "/tmp/greptimedb/wal"
+            file_size = "1GB"
+            purge_threshold = "50GB"
+            purge_interval = "10m"
+            read_batch_size = 128
+            sync_write = false
+
+            [logging]
+            level = "debug"
+            dir = "/tmp/greptimedb/test/logs"
+        "#;
+        write!(file, "{}", toml_str).unwrap();
+
+        let env_prefix = "DATANODE_UT";
+        temp_env::with_vars(
+            // The following environment variables will be used to override the values in the config file.
+            [
+                (
+                    // storage.type = S3
+                    [
+                        env_prefix.to_string(),
+                        "storage".to_uppercase(),
+                        "type".to_uppercase(),
+                    ]
+                    .join(ENV_VAR_SEP),
+                    Some("S3"),
+                ),
+                (
+                    // storage.bucket = mybucket
+                    [
+                        env_prefix.to_string(),
+                        "storage".to_uppercase(),
+                        "bucket".to_uppercase(),
+                    ]
+                    .join(ENV_VAR_SEP),
+                    Some("mybucket"),
+                ),
+                (
+                    // wal.dir = /other/wal/dir
+                    [
+                        env_prefix.to_string(),
+                        "wal".to_uppercase(),
+                        "dir".to_uppercase(),
+                    ]
+                    .join(ENV_VAR_SEP),
+                    Some("/other/wal/dir"),
+                ),
+                (
+                    // meta_client.metasrv_addrs = 127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003
+                    [
+                        env_prefix.to_string(),
+                        "meta_client".to_uppercase(),
+                        "metasrv_addrs".to_uppercase(),
+                    ]
+                    .join(ENV_VAR_SEP),
+                    Some("127.0.0.1:3001,127.0.0.1:3002,127.0.0.1:3003"),
+                ),
+            ],
+            || {
+                let opts = TestDatanodeConfig::load_layered_options(
+                    Some(file.path().to_str().unwrap()),
+                    env_prefix,
+                )
+                .unwrap();
+
+                // Check the configs from environment variables.
+                match &opts.storage.store {
+                    ObjectStoreConfig::S3(s3_config) => {
+                        assert_eq!(s3_config.bucket, "mybucket".to_string());
+                    }
+                    _ => panic!("unexpected store type"),
+                }
+                assert_eq!(
+                    opts.meta_client.unwrap().metasrv_addrs,
+                    vec![
+                        "127.0.0.1:3001".to_string(),
+                        "127.0.0.1:3002".to_string(),
+                        "127.0.0.1:3003".to_string()
+                    ]
+                );
+
+                // Should be the values from config file, not environment variables.
+                let DatanodeWalConfig::RaftEngine(raft_engine_config) = opts.wal else {
+                    unreachable!()
+                };
+                assert_eq!(raft_engine_config.dir.unwrap(), "/tmp/greptimedb/wal");
+
+                // Should be default values.
+                assert_eq!(opts.node_id, None);
+            },
+        );
+    }
+}

--- a/src/common/config/src/config.rs
+++ b/src/common/config/src/config.rs
@@ -22,8 +22,6 @@ pub const ENV_VAR_SEP: &str = "__";
 pub const ENV_LIST_SEP: &str = ",";
 
 pub trait Configurable<'de>: Serialize + Deserialize<'de> + Default + Sized {
-    fn as_any(&self) -> &dyn std::any::Any;
-
     /// Load the configuration from multiple sources and merge them.
     /// The precedence order is: config file > environment variables > default values.
     /// `env_prefix` is the prefix of environment variables, e.g. "FRONTEND__xxx".
@@ -126,10 +124,6 @@ mod tests {
     }
 
     impl Configurable<'_> for TestDatanodeConfig {
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
         fn env_list_keys() -> Option<&'static [&'static str]> {
             Some(&["meta_client.metasrv_addrs"])
         }

--- a/src/common/config/src/error.rs
+++ b/src/common/config/src/error.rs
@@ -1,0 +1,67 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::any::Any;
+
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
+use common_macro::stack_trace_debug;
+use config::ConfigError;
+use snafu::{Location, Snafu};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Snafu)]
+#[snafu(visibility(pub))]
+#[stack_trace_debug]
+pub enum Error {
+    #[snafu(display("Failed to load layered config"))]
+    LoadLayeredConfig {
+        #[snafu(source)]
+        error: ConfigError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to serde json"))]
+    SerdeJson {
+        #[snafu(source)]
+        error: serde_json::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to serialize options to TOML"))]
+    TomlFormat {
+        #[snafu(source)]
+        error: toml::ser::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+}
+
+impl ErrorExt for Error {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            Error::TomlFormat { .. } | Error::LoadLayeredConfig { .. } => {
+                StatusCode::InvalidArguments
+            }
+            Error::SerdeJson { .. } => StatusCode::Unexpected,
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/src/common/config/src/lib.rs
+++ b/src/common/config/src/lib.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod config;
+pub mod error;
 pub mod utils;
 
 use common_base::readable_size::ReadableSize;
+pub use config::*;
 use serde::{Deserialize, Serialize};
 
 pub fn metadata_store_dir(store_dir: &str) -> String {

--- a/src/datanode/Cargo.toml
+++ b/src/datanode/Cargo.toml
@@ -18,6 +18,7 @@ bytes.workspace = true
 catalog.workspace = true
 client.workspace = true
 common-base.workspace = true
+common-config.workspace = true
 common-error.workspace = true
 common-function.workspace = true
 common-greptimedb-telemetry.workspace = true

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -14,8 +14,11 @@
 
 //! Datanode configurations
 
+use std::any::Any;
+
 use common_base::readable_size::ReadableSize;
 use common_base::secrets::SecretString;
+use common_config::Configurable;
 use common_grpc::channel_manager::{
     DEFAULT_MAX_GRPC_RECV_MESSAGE_SIZE, DEFAULT_MAX_GRPC_SEND_MESSAGE_SIZE,
 };
@@ -266,13 +269,13 @@ impl Default for DatanodeOptions {
     }
 }
 
-impl DatanodeOptions {
-    pub fn env_list_keys() -> Option<&'static [&'static str]> {
-        Some(&["meta_client.metasrv_addrs", "wal.broker_endpoints"])
+impl Configurable<'_> for DatanodeOptions {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 
-    pub fn to_toml_string(&self) -> String {
-        toml::to_string(&self).unwrap()
+    fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["meta_client.metasrv_addrs", "wal.broker_endpoints"])
     }
 }
 

--- a/src/datanode/src/config.rs
+++ b/src/datanode/src/config.rs
@@ -14,8 +14,6 @@
 
 //! Datanode configurations
 
-use std::any::Any;
-
 use common_base::readable_size::ReadableSize;
 use common_base::secrets::SecretString;
 use common_config::Configurable;
@@ -270,10 +268,6 @@ impl Default for DatanodeOptions {
 }
 
 impl Configurable<'_> for DatanodeOptions {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn env_list_keys() -> Option<&'static [&'static str]> {
         Some(&["meta_client.metasrv_addrs", "wal.broker_endpoints"])
     }

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -359,6 +359,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to serialize options to TOML"))]
+    TomlFormat {
+        #[snafu(implicit)]
+        location: Location,
+        source: common_config::error::Error,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -391,7 +398,8 @@ impl ErrorExt for Error {
             | MissingNodeId { .. }
             | ColumnNoneDefaultValue { .. }
             | MissingWalDirConfig { .. }
-            | MissingKvBackend { .. } => StatusCode::InvalidArguments,
+            | MissingKvBackend { .. }
+            | TomlFormat { .. } => StatusCode::InvalidArguments,
 
             PayloadNotExist { .. } | Unexpected { .. } | WatchAsyncTaskChange { .. } => {
                 StatusCode::Unexpected

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -364,7 +364,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
-        source: common_config::error::Error,
+        source: Box<common_config::error::Error>,
     },
 }
 

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -364,6 +364,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
+        #[snafu(source(from(common_config::error::Error, Box::new)))]
         source: Box<common_config::error::Error>,
     },
 }

--- a/src/datanode/src/service.rs
+++ b/src/datanode/src/service.rs
@@ -76,12 +76,7 @@ impl<'a> DatanodeServiceBuilder<'a> {
         if self.enable_http_service {
             let http_server = HttpServerBuilder::new(self.opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(
-                    self.opts
-                        .to_toml()
-                        .map_err(Box::new)
-                        .context(TomlFormatSnafu)?,
-                )
+                .with_greptime_config_options(self.opts.to_toml().context(TomlFormatSnafu)?)
                 .build();
             let addr: SocketAddr = self.opts.http.addr.parse().context(ParseAddrSnafu {
                 addr: &self.opts.http.addr,

--- a/src/datanode/src/service.rs
+++ b/src/datanode/src/service.rs
@@ -76,7 +76,12 @@ impl<'a> DatanodeServiceBuilder<'a> {
         if self.enable_http_service {
             let http_server = HttpServerBuilder::new(self.opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(self.opts.to_toml().context(TomlFormatSnafu)?)
+                .with_greptime_config_options(
+                    self.opts
+                        .to_toml()
+                        .map_err(Box::new)
+                        .context(TomlFormatSnafu)?,
+                )
                 .build();
             let addr: SocketAddr = self.opts.http.addr.parse().context(ParseAddrSnafu {
                 addr: &self.opts.http.addr,

--- a/src/datanode/src/service.rs
+++ b/src/datanode/src/service.rs
@@ -15,6 +15,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use common_config::Configurable;
 use servers::grpc::builder::GrpcServerBuilder;
 use servers::grpc::{GrpcServer, GrpcServerConfig};
 use servers::http::HttpServerBuilder;
@@ -23,7 +24,7 @@ use servers::server::{ServerHandler, ServerHandlers};
 use snafu::ResultExt;
 
 use crate::config::DatanodeOptions;
-use crate::error::{ParseAddrSnafu, Result};
+use crate::error::{ParseAddrSnafu, Result, TomlFormatSnafu};
 use crate::region_server::RegionServer;
 
 pub struct DatanodeServiceBuilder<'a> {
@@ -75,7 +76,7 @@ impl<'a> DatanodeServiceBuilder<'a> {
         if self.enable_http_service {
             let http_server = HttpServerBuilder::new(self.opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(self.opts.to_toml_string())
+                .with_greptime_config_options(self.opts.to_toml().context(TomlFormatSnafu)?)
                 .build();
             let addr: SocketAddr = self.opts.http.addr.parse().context(ParseAddrSnafu {
                 addr: &self.opts.http.addr,

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -345,7 +345,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
-        source: common_config::error::Error,
+        source: Box<common_config::error::Error>,
     },
 
     #[snafu(display("Failed to get cache from cache registry: {}", name))]

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -345,6 +345,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
+        #[snafu(source(from(common_config::error::Error, Box::new)))]
         source: Box<common_config::error::Error>,
     },
 

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -343,8 +343,9 @@ pub enum Error {
 
     #[snafu(display("Failed to serialize options to TOML"))]
     TomlFormat {
-        #[snafu(source)]
-        error: toml::ser::Error,
+        #[snafu(implicit)]
+        location: Location,
+        source: common_config::error::Error,
     },
 
     #[snafu(display("Failed to get cache from cache registry: {}", name))]

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
+use common_config::config::Configurable;
 use meta_client::MetaClientOptions;
 use serde::{Deserialize, Serialize};
 use servers::export_metrics::ExportMetricsOption;
 use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
 use servers::Mode;
-use snafu::prelude::*;
 
-use crate::error::{Result, TomlFormatSnafu};
 use crate::service_config::{
     DatanodeOptions, GrpcOptions, InfluxdbOptions, MysqlOptions, OpentsdbOptions, OtlpOptions,
     PostgresOptions, PromStoreOptions,
@@ -75,23 +74,13 @@ impl Default for FrontendOptions {
     }
 }
 
-impl FrontendOptions {
-    pub fn env_list_keys() -> Option<&'static [&'static str]> {
+impl Configurable<'_> for FrontendOptions {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn env_list_keys() -> Option<&'static [&'static str]> {
         Some(&["meta_client.metasrv_addrs"])
-    }
-
-    pub fn to_toml_string(&self) -> String {
-        toml::to_string(&self).unwrap()
-    }
-}
-
-pub trait TomlSerializable {
-    fn to_toml(&self) -> Result<String>;
-}
-
-impl TomlSerializable for FrontendOptions {
-    fn to_toml(&self) -> Result<String> {
-        toml::to_string(&self).context(TomlFormatSnafu)
     }
 }
 

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -75,10 +75,6 @@ impl Default for FrontendOptions {
 }
 
 impl Configurable<'_> for FrontendOptions {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn env_list_keys() -> Option<&'static [&'static str]> {
         Some(&["meta_client.metasrv_addrs"])
     }

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use common_config::config::Configurable;
+use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use meta_client::MetaClientOptions;
 use serde::{Deserialize, Serialize};
 use servers::export_metrics::ExportMetricsOption;

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -30,7 +30,7 @@ use auth::{PermissionChecker, PermissionCheckerRef, PermissionReq};
 use catalog::CatalogManagerRef;
 use client::OutputData;
 use common_base::Plugins;
-use common_config::KvBackendConfig;
+use common_config::{Configurable, KvBackendConfig};
 use common_error::ext::{BoxedError, ErrorExt};
 use common_frontend::handler::FrontendInvoker;
 use common_grpc::channel_manager::{ChannelConfig, ChannelManager};
@@ -86,7 +86,7 @@ use crate::error::{
     PermissionSnafu, PlanStatementSnafu, Result, SqlExecInterceptedSnafu, StartServerSnafu,
     TableOperationSnafu,
 };
-use crate::frontend::{FrontendOptions, TomlSerializable};
+use crate::frontend::FrontendOptions;
 use crate::heartbeat::HeartbeatTask;
 use crate::script::ScriptExecutor;
 
@@ -188,7 +188,7 @@ impl Instance {
 
     pub fn build_servers(
         &mut self,
-        opts: impl Into<FrontendOptions> + TomlSerializable,
+        opts: impl Into<FrontendOptions> + for<'de> Configurable<'de>,
         servers: ServerHandlers,
     ) -> Result<()> {
         let opts: FrontendOptions = opts.into();

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -172,7 +172,7 @@ where
         let opts = self.opts.clone();
         let instance = self.instance.clone();
 
-        let toml = opts.to_toml().context(TomlFormatSnafu)?;
+        let toml = opts.to_toml().map_err(Box::new).context(TomlFormatSnafu)?;
         let opts: FrontendOptions = opts.into();
 
         let handlers = ServerHandlers::default();

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -172,7 +172,7 @@ where
         let opts = self.opts.clone();
         let instance = self.instance.clone();
 
-        let toml = opts.to_toml().map_err(Box::new).context(TomlFormatSnafu)?;
+        let toml = opts.to_toml().context(TomlFormatSnafu)?;
         let opts: FrontendOptions = opts.into();
 
         let handlers = ServerHandlers::default();

--- a/src/meta-srv/Cargo.toml
+++ b/src/meta-srv/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 client.workspace = true
 common-base.workspace = true
 common-catalog.workspace = true
+common-config.workspace = true
 common-error.workspace = true
 common-greptimedb-telemetry.workspace = true
 common-grpc.workspace = true

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -74,9 +74,7 @@ impl MetasrvInstance {
         let httpsrv = Arc::new(
             HttpServerBuilder::new(opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(
-                    opts.to_toml().map_err(Box::new).context(TomlFormatSnafu)?,
-                )
+                .with_greptime_config_options(opts.to_toml().context(TomlFormatSnafu)?)
                 .build(),
         );
         // put metasrv into plugins for later use

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -20,6 +20,7 @@ use api::v1::meta::lock_server::LockServer;
 use api::v1::meta::procedure_service_server::ProcedureServiceServer;
 use api::v1::meta::store_server::StoreServer;
 use common_base::Plugins;
+use common_config::Configurable;
 use common_meta::kv_backend::chroot::ChrootKvBackend;
 use common_meta::kv_backend::etcd::EtcdStore;
 use common_meta::kv_backend::memory::MemoryKvBackend;
@@ -38,7 +39,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use tonic::transport::server::{Router, TcpIncoming};
 
 use crate::election::etcd::EtcdElection;
-use crate::error::InitExportMetricsTaskSnafu;
+use crate::error::{InitExportMetricsTaskSnafu, TomlFormatSnafu};
 use crate::lock::etcd::EtcdLock;
 use crate::lock::memory::MemLock;
 use crate::metasrv::builder::MetasrvBuilder;
@@ -73,7 +74,7 @@ impl MetasrvInstance {
         let httpsrv = Arc::new(
             HttpServerBuilder::new(opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(opts.to_toml_string())
+                .with_greptime_config_options(opts.to_toml().context(TomlFormatSnafu)?)
                 .build(),
         );
         // put metasrv into plugins for later use

--- a/src/meta-srv/src/bootstrap.rs
+++ b/src/meta-srv/src/bootstrap.rs
@@ -74,7 +74,9 @@ impl MetasrvInstance {
         let httpsrv = Arc::new(
             HttpServerBuilder::new(opts.http.clone())
                 .with_metrics_handler(MetricsHandler)
-                .with_greptime_config_options(opts.to_toml().context(TomlFormatSnafu)?)
+                .with_greptime_config_options(
+                    opts.to_toml().map_err(Box::new).context(TomlFormatSnafu)?,
+                )
                 .build(),
         );
         // put metasrv into plugins for later use

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -837,7 +837,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
-        source: common_config::error::Error,
+        source: Box<common_config::error::Error>,
     },
 }
 

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -837,6 +837,7 @@ pub enum Error {
     TomlFormat {
         #[snafu(implicit)]
         location: Location,
+        #[snafu(source(from(common_config::error::Error, Box::new)))]
         source: Box<common_config::error::Error>,
     },
 }

--- a/src/meta-srv/src/error.rs
+++ b/src/meta-srv/src/error.rs
@@ -832,6 +832,13 @@ pub enum Error {
         location: Location,
         source: common_meta::error::Error,
     },
+
+    #[snafu(display("Failed to serialize options to TOML"))]
+    TomlFormat {
+        #[snafu(implicit)]
+        location: Location,
+        source: common_config::error::Error,
+    },
 }
 
 impl Error {
@@ -903,7 +910,8 @@ impl ErrorExt for Error {
             | Error::InitExportMetricsTask { .. }
             | Error::InvalidHeartbeatRequest { .. }
             | Error::ProcedureNotFound { .. }
-            | Error::TooManyPartitions { .. } => StatusCode::InvalidArguments,
+            | Error::TooManyPartitions { .. }
+            | Error::TomlFormat { .. } => StatusCode::InvalidArguments,
             Error::LeaseKeyFromUtf8 { .. }
             | Error::LeaseValueFromUtf8 { .. }
             | Error::StatKeyFromUtf8 { .. }

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -14,12 +14,14 @@
 
 pub mod builder;
 
+use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use common_base::readable_size::ReadableSize;
 use common_base::Plugins;
+use common_config::Configurable;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
 use common_grpc::channel_manager;
 use common_meta::ddl::ProcedureExecutorRef;
@@ -113,12 +115,6 @@ pub struct MetasrvOptions {
     pub tracing: TracingOptions,
 }
 
-impl MetasrvOptions {
-    pub fn env_list_keys() -> Option<&'static [&'static str]> {
-        Some(&["wal.broker_endpoints"])
-    }
-}
-
 impl Default for MetasrvOptions {
     fn default() -> Self {
         Self {
@@ -153,9 +149,13 @@ impl Default for MetasrvOptions {
     }
 }
 
-impl MetasrvOptions {
-    pub fn to_toml_string(&self) -> String {
-        toml::to_string(&self).unwrap()
+impl Configurable<'_> for MetasrvOptions {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn env_list_keys() -> Option<&'static [&'static str]> {
+        Some(&["wal.broker_endpoints"])
     }
 }
 

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -14,7 +14,6 @@
 
 pub mod builder;
 
-use std::any::Any;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -150,10 +149,6 @@ impl Default for MetasrvOptions {
 }
 
 impl Configurable<'_> for MetasrvOptions {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn env_list_keys() -> Option<&'static [&'static str]> {
         Some(&["wal.broker_endpoints"])
     }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -22,6 +22,7 @@ use auth::UserProviderRef;
 use axum::Router;
 use catalog::kvbackend::KvBackendCatalogManager;
 use common_base::secrets::ExposeSecret;
+use common_config::Configurable;
 use common_meta::key::catalog_name::CatalogNameKey;
 use common_meta::key::schema_name::SchemaNameKey;
 use common_runtime::Builder as RuntimeBuilder;
@@ -391,7 +392,7 @@ pub async fn setup_test_http_app(store_type: StorageType, name: &str) -> (Router
             None,
         )
         .with_metrics_handler(MetricsHandler)
-        .with_greptime_config_options(instance.opts.datanode_options().to_toml_string())
+        .with_greptime_config_options(instance.opts.datanode_options().to_toml().unwrap())
         .build();
     (http_server.build(http_server.make_app()), instance.guard)
 }
@@ -463,7 +464,7 @@ pub async fn setup_test_prom_app_with_frontend(
         )
         .with_prom_handler(frontend_ref.clone(), true, is_strict_mode)
         .with_prometheus_handler(frontend_ref)
-        .with_greptime_config_options(instance.opts.datanode_options().to_toml_string())
+        .with_greptime_config_options(instance.opts.datanode_options().to_toml().unwrap())
         .build();
     let app = http_server.build(http_server.make_app());
     (app, instance.guard)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add the `Configurable` trait to make configuration more general.

1. Add the new module `error.rs` and `config.rs` in `common/config`. Most of the code are from `cmd/`:

   - The `load_layer_options()` is from the original `cmd/options.rs`;
   - The errors are from `cmd/error.rs`;
   
3. Add `merge_with_cli_options()` to make `load_options()` more simple;
4. Implement `Configurable` trait and changed some tests for `{DatanodeOptions, FrontendOptions, MetasrvOptions, StandaloneOptions}`;

## Checklist

- [x]  I have written the necessary rustdoc comments.
- [x]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
