### PR TITLE
feat(flow): avg func rewrite to sum/count

### DIFF
--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -238,6 +238,12 @@ mod test {
         for now in time_range {
             state.set_current_ts(now);
             state.run_available_with_schedule(df);
+            if !state.get_err_collector().is_empty() {
+                panic!(
+                    "Errors occur: {:?}",
+                    state.get_err_collector().get_all_blocking()
+                )
+            }
             assert!(state.get_err_collector().is_empty());
             if let Some(expected) = expected.get(&now) {
                 assert_eq!(*output.borrow(), *expected, "at ts={}", now);

--- a/src/flow/src/compute/types.rs
+++ b/src/flow/src/compute/types.rs
@@ -153,6 +153,9 @@ pub struct ErrCollector {
 }
 
 impl ErrCollector {
+    pub fn get_all_blocking(&self) -> Vec<EvalError> {
+        self.inner.blocking_lock().drain(..).collect_vec()
+    }
     pub async fn get_all(&self) -> Vec<EvalError> {
         self.inner.lock().await.drain(..).collect_vec()
     }

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -375,6 +375,22 @@ impl BinaryFunc {
         )
     }
 
+    pub fn add(input_type: ConcreteDataType) -> Result<Self, Error> {
+        Self::specialization(GenericFn::Add, input_type)
+    }
+
+    pub fn sub(input_type: ConcreteDataType) -> Result<Self, Error> {
+        Self::specialization(GenericFn::Sub, input_type)
+    }
+
+    pub fn mul(input_type: ConcreteDataType) -> Result<Self, Error> {
+        Self::specialization(GenericFn::Mul, input_type)
+    }
+
+    pub fn div(input_type: ConcreteDataType) -> Result<Self, Error> {
+        Self::specialization(GenericFn::Div, input_type)
+    }
+
     /// Get the specialization of the binary function based on the generic function and the input type
     pub fn specialization(generic: GenericFn, input_type: ConcreteDataType) -> Result<Self, Error> {
         let rule = SPECIALIZATION.get_or_init(|| {

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -139,22 +139,42 @@ macro_rules! generate_signature {
     ($value:ident,
         { $($user_arm:tt)* },
         [ $(
-            $auto_arm:ident=>($con_type:ident,$generic:ident)
+            $auto_arm:ident=>($($arg:ident),*)
             ),*
         ]
     ) => {
         match $value {
             $($user_arm)*,
             $(
-                Self::$auto_arm => Signature {
-                    input: smallvec![
-                        ConcreteDataType::$con_type(),
-                        ConcreteDataType::$con_type(),
-                    ],
-                    output: ConcreteDataType::$con_type(),
-                    generic_fn: GenericFn::$generic,
-                },
+                Self::$auto_arm => gen_one_siginature!($($arg),*),
             )*
+        }
+    };
+}
+
+/// Generate one match arm with optional arguments
+macro_rules! gen_one_siginature {
+    (
+        $con_type:ident, $generic:ident
+    ) => {
+        Signature {
+            input: smallvec![
+                ConcreteDataType::$con_type(),
+                ConcreteDataType::$con_type(),
+            ],
+            output: ConcreteDataType::$con_type(),
+            generic_fn: GenericFn::$generic,
+        }
+    };
+    (
+        $in_type:ident, $out_type:ident, $generic:ident
+    ) => {
+        Signature {
+            input: smallvec![
+                ConcreteDataType::$in_type()
+            ],
+            output: ConcreteDataType::$out_type(),
+            generic_fn: GenericFn::$generic,
         }
     };
 }
@@ -267,12 +287,12 @@ impl AggregateFunc {
             MinTime => (time_second_datatype, Min),
             MinDuration => (duration_second_datatype, Min),
             MinInterval => (interval_year_month_datatype, Min),
-            SumInt16 => (int16_datatype, Sum),
-            SumInt32 => (int32_datatype, Sum),
-            SumInt64 => (int64_datatype, Sum),
-            SumUInt16 => (uint16_datatype, Sum),
-            SumUInt32 => (uint32_datatype, Sum),
-            SumUInt64 => (uint64_datatype, Sum),
+            SumInt16 => (int16_datatype, int64_datatype, Sum),
+            SumInt32 => (int32_datatype, int64_datatype, Sum),
+            SumInt64 => (int64_datatype, int64_datatype, Sum),
+            SumUInt16 => (uint16_datatype, uint64_datatype, Sum),
+            SumUInt32 => (uint32_datatype, uint64_datatype, Sum),
+            SumUInt64 => (uint64_datatype, uint64_datatype, Sum),
             SumFloat32 => (float32_datatype, Sum),
             SumFloat64 => (float64_datatype, Sum),
             Any => (boolean_datatype, Any),

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -158,10 +158,7 @@ macro_rules! gen_one_siginature {
         $con_type:ident, $generic:ident
     ) => {
         Signature {
-            input: smallvec![
-                ConcreteDataType::$con_type(),
-                ConcreteDataType::$con_type(),
-            ],
+            input: smallvec![ConcreteDataType::$con_type(), ConcreteDataType::$con_type(),],
             output: ConcreteDataType::$con_type(),
             generic_fn: GenericFn::$generic,
         }
@@ -170,9 +167,7 @@ macro_rules! gen_one_siginature {
         $in_type:ident, $out_type:ident, $generic:ident
     ) => {
         Signature {
-            input: smallvec![
-                ConcreteDataType::$in_type()
-            ],
+            input: smallvec![ConcreteDataType::$in_type()],
             output: ConcreteDataType::$out_type(),
             generic_fn: GenericFn::$generic,
         }
@@ -246,7 +241,7 @@ impl AggregateFunc {
     /// all concrete datatypes with precision types will be returned with largest possible variant
     /// as a exception, count have a signature of `null -> i64`, but it's actually `anytype -> i64`
     ///
-    /// TODO(discorcd9): fix signature for sum usign -> u64 sum signed -> i64
+    /// TODO(discorcd9): fix signature for sum unsign -> u64 sum signed -> i64
     pub fn signature(&self) -> Signature {
         generate_signature!(self, {
             AggregateFunc::Count => Signature {

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -136,11 +136,13 @@ impl AggregateFunc {
 
 /// Generate signature for each aggregate function
 macro_rules! generate_signature {
-    ($value:ident, { $($user_arm:tt)* },
-    [ $(
-        $auto_arm:ident=>($con_type:ident,$generic:ident)
-        ),*
-    ]) => {
+    ($value:ident,
+        { $($user_arm:tt)* },
+        [ $(
+            $auto_arm:ident=>($con_type:ident,$generic:ident)
+            ),*
+        ]
+    ) => {
         match $value {
             $($user_arm)*,
             $(
@@ -223,6 +225,8 @@ impl AggregateFunc {
 
     /// all concrete datatypes with precision types will be returned with largest possible variant
     /// as a exception, count have a signature of `null -> i64`, but it's actually `anytype -> i64`
+    ///
+    /// TODO(discorcd9): fix signature for sum usign -> u64 sum signed -> i64
     pub fn signature(&self) -> Signature {
         generate_signature!(self, {
             AggregateFunc::Count => Signature {

--- a/src/flow/src/plan.rs
+++ b/src/flow/src/plan.rs
@@ -44,7 +44,7 @@ pub struct TypedPlan {
 impl TypedPlan {
     /// directly apply a mfp to the plan
     pub fn mfp(self, mfp: MapFilterProject) -> Result<Self, Error> {
-        let new_type = self.typ.apply_mfp(&mfp, &[])?;
+        let new_type = self.typ.apply_mfp(&mfp)?;
         let plan = match self.plan {
             Plan::Mfp {
                 input,
@@ -75,7 +75,7 @@ impl TypedPlan {
         let mfp = MapFilterProject::new(input_arity)
             .map(exprs)?
             .project(input_arity..input_arity + output_arity)?;
-        let out_typ = self.typ.apply_mfp(&mfp, &expr_typs)?;
+        let out_typ = self.typ.apply_mfp(&mfp)?;
         // special case for mfp to compose when the plan is already mfp
         let plan = match self.plan {
             Plan::Mfp {

--- a/src/flow/src/plan.rs
+++ b/src/flow/src/plan.rs
@@ -68,7 +68,7 @@ impl TypedPlan {
     pub fn projection(self, exprs: Vec<TypedExpr>) -> Result<Self, Error> {
         let input_arity = self.typ.column_types.len();
         let output_arity = exprs.len();
-        let (exprs, expr_typs): (Vec<_>, Vec<_>) = exprs
+        let (exprs, _expr_typs): (Vec<_>, Vec<_>) = exprs
             .into_iter()
             .map(|TypedExpr { expr, typ }| (expr, typ))
             .unzip();

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -111,13 +111,13 @@ impl RelationType {
     /// then new key=`[1]`, new time index=`[0]`
     ///
     /// note that this function will remove empty keys like key=`[]` will be removed
-    pub fn apply_mfp(&self, mfp: &MapFilterProject, expr_typs: &[ColumnType]) -> Result<Self> {
-        let all_types = self
-            .column_types
-            .iter()
-            .chain(expr_typs.iter())
-            .cloned()
-            .collect_vec();
+    pub fn apply_mfp(&self, mfp: &MapFilterProject) -> Result<Self> {
+        let mut all_types = self.column_types.clone();
+        for expr in &mfp.expressions {
+            let expr_typ = expr.typ(&self.column_types)?;
+            all_types.push(expr_typ);
+        }
+        let all_types = all_types;
         let mfp_out_types = mfp
             .projection
             .iter()
@@ -131,6 +131,7 @@ impl RelationType {
                 })
             })
             .try_collect()?;
+
         let old_to_new_col = BTreeMap::from_iter(
             mfp.projection
                 .clone()

--- a/src/flow/src/transform/aggr.rs
+++ b/src/flow/src/transform/aggr.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use common_decimal::Decimal128;
 use common_time::{Date, Timestamp};
 use datatypes::arrow::compute::kernels::window;
 use datatypes::arrow::ipc::Binary;
-use datatypes::data_type::ConcreteDataType as CDT;
+use datatypes::data_type::{ConcreteDataType as CDT, DataType};
 use datatypes::value::Value;
 use hydroflow::futures::future::Map;
 use itertools::Itertools;
@@ -173,8 +173,13 @@ impl AggregateExpr {
             return not_impl_err!("Aggregated function without arguments is not supported");
         };
 
-        match extensions.get(&f.function_reference).map(|s| s.as_ref()) {
-            Some("avg") => AggregateExpr::from_avg_aggr_func(arg),
+        let fn_name = extensions
+            .get(&f.function_reference)
+            .cloned()
+            .map(|s| s.to_lowercase());
+
+        match fn_name.as_ref().map(|s| s.as_ref()) {
+            Some(Self::AVG_NAME) => AggregateExpr::from_avg_aggr_func(arg),
             Some(function_name) => {
                 let func = AggregateFunc::from_str_and_type(
                     function_name,
@@ -194,7 +199,7 @@ impl AggregateExpr {
             ),
         }
     }
-
+    const AVG_NAME: &'static str = "avg";
     /// convert `avg` function into `sum(x)/cast(count(x) as x_type)`
     fn from_avg_aggr_func(
         arg: &TypedExpr,
@@ -214,8 +219,15 @@ impl AggregateExpr {
             ScalarExpr::Column(1).call_unary(UnaryFunc::Cast(arg_type.clone())),
             BinaryFunc::div(arg_type.clone())?,
         );
+        // make sure we wouldn't divide by zero
+        let zero = ScalarExpr::literal(arg_type.default_value(), arg_type.clone());
+        let non_zero = ScalarExpr::If {
+            cond: Box::new(ScalarExpr::Column(1).call_binary(zero.clone(), BinaryFunc::Eq)),
+            then: Box::new(avg_output),
+            els: Box::new(ScalarExpr::literal(Value::Null, arg_type.clone())),
+        };
         let ret_aggr_exprs = vec![sum, count];
-        let ret_mfp = Some(avg_output);
+        let ret_mfp = Some(non_zero);
         Ok((ret_aggr_exprs, ret_mfp))
     }
 }
@@ -273,6 +285,10 @@ impl KeyValPlan {
 
 impl TypedPlan {
     /// Convert AggregateRel into Flow's TypedPlan
+    ///
+    /// The output of aggr plan is:
+    ///
+    /// <group_exprs>..<aggr_exprs>
     pub fn from_substrait_agg_rel(
         ctx: &mut FlownodeContext,
         agg: &proto::AggregateRel,
@@ -309,7 +325,11 @@ impl TypedPlan {
                 ));
             }
             // TODO(discord9): try best to get time
-            RelationType::new(output_types).with_key((0..group_exprs.len()).collect_vec())
+            if group_exprs.is_empty() {
+                RelationType::new(output_types)
+            } else {
+                RelationType::new(output_types).with_key((0..group_exprs.len()).collect_vec())
+            }
         };
 
         // copy aggr_exprs to full_aggrs, and split them into simple_aggrs and distinct_aggrs
@@ -345,10 +365,40 @@ impl TypedPlan {
             key_val_plan,
             reduce_plan: ReducePlan::Accumulable(accum_plan),
         };
-        Ok(TypedPlan {
-            typ: output_type,
-            plan,
-        })
+        // FIX(discord9): deal with key first
+        if post_mfp.is_identity() {
+            Ok(TypedPlan {
+                typ: output_type,
+                plan,
+            })
+        } else {
+            // make post_mfp map identical mapping of keys
+            let input = TypedPlan {
+                typ: output_type.clone(),
+                plan,
+            };
+            let key_arity = group_exprs.len();
+            let mut post_mfp = post_mfp;
+            let val_arity = post_mfp.input_arity;
+            // offset post_mfp's col ref by `key_arity`
+            let shuffle = BTreeMap::from_iter((0..val_arity).map(|v| (v, v + key_arity)));
+            let new_arity = key_arity + val_arity;
+            post_mfp.permute(shuffle, new_arity)?;
+            // add key projection to post mfp
+            let (m, f, p) = post_mfp.into_map_filter_project();
+            let p = (0..key_arity).chain(p).collect_vec();
+            let post_mfp = MapFilterProject::new(new_arity)
+                .map(m)?
+                .filter(f)?
+                .project(p)?;
+            Ok(TypedPlan {
+                typ: output_type.apply_mfp(&post_mfp)?,
+                plan: Plan::Mfp {
+                    input: Box::new(input),
+                    mfp: post_mfp,
+                },
+            })
+        }
     }
 }
 
@@ -361,6 +411,182 @@ mod test {
     use crate::plan::{Plan, TypedPlan};
     use crate::repr::{self, ColumnType, RelationType};
     use crate::transform::test::{create_test_ctx, create_test_query_engine, sql_to_substrait};
+
+    #[tokio::test]
+    async fn test_avg_group_by() {
+        let engine = create_test_query_engine();
+        let sql = "SELECT avg(number), number FROM numbers GROUP BY number";
+        let plan = sql_to_substrait(engine.clone(), sql).await;
+
+        let mut ctx = create_test_ctx();
+        let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
+
+        let aggr_exprs = vec![
+            AggregateExpr {
+                func: AggregateFunc::SumUInt32,
+                expr: ScalarExpr::Column(0),
+                distinct: false,
+            },
+            AggregateExpr {
+                func: AggregateFunc::Count,
+                expr: ScalarExpr::Column(0),
+                distinct: false,
+            },
+        ];
+        let avg_expr = ScalarExpr::If {
+            cond: Box::new(ScalarExpr::Column(2).call_binary(
+                ScalarExpr::Literal(Value::from(0u32), CDT::uint32_datatype()),
+                BinaryFunc::Eq,
+            )),
+            then: Box::new(ScalarExpr::Column(1).call_binary(
+                ScalarExpr::Column(2).call_unary(UnaryFunc::Cast(CDT::uint32_datatype())),
+                BinaryFunc::DivUInt32,
+            )),
+            els: Box::new(ScalarExpr::Literal(Value::Null, CDT::uint32_datatype())),
+        };
+        let expected = TypedPlan {
+            typ: RelationType::new(vec![
+                ColumnType::new(CDT::uint32_datatype(), true),
+                ColumnType::new(CDT::uint32_datatype(), false),
+            ]),
+            plan: Plan::Mfp {
+                input: Box::new(
+                    Plan::Reduce {
+                        input: Box::new(
+                            Plan::Get {
+                                id: crate::expr::Id::Global(GlobalId::User(0)),
+                            }
+                            .with_types(RelationType::new(vec![
+                                ColumnType::new(ConcreteDataType::uint32_datatype(), false),
+                            ])),
+                        ),
+                        key_val_plan: KeyValPlan {
+                            key_plan: MapFilterProject::new(1)
+                                .map(vec![ScalarExpr::Column(0)])
+                                .unwrap()
+                                .project(vec![1])
+                                .unwrap()
+                                .into_safe(),
+                            val_plan: MapFilterProject::new(1)
+                                .project(vec![0])
+                                .unwrap()
+                                .into_safe(),
+                        },
+                        reduce_plan: ReducePlan::Accumulable(AccumulablePlan {
+                            full_aggrs: aggr_exprs.clone(),
+                            simple_aggrs: vec![
+                                AggrWithIndex::new(aggr_exprs[0].clone(), 0, 0),
+                                AggrWithIndex::new(aggr_exprs[1].clone(), 0, 1),
+                            ],
+                            distinct_aggrs: vec![],
+                        }),
+                    }
+                    .with_types(
+                        RelationType::new(vec![
+                            ColumnType::new(ConcreteDataType::uint32_datatype(), false), // key: number
+                            ColumnType::new(ConcreteDataType::uint32_datatype(), true),  // sum
+                            ColumnType::new(ConcreteDataType::int64_datatype(), true),   // count
+                        ])
+                        .with_key(vec![0]),
+                    ),
+                ),
+                mfp: MapFilterProject::new(3)
+                    .map(vec![
+                        avg_expr, // col 3
+                        // TODO(discord9): optimize mfp so to remove indirect ref
+                        ScalarExpr::Column(3), // col 4
+                        ScalarExpr::Column(0), // col 5
+                    ])
+                    .unwrap()
+                    .project(vec![4, 5])
+                    .unwrap(),
+            },
+        };
+        assert_eq!(flow_plan.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_avg() {
+        let engine = create_test_query_engine();
+        let sql = "SELECT avg(number) FROM numbers";
+        let plan = sql_to_substrait(engine.clone(), sql).await;
+
+        let mut ctx = create_test_ctx();
+        let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
+        let typ = RelationType::new(vec![
+            ColumnType::new(ConcreteDataType::uint32_datatype(), true),
+            ColumnType::new(ConcreteDataType::int64_datatype(), true),
+        ]);
+        let aggr_exprs = vec![
+            AggregateExpr {
+                func: AggregateFunc::SumUInt32,
+                expr: ScalarExpr::Column(0),
+                distinct: false,
+            },
+            AggregateExpr {
+                func: AggregateFunc::Count,
+                expr: ScalarExpr::Column(0),
+                distinct: false,
+            },
+        ];
+        let avg_expr = ScalarExpr::If {
+            cond: Box::new(ScalarExpr::Column(1).call_binary(
+                ScalarExpr::Literal(Value::from(0u32), CDT::uint32_datatype()),
+                BinaryFunc::Eq,
+            )),
+            then: Box::new(ScalarExpr::Column(0).call_binary(
+                ScalarExpr::Column(1).call_unary(UnaryFunc::Cast(CDT::uint32_datatype())),
+                BinaryFunc::DivUInt32,
+            )),
+            els: Box::new(ScalarExpr::Literal(Value::Null, CDT::uint32_datatype())),
+        };
+        let expected = TypedPlan {
+            typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
+            plan: Plan::Mfp {
+                input: Box::new(
+                    Plan::Reduce {
+                        input: Box::new(
+                            Plan::Get {
+                                id: crate::expr::Id::Global(GlobalId::User(0)),
+                            }
+                            .with_types(RelationType::new(vec![
+                                ColumnType::new(ConcreteDataType::uint32_datatype(), false),
+                            ])),
+                        ),
+                        key_val_plan: KeyValPlan {
+                            key_plan: MapFilterProject::new(1)
+                                .project(vec![])
+                                .unwrap()
+                                .into_safe(),
+                            val_plan: MapFilterProject::new(1)
+                                .project(vec![0])
+                                .unwrap()
+                                .into_safe(),
+                        },
+                        reduce_plan: ReducePlan::Accumulable(AccumulablePlan {
+                            full_aggrs: aggr_exprs.clone(),
+                            simple_aggrs: vec![
+                                AggrWithIndex::new(aggr_exprs[0].clone(), 0, 0),
+                                AggrWithIndex::new(aggr_exprs[1].clone(), 0, 1),
+                            ],
+                            distinct_aggrs: vec![],
+                        }),
+                    }
+                    .with_types(typ),
+                ),
+                mfp: MapFilterProject::new(2)
+                    .map(vec![
+                        avg_expr,
+                        // TODO(discord9): optimize mfp so to remove indirect ref
+                        ScalarExpr::Column(2),
+                    ])
+                    .unwrap()
+                    .project(vec![3])
+                    .unwrap(),
+            },
+        };
+        assert_eq!(flow_plan.unwrap(), expected);
+    }
 
     #[tokio::test]
     async fn test_sum() {
@@ -411,9 +637,9 @@ mod test {
                     .with_types(typ),
                 ),
                 mfp: MapFilterProject::new(1)
-                    .map(vec![ScalarExpr::Column(0)])
+                    .map(vec![ScalarExpr::Column(0), ScalarExpr::Column(1)])
                     .unwrap()
-                    .project(vec![1])
+                    .project(vec![2])
                     .unwrap(),
             },
         };
@@ -477,9 +703,13 @@ mod test {
                     ),
                 ),
                 mfp: MapFilterProject::new(2)
-                    .map(vec![ScalarExpr::Column(1), ScalarExpr::Column(0)])
+                    .map(vec![
+                        ScalarExpr::Column(1),
+                        ScalarExpr::Column(2),
+                        ScalarExpr::Column(0),
+                    ])
                     .unwrap()
-                    .project(vec![2, 3])
+                    .project(vec![3, 4])
                     .unwrap(),
             },
         };
@@ -539,9 +769,9 @@ mod test {
                     )])),
                 ),
                 mfp: MapFilterProject::new(1)
-                    .map(vec![ScalarExpr::Column(0)])
+                    .map(vec![ScalarExpr::Column(0), ScalarExpr::Column(1)])
                     .unwrap()
-                    .project(vec![1])
+                    .project(vec![2])
                     .unwrap(),
             },
         };

--- a/src/flow/src/transform/aggr.rs
+++ b/src/flow/src/transform/aggr.rs
@@ -222,7 +222,7 @@ impl AggregateExpr {
         // make sure we wouldn't divide by zero
         let zero = ScalarExpr::literal(arg_type.default_value(), arg_type.clone());
         let non_zero = ScalarExpr::If {
-            cond: Box::new(ScalarExpr::Column(1).call_binary(zero.clone(), BinaryFunc::Eq)),
+            cond: Box::new(ScalarExpr::Column(1).call_binary(zero.clone(), BinaryFunc::NotEq)),
             then: Box::new(avg_output),
             els: Box::new(ScalarExpr::literal(Value::Null, arg_type.clone())),
         };
@@ -436,7 +436,7 @@ mod test {
         let avg_expr = ScalarExpr::If {
             cond: Box::new(ScalarExpr::Column(2).call_binary(
                 ScalarExpr::Literal(Value::from(0u32), CDT::uint32_datatype()),
-                BinaryFunc::Eq,
+                BinaryFunc::NotEq,
             )),
             then: Box::new(ScalarExpr::Column(1).call_binary(
                 ScalarExpr::Column(2).call_unary(UnaryFunc::Cast(CDT::uint32_datatype())),
@@ -532,7 +532,7 @@ mod test {
         let avg_expr = ScalarExpr::If {
             cond: Box::new(ScalarExpr::Column(1).call_binary(
                 ScalarExpr::Literal(Value::from(0u32), CDT::uint32_datatype()),
-                BinaryFunc::Eq,
+                BinaryFunc::NotEq,
             )),
             then: Box::new(ScalarExpr::Column(0).call_binary(
                 ScalarExpr::Column(1).call_unary(UnaryFunc::Cast(CDT::uint32_datatype())),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

added `avg` functino support

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- added `avg` function support, which will be rewrite to sum(x)/count(x) if count(x)!=0
- fix aggr func's signature's output type to be the real evaled type(i.e. SumUInt* -> u64, SumInt* -> i64)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
