### PR TITLE
fix(fuzz): sort inserted rows with primary keys and time index

### DIFF
--- a/tests-fuzz/src/ir/insert_expr.rs
+++ b/tests-fuzz/src/ir/insert_expr.rs
@@ -36,6 +36,8 @@ pub enum RowValue {
 impl RowValue {
     pub fn cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match (self, other) {
+            (RowValue::Value(Value::Null), RowValue::Value(v2)) => v2.partial_cmp(&Value::Null),
+            (RowValue::Value(v1), RowValue::Value(Value::Null)) => Value::Null.partial_cmp(v1),
             (RowValue::Value(v1), RowValue::Value(v2)) => v1.partial_cmp(v2),
             _ => panic!("Invalid comparison: {:?} and {:?}", self, other),
         }

--- a/tests-fuzz/targets/fuzz_insert.rs
+++ b/tests-fuzz/targets/fuzz_insert.rs
@@ -33,7 +33,8 @@ use tests_fuzz::generator::create_expr::CreateTableExprGeneratorBuilder;
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
 use tests_fuzz::ir::{
-    generate_random_value_for_mysql, CreateTableExpr, InsertIntoExpr, MySQLTsColumnTypeGenerator,
+    generate_random_value_for_mysql, replace_default, CreateTableExpr, InsertIntoExpr,
+    MySQLTsColumnTypeGenerator,
 };
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::mysql::insert_expr::InsertIntoExprTranslator;
@@ -141,17 +142,29 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
     );
 
     // Validate inserted rows
-    let ts_column_idx = create_expr
+    // The order of inserted rows are random, so we need to sort the inserted rows by primary keys and time index for comparison
+    let primary_keys_names = create_expr
         .columns
         .iter()
-        .position(|c| c.is_time_index())
-        .unwrap();
-    let ts_column_name = create_expr.columns[ts_column_idx].name.clone();
-    let ts_column_idx_in_insert = insert_expr
+        .filter(|c| c.is_primary_key() || c.is_time_index())
+        .map(|c| c.name.clone())
+        .collect::<Vec<_>>();
+
+    // Not all primary keys are in insert_expr
+    let primary_keys_idxs_in_insert_expr = insert_expr
         .columns
         .iter()
-        .position(|c| c.name == ts_column_name)
-        .unwrap();
+        .enumerate()
+        .filter(|(_, c)| primary_keys_names.contains(&c.name))
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    let primary_keys_column_list = primary_keys_idxs_in_insert_expr
+        .iter()
+        .map(|&i| insert_expr.columns[i].name.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+        .to_string();
+
     let column_list = insert_expr
         .columns
         .iter()
@@ -159,16 +172,29 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
         .collect::<Vec<_>>()
         .join(", ")
         .to_string();
+
     let select_sql = format!(
         "SELECT {} FROM {} ORDER BY {}",
-        column_list, create_expr.table_name, ts_column_name
+        column_list, create_expr.table_name, primary_keys_column_list
     );
     let fetched_rows = validator::row::fetch_values(&ctx.greptime, select_sql.as_str()).await?;
-    let mut expected_rows = insert_expr.values_list;
+    let mut expected_rows = replace_default(&insert_expr.values_list, &create_expr);
     expected_rows.sort_by(|a, b| {
-        a[ts_column_idx_in_insert]
-            .cmp(&b[ts_column_idx_in_insert])
-            .unwrap()
+        let a_keys: Vec<_> = primary_keys_idxs_in_insert_expr
+            .iter()
+            .map(|&i| &a[i])
+            .collect();
+        let b_keys: Vec<_> = primary_keys_idxs_in_insert_expr
+            .iter()
+            .map(|&i| &b[i])
+            .collect();
+        for (a_key, b_key) in a_keys.iter().zip(b_keys.iter()) {
+            match a_key.cmp(b_key) {
+                Some(std::cmp::Ordering::Equal) => continue,
+                non_eq => return non_eq.unwrap(),
+            }
+        }
+        std::cmp::Ordering::Equal
     });
     validator::row::assert_eq::<MySql>(&insert_expr.columns, &fetched_rows, &expected_rows)?;
 

--- a/tests-fuzz/targets/fuzz_insert.rs
+++ b/tests-fuzz/targets/fuzz_insert.rs
@@ -178,7 +178,7 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
         column_list, create_expr.table_name, primary_keys_column_list
     );
     let fetched_rows = validator::row::fetch_values(&ctx.greptime, select_sql.as_str()).await?;
-    let mut expected_rows = replace_default(&insert_expr.values_list, &create_expr);
+    let mut expected_rows = replace_default(&insert_expr.values_list, &create_expr, &insert_expr);
     expected_rows.sort_by(|a, b| {
         let a_keys: Vec<_> = primary_keys_idxs_in_insert_expr
             .iter()

--- a/tests-fuzz/targets/fuzz_insert_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_insert_logical_table.rs
@@ -34,7 +34,9 @@ use tests_fuzz::generator::create_expr::{
 };
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
-use tests_fuzz::ir::{generate_random_value_for_mysql, CreateTableExpr, InsertIntoExpr};
+use tests_fuzz::ir::{
+    generate_random_value_for_mysql, replace_default, CreateTableExpr, InsertIntoExpr,
+};
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::mysql::insert_expr::InsertIntoExprTranslator;
 use tests_fuzz::translator::DslTranslator;
@@ -163,19 +165,29 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
     );
 
     // Validate inserted rows
-    let ts_column_idx = create_logical_table_expr
+    // The order of inserted rows are random, so we need to sort the inserted rows by primary keys and time index for comparison
+    let primary_keys_names = create_logical_table_expr
         .columns
         .iter()
-        .position(|c| c.is_time_index())
-        .unwrap();
-    let ts_column_name = create_logical_table_expr.columns[ts_column_idx]
-        .name
-        .clone();
-    let ts_column_idx_in_insert = insert_expr
+        .filter(|c| c.is_primary_key() || c.is_time_index())
+        .map(|c| c.name.clone())
+        .collect::<Vec<_>>();
+
+    // Not all primary keys are in insert_expr
+    let primary_keys_idxs_in_insert_expr = insert_expr
         .columns
         .iter()
-        .position(|c| c.name == ts_column_name)
-        .unwrap();
+        .enumerate()
+        .filter(|(_, c)| primary_keys_names.contains(&c.name))
+        .map(|(i, _)| i)
+        .collect::<Vec<_>>();
+    let primary_keys_column_list = primary_keys_idxs_in_insert_expr
+        .iter()
+        .map(|&i| insert_expr.columns[i].name.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+        .to_string();
+
     let column_list = insert_expr
         .columns
         .iter()
@@ -183,16 +195,29 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
         .collect::<Vec<_>>()
         .join(", ")
         .to_string();
+
     let select_sql = format!(
         "SELECT {} FROM {} ORDER BY {}",
-        column_list, create_logical_table_expr.table_name, ts_column_name
+        column_list, create_logical_table_expr.table_name, primary_keys_column_list
     );
     let fetched_rows = validator::row::fetch_values(&ctx.greptime, select_sql.as_str()).await?;
-    let mut expected_rows = insert_expr.values_list;
+    let mut expected_rows = replace_default(&insert_expr.values_list, &create_logical_table_expr);
     expected_rows.sort_by(|a, b| {
-        a[ts_column_idx_in_insert]
-            .cmp(&b[ts_column_idx_in_insert])
-            .unwrap()
+        let a_keys: Vec<_> = primary_keys_idxs_in_insert_expr
+            .iter()
+            .map(|&i| &a[i])
+            .collect();
+        let b_keys: Vec<_> = primary_keys_idxs_in_insert_expr
+            .iter()
+            .map(|&i| &b[i])
+            .collect();
+        for (a_key, b_key) in a_keys.iter().zip(b_keys.iter()) {
+            match a_key.cmp(b_key) {
+                Some(std::cmp::Ordering::Equal) => continue,
+                non_eq => return non_eq.unwrap(),
+            }
+        }
+        std::cmp::Ordering::Equal
     });
     validator::row::assert_eq::<MySql>(&insert_expr.columns, &fetched_rows, &expected_rows)?;
 

--- a/tests-fuzz/targets/fuzz_insert_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_insert_logical_table.rs
@@ -201,7 +201,11 @@ async fn execute_insert(ctx: FuzzContext, input: FuzzInput) -> Result<()> {
         column_list, create_logical_table_expr.table_name, primary_keys_column_list
     );
     let fetched_rows = validator::row::fetch_values(&ctx.greptime, select_sql.as_str()).await?;
-    let mut expected_rows = replace_default(&insert_expr.values_list, &create_logical_table_expr);
+    let mut expected_rows = replace_default(
+        &insert_expr.values_list,
+        &create_logical_table_expr,
+        &insert_expr,
+    );
     expected_rows.sort_by(|a, b| {
         let a_keys: Vec<_> = primary_keys_idxs_in_insert_expr
             .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

close #4000

## What's changed and what's your intention?

As title. Correct the failed fuzz seed `FuzzInput { seed: 266, columns: 19, rows: 3995 }`

The time index is treated as one of the primary keys for sorting. To compare the `Value::Default` with other values, all the default values in the `insert_expr` is replaced with its original value.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
