### PR TITLE
fix: add tailing separator to prefix

### DIFF
--- a/src/common/function/src/scalars/math/clamp.rs
+++ b/src/common/function/src/scalars/math/clamp.rs
@@ -143,8 +143,6 @@ fn clamp_impl<T: LogicalPrimitiveType, const CLAMP_MIN: bool, const CLAMP_MAX: b
     min: T::Native,
     max: T::Native,
 ) -> Result<VectorRef> {
-    common_telemetry::info!("[DEBUG] min {min:?}, max {max:?}");
-
     let iter = ArrayIter::new(input);
     let result = iter.map(|x| {
         x.map(|x| {

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -72,12 +72,8 @@ impl DatanodeTableKey {
         }
     }
 
-    fn prefix(datanode_id: DatanodeId) -> String {
-        format!("{}/{datanode_id}", DATANODE_TABLE_KEY_PREFIX)
-    }
-
-    pub fn range_start_key(datanode_id: DatanodeId) -> String {
-        format!("{}/", Self::prefix(datanode_id))
+    pub fn prefix(datanode_id: DatanodeId) -> String {
+        format!("{}/{datanode_id}/", DATANODE_TABLE_KEY_PREFIX)
     }
 }
 
@@ -114,7 +110,7 @@ impl<'a> MetaKey<'a, DatanodeTableKey> for DatanodeTableKey {
 
 impl Display for DatanodeTableKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", Self::prefix(self.datanode_id), self.table_id)
+        write!(f, "{}{}", Self::prefix(self.datanode_id), self.table_id)
     }
 }
 
@@ -164,7 +160,7 @@ impl DatanodeTableManager {
         &self,
         datanode_id: DatanodeId,
     ) -> BoxStream<'static, Result<DatanodeTableValue>> {
-        let start_key = DatanodeTableKey::range_start_key(datanode_id);
+        let start_key = DatanodeTableKey::prefix(datanode_id);
         let req = RangeRequest::new().with_prefix(start_key.as_bytes());
 
         let stream = PaginationStream::new(

--- a/src/common/meta/src/key/flow/flownode_flow.rs
+++ b/src/common/meta/src/key/flow/flownode_flow.rs
@@ -69,8 +69,7 @@ impl FlownodeFlowKey {
 
     /// The prefix used to retrieve all [FlownodeFlowKey]s with the specified `flownode_id`.
     pub fn range_start_key(flownode_id: FlownodeId) -> Vec<u8> {
-        let inner =
-            BytesAdapter::from(FlownodeFlowKeyInner::range_start_key(flownode_id).into_bytes());
+        let inner = BytesAdapter::from(FlownodeFlowKeyInner::prefix(flownode_id).into_bytes());
 
         FlowScoped::new(inner).to_bytes()
     }
@@ -108,13 +107,8 @@ impl FlownodeFlowKeyInner {
         }
     }
 
-    fn prefix(flownode_id: FlownodeId) -> String {
-        format!("{}/{flownode_id}", FLOWNODE_FLOW_KEY_PREFIX)
-    }
-
-    /// The prefix used to retrieve all [FlownodeFlowKey]s with the specified `flownode_id`.
-    fn range_start_key(flownode_id: FlownodeId) -> String {
-        format!("{}/", Self::prefix(flownode_id))
+    pub fn prefix(flownode_id: FlownodeId) -> String {
+        format!("{}/{flownode_id}/", FLOWNODE_FLOW_KEY_PREFIX)
     }
 }
 

--- a/src/common/meta/src/key/flow/table_flow.rs
+++ b/src/common/meta/src/key/flow/table_flow.rs
@@ -80,7 +80,7 @@ impl TableFlowKey {
 
     /// The prefix used to retrieve all [TableFlowKey]s with the specified `table_id`.
     pub fn range_start_key(table_id: TableId) -> Vec<u8> {
-        let inner = BytesAdapter::from(TableFlowKeyInner::range_start_key(table_id).into_bytes());
+        let inner = BytesAdapter::from(TableFlowKeyInner::prefix(table_id).into_bytes());
 
         FlowScoped::new(inner).to_bytes()
     }
@@ -123,12 +123,7 @@ impl TableFlowKeyInner {
     }
 
     fn prefix(table_id: TableId) -> String {
-        format!("{}/{table_id}", TABLE_FLOW_KEY_PREFIX)
-    }
-
-    /// The prefix used to retrieve all [TableFlowKey]s with the specified `table_id`.
-    fn range_start_key(table_id: TableId) -> String {
-        format!("{}/", Self::prefix(table_id))
+        format!("{}/{table_id}/", TABLE_FLOW_KEY_PREFIX)
     }
 }
 

--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -48,7 +48,7 @@ impl<'a> TableNameKey<'a> {
     }
 
     pub fn prefix_to_table(catalog: &str, schema: &str) -> String {
-        format!("{}/{}/{}", TABLE_NAME_KEY_PREFIX, catalog, schema)
+        format!("{}/{}/{}/", TABLE_NAME_KEY_PREFIX, catalog, schema)
     }
 }
 
@@ -56,7 +56,7 @@ impl Display for TableNameKey<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}/{}",
+            "{}{}",
             Self::prefix_to_table(self.catalog, self.schema),
             self.table
         )
@@ -268,7 +268,11 @@ impl TableNameManager {
 #[cfg(test)]
 mod tests {
 
+    use futures::StreamExt;
+
     use super::*;
+    use crate::kv_backend::KvBackend;
+    use crate::rpc::store::PutRequest;
 
     #[test]
     fn test_strip_table_name() {
@@ -323,5 +327,40 @@ mod tests {
 
         assert_eq!(value.try_as_raw_value().unwrap(), literal);
         assert_eq!(TableNameValue::try_from_raw_value(literal).unwrap(), value);
+    }
+
+    #[tokio::test]
+    async fn test_prefix_scan_tables() {
+        let memory_kv = Arc::new(MemoryKvBackend::<crate::error::Error>::new());
+        memory_kv
+            .put(PutRequest {
+                key: TableNameKey {
+                    catalog: "greptime",
+                    schema: "👉",
+                    table: "t",
+                }
+                .to_bytes(),
+                value: vec![],
+                prev_kv: false,
+            })
+            .await
+            .unwrap();
+        memory_kv
+            .put(PutRequest {
+                key: TableNameKey {
+                    catalog: "greptime",
+                    schema: "👉👈",
+                    table: "t",
+                }
+                .to_bytes(),
+                value: vec![],
+                prev_kv: false,
+            })
+            .await
+            .unwrap();
+
+        let manager = TableNameManager::new(memory_kv);
+        let items = manager.tables("greptime", "👉").collect::<Vec<_>>().await;
+        assert_eq!(items.len(), 1);
     }
 }

--- a/tests/cases/standalone/common/information_schema/tables.result
+++ b/tests/cases/standalone/common/information_schema/tables.result
@@ -1,0 +1,46 @@
+create schema abc;
+
+Affected Rows: 1
+
+use abc;
+
+Affected Rows: 0
+
+create table t (ts timestamp time index);
+
+Affected Rows: 0
+
+create schema abcde;
+
+Affected Rows: 1
+
+use abcde;
+
+Affected Rows: 0
+
+create table t (ts timestamp time index);
+
+Affected Rows: 0
+
+select * from information_schema.tables where table_schema != 'information_schema';
+
++---------------+--------------+------------+-----------------+----------+-------------+
+| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
++---------------+--------------+------------+-----------------+----------+-------------+
+| greptime      | abc          | t          | BASE TABLE      | 1024     | mito        |
+| greptime      | abcde        | t          | BASE TABLE      | 1025     | mito        |
+| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
++---------------+--------------+------------+-----------------+----------+-------------+
+
+use public;
+
+Affected Rows: 0
+
+drop schema abc;
+
+Affected Rows: 0
+
+drop schema abcde;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/information_schema/tables.result
+++ b/tests/cases/standalone/common/information_schema/tables.result
@@ -22,15 +22,15 @@ create table t (ts timestamp time index);
 
 Affected Rows: 0
 
-select * from information_schema.tables where table_schema != 'information_schema';
+select table_catalog, table_schema, table_name from information_schema.tables where table_schema != 'information_schema';
 
-+---------------+--------------+------------+-----------------+----------+-------------+
-| table_catalog | table_schema | table_name | table_type      | table_id | engine      |
-+---------------+--------------+------------+-----------------+----------+-------------+
-| greptime      | abc          | t          | BASE TABLE      | 1024     | mito        |
-| greptime      | abcde        | t          | BASE TABLE      | 1025     | mito        |
-| greptime      | public       | numbers    | LOCAL TEMPORARY | 2        | test_engine |
-+---------------+--------------+------------+-----------------+----------+-------------+
++---------------+--------------+------------+
+| table_catalog | table_schema | table_name |
++---------------+--------------+------------+
+| greptime      | abc          | t          |
+| greptime      | abcde        | t          |
+| greptime      | public       | numbers    |
++---------------+--------------+------------+
 
 use public;
 

--- a/tests/cases/standalone/common/information_schema/tables.sql
+++ b/tests/cases/standalone/common/information_schema/tables.sql
@@ -1,0 +1,19 @@
+create schema abc;
+
+use abc;
+
+create table t (ts timestamp time index);
+
+create schema abcde;
+
+use abcde;
+
+create table t (ts timestamp time index);
+
+select * from information_schema.tables where table_schema != 'information_schema';
+
+use public;
+
+drop schema abc;
+
+drop schema abcde;

--- a/tests/cases/standalone/common/information_schema/tables.sql
+++ b/tests/cases/standalone/common/information_schema/tables.sql
@@ -10,7 +10,7 @@ use abcde;
 
 create table t (ts timestamp time index);
 
-select * from information_schema.tables where table_schema != 'information_schema';
+select table_catalog, table_schema, table_name from information_schema.tables where table_schema != 'information_schema';
 
 use public;
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add tailing separator to prefix, otherwise it cannot handle when one schema name is a substring of another.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
