### PR TITLE
refactor(naming): use the better naming for pubsub

### DIFF
--- a/src/meta-srv/src/handler/publish_heartbeat_handler.rs
+++ b/src/meta-srv/src/handler/publish_heartbeat_handler.rs
@@ -18,15 +18,15 @@ use async_trait::async_trait;
 use crate::error::Result;
 use crate::handler::{HandleControl, HeartbeatAccumulator, HeartbeatHandler};
 use crate::metasrv::Context;
-use crate::pubsub::{Message, PublishRef};
+use crate::pubsub::{Message, PublisherRef};
 
 pub struct PublishHeartbeatHandler {
-    publish: PublishRef,
+    publisher: PublisherRef,
 }
 
 impl PublishHeartbeatHandler {
-    pub fn new(publish: PublishRef) -> PublishHeartbeatHandler {
-        PublishHeartbeatHandler { publish }
+    pub fn new(publisher: PublisherRef) -> PublishHeartbeatHandler {
+        PublishHeartbeatHandler { publisher }
     }
 }
 
@@ -43,7 +43,7 @@ impl HeartbeatHandler for PublishHeartbeatHandler {
         _: &mut HeartbeatAccumulator,
     ) -> Result<HandleControl> {
         let msg = Message::Heartbeat(Box::new(req.clone()));
-        self.publish.send_msg(msg).await;
+        self.publisher.publish(msg).await;
 
         Ok(HandleControl::Continue)
     }

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -66,7 +66,7 @@ use crate::metasrv::{
 use crate::procedure::region_failover::RegionFailoverManager;
 use crate::procedure::region_migration::manager::RegionMigrationManager;
 use crate::procedure::region_migration::DefaultContextFactory;
-use crate::pubsub::PublishRef;
+use crate::pubsub::PublisherRef;
 use crate::selector::lease_based::LeaseBasedSelector;
 use crate::service::mailbox::MailboxRef;
 use crate::service::store::cached_kv::LeaderCachedKvBackend;
@@ -320,7 +320,7 @@ impl MetasrvBuilder {
 
                 let publish_heartbeat_handler = plugins
                     .clone()
-                    .and_then(|plugins| plugins.get::<PublishRef>())
+                    .and_then(|plugins| plugins.get::<PublisherRef>())
                     .map(|publish| PublishHeartbeatHandler::new(publish.clone()));
 
                 let region_lease_handler = RegionLeaseHandler::new(

--- a/src/meta-srv/src/pubsub.rs
+++ b/src/meta-srv/src/pubsub.rs
@@ -20,10 +20,10 @@ mod subscriber;
 #[cfg(test)]
 mod tests;
 
-pub use publish::{DefaultPublish, Publish, PublishRef};
+pub use publish::{DefaultPublisher, Publisher, PublisherRef};
 pub use subscribe_manager::{
-    AddSubRequest, DefaultSubscribeManager, SubscribeManager, SubscribeManagerRef, SubscribeQuery,
-    UnSubRequest,
+    DefaultSubscribeManager, SubscribeRequest, SubscriptionManager, SubscriptionManagerRef,
+    SubscriptionQuery, UnsubscribeRequest,
 };
 pub use subscriber::{Subscriber, SubscriberRef, Transport};
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Refactor the naming of pubsub and use names that are more in line with conventions, for example:

- `publish` / `subscribe` / `unsubscribe`
- `subscription`

...

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
