### PR TITLE
refactor(fuzz-tests): generate ts value separately

### DIFF
--- a/tests-fuzz/src/generator.rs
+++ b/tests-fuzz/src/generator.rs
@@ -20,6 +20,7 @@ pub mod select_expr;
 use std::fmt;
 
 use datatypes::data_type::ConcreteDataType;
+use datatypes::types::TimestampType;
 use datatypes::value::Value;
 use rand::Rng;
 
@@ -39,6 +40,8 @@ pub type ConcreteDataTypeGenerator<R> = Box<dyn Random<ConcreteDataType, R>>;
 
 pub type ValueGenerator<R> =
     Box<dyn Fn(&mut R, &ConcreteDataType, Option<&dyn Random<Ident, R>>) -> Value>;
+
+pub type TsValueGenerator<R> = Box<dyn Fn(&mut R, TimestampType) -> Value>;
 
 pub trait Generator<T, R: Rng> {
     type Error: Sync + Send + fmt::Debug;

--- a/tests-fuzz/targets/fuzz_insert.rs
+++ b/tests-fuzz/targets/fuzz_insert.rs
@@ -33,8 +33,8 @@ use tests_fuzz::generator::create_expr::CreateTableExprGeneratorBuilder;
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
 use tests_fuzz::ir::{
-    generate_random_value_for_mysql, replace_default, CreateTableExpr, InsertIntoExpr,
-    MySQLTsColumnTypeGenerator,
+    generate_random_timestamp_for_mysql, generate_random_value, replace_default, CreateTableExpr,
+    InsertIntoExpr, MySQLTsColumnTypeGenerator,
 };
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::mysql::insert_expr::InsertIntoExprTranslator;
@@ -101,7 +101,8 @@ fn generate_insert_expr<R: Rng + 'static>(
         .table_ctx(table_ctx)
         .omit_column_list(omit_column_list)
         .rows(input.rows)
-        .value_generator(Box::new(generate_random_value_for_mysql))
+        .value_generator(Box::new(generate_random_value))
+        .ts_value_generator(Box::new(generate_random_timestamp_for_mysql))
         .build()
         .unwrap();
     insert_generator.generate(rng)

--- a/tests-fuzz/targets/fuzz_insert_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_insert_logical_table.rs
@@ -36,7 +36,8 @@ use tests_fuzz::generator::create_expr::{
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
 use tests_fuzz::ir::{
-    generate_random_value_for_mysql, replace_default, CreateTableExpr, InsertIntoExpr,
+    generate_random_timestamp_for_mysql, generate_random_value, replace_default, CreateTableExpr,
+    InsertIntoExpr,
 };
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
 use tests_fuzz::translator::mysql::insert_expr::InsertIntoExprTranslator;
@@ -112,7 +113,8 @@ fn generate_insert_expr<R: Rng + 'static>(
         .omit_column_list(false)
         .table_ctx(table_ctx)
         .rows(rows)
-        .value_generator(Box::new(generate_random_value_for_mysql))
+        .value_generator(Box::new(generate_random_value))
+        .ts_value_generator(Box::new(generate_random_timestamp_for_mysql))
         .build()
         .unwrap();
     insert_generator.generate(rng)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Generate ts value separately

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
