### PR TITLE
fix: can't print log because the tracing guard is dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "toml 0.8.12",
+ "tracing-appender",
 ]
 
 [[package]]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -74,6 +74,7 @@ substrait.workspace = true
 table.workspace = true
 tokio.workspace = true
 toml.workspace = true
+tracing-appender = "0.2"
 
 [target.'cfg(not(windows))'.dependencies]
 tikv-jemallocator = "0.5"

--- a/src/cmd/src/cli.rs
+++ b/src/cmd/src/cli.rs
@@ -51,7 +51,6 @@ pub struct Instance {
     tool: Box<dyn Tool>,
 
     // Keep the logging guard to prevent the worker from being dropped.
-    #[allow(dead_code)]
     _guard: Vec<WorkerGuard>,
 }
 

--- a/src/cmd/src/cli/bench.rs
+++ b/src/cmd/src/cli/bench.rs
@@ -30,6 +30,7 @@ use datatypes::schema::{ColumnSchema, RawSchema};
 use rand::Rng;
 use store_api::storage::RegionNumber;
 use table::metadata::{RawTableInfo, RawTableMeta, TableId, TableIdent, TableType};
+use tracing_appender::non_blocking::WorkerGuard;
 
 use self::metadata::TableMetadataBencher;
 use crate::cli::{Instance, Tool};
