### PR TITLE
refactor:  make the command entry cleaner

### DIFF
--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use clap::{Parser, Subcommand};
 use cmd::error::Result;
 use cmd::options::{GlobalOptions, Options};
-use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, start_app, App};
+use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, App};
 use common_version::{short_version, version};
 
 #[derive(Parser)]
@@ -134,9 +134,7 @@ async fn start(cli: Command) -> Result<()> {
 
     log_versions(version!(), short_version!());
 
-    let app = subcmd.build(opts).await?;
-
-    start_app(app).await
+    subcmd.build(opts).await?.run().await
 }
 
 fn setup_human_panic() {

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -14,11 +14,9 @@
 
 #![doc = include_str!("../../../../README.md")]
 
-use std::fmt;
-
 use clap::{Parser, Subcommand};
 use cmd::error::Result;
-use cmd::options::{GlobalOptions, Options};
+use cmd::options::GlobalOptions;
 use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, App};
 use common_version::{short_version, version};
 
@@ -56,58 +54,6 @@ enum SubCommand {
     Cli(cli::Command),
 }
 
-impl SubCommand {
-    async fn build(self, opts: Options) -> Result<Box<dyn App>> {
-        let app: Box<dyn App> = match (self, opts) {
-            (SubCommand::Datanode(cmd), Options::Datanode(dn_opts)) => {
-                let app = cmd.build(*dn_opts).await?;
-                Box::new(app) as _
-            }
-            (SubCommand::Frontend(cmd), Options::Frontend(fe_opts)) => {
-                let app = cmd.build(*fe_opts).await?;
-                Box::new(app) as _
-            }
-            (SubCommand::Metasrv(cmd), Options::Metasrv(meta_opts)) => {
-                let app = cmd.build(*meta_opts).await?;
-                Box::new(app) as _
-            }
-            (SubCommand::Standalone(cmd), Options::Standalone(opts)) => {
-                let app = cmd.build(*opts).await?;
-                Box::new(app) as _
-            }
-            (SubCommand::Cli(cmd), Options::Cli(_)) => {
-                let app = cmd.build().await?;
-                Box::new(app) as _
-            }
-
-            _ => unreachable!(),
-        };
-        Ok(app)
-    }
-
-    fn load_options(&self, global_options: &GlobalOptions) -> Result<Options> {
-        match self {
-            SubCommand::Datanode(cmd) => cmd.load_options(global_options),
-            SubCommand::Frontend(cmd) => cmd.load_options(global_options),
-            SubCommand::Metasrv(cmd) => cmd.load_options(global_options),
-            SubCommand::Standalone(cmd) => cmd.load_options(global_options),
-            SubCommand::Cli(cmd) => cmd.load_options(global_options),
-        }
-    }
-}
-
-impl fmt::Display for SubCommand {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            SubCommand::Datanode(..) => write!(f, "greptime-datanode"),
-            SubCommand::Frontend(..) => write!(f, "greptime-frontend"),
-            SubCommand::Metasrv(..) => write!(f, "greptime-metasrv"),
-            SubCommand::Standalone(..) => write!(f, "greptime-standalone"),
-            SubCommand::Cli(_) => write!(f, "greptime-cli"),
-        }
-    }
-}
-
 #[cfg(not(windows))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -115,26 +61,43 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[tokio::main]
 async fn main() -> Result<()> {
     setup_human_panic();
+    log_versions(version!(), short_version!());
     start(Command::parse()).await
 }
 
 async fn start(cli: Command) -> Result<()> {
-    let subcmd = cli.subcmd;
-
-    let app_name = subcmd.to_string();
-
-    let opts = subcmd.load_options(&cli.global_options)?;
-
-    let _guard = common_telemetry::init_global_logging(
-        &app_name,
-        opts.logging_options(),
-        &cli.global_options.tracing_options(),
-        opts.node_id(),
-    );
-
-    log_versions(version!(), short_version!());
-
-    subcmd.build(opts).await?.run().await
+    match cli.subcmd {
+        SubCommand::Datanode(cmd) => {
+            cmd.build(cmd.load_options(&cli.global_options)?)
+                .await?
+                .run()
+                .await
+        }
+        SubCommand::Frontend(cmd) => {
+            cmd.build(cmd.load_options(&cli.global_options)?)
+                .await?
+                .run()
+                .await
+        }
+        SubCommand::Metasrv(cmd) => {
+            cmd.build(cmd.load_options(&cli.global_options)?)
+                .await?
+                .run()
+                .await
+        }
+        SubCommand::Standalone(cmd) => {
+            cmd.build(cmd.load_options(&cli.global_options)?)
+                .await?
+                .run()
+                .await
+        }
+        SubCommand::Cli(cmd) => {
+            cmd.build(cmd.load_options(&cli.global_options)?)
+                .await?
+                .run()
+                .await
+        }
+    }
 }
 
 fn setup_human_panic() {

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -72,21 +72,6 @@ pub trait App: Send {
     }
 }
 
