### PR TITLE
feat: Adds `RegionScanner` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10169,7 +10169,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "common-wal",
- "datafusion-physical-plan",
+ "datafusion-physical-plan 37.0.0",
  "datatypes",
  "derive_builder 0.12.0",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10169,6 +10169,7 @@ dependencies = [
  "common-query",
  "common-recordbatch",
  "common-wal",
+ "datafusion-physical-plan",
  "datatypes",
  "derive_builder 0.12.0",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ datafusion-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev 
 datafusion-functions = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
 datafusion-optimizer = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
 datafusion-physical-expr = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
+datafusion-physical-plan = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
 datafusion-sql = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
 datafusion-substrait = { git = "https://github.com/apache/arrow-datafusion.git", rev = "34eda15b73a9e278af8844b30ed2f1c21c10359c" }
 derive_builder = "0.12"

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -23,7 +23,6 @@ use common_function::function::FunctionRef;
 use common_function::scalars::aggregate::AggregateFunctionMetaRef;
 use common_query::prelude::ScalarUdf;
 use common_query::Output;
-use common_recordbatch::SendableRecordBatchStream;
 use common_runtime::Runtime;
 use query::dataframe::DataFrame;
 use query::plan::LogicalPlan;
@@ -187,14 +186,6 @@ impl RegionEngine for MockRegionEngine {
 
         let _ = self.sender.send((region_id, request)).await;
         Ok(RegionResponse::new(0))
-    }
-
-    async fn handle_query(
-        &self,
-        _region_id: RegionId,
-        _request: ScanRequest,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        unimplemented!()
     }
 
     async fn handle_partitioned_query(

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -202,7 +202,7 @@ impl RegionEngine for MockRegionEngine {
         _region_id: RegionId,
         _request: ScanRequest,
     ) -> Result<RegionScannerRef, BoxedError> {
-        todo!()
+        unimplemented!()
     }
 
     async fn get_metadata(&self, _region_id: RegionId) -> Result<RegionMetadataRef, BoxedError> {

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -188,7 +188,7 @@ impl RegionEngine for MockRegionEngine {
         Ok(RegionResponse::new(0))
     }
 
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         _region_id: RegionId,
         _request: ScanRequest,

--- a/src/datanode/src/tests.rs
+++ b/src/datanode/src/tests.rs
@@ -32,7 +32,7 @@ use query::query_engine::DescribeResult;
 use query::{QueryEngine, QueryEngineContext};
 use session::context::QueryContextRef;
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
 use store_api::region_request::{AffectedRows, RegionRequest};
 use store_api::storage::{RegionId, ScanRequest};
 use table::TableRef;
@@ -195,6 +195,14 @@ impl RegionEngine for MockRegionEngine {
         _request: ScanRequest,
     ) -> Result<SendableRecordBatchStream, BoxedError> {
         unimplemented!()
+    }
+
+    async fn handle_partitioned_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<RegionScannerRef, BoxedError> {
+        todo!()
     }
 
     async fn get_metadata(&self, _region_id: RegionId) -> Result<RegionMetadataRef, BoxedError> {

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -84,7 +84,7 @@ impl RegionEngine for FileRegionEngine {
             .map_err(BoxedError::new)
     }
 
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         region_id: RegionId,
         request: ScanRequest,

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -25,7 +25,7 @@ use common_telemetry::{error, info};
 use object_store::ObjectStore;
 use snafu::{ensure, OptionExt};
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
 use store_api::region_request::{
     AffectedRows, RegionCloseRequest, RegionCreateRequest, RegionDropRequest, RegionOpenRequest,
     RegionRequest,
@@ -80,6 +80,14 @@ impl RegionEngine for FileRegionEngine {
             .map_err(BoxedError::new)?
             .query(request)
             .map_err(BoxedError::new)
+    }
+
+    async fn handle_partitioned_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<RegionScannerRef, BoxedError> {
+        todo!()
     }
 
     async fn get_metadata(&self, region_id: RegionId) -> Result<RegionMetadataRef, BoxedError> {

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -51,6 +51,20 @@ impl FileRegionEngine {
             inner: Arc::new(EngineInner::new(object_store)),
         }
     }
+
+    async fn handle_query(
+        &self,
+        region_id: RegionId,
+        request: ScanRequest,
+    ) -> Result<SendableRecordBatchStream, BoxedError> {
+        self.inner
+            .get_region(region_id)
+            .await
+            .context(RegionNotFoundSnafu { region_id })
+            .map_err(BoxedError::new)?
+            .query(request)
+            .map_err(BoxedError::new)
+    }
 }
 
 #[async_trait]
@@ -67,20 +81,6 @@ impl RegionEngine for FileRegionEngine {
         self.inner
             .handle_request(region_id, request)
             .await
-            .map_err(BoxedError::new)
-    }
-
-    async fn handle_query(
-        &self,
-        region_id: RegionId,
-        request: ScanRequest,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        self.inner
-            .get_region(region_id)
-            .await
-            .context(RegionNotFoundSnafu { region_id })
-            .map_err(BoxedError::new)?
-            .query(request)
             .map_err(BoxedError::new)
     }
 

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -157,7 +157,7 @@ impl RegionEngine for MetricEngine {
         })
     }
 
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         region_id: RegionId,
         request: ScanRequest,

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -157,18 +157,6 @@ impl RegionEngine for MetricEngine {
         })
     }
 
