### PR TITLE
feat: implement the `LogStoreRawEntryReader` and `RawEntryReaderFilter`

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -250,6 +250,14 @@ pub enum Error {
         source: BoxedError,
     },
 
+    #[snafu(display("Failed to read WAL, topic: {}", topic))]
+    ReadKafkaWal {
+        topic: String,
+        #[snafu(implicit)]
+        location: Location,
+        source: BoxedError,
+    },
+
     #[snafu(display("Failed to decode WAL entry, region_id: {}", region_id))]
     DecodeWal {
         region_id: RegionId,
@@ -742,6 +750,7 @@ impl ErrorExt for Error {
             | ReadParquet { .. }
             | WriteWal { .. }
             | ReadWal { .. }
+            | ReadKafkaWal { .. }
             | DeleteWal { .. } => StatusCode::StorageUnavailable,
             CompressObject { .. }
             | DecompressObject { .. }

--- a/src/store-api/src/logstore/entry.rs
+++ b/src/store-api/src/logstore/entry.rs
@@ -19,10 +19,33 @@ use crate::storage::RegionId;
 pub type Id = u64;
 
 /// The raw Wal entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RawEntry {
     pub region_id: RegionId,
     pub entry_id: Id,
     pub data: Vec<u8>,
+}
+
+impl Entry for RawEntry {
+    fn into_raw_entry(self) -> RawEntry {
+        self
+    }
+
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+
+    fn id(&self) -> Id {
+        self.entry_id
+    }
+
+    fn region_id(&self) -> RegionId {
+        self.region_id
+    }
+
+    fn estimated_size(&self) -> usize {
+        std::mem::size_of_val(self)
+    }
 }
 
 /// Entry is the minimal data storage unit through which users interact with the log store.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4026 

## What's changed and what's your intention?


1. Implement the `LogStoreRawEntryReader`, which reads undecoded raw WAL entries from the underlying LogStore implementation.
2. Implement the `RawEntryReaderFilter`

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
