### PR TITLE
fix: display error in correct format

### DIFF
--- a/src/client/src/client.rs
+++ b/src/client/src/client.rs
@@ -173,14 +173,14 @@ impl Client {
         Ok(FlightClient { addr, client })
     }
 
-    pub(crate) fn raw_region_client(&self) -> Result<PbRegionClient<Channel>> {
-        let (_, channel) = self.find_channel()?;
+    pub(crate) fn raw_region_client(&self) -> Result<(String, PbRegionClient<Channel>)> {
+        let (addr, channel) = self.find_channel()?;
         let client = PbRegionClient::new(channel)
             .max_decoding_message_size(self.max_grpc_recv_message_size())
             .max_encoding_message_size(self.max_grpc_send_message_size())
             .accept_compressed(CompressionEncoding::Zstd)
             .send_compressed(CompressionEncoding::Zstd);
-        Ok(client)
+        Ok((addr, client))
     }
 
     pub fn make_prometheus_gateway_client(&self) -> Result<PrometheusGatewayClient<Channel>> {

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -89,8 +89,9 @@ pub enum Error {
         source: common_grpc::error::Error,
     },
 
-    #[snafu(display("Failed to request RegionServer, code: {}", code))]
+    #[snafu(display("Failed to request RegionServer {}, code: {}", addr, code))]
     RegionServer {
+        addr: String,
         code: Code,
         source: BoxedError,
         #[snafu(implicit)]

--- a/src/client/src/region.rs
+++ b/src/client/src/region.rs
@@ -177,7 +177,7 @@ impl RegionRequester {
             .with_label_values(&[request_type.as_str()])
             .start_timer();
 
-        let mut client = self.client.raw_region_client()?;
+        let (addr, mut client) = self.client.raw_region_client()?;
 
         let response = client
             .handle(request)
@@ -187,6 +187,7 @@ impl RegionRequester {
                 let err: error::Error = e.into();
                 // Uses `Error::RegionServer` instead of `Error::Server`
                 error::Error::RegionServer {
+                    addr,
                     code,
                     source: BoxedError::new(err),
                     location: location!(),

--- a/src/datanode/src/event_listener.rs
+++ b/src/datanode/src/event_listener.rs
@@ -41,19 +41,13 @@ pub struct RegionServerEventSender(pub(crate) UnboundedSender<RegionServerEvent>
 impl RegionServerEventListener for RegionServerEventSender {
     fn on_region_registered(&self, region_id: RegionId) {
         if let Err(e) = self.0.send(RegionServerEvent::Registered(region_id)) {
-            error!(
-                "Failed to send registering region: {region_id} event, source: {}",
-                e
-            );
+            error!(e; "Failed to send registering region: {region_id} event");
         }
     }
 
     fn on_region_deregistered(&self, region_id: RegionId) {
         if let Err(e) = self.0.send(RegionServerEvent::Deregistered(region_id)) {
-            error!(
-                "Failed to send deregistering region: {region_id} event, source: {}",
-                e
-            );
+            error!(e; "Failed to send deregistering region: {region_id} event");
         }
     }
 }

--- a/src/file-engine/src/engine.rs
+++ b/src/file-engine/src/engine.rs
@@ -229,8 +229,9 @@ impl EngineInner {
         let res = FileRegion::create(region_id, request, &self.object_store).await;
         let region = res.inspect_err(|err| {
             error!(
-                "Failed to create region, region_id: {}, err: {}",
-                region_id, err
+                err;
+                "Failed to create region, region_id: {}",
+                region_id
             );
         })?;
         self.regions.write().unwrap().insert(region_id, region);
@@ -259,8 +260,9 @@ impl EngineInner {
         let res = FileRegion::open(region_id, request, &self.object_store).await;
         let region = res.inspect_err(|err| {
             error!(
-                "Failed to open region, region_id: {}, err: {}",
-                region_id, err
+                err;
+                "Failed to open region, region_id: {}",
+                region_id
             );
         })?;
         self.regions.write().unwrap().insert(region_id, region);
@@ -302,8 +304,9 @@ impl EngineInner {
             let res = FileRegion::drop(&region, &self.object_store).await;
             res.inspect_err(|err| {
                 error!(
-                    "Failed to drop region, region_id: {}, err: {}",
-                    region_id, err
+                    err;
+                    "Failed to drop region, region_id: {}",
+                    region_id
                 );
             })?;
         }

--- a/src/flow/src/adapter/worker.rs
+++ b/src/flow/src/adapter/worker.rs
@@ -285,8 +285,8 @@ impl<'s> Worker<'s> {
                 Ok(Some((id, resp))) => {
                     if let Err(err) = self.itc_server.blocking_lock().resp(id, resp) {
                         common_telemetry::error!(
-                            "Worker's itc server has been closed unexpectedly, shutting down worker: {}",
-                            err
+                            err;
+                            "Worker's itc server has been closed unexpectedly, shutting down worker"
                         );
                         break;
                     };

--- a/src/index/src/inverted_index/create/sort/external_sort.rs
+++ b/src/index/src/inverted_index/create/sort/external_sort.rs
@@ -256,7 +256,7 @@ impl ExternalSorter {
         IntermediateWriter::new(writer).write_all(values, bitmap_leading_zeros as _).await.inspect(|_|
             debug!("Dumped {entries} entries ({memory_usage} bytes) to intermediate file {file_id} for index {index_name}")
         ).inspect_err(|e|
-            error!("Failed to dump {entries} entries to intermediate file {file_id} for index {index_name}. Error: {e}")
+            error!(e; "Failed to dump {entries} entries to intermediate file {file_id} for index {index_name}")
         )
     }
 

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -501,7 +501,7 @@ impl Inserter {
                 Ok(())
             }
             Err(err) => {
-                error!("Failed to create table {table_reference}: {err}",);
+                error!(err; "Failed to create table {table_reference}");
                 Err(err)
             }
         }
@@ -634,8 +634,9 @@ impl Inserter {
                     })
                     .collect::<Vec<_>>();
                 error!(
-                    "Failed to create logical tables {:?}: {}",
-                    failed_tables, err
+                    err;
+                    "Failed to create logical tables {:?}",
+                    failed_tables
                 );
                 Err(err)
             }

--- a/src/servers/src/export_metrics.rs
+++ b/src/servers/src/export_metrics.rs
@@ -226,7 +226,7 @@ pub async fn write_system_metric_by_network(
                     error!("report export metrics error, msg: {:#?}", resp);
                 }
             }
-            Err(e) => error!("report export metrics failed, error {}", e),
+            Err(e) => error!(e; "report export metrics failed"),
         };
     }
 }
@@ -265,7 +265,7 @@ pub async fn write_system_metric_by_handler(
         };
 
         if let Err(e) = handler.write(requests, ctx.clone(), false).await {
-            error!("report export metrics by handler failed, error {}", e);
+            error!(e; "report export metrics by handler failed");
         } else {
             crate::metrics::PROM_STORE_REMOTE_WRITE_SAMPLES.inc_by(samples as u64);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Change all `error!` usage without debug formatter on `Error`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
