### PR TITLE
chore: minor refactor on etcd kvbackend

### DIFF
--- a/src/common/meta/src/kv_backend/memory.rs
+++ b/src/common/meta/src/kv_backend/memory.rs
@@ -268,18 +268,15 @@ impl<T: ErrorExt + Send + Sync> TxnService for MemoryKvBackend<T> {
 
         let do_txn = |txn_op| match txn_op {
             TxnOp::Put(key, value) => {
-                kvs.insert(key.clone(), value);
+                kvs.insert(key, value);
                 TxnOpResponse::ResponsePut(PutResponse { prev_kv: None })
             }
 
             TxnOp::Get(key) => {
-                let value = kvs.get(&key);
+                let value = kvs.get(&key).cloned();
                 let kvs = value
+                    .map(|value| KeyValue { key, value })
                     .into_iter()
-                    .map(|value| KeyValue {
-                        key: key.clone(),
-                        value: value.clone(),
-                    })
                     .collect();
                 TxnOpResponse::ResponseGet(RangeResponse { kvs, more: false })
             }

--- a/src/log-store/src/raft_engine/backend.rs
+++ b/src/log-store/src/raft_engine/backend.rs
@@ -103,7 +103,7 @@ impl TxnService for RaftEngineBackend {
         let do_txn = |txn_op| match txn_op {
             TxnOp::Put(key, value) => {
                 batch
-                    .put(SYSTEM_NAMESPACE, key.clone(), value)
+                    .put(SYSTEM_NAMESPACE, key, value)
                     .context(RaftEngineSnafu)
                     .map_err(BoxedError::new)
                     .context(meta_error::ExternalSnafu)?;
@@ -113,11 +113,8 @@ impl TxnService for RaftEngineBackend {
             TxnOp::Get(key) => {
                 let value = engine_get(&engine, &key)?.map(|kv| kv.value);
                 let kvs = value
+                    .map(|value| KeyValue { key, value })
                     .into_iter()
-                    .map(|value| KeyValue {
-                        key: key.clone(),
-                        value,
-                    })
                     .collect();
                 Ok(TxnOpResponse::ResponseGet(RangeResponse {
                     kvs,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the title said:
1. Avoid `clone` in txn
2. Use `KeyValue::from` and remove `convert_key_value` method
3. Use `KeyValue::from` instead of `Into::into` for clearer code

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
