### PR TITLE
feat: skip read-only region when trying to flush on region full

### DIFF
--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -396,7 +396,7 @@ impl TwcsCompactionTask {
             compacted_inputs.extend(output.inputs.iter().map(FileHandle::meta));
 
             info!(
-                "Compaction region {} output [{}]-> {}",
+                "Compaction region {}. Input [{}] -> output {}",
                 self.region_id,
                 output
                     .inputs

--- a/src/mito2/src/flush.rs
+++ b/src/mito2/src/flush.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use common_telemetry::{error, info};
+use common_telemetry::{debug, error, info};
 use smallvec::SmallVec;
 use snafu::ResultExt;
 use store_api::storage::RegionId;
@@ -118,7 +118,7 @@ impl WriteBufferManager for WriteBufferManagerImpl {
     fn should_flush_engine(&self) -> bool {
         let mutable_memtable_memory_usage = self.memory_active.load(Ordering::Relaxed);
         if mutable_memtable_memory_usage > self.mutable_limit {
-            info!(
+            debug!(
                 "Engine should flush (over mutable limit), mutable_usage: {}, memory_usage: {}, mutable_limit: {}, global_limit: {}",
                 mutable_memtable_memory_usage, self.memory_usage(), self.mutable_limit, self.global_write_buffer_size,
             );
@@ -132,7 +132,7 @@ impl WriteBufferManager for WriteBufferManagerImpl {
         if memory_usage >= self.global_write_buffer_size
             && mutable_memtable_memory_usage >= self.global_write_buffer_size / 2
         {
-            info!(
+            debug!(
                 "Engine should flush (over total limit), memory_usage: {}, global_write_buffer_size: {}, \
                  mutable_usage: {}.",
                 memory_usage,

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -85,8 +85,8 @@ impl<S> RegionWorkerLoop<S> {
         let mut max_mem_region = None;
 
         for region in &regions {
-            if self.flush_scheduler.is_flush_requested(region.region_id) {
-                // Already flushing.
+            if self.flush_scheduler.is_flush_requested(region.region_id) || !region.is_writable() {
+                // Already flushing or not writable.
                 continue;
             }
 

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -134,8 +134,8 @@ impl<S> RegionWorkerLoop<S> {
         let min_last_flush_time = now - self.config.auto_flush_interval.as_millis() as i64;
 
         for region in &regions {
-            if self.flush_scheduler.is_flush_requested(region.region_id) {
-                // Already flushing.
+            if self.flush_scheduler.is_flush_requested(region.region_id) || !region.is_writable() {
+                // Already flushing or not writable.
                 continue;
             }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Read-only regions cannot be flushed. Skip them on trying to pick one when engine is full

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
