### PR TITLE
feat: implement the `handle_batch_open_requests`

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -50,6 +50,7 @@ mod set_readonly_test;
 mod truncate_test;
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -58,22 +59,31 @@ use async_trait::async_trait;
 use common_error::ext::BoxedError;
 use common_recordbatch::SendableRecordBatchStream;
 use common_telemetry::tracing;
+use common_wal::options::{WalOptions, WAL_OPTIONS_KEY};
+use futures::future::{join_all, try_join_all};
 use object_store::manager::ObjectStoreManagerRef;
 use snafu::{ensure, OptionExt, ResultExt};
+use store_api::logstore::provider::Provider;
 use store_api::logstore::LogStore;
 use store_api::metadata::RegionMetadataRef;
-use store_api::region_engine::{RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse};
-use store_api::region_request::{AffectedRows, RegionRequest};
+use store_api::region_engine::{
+    BatchResponses, RegionEngine, RegionRole, RegionScannerRef, SetReadonlyResponse,
+};
+use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::{RegionId, ScanRequest};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Semaphore};
 
 use crate::config::MitoConfig;
-use crate::error::{InvalidRequestSnafu, RecvSnafu, RegionNotFoundSnafu, Result};
+use crate::error::{
+    InvalidRequestSnafu, JoinSnafu, RecvSnafu, RegionNotFoundSnafu, Result, SerdeJsonSnafu,
+};
 use crate::manifest::action::RegionEdit;
 use crate::metrics::HANDLE_REQUEST_ELAPSED;
 use crate::read::scan_region::{ScanParallism, ScanRegion, Scanner};
 use crate::region::RegionUsage;
 use crate::request::WorkerRequest;
+use crate::wal::entry_distributor::build_wal_entry_distributor_and_receivers;
+use crate::wal::raw_entry_reader::{LogStoreRawEntryReader, RawEntryReader};
 use crate::worker::WorkerGroup;
 
 pub const MITO_ENGINE_NAME: &str = "mito";