@@ -61,7 +62,7 @@ pub struct BenchTableMetadataCommand {
 }
 
 impl BenchTableMetadataCommand {
-    pub async fn build(&self) -> Result<Instance> {
+    pub async fn build(&self, guard: Vec<WorkerGuard>) -> Result<Instance> {
         let etcd_store = EtcdStore::with_endpoints([&self.etcd_addr], 128)
             .await
             .unwrap();
@@ -72,7 +73,7 @@ impl BenchTableMetadataCommand {
             table_metadata_manager,
             count: self.count,
         };
-        Ok(Instance::new(Box::new(tool)))
+        Ok(Instance::new(Box::new(tool), guard))
     }
 }
 

--- a/src/cmd/src/cli/upgrade.rs
+++ b/src/cmd/src/cli/upgrade.rs
@@ -40,6 +40,7 @@ use etcd_client::Client;
 use futures::TryStreamExt;
 use prost::Message;
 use snafu::ResultExt;
+use tracing_appender::non_blocking::WorkerGuard;
 use v1_helper::{CatalogKey as v1CatalogKey, SchemaKey as v1SchemaKey, TableGlobalValue};
 
 use crate::cli::{Instance, Tool};
@@ -63,7 +64,7 @@ pub struct UpgradeCommand {
 }
 
 impl UpgradeCommand {
-    pub async fn build(&self) -> Result<Instance> {
+    pub async fn build(&self, guard: Vec<WorkerGuard>) -> Result<Instance> {
         let client = Client::connect([&self.etcd_addr], None)
             .await
             .context(ConnectEtcdSnafu {
@@ -77,7 +78,7 @@ impl UpgradeCommand {
             skip_schema_keys: self.skip_schema_keys,
             skip_table_route_keys: self.skip_table_route_keys,
         };
-        Ok(Instance::new(Box::new(tool)))
+        Ok(Instance::new(Box::new(tool), guard))
     }
 }
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -29,6 +29,7 @@ use datanode::service::DatanodeServiceBuilder;
 use meta_client::MetaClientOptions;
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
+use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{
     LoadLayeredConfigSnafu, MissingConfigSnafu, Result, ShutdownDatanodeSnafu, StartDatanodeSnafu,
@@ -40,11 +41,18 @@ pub const APP_NAME: &str = "greptime-datanode";
 
 pub struct Instance {
     datanode: Datanode,
+
+    // Keep the logging guard to prevent the worker from being dropped.
+    #[allow(dead_code)]
+    _guard: Vec<WorkerGuard>,
 }
 
 impl Instance {
-    pub fn new(datanode: Datanode) -> Self {
-        Self { datanode }
+    pub fn new(datanode: Datanode, guard: Vec<WorkerGuard>) -> Self {
+        Self {
+            datanode,
+            _guard: guard,
+        }
     }
 
     pub fn datanode_mut(&mut self) -> &mut Datanode {
@@ -228,7 +236,7 @@ impl StartCommand {
     }
 
     async fn build(&self, mut opts: DatanodeOptions) -> Result<Instance> {
-        let _guard = common_telemetry::init_global_logging(
+        let guard = common_telemetry::init_global_logging(
             APP_NAME,
             &opts.logging,
             &opts.tracing,
@@ -274,7 +282,7 @@ impl StartCommand {
             .context(StartDatanodeSnafu)?;
         datanode.setup_services(services);
 
-        Ok(Instance::new(datanode))
+        Ok(Instance::new(datanode, guard))
     }
 }
 

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -43,7 +43,6 @@ pub struct Instance {
     datanode: Datanode,
 
     // Keep the logging guard to prevent the worker from being dropped.
-    #[allow(dead_code)]
     _guard: Vec<WorkerGuard>,
 }
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -54,7 +54,6 @@ pub struct Instance {
     frontend: FeInstance,
 
     // Keep the logging guard to prevent the worker from being dropped.
-    #[allow(dead_code)]
     _guard: Vec<WorkerGuard>,
 }
 

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -42,6 +42,7 @@ use meta_client::MetaClientOptions;
 use servers::tls::{TlsMode, TlsOption};
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
+use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{
     self, InitTimezoneSnafu, LoadLayeredConfigSnafu, MissingConfigSnafu, Result, StartFrontendSnafu,
@@ -51,13 +52,20 @@ use crate::{log_versions, App};
 
 pub struct Instance {
     frontend: FeInstance,
+
+    // Keep the logging guard to prevent the worker from being dropped.
+    #[allow(dead_code)]
+    _guard: Vec<WorkerGuard>,
 }
 
 pub const APP_NAME: &str = "greptime-frontend";
 
 impl Instance {
-    pub fn new(frontend: FeInstance) -> Self {
-        Self { frontend }
+    pub fn new(frontend: FeInstance, guard: Vec<WorkerGuard>) -> Self {
+        Self {
+            frontend,
+            _guard: guard,
+        }
     }
 
     pub fn mut_inner(&mut self) -> &mut FeInstance {
@@ -241,7 +249,7 @@ impl StartCommand {
     }
 
     async fn build(&self, mut opts: FrontendOptions) -> Result<Instance> {
-        let _guard = common_telemetry::init_global_logging(
+        let guard = common_telemetry::init_global_logging(
             APP_NAME,
             &opts.logging,
             &opts.tracing,
@@ -358,7 +366,7 @@ impl StartCommand {
             .build_servers(opts, servers)
             .context(StartFrontendSnafu)?;
 
-        Ok(Instance::new(instance))
+        Ok(Instance::new(instance, guard))
     }
 }
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -35,7 +35,6 @@ pub struct Instance {
     instance: MetasrvInstance,
 
     // Keep the logging guard to prevent the worker from being dropped.
-    #[allow(dead_code)]
     _guard: Vec<WorkerGuard>,
 }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -213,7 +213,6 @@ pub struct Instance {
     wal_options_allocator: WalOptionsAllocatorRef,
 
     // Keep the logging guard to prevent the worker from being dropped.
-    #[allow(dead_code)]
     _guard: Vec<WorkerGuard>,
 }
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -62,6 +62,7 @@ use servers::http::HttpOptions;
 use servers::tls::{TlsMode, TlsOption};
 use servers::Mode;
 use snafu::{OptionExt, ResultExt};
+use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::error::{
     BuildCacheRegistrySnafu, CacheRequiredSnafu, CreateDirSnafu, IllegalConfigSnafu,
@@ -210,6 +211,10 @@ pub struct Instance {
     frontend: FeInstance,
     procedure_manager: ProcedureManagerRef,
     wal_options_allocator: WalOptionsAllocatorRef,
+
+    // Keep the logging guard to prevent the worker from being dropped.
+    #[allow(dead_code)]
+    _guard: Vec<WorkerGuard>,
 }
 
 #[async_trait]
@@ -375,7 +380,7 @@ impl StartCommand {
     #[allow(unused_variables)]
     #[allow(clippy::diverging_sub_expression)]
     async fn build(&self, opts: StandaloneOptions) -> Result<Instance> {
-        let _guard =
+        let guard =
             common_telemetry::init_global_logging(APP_NAME, &opts.logging, &opts.tracing, None);
         log_versions(version!(), short_version!());
 
@@ -521,6 +526,7 @@ impl StartCommand {
             frontend,
             procedure_manager,
             wal_options_allocator,
+            _guard: guard,
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The bug is caused by https://github.com/GreptimeTeam/greptimedb/pull/3981.

It's a fast fix for adding `guard` in `Instance` to avoid dropping.

I think the elegant way to resolve the problem is to refactor the `init_global_logging()`, split it into multiple functions, and initialize it at the beginning of `main()`.

**We should release the new version of db after the PR is merged**. Fortunately, it's not in the v0.8.0.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
