### PR TITLE
feat: manual compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,7 +4233,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=a11db14b8502f55ca5348917fd18e6fcf140f55e#a11db14b8502f55ca5348917fd18e6fcf140f55e"
+source = "git+https://github.com/v0y4g3r/greptime-proto.git?rev=3025c3da404c2c9ecc074757e7e76a78440ef20c#3025c3da404c2c9ecc074757e7e76a78440ef20c"
 dependencies = [
  "prost 0.12.4",
  "serde",
@@ -10538,6 +10538,7 @@ dependencies = [
  "datatypes",
  "derive_builder 0.12.0",
  "futures",
+ "greptime-proto",
  "humantime",
  "humantime-serde",
  "parquet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,7 +4233,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/v0y4g3r/greptime-proto.git?rev=3025c3da404c2c9ecc074757e7e76a78440ef20c#3025c3da404c2c9ecc074757e7e76a78440ef20c"
+source = "git+https://github.com/v0y4g3r/greptime-proto.git?rev=b10371f5270e31170b5f4cc8e3e705c8f9882308#b10371f5270e31170b5f4cc8e3e705c8f9882308"
 dependencies = [
  "prost 0.12.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,7 +4233,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/v0y4g3r/greptime-proto.git?rev=b10371f5270e31170b5f4cc8e3e705c8f9882308#b10371f5270e31170b5f4cc8e3e705c8f9882308"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=3cd71167ee067c5679a7fb17cf58bdfbb5487a0d#3cd71167ee067c5679a7fb17cf58bdfbb5487a0d"
 dependencies = [
  "prost 0.12.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev 
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "983852dcd661eaead2b9da5bd21462e15a629d40" }
+greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "3025c3da404c2c9ecc074757e7e76a78440ef20c" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev 
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "a11db14b8502f55ca5348917fd18e6fcf140f55e" }
+greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "983852dcd661eaead2b9da5bd21462e15a629d40" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev 
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "b10371f5270e31170b5f4cc8e3e705c8f9882308" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "3cd71167ee067c5679a7fb17cf58bdfbb5487a0d" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev 
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "3025c3da404c2c9ecc074757e7e76a78440ef20c" }
+greptime-proto = { git = "https://github.com/v0y4g3r/greptime-proto.git", rev = "b10371f5270e31170b5f4cc8e3e705c8f9882308" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/src/common/function/src/table/flush_compact_table.rs
+++ b/src/common/function/src/table/flush_compact_table.rs
@@ -66,7 +66,7 @@ pub(crate) async fn flush_table(
         .fail();
     };
 
-    let (catalog_name, schema_name, table_name) = table_name_to_full_name(table_name, &query_ctx)
+    let (catalog_name, schema_name, table_name) = table_name_to_full_name(table_name, query_ctx)
         .map_err(BoxedError::new)
         .context(TableMutationSnafu)?;
 
@@ -125,9 +125,9 @@ fn parse_compact_params(
     query_ctx: &QueryContextRef,
 ) -> Result<CompactTableRequest> {
     ensure!(
-        params.len() >= 1,
+        !params.is_empty(),
         InvalidFuncArgsSnafu {
-            err_msg: "The length of the args is not correct, expect at least 1",
+            err_msg: "Args cannot be empty",
         }
     );
 
@@ -139,7 +139,7 @@ fn parse_compact_params(
         .fail();
     };
 
-    let (catalog_name, schema_name, table_name) = table_name_to_full_name(table_name, &query_ctx)
+    let (catalog_name, schema_name, table_name) = table_name_to_full_name(table_name, query_ctx)
         .map_err(BoxedError::new)
         .context(TableMutationSnafu)?;
 

--- a/src/common/function/src/table/flush_compact_table.rs
+++ b/src/common/function/src/table/flush_compact_table.rs
@@ -203,6 +203,7 @@ mod tests {
     use std::sync::Arc;
 
     use api::v1::region::compact_request::Options;
+    use common_catalog::consts::{DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME};
     use common_query::prelude::TypeSignature;
     use datatypes::vectors::{StringVector, UInt64Vector};
     use session::context::QueryContext;
@@ -288,35 +289,38 @@ mod tests {
             (
                 &["table"],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "public".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::Regular(Default::default()),
                 },
             ),
             (
-                &["a.table"],
+                &[&format!("{}.table", DEFAULT_SCHEMA_NAME)],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "a".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::Regular(Default::default()),
                 },
             ),
             (
-                &["a.b.c"],
+                &[&format!(
+                    "{}.{}.table",
+                    DEFAULT_CATALOG_NAME, DEFAULT_SCHEMA_NAME
+                )],
                 CompactTableRequest {
-                    catalog_name: "a".to_string(),
-                    schema_name: "b".to_string(),
-                    table_name: "c".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
+                    table_name: "table".to_string(),
                     compact_options: Options::Regular(Default::default()),
                 },
             ),
             (
                 &["table", "regular"],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "public".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::Regular(Default::default()),
                 },
@@ -324,8 +328,8 @@ mod tests {
             (
                 &["table", "strict_window"],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "public".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::StrictWindow(StrictWindow { window_seconds: 0 }),
                 },
@@ -333,8 +337,8 @@ mod tests {
             (
                 &["table", "strict_window", "3600"],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "public".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::StrictWindow(StrictWindow {
                         window_seconds: 3600,
@@ -344,8 +348,8 @@ mod tests {
             (
                 &["table", "regular", "abcd"],
                 CompactTableRequest {
-                    catalog_name: "greptime".to_string(),
-                    schema_name: "public".to_string(),
+                    catalog_name: DEFAULT_CATALOG_NAME.to_string(),
+                    schema_name: DEFAULT_SCHEMA_NAME.to_string(),
                     table_name: "table".to_string(),
                     compact_options: Options::Regular(Default::default()),
                 },
@@ -354,6 +358,15 @@ mod tests {
 
         assert!(parse_compact_params(
             &["table", "strict_window", "abc"]
+                .into_iter()
+                .map(ValueRef::String)
+                .collect::<Vec<_>>(),
+            &QueryContext::arc(),
+        )
+        .is_err());
+
+        assert!(parse_compact_params(
+            &["a.b.table", "strict_window", "abc"]
                 .into_iter()
                 .map(ValueRef::String)
                 .collect::<Vec<_>>(),

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -219,6 +219,7 @@ impl RegionServerHandler for RegionServer {
             .context(BuildRegionRequestsSnafu)
             .map_err(BoxedError::new)
             .context(ExecuteGrpcRequestSnafu)?;
+
         let tracing_context = TracingContext::from_current_span();
 
         let results = if is_parallel {

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod buckets;
+mod picker;
+mod task;
+#[cfg(test)]
+mod test_util;
+mod twcs;
+mod window;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -53,14 +61,6 @@ use crate::sst::file::{FileHandle, FileId, Level};
 use crate::sst::file_purger::FilePurgerRef;
 use crate::sst::version::LevelMeta;
 use crate::worker::WorkerListener;
-
-mod buckets;
-mod picker;
-mod task;
-#[cfg(test)]
-mod test_util;
-mod twcs;
-mod window;
 
 /// Region compaction request.
 pub struct CompactionRequest {

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -425,6 +425,7 @@ pub(crate) struct CompactionOutput {
 async fn build_sst_reader(
     metadata: RegionMetadataRef,
     sst_layer: AccessLayerRef,
+    cache: Option<CacheManagerRef>,
     inputs: &[FileHandle],
     append_mode: bool,
     filter_deleted: bool,
@@ -433,6 +434,7 @@ async fn build_sst_reader(
     let mut scan_input = ScanInput::new(sst_layer, ProjectionMapper::all(&metadata)?)
         .with_files(inputs.to_vec())
         .with_append_mode(append_mode)
+        .with_cache(cache)
         .with_filter_deleted(filter_deleted)
         // We ignore file not found error during compaction.
         .with_ignore_file_not_found(true);

--- a/src/mito2/src/compaction/buckets.rs
+++ b/src/mito2/src/compaction/buckets.rs
@@ -1,0 +1,126 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use common_time::timestamp::TimeUnit;
+use common_time::Timestamp;
+
+use crate::sst::file::FileHandle;
+
+/// Infers the suitable time bucket duration.
+/// Now it simply find the max and min timestamp across all SSTs in level and fit the time span
+/// into time bucket.
+pub(crate) fn infer_time_bucket<'a>(files: impl Iterator<Item = &'a FileHandle>) -> i64 {
+    let mut max_ts = Timestamp::new(i64::MIN, TimeUnit::Second);
+    let mut min_ts = Timestamp::new(i64::MAX, TimeUnit::Second);
+
+    for f in files {
+        let (start, end) = f.time_range();
+        min_ts = min_ts.min(start);
+        max_ts = max_ts.max(end);
+    }
+
+    // safety: Convert whatever timestamp into seconds will not cause overflow.
+    let min_sec = min_ts.convert_to(TimeUnit::Second).unwrap().value();
+    let max_sec = max_ts.convert_to(TimeUnit::Second).unwrap().value();
+
+    max_sec
+        .checked_sub(min_sec)
+        .map(|span| TIME_BUCKETS.fit_time_bucket(span)) // return the max bucket on subtraction overflow.
+        .unwrap_or_else(|| TIME_BUCKETS.max()) // safety: TIME_BUCKETS cannot be empty.
+}
+
+pub(crate) struct TimeBuckets([i64; 7]);
+
+impl TimeBuckets {
+    /// Fits a given time span into time bucket by find the minimum bucket that can cover the span.
+    /// Returns the max bucket if no such bucket can be found.
+    fn fit_time_bucket(&self, span_sec: i64) -> i64 {
+        assert!(span_sec >= 0);
+        match self.0.binary_search(&span_sec) {
+            Ok(idx) => self.0[idx],
+            Err(idx) => {
+                if idx < self.0.len() {
+                    self.0[idx]
+                } else {
+                    self.0.last().copied().unwrap()
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn get(&self, idx: usize) -> i64 {
+        self.0[idx]
+    }
+
+    fn max(&self) -> i64 {
+        self.0.last().copied().unwrap()
+    }
+}
+
+/// A set of predefined time buckets.
+pub(crate) const TIME_BUCKETS: TimeBuckets = TimeBuckets([
+    60 * 60,                 // one hour
+    2 * 60 * 60,             // two hours
+    12 * 60 * 60,            // twelve hours
+    24 * 60 * 60,            // one day
+    7 * 24 * 60 * 60,        // one week
+    365 * 24 * 60 * 60,      // one year
+    10 * 365 * 24 * 60 * 60, // ten years
+]);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compaction::test_util::new_file_handle;
+    use crate::sst::file::FileId;
+
+    #[test]
+    fn test_time_bucket() {
+        assert_eq!(TIME_BUCKETS.get(0), TIME_BUCKETS.fit_time_bucket(1));
+        assert_eq!(TIME_BUCKETS.get(0), TIME_BUCKETS.fit_time_bucket(60 * 60));
+        assert_eq!(
+            TIME_BUCKETS.get(1),
+            TIME_BUCKETS.fit_time_bucket(60 * 60 + 1)
+        );
+
+        assert_eq!(
+            TIME_BUCKETS.get(2),
+            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(2) - 1)
+        );
+        assert_eq!(
+            TIME_BUCKETS.get(2),
+            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(2))
+        );
+        assert_eq!(
+            TIME_BUCKETS.get(3),
+            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(3) - 1)
+        );
+        assert_eq!(TIME_BUCKETS.get(6), TIME_BUCKETS.fit_time_bucket(i64::MAX));
+    }
+
+    #[test]
+    fn test_infer_time_buckets() {
+        assert_eq!(
+            TIME_BUCKETS.get(0),
+            infer_time_bucket(
+                [
+                    new_file_handle(FileId::random(), 0, TIME_BUCKETS.get(0) * 1000 - 1, 0),
+                    new_file_handle(FileId::random(), 1, 10_000, 0)
+                ]
+                .iter()
+            )
+        );
+    }
+}

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -1,0 +1,317 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use common_telemetry::{error, info};
+use smallvec::SmallVec;
+use snafu::ResultExt;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::RegionId;
+use tokio::sync::mpsc;
+
+use crate::access_layer::{AccessLayerRef, SstWriteRequest};
+use crate::cache::CacheManagerRef;
+use crate::compaction::picker::CompactionTask;
+use crate::compaction::{build_sst_reader, CompactionOutput};
+use crate::config::MitoConfig;
+use crate::error;
+use crate::error::CompactRegionSnafu;
+use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
+use crate::metrics::{COMPACTION_FAILURE_COUNT, COMPACTION_STAGE_ELAPSED};
+use crate::read::Source;
+use crate::region::options::IndexOptions;
+use crate::region::version::VersionControlRef;
+use crate::region::{ManifestContextRef, RegionState};
+use crate::request::{
+    BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
+};
+use crate::sst::file::{FileHandle, FileMeta, IndexType};
+use crate::sst::file_purger::FilePurgerRef;
+use crate::sst::parquet::WriteOptions;
+use crate::worker::WorkerListener;
+
+const MAX_PARALLEL_COMPACTION: usize = 8;
+
+pub(crate) struct CompactionTaskImpl {
+    pub engine_config: Arc<MitoConfig>,
+    pub region_id: RegionId,
+    pub metadata: RegionMetadataRef,
+    pub sst_layer: AccessLayerRef,
+    pub outputs: Vec<CompactionOutput>,
+    pub expired_ssts: Vec<FileHandle>,
+    pub compaction_time_window: Option<i64>,
+    pub file_purger: FilePurgerRef,
+    /// Request sender to notify the worker.
+    pub(crate) request_sender: mpsc::Sender<WorkerRequest>,
+    /// Senders that are used to notify waiters waiting for pending compaction tasks.
+    pub waiters: Vec<OutputTx>,
+    /// Start time of compaction task
+    pub start_time: Instant,
+    pub(crate) cache_manager: CacheManagerRef,
+    /// Target storage of the region.
+    pub(crate) storage: Option<String>,
+    /// Index options of the region.
+    pub(crate) index_options: IndexOptions,
+    /// The region is using append mode.
+    pub(crate) append_mode: bool,
+    /// Manifest context.
+    pub(crate) manifest_ctx: ManifestContextRef,
+    /// Version control to update.
+    pub(crate) version_control: VersionControlRef,
+    /// Event listener.
+    pub(crate) listener: WorkerListener,
+}
+
+impl Debug for CompactionTaskImpl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TwcsCompactionTask")
+            .field("region_id", &self.region_id)
+            .field("outputs", &self.outputs)
+            .field("expired_ssts", &self.expired_ssts)
+            .field("compaction_time_window", &self.compaction_time_window)
+            .field("append_mode", &self.append_mode)
+            .finish()
+    }
+}
+
+impl Drop for CompactionTaskImpl {
+    fn drop(&mut self) {
+        self.mark_files_compacting(false)
+    }
+}
+
+impl CompactionTaskImpl {
+    fn mark_files_compacting(&self, compacting: bool) {
+        self.outputs
+            .iter()
+            .flat_map(|o| o.inputs.iter())
+            .for_each(|f| f.set_compacting(compacting))
+    }
+
+    /// Merges all SST files.
+    /// Returns `(output files, input files)`.
+    async fn merge_ssts(&mut self) -> error::Result<(Vec<FileMeta>, Vec<FileMeta>)> {
+        let mut futs = Vec::with_capacity(self.outputs.len());
+        let mut compacted_inputs =
+            Vec::with_capacity(self.outputs.iter().map(|o| o.inputs.len()).sum());
+
+        for output in self.outputs.drain(..) {
+            compacted_inputs.extend(output.inputs.iter().map(FileHandle::meta));
+
+            info!(
+                "Compaction region {} output [{}]-> {}",
+                self.region_id,
+                output
+                    .inputs
+                    .iter()
+                    .map(|f| f.file_id().to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                output.output_file_id
+            );
+
+            let write_opts = WriteOptions {
+                write_buffer_size: self.engine_config.sst_write_buffer_size,
+                ..Default::default()
+            };
+            let create_inverted_index = self
+                .engine_config
+                .inverted_index
+                .create_on_compaction
+                .auto();
+            let mem_threshold_index_create = self
+                .engine_config
+                .inverted_index
+                .mem_threshold_on_create
+                .map(|m| m.as_bytes() as _);
+            let index_write_buffer_size = Some(
+                self.engine_config
+                    .inverted_index
+                    .write_buffer_size
+                    .as_bytes() as usize,
+            );
+
+            let metadata = self.metadata.clone();
+            let sst_layer = self.sst_layer.clone();
+            let region_id = self.region_id;
+            let file_id = output.output_file_id;
+            let cache_manager = self.cache_manager.clone();
+            let storage = self.storage.clone();
+            let index_options = self.index_options.clone();
+            let append_mode = self.append_mode;
+            futs.push(async move {
+                let reader = build_sst_reader(
+                    metadata.clone(),
+                    sst_layer.clone(),
+                    &output.inputs,
+                    append_mode,
+                    output.filter_deleted,
+                    output.output_time_range,
+                )
+                .await?;
+                let file_meta_opt = sst_layer
+                    .write_sst(
+                        SstWriteRequest {
+                            file_id,
+                            metadata,
+                            source: Source::Reader(reader),
+                            cache_manager,
+                            storage,
+                            create_inverted_index,
+                            mem_threshold_index_create,
+                            index_write_buffer_size,
+                            index_options,
+                        },
+                        &write_opts,
+                    )
+                    .await?
+                    .map(|sst_info| FileMeta {
+                        region_id,
+                        file_id,
+                        time_range: sst_info.time_range,
+                        level: output.output_level,
+                        file_size: sst_info.file_size,
+                        available_indexes: sst_info
+                            .inverted_index_available
+                            .then(|| SmallVec::from_iter([IndexType::InvertedIndex]))
+                            .unwrap_or_default(),
+                        index_file_size: sst_info.index_file_size,
+                    });
+                Ok(file_meta_opt)
+            });
+        }
+
+        let mut output_files = Vec::with_capacity(futs.len());
+        while !futs.is_empty() {
+            let mut task_chunk = Vec::with_capacity(MAX_PARALLEL_COMPACTION);
+            for _ in 0..MAX_PARALLEL_COMPACTION {
+                if let Some(task) = futs.pop() {
+                    task_chunk.push(common_runtime::spawn_bg(task));
+                }
+            }
+            let metas = futures::future::try_join_all(task_chunk)
+                .await
+                .context(error::JoinSnafu)?
+                .into_iter()
+                .collect::<error::Result<Vec<_>>>()?;
+            output_files.extend(metas.into_iter().flatten());
+        }
+
+        let inputs = compacted_inputs.into_iter().collect();
+        Ok((output_files, inputs))
+    }
+
+    async fn handle_compaction(&mut self) -> error::Result<()> {
+        self.mark_files_compacting(true);
+        let merge_timer = COMPACTION_STAGE_ELAPSED
+            .with_label_values(&["merge"])
+            .start_timer();
+        let (added, mut deleted) = match self.merge_ssts().await {
+            Ok(v) => v,
+            Err(e) => {
+                error!(e; "Failed to compact region: {}", self.region_id);
+                merge_timer.stop_and_discard();
+                return Err(e);
+            }
+        };
+        deleted.extend(self.expired_ssts.iter().map(FileHandle::meta));
+        let merge_time = merge_timer.stop_and_record();
+        info!(
+            "Compacted SST files, region_id: {}, input: {:?}, output: {:?}, window: {:?}, waiter_num: {}, merge_time: {}s",
+            self.region_id,
+            deleted,
+            added,
+            self.compaction_time_window,
+            self.waiters.len(),
+            merge_time,
+        );
+
+        self.listener.on_merge_ssts_finished(self.region_id).await;
+
+        let _manifest_timer = COMPACTION_STAGE_ELAPSED
+            .with_label_values(&["write_manifest"])
+            .start_timer();
+        // Write region edit to manifest.
+        let edit = RegionEdit {
+            files_to_add: added,
+            files_to_remove: deleted,
+            compaction_time_window: self
+                .compaction_time_window
+                .map(|seconds| Duration::from_secs(seconds as u64)),
+            flushed_entry_id: None,
+            flushed_sequence: None,
+        };
+        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
+        // We might leak files if we fail to update manifest. We can add a cleanup task to
+        // remove them later.
+        self.manifest_ctx
+            .update_manifest(RegionState::Writable, action_list, || {
+                self.version_control
+                    .apply_edit(edit, &[], self.file_purger.clone());
+            })
+            .await
+    }
+
+    /// Handles compaction failure, notifies all waiters.
+    fn on_failure(&mut self, err: Arc<error::Error>) {
+        COMPACTION_FAILURE_COUNT.inc();
+        for waiter in self.waiters.drain(..) {
+            waiter.send(Err(err.clone()).context(CompactRegionSnafu {
+                region_id: self.region_id,
+            }));
+        }
+    }
+
+    /// Notifies region worker to handle post-compaction tasks.
+    async fn send_to_worker(&self, request: WorkerRequest) {
+        if let Err(e) = self.request_sender.send(request).await {
+            error!(
+                "Failed to notify compaction job status for region {}, request: {:?}",
+                self.region_id, e.0
+            );
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CompactionTask for CompactionTaskImpl {
+    async fn run(&mut self) {
+        let notify = match self.handle_compaction().await {
+            Ok(()) => BackgroundNotify::CompactionFinished(CompactionFinished {
+                region_id: self.region_id,
+                senders: std::mem::take(&mut self.waiters),
+                start_time: self.start_time,
+            }),
+            Err(e) => {
+                error!(e; "Failed to compact region, region id: {}", self.region_id);
+                let err = Arc::new(e);
+                // notify compaction waiters
+                self.on_failure(err.clone());
+                BackgroundNotify::CompactionFailed(CompactionFailed {
+                    region_id: self.region_id,
+                    err,
+                })
+            }
+        };
+
+        self.send_to_worker(WorkerRequest::Background {
+            region_id: self.region_id,
+            notify,
+        })
+        .await;
+    }
+}

--- a/src/mito2/src/compaction/task.rs
+++ b/src/mito2/src/compaction/task.rs
@@ -157,6 +157,7 @@ impl CompactionTaskImpl {
                 let reader = build_sst_reader(
                     metadata.clone(),
                     sst_layer.clone(),
+                    Some(cache_manager.clone()),
                     &output.inputs,
                     append_mode,
                     output.filter_deleted,

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -139,6 +139,7 @@ impl Picker for TwcsPicker {
             engine_config,
             current_version,
             access_layer,
+            compact_type,
             request_sender,
             waiters,
             file_purger,

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -15,44 +15,18 @@
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
 
-use common_telemetry::{debug, error, info};
+use common_telemetry::{debug, info};
 use common_time::timestamp::TimeUnit;
 use common_time::timestamp_millis::BucketAligned;
 use common_time::Timestamp;
-use smallvec::SmallVec;
-use snafu::ResultExt;
-use store_api::metadata::RegionMetadataRef;
-use store_api::storage::RegionId;
-use tokio::sync::mpsc;
 
-use crate::access_layer::{AccessLayerRef, SstWriteRequest};
-use crate::cache::CacheManagerRef;
+use crate::compaction::buckets::infer_time_bucket;
 use crate::compaction::picker::{CompactionTask, Picker};
-use crate::compaction::CompactionRequest;
-use crate::config::MitoConfig;
-use crate::error::{self, CompactRegionSnafu};
-use crate::manifest::action::{RegionEdit, RegionMetaAction, RegionMetaActionList};
-use crate::metrics::{COMPACTION_FAILURE_COUNT, COMPACTION_STAGE_ELAPSED};
-use crate::read::projection::ProjectionMapper;
-use crate::read::scan_region::ScanInput;
-use crate::read::seq_scan::SeqScan;
-use crate::read::{BoxedBatchReader, Source};
-use crate::region::options::IndexOptions;
-use crate::region::version::VersionControlRef;
-use crate::region::{ManifestContextRef, RegionState};
-use crate::request::{
-    BackgroundNotify, CompactionFailed, CompactionFinished, OutputTx, WorkerRequest,
-};
-use crate::sst::file::{FileHandle, FileId, FileMeta, IndexType, Level};
-use crate::sst::file_purger::FilePurgerRef;
-use crate::sst::parquet::WriteOptions;
+use crate::compaction::task::CompactionTaskImpl;
+use crate::compaction::{get_expired_ssts, CompactionOutput, CompactionRequest};
+use crate::sst::file::{FileHandle, FileId};
 use crate::sst::version::LevelMeta;
-use crate::worker::WorkerListener;
-
-const MAX_PARALLEL_COMPACTION: usize = 8;
 
 /// `TwcsPicker` picks files of which the max timestamp are in the same time window as compaction
 /// candidates.
@@ -107,6 +81,7 @@ impl TwcsPicker {
                         output_level: 1, // we only have two levels and always compact to l1
                         inputs: files_in_window.clone(),
                         filter_deleted,
+                        output_time_range: None, // we do not enforce output time range in twcs compactions.
                     });
                 } else {
                     debug!("Active window not present or no enough files in active window {:?}, window: {}", active_window, *window);
@@ -119,6 +94,7 @@ impl TwcsPicker {
                         output_level: 1,
                         inputs: files_in_window.clone(),
                         filter_deleted,
+                        output_time_range: None,
                     });
                 } else {
                     debug!(
@@ -189,7 +165,7 @@ impl Picker for TwcsPicker {
             }
             return None;
         }
-        let task = TwcsCompactionTask {
+        let task = CompactionTaskImpl {
             engine_config,
             region_id,
             metadata: region_metadata,
@@ -328,393 +304,6 @@ fn find_latest_window_in_seconds<'a>(
     latest_timestamp
         .and_then(|ts| ts.convert_to_ceil(TimeUnit::Second))
         .and_then(|ts| ts.value().align_to_ceil_by_bucket(time_window_size))
-}
-
-pub(crate) struct TwcsCompactionTask {
-    pub engine_config: Arc<MitoConfig>,
-    pub region_id: RegionId,
-    pub metadata: RegionMetadataRef,
-    pub sst_layer: AccessLayerRef,
-    pub outputs: Vec<CompactionOutput>,
-    pub expired_ssts: Vec<FileHandle>,
-    pub compaction_time_window: Option<i64>,
-    pub file_purger: FilePurgerRef,
-    /// Request sender to notify the worker.
-    pub(crate) request_sender: mpsc::Sender<WorkerRequest>,
-    /// Senders that are used to notify waiters waiting for pending compaction tasks.
-    pub waiters: Vec<OutputTx>,
-    /// Start time of compaction task
-    pub start_time: Instant,
-    pub(crate) cache_manager: CacheManagerRef,
-    /// Target storage of the region.
-    pub(crate) storage: Option<String>,
-    /// Index options of the region.
-    pub(crate) index_options: IndexOptions,
-    /// The region is using append mode.
-    pub(crate) append_mode: bool,
-    /// Manifest context.
-    pub(crate) manifest_ctx: ManifestContextRef,
-    /// Version control to update.
-    pub(crate) version_control: VersionControlRef,
-    /// Event listener.
-    pub(crate) listener: WorkerListener,
-}
-
-impl Debug for TwcsCompactionTask {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TwcsCompactionTask")
-            .field("region_id", &self.region_id)
-            .field("outputs", &self.outputs)
-            .field("expired_ssts", &self.expired_ssts)
-            .field("compaction_time_window", &self.compaction_time_window)
-            .field("append_mode", &self.append_mode)
-            .finish()
-    }
-}
-
-impl Drop for TwcsCompactionTask {
-    fn drop(&mut self) {
-        self.mark_files_compacting(false)
-    }
-}
-
-impl TwcsCompactionTask {
-    fn mark_files_compacting(&self, compacting: bool) {
-        self.outputs
-            .iter()
-            .flat_map(|o| o.inputs.iter())
-            .for_each(|f| f.set_compacting(compacting))
-    }
-
-    /// Merges all SST files.
-    /// Returns `(output files, input files)`.
-    async fn merge_ssts(&mut self) -> error::Result<(Vec<FileMeta>, Vec<FileMeta>)> {
-        let mut futs = Vec::with_capacity(self.outputs.len());
-        let mut compacted_inputs =
-            Vec::with_capacity(self.outputs.iter().map(|o| o.inputs.len()).sum());
-
-        for output in self.outputs.drain(..) {
-            compacted_inputs.extend(output.inputs.iter().map(FileHandle::meta));
-
-            info!(
-                "Compaction region {}. Input [{}] -> output {}",
-                self.region_id,
-                output
-                    .inputs
-                    .iter()
-                    .map(|f| f.file_id().to_string())
-                    .collect::<Vec<_>>()
-                    .join(","),
-                output.output_file_id
-            );
-
-            let write_opts = WriteOptions {
-                write_buffer_size: self.engine_config.sst_write_buffer_size,
-                ..Default::default()
-            };
-            let create_inverted_index = self
-                .engine_config
-                .inverted_index
-                .create_on_compaction
-                .auto();
-            let mem_threshold_index_create = self
-                .engine_config
-                .inverted_index
-                .mem_threshold_on_create
-                .map(|m| m.as_bytes() as _);
-            let index_write_buffer_size = Some(
-                self.engine_config
-                    .inverted_index
-                    .write_buffer_size
-                    .as_bytes() as usize,
-            );
-
-            let metadata = self.metadata.clone();
-            let sst_layer = self.sst_layer.clone();
-            let region_id = self.region_id;
-            let file_id = output.output_file_id;
-            let cache_manager = self.cache_manager.clone();
-            let storage = self.storage.clone();
-            let index_options = self.index_options.clone();
-            let append_mode = self.append_mode;
-            futs.push(async move {
-                let reader = build_sst_reader(
-                    metadata.clone(),
-                    sst_layer.clone(),
-                    Some(cache_manager.clone()),
-                    &output.inputs,
-                    append_mode,
-                    output.filter_deleted,
-                )
-                .await?;
-                let file_meta_opt = sst_layer
-                    .write_sst(
-                        SstWriteRequest {
-                            file_id,
-                            metadata,
-                            source: Source::Reader(reader),
-                            cache_manager,
-                            storage,
-                            create_inverted_index,
-                            mem_threshold_index_create,
-                            index_write_buffer_size,
-                            index_options,
-                        },
-                        &write_opts,
-                    )
-                    .await?
-                    .map(|sst_info| FileMeta {
-                        region_id,
-                        file_id,
-                        time_range: sst_info.time_range,
-                        level: output.output_level,
-                        file_size: sst_info.file_size,
-                        available_indexes: sst_info
-                            .inverted_index_available
-                            .then(|| SmallVec::from_iter([IndexType::InvertedIndex]))
-                            .unwrap_or_default(),
-                        index_file_size: sst_info.index_file_size,
-                    });
-                Ok(file_meta_opt)
-            });
-        }
-
-        let mut output_files = Vec::with_capacity(futs.len());
-        while !futs.is_empty() {
-            let mut task_chunk = Vec::with_capacity(MAX_PARALLEL_COMPACTION);
-            for _ in 0..MAX_PARALLEL_COMPACTION {
-                if let Some(task) = futs.pop() {
-                    task_chunk.push(common_runtime::spawn_bg(task));
-                }
-            }
-            let metas = futures::future::try_join_all(task_chunk)
-                .await
-                .context(error::JoinSnafu)?
-                .into_iter()
-                .collect::<error::Result<Vec<_>>>()?;
-            output_files.extend(metas.into_iter().flatten());
-        }
-
-        let inputs = compacted_inputs.into_iter().collect();
-        Ok((output_files, inputs))
-    }
-
-    async fn handle_compaction(&mut self) -> error::Result<()> {
-        self.mark_files_compacting(true);
-        let merge_timer = COMPACTION_STAGE_ELAPSED
-            .with_label_values(&["merge"])
-            .start_timer();
-        let (added, mut deleted) = match self.merge_ssts().await {
-            Ok(v) => v,
-            Err(e) => {
-                error!(e; "Failed to compact region: {}", self.region_id);
-                merge_timer.stop_and_discard();
-                return Err(e);
-            }
-        };
-        deleted.extend(self.expired_ssts.iter().map(FileHandle::meta));
-        let merge_time = merge_timer.stop_and_record();
-        info!(
-            "Compacted SST files, region_id: {}, input: {:?}, output: {:?}, window: {:?}, waiter_num: {}, merge_time: {}s",
-            self.region_id,
-            deleted,
-            added,
-            self.compaction_time_window,
-            self.waiters.len(),
-            merge_time,
-        );
-
-        self.listener.on_merge_ssts_finished(self.region_id).await;
-
-        let _manifest_timer = COMPACTION_STAGE_ELAPSED
-            .with_label_values(&["write_manifest"])
-            .start_timer();
-        // Write region edit to manifest.
-        let edit = RegionEdit {
-            files_to_add: added,
-            files_to_remove: deleted,
-            compaction_time_window: self
-                .compaction_time_window
-                .map(|seconds| Duration::from_secs(seconds as u64)),
-            flushed_entry_id: None,
-            flushed_sequence: None,
-        };
-        let action_list = RegionMetaActionList::with_action(RegionMetaAction::Edit(edit.clone()));
-        // We might leak files if we fail to update manifest. We can add a cleanup task to
-        // remove them later.
-        self.manifest_ctx
-            .update_manifest(RegionState::Writable, action_list, || {
-                self.version_control
-                    .apply_edit(edit, &[], self.file_purger.clone());
-            })
-            .await
-    }
-
-    /// Handles compaction failure, notifies all waiters.
-    fn on_failure(&mut self, err: Arc<error::Error>) {
-        COMPACTION_FAILURE_COUNT.inc();
-        for waiter in self.waiters.drain(..) {
-            waiter.send(Err(err.clone()).context(CompactRegionSnafu {
-                region_id: self.region_id,
-            }));
-        }
-    }
-
-    /// Notifies region worker to handle post-compaction tasks.
-    async fn send_to_worker(&self, request: WorkerRequest) {
-        if let Err(e) = self.request_sender.send(request).await {
-            error!(
-                "Failed to notify compaction job status for region {}, request: {:?}",
-                self.region_id, e.0
-            );
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl CompactionTask for TwcsCompactionTask {
-    async fn run(&mut self) {
-        let notify = match self.handle_compaction().await {
-            Ok(()) => BackgroundNotify::CompactionFinished(CompactionFinished {
-                region_id: self.region_id,
-                senders: std::mem::take(&mut self.waiters),
-                start_time: self.start_time,
-            }),
-            Err(e) => {
-                error!(e; "Failed to compact region, region id: {}", self.region_id);
-                let err = Arc::new(e);
-                // notify compaction waiters
-                self.on_failure(err.clone());
-                BackgroundNotify::CompactionFailed(CompactionFailed {
-                    region_id: self.region_id,
-                    err,
-                })
-            }
-        };
-
-        self.send_to_worker(WorkerRequest::Background {
-            region_id: self.region_id,
-            notify,
-        })
-        .await;
-    }
-}
-
-/// Infers the suitable time bucket duration.
-/// Now it simply find the max and min timestamp across all SSTs in level and fit the time span
-/// into time bucket.
-pub(crate) fn infer_time_bucket<'a>(files: impl Iterator<Item = &'a FileHandle>) -> i64 {
-    let mut max_ts = Timestamp::new(i64::MIN, TimeUnit::Second);
-    let mut min_ts = Timestamp::new(i64::MAX, TimeUnit::Second);
-
-    for f in files {
-        let (start, end) = f.time_range();
-        min_ts = min_ts.min(start);
-        max_ts = max_ts.max(end);
-    }
-
-    // safety: Convert whatever timestamp into seconds will not cause overflow.
-    let min_sec = min_ts.convert_to(TimeUnit::Second).unwrap().value();
-    let max_sec = max_ts.convert_to(TimeUnit::Second).unwrap().value();
-
-    max_sec
-        .checked_sub(min_sec)
-        .map(|span| TIME_BUCKETS.fit_time_bucket(span)) // return the max bucket on subtraction overflow.
-        .unwrap_or_else(|| TIME_BUCKETS.max()) // safety: TIME_BUCKETS cannot be empty.
-}
-
-pub(crate) struct TimeBuckets([i64; 7]);
-
-impl TimeBuckets {
-    /// Fits a given time span into time bucket by find the minimum bucket that can cover the span.
-    /// Returns the max bucket if no such bucket can be found.
-    fn fit_time_bucket(&self, span_sec: i64) -> i64 {
-        assert!(span_sec >= 0);
-        match self.0.binary_search(&span_sec) {
-            Ok(idx) => self.0[idx],
-            Err(idx) => {
-                if idx < self.0.len() {
-                    self.0[idx]
-                } else {
-                    self.0.last().copied().unwrap()
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    fn get(&self, idx: usize) -> i64 {
-        self.0[idx]
-    }
-
-    fn max(&self) -> i64 {
-        self.0.last().copied().unwrap()
-    }
-}
-
-/// A set of predefined time buckets.
-pub(crate) const TIME_BUCKETS: TimeBuckets = TimeBuckets([
-    60 * 60,                 // one hour
-    2 * 60 * 60,             // two hours
-    12 * 60 * 60,            // twelve hours
-    24 * 60 * 60,            // one day
-    7 * 24 * 60 * 60,        // one week
-    365 * 24 * 60 * 60,      // one year
-    10 * 365 * 24 * 60 * 60, // ten years
-]);
-
-/// Finds all expired SSTs across levels.
-fn get_expired_ssts(
-    levels: &[LevelMeta],
-    ttl: Option<Duration>,
-    now: Timestamp,
-) -> Vec<FileHandle> {
-    let Some(ttl) = ttl else {
-        return vec![];
-    };
-
-    let expire_time = match now.sub_duration(ttl) {
-        Ok(expire_time) => expire_time,
-        Err(e) => {
-            error!(e; "Failed to calculate region TTL expire time");
-            return vec![];
-        }
-    };
-
-    levels
-        .iter()
-        .flat_map(|l| l.get_expired_files(&expire_time).into_iter())
-        .collect()
-}
-
-#[derive(Debug)]
-pub(crate) struct CompactionOutput {
-    pub output_file_id: FileId,
-    /// Compaction output file level.
-    pub output_level: Level,
-    /// Compaction input files.
-    pub inputs: Vec<FileHandle>,
-    /// Whether to remove deletion markers.
-    pub filter_deleted: bool,
-}
-
-/// Builds [BoxedBatchReader] that reads all SST files and yields batches in primary key order.
-async fn build_sst_reader(
-    metadata: RegionMetadataRef,
-    sst_layer: AccessLayerRef,
-    cache: Option<CacheManagerRef>,
-    inputs: &[FileHandle],
-    append_mode: bool,
-    filter_deleted: bool,
-) -> error::Result<BoxedBatchReader> {
-    let scan_input = ScanInput::new(sst_layer, ProjectionMapper::all(&metadata)?)
-        .with_files(inputs.to_vec())
-        .with_cache(cache)
-        .with_append_mode(append_mode)
-        .with_filter_deleted(filter_deleted)
-        // We ignore file not found error during compaction.
-        .with_ignore_file_not_found(true);
-    SeqScan::new(scan_input).build_reader().await
 }
 
 #[cfg(test)]
@@ -1016,44 +605,6 @@ mod tests {
             ],
         }
         .check();
-    }
-
-    #[test]
-    fn test_time_bucket() {
-        assert_eq!(TIME_BUCKETS.get(0), TIME_BUCKETS.fit_time_bucket(1));
-        assert_eq!(TIME_BUCKETS.get(0), TIME_BUCKETS.fit_time_bucket(60 * 60));
-        assert_eq!(
-            TIME_BUCKETS.get(1),
-            TIME_BUCKETS.fit_time_bucket(60 * 60 + 1)
-        );
-
-        assert_eq!(
-            TIME_BUCKETS.get(2),
-            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(2) - 1)
-        );
-        assert_eq!(
-            TIME_BUCKETS.get(2),
-            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(2))
-        );
-        assert_eq!(
-            TIME_BUCKETS.get(3),
-            TIME_BUCKETS.fit_time_bucket(TIME_BUCKETS.get(3) - 1)
-        );
-        assert_eq!(TIME_BUCKETS.get(6), TIME_BUCKETS.fit_time_bucket(i64::MAX));
-    }
-
-    #[test]
-    fn test_infer_time_buckets() {
-        assert_eq!(
-            TIME_BUCKETS.get(0),
-            infer_time_bucket(
-                [
-                    new_file_handle(FileId::random(), 0, TIME_BUCKETS.get(0) * 1000 - 1, 0),
-                    new_file_handle(FileId::random(), 1, 10_000, 0)
-                ]
-                .iter()
-            )
-        );
     }
 
     // TODO(hl): TTL tester that checks if get_expired_ssts function works as expected.

--- a/src/mito2/src/compaction/twcs.rs
+++ b/src/mito2/src/compaction/twcs.rs
@@ -115,7 +115,6 @@ impl Picker for TwcsPicker {
             engine_config,
             current_version,
             access_layer,
-            compact_type,
             request_sender,
             waiters,
             file_purger,
@@ -124,6 +123,7 @@ impl Picker for TwcsPicker {
             manifest_ctx,
             version_control,
             listener,
+            ..
         } = req;
 
         let region_metadata = current_version.metadata.clone();

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -15,8 +15,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use api::v1::region::compact_type::Ty;
-use api::v1::region::CompactType;
+use api::v1::region::compact_request;
 use common_telemetry::info;
 use common_time::range::TimestampRange;
 use common_time::timestamp::TimeUnit;
@@ -53,13 +52,13 @@ impl WindowedCompactionPicker {
     fn calculate_time_window(
         &self,
         region_id: RegionId,
-        compact_type: CompactType,
+        options: compact_request::Options,
         current_version: &VersionRef,
     ) -> i64 {
-        let window = if let Some(Ty::StrictWindow(w)) = &compact_type.ty {
-            if w.window != 0 {
+        let window = if let compact_request::Options::StrictWindow(w) = &options {
+            if w.window_seconds != 0 {
                 // 0 means window is not provided.
-                Some(w.window)
+                Some(w.window_seconds)
             } else {
                 None
             }
@@ -90,7 +89,7 @@ impl Picker for WindowedCompactionPicker {
             engine_config,
             current_version,
             access_layer,
-            compact_type,
+            compact_options: compact_type,
             request_sender,
             waiters,
             file_purger,

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -1,0 +1,220 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::BTreeMap;
+use std::fmt::{Debug, Formatter};
+
+use api::v1::region::compact_type::Ty;
+use api::v1::region::CompactType;
+use common_telemetry::info;
+use common_time::range::TimestampRange;
+use common_time::timestamp::TimeUnit;
+use common_time::timestamp_millis::BucketAligned;
+use common_time::Timestamp;
+use store_api::storage::RegionId;
+
+use crate::compaction::buckets::infer_time_bucket;
+use crate::compaction::picker::{CompactionTask, Picker};
+use crate::compaction::task::CompactionTaskImpl;
+use crate::compaction::{get_expired_ssts, CompactionOutput, CompactionRequest};
+use crate::region::version::VersionRef;
+use crate::sst::file::{FileHandle, FileId};
+
+/// Compaction picker that splits the time range of all involved files to windows, and merges
+/// the data segments intersects with those windows of files together so that the output files
+/// never overlaps.
+#[derive(Debug)]
+pub struct WindowedCompactionPicker {
+    compaction_time_window_seconds: Option<i64>,
+}
+
+impl WindowedCompactionPicker {
+    // Computes compaction time window. First we respect user specified parameter, then
+    // use persisted window. If persist window is not present, we check the time window
+    // provided while creating table. If all of those are absent, we infer the window
+    // from files in level0.
+    fn calculate_time_window(
+        &self,
+        region_id: RegionId,
+        compact_type: CompactType,
+        current_version: &VersionRef,
+    ) -> i64 {
+        let window = if let Some(Ty::StrictWindow(w)) = &compact_type.ty {
+            if w.window != 0 {
+                // 0 means window is not provided.
+                Some(w.window)
+            } else {
+                None
+            }
+        } else {
+            unreachable!()
+        };
+        window
+            .or(current_version
+                .compaction_time_window
+                .map(|t| t.as_secs() as i64))
+            .or(self.compaction_time_window_seconds)
+            .unwrap_or_else(|| {
+                let levels = current_version.ssts.levels();
+                let inferred = infer_time_bucket(levels[0].files());
+                info!(
+                    "Compaction window for region {} is not present, inferring from files: {:?}",
+                    region_id, inferred
+                );
+                inferred
+            })
+    }
+}
+
+impl Picker for WindowedCompactionPicker {
+    fn pick(&self, req: CompactionRequest) -> Option<Box<dyn CompactionTask>> {
+        let region_id = req.region_id();
+        let CompactionRequest {
+            engine_config,
+            current_version,
+            access_layer,
+            compact_type,
+            request_sender,
+            waiters,
+            file_purger,
+            start_time,
+            cache_manager,
+            manifest_ctx,
+            version_control,
+            listener,
+        } = req;
+
+        let time_window = self.calculate_time_window(region_id, compact_type, &current_version);
+        info!(
+            "Compaction window for region: {} is {} seconds",
+            region_id, time_window
+        );
+
+        let expired_ssts = get_expired_ssts(
+            current_version.ssts.levels(),
+            current_version.options.ttl,
+            Timestamp::current_millis(),
+        );
+        if !expired_ssts.is_empty() {
+            info!("Expired SSTs in region {}: {:?}", region_id, expired_ssts);
+            // here we mark expired SSTs as compacting to avoid them being picked.
+            expired_ssts.iter().for_each(|f| f.set_compacting(true));
+        }
+
+        let windows = calculate_time_buckets(
+            time_window,
+            current_version
+                .ssts
+                .levels()
+                .iter()
+                .flat_map(|level| level.files.values()),
+        );
+
+        let outputs = build_output(windows, time_window);
+
+        let task = CompactionTaskImpl {
+            engine_config: engine_config.clone(),
+            region_id,
+            metadata: current_version.metadata.clone().clone(),
+            sst_layer: access_layer.clone(),
+            outputs,
+            expired_ssts,
+            compaction_time_window: Some(time_window),
+            request_sender,
+            waiters,
+            file_purger,
+            start_time,
+            cache_manager,
+            storage: current_version.options.storage.clone(),
+            index_options: current_version.options.index_options.clone(),
+            append_mode: current_version.options.append_mode,
+            manifest_ctx,
+            version_control,
+            listener,
+        };
+        Some(Box::new(task))
+    }
+}
+
+fn build_output(
+    windows: BTreeMap<i64, Vec<FileHandle>>,
+    window_size: i64,
+) -> Vec<CompactionOutput> {
+    let mut outputs = Vec::with_capacity(windows.len());
+    for (window_lower_bound, files) in windows {
+        // safety: the upper bound must > lower bound.
+        let output_time_range = Some(
+            TimestampRange::new(
+                Timestamp::new_second(window_lower_bound),
+                Timestamp::new_second(window_lower_bound + window_size),
+            )
+            .unwrap(),
+        );
+
+        let output = CompactionOutput {
+            output_file_id: FileId::random(),
+            output_level: 1,
+            inputs: files,
+            filter_deleted: false,
+            output_time_range,
+        };
+        outputs.push(output);
+    }
+
+    outputs
+}
+
+/// Calculates buckets for files. If file does not contain a time range in metadata, it will be
+/// assigned to a special bucket `i64::MAX` (normally no timestamp can be aligned to this bucket)
+/// so that all files without timestamp can be compacted together.
+fn calculate_time_buckets<'a>(
+    bucket_sec: i64,
+    files: impl Iterator<Item = &'a FileHandle>,
+) -> BTreeMap<i64, Vec<FileHandle>> {
+    let mut buckets = BTreeMap::new();
+
+    for file in files {
+        let (start, end) = file.time_range();
+        let bounds = file_time_bucket_span(
+            start.convert_to(TimeUnit::Second).unwrap().value(),
+            end.convert_to(TimeUnit::Second).unwrap().value(),
+            bucket_sec,
+        );
+        for bound in bounds {
+            buckets
+                .entry(bound)
+                .or_insert_with(Vec::new)
+                .push(file.clone());
+        }
+    }
+    buckets
+}
+
+/// Calculates timestamp span between start and end timestamp.
+fn file_time_bucket_span(start_sec: i64, end_sec: i64, bucket_sec: i64) -> Vec<i64> {
+    assert!(start_sec <= end_sec);
+
+    // if timestamp is between `[i64::MIN, i64::MIN.align_by_bucket(bucket)]`, which cannot
+    // be aligned to a valid i64 bound, simply return `i64::MIN` rather than just underflow.
+    let mut start_aligned = start_sec.align_by_bucket(bucket_sec).unwrap_or(i64::MIN);
+    let end_aligned = end_sec.align_by_bucket(bucket_sec).unwrap_or(i64::MIN);
+
+    let mut res = Vec::with_capacity(((end_aligned - start_aligned) / bucket_sec + 1) as usize);
+    while start_aligned < end_aligned {
+        res.push(start_aligned);
+        start_aligned += bucket_sec;
+    }
+    res.push(end_aligned);
+    res
+}

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -217,8 +217,9 @@ fn file_time_bucket_span(start_sec: i64, end_sec: i64, bucket_sec: i64) -> Vec<(
         } else {
             (start_aligned % bucket_sec).abs()
         };
-        res.push((start_aligned, start_aligned + window_size));
-        start_aligned += window_size;
+        let upper_bound = start_aligned.checked_add(window_size).unwrap_or(i64::MAX);
+        res.push((start_aligned, upper_bound));
+        start_aligned = upper_bound;
     }
     res
 }
@@ -410,5 +411,10 @@ mod tests {
         );
 
         assert_eq!(vec![(0, 10)], file_time_bucket_span(0, 9, 10));
+
+        assert_eq!(
+            vec![(i64::MAX - (i64::MAX % 10), i64::MAX)],
+            file_time_bucket_span(i64::MAX - 1, i64::MAX, 10)
+        );
     }
 }

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -87,7 +87,7 @@ impl WindowedCompactionPicker {
             expired_ssts.iter().for_each(|f| f.set_compacting(true));
         }
 
-        let windows = asign_files_to_time_windows(
+        let windows = assign_files_to_time_windows(
             time_window,
             current_version
                 .ssts
@@ -179,7 +179,7 @@ fn build_output(
 /// Assigns files to time windows. If file does not contain a time range in metadata, it will be
 /// assigned to a special bucket `i64::MAX` (normally no timestamp can be aligned to this bucket)
 /// so that all files without timestamp can be compacted together.
-fn asign_files_to_time_windows<'a>(
+fn assign_files_to_time_windows<'a>(
     bucket_sec: i64,
     files: impl Iterator<Item = &'a FileHandle>,
 ) -> BTreeMap<i64, Vec<FileHandle>> {

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
 use api::v1::region::compact_type::Ty;
 use api::v1::region::CompactType;
@@ -40,6 +40,12 @@ pub struct WindowedCompactionPicker {
 }
 
 impl WindowedCompactionPicker {
+    pub fn new(window_seconds: Option<i64>) -> Self {
+        Self {
+            compaction_time_window_seconds: window_seconds,
+        }
+    }
+
     // Computes compaction time window. First we respect user specified parameter, then
     // use persisted window. If persist window is not present, we check the time window
     // provided while creating table. If all of those are absent, we infer the window

--- a/src/mito2/src/compaction/window.rs
+++ b/src/mito2/src/compaction/window.rs
@@ -191,6 +191,7 @@ fn assign_files_to_time_windows<'a>(
         }
         let (start, end) = file.time_range();
         let bounds = file_time_bucket_span(
+            // safety: converting whatever timestamp to seconds will not overflow.
             start.convert_to(TimeUnit::Second).unwrap().value(),
             end.convert_to(TimeUnit::Second).unwrap().value(),
             bucket_sec,

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -14,6 +14,7 @@
 
 //! Tests for append mode.
 
+use api::v1::region::CompactType;
 use api::v1::Rows;
 use common_recordbatch::RecordBatches;
 use store_api::region_engine::RegionEngine;
@@ -137,7 +138,12 @@ async fn test_append_mode_compaction() {
     flush_region(&engine, region_id, None).await;
 
     let output = engine
-        .handle_request(region_id, RegionRequest::Compact(RegionCompactRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest {
+                compact_type: CompactType::default(),
+            }),
+        )
         .await
         .unwrap();
     assert_eq!(output.affected_rows, 0);

--- a/src/mito2/src/engine/append_mode_test.rs
+++ b/src/mito2/src/engine/append_mode_test.rs
@@ -14,7 +14,6 @@
 
 //! Tests for append mode.
 
-use api::v1::region::CompactType;
 use api::v1::Rows;
 use common_recordbatch::RecordBatches;
 use store_api::region_engine::RegionEngine;
@@ -140,9 +139,7 @@ async fn test_append_mode_compaction() {
     let output = engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest {
-                compact_type: CompactType::default(),
-            }),
+            RegionRequest::Compact(RegionCompactRequest::default()),
         )
         .await
         .unwrap();

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -131,7 +131,12 @@ async fn test_compaction_region() {
     put_and_flush(&engine, region_id, &column_schemas, 15..25).await;
 
     let result = engine
-        .handle_request(region_id, RegionRequest::Compact(RegionCompactRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest {
+                compact_type: Default::default(),
+            }),
+        )
         .await
         .unwrap();
     assert_eq!(result.affected_rows, 0);
@@ -179,7 +184,12 @@ async fn test_compaction_region_with_overlapping() {
     delete_and_flush(&engine, region_id, &column_schemas, 0..3600).await; // window 3600
 
     let result = engine
-        .handle_request(region_id, RegionRequest::Compact(RegionCompactRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest {
+                compact_type: Default::default(),
+            }),
+        )
         .await
         .unwrap();
     assert_eq!(result.affected_rows, 0);
@@ -227,7 +237,12 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     delete_and_flush(&engine, region_id, &column_schemas, 0..10800).await; // window 10800
 
     let result = engine
-        .handle_request(region_id, RegionRequest::Compact(RegionCompactRequest {}))
+        .handle_request(
+            region_id,
+            RegionRequest::Compact(RegionCompactRequest {
+                compact_type: Default::default(),
+            }),
+        )
         .await
         .unwrap();
     assert_eq!(result.affected_rows, 0);

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -133,9 +133,7 @@ async fn test_compaction_region() {
     let result = engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest {
-                compact_type: Default::default(),
-            }),
+            RegionRequest::Compact(RegionCompactRequest::default()),
         )
         .await
         .unwrap();
@@ -186,9 +184,7 @@ async fn test_compaction_region_with_overlapping() {
     let result = engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest {
-                compact_type: Default::default(),
-            }),
+            RegionRequest::Compact(RegionCompactRequest::default()),
         )
         .await
         .unwrap();
@@ -239,9 +235,7 @@ async fn test_compaction_region_with_overlapping_delete_all() {
     let result = engine
         .handle_request(
             region_id,
-            RegionRequest::Compact(RegionCompactRequest {
-                compact_type: Default::default(),
-            }),
+            RegionRequest::Compact(RegionCompactRequest::default()),
         )
         .await
         .unwrap();

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -20,6 +20,7 @@ use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use common_runtime::JoinError;
+use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
 use datatypes::arrow::error::ArrowError;
 use datatypes::prelude::ConcreteDataType;
@@ -695,6 +696,18 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "Time range predicate overflows, timestamp: {:?}, target unit: {}",
+        timestamp,
+        unit
+    ))]
+    TimeRangePredicateOverflow {
+        timestamp: Timestamp,
+        unit: TimeUnit,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to build time range filters for value: {:?}", timestamp))]
     BuildTimeRangeFilter {
         timestamp: Timestamp,
@@ -810,6 +823,7 @@ impl ErrorExt for Error {
             EncodeMemtable { .. } | ReadDataPart { .. } => StatusCode::Internal,
             ChecksumMismatch { .. } => StatusCode::Unexpected,
             RegionStopped { .. } => StatusCode::RegionNotReady,
+            TimeRangePredicateOverflow { .. } => StatusCode::InvalidArguments,
             BuildTimeRangeFilter { .. } => StatusCode::Unexpected,
         }
     }

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -664,8 +664,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         .await;
                     continue;
                 }
-                DdlRequest::Compact(_) => {
-                    self.handle_compaction_request(ddl.region_id, ddl.sender);
+                DdlRequest::Compact(req) => {
+                    self.handle_compaction_request(ddl.region_id, req, ddl.sender);
                     continue;
                 }
                 DdlRequest::Truncate(_) => {

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -14,6 +14,7 @@
 
 use common_telemetry::{error, info, warn};
 use store_api::logstore::LogStore;
+use store_api::region_request::RegionCompactRequest;
 use store_api::storage::RegionId;
 
 use crate::metrics::COMPACTION_REQUEST_COUNT;
@@ -25,6 +26,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
     pub(crate) fn handle_compaction_request(
         &mut self,
         region_id: RegionId,
+        req: RegionCompactRequest,
         mut sender: OptionOutputTx,
     ) {
         let Some(region) = self.regions.writable_region_or(region_id, &mut sender) else {
@@ -33,6 +35,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         COMPACTION_REQUEST_COUNT.inc();
         if let Err(e) = self.compaction_scheduler.schedule_compaction(
             region.region_id,
+            req.compact_type,
             &region.version_control,
             &region.access_layer,
             &region.file_purger,

--- a/src/mito2/src/worker/handle_compaction.rs
+++ b/src/mito2/src/worker/handle_compaction.rs
@@ -35,7 +35,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         COMPACTION_REQUEST_COUNT.inc();
         if let Err(e) = self.compaction_scheduler.schedule_compaction(
             region.region_id,
-            req.compact_type,
+            req.options,
             &region.version_control,
             &region.access_layer,
             &region.file_purger,

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -16,6 +16,7 @@
 
 use std::sync::Arc;
 
+use api::v1::region::CompactType;
 use common_telemetry::{error, info, warn};
 use store_api::logstore::LogStore;
 use store_api::region_request::RegionFlushRequest;
@@ -236,6 +237,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         // Schedules compaction.
         if let Err(e) = self.compaction_scheduler.schedule_compaction(
             region.region_id,
+            CompactType::default(),
             &region.version_control,
             &region.access_layer,
             &region.file_purger,

--- a/src/mito2/src/worker/handle_flush.rs
+++ b/src/mito2/src/worker/handle_flush.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use api::v1::region::CompactType;
+use api::v1::region::compact_request;
 use common_telemetry::{error, info, warn};
 use store_api::logstore::LogStore;
 use store_api::region_request::RegionFlushRequest;
@@ -237,7 +237,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         // Schedules compaction.
         if let Err(e) = self.compaction_scheduler.schedule_compaction(
             region.region_id,
-            CompactType::default(),
+            compact_request::Options::Regular(Default::default()),
             &region.version_control,
             &region.access_layer,
             &region.file_purger,

--- a/src/operator/src/request.rs
+++ b/src/operator/src/request.rs
@@ -109,7 +109,7 @@ impl Requester {
             .map(|partition| {
                 RegionRequestBody::Compact(CompactRequest {
                     region_id: partition.id.into(),
-                    compact_type: Some(request.compact_type.clone()),
+                    options: Some(request.compact_options.clone()),
                 })
             })
             .collect();
@@ -146,7 +146,7 @@ impl Requester {
     ) -> Result<AffectedRows> {
         let request = RegionRequestBody::Compact(CompactRequest {
             region_id: region_id.into(),
-            compact_type: None, // todo(hl): maybe also support parameters in region compaction.
+            options: None, // todo(hl): maybe also support parameters in region compaction.
         });
 
         info!("Handle region manual compaction request: {region_id}");

--- a/src/operator/src/request.rs
+++ b/src/operator/src/request.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use api::v1::region::region_request::Body as RegionRequestBody;
-use api::v1::region::{CompactRequest, CompactType, FlushRequest, RegionRequestHeader};
+use api::v1::region::{CompactRequest, FlushRequest, RegionRequestHeader};
 use catalog::CatalogManagerRef;
 use common_catalog::build_db_string;
 use common_meta::node_manager::{AffectedRows, NodeManagerRef};
@@ -104,13 +104,12 @@ impl Requester {
             )
             .await?;
 
-        let compact_type = CompactType::from(&request.compact_type);
         let requests = partitions
             .into_iter()
             .map(|partition| {
                 RegionRequestBody::Compact(CompactRequest {
                     region_id: partition.id.into(),
-                    compact_type: Some(compact_type.clone()),
+                    compact_type: Some(request.compact_type.clone()),
                 })
             })
             .collect();

--- a/src/session/src/table_name.rs
+++ b/src/session/src/table_name.rs
@@ -12,20 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use snafu::ensure;
 use sql::ast::ObjectName;
-use sql::error::{InvalidSqlSnafu, Result};
+use sql::error::{InvalidSqlSnafu, PermissionDeniedSnafu, Result};
 use sql::parser::ParserContext;
 
 use crate::QueryContextRef;
 
-/// Parse table name into `(catalog, schema, table)` with query context.
+/// Parse table name into `(catalog, schema, table)` with query context and validates
+/// if catalog matches current catalog in query context.
 pub fn table_name_to_full_name(
     name: &str,
     query_ctx: &QueryContextRef,
 ) -> Result<(String, String, String)> {
     let obj_name = ParserContext::parse_table_name(name, query_ctx.sql_dialect())?;
 
-    table_idents_to_full_name(&obj_name, query_ctx)
+    let (catalog, schema, table) = table_idents_to_full_name(&obj_name, query_ctx)?;
+    ensure!(
+        catalog == query_ctx.current_catalog(),
+        PermissionDeniedSnafu {
+            target: catalog,
+            current: query_ctx.current_catalog(),
+        }
+    );
+    Ok((catalog, schema, table))
 }
 
 /// Converts maybe fully-qualified table name (`<catalog>.<schema>.<table>`) to tuple.

--- a/src/session/src/table_name.rs
+++ b/src/session/src/table_name.rs
@@ -28,6 +28,7 @@ pub fn table_name_to_full_name(
     let obj_name = ParserContext::parse_table_name(name, query_ctx.sql_dialect())?;
 
     let (catalog, schema, table) = table_idents_to_full_name(&obj_name, query_ctx)?;
+    // todo(hl): also check if schema matches when rbac is ready. https://github.com/GreptimeTeam/greptimedb/pull/3988/files#r1608687652
     ensure!(
         catalog == query_ctx.current_catalog(),
         PermissionDeniedSnafu {

--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -213,6 +213,18 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display(
+        "Permission denied while operating catalog {} from current catalog {}",
+        target,
+        current
+    ))]
+    PermissionDenied {
+        target: String,
+        current: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl ErrorExt for Error {
@@ -241,7 +253,8 @@ impl ErrorExt for Error {
             | InvalidSqlValue { .. }
             | TimestampOverflow { .. }
             | InvalidTableOption { .. }
-            | InvalidCast { .. } => StatusCode::InvalidArguments,
+            | InvalidCast { .. }
+            | PermissionDenied { .. } => StatusCode::InvalidArguments,
 
             SerializeColumnDefaultConstraint { source, .. } => source.status_code(),
             ConvertToGrpcDataType { source, .. } => source.status_code(),

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -19,8 +19,8 @@ use api::helper::ColumnDataTypeWrapper;
 use api::v1::add_column_location::LocationType;
 use api::v1::region::{
     alter_request, region_request, AlterRequest, AlterRequests, CloseRequest, CompactRequest,
-    CreateRequest, CreateRequests, DeleteRequests, DropRequest, DropRequests, FlushRequest,
-    InsertRequests, OpenRequest, TruncateRequest,
+    CompactType, CreateRequest, CreateRequests, DeleteRequests, DropRequest, DropRequests,
+    FlushRequest, InsertRequests, OpenRequest, TruncateRequest,
 };
 use api::v1::{self, Rows, SemanticType};
 pub use common_base::AffectedRows;
@@ -199,9 +199,10 @@ fn make_region_flush(flush: FlushRequest) -> Result<Vec<(RegionId, RegionRequest
 
 fn make_region_compact(compact: CompactRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
     let region_id = compact.region_id.into();
+    let compact_type = compact.compact_type.unwrap_or_default();
     Ok(vec![(
         region_id,
-        RegionRequest::Compact(RegionCompactRequest {}),
+        RegionRequest::Compact(RegionCompactRequest { compact_type }),
     )])
 }
 
@@ -642,7 +643,9 @@ pub struct RegionFlushRequest {
 }
 
 #[derive(Debug)]
-pub struct RegionCompactRequest {}
+pub struct RegionCompactRequest {
+    pub compact_type: CompactType,
+}
 
 /// Truncate region request.
 #[derive(Debug)]

--- a/src/store-api/src/region_request.rs
+++ b/src/store-api/src/region_request.rs
@@ -18,8 +18,8 @@ use std::fmt;
 use api::helper::ColumnDataTypeWrapper;
 use api::v1::add_column_location::LocationType;
 use api::v1::region::{
-    alter_request, region_request, AlterRequest, AlterRequests, CloseRequest, CompactRequest,
-    CompactType, CreateRequest, CreateRequests, DeleteRequests, DropRequest, DropRequests,
+    alter_request, compact_request, region_request, AlterRequest, AlterRequests, CloseRequest,
+    CompactRequest, CreateRequest, CreateRequests, DeleteRequests, DropRequest, DropRequests,
     FlushRequest, InsertRequests, OpenRequest, TruncateRequest,
 };
 use api::v1::{self, Rows, SemanticType};
@@ -199,10 +199,12 @@ fn make_region_flush(flush: FlushRequest) -> Result<Vec<(RegionId, RegionRequest
 
 fn make_region_compact(compact: CompactRequest) -> Result<Vec<(RegionId, RegionRequest)>> {
     let region_id = compact.region_id.into();
-    let compact_type = compact.compact_type.unwrap_or_default();
+    let options = compact
+        .options
+        .unwrap_or(compact_request::Options::Regular(Default::default()));
     Ok(vec![(
         region_id,
-        RegionRequest::Compact(RegionCompactRequest { compact_type }),
+        RegionRequest::Compact(RegionCompactRequest { options }),
     )])
 }
 
@@ -644,7 +646,16 @@ pub struct RegionFlushRequest {
 
 #[derive(Debug)]
 pub struct RegionCompactRequest {
-    pub compact_type: CompactType,
+    pub options: compact_request::Options,
+}
+
+impl Default for RegionCompactRequest {
+    fn default() -> Self {
+        Self {
+            // Default to regular compaction.
+            options: compact_request::Options::Regular(Default::default()),
+        }
+    }
 }
 
 /// Truncate region request.

--- a/src/table/Cargo.toml
+++ b/src/table/Cargo.toml
@@ -29,6 +29,7 @@ datafusion-physical-expr.workspace = true
 datatypes.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
+greptime-proto.workspace = true
 humantime.workspace = true
 humantime-serde.workspace = true
 paste = "1.0"

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -239,10 +239,23 @@ pub struct FlushTableRequest {
 }
 
 #[derive(Debug, Clone, Default)]
+pub enum CompactType {
+    #[default]
+    Regular,
+    StrictWindow(StrictWindowOptions),
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct StrictWindowOptions {
+    pub window_size: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct CompactTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
+    pub compact_type: CompactType,
 }
 
 /// Truncate table request

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -25,7 +25,7 @@ use common_time::range::TimestampRange;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::VectorRef;
 use datatypes::schema::ColumnSchema;
-use greptime_proto::v1::region::CompactType;
+use greptime_proto::v1::region::compact_request;
 use serde::{Deserialize, Serialize};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 use store_api::mito_engine_options::is_mito_engine_option_key;
@@ -239,53 +239,24 @@ pub struct FlushTableRequest {
     pub table_name: String,
 }
 
-// #[derive(Debug, Clone, Default)]
-// pub enum CompactType {
-//     #[default]
-//     Regular,
-//     StrictWindow(StrictWindowOptions),
-// }
-
-// #[derive(Debug, Clone, Default)]
-// pub struct StrictWindowOptions {
-//     pub window_size: Option<i64>,
-// }
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct CompactTableRequest {
     pub catalog_name: String,
     pub schema_name: String,
     pub table_name: String,
-    pub compact_type: CompactType,
+    pub compact_options: compact_request::Options,
 }
 
-// impl From<&CompactType> for greptime_proto::v1::region::CompactType {
-//     fn from(value: &CompactType) -> Self {
-//         let compact_type = match value {
-//             CompactType::Regular => Ty::Regular(Regular::default()),
-//             CompactType::StrictWindow(window) => Ty::StrictWindow(StrictWindow {
-//                 window: window.window_size.unwrap_or(0),
-//             }),
-//         };
-//         greptime_proto::v1::region::CompactType {
-//             ty: Some(compact_type),
-//         }
-//     }
-// }
-//
-// impl From<&greptime_proto::v1::region::CompactType> for CompactType {
-//     fn from(value: &greptime_proto::v1::region::CompactType) -> Self {
-//         match &value.ty {
-//             None => CompactType::Regular,
-//             Some(t) => match t {
-//                 Ty::Regular(_) => CompactType::Regular,
-//                 Ty::StrictWindow(window) => CompactType::StrictWindow(StrictWindowOptions {
-//                     window_size: Some(window.window),
-//                 }),
-//             },
-//         }
-//     }
-// }
+impl Default for CompactTableRequest {
+    fn default() -> Self {
+        Self {
+            catalog_name: Default::default(),
+            schema_name: Default::default(),
+            table_name: Default::default(),
+            compact_options: compact_request::Options::Regular(Default::default()),
+        }
+    }
+}
 
 /// Truncate table request
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -25,6 +25,8 @@ use common_time::range::TimestampRange;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::VectorRef;
 use datatypes::schema::ColumnSchema;
+use greptime_proto::v1::region::compact_type::Ty;
+use greptime_proto::v1::region::{Regular, StrictWindow};
 use serde::{Deserialize, Serialize};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 use store_api::mito_engine_options::is_mito_engine_option_key;
@@ -256,6 +258,20 @@ pub struct CompactTableRequest {
     pub schema_name: String,
     pub table_name: String,
     pub compact_type: CompactType,
+}
+
+impl From<&CompactType> for greptime_proto::v1::region::CompactType {
+    fn from(value: &CompactType) -> Self {
+        let compact_type = match value {
+            CompactType::Regular => Ty::Regular(Regular::default()),
+            CompactType::StrictWindow(window) => Ty::StrictWindow(StrictWindow {
+                window: window.window_size.unwrap_or(0),
+            }),
+        };
+        greptime_proto::v1::region::CompactType {
+            ty: Some(compact_type),
+        }
+    }
 }
 
 /// Truncate table request

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -25,8 +25,7 @@ use common_time::range::TimestampRange;
 use datatypes::data_type::ConcreteDataType;
 use datatypes::prelude::VectorRef;
 use datatypes::schema::ColumnSchema;
-use greptime_proto::v1::region::compact_type::Ty;
-use greptime_proto::v1::region::{Regular, StrictWindow};
+use greptime_proto::v1::region::CompactType;
 use serde::{Deserialize, Serialize};
 use store_api::metric_engine_consts::{LOGICAL_TABLE_METADATA_KEY, PHYSICAL_TABLE_METADATA_KEY};
 use store_api::mito_engine_options::is_mito_engine_option_key;
@@ -240,17 +239,17 @@ pub struct FlushTableRequest {
     pub table_name: String,
 }
 
-#[derive(Debug, Clone, Default)]
-pub enum CompactType {
-    #[default]
-    Regular,
-    StrictWindow(StrictWindowOptions),
-}
+// #[derive(Debug, Clone, Default)]
+// pub enum CompactType {
+//     #[default]
+//     Regular,
+//     StrictWindow(StrictWindowOptions),
+// }
 
-#[derive(Debug, Clone, Default)]
-pub struct StrictWindowOptions {
-    pub window_size: Option<i64>,
-}
+// #[derive(Debug, Clone, Default)]
+// pub struct StrictWindowOptions {
+//     pub window_size: Option<i64>,
+// }
 
 #[derive(Debug, Clone, Default)]
 pub struct CompactTableRequest {
@@ -260,19 +259,33 @@ pub struct CompactTableRequest {
     pub compact_type: CompactType,
 }
 
-impl From<&CompactType> for greptime_proto::v1::region::CompactType {
-    fn from(value: &CompactType) -> Self {
-        let compact_type = match value {
-            CompactType::Regular => Ty::Regular(Regular::default()),
-            CompactType::StrictWindow(window) => Ty::StrictWindow(StrictWindow {
-                window: window.window_size.unwrap_or(0),
-            }),
-        };
-        greptime_proto::v1::region::CompactType {
-            ty: Some(compact_type),
-        }
-    }
-}
+// impl From<&CompactType> for greptime_proto::v1::region::CompactType {
+//     fn from(value: &CompactType) -> Self {
+//         let compact_type = match value {
+//             CompactType::Regular => Ty::Regular(Regular::default()),
+//             CompactType::StrictWindow(window) => Ty::StrictWindow(StrictWindow {
+//                 window: window.window_size.unwrap_or(0),
+//             }),
+//         };
+//         greptime_proto::v1::region::CompactType {
+//             ty: Some(compact_type),
+//         }
+//     }
+// }
+//
+// impl From<&greptime_proto::v1::region::CompactType> for CompactType {
+//     fn from(value: &greptime_proto::v1::region::CompactType) -> Self {
+//         match &value.ty {
+//             None => CompactType::Regular,
+//             Some(t) => match t {
+//                 Ty::Regular(_) => CompactType::Regular,
+//                 Ty::StrictWindow(window) => CompactType::StrictWindow(StrictWindowOptions {
+//                     window_size: Some(window.window),
+//                 }),
+//             },
+//         }
+//     }
+// }
 
 /// Truncate table request
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/table/src/requests.rs
+++ b/src/table/src/requests.rs
@@ -239,7 +239,7 @@ pub struct FlushTableRequest {
     pub table_name: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CompactTableRequest {
     pub catalog_name: String,
     pub schema_name: String,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- closes #3882


## What's changed and what's your intention?
This PR adds support for manually trigger different types of compactions.

The syntax is:
```sql

SELECT COMPACT_TABLE("<table_name>", ["<compact_type>"], ["<options>"])
```



Currently, `compact_type` supports `regular` and `strict_window`.
- `regular`: regular compaction like those triggered by flush.
- `strict_window`: split SST files strictly by time window.

The `<options>` argument is type-sepecific compaction options. For `strict_window`, the option value is the compaction window in seconds.



## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
