### PR TITLE
refactor: introduce `AppBuilder` trait

### DIFF
--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use clap::{Parser, Subcommand};
 use cmd::error::Result;
 use cmd::options::{GlobalOptions, Options};
-use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, start_app, App};
+use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, App};
 use common_version::{short_version, version};
 
 #[derive(Parser)]
@@ -134,9 +134,7 @@ async fn start(cli: Command) -> Result<()> {
 
     log_versions(version!(), short_version!());
 
-    let app = subcmd.build(opts).await?;
-
-    start_app(app).await
+    subcmd.build(opts).await?.run().await
 }
 
 fn setup_human_panic() {

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -72,6 +72,21 @@ pub trait App: Send {
     }
 }
 
+/// AppBuilder is a trait builds the App from the options and starts the App.
+#[async_trait]
+pub trait AppBuilder: Default {
+    /// Build the options. The final options will be merged from multiple sources(e.g. config file, cli arguments) and stored in the builder.
+    fn build_options(self) -> Result<Self>;
+
+    /// Build the App. After the options are built, the App can be built from the options.
+    async fn build_app(self) -> Result<Box<dyn App>>;
+
+    /// Build the options and app, then start the app.
+    async fn start(self) -> Result<()> {
+        self.build_options()?.build_app().await?.run().await
+    }
+}
+
 /// Log the versions of the application, and the arguments passed to the cli.
 /// `version_string` should be the same as the output of cli "--version";
 /// and the `app_version` is the short version of the codes, often consist of git branch and commit.

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -17,6 +17,8 @@
 use async_trait::async_trait;
 use common_telemetry::{error, info};
 
+use crate::error::Result;
+
 pub mod cli;
 pub mod datanode;
 pub mod error;
@@ -35,39 +37,39 @@ pub trait App: Send {
     fn name(&self) -> &str;
 
     /// A hook for implementor to make something happened before actual startup. Defaults to no-op.
-    async fn pre_start(&mut self) -> error::Result<()> {
+    async fn pre_start(&mut self) -> Result<()> {
         Ok(())
     }
 
-    async fn start(&mut self) -> error::Result<()>;
+    async fn start(&mut self) -> Result<()>;
 
     /// Waits the quit signal by default.
     fn wait_signal(&self) -> bool {
         true
     }
 
-    async fn stop(&self) -> error::Result<()>;
-}
+    async fn stop(&self) -> Result<()>;
 
-pub async fn start_app(mut app: Box<dyn App>) -> error::Result<()> {
-    info!("Starting app: {}", app.name());
+    async fn run(&mut self) -> Result<()> {
+        info!("Starting app: {}", self.name());
 
-    app.pre_start().await?;
+        self.pre_start().await?;
 
-    app.start().await?;
+        self.start().await?;
 
-    if app.wait_signal() {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            error!("Failed to listen for ctrl-c signal: {}", e);
-            // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
-            // the underlying system. So we stop the app instead of running nonetheless to let people
-            // investigate the issue.
+        if self.wait_signal() {
+            if let Err(e) = tokio::signal::ctrl_c().await {
+                error!("Failed to listen for ctrl-c signal: {}", e);
+                // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
+                // the underlying system. So we stop the app instead of running nonetheless to let people
+                // investigate the issue.
+            }
         }
-    }
 
-    app.stop().await?;
-    info!("Goodbye!");
-    Ok(())
+        self.stop().await?;
+        info!("Goodbye!");
+        Ok(())
+    }
 }
 
 /// Log the versions of the application, and the arguments passed to the cli.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**NOTE**: The PR is now in draft mode for discussion. Since the whole PR may be bigger(>1000 LOC), I will separate it into multiple small PRs and share the important abstraction first.

This PR introduces the new trait in the `cmd/` crate called `AppBuilder`. It's a simple abstraction based on the original code that makes our cli structure cleaner.

Based on the original design, we can have the following concept:

- `App`: For most scenarios, it's a running service, for example, frontend, metasrv, etc. Also, it can be a cli tool. Each subcommand can be treated as `App`;

- `AppBuilder`: The builder of the `App`;

- `Options`: For building the `App`, we need `Options`. For most scenarios, `Options` can implement [`Configurable`](https://github.com/GreptimeTeam/greptimedb/pull/3917) trait;

We can use the `AppBuilder` to build and run the `App`:

```rust
/// Build the options and app, then start the app.
async fn start(self) -> Result<()> {
    self.build_options()?.build_app().await?.run().await
}
```

The original implementation has many `build()` and `load_options()`, which seems too complicated. If we use `AppBuilder`, the code can be:

- Accept the command line argument to create `AppBuilder`, then build and run the `App`;
- Each component(`frontend.rs`/`datanode.rs`/`metasrv.rs`/`cli.rs`) only needs to implement `AppBuilder`;

The following is the snippet of the code:

```rust
...
#[tokio::main]
async fn main() -> Result<()> {
    ...
    start(Command::parse()).await
}

async fn start(cli: Command) -> Result<()> {
    match cli.subcmd {
        SubCommand::Datanode(cmd) => cmd.new_app_builder(cli.global_options).start().await,
        SubCommand::Frontend(cmd) => cmd.new_app_builder(cli.global_options).start().await,
        SubCommand::Metasrv(cmd) => cmd.new_app_builder(cli.global_options).start().await,
        SubCommand::Standalone(cmd) => cmd.new_app_builder(cli.global_options).start().await,
        SubCommand::Cli(cmd) => cmd.new_app_builder(cli.global_options).start().await,
    }
}
...
```

For each `App`, we need to create the `AppBuilder` struct and implement the trait(most methods are from the original implementation). Take `cmd/datanode.rs` for example:

```rust
...
#[derive(Default)]
pub struct DatanodeAppBuilder {
    command: Option<StartCommand>,
    global_options: GlobalOptions,
    datanode_options: Option<DatanodeOptions>,
}

#[async_trait]
impl AppBuilder for DatanodeAppBuilder {
    fn build_options(mut self) -> Result<Self> { ... }

    async fn build_app(mut self) -> Result<Box<dyn App>> { ... }
}

...
```

There are some references for implementation:

- [`src/bin/greptime.rs`](https://github.com/zyy17/greptimedb/blob/refactor/app-builder-trait/src/cmd/src/bin/greptime.rs)

- [`src/datanode.rs`](https://github.com/zyy17/greptimedb/blob/refactor/app-builder-trait/src/cmd/src/datanode.rs)


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
