### PR TITLE
feat: remove one clone on constructing partition

### DIFF
--- a/src/partition/src/manager.rs
+++ b/src/partition/src/manager.rs
@@ -290,7 +290,7 @@ fn create_partitions_from_region_routes(
         let partition = r
             .region
             .partition
-            .clone()
+            .as_ref()
             .context(error::FindRegionRoutesSnafu {
                 region_id: r.region.id,
                 table_id,

--- a/src/partition/src/partition.rs
+++ b/src/partition/src/partition.rs
@@ -99,23 +99,23 @@ impl PartitionDef {
     }
 }
 
-impl TryFrom<MetaPartition> for PartitionDef {
+impl TryFrom<&MetaPartition> for PartitionDef {
     type Error = Error;
 
-    fn try_from(partition: MetaPartition) -> Result<Self> {
+    fn try_from(partition: &MetaPartition) -> Result<Self> {
         let MetaPartition {
             column_list,
             value_list,
         } = partition;
 
         let partition_columns = column_list
-            .into_iter()
-            .map(|x| String::from_utf8_lossy(&x).to_string())
+            .iter()
+            .map(|x| String::from_utf8_lossy(x).to_string())
             .collect::<Vec<String>>();
 
         let partition_bounds = value_list
-            .into_iter()
-            .map(|x| serde_json::from_str(&String::from_utf8_lossy(&x)))
+            .iter()
+            .map(|x| serde_json::from_str(&String::from_utf8_lossy(x)))
             .collect::<std::result::Result<Vec<PartitionBound>, serde_json::Error>>()
             .context(error::DeserializeJsonSnafu)?;
 
@@ -197,7 +197,7 @@ mod tests {
         );
 
         // MetaPartition -> PartitionDef
-        let partition = MetaPartition {
+        let partition = &MetaPartition {
             column_list: vec![b"a".to_vec(), b"b".to_vec()],
             value_list: vec![
                 b"\"MaxValue\"".to_vec(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

`String::from_utf8_lossy` and `serde_json::from_str` are not in-place operations. It's not necessary to clone it and use by ref.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
