### PR TITLE
ci: Use lld linker in windows tests

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -69,7 +69,7 @@ jobs:
     name: Run tests on Windows
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     runs-on: windows-2022-8-cores
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -76,6 +76,9 @@ jobs:
       - uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: KyleMayes/install-llvm-action@v1
+        with:
+          version: "14.0"
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -98,6 +101,7 @@ jobs:
       - name: Running tests
         run: cargo nextest run -F pyo3_backend,dashboard
         env:
+          CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
           GT_S3_BUCKET: ${{ vars.AWS_CI_TEST_BUCKET }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Running tests
         run: cargo nextest run -F pyo3_backend,dashboard
         env:
-          CARGO_BUILD_RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+          CARGO_BUILD_RUSTFLAGS: "-C linker=lld-link"
           RUST_BACKTRACE: 1
           CARGO_INCREMENTAL: 0
           GT_S3_BUCKET: ${{ vars.AWS_CI_TEST_BUCKET }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: '0 23 * * 1-5'
+    - cron: "0 23 * * 1-5"
   workflow_dispatch:
 
 name: Nightly CI
@@ -13,57 +13,57 @@ env:
   RUST_TOOLCHAIN: nightly-2024-04-20
 
 jobs:
-  sqlness-test:
-    name: Run sqlness test
-    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # sqlness-test:
+  #   name: Run sqlness test
+  #   if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Run sqlness test
-        uses: ./.github/actions/sqlness-test
-        with:
-          data-root: sqlness-test
-          aws-ci-test-bucket: ${{ vars.AWS_CI_TEST_BUCKET }}
-          aws-region: ${{ vars.AWS_CI_TEST_BUCKET_REGION }}
-          aws-access-key-id: ${{ secrets.AWS_CI_TEST_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_CI_TEST_SECRET_ACCESS_KEY }}
+  #     - name: Run sqlness test
+  #       uses: ./.github/actions/sqlness-test
+  #       with:
+  #         data-root: sqlness-test
+  #         aws-ci-test-bucket: ${{ vars.AWS_CI_TEST_BUCKET }}
+  #         aws-region: ${{ vars.AWS_CI_TEST_BUCKET_REGION }}
+  #         aws-access-key-id: ${{ secrets.AWS_CI_TEST_ACCESS_KEY_ID }}
+  #         aws-secret-access-key: ${{ secrets.AWS_CI_TEST_SECRET_ACCESS_KEY }}
 
-  sqlness-windows:
-    name: Sqlness tests on Windows
-    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
-    runs-on: windows-2022-8-cores
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-      - name: Run sqlness
-        run: cargo sqlness
-      - name: Notify slack if failed
-        if: failure()
-        uses: slackapi/slack-github-action@v1.23.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}
-        with:
-          payload: |
-            {"text": "Nightly CI failed for sqlness tests"}
-      - name: Upload sqlness logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: sqlness-logs
-          path: /tmp/greptime-*.log
-          retention-days: 3
+  # sqlness-windows:
+  #   name: Sqlness tests on Windows
+  #   if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+  #   runs-on: windows-2022-8-cores
+  #   timeout-minutes: 60
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: arduino/setup-protoc@v3
+  #       with:
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     - uses: dtolnay/rust-toolchain@master
+  #       with:
+  #         toolchain: ${{ env.RUST_TOOLCHAIN }}
+  #     - name: Rust Cache
+  #       uses: Swatinem/rust-cache@v2
+  #     - name: Run sqlness
+  #       run: cargo sqlness
+  #     - name: Notify slack if failed
+  #       if: failure()
+  #       uses: slackapi/slack-github-action@v1.23.0
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}
+  #       with:
+  #         payload: |
+  #           {"text": "Nightly CI failed for sqlness tests"}
+  #     - name: Upload sqlness logs
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: sqlness-logs
+  #         path: /tmp/greptime-*.log
+  #         retention-days: 3
 
   test-on-windows:
     name: Run tests on Windows
@@ -88,7 +88,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install PyArrow Package
         run: pip install pyarrow
       - name: Install WSL distribution

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -13,63 +13,63 @@ env:
   RUST_TOOLCHAIN: nightly-2024-04-20
 
 jobs:
