### PR TITLE
test: gracefully shutdown postgres client in sql tests

### DIFF
--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -431,8 +431,10 @@ pub async fn test_postgres_bytea(store_type: StorageType) {
     let (client, connection) = tokio_postgres::connect(&format!("postgres://{addr}/public"), NoTls)
         .await
         .unwrap();
+    let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         connection.await.unwrap();
+        tx.send(()).unwrap();
     });
     let _ = client
         .simple_query("CREATE TABLE test(b BLOB, ts TIMESTAMP TIME INDEX)")
@@ -485,6 +487,9 @@ pub async fn test_postgres_bytea(store_type: StorageType) {
     let val: Vec<u8> = row.get("b");
     assert_eq!(val, [97, 98, 99, 107, 108, 109, 42, 169, 84]);
 
+    drop(client);
+    rx.await.unwrap();
+
     let _ = fe_pg_server.shutdown().await;
     guard.remove_all().await;
 }
@@ -496,8 +501,10 @@ pub async fn test_postgres_datestyle(store_type: StorageType) {
         .await
         .unwrap();
 
+    let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         connection.await.unwrap();
+        tx.send(()).unwrap();
     });
 
     let validate_datestyle = |client: Client, datestyle: &str, is_valid: bool| {
@@ -707,6 +714,9 @@ pub async fn test_postgres_datestyle(store_type: StorageType) {
         }
     }
 
+    drop(client);
+    rx.await.unwrap();
+
     let _ = fe_pg_server.shutdown().await;
     guard.remove_all().await;
 }
@@ -718,8 +728,10 @@ pub async fn test_postgres_timezone(store_type: StorageType) {
         .await
         .unwrap();
 
+    let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         connection.await.unwrap();
+        tx.send(()).unwrap();
     });
 
     let get_row = |mess: Vec<SimpleQueryMessage>| -> String {
@@ -762,6 +774,10 @@ pub async fn test_postgres_timezone(store_type: StorageType) {
             .unwrap(),
     );
     assert_eq!(timezone, "UTC");
+
+    drop(client);
+    rx.await.unwrap();
+
     let _ = fe_pg_server.shutdown().await;
     guard.remove_all().await;
 }
@@ -773,8 +789,10 @@ pub async fn test_postgres_parameter_inference(store_type: StorageType) {
         .await
         .unwrap();
 
+    let (tx, rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
         connection.await.unwrap();
+        tx.send(()).unwrap();
     });
 
     // Create demo table
@@ -799,6 +817,10 @@ pub async fn test_postgres_parameter_inference(store_type: StorageType) {
         .unwrap();
 
     assert_eq!(1, rows.len());
+
+    // Shutdown the client.
+    drop(client);
+    rx.await.unwrap();
 
     let _ = fe_pg_server.shutdown().await;
     guard.remove_all().await;

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -36,8 +36,12 @@ macro_rules! sql_test {
                         #[$meta]
                     )*
                     async fn [< $test >]() {
+                        common_telemetry::init_default_ut_logging();
+
                         let store_type = tests_integration::test_util::StorageType::$service;
                         if store_type.test_on() {
+                            common_telemetry::info!("test {} starts, store_type: {:?}", stringify!($test), store_type);
+
                             let _ = $crate::sql::$test(store_type).await;
                         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Some tests of our postgres server failed on macOS
```bash
integration_sql_file_test::test_postgres_parameter_inference ---
thread 'tokio-runtime-worker' panicked at tests-integration/tests/sql.rs:773:26:
called `Result::unwrap()` on an `Err` value: Error { kind: Io, cause: Some(Os { code: 54, kind: ConnectionReset, message: "Connection reset by peer" }) }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
```

After adding some logs, I found that the test finished and the server was shut down. We unwrap the result from the connection in tests so the test is panic if the server is shut down.
```rust
connection.await.unwrap();
```

This PR drops the client and then waits for the connection before shutting down the server.

The macOS action with this patch:
https://github.com/GreptimeTeam/greptimedb/actions/runs/9108898568

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
