### PR TITLE
fix(fuzz-tests): avoid to drop in-use database

### DIFF
--- a/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
+++ b/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
@@ -151,7 +151,7 @@ async fn execute_unstable_create_table(
             Ok(result) => {
                 let state = *rx.borrow();
                 table_states.insert(table_name, state);
-                validate_columns(&ctx.greptime, &table_ctx).await;
+                validate_columns(&ctx.greptime, FUZZ_TESTS_DATABASE.to_string(), &table_ctx).await;
                 info!("Create table: {sql}, result: {result:?}");
             }
             Err(err) => {
@@ -191,10 +191,14 @@ async fn execute_unstable_create_table(
     Ok(())
 }
 
-async fn validate_columns(client: &Pool<MySql>, table_ctx: &TableContext) {
+async fn validate_columns(client: &Pool<MySql>, schema_name: String, table_ctx: &TableContext) {
     loop {
-        match validator::column::fetch_columns(client, "public".into(), table_ctx.name.clone())
-            .await
+        match validator::column::fetch_columns(
+            client,
+            schema_name.clone().into(),
+            table_ctx.name.clone(),
+        )
+        .await
         {
             Ok(mut column_entries) => {
                 column_entries.sort_by(|a, b| a.column_name.cmp(&b.column_name));

--- a/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
+++ b/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
@@ -151,7 +151,7 @@ async fn execute_unstable_create_table(
             Ok(result) => {
                 let state = *rx.borrow();
                 table_states.insert(table_name, state);
-                validate_columns(&ctx.greptime, FUZZ_TESTS_DATABASE.to_string(), &table_ctx).await;
+                validate_columns(&ctx.greptime, FUZZ_TESTS_DATABASE, &table_ctx).await;
                 info!("Create table: {sql}, result: {result:?}");
             }
             Err(err) => {
@@ -191,14 +191,10 @@ async fn execute_unstable_create_table(
     Ok(())
 }
 
-async fn validate_columns(client: &Pool<MySql>, schema_name: String, table_ctx: &TableContext) {
+async fn validate_columns(client: &Pool<MySql>, schema_name: &str, table_ctx: &TableContext) {
     loop {
-        match validator::column::fetch_columns(
-            client,
-            schema_name.clone().into(),
-            table_ctx.name.clone(),
-        )
-        .await
+        match validator::column::fetch_columns(client, schema_name.into(), table_ctx.name.clone())
+            .await
         {
             Ok(mut column_entries) => {
                 column_entries.sort_by(|a, b| a.column_name.cmp(&b.column_name));

--- a/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
+++ b/tests-fuzz/targets/unstable/fuzz_create_table_standalone.rs
@@ -76,7 +76,6 @@ impl Arbitrary<'_> for FuzzInput {
 const DEFAULT_TEMPLATE: &str = "standalone.template.toml";
 const DEFAULT_CONFIG_NAME: &str = "standalone.template.toml";
 const DEFAULT_ROOT_DIR: &str = "/tmp/unstable_greptime/";
-const DEFAULT_DATA_HOME: &str = "/tmp/unstable_greptime/datahome/";
 const DEFAULT_MYSQL_URL: &str = "127.0.0.1:4002";
 const DEFAULT_HTTP_HEALTH_URL: &str = "http://127.0.0.1:4000/health";
 
@@ -219,6 +218,8 @@ fuzz_target!(|input: FuzzInput| {
         let root_dir = variables.root_dir.unwrap_or(DEFAULT_ROOT_DIR.to_string());
         create_dir_all(&root_dir).unwrap();
         let output_config_path = format!("{root_dir}{DEFAULT_CONFIG_NAME}");
+        let data_home = format!("{root_dir}datahome");
+
         let mut conf_path = get_conf_path();
         conf_path.push(DEFAULT_TEMPLATE);
         let template_path = conf_path.to_str().unwrap().to_string();
@@ -228,15 +229,9 @@ fuzz_target!(|input: FuzzInput| {
         struct Context {
             data_home: String,
         }
-        write_config_file(
-            &template_path,
-            &Context {
-                data_home: DEFAULT_DATA_HOME.to_string(),
-            },
-            &output_config_path,
-        )
-        .await
-        .unwrap();
+        write_config_file(&template_path, &Context { data_home }, &output_config_path)
+            .await
+            .unwrap();
 
         let args = vec![
             "standalone".to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Avoid to drop in-use database

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
