### PR TITLE
feat: implement drop multiple tables

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -543,7 +543,9 @@ pub fn check_permission(
             validate_param(&stmt.source_name, query_ctx)?;
         }
         Statement::DropTable(drop_stmt) => {
-            validate_param(drop_stmt.table_name(), query_ctx)?;
+            for table_name in drop_stmt.table_names() {
+                validate_param(table_name, query_ctx)?;
+            }
         }
         Statement::ShowTables(stmt) => {
             validate_db_permission!(stmt, query_ctx);

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -185,7 +185,7 @@ impl StatementExecutor {
             }
             Statement::Alter(alter_table) => self.alter_table(alter_table, query_ctx).await,
             Statement::DropTable(stmt) => {
-                let mut table_names = Vec::new();
+                let mut table_names = Vec::with_capacity(stmt.table_names().len());
                 for table_name_stmt in stmt.table_names() {
                     let (catalog, schema, table) =
                         table_idents_to_full_name(table_name_stmt, &query_ctx)
@@ -193,7 +193,7 @@ impl StatementExecutor {
                             .context(error::ExternalSnafu)?;
                     table_names.push(TableName::new(catalog, schema, table));
                 }
-                self.drop_tables(table_names, stmt.drop_if_exists(), query_ctx.clone())
+                self.drop_tables(&table_names[..], stmt.drop_if_exists(), query_ctx.clone())
                     .await
             }
             Statement::DropDatabase(stmt) => {

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -193,7 +193,8 @@ impl StatementExecutor {
                             .context(error::ExternalSnafu)?;
                     table_names.push(TableName::new(catalog, schema, table));
                 }
-                self.drop_tables(table_names, stmt.drop_if_exists(), query_ctx.clone()).await
+                self.drop_tables(table_names, stmt.drop_if_exists(), query_ctx.clone())
+                    .await
             }
             Statement::DropDatabase(stmt) => {
                 self.drop_database(

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -679,8 +679,8 @@ impl StatementExecutor {
             }
         }
 
-        for (table_name, table_id) in table_names.into_iter().zip(tables.iter()) {
-            self.drop_table_procedure(table_name, *table_id, drop_if_exists, query_context.clone())
+        for (table_name, table_id) in table_names.iter().zip(tables.into_iter()) {
+            self.drop_table_procedure(table_name, table_id, drop_if_exists, query_context.clone())
                 .await?;
 
             // Invalidates local cache ASAP.
@@ -688,7 +688,7 @@ impl StatementExecutor {
                 .invalidate(
                     &Context::default(),
                     &[
-                        CacheIdent::TableId(*table_id),
+                        CacheIdent::TableId(table_id),
                         CacheIdent::TableName(table_name.clone()),
                     ],
                 )

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -644,19 +644,19 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<Output> {
         // Reserved for grpc call
-        self.drop_tables(vec![table_name], drop_if_exists, query_context)
+        self.drop_tables(&[table_name], drop_if_exists, query_context)
             .await
     }
 
     #[tracing::instrument(skip_all)]
     pub async fn drop_tables(
         &self,
-        table_names: Vec<TableName>,
+        table_names: &[TableName],
         drop_if_exists: bool,
         query_context: QueryContextRef,
     ) -> Result<Output> {
         let mut tables = Vec::with_capacity(table_names.len());
-        for table_name in &table_names {
+        for table_name in table_names {
             if let Some(table) = self
                 .catalog_manager
                 .table(

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -679,7 +679,7 @@ impl StatementExecutor {
             }
         }
 
-        for (table_name, table_id) in table_names.iter().zip(tables.iter()) {
+        for (table_name, table_id) in table_names.into_iter().zip(tables.iter()) {
             self.drop_table_procedure(table_name, *table_id, drop_if_exists, query_context.clone())
                 .await?;
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -644,7 +644,8 @@ impl StatementExecutor {
         query_context: QueryContextRef,
     ) -> Result<Output> {
         // Reserved for grpc call
-        self.drop_tables(vec![table_name], drop_if_exists, query_context).await
+        self.drop_tables(vec![table_name], drop_if_exists, query_context)
+            .await
     }
 
     #[tracing::instrument(skip_all)]
@@ -664,20 +665,22 @@ impl StatementExecutor {
                     &table_name.table_name,
                 )
                 .await
-                .context(CatalogSnafu)? {
+                .context(CatalogSnafu)?
+            {
                 tables.push(table.table_info().table_id());
             } else if drop_if_exists {
                 // DROP TABLE IF EXISTS meets table not found - ignored
-                continue
+                continue;
             } else {
                 return TableNotFoundSnafu {
                     table_name: table_name.to_string(),
-                }.fail();
+                }
+                .fail();
             }
         }
 
         for (table_name, table_id) in table_names.iter().zip(tables.iter()) {
-            self.drop_table_procedure(&table_name, *table_id, drop_if_exists, query_context.clone())
+            self.drop_table_procedure(table_name, *table_id, drop_if_exists, query_context.clone())
                 .await?;
 
             // Invalidates local cache ASAP.

--- a/src/sql/src/parsers/drop_parser.rs
+++ b/src/sql/src/parsers/drop_parser.rs
@@ -90,7 +90,7 @@ impl<'a> ParserContext<'a> {
             }
         }
 
-        Ok(Statement::DropTable(DropTable::new(table_names,if_exists)))
+        Ok(Statement::DropTable(DropTable::new(table_names, if_exists)))
     }
 
     fn parse_drop_database(&mut self) -> Result<Statement> {
@@ -129,7 +129,10 @@ mod tests {
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
-            Statement::DropTable(DropTable::new(vec![ObjectName(vec![Ident::new("foo")])],false))
+            Statement::DropTable(DropTable::new(
+                vec![ObjectName(vec![Ident::new("foo")])],
+                false
+            ))
         );
 
         let sql = "DROP TABLE IF EXISTS foo";
@@ -138,7 +141,10 @@ mod tests {
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
-            Statement::DropTable(DropTable::new(vec![ObjectName(vec![Ident::new("foo")])],true))
+            Statement::DropTable(DropTable::new(
+                vec![ObjectName(vec![Ident::new("foo")])],
+                true
+            ))
         );
 
         let sql = "DROP TABLE my_schema.foo";
@@ -148,9 +154,7 @@ mod tests {
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::DropTable(DropTable::new(
-                vec![ObjectName(
-                    vec![Ident::new("my_schema"), Ident::new("foo")]
-                )],
+                vec![ObjectName(vec![Ident::new("my_schema"), Ident::new("foo")])],
                 false
             ))
         );

--- a/src/sql/src/parsers/drop_parser.rs
+++ b/src/sql/src/parsers/drop_parser.rs
@@ -68,22 +68,29 @@ impl<'a> ParserContext<'a> {
         let _ = self.parser.next_token();
 
         let if_exists = self.parser.parse_keywords(&[Keyword::IF, Keyword::EXISTS]);
-        let raw_table_ident =
-            self.parse_object_name()
-                .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
-                    expected: "a table name",
-                    actual: self.peek_token_as_string(),
-                })?;
-        let table_ident = Self::canonicalize_object_name(raw_table_ident);
-        ensure!(
-            !table_ident.0.is_empty(),
-            InvalidTableNameSnafu {
-                name: table_ident.to_string()
+        let mut table_names = Vec::with_capacity(1);
+        loop {
+            let raw_table_ident =
+                self.parse_object_name()
+                    .with_context(|_| error::UnexpectedSnafu {
+                        sql: self.sql,
+                        expected: "a table name",
+                        actual: self.peek_token_as_string(),
+                    })?;
+            let table_ident = Self::canonicalize_object_name(raw_table_ident);
+            ensure!(
+                !table_ident.0.is_empty(),
+                InvalidTableNameSnafu {
+                    name: table_ident.to_string()
+                }
+            );
+            table_names.push(table_ident);
+            if !self.parser.consume_token(&Token::Comma) {
+                break;
             }
-        );
+        }
 
-        Ok(Statement::DropTable(DropTable::new(table_ident, if_exists)))
+        Ok(Statement::DropTable(DropTable::new(table_names,if_exists)))
     }
 
     fn parse_drop_database(&mut self) -> Result<Statement> {
@@ -122,7 +129,7 @@ mod tests {
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
-            Statement::DropTable(DropTable::new(ObjectName(vec![Ident::new("foo")]), false))
+            Statement::DropTable(DropTable::new(vec![ObjectName(vec![Ident::new("foo")])],false))
         );
 
         let sql = "DROP TABLE IF EXISTS foo";
@@ -131,7 +138,7 @@ mod tests {
         let mut stmts = result.unwrap();
         assert_eq!(
             stmts.pop().unwrap(),
-            Statement::DropTable(DropTable::new(ObjectName(vec![Ident::new("foo")]), true))
+            Statement::DropTable(DropTable::new(vec![ObjectName(vec![Ident::new("foo")])],true))
         );
 
         let sql = "DROP TABLE my_schema.foo";
@@ -141,7 +148,9 @@ mod tests {
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::DropTable(DropTable::new(
-                ObjectName(vec![Ident::new("my_schema"), Ident::new("foo")]),
+                vec![ObjectName(
+                    vec![Ident::new("my_schema"), Ident::new("foo")]
+                )],
                 false
             ))
         );
@@ -153,11 +162,11 @@ mod tests {
         assert_eq!(
             stmts.pop().unwrap(),
             Statement::DropTable(DropTable::new(
-                ObjectName(vec![
+                vec![ObjectName(vec![
                     Ident::new("my_catalog"),
                     Ident::new("my_schema"),
                     Ident::new("foo")
-                ]),
+                ])],
                 false
             ))
         )

--- a/src/sql/src/statements/drop.rs
+++ b/src/sql/src/statements/drop.rs
@@ -35,7 +35,7 @@ impl DropTable {
         }
     }
 
-    pub fn table_names(&self) -> &Vec<ObjectName> {
+    pub fn table_names(&self) -> &[ObjectName] {
         &self.table_names
     }
 
@@ -50,14 +50,12 @@ impl Display for DropTable {
         if self.drop_if_exists() {
             f.write_str(" IF EXISTS")?;
         }
-        // let table_name = self.table_name();
-        // write!(f, r#" {table_name}"#)
         let table_names = self.table_names();
         for (i, table_name) in table_names.iter().enumerate() {
             if i > 0 {
                 f.write_str(",")?;
             }
-            f.write_str(format!(" {}", table_name).as_str())?;
+            write!(f, " {}", table_name)?;
         }
         Ok(())
     }

--- a/src/sql/src/statements/drop.rs
+++ b/src/sql/src/statements/drop.rs
@@ -28,14 +28,16 @@ pub struct DropTable {
 
 impl DropTable {
     /// Creates a statement for `DROP TABLE`
-    pub fn new(table_names: Vec<ObjectName>,if_exists: bool) -> Self {
+    pub fn new(table_names: Vec<ObjectName>, if_exists: bool) -> Self {
         Self {
             table_names,
             drop_if_exists: if_exists,
         }
     }
 
-    pub fn table_names(&self) -> &Vec<ObjectName> { &self.table_names }
+    pub fn table_names(&self) -> &Vec<ObjectName> {
+        &self.table_names
+    }
 
     pub fn drop_if_exists(&self) -> bool {
         self.drop_if_exists
@@ -51,11 +53,11 @@ impl Display for DropTable {
         // let table_name = self.table_name();
         // write!(f, r#" {table_name}"#)
         let table_names = self.table_names();
-        for i in 0..table_names.len() {
+        for (i, table_name) in table_names.iter().enumerate() {
             if i > 0 {
                 f.write_str(",")?;
             }
-            f.write_str( format!(" {}", table_names[i]).as_str())?
+            f.write_str(format!(" {}", table_name).as_str())?;
         }
         Ok(())
     }

--- a/tests/cases/standalone/common/drop/drop_table.result
+++ b/tests/cases/standalone/common/drop/drop_table.result
@@ -20,3 +20,58 @@ DROP TABLE IF EXISTS foo;
 
 Affected Rows: 0
 
+DROP TABLE IF EXISTS foo, bar;
+
+Affected Rows: 0
+
+create table foo (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+Affected Rows: 0
+
+DROP TABLE foo, bar;
+
+Error: 4001(TableNotFound), Table not found: greptime.public.bar
+
+SHOW TABLES;
+
++---------+
+| Tables  |
++---------+
+| foo     |
+| numbers |
++---------+
+
+DROP TABLE IF EXISTS foo, bar;
+
+Affected Rows: 0
+
+create table foo (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+Affected Rows: 0
+
+create table bar (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+Affected Rows: 0
+
+DROP TABLE foo, bar;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/drop/drop_table.sql
+++ b/tests/cases/standalone/common/drop/drop_table.sql
@@ -11,3 +11,38 @@ create table foo (
 DROP TABLE IF EXISTS foo;
 
 DROP TABLE IF EXISTS foo;
+
+DROP TABLE IF EXISTS foo, bar;
+
+create table foo (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+DROP TABLE foo, bar;
+
+SHOW TABLES;
+
+DROP TABLE IF EXISTS foo, bar;
+
+create table foo (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+create table bar (
+     host string,
+     ts timestamp DEFAULT '2024-06-01 00:00:00+00:00',
+     cpu double default 0,
+     TIME INDEX (ts),
+     PRIMARY KEY(host)
+) engine=mito;
+
+DROP TABLE foo, bar;
+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #4020 
## What's changed and what's your intention?

Implemet dropping multiple tables in the single statement.

If any tables do not exist without IF EXISTS, the statement fails with an error and don`t make any change, referencing MySQL.

It works for SQL requests, not ready for gRPC.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
