### PR TITLE
fix: move log_version() into build() of App to fix no log version on bootstrap

### DIFF
--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -17,8 +17,8 @@
 use clap::{Parser, Subcommand};
 use cmd::error::Result;
 use cmd::options::GlobalOptions;
-use cmd::{cli, datanode, frontend, log_versions, metasrv, standalone, App};
-use common_version::{short_version, version};
+use cmd::{cli, datanode, frontend, metasrv, standalone, App};
+use common_version::version;
 
 #[derive(Parser)]
 #[command(name = "greptime", author, version, long_version = version!(), about)]
@@ -61,7 +61,6 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 #[tokio::main]
 async fn main() -> Result<()> {
     setup_human_panic();
-    log_versions(version!(), short_version!());
     start(Command::parse()).await
 }
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -21,6 +21,7 @@ use clap::Parser;
 use common_config::Configurable;
 use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
+use common_version::{short_version, version};
 use common_wal::config::DatanodeWalConfig;
 use datanode::config::DatanodeOptions;
 use datanode::datanode::{Datanode, DatanodeBuilder};
@@ -33,7 +34,7 @@ use crate::error::{
     LoadLayeredConfigSnafu, MissingConfigSnafu, Result, ShutdownDatanodeSnafu, StartDatanodeSnafu,
 };
 use crate::options::GlobalOptions;
-use crate::App;
+use crate::{log_versions, App};
 
 pub const APP_NAME: &str = "greptime-datanode";
 
@@ -233,6 +234,7 @@ impl StartCommand {
             &opts.tracing,
             opts.node_id.map(|x| x.to_string()),
         );
+        log_versions(version!(), short_version!());
 
         let plugins = plugins::setup_datanode_plugins(&mut opts)
             .await

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -31,6 +31,7 @@ use common_meta::heartbeat::handler::HandlerGroupExecutor;
 use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
 use common_time::timezone::set_default_timezone;
+use common_version::{short_version, version};
 use frontend::frontend::FrontendOptions;
 use frontend::heartbeat::handler::invalidate_table_cache::InvalidateTableCacheHandler;
 use frontend::heartbeat::HeartbeatTask;
@@ -46,7 +47,7 @@ use crate::error::{
     self, InitTimezoneSnafu, LoadLayeredConfigSnafu, MissingConfigSnafu, Result, StartFrontendSnafu,
 };
 use crate::options::GlobalOptions;
-use crate::App;
+use crate::{log_versions, App};
 
 pub struct Instance {
     frontend: FeInstance,
@@ -246,6 +247,7 @@ impl StartCommand {
             &opts.tracing,
             opts.node_id.clone(),
         );
+        log_versions(version!(), short_version!());
 
         #[allow(clippy::unnecessary_mut_passed)]
         let plugins = plugins::setup_frontend_plugins(&mut opts)

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -19,13 +19,14 @@ use clap::Parser;
 use common_config::Configurable;
 use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
+use common_version::{short_version, version};
 use meta_srv::bootstrap::MetasrvInstance;
 use meta_srv::metasrv::MetasrvOptions;
 use snafu::ResultExt;
 
 use crate::error::{self, LoadLayeredConfigSnafu, Result, StartMetaServerSnafu};
 use crate::options::GlobalOptions;
-use crate::App;
+use crate::{log_versions, App};
 
 pub const APP_NAME: &str = "greptime-metasrv";
 
@@ -215,6 +216,7 @@ impl StartCommand {
     async fn build(&self, mut opts: MetasrvOptions) -> Result<Instance> {
         let _guard =
             common_telemetry::init_global_logging(APP_NAME, &opts.logging, &opts.tracing, None);
+        log_versions(version!(), short_version!());
 
         let plugins = plugins::setup_metasrv_plugins(&mut opts)
             .await

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -41,6 +41,7 @@ use common_procedure::ProcedureManagerRef;
 use common_telemetry::info;
 use common_telemetry::logging::{LoggingOptions, TracingOptions};
 use common_time::timezone::set_default_timezone;
+use common_version::{short_version, version};
 use common_wal::config::StandaloneWalConfig;
 use datanode::config::{DatanodeOptions, ProcedureConfig, RegionEngineConfig, StorageConfig};
 use datanode::datanode::{Datanode, DatanodeBuilder};
@@ -69,7 +70,7 @@ use crate::error::{
     StartProcedureManagerSnafu, StartWalOptionsAllocatorSnafu, StopProcedureManagerSnafu,
 };
 use crate::options::GlobalOptions;
-use crate::App;
+use crate::{log_versions, App};
 
 pub const APP_NAME: &str = "greptime-standalone";
 
@@ -376,6 +377,7 @@ impl StartCommand {
     async fn build(&self, opts: StandaloneOptions) -> Result<Instance> {
         let _guard =
             common_telemetry::init_global_logging(APP_NAME, &opts.logging, &opts.tracing, None);
+        log_versions(version!(), short_version!());
 
         info!("Standalone start command: {:#?}", self);
         info!("Building standalone instance with {opts:#?}");


### PR DESCRIPTION


I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Move `log_version()` into `build()` of `App` to fix no log version on bootstrap since the `common_telemetry::init_global_logging` is in the `build()`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
