### PR TITLE
refactor: rename metasrv_addr to metasrv_addrs

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -114,8 +114,8 @@ struct StartCommand {
     rpc_addr: Option<String>,
     #[clap(long)]
     rpc_hostname: Option<String>,
-    #[clap(long, value_delimiter = ',', num_args = 1..)]
-    metasrv_addr: Option<Vec<String>>,
+    #[clap(long, aliases = ["metasrv-addr"], value_delimiter = ',', num_args = 1..)]
+    metasrv_addrs: Option<Vec<String>>,
     #[clap(short, long)]
     config_file: Option<String>,
     #[clap(long)]
@@ -158,7 +158,7 @@ impl StartCommand {
             opts.node_id = Some(node_id);
         }
 
-        if let Some(metasrv_addrs) = &self.metasrv_addr {
+        if let Some(metasrv_addrs) = &self.metasrv_addrs {
             opts.meta_client
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs
@@ -386,7 +386,7 @@ mod tests {
 
         if let Options::Datanode(opt) = (StartCommand {
             node_id: Some(42),
-            metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
+            metasrv_addrs: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
         .load_options(&GlobalOptions::default())
@@ -396,7 +396,7 @@ mod tests {
         }
 
         assert!((StartCommand {
-            metasrv_addr: Some(vec!["127.0.0.1:3002".to_string()]),
+            metasrv_addrs: Some(vec!["127.0.0.1:3002".to_string()]),
             ..Default::default()
         })
         .load_options(&GlobalOptions::default())

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -130,8 +130,8 @@ pub struct StartCommand {
     config_file: Option<String>,
     #[clap(short, long)]
     influxdb_enable: Option<bool>,
-    #[clap(long, value_delimiter = ',', num_args = 1..)]
-    metasrv_addr: Option<Vec<String>>,
+    #[clap(long, aliases = ["metasrv-addr"], value_delimiter = ',', num_args = 1..)]
+    metasrv_addrs: Option<Vec<String>>,
     #[clap(long)]
     tls_mode: Option<TlsMode>,
     #[clap(long)]
@@ -200,7 +200,7 @@ impl StartCommand {
             opts.influxdb.enable = enable;
         }
 
-        if let Some(metasrv_addrs) = &self.metasrv_addr {
+        if let Some(metasrv_addrs) = &self.metasrv_addrs {
             opts.meta_client
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR renames `metasrv_addr` to `metasrv_addrs` in start command.
Use the alias mechanism `aliases = ["metasrv-addr"]` to ensure forward compatibility.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
