### PR TITLE
fix: changing column data type can't process type alias

### DIFF
--- a/src/sql/src/statements/alter.rs
+++ b/src/sql/src/statements/alter.rs
@@ -39,6 +39,10 @@ impl AlterTable {
     pub fn alter_operation(&self) -> &AlterTableOperation {
         &self.alter_operation
     }
+
+    pub fn alter_operation_mut(&mut self) -> &mut AlterTableOperation {
+        &mut self.alter_operation
+    }
 }
 
 impl Display for AlterTable {

--- a/src/sql/src/statements/transform/type_alias.rs
+++ b/src/sql/src/statements/transform/type_alias.rs
@@ -20,6 +20,7 @@ use sqlparser::ast::{
 };
 
 use crate::error::Result;
+use crate::statements::alter::AlterTableOperation;
 use crate::statements::create::{CreateExternalTable, CreateTable};
 use crate::statements::statement::Statement;
 use crate::statements::transform::TransformRule;
@@ -50,6 +51,13 @@ impl TransformRule for TypeAliasTransformRule {
                 columns
                     .iter_mut()
                     .for_each(|ColumnDef { data_type, .. }| replace_type_alias(data_type));
+            }
+            Statement::Alter(alter_table) => {
+                if let AlterTableOperation::ChangeColumnType { target_type, .. } =
+                    alter_table.alter_operation_mut()
+                {
+                    replace_type_alias(target_type)
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fixed `alter table modify column` statement change column data type can't process data type alias. For example:

```
alter table monitor modify column host TinyText
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
