### PR TITLE
fix: set local or session time_zone not work

### DIFF
--- a/src/servers/src/mysql/federated.rs
+++ b/src/servers/src/mysql/federated.rs
@@ -72,7 +72,6 @@ static OTHER_NOT_SUPPORTED_STMT: Lazy<RegexSet> = Lazy::new(|| {
         "(?i)^(SELECT \\$\\$)",
 
         // mysqldump.
-        "(?i)^(SET SESSION(.*))",
         "(?i)^(SET SQL_QUOTE_SHOW_CREATE(.*))",
         "(?i)^(LOCK TABLES(.*))",
         "(?i)^(UNLOCK TABLES(.*))",

--- a/tests/cases/standalone/common/system/timezone.result
+++ b/tests/cases/standalone/common/system/timezone.result
@@ -187,7 +187,7 @@ select to_unixtime('2024-01-02 00:00:00+08:00');
 +------------------------------------------------+
 
 --- UTC-8 ---
-SET TIME_ZONE = '-8:00';
+SET SESSION TIME_ZONE = '-8:00';
 
 Affected Rows: 0
 
@@ -281,7 +281,7 @@ drop table test;
 Affected Rows: 0
 
 -- revert timezone to UTC
-SET TIME_ZONE = 'UTC';
+SET LOCAL TIME_ZONE = 'UTC';
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/system/timezone.sql
+++ b/tests/cases/standalone/common/system/timezone.sql
@@ -48,7 +48,7 @@ select to_unixtime('2024-01-02 00:00:00');
 select to_unixtime('2024-01-02 00:00:00+08:00');
 
 --- UTC-8 ---
-SET TIME_ZONE = '-8:00';
+SET SESSION TIME_ZONE = '-8:00';
 
 SHOW VARIABLES time_zone;
 
@@ -71,7 +71,7 @@ select to_unixtime('2024-01-02 00:00:00+08:00');
 drop table test;
 
 -- revert timezone to UTC
-SET TIME_ZONE = 'UTC';
+SET LOCAL TIME_ZONE = 'UTC';
 
 SHOW VARIABLES time_zone;
 

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -436,7 +436,9 @@ impl Database for GreptimeDB {
 
         let mut client = self.client.lock().await;
 
-        if query.trim().to_lowercase().starts_with("use ") {
+        let query_str = query.trim().to_lowercase();
+
+        if query_str.starts_with("use ") {
             // use [db]
             let database = query
                 .split_ascii_whitespace()
@@ -447,7 +449,10 @@ impl Database for GreptimeDB {
             Box::new(ResultDisplayer {
                 result: Ok(Output::new_with_affected_rows(0)),
             }) as _
-        } else if query.trim().to_lowercase().starts_with("set time_zone") {
+        } else if query_str.starts_with("set time_zone")
+            || query_str.starts_with("set session time_zone")
+            || query_str.starts_with("set local time_zone")
+        {
             // set time_zone='xxx'
             let timezone = query
                 .split('=')


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

See https://github.com/GreptimeTeam/greptimedb/issues/3887

The doc PR https://github.com/GreptimeTeam/docs/pull/988

## What's changed and what's your intention?

Fix `SET SESSION time_zone='Asia/Shanghai'` or `SET LOCAL time_zone='Asia/Shanghai'`  not work.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