-  # sqlness-test:
-  #   name: Run sqlness test
-  #   if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
-  #   runs-on: ubuntu-22.04
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+  sqlness-test:
+    name: Run sqlness test
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Run sqlness test
-  #       uses: ./.github/actions/sqlness-test
-  #       with:
-  #         data-root: sqlness-test
-  #         aws-ci-test-bucket: ${{ vars.AWS_CI_TEST_BUCKET }}
-  #         aws-region: ${{ vars.AWS_CI_TEST_BUCKET_REGION }}
-  #         aws-access-key-id: ${{ secrets.AWS_CI_TEST_ACCESS_KEY_ID }}
-  #         aws-secret-access-key: ${{ secrets.AWS_CI_TEST_SECRET_ACCESS_KEY }}
+      - name: Run sqlness test
+        uses: ./.github/actions/sqlness-test
+        with:
+          data-root: sqlness-test
+          aws-ci-test-bucket: ${{ vars.AWS_CI_TEST_BUCKET }}
+          aws-region: ${{ vars.AWS_CI_TEST_BUCKET_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_CI_TEST_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_CI_TEST_SECRET_ACCESS_KEY }}
 
-  # sqlness-windows:
-  #   name: Sqlness tests on Windows
-  #   if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
-  #   runs-on: windows-2022-8-cores
-  #   timeout-minutes: 60
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: arduino/setup-protoc@v3
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-  #     - uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: ${{ env.RUST_TOOLCHAIN }}
-  #     - name: Rust Cache
-  #       uses: Swatinem/rust-cache@v2
-  #     - name: Run sqlness
-  #       run: cargo sqlness
-  #     - name: Notify slack if failed
-  #       if: failure()
-  #       uses: slackapi/slack-github-action@v1.23.0
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}
-  #       with:
-  #         payload: |
-  #           {"text": "Nightly CI failed for sqlness tests"}
-  #     - name: Upload sqlness logs
-  #       if: always()
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: sqlness-logs
-  #         path: /tmp/greptime-*.log
-  #         retention-days: 3
+  sqlness-windows:
+    name: Sqlness tests on Windows
+    if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
+    runs-on: windows-2022-8-cores
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Run sqlness
+        run: cargo sqlness
+      - name: Notify slack if failed
+        if: failure()
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}
+        with:
+          payload: |
+            {"text": "Nightly CI failed for sqlness tests"}
+      - name: Upload sqlness logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlness-logs
+          path: /tmp/greptime-*.log
+          retention-days: 3
 
   test-on-windows:
     name: Run tests on Windows
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' }}
     runs-on: windows-2022-8-cores
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4

--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -425,7 +425,12 @@ mod tests {
             .expect("failed to copy key to tmpdir");
 
         // waiting for async load
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        for _ in 0..3 {
+            std::thread::sleep(std::time::Duration::from_millis(300));
+            if server_config.get_version() > 1 {
+                break;
+            }
+        }
         assert!(server_config.get_version() > 1);
         assert!(server_config.get_server_config().is_some());
     }

--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -391,6 +391,8 @@ mod tests {
 
     #[test]
     fn test_tls_file_change_watch() {
+        common_telemetry::init_default_ut_logging();
+
         let dir = tempfile::tempdir().unwrap();
         let cert_path = dir.path().join("serevr.crt");
         let key_path = dir.path().join("server.key");
@@ -425,12 +427,7 @@ mod tests {
             .expect("failed to copy key to tmpdir");
 
         // waiting for async load
-        for _ in 0..3 {
-            std::thread::sleep(std::time::Duration::from_millis(300));
-            if server_config.get_version() > 1 {
-                break;
-            }
-        }
+        std::thread::sleep(std::time::Duration::from_millis(300));
         assert!(server_config.get_version() > 1);
         assert!(server_config.get_server_config().is_some());
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3902

## What's changed and what's your intention?

This PR attempts to **Make Actions Pass Again**, **MAPA** in short.

It switches the default linker to LLVM's lld which has lower memory consumption. It also enables logs for the test `test_tls_file_change_watch`.

The previous action cost 50m to compile tests...... Most time is spent in linking.
https://github.com/GreptimeTeam/greptimedb/actions/runs/9087338152/job/24981188499

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
