### PR TITLE
feat: respect time range when building parquet reader

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -20,6 +20,7 @@ use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::JoinError;
+use common_time::Timestamp;
 use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
 use object_store::ErrorKind;
@@ -693,6 +694,12 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to build time range filters for value: {:?}", timestamp))]
+    BuildTimeRangeFilter {
+        timestamp: Timestamp,
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -802,6 +809,7 @@ impl ErrorExt for Error {
             EncodeMemtable { .. } | ReadDataPart { .. } => StatusCode::Internal,
             ChecksumMismatch { .. } => StatusCode::Unexpected,
             RegionStopped { .. } => StatusCode::RegionNotReady,
+            BuildTimeRangeFilter { .. } => StatusCode::Unexpected,
         }
     }
 

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -698,6 +698,7 @@ pub enum Error {
     #[snafu(display("Failed to build time range filters for value: {:?}", timestamp))]
     BuildTimeRangeFilter {
         timestamp: Timestamp,
+        #[snafu(implicit)]
         location: Location,
     },
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use common_recordbatch::SendableRecordBatchStream;
-use common_telemetry::{debug, error, info, warn};
+use common_telemetry::{debug, error, warn};
 use common_time::range::TimestampRange;
 use store_api::region_engine::{RegionScannerRef, SinglePartitionScanner};
 use store_api::storage::ScanRequest;
@@ -278,7 +278,6 @@ impl ScanRegion {
         );
 
         let index_applier = self.build_index_applier();
-        info!("Request filters: {:?}", self.request.filters);
         let predicate = Predicate::new(self.request.filters.clone());
         // The mapper always computes projected column ids as the schema of SSTs may change.
         let mapper = match &self.request.projection {

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -114,14 +114,14 @@ struct TimeRangeTester {
 impl TimeRangeTester {
     async fn check(&self, sql: &str, expect: TimestampRange) {
         let _ = exec_selection(self.engine.clone(), sql).await;
-        let mut filters = self.get_filters();
+        let mut filters = self.take_filters();
 
         let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &mut filters);
         assert_eq!(expect, range);
     }
 
-    fn get_filters(&self) -> Vec<Expr> {
-        self.filter.write().unwrap().drain(..).collect()
+    fn take_filters(&self) -> Vec<Expr> {
+        std::mem::take(&mut self.filter.write().unwrap())
     }
 }
 

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -114,9 +114,9 @@ struct TimeRangeTester {
 impl TimeRangeTester {
     async fn check(&self, sql: &str, expect: TimestampRange) {
         let _ = exec_selection(self.engine.clone(), sql).await;
-        let filters = self.get_filters();
+        let mut filters = self.get_filters();
 
-        let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &filters);
+        let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &mut filters);
         assert_eq!(expect, range);
     }
 

--- a/src/query/src/tests/time_range_filter_test.rs
+++ b/src/query/src/tests/time_range_filter_test.rs
@@ -29,7 +29,7 @@ use datatypes::vectors::{Int64Vector, TimestampMillisecondVector};
 use store_api::data_source::{DataSource, DataSourceRef};
 use store_api::storage::ScanRequest;
 use table::metadata::FilterPushDownType;
-use table::predicate::TimeRangePredicateBuilder;
+use table::predicate::build_time_range_predicate;
 use table::test_util::MemTable;
 use table::{Table, TableRef};
 
@@ -116,7 +116,7 @@ impl TimeRangeTester {
         let _ = exec_selection(self.engine.clone(), sql).await;
         let filters = self.get_filters();
 
-        let range = TimeRangePredicateBuilder::new("ts", TimeUnit::Millisecond, &filters).build();
+        let range = build_time_range_predicate("ts", TimeUnit::Millisecond, &filters);
         assert_eq!(expect, range);
     }
 

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -140,8 +140,7 @@ pub fn build_time_range_predicate<'a>(
     let mut res = TimestampRange::min_to_max();
     let mut filters_remain = vec![];
     for expr in std::mem::take(filters) {
-        if let Some(range) = extract_time_range_from_expr(ts_col_name, ts_col_unit, expr.df_expr())
-        {
+        if let Some(range) = extract_time_range_from_expr(ts_col_name, ts_col_unit, &expr) {
             res = res.and(&range);
         } else {
             filters_remain.push(expr);
@@ -283,11 +282,7 @@ fn extract_from_binary_expr(
     }
 }
 
-fn get_timestamp_filter(
-    ts_col_name: &str,
-    left: &Expr,
-    right: &Expr,
-) -> Option<(Timestamp, bool)> {
+fn get_timestamp_filter(ts_col_name: &str, left: &Expr, right: &Expr) -> Option<(Timestamp, bool)> {
     let (col, lit, reverse) = match (left, right) {
         (Expr::Column(column), Expr::Literal(scalar)) => (column, scalar, false),
         (Expr::Literal(scalar), Expr::Column(column)) => (column, scalar, true),
@@ -394,7 +389,7 @@ mod tests {
     fn check_build_predicate(expr: Expr, expect: TimestampRange) {
         assert_eq!(
             expect,
-            build_time_range_predicate("ts", TimeUnit::Millisecond, &mut vec![Expr::from(expr)])
+            build_time_range_predicate("ts", TimeUnit::Millisecond, &mut vec![expr])
         );
     }
 

--- a/src/table/src/table/adapter.rs
+++ b/src/table/src/table/adapter.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 use std::sync::{Arc, Mutex};
 
 use common_recordbatch::OrderOption;
-use common_telemetry::info;
 use datafusion::arrow::datatypes::SchemaRef as DfSchemaRef;
 use datafusion::datasource::{TableProvider, TableType as DfTableType};
 use datafusion::error::Result as DfResult;
@@ -86,7 +85,6 @@ impl TableProvider for DfTableProviderAdapter {
         limit: Option<usize>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
         let filters: Vec<Expr> = filters.iter().map(Clone::clone).map(Into::into).collect();
-        info!("Filters: {:?}", filters);
         let request = {
             let mut request = self.scan_req.lock().unwrap();
             request.filters = filters;

--- a/src/table/src/table/adapter.rs
+++ b/src/table/src/table/adapter.rs
@@ -16,6 +16,7 @@ use std::any::Any;
 use std::sync::{Arc, Mutex};
 
 use common_recordbatch::OrderOption;
+use common_telemetry::info;
 use datafusion::arrow::datatypes::SchemaRef as DfSchemaRef;
 use datafusion::datasource::{TableProvider, TableType as DfTableType};
 use datafusion::error::Result as DfResult;
@@ -85,6 +86,7 @@ impl TableProvider for DfTableProviderAdapter {
         limit: Option<usize>,
     ) -> DfResult<Arc<dyn ExecutionPlan>> {
         let filters: Vec<Expr> = filters.iter().map(Clone::clone).map(Into::into).collect();
+        info!("Filters: {:?}", filters);
         let request = {
             let mut request = self.scan_req.lock().unwrap();
             request.filters = filters;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- #3944

## What's changed and what's your intention?

This PR converts the desired time range into `SimpleFilterContext` while building parquet readers so that the reader can filter out those rows outside the desired time range.


## Checklist

- [x]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
