### PR TITLE
feat: enable tcp keepalive for http server

### DIFF
--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -306,7 +306,7 @@ impl StartCommand {
     }
 
     // The precedence order is: cli > config file > environment variables > default values.
-    fn merge_with_cli_options(
+    pub fn merge_with_cli_options(
         &self,
         global_options: &GlobalOptions,
         mut opts: StandaloneOptions,

--- a/src/datanode/src/error.rs
+++ b/src/datanode/src/error.rs
@@ -367,6 +367,19 @@ pub enum Error {
         #[snafu(source(from(common_config::error::Error, Box::new)))]
         source: Box<common_config::error::Error>,
     },
+
+    #[snafu(display(
+        "Failed to get region metadata from engine {} for region_id {}",
+        engine,
+        region_id,
+    ))]
+    GetRegionMetadata {
+        engine: String,
+        region_id: RegionId,
+        #[snafu(implicit)]
+        location: Location,
+        source: BoxedError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -433,7 +446,9 @@ impl ErrorExt for Error {
             TableIdProviderNotFound { .. } | UnsupportedGrpcRequest { .. } => {
                 StatusCode::Unsupported
             }
-            HandleRegionRequest { source, .. } => source.status_code(),
+            HandleRegionRequest { source, .. } | GetRegionMetadata { source, .. } => {
+                source.status_code()
+            }
             StopRegionEngine { source, .. } => source.status_code(),
 
             FindLogicalRegions { source, .. } => source.status_code(),

--- a/src/servers/src/grpc/builder.rs
+++ b/src/servers/src/grpc/builder.rs
@@ -46,6 +46,7 @@ macro_rules! add_service {
         let max_recv_message_size = $builder.config().max_recv_message_size;
         let max_send_message_size = $builder.config().max_send_message_size;
 
+        use tonic::codec::CompressionEncoding;
         let service_builder = $service
             .max_decoding_message_size(max_recv_message_size)
             .max_encoding_message_size(max_send_message_size)

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -25,9 +25,11 @@ use common_base::secrets::ExposeSecret;
 use common_config::Configurable;
 use common_meta::key::catalog_name::CatalogNameKey;
 use common_meta::key::schema_name::SchemaNameKey;
+use common_query::OutputData;
 use common_runtime::Builder as RuntimeBuilder;
 use common_telemetry::warn;
 use common_test_util::ports;
+use common_test_util::recordbatch::{check_output_stream, ExpectedOutput};
 use common_test_util::temp_dir::{create_temp_dir, TempDir};
 use common_wal::config::DatanodeWalConfig;
 use datanode::config::{
@@ -54,6 +56,7 @@ use servers::tls::ReloadableTlsServerConfig;
 use servers::Mode;
 use session::context::QueryContext;
 
+use crate::database::Database;
 use crate::standalone::{GreptimeDbStandalone, GreptimeDbStandaloneBuilder};
 
 pub const PEER_PLACEHOLDER_ADDR: &str = "127.0.0.1:3001";
@@ -684,4 +687,20 @@ where
         .collect::<Vec<_>>();
 
     test(endpoints).await
+}
+
+pub async fn execute_and_check_output(db: &Database, sql: &str, expected: ExpectedOutput<'_>) {
+    let output = db.sql(sql).await.unwrap();
+    let output = output.data;
+
+    match (&output, expected) {
+        (OutputData::AffectedRows(x), ExpectedOutput::AffectedRows(y)) => {
+            assert_eq!(*x, y, "actual: \n{}", x)
+        }
+        (OutputData::RecordBatches(_), ExpectedOutput::QueryResult(x))
+        | (OutputData::Stream(_), ExpectedOutput::QueryResult(x)) => {
+            check_output_stream(output, x).await
+        }
+        _ => panic!(),
+    }
 }

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -695,7 +695,13 @@ pub async fn execute_and_check_output(db: &Database, sql: &str, expected: Expect
 
     match (&output, expected) {
         (OutputData::AffectedRows(x), ExpectedOutput::AffectedRows(y)) => {
-            assert_eq!(*x, y, "actual: \n{}", x)
+            assert_eq!(
+                *x, y,
+                r#"
+expected: {y}
+actual: {x}
+"#
+            )
         }
         (OutputData::RecordBatches(_), ExpectedOutput::QueryResult(x))
         | (OutputData::Stream(_), ExpectedOutput::QueryResult(x)) => {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In our customer's env, we've observed a lot of "dangling" http connections. They are all in the “established” state, even the client side pods were already destroyed long before. These dangling connections are harmful, somehow they consumed a lot of memory.

For the origin of the dangling connections, my guessing is that the client side pods are not gracefully shutdown, or the bad network. They are both common situations in cloud env, so I decide to add the keepalive option for http server: if the connections are idle for 1 hour, close it actively in the server side.

I'm a little hesitate to expose the keepalive option in the config file. For http connection, if not http2, rebuilding is very common. Any decent http connection pool can do that (there are keepalive options in themselves, too). So I think for the sake of simplicity, the keepalive option is hardcoded, and make it one hour long so to give the connections long enough time to say they are alive.

After adding the keepalive option, our customer says the memory issue is gone.

This PR also modify some codes to make greptimedb able to be integrated into other projects.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
