### PR TITLE
fix(flow): mfp operator missing rows

### DIFF
--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -64,8 +64,6 @@ mod table_source;
 
 use error::Error;
 
-pub const PER_REQ_MAX_ROW_CNT: usize = 8192;
-
 // TODO: replace this with `GREPTIME_TIMESTAMP` before v0.9
 pub const AUTO_CREATED_PLACEHOLDER_TS_COL: &str = "__ts_placeholder";
 

--- a/src/flow/src/compute/render/map.rs
+++ b/src/flow/src/compute/render/map.rs
@@ -125,9 +125,9 @@ fn mfp_subgraph(
                 false
             }
         });
-        let future_udpates = all_updates;
+        let future_updates = all_updates;
 
-        arrange.write().apply_updates(now, future_udpates)?;
+        arrange.write().apply_updates(now, future_updates)?;
         Ok(())
     };
     err_collector.run(run_mfp);

--- a/src/flow/src/repr.rs
+++ b/src/flow/src/repr.rs
@@ -53,7 +53,7 @@ pub type KeyValDiffRow = ((Row, Row), Timestamp, Diff);
 
 /// broadcast channel capacity, can be important to memory consumption, since this influence how many
 /// updates can be buffered in memory in the entire dataflow
-/// TODO(discord9): add config for this, so cpu&mem usage can be balanced and configed by this
+/// TODO(discord9): add config for this, so cpu&mem usage can be balanced and configured by this
 pub const BROADCAST_CAP: usize = 65535;
 
 /// Convert a value that is or can be converted to Datetime to internal timestamp

--- a/src/flow/src/repr.rs
+++ b/src/flow/src/repr.rs
@@ -53,7 +53,8 @@ pub type KeyValDiffRow = ((Row, Row), Timestamp, Diff);
 
 /// broadcast channel capacity, can be important to memory consumption, since this influence how many
 /// updates can be buffered in memory in the entire dataflow
-pub const BROADCAST_CAP: usize = 8192;
+/// TODO(discord9): add config for this, so cpu&mem usage can be balanced and configed by this
+pub const BROADCAST_CAP: usize = 65535;
 
 /// Convert a value that is or can be converted to Datetime to internal timestamp
 ///

--- a/src/flow/src/utils.rs
+++ b/src/flow/src/utils.rs
@@ -295,10 +295,6 @@ impl Arrangement {
         self.last_compaction_time
     }
 
-    pub fn set_compaction_time(&mut self, time: Timestamp) {
-        self.last_compaction_time = Some(time);
-    }
-
     /// Split spine off at `split_ts`, and return the spine that's before `split_ts` (including `split_ts`).
     fn split_spine_le(&mut self, split_ts: &Timestamp) -> Spine {
         self.split_batch_at(split_ts);

--- a/src/flow/src/utils.rs
+++ b/src/flow/src/utils.rs
@@ -295,6 +295,10 @@ impl Arrangement {
         self.last_compaction_time
     }
 
+    pub fn set_compaction_time(&mut self, time: Timestamp) {
+        self.last_compaction_time = Some(time);
+    }
+
     /// Split spine off at `split_ts`, and return the spine that's before `split_ts` (including `split_ts`).
     fn split_spine_le(&mut self, split_ts: &Timestamp) -> Spine {
         self.split_batch_at(split_ts);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
fix a bug that mfp operator will missing rows if run multiple tims in same tick

Please explain IN DETAIL what the changes are in this PR and why they are needed:

- fix a bug that mfp operator will missing rows if run multiple tims in same tick
- add related tests

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
