### PR TITLE
feat(flow): add types for every plan enum variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,6 +3824,7 @@ dependencies = [
  "minstant",
  "nom",
  "num-traits",
+ "pretty_assertions",
  "prost 0.12.4",
  "query",
  "serde",
@@ -7362,6 +7363,16 @@ checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -12602,6 +12613,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -50,6 +50,7 @@ tonic.workspace = true
 [dev-dependencies]
 catalog.workspace = true
 common-catalog.workspace = true
+pretty_assertions = "1.4.0"
 prost.workspace = true
 query.workspace = true
 serde_json = "1.0"

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -39,7 +39,7 @@ use crate::expr::error::{DataTypeSnafu, InternalSnafu};
 use crate::expr::{
     self, EvalError, GlobalId, LocalId, MapFilterProject, MfpPlan, SafeMfpPlan, ScalarExpr,
 };
-use crate::plan::{AccumulablePlan, KeyValPlan, Plan, ReducePlan};
+use crate::plan::{AccumulablePlan, KeyValPlan, Plan, ReducePlan, TypedPlan};
 use crate::repr::{self, DiffRow, KeyValDiffRow, Row};
 use crate::utils::{ArrangeHandler, ArrangeReader, ArrangeWriter, Arrangement};
 
@@ -101,8 +101,8 @@ impl<'referred, 'df> Context<'referred, 'df> {
     /// Interpret and execute plan
     ///
     /// return the output of this plan
-    pub fn render_plan(&mut self, plan: Plan) -> Result<CollectionBundle, Error> {
-        match plan {
+    pub fn render_plan(&mut self, plan: TypedPlan) -> Result<CollectionBundle, Error> {
+        match plan.plan {
             Plan::Constant { rows } => Ok(self.render_constant(rows)),
             Plan::Get { id } => self.get_by_id(id),
             Plan::Let { id, value, body } => self.eval_let(id, value, body),
@@ -193,8 +193,8 @@ impl<'referred, 'df> Context<'referred, 'df> {
     pub fn eval_let(
         &mut self,
         id: LocalId,
-        value: Box<Plan>,
-        body: Box<Plan>,
+        value: Box<TypedPlan>,
+        body: Box<TypedPlan>,
     ) -> Result<CollectionBundle, Error> {
         let value = self.render_plan(*value)?;
 

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -28,7 +28,7 @@ use crate::compute::state::Scheduler;
 use crate::compute::types::{Arranged, Collection, CollectionBundle, ErrCollector, Toff};
 use crate::expr::error::{DataTypeSnafu, InternalSnafu};
 use crate::expr::{AggregateExpr, EvalError, ScalarExpr};
-use crate::plan::{AccumulablePlan, AggrWithIndex, KeyValPlan, Plan, ReducePlan};
+use crate::plan::{AccumulablePlan, AggrWithIndex, KeyValPlan, Plan, ReducePlan, TypedPlan};
 use crate::repr::{self, DiffRow, KeyValDiffRow, Row};
 use crate::utils::{ArrangeHandler, ArrangeReader, ArrangeWriter};
 
@@ -39,7 +39,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
     #[allow(clippy::mutable_key_type)]
     pub fn render_reduce(
         &mut self,
-        input: Box<Plan>,
+        input: Box<TypedPlan>,
         key_val_plan: KeyValPlan,
         reduce_plan: ReducePlan,
     ) -> Result<CollectionBundle, Error> {
@@ -736,6 +736,7 @@ mod test {
     use crate::compute::render::test::{get_output_handle, harness_test_ctx, run_and_check};
     use crate::compute::state::DataflowState;
     use crate::expr::{self, AggregateFunc, BinaryFunc, GlobalId, MapFilterProject};
+    use crate::repr::{ColumnType, RelationType};
 
     /// SELECT DISTINCT col FROM table
     ///
@@ -762,13 +763,20 @@ mod test {
         let input_plan = Plan::Get {
             id: expr::Id::Global(GlobalId::User(1)),
         };
+        let typ = RelationType::new(vec![ColumnType::new_nullable(
+            ConcreteDataType::int64_datatype(),
+        )]);
         let key_val_plan = KeyValPlan {
             key_plan: MapFilterProject::new(1).project([0]).unwrap().into_safe(),
             val_plan: MapFilterProject::new(1).project([]).unwrap().into_safe(),
         };
         let reduce_plan = ReducePlan::Distinct;
         let bundle = ctx
-            .render_reduce(Box::new(input_plan), key_val_plan, reduce_plan)
+            .render_reduce(
+                Box::new(input_plan.with_types(typ)),
+                key_val_plan,
+                reduce_plan,
+            )
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);
@@ -809,6 +817,9 @@ mod test {
         let input_plan = Plan::Get {
             id: expr::Id::Global(GlobalId::User(1)),
         };
+        let typ = RelationType::new(vec![ColumnType::new_nullable(
+            ConcreteDataType::int64_datatype(),
+        )]);
         let key_val_plan = KeyValPlan {
             key_plan: MapFilterProject::new(1).project([]).unwrap().into_safe(),
             val_plan: MapFilterProject::new(1).project([0]).unwrap().into_safe(),
@@ -835,7 +846,11 @@ mod test {
 
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
-            .render_reduce(Box::new(input_plan), key_val_plan, reduce_plan)
+            .render_reduce(
+                Box::new(input_plan.with_types(typ)),
+                key_val_plan,
+                reduce_plan,
+            )
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);
@@ -882,6 +897,9 @@ mod test {
         let input_plan = Plan::Get {
             id: expr::Id::Global(GlobalId::User(1)),
         };
+        let typ = RelationType::new(vec![ColumnType::new_nullable(
+            ConcreteDataType::int64_datatype(),
+        )]);
         let key_val_plan = KeyValPlan {
             key_plan: MapFilterProject::new(1).project([]).unwrap().into_safe(),
             val_plan: MapFilterProject::new(1).project([0]).unwrap().into_safe(),
@@ -908,7 +926,11 @@ mod test {
 
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
-            .render_reduce(Box::new(input_plan), key_val_plan, reduce_plan)
+            .render_reduce(
+                Box::new(input_plan.with_types(typ)),
+                key_val_plan,
+                reduce_plan,
+            )
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);
@@ -951,6 +973,9 @@ mod test {
         let input_plan = Plan::Get {
             id: expr::Id::Global(GlobalId::User(1)),
         };
+        let typ = RelationType::new(vec![ColumnType::new_nullable(
+            ConcreteDataType::int64_datatype(),
+        )]);
         let key_val_plan = KeyValPlan {
             key_plan: MapFilterProject::new(1).project([]).unwrap().into_safe(),
             val_plan: MapFilterProject::new(1).project([0]).unwrap().into_safe(),
@@ -977,7 +1002,11 @@ mod test {
 
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
-            .render_reduce(Box::new(input_plan), key_val_plan, reduce_plan)
+            .render_reduce(
+                Box::new(input_plan.with_types(typ)),
+                key_val_plan,
+                reduce_plan,
+            )
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);
@@ -1020,6 +1049,9 @@ mod test {
         let input_plan = Plan::Get {
             id: expr::Id::Global(GlobalId::User(1)),
         };
+        let typ = RelationType::new(vec![ColumnType::new_nullable(
+            ConcreteDataType::int64_datatype(),
+        )]);
         let key_val_plan = KeyValPlan {
             key_plan: MapFilterProject::new(1).project([]).unwrap().into_safe(),
             val_plan: MapFilterProject::new(1).project([0]).unwrap().into_safe(),
@@ -1061,7 +1093,11 @@ mod test {
 
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
-            .render_reduce(Box::new(input_plan), key_val_plan, reduce_plan)
+            .render_reduce(
+                Box::new(input_plan.with_types(typ)),
+                key_val_plan,
+                reduce_plan,
+            )
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -21,7 +21,9 @@ use datatypes::value::Value;
 use serde::{Deserialize, Serialize};
 use snafu::ensure;
 
-use crate::adapter::error::{Error, InvalidQuerySnafu, UnsupportedTemporalFilterSnafu};
+use crate::adapter::error::{
+    Error, InvalidQuerySnafu, UnexpectedSnafu, UnsupportedTemporalFilterSnafu,
+};
 use crate::expr::error::{EvalError, InvalidArgumentSnafu, OptimizeSnafu};
 use crate::expr::func::{BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 use crate::repr::ColumnType;
@@ -78,6 +80,38 @@ pub enum ScalarExpr {
         then: Box<ScalarExpr>,
         els: Box<ScalarExpr>,
     },
+}
+
+impl ScalarExpr {
+    /// try to determine the type of the expression
+    pub fn typ(&self, input_types: &[ColumnType]) -> Result<ColumnType, Error> {
+        match self {
+            ScalarExpr::Column(i) => input_types.get(*i).cloned().ok_or_else(|| {
+                UnexpectedSnafu {
+                    reason: format!(
+                        "column index {} out of range of len={}",
+                        i,
+                        input_types.len()
+                    ),
+                }
+                .build()
+            }),
+            ScalarExpr::Literal(_, typ) => Ok(ColumnType::new_nullable(typ.clone())),
+            ScalarExpr::CallUnmaterializable(func) => {
+                Ok(ColumnType::new_nullable(func.signature().output))
+            }
+            ScalarExpr::CallUnary { func, .. } => {
+                Ok(ColumnType::new_nullable(func.signature().output))
+            }
+            ScalarExpr::CallBinary { func, .. } => {
+                Ok(ColumnType::new_nullable(func.signature().output))
+            }
+            ScalarExpr::CallVariadic { func, .. } => {
+                Ok(ColumnType::new_nullable(func.signature().output))
+            }
+            ScalarExpr::If { then, .. } => then.typ(input_types),
+        }
+    }
 }
 
 impl ScalarExpr {

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -84,15 +84,11 @@ pub enum ScalarExpr {
 
 impl ScalarExpr {
     /// try to determine the type of the expression
-    pub fn typ(&self, input_types: &[ColumnType]) -> Result<ColumnType, Error> {
+    pub fn typ(&self, context: &[ColumnType]) -> Result<ColumnType, Error> {
         match self {
-            ScalarExpr::Column(i) => input_types.get(*i).cloned().ok_or_else(|| {
+            ScalarExpr::Column(i) => context.get(*i).cloned().ok_or_else(|| {
                 UnexpectedSnafu {
-                    reason: format!(
-                        "column index {} out of range of len={}",
-                        i,
-                        input_types.len()
-                    ),
+                    reason: format!("column index {} out of range of len={}", i, context.len()),
                 }
                 .build()
             }),
@@ -109,7 +105,7 @@ impl ScalarExpr {
             ScalarExpr::CallVariadic { func, .. } => {
                 Ok(ColumnType::new_nullable(func.signature().output))
             }
-            ScalarExpr::If { then, .. } => then.typ(input_types),
+            ScalarExpr::If { then, .. } => then.typ(context),
         }
     }
 }

--- a/src/flow/src/plan.rs
+++ b/src/flow/src/plan.rs
@@ -44,6 +44,7 @@ pub struct TypedPlan {
 impl TypedPlan {
     /// directly apply a mfp to the plan
     pub fn mfp(self, mfp: MapFilterProject) -> Result<Self, Error> {
+        let new_type = self.typ.apply_mfp(&mfp, &[])?;
         let plan = match self.plan {
             Plan::Mfp {
                 input,
@@ -53,12 +54,12 @@ impl TypedPlan {
                 mfp: MapFilterProject::compose(old_mfp, mfp)?,
             },
             _ => Plan::Mfp {
-                input: Box::new(self.plan),
+                input: Box::new(self),
                 mfp,
             },
         };
         Ok(TypedPlan {
-            typ: self.typ,
+            typ: new_type,
             plan,
         })
     }
@@ -85,7 +86,7 @@ impl TypedPlan {
                 mfp: MapFilterProject::compose(old_mfp, mfp)?,
             },
             _ => Plan::Mfp {
-                input: Box::new(self.plan),
+                input: Box::new(self),
                 mfp,
             },
         };
@@ -94,6 +95,7 @@ impl TypedPlan {
 
     /// Add a new filter to the plan, will filter out the records that do not satisfy the filter
     pub fn filter(self, filter: TypedExpr) -> Result<Self, Error> {
+        let typ = self.typ.clone();
         let plan = match self.plan {
             Plan::Mfp {
                 input,
@@ -103,15 +105,11 @@ impl TypedPlan {
                 mfp: old_mfp.filter(vec![filter.expr])?,
             },
             _ => Plan::Mfp {
-                input: Box::new(self.plan),
-                mfp: MapFilterProject::new(self.typ.column_types.len())
-                    .filter(vec![filter.expr])?,
+                input: Box::new(self),
+                mfp: MapFilterProject::new(typ.column_types.len()).filter(vec![filter.expr])?,
             },
         };
-        Ok(TypedPlan {
-            typ: self.typ,
-            plan,
-        })
+        Ok(TypedPlan { typ, plan })
     }
 }
 
@@ -135,20 +133,20 @@ pub enum Plan {
     /// }
     Let {
         id: LocalId,
-        value: Box<Plan>,
-        body: Box<Plan>,
+        value: Box<TypedPlan>,
+        body: Box<TypedPlan>,
     },
     /// Map, Filter, and Project operators. Chained together.
     Mfp {
         /// The input collection.
-        input: Box<Plan>,
+        input: Box<TypedPlan>,
         /// Linear operator to apply to each record.
         mfp: MapFilterProject,
     },
     /// Reduce operator, aggregation by key assembled from KeyValPlan
     Reduce {
         /// The input collection.
-        input: Box<Plan>,
+        input: Box<TypedPlan>,
         /// A plan for changing input records into key, value pairs.
         key_val_plan: KeyValPlan,
         /// A plan for performing the reduce.
@@ -164,7 +162,7 @@ pub enum Plan {
     /// strategy we will use, and any pushed down per-record work.
     Join {
         /// An ordered list of inputs that will be joined.
-        inputs: Vec<Plan>,
+        inputs: Vec<TypedPlan>,
         /// Detailed information about the implementation of the join.
         ///
         /// This includes information about the implementation strategy, but also
@@ -180,7 +178,7 @@ pub enum Plan {
     /// implementing the "distinct" operator.
     Union {
         /// The input collections
-        inputs: Vec<Plan>,
+        inputs: Vec<TypedPlan>,
         /// Whether to consolidate the output, e.g., cancel negated records.
         consolidate_output: bool,
     },
@@ -200,23 +198,23 @@ impl Plan {
                     };
                 }
                 Plan::Let { value, body, .. } => {
-                    recur_find_use(value, used);
-                    recur_find_use(body, used);
+                    recur_find_use(&value.plan, used);
+                    recur_find_use(&body.plan, used);
                 }
                 Plan::Mfp { input, .. } => {
-                    recur_find_use(input, used);
+                    recur_find_use(&input.plan, used);
                 }
                 Plan::Reduce { input, .. } => {
-                    recur_find_use(input, used);
+                    recur_find_use(&input.plan, used);
                 }
                 Plan::Join { inputs, .. } => {
                     for input in inputs {
-                        recur_find_use(input, used);
+                        recur_find_use(&input.plan, used);
                     }
                 }
                 Plan::Union { inputs, .. } => {
                     for input in inputs {
-                        recur_find_use(input, used);
+                        recur_find_use(&input.plan, used);
                     }
                 }
                 _ => {}
@@ -225,5 +223,11 @@ impl Plan {
         let mut ret = Default::default();
         recur_find_use(self, &mut ret);
         ret
+    }
+}
+
+impl Plan {
+    pub fn with_types(self, typ: RelationType) -> TypedPlan {
+        TypedPlan { typ, plan: self }
     }
 }

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -197,7 +197,6 @@ impl RelationType {
 
     /// Adds new keys for the relation. Also sorts the key indices.
     ///
-    ///
     /// will ignore empty keys
     pub fn with_keys(mut self, keys: Vec<Vec<usize>>) -> Self {
         for key in keys {

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -181,7 +181,12 @@ impl RelationType {
     }
 
     /// Adds a new key for the relation. Also sorts the key indices.
+    ///
+    /// will ignore empty key
     pub fn with_key(mut self, mut indices: Vec<usize>) -> Self {
+        if indices.is_empty() {
+            return self;
+        }
         indices.sort_unstable();
         let key = Key::from(indices);
         if !self.keys.contains(&key) {
@@ -191,6 +196,9 @@ impl RelationType {
     }
 
     /// Adds new keys for the relation. Also sorts the key indices.
+    ///
+    ///
+    /// will ignore empty keys
     pub fn with_keys(mut self, keys: Vec<Vec<usize>>) -> Self {
         for key in keys {
             self = self.with_key(key)

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -321,6 +321,7 @@ impl TypedExpr {
 
 #[cfg(test)]
 mod test {
+    use datatypes::prelude::ConcreteDataType;
     use datatypes::value::Value;
 
     use super::*;
@@ -359,9 +360,15 @@ mod test {
         let expected = TypedPlan {
             typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
             plan: Plan::Mfp {
-                input: Box::new(Plan::Get {
-                    id: crate::expr::Id::Global(GlobalId::User(0)),
-                }),
+                input: Box::new(
+                    Plan::Get {
+                        id: crate::expr::Id::Global(GlobalId::User(0)),
+                    }
+                    .with_types(RelationType::new(vec![ColumnType::new(
+                        ConcreteDataType::uint32_datatype(),
+                        false,
+                    )])),
+                ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0)])
                     .unwrap()
@@ -411,9 +418,15 @@ mod test {
         let expected = TypedPlan {
             typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
             plan: Plan::Mfp {
-                input: Box::new(Plan::Get {
-                    id: crate::expr::Id::Global(GlobalId::User(0)),
-                }),
+                input: Box::new(
+                    Plan::Get {
+                        id: crate::expr::Id::Global(GlobalId::User(0)),
+                    }
+                    .with_types(RelationType::new(vec![ColumnType::new(
+                        ConcreteDataType::uint32_datatype(),
+                        false,
+                    )])),
+                ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0).call_binary(
                         ScalarExpr::Literal(Value::from(1u32), CDT::uint32_datatype()),
@@ -439,9 +452,15 @@ mod test {
         let expected = TypedPlan {
             typ: RelationType::new(vec![ColumnType::new(CDT::int16_datatype(), true)]),
             plan: Plan::Mfp {
-                input: Box::new(Plan::Get {
-                    id: crate::expr::Id::Global(GlobalId::User(0)),
-                }),
+                input: Box::new(
+                    Plan::Get {
+                        id: crate::expr::Id::Global(GlobalId::User(0)),
+                    }
+                    .with_types(RelationType::new(vec![ColumnType::new(
+                        ConcreteDataType::uint32_datatype(),
+                        false,
+                    )])),
+                ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Literal(
                         Value::Int64(1),
@@ -468,9 +487,15 @@ mod test {
         let expected = TypedPlan {
             typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
             plan: Plan::Mfp {
-                input: Box::new(Plan::Get {
-                    id: crate::expr::Id::Global(GlobalId::User(0)),
-                }),
+                input: Box::new(
+                    Plan::Get {
+                        id: crate::expr::Id::Global(GlobalId::User(0)),
+                    }
+                    .with_types(RelationType::new(vec![ColumnType::new(
+                        ConcreteDataType::uint32_datatype(),
+                        false,
+                    )])),
+                ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0)
                         .call_binary(ScalarExpr::Column(0), BinaryFunc::AddUInt32)])

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -180,6 +180,8 @@ impl TypedPlan {
 
 #[cfg(test)]
 mod test {
+    use datatypes::prelude::ConcreteDataType;
+
     use super::*;
     use crate::expr::{GlobalId, ScalarExpr};
     use crate::plan::{Plan, TypedPlan};
@@ -199,9 +201,15 @@ mod test {
         let expected = TypedPlan {
             typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
             plan: Plan::Mfp {
-                input: Box::new(Plan::Get {
-                    id: crate::expr::Id::Global(GlobalId::User(0)),
-                }),
+                input: Box::new(
+                    Plan::Get {
+                        id: crate::expr::Id::Global(GlobalId::User(0)),
+                    }
+                    .with_types(RelationType::new(vec![ColumnType::new(
+                        ConcreteDataType::uint32_datatype(),
+                        false,
+                    )])),
+                ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0)])
                     .unwrap()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Added types(`RelationType`) for every flow plan's variant

Please explain IN DETAIL what the changes are in this PR and why they are needed:

Added type info to every plan enum, and also add `typ()` for `ScalarExpr` so to determine expressions' types

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
