### PR TITLE
feat: avoid some cloning when mirror requests to flownode

### DIFF
--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -208,7 +208,7 @@ impl Inserter {
                 let node_manager = self.node_manager.clone();
                 let flow_tasks = flow_requests.into_iter().map(|(peer, inserts)| {
                     let node_manager = node_manager.clone();
-                    common_runtime::spawn_write(async move {
+                    common_runtime::spawn_bg(async move {
                         node_manager
                             .flownode(&peer)
                             .await

--- a/src/operator/src/metrics.rs
+++ b/src/operator/src/metrics.rs
@@ -36,6 +36,11 @@ lazy_static! {
         "table operator ingest rows"
     )
     .unwrap();
+    pub static ref DIST_MIRROR_ROW_COUNT: IntCounter = register_int_counter!(
+        "greptime_table_operator_mirror_rows",
+        "table operator mirror rows"
+    )
+    .unwrap();
     pub static ref DIST_DELETE_ROW_COUNT: IntCounter = register_int_counter!(
         "greptime_table_operator_delete_rows",
         "table operator delete rows"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Do not spawn to check `source table` since there already has cache for this.
2. Avoid to cloning all requests to mirror.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
