### PR TITLE
docs: add v0.8.0 TSBS report

### DIFF
--- a/docs/benchmarks/tsbs/v0.8.0.md
+++ b/docs/benchmarks/tsbs/v0.8.0.md
@@ -1,0 +1,58 @@
+# TSBS benchmark - v0.8.0
+
+## Environment
+
+### Local
+
+|        |                                    |
+| ------ | ---------------------------------- |
+| CPU    | AMD Ryzen 7 7735HS (8 core 3.2GHz) |
+| Memory | 32GB                               |
+| Disk   | SOLIDIGM SSDPFKNU010TZ             |
+| OS     | Ubuntu 22.04.2 LTS                 |
+
+### Amazon EC2
+
+|         |                |
+| ------- | -------------- |
+| Machine | c5d.2xlarge    |
+| CPU     | 8 core         |
+| Memory  | 16GB           |
+| Disk    | 50GB (GP3)     |
+| OS      | Ubuntu 22.04.1 |
+
+## Write performance
+
+| Environment     | Ingest rate (rows/s) |
+| --------------- | -------------------- |
+| Local           | 315369.66            |
+| EC2 c5d.2xlarge | 222148.56            |
+
+## Query performance
+
+| Query type            | Local (ms) | EC2 c5d.2xlarge (ms) |
+| --------------------- | ---------- | -------------------- |
+| cpu-max-all-1         | 24.63      | 15.29                |
+| cpu-max-all-8         | 51.69      | 33.53                |
+| double-groupby-1      | 673.51     | 1295.38              |
+| double-groupby-5      | 1244.93    | 1993.91              |
+| double-groupby-all    | 2215.44    | 3056.77              |
+| groupby-orderby-limit | 754.50     | 1546.49              |
+| high-cpu-1            | 19.62      | 11.58                |
+| high-cpu-all          | 5402.31    | 8011.43              |
+| lastpoint             | 6756.12    | 9312.67              |
+| single-groupby-1-1-1  | 15.70      | 7.67                 |
+| single-groupby-1-1-12 | 16.72      | 9.29                 |
+| single-groupby-1-8-1  | 26.72      | 17.97                |
+| single-groupby-5-1-1  | 18.17      | 10.09                |
+| single-groupby-5-1-12 | 20.04      | 12.37                |
+| single-groupby-5-8-1  | 35.63      | 23.13                |
+
+`single-groupby-1-1-1` query throughput
+
+| Environment     | Client concurrency | mean time (ms) | qps (queries/sec) |
+| --------------- | ------------------ | -------------- | ----------------- |
+| Local           | 50                 | 42.87          | 1165.73           |
+| Local           | 100                | 89.29          | 1119.38           |
+| EC2 c5d.2xlarge | 50                 | 69.25          | 721.73            |
+| EC2 c5d.2xlarge | 100                | 140.93         | 709.35            |


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- https://github.com/GreptimeTeam/greptimedb/issues/3959

## What's changed and what's your intention?
Adds v0.8.0 TSBS benchmark results to docs.

There is a regression in the ingest rate compared to v0.7.0. A possible cause is that we switch to the `time_series` memtable but the impact under TSBS should be small. We may need further investigation.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