-    /// Handles substrait query and return a stream of record batches
-    async fn handle_query(
-        &self,
-        region_id: RegionId,
-        request: ScanRequest,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
-        self.inner
-            .read_region(region_id, request)
-            .await
-            .map_err(BoxedError::new)
-    }
-
     async fn handle_partitioned_query(
         &self,
         region_id: RegionId,
@@ -262,6 +250,18 @@ impl MetricEngine {
             .metadata_region
             .logical_regions(physical_region_id)
             .await
+    }
+
+    /// Handles substrait query and return a stream of record batches
+    async fn handle_query(
+        &self,
+        region_id: RegionId,
+        request: ScanRequest,
+    ) -> Result<SendableRecordBatchStream, BoxedError> {
+        self.inner
+            .read_region(region_id, request)
+            .await
+            .map_err(BoxedError::new)
     }
 }
 

--- a/src/metric-engine/src/engine.rs
+++ b/src/metric-engine/src/engine.rs
@@ -35,7 +35,7 @@ use common_recordbatch::SendableRecordBatchStream;
 use mito2::engine::MitoEngine;
 use store_api::metadata::RegionMetadataRef;
 use store_api::metric_engine_consts::METRIC_ENGINE_NAME;
-use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
 use store_api::region_request::RegionRequest;
 use store_api::storage::{RegionId, ScanRequest};
 
@@ -165,6 +165,14 @@ impl RegionEngine for MetricEngine {
             .read_region(region_id, request)
             .await
             .map_err(BoxedError::new)
+    }
+
+    async fn handle_partitioned_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<RegionScannerRef, BoxedError> {
+        todo!()
     }
 
     /// Retrieves region's metadata.

--- a/src/metric-engine/src/engine/read.rs
+++ b/src/metric-engine/src/engine/read.rs
@@ -62,7 +62,7 @@ impl MetricEngineInner {
             .start_timer();
 
         self.mito
-            .handle_query(region_id, request)
+            .scan_to_stream(region_id, request)
             .await
             .context(MitoReadOperationSnafu)
     }
@@ -82,7 +82,7 @@ impl MetricEngineInner {
             .transform_request(physical_region_id, logical_region_id, request)
             .await?;
         self.mito
-            .handle_query(data_region_id, request)
+            .scan_to_stream(data_region_id, request)
             .await
             .context(MitoReadOperationSnafu)
     }

