### PR TITLE
test: give windows file watcher more time

### DIFF
--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -426,9 +426,11 @@ mod tests {
 
         // waiting for async load
         #[cfg(not(target_os = "windows"))]
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        let timeout_millis = 300;
         #[cfg(target_os = "windows")]
-        std::thread::sleep(std::time::Duration::from_millis(2000));
+        let timeout_millis = 2000;
+
+        std::thread::sleep(std::time::Duration::from_millis(timeout_millis));
 
         assert!(server_config.get_version() > 1);
         assert!(server_config.get_server_config().is_some());

--- a/src/servers/src/tls.rs
+++ b/src/servers/src/tls.rs
@@ -425,7 +425,11 @@ mod tests {
             .expect("failed to copy key to tmpdir");
 
         // waiting for async load
+        #[cfg(not(target_os = "windows"))]
         std::thread::sleep(std::time::Duration::from_millis(300));
+        #[cfg(target_os = "windows")]
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+
         assert!(server_config.get_version() > 1);
         assert!(server_config.get_server_config().is_some());
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Give file change detection test on windows more time.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
