### PR TITLE
feat(flow): expire arrange according to time_index type

### DIFF
--- a/src/flow/src/adapter/worker.rs
+++ b/src/flow/src/adapter/worker.rs
@@ -208,7 +208,6 @@ impl<'s> Worker<'s> {
         create_if_not_exist: bool,
         err_collector: ErrCollector,
     ) -> Result<Option<FlowId>, Error> {
-        let _ = expire_when;
         let already_exist = self.task_states.contains_key(&flow_id);
         match (already_exist, create_if_not_exist) {
             (true, true) => return Ok(None),
@@ -220,6 +219,7 @@ impl<'s> Worker<'s> {
             err_collector,
             ..Default::default()
         };
+        cur_task_state.state.set_expire_after(expire_when);
 
         {
             let mut ctx = cur_task_state.new_ctx(sink_id);

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -111,7 +111,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
                 input,
                 key_val_plan,
                 reduce_plan,
-            } => self.render_reduce(input, key_val_plan, reduce_plan),
+            } => self.render_reduce(input, key_val_plan, reduce_plan, plan.typ),
             Plan::Join { .. } => NotImplementedSnafu {
                 reason: "Join is still WIP",
             }

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -29,8 +29,8 @@ use crate::compute::types::{Arranged, Collection, CollectionBundle, ErrCollector
 use crate::expr::error::{DataTypeSnafu, InternalSnafu};
 use crate::expr::{AggregateExpr, EvalError, ScalarExpr};
 use crate::plan::{AccumulablePlan, AggrWithIndex, KeyValPlan, Plan, ReducePlan, TypedPlan};
-use crate::repr::{self, DiffRow, KeyValDiffRow, Row};
-use crate::utils::{ArrangeHandler, ArrangeReader, ArrangeWriter};
+use crate::repr::{self, DiffRow, KeyValDiffRow, RelationType, Row};
+use crate::utils::{ArrangeHandler, ArrangeReader, ArrangeWriter, KeyExpiryManager};
 
 impl<'referred, 'df> Context<'referred, 'df> {
     const REDUCE: &'static str = "reduce";
@@ -42,6 +42,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
         input: Box<TypedPlan>,
         key_val_plan: KeyValPlan,
         reduce_plan: ReducePlan,
+        output_type: RelationType,
     ) -> Result<CollectionBundle, Error> {
         let input = self.render_plan(*input)?;
         // first assembly key&val that's ((Row, Row), tick, diff)
@@ -52,6 +53,15 @@ impl<'referred, 'df> Context<'referred, 'df> {
 
         // TODO(discord9): config global expire time from self
         let arrange_handler = self.compute_state.new_arrange(None);
+
+        if let (Some(time_index), Some(expire_after)) =
+            (output_type.time_index, self.compute_state.expire_after())
+        {
+            let expire_man =
+                KeyExpiryManager::new(Some(expire_after), Some(ScalarExpr::Column(time_index)));
+            arrange_handler.write().set_expire_state(expire_man);
+        }
+
         // reduce need full arrangement to be able to query all keys
         let arrange_handler_inner = arrange_handler.clone_full_arrange().context(PlanSnafu {
             reason: "No write is expected at this point",
@@ -776,6 +786,7 @@ mod test {
                 Box::new(input_plan.with_types(typ)),
                 key_val_plan,
                 reduce_plan,
+                RelationType::empty(),
             )
             .unwrap();
 
@@ -850,6 +861,7 @@ mod test {
                 Box::new(input_plan.with_types(typ)),
                 key_val_plan,
                 reduce_plan,
+                RelationType::empty(),
             )
             .unwrap();
 
@@ -930,6 +942,7 @@ mod test {
                 Box::new(input_plan.with_types(typ)),
                 key_val_plan,
                 reduce_plan,
+                RelationType::empty(),
             )
             .unwrap();
 
@@ -1006,6 +1019,7 @@ mod test {
                 Box::new(input_plan.with_types(typ)),
                 key_val_plan,
                 reduce_plan,
+                RelationType::empty(),
             )
             .unwrap();
 
@@ -1097,6 +1111,7 @@ mod test {
                 Box::new(input_plan.with_types(typ)),
                 key_val_plan,
                 reduce_plan,
+                RelationType::empty(),
             )
             .unwrap();
 

--- a/src/flow/src/compute/state.rs
+++ b/src/flow/src/compute/state.rs
@@ -102,6 +102,10 @@ impl DataflowState {
         self.err_collector.clone()
     }
 
+    pub fn set_expire_after(&mut self, after: Option<repr::Duration>) {
+        self.expire_after = after;
+    }
+
     pub fn expire_after(&self) -> Option<Timestamp> {
         self.expire_after
     }

--- a/src/flow/src/compute/state.rs
+++ b/src/flow/src/compute/state.rs
@@ -42,6 +42,8 @@ pub struct DataflowState {
     /// save all used arrange in this dataflow, since usually there is no delete operation
     /// we can just keep track of all used arrange and schedule subgraph when they need to be updated
     arrange_used: Vec<ArrangeHandler>,
+    /// the time arrangement need to be expired after a certain time in milliseconds
+    expire_after: Option<Timestamp>,
 }
 
 impl DataflowState {
@@ -98,6 +100,10 @@ impl DataflowState {
 
     pub fn get_err_collector(&self) -> ErrCollector {
         self.err_collector.clone()
+    }
+
+    pub fn expire_after(&self) -> Option<Timestamp> {
+        self.expire_after
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

set arrangement's expire time with `TypedPlan`'s time index

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Set arrangement's expire time with `TypedPlan`'s time index
- Added expire when to dataflow's state, so `render_reduce` can access it and set arrangement to expire accordingly

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