@@ -211,6 +221,45 @@ struct EngineInner {
     workers: WorkerGroup,
     /// Config of the engine.
     config: Arc<MitoConfig>,
+    /// The Wal raw entry reader.
+    wal_raw_entry_reader: Arc<dyn RawEntryReader>,
+}
+
+type TopicGroupedRegionOpenRequests = HashMap<String, Vec<(RegionId, RegionOpenRequest)>>;
+
+/// **For Kafka Remote Wal:**
+/// Group requests by topic.
+///
+/// **For RaftEngine Wal:**
+/// Do nothing
+fn prepare_batch_open_requests(
+    requests: Vec<(RegionId, RegionOpenRequest)>,
+) -> Result<(
+    TopicGroupedRegionOpenRequests,
+    Vec<(RegionId, RegionOpenRequest)>,
+)> {
+    let mut topic_to_regions: HashMap<String, Vec<(RegionId, RegionOpenRequest)>> = HashMap::new();
+    let mut remaining_regions: Vec<(RegionId, RegionOpenRequest)> = Vec::new();
+    for (region_id, request) in requests {
+        let options = if let Some(options) = request.options.get(WAL_OPTIONS_KEY) {
+            serde_json::from_str(options).context(SerdeJsonSnafu)?
+        } else {
+            WalOptions::RaftEngine
+        };
+        match options {
+            WalOptions::Kafka(options) => {
+                topic_to_regions
+                    .entry(options.topic)
+                    .or_default()
+                    .push((region_id, request));
+            }
+            WalOptions::RaftEngine => {
+                remaining_regions.push((region_id, request));
+            }
+        }
+    }
+
+    Ok((topic_to_regions, remaining_regions))
 }
 
 impl EngineInner {
@@ -221,9 +270,11 @@ impl EngineInner {
         object_store_manager: ObjectStoreManagerRef,
     ) -> Result<EngineInner> {
         let config = Arc::new(config);
+        let wal_raw_entry_reader = Arc::new(LogStoreRawEntryReader::new(log_store.clone()));
         Ok(EngineInner {
             workers: WorkerGroup::start(config.clone(), log_store, object_store_manager).await?,
             config,
+            wal_raw_entry_reader,
         })
     }
 
@@ -242,6 +293,106 @@ impl EngineInner {
             .get_region(region_id)
             .context(RegionNotFoundSnafu { region_id })?;
         Ok(region.metadata())
+    }
+
+    async fn open_topic_regions(
+        &self,
+        topic: String,
+        region_requests: Vec<(RegionId, RegionOpenRequest)>,
+    ) -> Result<Vec<Result<(RegionId, AffectedRows)>>> {
+        let mut response_receivers = Vec::with_capacity(region_requests.len());
+        let region_ids = region_requests
+            .iter()
+            .map(|(region_id, _)| *region_id)
+            .collect();
+        let provider = Provider::kafka_provider(topic);
+        let (distributor, entry_receivers) = build_wal_entry_distributor_and_receivers(
+            provider,
+            self.wal_raw_entry_reader.clone(),
+            region_ids,
+            2048,
+        );
+
+        for (region_id, request, receiver) in region_requests.into_iter().zip(entry_receivers).map(
+            |((region_id, request), entry_receiver)| {
+                let (request, receiver) = WorkerRequest::new_open_region_request(
+                    region_id,
+                    request,
+                    Some(entry_receiver),
+                );
+
+                (region_id, request, receiver)
+            },
+        ) {
+            self.workers.submit_to_worker(region_id, request).await?;
+            response_receivers.push((region_id, receiver));
+        }
+        // Waits for entries distribution.
+        let distribution =
+            common_runtime::spawn_read(async move { distributor.distribute().await });
+
+        // Waits for worker returns.
+        let responses = join_all(response_receivers.into_iter().map(
+            |(region_id, receiver)| async move {
+                receiver
+                    .await
+                    .context(RecvSnafu)?
+                    .map(|response| (region_id, response))
+            },
+        ))
+        .await;
+
+        let _ = distribution.await.context(JoinSnafu)?;
+        Ok(responses)
+    }
+
+    async fn handle_batch_open_requests(
+        &self,
+        parallelism: usize,
+        requests: Vec<(RegionId, RegionOpenRequest)>,
+    ) -> Result<Vec<Result<(RegionId, AffectedRows)>>> {
+        let semaphore = Arc::new(Semaphore::new(parallelism));
+        let (topic_to_region_requests, remaining_region_requests) =
+            prepare_batch_open_requests(requests)?;
+        let mut responses =
+            Vec::with_capacity(topic_to_region_requests.len() + remaining_region_requests.len());
+
+        if !topic_to_region_requests.is_empty() {
+            let mut tasks = Vec::with_capacity(topic_to_region_requests.len());
+            for (topic, region_requests) in topic_to_region_requests {
+                let self_ref = self;
+                let semaphore_moved = semaphore.clone();
+                tasks.push(async move {
+                    // Safety: semaphore must exist
+                    let _permit = semaphore_moved.acquire().await.unwrap();
+                    self_ref.open_topic_regions(topic, region_requests).await
+                })
+            }
+            let r = try_join_all(tasks).await?;
+            responses.extend(r.into_iter().flatten());
+        }
+
+        if !remaining_region_requests.is_empty() {
+            let mut tasks = Vec::with_capacity(remaining_region_requests.len());
+            for (region_id, request) in remaining_region_requests {
+                tasks.push(async move {
+                    let (request, receiver) =
+                        WorkerRequest::new_open_region_request(region_id, request, None);
+
+                    self.workers.submit_to_worker(region_id, request).await?;
+
+                    receiver
+                        .await
+                        .context(RecvSnafu)?
+                        .map(|response| (region_id, response))
+                })
+            }
+
+            let r = join_all(tasks).await;
+            responses.extend(r);
+        }
+
+        Ok(responses)
     }
 
     /// Handles [RegionRequest] and return its executed result.
@@ -321,6 +472,29 @@ impl EngineInner {
 impl RegionEngine for MitoEngine {
     fn name(&self) -> &str {
         MITO_ENGINE_NAME
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn handle_batch_open_requests(
+        &self,
+        parallelism: usize,
+        requests: Vec<(RegionId, RegionOpenRequest)>,
+    ) -> Result<BatchResponses, BoxedError> {
+        // TODO(weny): add metrics.
+        self.inner
+            .handle_batch_open_requests(parallelism, requests)
+            .await
+            .map(|responses| {
+                responses
+                    .into_iter()
+                    .map(|response| {
+                        response
+                            .map(|(region_id, row)| (region_id, RegionResponse::new(row)))
+                            .map_err(BoxedError::new)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .map_err(BoxedError::new)
     }
 
     #[tracing::instrument(skip_all)]
@@ -421,6 +595,7 @@ impl MitoEngine {
         config.sanitize(data_home)?;
 
         let config = Arc::new(config);
+        let wal_raw_entry_reader = Arc::new(LogStoreRawEntryReader::new(log_store.clone()));
         Ok(MitoEngine {
             inner: Arc::new(EngineInner {
                 workers: WorkerGroup::start_for_test(
@@ -433,6 +608,7 @@ impl MitoEngine {
                 )
                 .await?,
                 config,
+                wal_raw_entry_reader,
             }),
         })
     }

--- a/src/mito2/src/engine/batch_open_test.rs
+++ b/src/mito2/src/engine/batch_open_test.rs
@@ -1,0 +1,244 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use api::v1::Rows;
+use common_error::ext::ErrorExt;
+use common_error::status_code::StatusCode;
+use common_recordbatch::RecordBatches;
+use common_wal::options::{KafkaWalOptions, WalOptions, WAL_OPTIONS_KEY};
+use futures::future::join_all;
+use rstest::rstest;
+use rstest_reuse::apply;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::{RegionOpenRequest, RegionRequest};
+use store_api::storage::{RegionId, ScanRequest};
+use tokio::sync::Barrier;
+
+use super::MitoEngine;
+use crate::config::MitoConfig;
+use crate::test_util::{
+    build_rows, kafka_log_store_factory, multiple_log_store_factories,
+    prepare_test_for_kafka_log_store, put_rows, raft_engine_log_store_factory, rows_schema,
+    CreateRequestBuilder, LogStoreFactory, TestEnv,
+};
+
+#[apply(multiple_log_store_factories)]
+async fn test_batch_open(factory: Option<LogStoreFactory>) {
+    common_telemetry::init_default_ut_logging();
+    let Some(factory) = factory else {
+        return;
+    };
+    let mut env =
+        TestEnv::with_prefix("open-batch-regions").with_log_store_factory(factory.clone());
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let topic = prepare_test_for_kafka_log_store(&factory).await;
+
+    let num_regions = 3u32;
+    let barrier = Arc::new(Barrier::new(num_regions as usize));
+    let region_dir = |region_id| format!("test/{region_id}");
+    let mut tasks = vec![];
+    for id in 1..=num_regions {
+        let barrier = barrier.clone();
+        let engine = engine.clone();
+        let topic = topic.clone();
+        tasks.push(async move {
+            let region_id = RegionId::new(1, id);
+            let request = CreateRequestBuilder::new()
+                .region_dir(&region_dir(region_id))
+                .kafka_topic(topic.clone())
+                .build();
+            let column_schemas = rows_schema(&request);
+            engine
+                .handle_request(region_id, RegionRequest::Create(request))
+                .await
+                .unwrap();
+            barrier.wait().await;
+            for i in 0..10 {
+                let rows = Rows {
+                    schema: column_schemas.clone(),
+                    rows: build_rows(
+                        (id as usize) * 100 + i as usize,
+                        (id as usize) * 100 + i as usize + 1,
+                    ),
+                };
+                put_rows(&engine, region_id, rows).await;
+            }
+        });
+    }
+    join_all(tasks).await;
+
+    let assert_result = |engine: MitoEngine| async move {
+        let region_id = RegionId::new(1, 1);
+        let request = ScanRequest::default();
+        let stream = engine.scan_to_stream(region_id, request).await.unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        let expected = "+-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 100   | 100.0   | 1970-01-01T00:01:40 |
+| 101   | 101.0   | 1970-01-01T00:01:41 |
+| 102   | 102.0   | 1970-01-01T00:01:42 |
+| 103   | 103.0   | 1970-01-01T00:01:43 |
+| 104   | 104.0   | 1970-01-01T00:01:44 |
+| 105   | 105.0   | 1970-01-01T00:01:45 |
+| 106   | 106.0   | 1970-01-01T00:01:46 |
+| 107   | 107.0   | 1970-01-01T00:01:47 |
+| 108   | 108.0   | 1970-01-01T00:01:48 |
+| 109   | 109.0   | 1970-01-01T00:01:49 |
++-------+---------+---------------------+";
+        assert_eq!(expected, batches.pretty_print().unwrap());
+
+        let region_id = RegionId::new(1, 2);
+        let request = ScanRequest::default();
+        let stream = engine.scan_to_stream(region_id, request).await.unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        let expected = "+-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 200   | 200.0   | 1970-01-01T00:03:20 |
+| 201   | 201.0   | 1970-01-01T00:03:21 |
+| 202   | 202.0   | 1970-01-01T00:03:22 |
+| 203   | 203.0   | 1970-01-01T00:03:23 |
+| 204   | 204.0   | 1970-01-01T00:03:24 |
+| 205   | 205.0   | 1970-01-01T00:03:25 |
+| 206   | 206.0   | 1970-01-01T00:03:26 |
+| 207   | 207.0   | 1970-01-01T00:03:27 |
+| 208   | 208.0   | 1970-01-01T00:03:28 |
+| 209   | 209.0   | 1970-01-01T00:03:29 |
++-------+---------+---------------------+";
+        assert_eq!(expected, batches.pretty_print().unwrap());
+
+        let region_id = RegionId::new(1, 3);
+        let request = ScanRequest::default();
+        let stream = engine.scan_to_stream(region_id, request).await.unwrap();
+        let batches = RecordBatches::try_collect(stream).await.unwrap();
+        let expected = "+-------+---------+---------------------+
+| tag_0 | field_0 | ts                  |
++-------+---------+---------------------+
+| 300   | 300.0   | 1970-01-01T00:05:00 |
+| 301   | 301.0   | 1970-01-01T00:05:01 |
+| 302   | 302.0   | 1970-01-01T00:05:02 |
+| 303   | 303.0   | 1970-01-01T00:05:03 |
+| 304   | 304.0   | 1970-01-01T00:05:04 |
+| 305   | 305.0   | 1970-01-01T00:05:05 |
+| 306   | 306.0   | 1970-01-01T00:05:06 |
+| 307   | 307.0   | 1970-01-01T00:05:07 |
+| 308   | 308.0   | 1970-01-01T00:05:08 |
+| 309   | 309.0   | 1970-01-01T00:05:09 |
++-------+---------+---------------------+";
+        assert_eq!(expected, batches.pretty_print().unwrap());
+    };
+    assert_result(engine.clone()).await;
+
+    let mut options = HashMap::new();
+    if let Some(topic) = &topic {
+        options.insert(
+            WAL_OPTIONS_KEY.to_string(),
+            serde_json::to_string(&WalOptions::Kafka(KafkaWalOptions {
+                topic: topic.to_string(),
+            }))
+            .unwrap(),
+        );
+    };
+    let mut requests = (1..=num_regions)
+        .map(|id| {
+            let region_id = RegionId::new(1, id);
+            (
+                region_id,
+                RegionOpenRequest {
+                    engine: String::new(),
+                    region_dir: region_dir(region_id),
+                    options: options.clone(),
+                    skip_wal_replay: false,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    requests.push((
+        RegionId::new(1, 4),
+        RegionOpenRequest {
+            engine: String::new(),
+            region_dir: "no-exists".to_string(),
+            options: options.clone(),
+            skip_wal_replay: false,
+        },
+    ));
+
+    // Reopen engine.
+    let engine = env.reopen_engine(engine, MitoConfig::default()).await;
+    let mut results = engine
+        .handle_batch_open_requests(4, requests)
+        .await
+        .unwrap();
+    let (_, result) = results.pop().unwrap();
+    assert_eq!(
+        result.unwrap_err().status_code(),
+        StatusCode::RegionNotFound
+    );
+    for (_, result) in results {
+        assert!(result.is_ok());
+    }
+    assert_result(engine.clone()).await;
+}
+
+#[apply(multiple_log_store_factories)]
+async fn test_batch_open_err(factory: Option<LogStoreFactory>) {
+    common_telemetry::init_default_ut_logging();
+    let Some(factory) = factory else {
+        return;
+    };
+    let mut env =
+        TestEnv::with_prefix("open-batch-regions-err").with_log_store_factory(factory.clone());
+    let engine = env.create_engine(MitoConfig::default()).await;
+    let topic = prepare_test_for_kafka_log_store(&factory).await;
+    let mut options = HashMap::new();
+    if let Some(topic) = &topic {
+        options.insert(
+            WAL_OPTIONS_KEY.to_string(),
+            serde_json::to_string(&WalOptions::Kafka(KafkaWalOptions {
+                topic: topic.to_string(),
+            }))
+            .unwrap(),
+        );
+    };
+    let num_regions = 3u32;
+    let region_dir = "test".to_string();
+    let requests = (1..=num_regions)
+        .map(|id| {
+            (
+                RegionId::new(1, id),
+                RegionOpenRequest {
+                    engine: String::new(),
+                    region_dir: region_dir.to_string(),
+                    options: options.clone(),
+                    skip_wal_replay: false,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let results = engine
+        .handle_batch_open_requests(3, requests)
+        .await
+        .unwrap();
+    for (_, result) in results {
+        assert_eq!(
+            result.unwrap_err().status_code(),
+            StatusCode::RegionNotFound
+        );
+    }
+}

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -110,8 +110,11 @@ impl RegionOpener {
 
     /// If a [WalEntryReader] is set, the [RegionOpener] will use [WalEntryReader] instead of
     /// constructing a new one from scratch.
-    pub(crate) fn wal_entry_reader(mut self, wal_entry_reader: Box<dyn WalEntryReader>) -> Self {
-        self.wal_entry_reader = Some(wal_entry_reader);
+    pub(crate) fn wal_entry_reader(
+        mut self,
+        wal_entry_reader: Option<Box<dyn WalEntryReader>>,
+    ) -> Self {
+        self.wal_entry_reader = wal_entry_reader;
         self
     }
 

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -108,7 +108,7 @@ impl RegionOpener {
         Ok(self)
     }
 
-    /// If a [WalEntryReader] is set, the [RegionOpener] will use [WalEntryReader] instead of 
+    /// If a [WalEntryReader] is set, the [RegionOpener] will use [WalEntryReader] instead of
     /// constructing a new one from scratch.
     pub(crate) fn wal_entry_reader(mut self, wal_entry_reader: Box<dyn WalEntryReader>) -> Self {
         self.wal_entry_reader = Some(wal_entry_reader);

--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use common_telemetry::{debug, error, info, warn};
 use common_wal::options::WalOptions;
+use futures::future::BoxFuture;
 use futures::StreamExt;
 use object_store::manager::ObjectStoreManagerRef;
 use object_store::util::{join_dir, normalize_dir};
@@ -48,6 +49,7 @@ use crate::schedule::scheduler::SchedulerRef;
 use crate::sst::file_purger::LocalFilePurger;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::time_provider::{StdTimeProvider, TimeProviderRef};
+use crate::wal::entry_reader::WalEntryReader;
 use crate::wal::{EntryId, Wal};
 
 /// Builder to create a new [MitoRegion] or open an existing one.
@@ -64,6 +66,7 @@ pub(crate) struct RegionOpener {
     intermediate_manager: IntermediateManager,
     time_provider: Option<TimeProviderRef>,
     stats: ManifestStats,
+    wal_entry_reader: Option<Box<dyn WalEntryReader>>,
 }
 
 impl RegionOpener {
@@ -89,6 +92,7 @@ impl RegionOpener {
             intermediate_manager,
             time_provider: None,
             stats: Default::default(),
+            wal_entry_reader: None,
         }
     }
 
@@ -102,6 +106,13 @@ impl RegionOpener {
     pub(crate) fn parse_options(mut self, options: HashMap<String, String>) -> Result<Self> {
         self.options = Some(RegionOptions::try_from(&options)?);
         Ok(self)
+    }
+
+    /// If a [WalEntryReader] is set, the [RegionOpener] will use [WalEntryReader] instead of 
+    /// constructing a new one from scratch.
+    pub(crate) fn wal_entry_reader(mut self, wal_entry_reader: Box<dyn WalEntryReader>) -> Self {
+        self.wal_entry_reader = Some(wal_entry_reader);
+        self
     }
 
     /// Sets options for the region.
@@ -165,8 +176,8 @@ impl RegionOpener {
             }
         }
         let options = self.options.take().unwrap();
-        let provider = self.provider(&options.wal_options);
         let object_store = self.object_store(&options.storage)?.clone();
+        let provider = self.provider(&options.wal_options);
 
         // Create a manifest manager for this region and writes regions to the manifest file.
         let region_manifest_options = self.manifest_options(config, &options)?;
@@ -231,7 +242,7 @@ impl RegionOpener {
     ///
     /// Returns error if the region doesn't exist.
     pub(crate) async fn open<S: LogStore>(
-        self,
+        mut self,
         config: &MitoConfig,
         wal: &Wal<S>,
     ) -> Result<MitoRegion> {
@@ -267,7 +278,7 @@ impl RegionOpener {
 
     /// Tries to open the region and returns `None` if the region directory is empty.
     async fn maybe_open<S: LogStore>(
-        &self,
+        &mut self,
         config: &MitoConfig,
         wal: &Wal<S>,
     ) -> Result<Option<MitoRegion>> {
@@ -288,6 +299,11 @@ impl RegionOpener {
 
         let region_id = self.region_id;
         let provider = self.provider(&region_options.wal_options);
+        let wal_entry_reader = self
+            .wal_entry_reader
+            .take()
+            .unwrap_or_else(|| wal.wal_entry_reader(&provider, region_id));
+        let on_region_opened = wal.on_region_opened();
         let object_store = self.object_store(&region_options.storage)?.clone();
 
         debug!("Open region {} with options: {:?}", region_id, self.options);
@@ -331,12 +347,13 @@ impl RegionOpener {
                 region_id
             );
             replay_memtable(
-                wal,
                 &provider,
+                wal_entry_reader,
                 region_id,
                 flushed_entry_id,
                 &version_control,
                 config.allow_stale_entries,
+                on_region_opened,
             )
             .await?;
         } else {
@@ -357,7 +374,7 @@ impl RegionOpener {
                 RegionState::ReadOnly,
             )),
             file_purger,
-            provider,
+            provider: provider.clone(),
             last_flush_millis: AtomicI64::new(time_provider.current_time_millis()),
             time_provider,
             memtable_builder,
@@ -448,21 +465,25 @@ pub(crate) fn check_recovered_region(
 }
 
 /// Replays the mutations from WAL and inserts mutations to memtable of given region.
-pub(crate) async fn replay_memtable<S: LogStore>(
-    wal: &Wal<S>,
+pub(crate) async fn replay_memtable<F>(
     provider: &Provider,
+    mut wal_entry_reader: Box<dyn WalEntryReader>,
     region_id: RegionId,
     flushed_entry_id: EntryId,
     version_control: &VersionControlRef,
     allow_stale_entries: bool,
-) -> Result<EntryId> {
+    on_region_opened: F,
+) -> Result<EntryId>
+where
+    F: FnOnce(RegionId, EntryId, &Provider) -> BoxFuture<Result<()>> + Send,
+{
     let mut rows_replayed = 0;
     // Last entry id should start from flushed entry id since there might be no
     // data in the WAL.
     let mut last_entry_id = flushed_entry_id;
     let replay_from_entry_id = flushed_entry_id + 1;
 
-    let mut wal_stream = wal.scan(region_id, replay_from_entry_id, provider)?;
+    let mut wal_stream = wal_entry_reader.read(provider, replay_from_entry_id)?;
     while let Some(res) = wal_stream.next().await {
         let (entry_id, entry) = res?;
         if entry_id <= flushed_entry_id {
@@ -496,7 +517,7 @@ pub(crate) async fn replay_memtable<S: LogStore>(
 
     // TODO(weny): We need to update `flushed_entry_id` in the region manifest
     // to avoid reading potentially incomplete entries in the future.
-    wal.obsolete(region_id, flushed_entry_id, provider).await?;
+    (on_region_opened)(region_id, flushed_entry_id, provider).await?;
 
     info!(
         "Replay WAL for region: {}, rows recovered: {}, last entry id: {}",

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -107,7 +107,7 @@ pub(crate) fn kafka_log_store_factory() -> Option<LogStoreFactory> {
 #[rstest]
 #[case::with_raft_engine(raft_engine_log_store_factory())]
 #[case::with_kafka(kafka_log_store_factory())]
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 pub(crate) fn multiple_log_store_factories(#[case] factory: Option<LogStoreFactory>) {}
 
 #[derive(Clone)]

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -107,7 +107,7 @@ pub(crate) fn kafka_log_store_factory() -> Option<LogStoreFactory> {
 #[rstest]
 #[case::with_raft_engine(raft_engine_log_store_factory())]
 #[case::with_kafka(kafka_log_store_factory())]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 pub(crate) fn multiple_log_store_factories(#[case] factory: Option<LogStoreFactory>) {}
 
 #[derive(Clone)]

--- a/src/mito2/src/wal.rs
+++ b/src/mito2/src/wal.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 
 use api::v1::WalEntry;
 use common_error::ext::BoxedError;
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use prost::Message;
 use snafu::ResultExt;
@@ -83,6 +84,39 @@ impl<S: LogStore> Wal<S> {
             entries: Vec::new(),
             entry_encode_buf: Vec::new(),
             providers: HashMap::new(),
+        }
+    }
+
+    /// Returns a [OnRegionOpened] function.
+    pub(crate) fn on_region_opened(
+        &self,
+    ) -> impl FnOnce(RegionId, EntryId, &Provider) -> BoxFuture<Result<()>> {
+        let store = self.store.clone();
+        move |region_id, last_entry_id, provider| -> BoxFuture<'_, Result<()>> {
+            Box::pin(async move {
+                store
+                    .obsolete(provider, last_entry_id)
+                    .await
+                    .map_err(BoxedError::new)
+                    .context(DeleteWalSnafu { region_id })
+            })
+        }
+    }
+
+    /// Returns a [WalEntryReader]
+    pub(crate) fn wal_entry_reader(
+        &self,
+        provider: &Provider,
+        region_id: RegionId,
+    ) -> Box<dyn WalEntryReader> {
+        match provider {
+            Provider::RaftEngine(_) => Box::new(LogStoreEntryReader::new(
+                LogStoreRawEntryReader::new(self.store.clone()),
+            )),
+            Provider::Kafka(_) => Box::new(LogStoreEntryReader::new(RegionRawEntryReader::new(
+                LogStoreRawEntryReader::new(self.store.clone()),
+                region_id,
+            ))),
         }
     }
 

--- a/src/mito2/src/wal/entry_distributor.rs
+++ b/src/mito2/src/wal/entry_distributor.rs
@@ -122,12 +122,12 @@ impl WalEntryReceiver {
 
 impl WalEntryReader for WalEntryReceiver {
     fn read(&mut self, provider: &Provider, start_id: EntryId) -> Result<WalEntryStream<'static>> {
-        let mut arg_sender = self
-            .arg_sender
-            .take()
-            .context(error::InvalidWalReadRequestSnafu {
-                reason: format!("Call WalEntryReceiver multiple time, start_id: {start_id}"),
-            })?;
+        let mut arg_sender =
+            self.arg_sender
+                .take()
+                .with_context(|| error::InvalidWalReadRequestSnafu {
+                    reason: format!("Call WalEntryReceiver multiple time, start_id: {start_id}"),
+                })?;
         // Safety: check via arg_sender
         let mut entry_receiver = self.entry_receiver.take().unwrap();
 
@@ -169,6 +169,9 @@ struct EntryReceiver {
     start_id: EntryId,
     sender: Sender<Entry>,
 }
+
+/// The default buffer size of the [Entry] receiver.
+pub const DEFAULT_ENTRY_RECEIVER_BUFFER_SIZE: usize = 2048;
 
 /// Returns [WalEntryDistributor] and batch [WalEntryReceiver]s.
 ///

--- a/src/mito2/src/wal/entry_distributor.rs
+++ b/src/mito2/src/wal/entry_distributor.rs
@@ -192,14 +192,14 @@ pub const DEFAULT_ENTRY_RECEIVER_BUFFER_SIZE: usize = 2048;
 pub fn build_wal_entry_distributor_and_receivers(
     provider: Provider,
     raw_wal_reader: Arc<dyn RawEntryReader>,
-    region_ids: Vec<RegionId>,
+    region_ids: &[RegionId],
     buffer_size: usize,
 ) -> (WalEntryDistributor, Vec<WalEntryReceiver>) {
     let mut senders = HashMap::with_capacity(region_ids.len());
     let mut readers = Vec::with_capacity(region_ids.len());
     let mut arg_receivers = Vec::with_capacity(region_ids.len());
 
-    for region_id in region_ids {
+    for &region_id in region_ids {
         let (entry_sender, entry_receiver) = mpsc::channel(buffer_size);
         let (arg_sender, arg_receiver) = oneshot::channel();
 
@@ -263,7 +263,7 @@ mod tests {
         let (distributor, receivers) = build_wal_entry_distributor_and_receivers(
             provider,
             reader,
-            vec![RegionId::new(1024, 1), RegionId::new(1025, 1)],
+            &[RegionId::new(1024, 1), RegionId::new(1025, 1)],
             128,
         );
 
@@ -323,7 +323,7 @@ mod tests {
         let (distributor, mut receivers) = build_wal_entry_distributor_and_receivers(
             provider.clone(),
             reader,
-            vec![
+            &[
                 RegionId::new(1024, 1),
                 RegionId::new(1024, 2),
                 RegionId::new(1024, 3),
@@ -433,7 +433,7 @@ mod tests {
         let (distributor, mut receivers) = build_wal_entry_distributor_and_receivers(
             provider.clone(),
             Arc::new(corrupted_stream),
-            vec![region1, region2, region3],
+            &[region1, region2, region3],
             128,
         );
         assert_eq!(receivers.len(), 3);
@@ -516,7 +516,7 @@ mod tests {
         let (distributor, mut receivers) = build_wal_entry_distributor_and_receivers(
             provider.clone(),
             Arc::new(corrupted_stream),
-            vec![region1, region2],
+            &[region1, region2],
             128,
         );
         assert_eq!(receivers.len(), 2);
@@ -608,7 +608,7 @@ mod tests {
         let (distributor, mut receivers) = build_wal_entry_distributor_and_receivers(
             provider.clone(),
             reader,
-            vec![RegionId::new(1024, 1), RegionId::new(1024, 2)],
+            &[RegionId::new(1024, 1), RegionId::new(1024, 2)],
             128,
         );
         assert_eq!(receivers.len(), 2);

--- a/src/mito2/src/wal/entry_reader.rs
+++ b/src/mito2/src/wal/entry_reader.rs
@@ -38,6 +38,8 @@ pub(crate) fn decode_raw_entry(raw_entry: Entry) -> Result<(EntryId, WalEntry)> 
 }
 
 /// [WalEntryReader] provides the ability to read and decode entries from the underlying store.
+///
+/// Notes: It will consume the inner stream and only allow invoking the `read` at once.
 pub(crate) trait WalEntryReader: Send + Sync {
     fn read(&mut self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>>;
 }

--- a/src/mito2/src/wal/entry_reader.rs
+++ b/src/mito2/src/wal/entry_reader.rs
@@ -39,7 +39,7 @@ pub(crate) fn decode_raw_entry(raw_entry: Entry) -> Result<(EntryId, WalEntry)> 
 
 /// [WalEntryReader] provides the ability to read and decode entries from the underlying store.
 pub(crate) trait WalEntryReader: Send + Sync {
-    fn read(self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>>;
+    fn read(&mut self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>>;
 }
 
 /// A Reader reads the [RawEntry] from [RawEntryReader] and decodes [RawEntry] into [WalEntry].
@@ -54,7 +54,7 @@ impl<R> LogStoreEntryReader<R> {
 }
 
 impl<R: RawEntryReader> WalEntryReader for LogStoreEntryReader<R> {
-    fn read(self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>> {
+    fn read(&mut self, ns: &'_ Provider, start_id: EntryId) -> Result<WalEntryStream<'static>> {
         let LogStoreEntryReader { reader } = self;
         let mut stream = reader.read(ns, start_id)?;
 
@@ -136,7 +136,7 @@ mod tests {
             ],
         };
 
-        let reader = LogStoreEntryReader::new(raw_entry_stream);
+        let mut reader = LogStoreEntryReader::new(raw_entry_stream);
         let entries = reader
             .read(&provider, 0)
             .unwrap()
@@ -172,7 +172,7 @@ mod tests {
             ],
         };
 
-        let reader = LogStoreEntryReader::new(raw_entry_stream);
+        let mut reader = LogStoreEntryReader::new(raw_entry_stream);
         let err = reader
             .read(&provider, 0)
             .unwrap()

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -721,8 +721,8 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             let res = match ddl.request {
                 DdlRequest::Create(req) => self.handle_create_request(ddl.region_id, req).await,
                 DdlRequest::Drop(_) => self.handle_drop_request(ddl.region_id).await,
-                DdlRequest::Open(req) => {
-                    self.handle_open_request(ddl.region_id, req, ddl.sender)
+                DdlRequest::Open((req, wal_entry_receiver)) => {
+                    self.handle_open_request(ddl.region_id, req, wal_entry_receiver, ddl.sender)
                         .await;
                     continue;
                 }

--- a/src/mito2/src/worker/handle_catchup.rs
+++ b/src/mito2/src/worker/handle_catchup.rs
@@ -73,13 +73,16 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let flushed_entry_id = region.version_control.current().last_entry_id;
         info!("Trying to replay memtable for region: {region_id}, flushed entry id: {flushed_entry_id}");
         let timer = Instant::now();
+        let wal_entry_reader = self.wal.wal_entry_reader(&region.provider, region_id);
+        let on_region_opened = self.wal.on_region_opened();
         let last_entry_id = replay_memtable(
-            &self.wal,
             &region.provider,
+            wal_entry_reader,
             region_id,
             flushed_entry_id,
             &region.version_control,
             self.config.allow_stale_entries,
+            on_region_opened,
         )
         .await?;
         info!(

--- a/src/store-api/Cargo.toml
+++ b/src/store-api/Cargo.toml
@@ -26,8 +26,8 @@ serde.workspace = true
 serde_json.workspace = true
 snafu.workspace = true
 strum.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 async-stream.workspace = true
 serde_json.workspace = true
-tokio.workspace = true

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -193,7 +193,7 @@ pub trait RegionEngine: Send + Sync {
         requests: Vec<(RegionId, RegionOpenRequest)>,
     ) -> Result<BatchResponses, BoxedError> {
         let semaphore = Arc::new(Semaphore::new(parallelism));
-        let mut tasks = Vec::with_capacity(parallelism);
+        let mut tasks = Vec::with_capacity(requests.len());
 
         for (region_id, request) in requests {
             let semaphore_moved = semaphore.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4026

## What's changed and what's your intention?

1. Add the `handle_batch_open_requests ` method for the `RegionEngine` trait
2. Implement the `handle_batch_open_requests` method for `mito`. It tries to group opening regions by topic and then open regions with the same topic in a batch.


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