-/// AppBuilder is a trait builds the App from the options and starts the App.
-#[async_trait]
-pub trait AppBuilder: Default {
-    /// Build the options. The final options will be merged from multiple sources(e.g. config file, cli arguments) and stored in the builder.
-    fn build_options(self) -> Result<Self>;
-
-    /// Build the App. After the options are built, the App can be built from the options.
-    async fn build_app(self) -> Result<Box<dyn App>>;
-
-    /// Build the options and app, then start the app.
-    async fn start(self) -> Result<()> {
-        self.build_options()?.build_app().await?.run().await
-    }
-}
-
 /// Log the versions of the application, and the arguments passed to the cli.
 /// `version_string` should be the same as the output of cli "--version";
 /// and the `app_version` is the short version of the codes, often consist of git branch and commit.

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -72,6 +72,21 @@ pub trait App: Send {
     }
 }
 
+/// AppBuilder is a trait builds the App from the options and starts the App.
+#[async_trait]
+pub trait AppBuilder: Default {
+    /// Build the options. The final options will be merged from multiple sources(e.g. config file, cli arguments) and stored in the builder.
+    fn build_options(self) -> Result<Self>;
+
+    /// Build the App. After the options are built, the App can be built from the options.
+    async fn build_app(self) -> Result<Box<dyn App>>;
+
+    /// Build the options and app, then start the app.
+    async fn start(self) -> Result<()> {
+        self.build_options()?.build_app().await?.run().await
+    }
+}
+
 /// Log the versions of the application, and the arguments passed to the cli.
 /// `version_string` should be the same as the output of cli "--version";
 /// and the `app_version` is the short version of the codes, often consist of git branch and commit.

--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -17,6 +17,8 @@
 use async_trait::async_trait;
 use common_telemetry::{error, info};
 
+use crate::error::Result;
+
 pub mod cli;
 pub mod datanode;
 pub mod error;