--- a/src/metric-engine/src/metadata_region.rs
+++ b/src/metric-engine/src/metadata_region.rs
@@ -300,7 +300,7 @@ impl MetadataRegion {
         let scan_req = Self::build_read_request(key);
         let record_batch_stream = self
             .mito
-            .handle_query(region_id, scan_req)
+            .scan_to_stream(region_id, scan_req)
             .await
             .context(MitoReadOperationSnafu)?;
         let scan_result = collect(record_batch_stream)
@@ -317,7 +317,7 @@ impl MetadataRegion {
         let scan_req = Self::build_read_request(key);
         let record_batch_stream = self
             .mito
-            .handle_query(region_id, scan_req)
+            .scan_to_stream(region_id, scan_req)
             .await
             .context(MitoReadOperationSnafu)?;
         let scan_result = collect(record_batch_stream)
@@ -351,7 +351,7 @@ impl MetadataRegion {
         };
         let record_batch_stream = self
             .mito
-            .handle_query(region_id, scan_req)
+            .scan_to_stream(region_id, scan_req)
             .await
             .context(MitoReadOperationSnafu)?;
         let scan_result = collect(record_batch_stream)
@@ -590,7 +590,7 @@ mod test {
         let scan_req = MetadataRegion::build_read_request("test_key");
         let record_batch_stream = metadata_region
             .mito
-            .handle_query(region_id, scan_req)
+            .scan_to_stream(region_id, scan_req)
             .await
             .unwrap();
         let scan_result = collect(record_batch_stream).await.unwrap();

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -117,7 +117,7 @@ impl MitoEngine {
 
     /// Handle substrait query and return a stream of record batches
     #[tracing::instrument(skip_all)]
-    pub async fn handle_query(
+    pub async fn scan_to_stream(
         &self,
         region_id: RegionId,
         request: ScanRequest,
@@ -337,7 +337,7 @@ impl RegionEngine for MitoEngine {
     }
 
     #[tracing::instrument(skip_all)]
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         region_id: RegionId,
         request: ScanRequest,

--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -62,7 +62,7 @@ use object_store::manager::ObjectStoreManagerRef;
 use snafu::{ensure, OptionExt, ResultExt};
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
 use store_api::region_request::{AffectedRows, RegionRequest};
 use store_api::storage::{RegionId, ScanRequest};
 use tokio::sync::oneshot;
@@ -324,6 +324,15 @@ impl RegionEngine for MitoEngine {
             .scan()
             .await
             .map_err(BoxedError::new)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn handle_partitioned_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<RegionScannerRef, BoxedError> {
+        unimplemented!()
     }
 
     /// Retrieve region's metadata.

--- a/src/mito2/src/engine/alter_test.rs
+++ b/src/mito2/src/engine/alter_test.rs
@@ -245,7 +245,7 @@ async fn test_put_after_alter() {
 |       | b     | 2.0     | 1970-01-01T00:00:02 |
 +-------+-------+---------+---------------------+";
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     assert_eq!(expected, batches.pretty_print().unwrap());
 }

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -63,7 +63,7 @@ async fn test_append_mode_write_query() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -183,7 +183,7 @@ async fn test_append_mode_compaction() {
     // Reopens the region.
     reopen_region(&engine, region_id, region_dir, false, region_opts).await;
     let stream = engine
-        .handle_query(region_id, ScanRequest::default())
+        .scan_to_stream(region_id, ScanRequest::default())
         .await
         .unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -128,7 +128,7 @@ async fn test_region_replay() {
     assert_eq!(0, result.affected_rows);
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     assert_eq!(42, batches.iter().map(|b| b.num_rows()).sum::<usize>());
 
@@ -166,7 +166,7 @@ async fn test_write_query_region() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -227,7 +227,7 @@ async fn test_different_order() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+-------+---------+---------+---------------------+
@@ -289,7 +289,7 @@ async fn test_different_order_and_type() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+-------+---------+---------+---------------------+
@@ -341,7 +341,7 @@ async fn test_put_delete() {
     delete_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -383,7 +383,7 @@ async fn test_delete_not_null_fields() {
     delete_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -398,7 +398,7 @@ async fn test_delete_not_null_fields() {
     // Reopen and scan again.
     reopen_region(&engine, region_id, region_dir, false, HashMap::new()).await;
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     assert_eq!(expected, batches.pretty_print().unwrap());
 }
@@ -447,7 +447,7 @@ async fn test_put_overwrite() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -688,7 +688,7 @@ async fn test_cache_null_primary_key() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+-------+---------+---------------------+

--- a/src/mito2/src/engine/catchup_test.rs
+++ b/src/mito2/src/engine/catchup_test.rs
@@ -104,7 +104,7 @@ async fn test_catchup_with_last_entry_id() {
     // Scans
     let request = ScanRequest::default();
     let stream = follower_engine
-        .handle_query(region_id, request)
+        .scan_to_stream(region_id, request)
         .await
         .unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
@@ -264,7 +264,7 @@ async fn test_catchup_without_last_entry_id() {
 
     let request = ScanRequest::default();
     let stream = follower_engine
-        .handle_query(region_id, request)
+        .scan_to_stream(region_id, request)
         .await
         .unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
@@ -367,7 +367,7 @@ async fn test_catchup_with_manifest_update() {
 
     let request = ScanRequest::default();
     let stream = follower_engine
-        .handle_query(region_id, request)
+        .scan_to_stream(region_id, request)
         .await
         .unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();

--- a/src/mito2/src/engine/create_test.rs
+++ b/src/mito2/src/engine/create_test.rs
@@ -231,7 +231,7 @@ async fn test_engine_create_with_memtable_opts() {
     put_rows(&engine, region_id, rows).await;
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/engine/filter_deleted_test.rs
+++ b/src/mito2/src/engine/filter_deleted_test.rs
@@ -69,7 +69,7 @@ async fn test_scan_without_filtering_deleted() {
 
     // scan
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/engine/open_test.rs
+++ b/src/mito2/src/engine/open_test.rs
@@ -276,7 +276,7 @@ async fn test_open_region_skip_wal_replay() {
         .unwrap();
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -305,7 +305,7 @@ async fn test_open_region_skip_wal_replay() {
         .unwrap();
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/engine/parallel_test.rs
+++ b/src/mito2/src/engine/parallel_test.rs
@@ -57,7 +57,7 @@ async fn scan_in_parallel(
         .unwrap();
 
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/engine/projection_test.rs
+++ b/src/mito2/src/engine/projection_test.rs
@@ -79,7 +79,7 @@ async fn test_scan_projection() {
         output_ordering: None,
         limit: None,
     };
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+

--- a/src/mito2/src/engine/prune_test.rs
+++ b/src/mito2/src/engine/prune_test.rs
@@ -53,7 +53,7 @@ async fn check_prune_row_groups(expr: DfExpr, expected: &str) {
     flush_region(&engine, region_id, Some(5)).await;
 
     let stream = engine
-        .handle_query(
+        .scan_to_stream(
             region_id,
             ScanRequest {
                 filters: vec![Expr::from(expr)],
@@ -186,7 +186,7 @@ async fn test_prune_memtable() {
     .await;
 
     let stream = engine
-        .handle_query(
+        .scan_to_stream(
             region_id,
             ScanRequest {
                 filters: vec![time_range_expr(0, 20)],
@@ -238,7 +238,7 @@ async fn test_prune_memtable_complex_expr() {
     let filters = vec![time_range_expr(4, 7), Expr::from(col("tag_0").lt(lit("6")))];
 
     let stream = engine
-        .handle_query(
+        .scan_to_stream(
             region_id,
             ScanRequest {
                 filters,

--- a/src/mito2/src/engine/truncate_test.rs
+++ b/src/mito2/src/engine/truncate_test.rs
@@ -55,7 +55,7 @@ async fn test_engine_truncate_region_basic() {
 
     // Scan the region.
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -75,7 +75,7 @@ async fn test_engine_truncate_region_basic() {
 
     // Scan the region.
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "++\n++";
     assert_eq!(expected, batches.pretty_print().unwrap());
@@ -104,7 +104,7 @@ async fn test_engine_put_data_after_truncate() {
 
     // Scan the region
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -131,7 +131,7 @@ async fn test_engine_put_data_after_truncate() {
 
     // Scan the region.
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "\
 +-------+---------+---------------------+
@@ -261,7 +261,7 @@ async fn test_engine_truncate_reopen() {
 
     // Scan the region.
     let request = ScanRequest::default();
-    let stream = engine.handle_query(region_id, request).await.unwrap();
+    let stream = engine.scan_to_stream(region_id, request).await.unwrap();
     let batches = RecordBatches::try_collect(stream).await.unwrap();
     let expected = "++\n++";
     assert_eq!(expected, batches.pretty_print().unwrap());

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -198,6 +198,14 @@ impl UnorderedScan {
     }
 }
 
+#[cfg(test)]
+impl UnorderedScan {
+    /// Returns the input.
+    pub(crate) fn input(&self) -> &ScanInput {
+        &self.input
+    }
+}
+
 /// Metrics for [UnorderedScan].
 #[derive(Debug, Default)]
 struct Metrics {
@@ -215,12 +223,4 @@ struct Metrics {
     num_batches: usize,
     /// Number of rows returned.
     num_rows: usize,
-}
-
-#[cfg(test)]
-impl UnorderedScan {
-    /// Returns the input.
-    pub(crate) fn input(&self) -> &ScanInput {
-        &self.input
-    }
 }

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -31,7 +31,7 @@ use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngineRef;
 use store_api::storage::{RegionId, ScanRequest};
-use table::table::scan::ReadFromRegion;
+use table::table::scan::RegionScanExec;
 
 use crate::error::{GetRegionMetadataSnafu, Result};
 
@@ -173,7 +173,7 @@ impl TableProvider for DummyTableProvider {
             .handle_query(self.region_id, request)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        Ok(Arc::new(ReadFromRegion::new(scanner)))
+        Ok(Arc::new(RegionScanExec::new(scanner)))
     }
 
     fn supports_filters_pushdown(

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -170,7 +170,7 @@ impl TableProvider for DummyTableProvider {
 
         let scanner = self
             .engine
-            .handle_partitioned_query(self.region_id, request)
+            .handle_query(self.region_id, request)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         Ok(Arc::new(ReadFromRegion::new(scanner)))

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -31,7 +31,7 @@ use snafu::ResultExt;
 use store_api::metadata::RegionMetadataRef;
 use store_api::region_engine::RegionEngineRef;
 use store_api::storage::{RegionId, ScanRequest};
-use table::table::scan::{ReadFromRegion, StreamScanAdapter};
+use table::table::scan::ReadFromRegion;
 
 use crate::error::{GetRegionMetadataSnafu, Result};
 

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -28,7 +28,7 @@ use datatypes::schema::ColumnSchema;
 use store_api::metadata::{
     ColumnMetadata, RegionMetadata, RegionMetadataBuilder, RegionMetadataRef,
 };
-use store_api::region_engine::{RegionEngine, RegionRole, SetReadonlyResponse};
+use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
 use store_api::region_request::RegionRequest;
 use store_api::storage::{ConcreteDataType, RegionId, ScanRequest};
 
@@ -68,6 +68,14 @@ impl RegionEngine for MetaRegionEngine {
         _region_id: RegionId,
         _request: ScanRequest,
     ) -> Result<SendableRecordBatchStream, BoxedError> {
+        unimplemented!()
+    }
+
+    async fn handle_partitioned_query(
+        &self,
+        _region_id: RegionId,
+        _request: ScanRequest,
+    ) -> Result<RegionScannerRef, BoxedError> {
         unimplemented!()
     }
 

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -23,7 +23,6 @@ use api::v1::SemanticType;
 use async_trait::async_trait;
 use common_error::ext::{BoxedError, PlainError};
 use common_error::status_code::StatusCode;
-use common_recordbatch::SendableRecordBatchStream;
 use datatypes::schema::ColumnSchema;
 use store_api::metadata::{
     ColumnMetadata, RegionMetadata, RegionMetadataBuilder, RegionMetadataRef,
@@ -60,14 +59,6 @@ impl RegionEngine for MetaRegionEngine {
         _region_id: RegionId,
         _request: RegionRequest,
     ) -> Result<RegionResponse, BoxedError> {
-        unimplemented!()
-    }
-
-    async fn handle_query(
-        &self,
-        _region_id: RegionId,
-        _request: ScanRequest,
-    ) -> Result<SendableRecordBatchStream, BoxedError> {
         unimplemented!()
     }
 

--- a/src/query/src/optimizer/test_util.rs
+++ b/src/query/src/optimizer/test_util.rs
@@ -62,7 +62,7 @@ impl RegionEngine for MetaRegionEngine {
         unimplemented!()
     }
 
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         _region_id: RegionId,
         _request: ScanRequest,

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -17,6 +17,7 @@ common-macro.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
 common-wal.workspace = true
+datafusion-physical-plan.workspace = true
 datatypes.workspace = true
 derive_builder.workspace = true
 futures.workspace = true

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -282,7 +282,7 @@ impl RegionScanner for SinglePartitionScanner {
         stream
             .take()
             .context(ExecuteRepeatedlySnafu)
-            .map_err(|e| BoxedError::new(e))
+            .map_err(BoxedError::new)
     }
 }
 

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -188,7 +188,7 @@ pub trait RegionEngine: Send + Sync {
     ) -> Result<RegionResponse, BoxedError>;
 
     /// Handles query and return a scanner that can be used to scan the region concurrently.
-    async fn handle_partitioned_query(
+    async fn handle_query(
         &self,
         region_id: RegionId,
         request: ScanRequest,

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -195,13 +195,6 @@ pub trait RegionEngine: Send + Sync {
         request: RegionRequest,
     ) -> Result<RegionResponse, BoxedError>;
 
-    /// Handles substrait query and return a stream of record batches
-    async fn handle_query(
-        &self,
-        region_id: RegionId,
-        request: ScanRequest,
-    ) -> Result<SendableRecordBatchStream, BoxedError>;
-
     /// Handles query and return a scanner that can be used to scan the region concurrently.
     async fn handle_partitioned_query(
         &self,

--- a/src/table/src/table/adapter.rs
+++ b/src/table/src/table/adapter.rs
@@ -29,7 +29,7 @@ use datafusion_physical_expr::PhysicalSortExpr;
 use store_api::region_engine::SinglePartitionScanner;
 use store_api::storage::ScanRequest;
 
-use crate::table::scan::{ReadFromRegion, StreamScanAdapter};
+use crate::table::scan::ReadFromRegion;
 use crate::table::{TableRef, TableType};
 
 /// Adapt greptime's [TableRef] to DataFusion's [TableProvider].

--- a/src/table/src/table/adapter.rs
+++ b/src/table/src/table/adapter.rs
@@ -26,9 +26,10 @@ use datafusion_expr::expr::Expr as DfExpr;
 use datafusion_expr::TableProviderFilterPushDown as DfTableProviderFilterPushDown;
 use datafusion_physical_expr::expressions::Column;
 use datafusion_physical_expr::PhysicalSortExpr;
+use store_api::region_engine::SinglePartitionScanner;
 use store_api::storage::ScanRequest;
 
-use crate::table::scan::StreamScanAdapter;
+use crate::table::scan::{ReadFromRegion, StreamScanAdapter};
 use crate::table::{TableRef, TableType};
 
 /// Adapt greptime's [TableRef] to DataFusion's [TableProvider].
@@ -110,11 +111,12 @@ impl TableProvider for DfTableProviderAdapter {
                 .collect::<Vec<_>>()
         });
 
-        let mut stream_adapter = StreamScanAdapter::new(stream);
+        let scanner = Arc::new(SinglePartitionScanner::new(stream));
+        let mut plan = ReadFromRegion::new(scanner);
         if let Some(sort_expr) = sort_expr {
-            stream_adapter = stream_adapter.with_output_ordering(sort_expr);
+            plan = plan.with_output_ordering(sort_expr);
         }
-        Ok(Arc::new(stream_adapter))
+        Ok(Arc::new(plan))
     }
 
     fn supports_filters_pushdown(

--- a/src/table/src/table/adapter.rs
+++ b/src/table/src/table/adapter.rs
@@ -29,7 +29,7 @@ use datafusion_physical_expr::PhysicalSortExpr;
 use store_api::region_engine::SinglePartitionScanner;
 use store_api::storage::ScanRequest;
 
-use crate::table::scan::ReadFromRegion;
+use crate::table::scan::RegionScanExec;
 use crate::table::{TableRef, TableType};
 
 /// Adapt greptime's [TableRef] to DataFusion's [TableProvider].
@@ -112,7 +112,7 @@ impl TableProvider for DfTableProviderAdapter {
         });
 
         let scanner = Arc::new(SinglePartitionScanner::new(stream));
-        let mut plan = ReadFromRegion::new(scanner);
+        let mut plan = RegionScanExec::new(scanner);
         if let Some(sort_expr) = sort_expr {
             plan = plan.with_output_ordering(sort_expr);
         }

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -28,7 +28,7 @@ use datafusion::physical_plan::{
     RecordBatchStream as DfRecordBatchStream,
 };
 use datafusion_common::DataFusionError;
-use datafusion_physical_expr::{EquivalenceProperties, PhysicalSortExpr};
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning, PhysicalSortExpr};
 use datatypes::arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use futures::{Stream, StreamExt};
 use store_api::region_engine::RegionScannerRef;
@@ -52,7 +52,7 @@ impl ReadFromRegion {
         let scanner_props = scanner.properties();
         let properties = PlanProperties::new(
             EquivalenceProperties::new(arrow_schema.clone()),
-            scanner_props.partitioning().to_df_partitioning(),
+            Partitioning::UnknownPartitioning(scanner_props.partitioning().num_partitions()),
             ExecutionMode::Bounded,
         );
         Self {

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -37,7 +37,7 @@ use crate::table::metrics::MemoryUsageMetrics;
 
 /// A plan to read multiple partitions from a region of a table.
 #[derive(Debug)]
-pub struct ReadFromRegion {
+pub struct RegionScanExec {
     scanner: RegionScannerRef,
     arrow_schema: ArrowSchemaRef,
     /// The expected output ordering for the plan.
@@ -46,7 +46,7 @@ pub struct ReadFromRegion {
     properties: PlanProperties,
 }
 
-impl ReadFromRegion {
+impl RegionScanExec {
     pub fn new(scanner: RegionScannerRef) -> Self {
         let arrow_schema = scanner.schema().arrow_schema().clone();
         let scanner_props = scanner.properties();
@@ -71,7 +71,7 @@ impl ReadFromRegion {
     }
 }
 
-impl ExecutionPlan for ReadFromRegion {
+impl ExecutionPlan for RegionScanExec {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -121,7 +121,7 @@ impl ExecutionPlan for ReadFromRegion {
     }
 }
 
-impl DisplayAs for ReadFromRegion {
+impl DisplayAs for RegionScanExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         // The scanner contains all information needed to display the plan.
         write!(f, "{:?}", self.scanner)
@@ -211,7 +211,7 @@ mod test {
         let stream = recordbatches.as_stream();
 
         let scanner = Arc::new(SinglePartitionScanner::new(stream));
-        let plan = ReadFromRegion::new(scanner);
+        let plan = RegionScanExec::new(scanner);
         let actual: SchemaRef = Arc::new(
             plan.properties
                 .eq_properties

--- a/tests/cases/distributed/explain/analyze.result
+++ b/tests/cases/distributed/explain/analyze.result
@@ -35,7 +35,7 @@ explain analyze SELECT count(*) FROM system_metrics;
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[COUNT(greptime.public.system_REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+|_|_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/distributed/optimizer/order_by.result
+++ b/tests/cases/distributed/optimizer/order_by.result
@@ -1,61 +1,61 @@
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers;
 
-+---------------+-------------------------------------------------------------+
-| plan_type     | plan                                                        |
-+---------------+-------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                            |
-| physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                             |
-+---------------+-------------------------------------------------------------+
++---------------+-----------------------------------------------------+
+| plan_type     | plan                                                |
++---------------+-----------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                    |
+| physical_plan | SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                     |
++---------------+-----------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number desc;
 
-+---------------+---------------------------------------------------------------+
-| plan_type     | plan                                                          |
-+---------------+---------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                              |
-| physical_plan | SortExec: expr=[number@0 DESC]                                |
-|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                               |
-+---------------+---------------------------------------------------------------+
++---------------+-------------------------------------------------------+
+| plan_type     | plan                                                  |
++---------------+-------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                      |
+| physical_plan | SortExec: expr=[number@0 DESC]                        |
+|               |   SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                       |
++---------------+-------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number asc;
 
-+---------------+---------------------------------------------------------------+
-| plan_type     | plan                                                          |
-+---------------+---------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                              |
-| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                      |
-|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                               |
-+---------------+---------------------------------------------------------------+
++---------------+-------------------------------------------------------+
+| plan_type     | plan                                                  |
++---------------+-------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                      |
+| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]              |
+|               |   SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                       |
++---------------+-------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number desc limit 10;
 
-+---------------+-----------------------------------------------------------------+
-| plan_type     | plan                                                            |
-+---------------+-----------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                               |
-|               |   SortExec: TopK(fetch=10), expr=[number@0 DESC]                |
-|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                                 |
-+---------------+-----------------------------------------------------------------+
++---------------+---------------------------------------------------------+
+| plan_type     | plan                                                    |
++---------------+---------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                        |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                       |
+|               |   SortExec: TopK(fetch=10), expr=[number@0 DESC]        |
+|               |     SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                         |
++---------------+---------------------------------------------------------+
 
 -- SQLNESS REPLACE (peers.*) REDACTED
 explain select * from numbers order by number asc limit 10;
 
-+---------------+-----------------------------------------------------------------+
-| plan_type     | plan                                                            |
-+---------------+-----------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                               |
-|               |   SortExec: TopK(fetch=10), expr=[number@0 ASC NULLS LAST]      |
-|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                                 |
-+---------------+-----------------------------------------------------------------+
++---------------+------------------------------------------------------------+
+| plan_type     | plan                                                       |
++---------------+------------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                           |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                          |
+|               |   SortExec: TopK(fetch=10), expr=[number@0 ASC NULLS LAST] |
+|               |     SinglePartitionScanner: <SendableRecordBatchStream>    |
+|               |                                                            |
++---------------+------------------------------------------------------------+
 

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -74,7 +74,7 @@ EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 | 0_| 0_|_RangeSelectExec: range_expr=[MIN(host.val) RANGE 5s], align=5000ms, align_to=0ms, align_by=[host@1], time_index=ts REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+| 1_| 0_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 10_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/analyze.result
@@ -30,7 +30,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+|_|_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -59,7 +59,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -2000 AND j@1 <= 12000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+|_|_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -87,7 +87,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+|_|_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -117,7 +117,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_StreamScanAdapter { stream: "<SendableRecordBatchStream>" } REDACTED
+|_|_|_SinglePartitionScanner: <SendableRecordBatchStream> REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/order_by.result
+++ b/tests/cases/standalone/optimizer/order_by.result
@@ -1,56 +1,56 @@
 explain select * from numbers;
 
-+---------------+-------------------------------------------------------------+
-| plan_type     | plan                                                        |
-+---------------+-------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                            |
-| physical_plan | StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                             |
-+---------------+-------------------------------------------------------------+
++---------------+-----------------------------------------------------+
+| plan_type     | plan                                                |
++---------------+-----------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                    |
+| physical_plan | SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                     |
++---------------+-----------------------------------------------------+
 
 explain select * from numbers order by number desc;
 
-+---------------+---------------------------------------------------------------+
-| plan_type     | plan                                                          |
-+---------------+---------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                              |
-| physical_plan | SortExec: expr=[number@0 DESC]                                |
-|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                               |
-+---------------+---------------------------------------------------------------+
++---------------+-------------------------------------------------------+
+| plan_type     | plan                                                  |
++---------------+-------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                      |
+| physical_plan | SortExec: expr=[number@0 DESC]                        |
+|               |   SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                       |
++---------------+-------------------------------------------------------+
 
 explain select * from numbers order by number asc;
 
-+---------------+---------------------------------------------------------------+
-| plan_type     | plan                                                          |
-+---------------+---------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                              |
-| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]                      |
-|               |   StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                               |
-+---------------+---------------------------------------------------------------+
++---------------+-------------------------------------------------------+
+| plan_type     | plan                                                  |
++---------------+-------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                      |
+| physical_plan | SortExec: expr=[number@0 ASC NULLS LAST]              |
+|               |   SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                       |
++---------------+-------------------------------------------------------+
 
 explain select * from numbers order by number desc limit 10;
 
-+---------------+-----------------------------------------------------------------+
-| plan_type     | plan                                                            |
-+---------------+-----------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                               |
-|               |   SortExec: TopK(fetch=10), expr=[number@0 DESC]                |
-|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                                 |
-+---------------+-----------------------------------------------------------------+
++---------------+---------------------------------------------------------+
+| plan_type     | plan                                                    |
++---------------+---------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                        |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                       |
+|               |   SortExec: TopK(fetch=10), expr=[number@0 DESC]        |
+|               |     SinglePartitionScanner: <SendableRecordBatchStream> |
+|               |                                                         |
++---------------+---------------------------------------------------------+
 
 explain select * from numbers order by number asc limit 10;
 
-+---------------+-----------------------------------------------------------------+
-| plan_type     | plan                                                            |
-+---------------+-----------------------------------------------------------------+
-| logical_plan  | MergeScan [is_placeholder=false]                                |
-| physical_plan | GlobalLimitExec: skip=0, fetch=10                               |
-|               |   SortExec: TopK(fetch=10), expr=[number@0 ASC NULLS LAST]      |
-|               |     StreamScanAdapter { stream: "<SendableRecordBatchStream>" } |
-|               |                                                                 |
-+---------------+-----------------------------------------------------------------+
++---------------+------------------------------------------------------------+
+| plan_type     | plan                                                       |
++---------------+------------------------------------------------------------+
+| logical_plan  | MergeScan [is_placeholder=false]                           |
+| physical_plan | GlobalLimitExec: skip=0, fetch=10                          |
+|               |   SortExec: TopK(fetch=10), expr=[number@0 ASC NULLS LAST] |
+|               |     SinglePartitionScanner: <SendableRecordBatchStream>    |
+|               |                                                            |
++---------------+------------------------------------------------------------+
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/2806
- https://github.com/GreptimeTeam/greptimedb/issues/3886

## What's changed and what's your intention?
This PR adds the `RegionScanner` trait mentioned in https://github.com/GreptimeTeam/greptimedb/issues/3886

```rust
pub trait RegionScanner: Debug + DisplayAs + Send + Sync {
    fn properties(&self) -> &ScannerProperties;
    fn schema(&self) -> SchemaRef;
    fn scan_partition(&self, partition: usize) -> Result<SendableRecordBatchStream, BoxedError>;
}
```

It allows us to split rows to scan into multiple partitions and increase scan parallelism. The `RegionEngine` has a new method `handle_partitioned_query()` to get the `RegionScanner`. It removes the old `handle_query()` method from the trait and only exposes it in the `MitoEngine`.

Since most region engines don't support partitioning, this PR adds a `SinglePartitionScanner` to turn a stream into a region scanner.

The execution plan returned by the dummy table provider now becomes the `ReadFromRegion` plan. This plan adapts a `RegionScanner` to the `ExecutionPlan` trait.

## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.