@@ -35,39 +37,39 @@ pub trait App: Send {
     fn name(&self) -> &str;
 
     /// A hook for implementor to make something happened before actual startup. Defaults to no-op.
-    async fn pre_start(&mut self) -> error::Result<()> {
+    async fn pre_start(&mut self) -> Result<()> {
         Ok(())
     }
 
-    async fn start(&mut self) -> error::Result<()>;
+    async fn start(&mut self) -> Result<()>;
 
     /// Waits the quit signal by default.
     fn wait_signal(&self) -> bool {
         true
     }
 
-    async fn stop(&self) -> error::Result<()>;
-}
+    async fn stop(&self) -> Result<()>;
 
-pub async fn start_app(mut app: Box<dyn App>) -> error::Result<()> {
-    info!("Starting app: {}", app.name());
+    async fn run(&mut self) -> Result<()> {
+        info!("Starting app: {}", self.name());
 
-    app.pre_start().await?;
+        self.pre_start().await?;
 
-    app.start().await?;
+        self.start().await?;
 
-    if app.wait_signal() {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            error!("Failed to listen for ctrl-c signal: {}", e);
-            // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
-            // the underlying system. So we stop the app instead of running nonetheless to let people
-            // investigate the issue.
+        if self.wait_signal() {
+            if let Err(e) = tokio::signal::ctrl_c().await {
+                error!("Failed to listen for ctrl-c signal: {}", e);
+                // It's unusual to fail to listen for ctrl-c signal, maybe there's something unexpected in
+                // the underlying system. So we stop the app instead of running nonetheless to let people
+                // investigate the issue.
+            }
         }
-    }
 
-    app.stop().await?;
-    info!("Goodbye!");
-    Ok(())
+        self.stop().await?;
+        info!("Goodbye!");
+        Ok(())
+    }
 }
 
 /// Log the versions of the application, and the arguments passed to the cli.

--- a/src/cmd/src/options.rs
+++ b/src/cmd/src/options.rs
@@ -13,20 +13,6 @@
 // limitations under the License.
 
 use clap::Parser;
-use common_telemetry::logging::{LoggingOptions, TracingOptions};
-use datanode::config::DatanodeOptions;
-use frontend::frontend::FrontendOptions;
-use meta_srv::metasrv::MetasrvOptions;
-
-use crate::standalone::StandaloneOptions;
-
-pub enum Options {
-    Datanode(Box<DatanodeOptions>),
-    Frontend(Box<FrontendOptions>),
-    Metasrv(Box<MetasrvOptions>),
-    Standalone(Box<StandaloneOptions>),
-    Cli(Box<LoggingOptions>),
-}
 
 #[derive(Parser, Default, Debug, Clone)]
 pub struct GlobalOptions {
@@ -42,33 +28,4 @@ pub struct GlobalOptions {
     #[clap(long, value_name = "TOKIO_CONSOLE_ADDR")]
     #[arg(global = true)]
     pub tokio_console_addr: Option<String>,
-}
-
-impl GlobalOptions {
-    pub fn tracing_options(&self) -> TracingOptions {
-        TracingOptions {
-            #[cfg(feature = "tokio-console")]
-            tokio_console_addr: self.tokio_console_addr.clone(),
-        }
-    }
-}
-
-impl Options {
-    pub fn logging_options(&self) -> &LoggingOptions {
-        match self {
-            Options::Datanode(opts) => &opts.logging,
-            Options::Frontend(opts) => &opts.logging,
-            Options::Metasrv(opts) => &opts.logging,
-            Options::Standalone(opts) => &opts.logging,
-            Options::Cli(opts) => opts,
-        }
-    }
-
-    pub fn node_id(&self) -> Option<String> {
-        match self {
-            Options::Metasrv(_) | Options::Cli(_) | Options::Standalone(_) => None,
-            Options::Datanode(opt) => opt.node_id.map(|x| x.to_string()),
-            Options::Frontend(opt) => opt.node_id.clone(),
-        }
-    }
 }

--- a/tests-integration/src/database.rs
+++ b/tests-integration/src/database.rs
@@ -274,9 +274,10 @@ mod tests {
     use clap::Parser;
     use client::Client;
     use cmd::error::Result as CmdResult;
-    use cmd::options::{GlobalOptions, Options};
+    use cmd::options::GlobalOptions;
     use cmd::{cli, standalone, App};
     use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
+    use common_telemetry::logging::LoggingOptions;
 
     use super::{Database, FlightContext};
 
@@ -312,12 +313,9 @@ mod tests {
             "--data-home",
             &*output_dir.path().to_string_lossy(),
         ]);
-        let Options::Standalone(standalone_opts) =
-            standalone.load_options(&GlobalOptions::default())?
-        else {
-            unreachable!()
-        };
-        let mut instance = standalone.build(*standalone_opts).await?;
+
+        let standalone_opts = standalone.load_options(&GlobalOptions::default()).unwrap();
+        let mut instance = standalone.build(standalone_opts).await?;
         instance.start().await?;
 
         let client = Client::with_urls(["127.0.0.1:4001"]);
@@ -348,7 +346,7 @@ mod tests {
             "--target",
             "create-table",
         ]);
-        let mut cli_app = cli.build().await?;
+        let mut cli_app = cli.build(LoggingOptions::default()).await?;
         cli_app.start().await?;
 
         instance.stop().await?;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**NOTE**: The PR is decoupled with draft PR https://github.com/GreptimeTeam/greptimedb/pull/3941, and it's just a simple refactoring based on the original implementation.

- **Remove** `Options{}` and some related methods, and all the building process of options can be in their app(for example, `datanode.rs`/`metasrv.rs`/...);

- **Remove** `SubCommand.build()` and `SubCommand.load_options()` which are unnecessary;

- **Move** `common_telemetry::init_global_logging` into `<app>:build()` which can be easy to receive the arguments;

- **Move** `start_app()` into `App` and rename `run()`;

- Make `common_telemetry::init_global_logging` init once, or it will fail in integration test (what an ugly function...);



## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
