### PR TITLE
feat: show create view and creating view with columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,7 +4208,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b83f00958fe4cbc77b85b7407bca206e98bdc845#b83f00958fe4cbc77b85b7407bca206e98bdc845"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=5c801650435d464891114502539b701c77a1b914#5c801650435d464891114502539b701c77a1b914"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ etcd-client = { version = "0.13" }
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b83f00958fe4cbc77b85b7407bca206e98bdc845" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "5c801650435d464891114502539b701c77a1b914" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -253,8 +253,9 @@ impl ErrorExt for Error {
             | Error::FindPartitions { .. }
             | Error::FindRegionRoutes { .. }
             | Error::CacheNotFound { .. }
-            | Error::ViewPlanColumnsChanged { .. }
             | Error::CastManager { .. } => StatusCode::Unexpected,
+
+            Error::ViewPlanColumnsChanged { .. } => StatusCode::InvalidArguments,
 
             Error::ViewInfoNotFound { .. } => StatusCode::TableNotFound,
 

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -114,6 +114,18 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display(
+        "View plan columns changed from: {} to: {}",
+        origin_names,
+        actual_names
+    ))]
+    ViewPlanColumnsChanged {
+        origin_names: String,
+        actual_names: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Failed to find table partitions"))]
     FindPartitions { source: partition::error::Error },
 
@@ -173,6 +185,14 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to project view columns"))]
+    ProjectViewColumns {
+        #[snafu(source)]
+        error: DataFusionError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("Table metadata manager error"))]
     TableMetadataManager {
         source: common_meta::error::Error,
@@ -208,6 +228,21 @@ pub enum Error {
     },
 }
 
+impl Error {
+    pub fn should_fail(&self) -> bool {
+        use Error::*;
+
+        matches!(
+            self,
+            GetViewCache { .. }
+                | ViewInfoNotFound { .. }
+                | DecodePlan { .. }
+                | ViewPlanColumnsChanged { .. }
+                | ProjectViewColumns { .. }
+        )
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl ErrorExt for Error {
@@ -218,6 +253,7 @@ impl ErrorExt for Error {
             | Error::FindPartitions { .. }
             | Error::FindRegionRoutes { .. }
             | Error::CacheNotFound { .. }
+            | Error::ViewPlanColumnsChanged { .. }
             | Error::CastManager { .. } => StatusCode::Unexpected,
 
             Error::ViewInfoNotFound { .. } => StatusCode::TableNotFound,
@@ -245,7 +281,9 @@ impl ErrorExt for Error {
             }
 
             Error::QueryAccessDenied { .. } => StatusCode::AccessDenied,
-            Error::Datafusion { .. } => StatusCode::EngineExecuteQuery,
+            Error::ProjectViewColumns { .. } | Error::Datafusion { .. } => {
+                StatusCode::EngineExecuteQuery
+            }
             Error::TableMetadataManager { source, .. } => source.status_code(),
             Error::GetViewCache { source, .. } | Error::GetTableCache { source, .. } => {
                 source.status_code()

--- a/src/catalog/src/table_source.rs
+++ b/src/catalog/src/table_source.rs
@@ -153,7 +153,7 @@ impl DfTableSourceProvider {
 
         let columns: Vec<_> = view_info.columns.iter().map(|c| c.as_str()).collect();
 
-        let origin_plan_columns: Vec<_> =
+        let original_plan_columns: Vec<_> =
             view_info.plan_columns.iter().map(|c| c.as_str()).collect();
 
         let plan_columns: Vec<_> = logical_plan
@@ -168,9 +168,9 @@ impl DfTableSourceProvider {
         // and https://github.com/apache/datafusion/issues/6489
         // TODO(dennis): check column names
         ensure!(
-            origin_plan_columns.len() == plan_columns.len(),
+            original_plan_columns.len() == plan_columns.len(),
             ViewPlanColumnsChangedSnafu {
-                origin_names: origin_plan_columns.iter().join(","),
+                origin_names: original_plan_columns.iter().join(","),
                 actual_names: plan_columns.iter().join(","),
             }
         );

--- a/src/catalog/src/table_source.rs
+++ b/src/catalog/src/table_source.rs
@@ -133,7 +133,10 @@ impl DfTableSourceProvider {
                     name: &table.table_info().name,
                 })?;
 
-            Arc::new(ViewTable::try_new(logical_plan, None).context(DatafusionSnafu)?)
+            Arc::new(
+                ViewTable::try_new(logical_plan, Some(view_info.definition.to_string()))
+                    .context(DatafusionSnafu)?,
+            )
         } else {
             Arc::new(DfTableProviderAdapter::new(table))
         };
@@ -277,7 +280,12 @@ mod tests {
         let logical_plan = vec![1, 2, 3];
         // Create view metadata
         table_metadata_manager
-            .create_view_metadata(view_info.clone().into(), logical_plan, HashSet::new())
+            .create_view_metadata(
+                view_info.clone().into(),
+                logical_plan,
+                HashSet::new(),
+                "definition".to_string(),
+            )
             .await
             .unwrap();
 

--- a/src/common/meta/src/cache/table/view_info.rs
+++ b/src/common/meta/src/cache/table/view_info.rs
@@ -137,6 +137,8 @@ mod tests {
                 .collect::<HashSet<_>>()
         );
         assert_eq!(view_info.definition, task.create_view.definition);
+        assert_eq!(view_info.columns, task.create_view.columns);
+        assert_eq!(view_info.plan_columns, task.create_view.plan_columns);
 
         assert!(cache.contains_key(&1024));
         cache

--- a/src/common/meta/src/cache/table/view_info.rs
+++ b/src/common/meta/src/cache/table/view_info.rs
@@ -111,6 +111,7 @@ mod tests {
             });
             set
         };
+        let definition = "CREATE VIEW test AS SELECT * FROM numbers";
 
         task.view_info.ident.table_id = 1024;
         table_metadata_manager
@@ -118,6 +119,7 @@ mod tests {
                 task.view_info.clone(),
                 task.create_view.logical_plan.clone(),
                 table_names,
+                definition.to_string(),
             )
             .await
             .unwrap();
@@ -132,6 +134,7 @@ mod tests {
                 .map(|t| t.clone().into())
                 .collect::<HashSet<_>>()
         );
+        assert_eq!(view_info.definition, task.create_view.definition);
 
         assert!(cache.contains_key(&1024));
         cache

--- a/src/common/meta/src/cache/table/view_info.rs
+++ b/src/common/meta/src/cache/table/view_info.rs
@@ -119,6 +119,7 @@ mod tests {
                 task.view_info.clone(),
                 task.create_view.logical_plan.clone(),
                 table_names,
+                vec!["a".to_string()],
                 definition.to_string(),
             )
             .await

--- a/src/common/meta/src/cache/table/view_info.rs
+++ b/src/common/meta/src/cache/table/view_info.rs
@@ -63,8 +63,8 @@ fn invalidator<'a>(
     ident: &'a CacheIdent,
 ) -> BoxFuture<'a, Result<()>> {
     Box::pin(async move {
-        if let CacheIdent::TableId(table_id) = ident {
-            cache.invalidate(table_id).await
+        if let CacheIdent::TableId(view_id) = ident {
+            cache.invalidate(view_id).await
         }
         Ok(())
     })
@@ -120,6 +120,7 @@ mod tests {
                 task.create_view.logical_plan.clone(),
                 table_names,
                 vec!["a".to_string()],
+                vec!["number".to_string()],
                 definition.to_string(),
             )
             .await

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -23,6 +23,7 @@ use crate::key::schema_name::SchemaNameKey;
 use crate::key::table_info::TableInfoKey;
 use crate::key::table_name::TableNameKey;
 use crate::key::table_route::TableRouteKey;
+use crate::key::view_info::ViewInfoKey;
 use crate::key::MetaKey;
 
 /// KvBackend cache invalidator
@@ -75,6 +76,9 @@ where
                     self.invalidate_key(&key.to_bytes()).await;
 
                     let key = TableRouteKey::new(*table_id);
+                    self.invalidate_key(&key.to_bytes()).await;
+
+                    let key = ViewInfoKey::new(*table_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }
                 CacheIdent::TableName(table_name) => {

--- a/src/common/meta/src/ddl/create_view.rs
+++ b/src/common/meta/src/ddl/create_view.rs
@@ -197,9 +197,16 @@ impl CreateViewProcedure {
                 })?;
             let new_logical_plan = self.data.task.raw_logical_plan().clone();
             let table_names = self.data.task.table_names();
+            let new_view_definition = self.data.task.view_definition().to_string();
 
             manager
-                .update_view_info(view_id, &current_view_info, new_logical_plan, table_names)
+                .update_view_info(
+                    view_id,
+                    &current_view_info,
+                    new_logical_plan,
+                    table_names,
+                    new_view_definition,
+                )
                 .await?;
 
             info!("Updated view metadata for view {view_id}");
@@ -210,6 +217,7 @@ impl CreateViewProcedure {
                     raw_view_info,
                     self.data.task.raw_logical_plan().clone(),
                     self.data.task.table_names(),
+                    self.data.task.view_definition().to_string(),
                 )
                 .await?;
 

--- a/src/common/meta/src/ddl/create_view.rs
+++ b/src/common/meta/src/ddl/create_view.rs
@@ -197,6 +197,7 @@ impl CreateViewProcedure {
                 })?;
             let new_logical_plan = self.data.task.raw_logical_plan().clone();
             let table_names = self.data.task.table_names();
+            let columns = self.data.task.columns().clone();
             let new_view_definition = self.data.task.view_definition().to_string();
 
             manager
@@ -205,6 +206,7 @@ impl CreateViewProcedure {
                     &current_view_info,
                     new_logical_plan,
                     table_names,
+                    columns,
                     new_view_definition,
                 )
                 .await?;
@@ -217,6 +219,7 @@ impl CreateViewProcedure {
                     raw_view_info,
                     self.data.task.raw_logical_plan().clone(),
                     self.data.task.table_names(),
+                    self.data.task.columns().clone(),
                     self.data.task.view_definition().to_string(),
                 )
                 .await?;

--- a/src/common/meta/src/ddl/create_view.rs
+++ b/src/common/meta/src/ddl/create_view.rs
@@ -198,6 +198,7 @@ impl CreateViewProcedure {
             let new_logical_plan = self.data.task.raw_logical_plan().clone();
             let table_names = self.data.task.table_names();
             let columns = self.data.task.columns().clone();
+            let plan_columns = self.data.task.plan_columns().clone();
             let new_view_definition = self.data.task.view_definition().to_string();
 
             manager
@@ -207,6 +208,7 @@ impl CreateViewProcedure {
                     new_logical_plan,
                     table_names,
                     columns,
+                    plan_columns,
                     new_view_definition,
                 )
                 .await?;
@@ -220,6 +222,7 @@ impl CreateViewProcedure {
                     self.data.task.raw_logical_plan().clone(),
                     self.data.task.table_names(),
                     self.data.task.columns().clone(),
+                    self.data.task.plan_columns().clone(),
                     self.data.task.view_definition().to_string(),
                 )
                 .await?;

--- a/src/common/meta/src/ddl/tests/create_view.rs
+++ b/src/common/meta/src/ddl/tests/create_view.rs
@@ -70,6 +70,7 @@ pub(crate) fn test_create_view_task(name: &str) -> CreateViewTask {
         logical_plan: vec![1, 2, 3],
         table_names,
         columns: vec!["a".to_string()],
+        plan_columns: vec!["number".to_string()],
         definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
     };
 
@@ -107,6 +108,7 @@ async fn test_on_prepare_view_exists_err() {
             task.create_view.logical_plan.clone(),
             test_table_names(),
             vec!["a".to_string()],
+            vec!["number".to_string()],
             "the definition".to_string(),
         )
         .await
@@ -133,6 +135,7 @@ async fn test_on_prepare_with_create_if_view_exists() {
             task.create_view.logical_plan.clone(),
             test_table_names(),
             vec!["a".to_string()],
+            vec!["number".to_string()],
             "the definition".to_string(),
         )
         .await

--- a/src/common/meta/src/ddl/tests/create_view.rs
+++ b/src/common/meta/src/ddl/tests/create_view.rs
@@ -69,6 +69,7 @@ pub(crate) fn test_create_view_task(name: &str) -> CreateViewTask {
         create_if_not_exists: false,
         logical_plan: vec![1, 2, 3],
         table_names,
+        definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
     };
 
     let view_info = RawTableInfo {
@@ -104,6 +105,7 @@ async fn test_on_prepare_view_exists_err() {
             task.view_info.clone(),
             task.create_view.logical_plan.clone(),
             test_table_names(),
+            "the definition".to_string(),
         )
         .await
         .unwrap();
@@ -128,6 +130,7 @@ async fn test_on_prepare_with_create_if_view_exists() {
             task.view_info.clone(),
             task.create_view.logical_plan.clone(),
             test_table_names(),
+            "the definition".to_string(),
         )
         .await
         .unwrap();
@@ -213,6 +216,8 @@ async fn test_replace_view_metadata() {
     // Set `or_replce` to be `true` and try again
     task.create_view.or_replace = true;
     task.create_view.logical_plan = vec![4, 5, 6];
+    task.create_view.definition = "new_definition".to_string();
+
     let mut procedure = CreateViewProcedure::new(cluster_id, task, ddl_context.clone());
     procedure.on_prepare().await.unwrap();
     let ctx = ProcedureContext {
@@ -233,6 +238,7 @@ async fn test_replace_view_metadata() {
         .unwrap();
 
     assert_eq!(current_view_info.view_info, vec![4, 5, 6]);
+    assert_eq!(current_view_info.definition, "new_definition");
 }
 
 #[tokio::test]

--- a/src/common/meta/src/ddl/tests/create_view.rs
+++ b/src/common/meta/src/ddl/tests/create_view.rs
@@ -69,6 +69,7 @@ pub(crate) fn test_create_view_task(name: &str) -> CreateViewTask {
         create_if_not_exists: false,
         logical_plan: vec![1, 2, 3],
         table_names,
+        columns: vec!["a".to_string()],
         definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
     };
 
@@ -105,6 +106,7 @@ async fn test_on_prepare_view_exists_err() {
             task.view_info.clone(),
             task.create_view.logical_plan.clone(),
             test_table_names(),
+            vec!["a".to_string()],
             "the definition".to_string(),
         )
         .await
@@ -130,6 +132,7 @@ async fn test_on_prepare_with_create_if_view_exists() {
             task.view_info.clone(),
             task.create_view.logical_plan.clone(),
             test_table_names(),
+            vec!["a".to_string()],
             "the definition".to_string(),
         )
         .await

--- a/src/common/meta/src/ddl/tests/create_view.rs
+++ b/src/common/meta/src/ddl/tests/create_view.rs
@@ -245,6 +245,8 @@ async fn test_replace_view_metadata() {
 
     assert_eq!(current_view_info.view_info, vec![4, 5, 6]);
     assert_eq!(current_view_info.definition, "new_definition");
+    assert_eq!(current_view_info.columns, vec!["a".to_string()]);
+    assert_eq!(current_view_info.plan_columns, vec!["number".to_string()]);
 }
 
 #[tokio::test]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -492,6 +492,7 @@ impl TableMetadataManager {
         view_info: RawTableInfo,
         raw_logical_plan: Vec<u8>,
         table_names: HashSet<TableName>,
+        columns: Vec<String>,
         definition: String,
     ) -> Result<()> {
         let view_id = view_info.ident.table_id;
@@ -514,7 +515,8 @@ impl TableMetadataManager {
             .build_create_txn(view_id, &table_info_value)?;
 
         // Creates view info
-        let view_info_value = ViewInfoValue::new(raw_logical_plan, table_names, definition);
+        let view_info_value =
+            ViewInfoValue::new(raw_logical_plan, table_names, columns, definition);
         let (create_view_info_txn, on_create_view_info_failure) = self
             .view_info_manager()
             .build_create_txn(view_id, &view_info_value)?;
@@ -933,10 +935,11 @@ impl TableMetadataManager {
         current_view_info_value: &DeserializedValueWithBytes<ViewInfoValue>,
         new_view_info: Vec<u8>,
         table_names: HashSet<TableName>,
+        columns: Vec<String>,
         definition: String,
     ) -> Result<()> {
         let new_view_info_value =
-            current_view_info_value.update(new_view_info, table_names, definition);
+            current_view_info_value.update(new_view_info, table_names, columns, definition);
 
         // Updates view info.
         let (update_view_info_txn, on_update_view_info_failure) = self
@@ -2009,7 +2012,7 @@ mod tests {
         let view_id = view_info.ident.table_id;
 
         let logical_plan: Vec<u8> = vec![1, 2, 3];
-
+        let columns = vec!["a".to_string()];
         let table_names = new_test_table_names();
         let definition = "CREATE VIEW test AS SELECT * FROM numbers";
 
@@ -2019,6 +2022,7 @@ mod tests {
                 view_info.clone(),
                 logical_plan.clone(),
                 table_names.clone(),
+                columns.clone(),
                 definition.to_string(),
             )
             .await
@@ -2036,6 +2040,7 @@ mod tests {
             assert_eq!(current_view_info.view_info, logical_plan);
             assert_eq!(current_view_info.table_names, table_names);
             assert_eq!(current_view_info.definition, definition);
+            assert_eq!(current_view_info.columns, columns);
             // assert table info
             let current_table_info = table_metadata_manager
                 .table_info_manager()
@@ -2062,11 +2067,13 @@ mod tests {
             });
             set
         };
+        let new_columns = vec!["b".to_string()];
         let new_definition = "CREATE VIEW test AS SELECT * FROM b_table join c_table";
 
         let current_view_info_value = DeserializedValueWithBytes::from_inner(ViewInfoValue::new(
             logical_plan.clone(),
             table_names,
+            columns,
             definition.to_string(),
         ));
         // should be ok.
@@ -2076,6 +2083,7 @@ mod tests {
                 &current_view_info_value,
                 new_logical_plan.clone(),
                 new_table_names.clone(),
+                new_columns.clone(),
                 new_definition.to_string(),
             )
             .await
@@ -2087,6 +2095,7 @@ mod tests {
                 &current_view_info_value,
                 new_logical_plan.clone(),
                 new_table_names.clone(),
+                new_columns.clone(),
                 new_definition.to_string(),
             )
             .await
@@ -2103,6 +2112,7 @@ mod tests {
         assert_eq!(updated_view_info.view_info, new_logical_plan);
         assert_eq!(updated_view_info.table_names, new_table_names);
         assert_eq!(updated_view_info.definition, new_definition);
+        assert_eq!(updated_view_info.columns, new_columns);
 
         let wrong_view_info = logical_plan.clone();
         let wrong_definition = "wrong_definition";
@@ -2110,6 +2120,7 @@ mod tests {
             DeserializedValueWithBytes::from_inner(current_view_info_value.update(
                 wrong_view_info,
                 new_table_names.clone(),
+                new_columns.clone(),
                 wrong_definition.to_string(),
             ));
         // if the current_view_info_value is wrong, it should return an error.
@@ -2120,6 +2131,7 @@ mod tests {
                 &wrong_view_info_value,
                 new_logical_plan.clone(),
                 new_table_names.clone(),
+                new_columns.clone(),
                 wrong_definition.to_string(),
             )
             .await
@@ -2136,5 +2148,6 @@ mod tests {
         assert_eq!(current_view_info.view_info, new_logical_plan);
         assert_eq!(current_view_info.table_names, new_table_names);
         assert_eq!(current_view_info.definition, new_definition);
+        assert_eq!(current_view_info.columns, new_columns);
     }
 }

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -487,6 +487,13 @@ impl TableMetadataManager {
 
     /// Creates metadata for view and returns an error if different metadata exists.
     /// The caller MUST ensure it has the exclusive access to `TableNameKey`.
+    /// Parameters include:
+    /// - `view_info`: the encoded logical plan
+    /// - `table_names`: the resolved fully table names in logical plan
+    /// - `columns`: the view columns
+    /// - `plan_columns`: the original plan columns
+    /// - `definition`: The SQL to create the view
+    ///
     pub async fn create_view_metadata(
         &self,
         view_info: RawTableInfo,
@@ -935,6 +942,15 @@ impl TableMetadataManager {
     }
 
     /// Updates view info and returns an error if different metadata exists.
+    /// Parameters include:
+    /// - `view_id`: the view id
+    /// - `current_view_info_value`: the current view info for CAS checking
+    /// - `new_view_info`: the encoded logical plan
+    /// - `table_names`: the resolved fully table names in logical plan
+    /// - `columns`: the view columns
+    /// - `plan_columns`: the original plan columns
+    /// - `definition`: The SQL to create the view
+    ///
     #[allow(clippy::too_many_arguments)]
     pub async fn update_view_info(
         &self,

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -493,6 +493,7 @@ impl TableMetadataManager {
         raw_logical_plan: Vec<u8>,
         table_names: HashSet<TableName>,
         columns: Vec<String>,
+        plan_columns: Vec<String>,
         definition: String,
     ) -> Result<()> {
         let view_id = view_info.ident.table_id;
@@ -515,8 +516,13 @@ impl TableMetadataManager {
             .build_create_txn(view_id, &table_info_value)?;
 
         // Creates view info
-        let view_info_value =
-            ViewInfoValue::new(raw_logical_plan, table_names, columns, definition);
+        let view_info_value = ViewInfoValue::new(
+            raw_logical_plan,
+            table_names,
+            columns,
+            plan_columns,
+            definition,
+        );
         let (create_view_info_txn, on_create_view_info_failure) = self
             .view_info_manager()
             .build_create_txn(view_id, &view_info_value)?;
@@ -929,6 +935,7 @@ impl TableMetadataManager {
     }
 
     /// Updates view info and returns an error if different metadata exists.
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_view_info(
         &self,
         view_id: TableId,
@@ -936,10 +943,16 @@ impl TableMetadataManager {
         new_view_info: Vec<u8>,
         table_names: HashSet<TableName>,
         columns: Vec<String>,
+        plan_columns: Vec<String>,
         definition: String,
     ) -> Result<()> {
-        let new_view_info_value =
-            current_view_info_value.update(new_view_info, table_names, columns, definition);
+        let new_view_info_value = current_view_info_value.update(
+            new_view_info,
+            table_names,
+            columns,
+            plan_columns,
+            definition,
+        );
 
         // Updates view info.
         let (update_view_info_txn, on_update_view_info_failure) = self
@@ -2013,6 +2026,7 @@ mod tests {
 
         let logical_plan: Vec<u8> = vec![1, 2, 3];
         let columns = vec!["a".to_string()];
+        let plan_columns = vec!["number".to_string()];
         let table_names = new_test_table_names();
         let definition = "CREATE VIEW test AS SELECT * FROM numbers";
 
@@ -2023,6 +2037,7 @@ mod tests {
                 logical_plan.clone(),
                 table_names.clone(),
                 columns.clone(),
+                plan_columns.clone(),
                 definition.to_string(),
             )
             .await
@@ -2041,6 +2056,7 @@ mod tests {
             assert_eq!(current_view_info.table_names, table_names);
             assert_eq!(current_view_info.definition, definition);
             assert_eq!(current_view_info.columns, columns);
+            assert_eq!(current_view_info.plan_columns, plan_columns);
             // assert table info
             let current_table_info = table_metadata_manager
                 .table_info_manager()
@@ -2068,12 +2084,14 @@ mod tests {
             set
         };
         let new_columns = vec!["b".to_string()];
+        let new_plan_columns = vec!["number2".to_string()];
         let new_definition = "CREATE VIEW test AS SELECT * FROM b_table join c_table";
 
         let current_view_info_value = DeserializedValueWithBytes::from_inner(ViewInfoValue::new(
             logical_plan.clone(),
             table_names,
             columns,
+            plan_columns,
             definition.to_string(),
         ));
         // should be ok.
@@ -2084,6 +2102,7 @@ mod tests {
                 new_logical_plan.clone(),
                 new_table_names.clone(),
                 new_columns.clone(),
+                new_plan_columns.clone(),
                 new_definition.to_string(),
             )
             .await
@@ -2096,6 +2115,7 @@ mod tests {
                 new_logical_plan.clone(),
                 new_table_names.clone(),
                 new_columns.clone(),
+                new_plan_columns.clone(),
                 new_definition.to_string(),
             )
             .await
@@ -2113,6 +2133,7 @@ mod tests {
         assert_eq!(updated_view_info.table_names, new_table_names);
         assert_eq!(updated_view_info.definition, new_definition);
         assert_eq!(updated_view_info.columns, new_columns);
+        assert_eq!(updated_view_info.plan_columns, new_plan_columns);
 
         let wrong_view_info = logical_plan.clone();
         let wrong_definition = "wrong_definition";
@@ -2121,6 +2142,7 @@ mod tests {
                 wrong_view_info,
                 new_table_names.clone(),
                 new_columns.clone(),
+                new_plan_columns.clone(),
                 wrong_definition.to_string(),
             ));
         // if the current_view_info_value is wrong, it should return an error.
@@ -2131,7 +2153,8 @@ mod tests {
                 &wrong_view_info_value,
                 new_logical_plan.clone(),
                 new_table_names.clone(),
-                new_columns.clone(),
+                vec!["c".to_string()],
+                vec!["number3".to_string()],
                 wrong_definition.to_string(),
             )
             .await
@@ -2149,5 +2172,6 @@ mod tests {
         assert_eq!(current_view_info.table_names, new_table_names);
         assert_eq!(current_view_info.definition, new_definition);
         assert_eq!(current_view_info.columns, new_columns);
+        assert_eq!(current_view_info.plan_columns, new_plan_columns);
     }
 }

--- a/src/common/meta/src/key/view_info.rs
+++ b/src/common/meta/src/key/view_info.rs
@@ -86,6 +86,8 @@ pub struct ViewInfoValue {
     pub view_info: RawViewLogicalPlan,
     /// The resolved fully table names in logical plan
     pub table_names: HashSet<TableName>,
+    /// The view columns
+    pub columns: Vec<String>,
     /// The SQL to create the view
     pub definition: String,
     version: u64,
@@ -95,11 +97,13 @@ impl ViewInfoValue {
     pub fn new(
         view_info: RawViewLogicalPlan,
         table_names: HashSet<TableName>,
+        columns: Vec<String>,
         definition: String,
     ) -> Self {
         Self {
             view_info,
             table_names,
+            columns,
             definition,
             version: 0,
         }
@@ -109,11 +113,13 @@ impl ViewInfoValue {
         &self,
         new_view_info: RawViewLogicalPlan,
         table_names: HashSet<TableName>,
+        columns: Vec<String>,
         definition: String,
     ) -> Self {
         Self {
             view_info: new_view_info,
             table_names,
+            columns,
             definition,
             version: self.version + 1,
         }
@@ -295,6 +301,7 @@ mod tests {
             view_info: vec![1, 2, 3],
             version: 1,
             table_names,
+            columns: vec!["a".to_string()],
             definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
         };
         let serialized = value.try_as_raw_value().unwrap();

--- a/src/common/meta/src/key/view_info.rs
+++ b/src/common/meta/src/key/view_info.rs
@@ -82,15 +82,15 @@ impl<'a> MetaKey<'a, ViewInfoKey> for ViewInfoKey {
 /// The VIEW info value that keeps the metadata.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ViewInfoValue {
-    /// The encoded logical plan
+    // The encoded logical plan
     pub view_info: RawViewLogicalPlan,
-    /// The resolved fully table names in logical plan
+    // The resolved fully table names in logical plan
     pub table_names: HashSet<TableName>,
-    /// The view columns
+    // The view columns
     pub columns: Vec<String>,
-    /// The plan columns
+    // The original plan columns
     pub plan_columns: Vec<String>,
-    /// The SQL to create the view
+    // The SQL to create the view
     pub definition: String,
     version: u64,
 }

--- a/src/common/meta/src/key/view_info.rs
+++ b/src/common/meta/src/key/view_info.rs
@@ -88,6 +88,8 @@ pub struct ViewInfoValue {
     pub table_names: HashSet<TableName>,
     /// The view columns
     pub columns: Vec<String>,
+    /// The plan columns
+    pub plan_columns: Vec<String>,
     /// The SQL to create the view
     pub definition: String,
     version: u64,
@@ -98,12 +100,14 @@ impl ViewInfoValue {
         view_info: RawViewLogicalPlan,
         table_names: HashSet<TableName>,
         columns: Vec<String>,
+        plan_columns: Vec<String>,
         definition: String,
     ) -> Self {
         Self {
             view_info,
             table_names,
             columns,
+            plan_columns,
             definition,
             version: 0,
         }
@@ -114,12 +118,14 @@ impl ViewInfoValue {
         new_view_info: RawViewLogicalPlan,
         table_names: HashSet<TableName>,
         columns: Vec<String>,
+        plan_columns: Vec<String>,
         definition: String,
     ) -> Self {
         Self {
             view_info: new_view_info,
             table_names,
             columns,
+            plan_columns,
             definition,
             version: self.version + 1,
         }
@@ -302,6 +308,7 @@ mod tests {
             version: 1,
             table_names,
             columns: vec!["a".to_string()],
+            plan_columns: vec!["number".to_string()],
             definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
         };
         let serialized = value.try_as_raw_value().unwrap();

--- a/src/common/meta/src/key/view_info.rs
+++ b/src/common/meta/src/key/view_info.rs
@@ -86,14 +86,21 @@ pub struct ViewInfoValue {
     pub view_info: RawViewLogicalPlan,
     /// The resolved fully table names in logical plan
     pub table_names: HashSet<TableName>,
+    /// The SQL to create the view
+    pub definition: String,
     version: u64,
 }
 
 impl ViewInfoValue {
-    pub fn new(view_info: RawViewLogicalPlan, table_names: HashSet<TableName>) -> Self {
+    pub fn new(
+        view_info: RawViewLogicalPlan,
+        table_names: HashSet<TableName>,
+        definition: String,
+    ) -> Self {
         Self {
             view_info,
             table_names,
+            definition,
             version: 0,
         }
     }
@@ -102,10 +109,12 @@ impl ViewInfoValue {
         &self,
         new_view_info: RawViewLogicalPlan,
         table_names: HashSet<TableName>,
+        definition: String,
     ) -> Self {
         Self {
             view_info: new_view_info,
             table_names,
+            definition,
             version: self.version + 1,
         }
     }
@@ -286,6 +295,7 @@ mod tests {
             view_info: vec![1, 2, 3],
             version: 1,
             table_names,
+            definition: "CREATE VIEW test AS SELECT * FROM numbers".to_string(),
         };
         let serialized = value.try_as_raw_value().unwrap();
         let deserialized = ViewInfoValue::try_from_raw_value(&serialized).unwrap();

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -325,6 +325,10 @@ impl CreateViewTask {
         &self.create_view.logical_plan
     }
 
+    pub fn view_definition(&self) -> &str {
+        &self.create_view.definition
+    }
+
     pub fn table_names(&self) -> HashSet<TableName> {
         self.create_view
             .table_names

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -336,6 +336,10 @@ impl CreateViewTask {
             .map(|t| t.clone().into())
             .collect()
     }
+
+    pub fn columns(&self) -> &Vec<String> {
+        &self.create_view.columns
+    }
 }
 
 impl TryFrom<PbCreateViewTask> for CreateViewTask {

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -340,6 +340,10 @@ impl CreateViewTask {
     pub fn columns(&self) -> &Vec<String> {
         &self.create_view.columns
     }
+
+    pub fn plan_columns(&self) -> &Vec<String> {
+        &self.create_view.plan_columns
+    }
 }
 
 impl TryFrom<PbCreateViewTask> for CreateViewTask {

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -321,14 +321,17 @@ impl CreateViewTask {
         }
     }
 
+    /// Returns the encoded logical plan
     pub fn raw_logical_plan(&self) -> &Vec<u8> {
         &self.create_view.logical_plan
     }
 
+    /// Returns the view definition in SQL
     pub fn view_definition(&self) -> &str {
         &self.create_view.definition
     }
 
+    /// Returns the resolved table names in view's logical plan
     pub fn table_names(&self) -> HashSet<TableName> {
         self.create_view
             .table_names
@@ -337,10 +340,12 @@ impl CreateViewTask {
             .collect()
     }
 
+    /// Returns the view's columns
     pub fn columns(&self) -> &Vec<String> {
         &self.create_view.columns
     }
 
+    /// Returns the original logical plan's columns
     pub fn plan_columns(&self) -> &Vec<String> {
         &self.create_view.plan_columns
     }

--- a/src/common/query/src/logical_plan.rs
+++ b/src/common/query/src/logical_plan.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use datafusion::catalog::CatalogProviderList;
 use datafusion::error::Result as DatafusionResult;
 use datafusion::logical_expr::{LogicalPlan, LogicalPlanBuilder};
-use datafusion_common::{Column, DataFusionError, SchemaError};
+use datafusion_common::Column;
 use datafusion_expr::col;
 use datatypes::prelude::ConcreteDataType;
 pub use expr::build_filter_from_timestamp;
@@ -74,7 +74,7 @@ pub fn create_aggregate_function(
     )
 }
 
-/// Rename columns by applying a new projection. This is a no-op if the column to be
+/// Rename columns by applying a new projection. Returns an error if the column to be
 /// renamed does not exist. The `renames` parameter is a `Vector` with elements
 /// in the form of `(old_name, new_name)`.
 pub fn rename_logical_plan_columns(
@@ -94,8 +94,6 @@ pub fn rename_logical_plan_columns(
         let (qualifier_rename, field_rename) =
             match plan.schema().qualified_field_from_column(&old_column) {
                 Ok(qualifier_and_field) => qualifier_and_field,
-                // no-op if field not found
-                Err(DataFusionError::SchemaError(SchemaError::FieldNotFound { .. }, _)) => continue,
                 Err(err) => return Err(err),
             };
 

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -455,6 +455,9 @@ pub fn check_permission(
         Statement::ShowCreateFlow(stmt) => {
             validate_param(&stmt.flow_name, query_ctx)?;
         }
+        Statement::ShowCreateView(stmt) => {
+            validate_param(&stmt.view_name, query_ctx)?;
+        }
         Statement::CreateExternalTable(stmt) => {
             validate_param(&stmt.name, query_ctx)?;
         }

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -148,8 +148,9 @@ pub enum Error {
         location: Location,
     },
 
-    #[snafu(display("Expect {expected} columns for view, but actual: {actual}"))]
+    #[snafu(display("Expect {expected} columns for view {view_name}, but found {actual}"))]
     ViewColumnsMismatch {
+        view_name: String,
         expected: usize,
         actual: usize,
         #[snafu(implicit)]

--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -120,6 +120,13 @@ pub enum Error {
         source: query::error::Error,
     },
 
+    #[snafu(display("Failed to get schema from logical plan"))]
+    GetSchema {
+        #[snafu(implicit)]
+        location: Location,
+        source: query::error::Error,
+    },
+
     #[snafu(display("Column datatype error"))]
     ColumnDataType {
         #[snafu(implicit)]
@@ -137,6 +144,14 @@ pub enum Error {
 
     #[snafu(display("Invalid statement to create view"))]
     InvalidViewStmt {
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Expect {expected} columns for view, but actual: {actual}"))]
+    ViewColumnsMismatch {
+        expected: usize,
+        actual: usize,
         #[snafu(implicit)]
         location: Location,
     },
@@ -203,6 +218,28 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
         source: catalog::error::Error,
+    },
+
+    #[snafu(display("Failed to find view info for: {}", view_name))]
+    FindViewInfo {
+        view_name: String,
+        #[snafu(implicit)]
+        location: Location,
+        source: common_meta::error::Error,
+    },
+
+    #[snafu(display("View info not found: {}", view_name))]
+    ViewInfoNotFound {
+        view_name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("View not found: {}", view_name))]
+    ViewNotFound {
+        view_name: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Failed to find table partition rule for table {}", table_name))]
@@ -740,6 +777,7 @@ impl ErrorExt for Error {
             | Error::InvalidTableName { .. }
             | Error::InvalidViewName { .. }
             | Error::InvalidExpr { .. }
+            | Error::ViewColumnsMismatch { .. }
             | Error::InvalidViewStmt { .. }
             | Error::ConvertIdentifier { .. }
             | Error::InvalidPartition { .. } => StatusCode::InvalidArguments,
@@ -770,7 +808,9 @@ impl ErrorExt for Error {
             | Error::CreateTableInfo { source, .. }
             | Error::IntoVectors { source, .. } => source.status_code(),
 
-            Error::RequestInserts { source, .. } => source.status_code(),
+            Error::RequestInserts { source, .. } | Error::FindViewInfo { source, .. } => {
+                source.status_code()
+            }
             Error::RequestRegion { source, .. } => source.status_code(),
             Error::RequestDeletes { source, .. } => source.status_code(),
             Error::SubstraitCodec { source, .. } => source.status_code(),
@@ -787,7 +827,10 @@ impl ErrorExt for Error {
 
             Error::EncodeJson { .. } => StatusCode::Unexpected,
 
-            Error::TableNotFound { .. } => StatusCode::TableNotFound,
+            Error::ViewNotFound { .. }
+            | Error::ViewInfoNotFound { .. }
+            | Error::TableNotFound { .. } => StatusCode::TableNotFound,
+
             Error::FlowNotFound { .. } => StatusCode::FlowNotFound,
 
             Error::JoinTask { .. } => StatusCode::Internal,
@@ -804,6 +847,7 @@ impl ErrorExt for Error {
             | Error::FindNewColumnsOnInsertion { source, .. } => source.status_code(),
 
             Error::ExecuteStatement { source, .. }
+            | Error::GetSchema { source, .. }
             | Error::ExtractTableNames { source, .. }
             | Error::PlanStatement { source, .. }
             | Error::ParseQuery { source, .. }

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -498,6 +498,7 @@ pub fn to_create_view_expr(
     stmt: CreateView,
     logical_plan: Vec<u8>,
     table_names: Vec<TableName>,
+    columns: Vec<String>,
     definition: String,
     query_ctx: QueryContextRef,
 ) -> Result<CreateViewExpr> {
@@ -513,6 +514,7 @@ pub fn to_create_view_expr(
         create_if_not_exists: stmt.if_not_exists,
         or_replace: stmt.or_replace,
         table_names,
+        columns,
         definition,
     };
 
@@ -803,11 +805,13 @@ mod tests {
 
         let logical_plan = vec![1, 2, 3];
         let table_names = new_test_table_names();
+        let columns = vec!["a".to_string()];
 
         let expr = to_create_view_expr(
             stmt,
             logical_plan.clone(),
             table_names.clone(),
+            columns.clone(),
             sql.to_string(),
             QueryContext::arc(),
         )
@@ -821,6 +825,7 @@ mod tests {
         assert_eq!(logical_plan, expr.logical_plan);
         assert_eq!(table_names, expr.table_names);
         assert_eq!(sql, expr.definition);
+        assert_eq!(columns, expr.columns);
     }
 
     #[test]
@@ -838,11 +843,13 @@ mod tests {
 
         let logical_plan = vec![1, 2, 3];
         let table_names = new_test_table_names();
+        let columns = vec!["a".to_string()];
 
         let expr = to_create_view_expr(
             stmt,
             logical_plan.clone(),
             table_names.clone(),
+            columns.clone(),
             sql.to_string(),
             QueryContext::arc(),
         )
@@ -856,5 +863,6 @@ mod tests {
         assert_eq!(logical_plan, expr.logical_plan);
         assert_eq!(table_names, expr.table_names);
         assert_eq!(sql, expr.definition);
+        assert_eq!(columns, expr.columns);
     }
 }

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -498,6 +498,7 @@ pub fn to_create_view_expr(
     stmt: CreateView,
     logical_plan: Vec<u8>,
     table_names: Vec<TableName>,
+    definition: String,
     query_ctx: QueryContextRef,
 ) -> Result<CreateViewExpr> {
     let (catalog_name, schema_name, view_name) = table_idents_to_full_name(&stmt.name, &query_ctx)
@@ -512,6 +513,7 @@ pub fn to_create_view_expr(
         create_if_not_exists: stmt.if_not_exists,
         or_replace: stmt.or_replace,
         table_names,
+        definition,
     };
 
     Ok(expr)
@@ -806,6 +808,7 @@ mod tests {
             stmt,
             logical_plan.clone(),
             table_names.clone(),
+            sql.to_string(),
             QueryContext::arc(),
         )
         .unwrap();
@@ -817,6 +820,7 @@ mod tests {
         assert!(!expr.or_replace);
         assert_eq!(logical_plan, expr.logical_plan);
         assert_eq!(table_names, expr.table_names);
+        assert_eq!(sql, expr.definition);
     }
 
     #[test]
@@ -839,6 +843,7 @@ mod tests {
             stmt,
             logical_plan.clone(),
             table_names.clone(),
+            sql.to_string(),
             QueryContext::arc(),
         )
         .unwrap();
@@ -850,5 +855,6 @@ mod tests {
         assert!(expr.or_replace);
         assert_eq!(logical_plan, expr.logical_plan);
         assert_eq!(table_names, expr.table_names);
+        assert_eq!(sql, expr.definition);
     }
 }

--- a/src/operator/src/expr_factory.rs
+++ b/src/operator/src/expr_factory.rs
@@ -499,6 +499,7 @@ pub fn to_create_view_expr(
     logical_plan: Vec<u8>,
     table_names: Vec<TableName>,
     columns: Vec<String>,
+    plan_columns: Vec<String>,
     definition: String,
     query_ctx: QueryContextRef,
 ) -> Result<CreateViewExpr> {
@@ -515,6 +516,7 @@ pub fn to_create_view_expr(
         or_replace: stmt.or_replace,
         table_names,
         columns,
+        plan_columns,
         definition,
     };
 
@@ -806,12 +808,14 @@ mod tests {
         let logical_plan = vec![1, 2, 3];
         let table_names = new_test_table_names();
         let columns = vec!["a".to_string()];
+        let plan_columns = vec!["number".to_string()];
 
         let expr = to_create_view_expr(
             stmt,
             logical_plan.clone(),
             table_names.clone(),
             columns.clone(),
+            plan_columns.clone(),
             sql.to_string(),
             QueryContext::arc(),
         )
@@ -826,6 +830,7 @@ mod tests {
         assert_eq!(table_names, expr.table_names);
         assert_eq!(sql, expr.definition);
         assert_eq!(columns, expr.columns);
+        assert_eq!(plan_columns, expr.plan_columns);
     }
 
     #[test]
@@ -844,12 +849,14 @@ mod tests {
         let logical_plan = vec![1, 2, 3];
         let table_names = new_test_table_names();
         let columns = vec!["a".to_string()];
+        let plan_columns = vec!["number".to_string()];
 
         let expr = to_create_view_expr(
             stmt,
             logical_plan.clone(),
             table_names.clone(),
             columns.clone(),
+            plan_columns.clone(),
             sql.to_string(),
             QueryContext::arc(),
         )
@@ -864,5 +871,6 @@ mod tests {
         assert_eq!(table_names, expr.table_names);
         assert_eq!(sql, expr.definition);
         assert_eq!(columns, expr.columns);
+        assert_eq!(plan_columns, expr.plan_columns);
     }
 }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -31,6 +31,7 @@ use common_meta::cache::TableRouteCacheRef;
 use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::ddl::ProcedureExecutorRef;
 use common_meta::key::flow::{FlowMetadataManager, FlowMetadataManagerRef};
+use common_meta::key::view_info::{ViewInfoManager, ViewInfoManagerRef};
 use common_meta::key::{TableMetadataManager, TableMetadataManagerRef};
 use common_meta::kv_backend::KvBackendRef;
 use common_query::Output;
@@ -45,6 +46,7 @@ use session::context::QueryContextRef;
 use session::table_name::table_idents_to_full_name;
 use snafu::{ensure, OptionExt, ResultExt};
 use sql::statements::copy::{CopyDatabase, CopyDatabaseArgument, CopyTable, CopyTableArgument};
+use sql::statements::set_variables::SetVariables;
 use sql::statements::statement::Statement;
 use sql::statements::OptionMap;
 use sql::util::format_raw_object_name;
@@ -69,6 +71,7 @@ pub struct StatementExecutor {
     procedure_executor: ProcedureExecutorRef,
     table_metadata_manager: TableMetadataManagerRef,
     flow_metadata_manager: FlowMetadataManagerRef,
+    view_info_manager: ViewInfoManagerRef,
     partition_manager: PartitionRuleManagerRef,
     cache_invalidator: CacheInvalidatorRef,
     inserter: InserterRef,
@@ -92,6 +95,7 @@ impl StatementExecutor {
             procedure_executor,
             table_metadata_manager: Arc::new(TableMetadataManager::new(kv_backend.clone())),
             flow_metadata_manager: Arc::new(FlowMetadataManager::new(kv_backend.clone())),
+            view_info_manager: Arc::new(ViewInfoManager::new(kv_backend.clone())),
             partition_manager: Arc::new(PartitionRuleManager::new(kv_backend, table_route_cache)),
             cache_invalidator,
             inserter,
@@ -244,66 +248,9 @@ impl StatementExecutor {
                 self.show_create_table(table_name, table_ref, query_ctx)
                     .await
             }
-            Statement::ShowCreateFlow(show) => {
-                let obj_name = &show.flow_name;
-                let (catalog_name, flow_name) = match &obj_name.0[..] {
-                    [table] => (query_ctx.current_catalog().to_string(), table.value.clone()),
-                    [catalog, table] => (catalog.value.clone(), table.value.clone()),
-                    _ => {
-                        return InvalidSqlSnafu {
-                            err_msg: format!(
-                "expect flow name to be <catalog>.<flow_name> or <flow_name>, actual: {obj_name}",
-            ),
-                        }
-                        .fail()
-                    }
-                };
-
-                let flow_name_val = self
-                    .flow_metadata_manager
-                    .flow_name_manager()
-                    .get(&catalog_name, &flow_name)
-                    .await
-                    .context(error::TableMetadataManagerSnafu)?
-                    .context(error::FlowNotFoundSnafu {
-                        flow_name: &flow_name,
-                    })?;
-
-                let flow_val = self
-                    .flow_metadata_manager
-                    .flow_info_manager()
-                    .get(flow_name_val.flow_id())
-                    .await
-                    .context(error::TableMetadataManagerSnafu)?
-                    .context(error::FlowNotFoundSnafu {
-                        flow_name: &flow_name,
-                    })?;
-
-                self.show_create_flow(obj_name.clone(), flow_val, query_ctx)
-                    .await
-            }
-            Statement::SetVariables(set_var) => {
-                let var_name = set_var.variable.to_string().to_uppercase();
-                match var_name.as_str() {
-                    "TIMEZONE" | "TIME_ZONE" => set_timezone(set_var.value, query_ctx)?,
-
-                    "BYTEA_OUTPUT" => set_bytea_output(set_var.value, query_ctx)?,
-
-                    // Same as "bytea_output", we just ignore it here.
-                    // Not harmful since it only relates to how date is viewed in client app's output.
-                    // The tracked issue is https://github.com/GreptimeTeam/greptimedb/issues/3442.
-                    "DATESTYLE" => set_datestyle(set_var.value, query_ctx)?,
-
-                    "CLIENT_ENCODING" => validate_client_encoding(set_var)?,
-                    _ => {
-                        return NotSupportedSnafu {
-                            feat: format!("Unsupported set variable {}", var_name),
-                        }
-                        .fail()
-                    }
-                }
-                Ok(Output::new_with_affected_rows(0))
-            }
+            Statement::ShowCreateFlow(show) => self.show_create_flow(show, query_ctx).await,
+            Statement::ShowCreateView(show) => self.show_create_view(show, query_ctx).await,
+            Statement::SetVariables(set_var) => self.set_variables(set_var, query_ctx),
             Statement::ShowVariables(show_variable) => self.show_variable(show_variable, query_ctx),
             Statement::ShowColumns(show_columns) => {
                 self.show_columns(show_columns, query_ctx).await
@@ -327,6 +274,29 @@ impl StatementExecutor {
         query_ctx.set_current_schema(&db);
 
         Ok(Output::new_with_record_batches(RecordBatches::empty()))
+    }
+
+    fn set_variables(&self, set_var: SetVariables, query_ctx: QueryContextRef) -> Result<Output> {
+        let var_name = set_var.variable.to_string().to_uppercase();
+        match var_name.as_str() {
+            "TIMEZONE" | "TIME_ZONE" => set_timezone(set_var.value, query_ctx)?,
+
+            "BYTEA_OUTPUT" => set_bytea_output(set_var.value, query_ctx)?,
+
+            // Same as "bytea_output", we just ignore it here.
+            // Not harmful since it only relates to how date is viewed in client app's output.
+            // The tracked issue is https://github.com/GreptimeTeam/greptimedb/issues/3442.
+            "DATESTYLE" => set_datestyle(set_var.value, query_ctx)?,
+
+            "CLIENT_ENCODING" => validate_client_encoding(set_var)?,
+            _ => {
+                return NotSupportedSnafu {
+                    feat: format!("Unsupported set variable {}", var_name),
+                }
+                .fail()
+            }
+        }
+        Ok(Output::new_with_affected_rows(0))
     }
 
     pub async fn plan(

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -424,6 +424,7 @@ impl StatementExecutor {
             ensure!(
                 columns.len() == plan_columns.len(),
                 error::ViewColumnsMismatchSnafu {
+                    view_name: create_view.name.to_string(),
                     expected: plan_columns.len(),
                     actual: columns.len(),
                 }

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -430,7 +430,7 @@ impl StatementExecutor {
             );
         }
 
-        // Extract the table names from the origin plan
+        // Extract the table names from the original plan
         // and rewrite them as fully qualified names.
         let (table_names, plan) =
             extract_and_rewrite_full_table_names(logical_plan.unwrap_df_plan(), ctx.clone())

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -400,6 +400,7 @@ impl StatementExecutor {
                 return InvalidViewStmtSnafu {}.fail();
             }
         };
+        let definition = create_view.to_string();
 
         // Extract the table names from the origin plan
         // and rewrite them as fully qualified names.
@@ -423,6 +424,7 @@ impl StatementExecutor {
             create_view,
             encoded_plan.to_vec(),
             table_names,
+            definition,
             ctx.clone(),
         )?;
 

--- a/src/operator/src/statement/ddl.rs
+++ b/src/operator/src/statement/ddl.rs
@@ -400,7 +400,7 @@ impl StatementExecutor {
                 return InvalidViewStmtSnafu {}.fail();
             }
         };
-        //Save the definition for `show create view`.
+        // Save the definition for `show create view`.
         let definition = create_view.to_string();
 
         // Save the columns in plan, it may changed when the schemas of tables in plan

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -23,8 +23,8 @@ use snafu::{OptionExt, ResultExt};
 use sql::ast::Ident;
 use sql::statements::create::Partitions;
 use sql::statements::show::{
-    ShowColumns, ShowCreateFlow, ShowCreateView, ShowDatabases, ShowIndex, ShowKind, ShowTables,
-    ShowVariables,ShowTableStatus
+    ShowColumns, ShowCreateFlow, ShowCreateView, ShowDatabases, ShowIndex, ShowKind,
+    ShowTableStatus, ShowTables, ShowVariables,
 };
 use table::metadata::TableType;
 use table::table_name::TableName;

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -12,24 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_meta::key::flow::flow_info::FlowInfoValue;
+use common_error::ext::BoxedError;
 use common_query::Output;
 use common_telemetry::tracing;
 use partition::manager::PartitionInfo;
 use partition::partition::PartitionBound;
 use session::context::QueryContextRef;
-use snafu::ResultExt;
+use session::table_name::table_idents_to_full_name;
+use snafu::{OptionExt, ResultExt};
 use sql::ast::Ident;
 use sql::statements::create::Partitions;
 use sql::statements::show::{
-    ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTableStatus, ShowTables, ShowVariables,
+    ShowColumns, ShowCreateFlow, ShowCreateView, ShowDatabases, ShowIndex, ShowKind, ShowTables,
+    ShowVariables,ShowTableStatus
 };
-use sqlparser::ast::ObjectName;
 use table::metadata::TableType;
 use table::table_name::TableName;
 use table::TableRef;
 
-use crate::error::{self, ExecuteStatementSnafu, Result};
+use crate::error::{
+    self, CatalogSnafu, ExecuteStatementSnafu, ExternalSnafu, FindViewInfoSnafu, InvalidSqlSnafu,
+    Result, ViewInfoNotFoundSnafu, ViewNotFoundSnafu,
+};
 use crate::statement::StatementExecutor;
 
 impl StatementExecutor {
@@ -119,13 +123,76 @@ impl StatementExecutor {
     }
 
     #[tracing::instrument(skip_all)]
-    pub async fn show_create_flow(
+    pub async fn show_create_view(
         &self,
-        flow_name: ObjectName,
-        flow_val: FlowInfoValue,
+        show: ShowCreateView,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
-        query::sql::show_create_flow(flow_name, flow_val, query_ctx)
+        let (catalog, schema, view) = table_idents_to_full_name(&show.view_name, &query_ctx)
+            .map_err(BoxedError::new)
+            .context(ExternalSnafu)?;
+
+        let table_ref = self
+            .catalog_manager
+            .table(&catalog, &schema, &view)
+            .await
+            .context(CatalogSnafu)?
+            .context(ViewNotFoundSnafu { view_name: &view })?;
+
+        let view_id = table_ref.table_info().ident.table_id;
+
+        let view_info = self
+            .view_info_manager
+            .get(view_id)
+            .await
+            .context(FindViewInfoSnafu { view_name: &view })?
+            .context(ViewInfoNotFoundSnafu { view_name: &view })?;
+
+        query::sql::show_create_view(show.view_name.clone(), &view_info.definition, query_ctx)
+            .context(error::ExecuteStatementSnafu)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn show_create_flow(
+        &self,
+        show: ShowCreateFlow,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        let obj_name = &show.flow_name;
+        let (catalog_name, flow_name) = match &obj_name.0[..] {
+            [table] => (query_ctx.current_catalog().to_string(), table.value.clone()),
+            [catalog, table] => (catalog.value.clone(), table.value.clone()),
+            _ => {
+                return InvalidSqlSnafu {
+                    err_msg: format!(
+                        "expect flow name to be <catalog>.<flow_name> or <flow_name>, actual: {obj_name}",
+                    ),
+                }
+                .fail()
+            }
+        };
+
+        let flow_name_val = self
+            .flow_metadata_manager
+            .flow_name_manager()
+            .get(&catalog_name, &flow_name)
+            .await
+            .context(error::TableMetadataManagerSnafu)?
+            .context(error::FlowNotFoundSnafu {
+                flow_name: &flow_name,
+            })?;
+
+        let flow_val = self
+            .flow_metadata_manager
+            .flow_info_manager()
+            .get(flow_name_val.flow_id())
+            .await
+            .context(error::TableMetadataManagerSnafu)?
+            .context(error::FlowNotFoundSnafu {
+                flow_name: &flow_name,
+            })?;
+
+        query::sql::show_create_flow(obj_name.clone(), flow_val, query_ctx)
             .context(error::ExecuteStatementSnafu)
     }
 

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -148,7 +148,7 @@ impl StatementExecutor {
             .context(FindViewInfoSnafu { view_name: &view })?
             .context(ViewInfoNotFoundSnafu { view_name: &view })?;
 
-        query::sql::show_create_view(show.view_name.clone(), &view_info.definition, query_ctx)
+        query::sql::show_create_view(show.view_name, &view_info.definition, query_ctx)
             .context(error::ExecuteStatementSnafu)
     }
 

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -95,10 +95,18 @@ async fn resolve_tables(
 
         if let Entry::Vacant(v) = tables.entry(resolved_name.to_string()) {
             // Try our best to resolve the tables here, but we don't return an error if table is not found,
-            // because the table name may be a temporary name of CTE or view, they can't be found until plan
+            // because the table name may be a temporary name of CTE, they can't be found until plan
             // execution.
-            if let Ok(table) = table_provider.resolve_table(table_name).await {
-                let _ = v.insert(table);
+            match table_provider.resolve_table(table_name).await {
+                Ok(table) => {
+                    let _ = v.insert(table);
+                }
+                Err(e) if e.should_fail() => {
+                    return Err(e).context(CatalogSnafu);
+                }
+                _ => {
+                    // ignore
+                }
             }
         }
     }

--- a/src/query/src/datafusion/planner.rs
+++ b/src/query/src/datafusion/planner.rs
@@ -64,6 +64,10 @@ impl DfContextProviderAdapter {
             engine_state.disallow_cross_catalog_query(),
             query_ctx.as_ref(),
             Arc::new(DefaultPlanDecoder::new(session_state.clone(), &query_ctx)?),
+            session_state
+                .config_options()
+                .sql_parser
+                .enable_ident_normalization,
         );
 
         let tables = resolve_tables(table_names, &mut table_provider).await?;

--- a/src/query/src/planner.rs
+++ b/src/query/src/planner.rs
@@ -73,6 +73,10 @@ impl DfLogicalPlanner {
                 self.session_state.clone(),
                 &query_ctx,
             )?),
+            self.session_state
+                .config_options()
+                .sql_parser
+                .enable_ident_normalization,
         );
 
         let context_provider = DfContextProviderAdapter::try_new(
@@ -148,6 +152,10 @@ impl DfLogicalPlanner {
                 self.session_state.clone(),
                 &query_ctx,
             )?),
+            self.session_state
+                .config_options()
+                .sql_parser
+                .enable_ident_normalization,
         );
         PromPlanner::stmt_to_plan(table_provider, stmt, &self.session_state)
             .await

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -2337,6 +2337,7 @@ mod test {
             false,
             QueryContext::arc().as_ref(),
             DummyDecoder::arc(),
+            true,
         )
     }
 
@@ -3176,6 +3177,7 @@ mod test {
                 false,
                 QueryContext::arc().as_ref(),
                 DummyDecoder::arc(),
+                true,
             ),
             EvalStmt {
                 expr: parser::parse("metrics{tag = \"1\"}").unwrap(),
@@ -3205,6 +3207,7 @@ mod test {
                 false,
                 QueryContext::arc().as_ref(),
                 DummyDecoder::arc(),
+                true,
             ),
             EvalStmt {
                 expr: parser::parse("avg_over_time(metrics{tag = \"1\"}[5s])").unwrap(),

--- a/src/query/src/promql/planner.rs
+++ b/src/query/src/promql/planner.rs
@@ -2337,7 +2337,7 @@ mod test {
             false,
             QueryContext::arc().as_ref(),
             DummyDecoder::arc(),
-            true,
+            false,
         )
     }
 

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -110,12 +110,16 @@ impl SubstraitPlanDecoder for DefaultPlanDecoder {
         catalog_list: Arc<dyn CatalogProviderList>,
         optimize: bool,
     ) -> common_query::error::Result<LogicalPlan> {
+        println!("{:?}", message);
+
         // The session_state already has the `DefaultSerialzier` as `SerializerRegistry`.
         let logical_plan = DFLogicalSubstraitConvertor
             .decode(message, catalog_list.clone(), self.session_state.clone())
             .await
             .map_err(BoxedError::new)
             .context(common_query::error::DecodePlanSnafu)?;
+
+        println!("{:?}", logical_plan);
 
         if optimize {
             self.session_state

--- a/src/query/src/query_engine/default_serializer.rs
+++ b/src/query/src/query_engine/default_serializer.rs
@@ -110,16 +110,12 @@ impl SubstraitPlanDecoder for DefaultPlanDecoder {
         catalog_list: Arc<dyn CatalogProviderList>,
         optimize: bool,
     ) -> common_query::error::Result<LogicalPlan> {
-        println!("{:?}", message);
-
         // The session_state already has the `DefaultSerialzier` as `SerializerRegistry`.
         let logical_plan = DFLogicalSubstraitConvertor
             .decode(message, catalog_list.clone(), self.session_state.clone())
             .await
             .map_err(BoxedError::new)
             .context(common_query::error::DecodePlanSnafu)?;
-
-        println!("{:?}", logical_plan);
 
         if optimize {
             self.session_state

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -2067,6 +2067,10 @@ CREATE TABLE log (
             }
             _ => unreachable!(),
         }
+        assert_eq!(
+            "CREATE VIEW test AS SELECT * FROM NUMBERS",
+            result[0].to_string()
+        );
 
         let sql = "CREATE VIEW test (n1) AS SELECT * FROM NUMBERS";
         let result =
@@ -2082,6 +2086,7 @@ CREATE TABLE log (
             }
             _ => unreachable!(),
         }
+        assert_eq!(sql, result[0].to_string());
 
         let sql = "CREATE VIEW test (n1, n2) AS SELECT * FROM NUMBERS";
         let result =
@@ -2097,6 +2102,7 @@ CREATE TABLE log (
             }
             _ => unreachable!(),
         }
+        assert_eq!(sql, result[0].to_string());
 
         // Some invalid syntax cases
         let sql = "CREATE VIEW test (n1 AS select * from demo";

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -24,7 +24,7 @@ use sqlparser::ast::{ColumnOption, ColumnOptionDef, DataType, Expr, KeyOrIndexDi
 use sqlparser::dialect::keywords::Keyword;
 use sqlparser::keywords::ALL_KEYWORDS;
 use sqlparser::parser::IsOptional::Mandatory;
-use sqlparser::parser::Parser;
+use sqlparser::parser::{Parser, ParserError};
 use sqlparser::tokenizer::{Token, TokenWithLocation, Word};
 use table::requests::validate_table_option;
 
@@ -590,7 +590,7 @@ impl<'a> ParserContext<'a> {
     }
 
     pub fn parse_column_def(&mut self) -> Result<Column> {
-        let name = self.parse_column_name()?;
+        let name = self.parse_column_name().context(SyntaxSnafu)?;
         let parser = &mut self.parser;
 
         ensure!(
@@ -2052,6 +2052,7 @@ CREATE TABLE log (
             .contains("invalid FULLTEXT option"));
     }
 
+    #[test]
     fn test_parse_create_view_with_columns() {
         let sql = "CREATE VIEW test () AS SELECT * FROM NUMBERS";
         let result =

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -125,6 +125,8 @@ impl<'a> ParserContext<'a> {
         let if_not_exists = self.parse_if_not_exist()?;
         let view_name = self.intern_parse_table_name()?;
 
+        let columns = self.parse_view_columns()?;
+
         self.parser
             .expect_keyword(Keyword::AS)
             .context(SyntaxSnafu)?;
@@ -133,10 +135,34 @@ impl<'a> ParserContext<'a> {
 
         Ok(Statement::CreateView(CreateView {
             name: view_name,
+            columns,
             or_replace,
             query: Box::new(query),
             if_not_exists,
         }))
+    }
+
+    fn parse_view_columns(&mut self) -> Result<Vec<Ident>> {
+        let mut columns = vec![];
+        if !self.parser.consume_token(&Token::LParen) || self.parser.consume_token(&Token::RParen) {
+            return Ok(columns);
+        }
+
+        loop {
+            let name = self.parse_column_name().context(SyntaxSnafu)?;
+
+            columns.push(name);
+
+            let comma = self.parser.consume_token(&Token::Comma);
+            if self.parser.consume_token(&Token::RParen) {
+                // allow a trailing comma, even though it's not in standard
+                break;
+            } else if !comma {
+                return self.expected("',' or ')' after column name", self.parser.peek_token());
+            }
+        }
+
+        Ok(columns)
     }
 
     fn parse_create_external_table(&mut self) -> Result<Statement> {
@@ -547,10 +573,26 @@ impl<'a> ParserContext<'a> {
         Ok(())
     }
 
+    /// Parse the column name and check if it's valid.
+    fn parse_column_name(&mut self) -> std::result::Result<Ident, ParserError> {
+        let name = self.parser.parse_identifier(false)?;
+        if name.quote_style.is_none() &&
+        // "ALL_KEYWORDS" are sorted.
+            ALL_KEYWORDS.binary_search(&name.value.to_uppercase().as_str()).is_ok()
+        {
+            return Err(ParserError::ParserError(format!(
+                "Cannot use keyword '{}' as column name. Hint: add quotes to the name.",
+                &name.value
+            )));
+        }
+
+        Ok(name)
+    }
+
     pub fn parse_column_def(&mut self) -> Result<Column> {
+        let name = self.parse_column_name()?;
         let parser = &mut self.parser;
 
-        let name = parser.parse_identifier(false).context(SyntaxSnafu)?;
         ensure!(
             !(name.quote_style.is_none() &&
             // "ALL_KEYWORDS" are sorted.
@@ -2008,5 +2050,79 @@ CREATE TABLE log (
             .unwrap_err()
             .to_string()
             .contains("invalid FULLTEXT option"));
+    }
+
+    fn test_parse_create_view_with_columns() {
+        let sql = "CREATE VIEW test () AS SELECT * FROM NUMBERS";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+
+        match &result[0] {
+            Statement::CreateView(c) => {
+                assert_eq!(c.to_string(), "CREATE VIEW test AS SELECT * FROM NUMBERS");
+                assert!(!c.or_replace);
+                assert!(!c.if_not_exists);
+                assert_eq!("test", c.name.to_string());
+            }
+            _ => unreachable!(),
+        }
+
+        let sql = "CREATE VIEW test (n1) AS SELECT * FROM NUMBERS";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+
+        match &result[0] {
+            Statement::CreateView(c) => {
+                assert_eq!(c.to_string(), sql);
+                assert!(!c.or_replace);
+                assert!(!c.if_not_exists);
+                assert_eq!("test", c.name.to_string());
+            }
+            _ => unreachable!(),
+        }
+
+        let sql = "CREATE VIEW test (n1, n2) AS SELECT * FROM NUMBERS";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default())
+                .unwrap();
+
+        match &result[0] {
+            Statement::CreateView(c) => {
+                assert_eq!(c.to_string(), sql);
+                assert!(!c.or_replace);
+                assert!(!c.if_not_exists);
+                assert_eq!("test", c.name.to_string());
+            }
+            _ => unreachable!(),
+        }
+
+        // Some invalid syntax cases
+        let sql = "CREATE VIEW test (n1 AS select * from demo";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
+
+        let sql = "CREATE VIEW test (n1, AS select * from demo";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
+
+        let sql = "CREATE VIEW test n1,n2) AS select * from demo";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
+
+        let sql = "CREATE VIEW test (1) AS select * from demo";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
+
+        // keyword
+        let sql = "CREATE VIEW test (n1, select) AS select * from demo";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
     }
 }

--- a/src/sql/src/statements/create.rs
+++ b/src/sql/src/statements/create.rs
@@ -385,6 +385,8 @@ impl Display for CreateFlow {
 pub struct CreateView {
     /// View name
     pub name: ObjectName,
+    /// An optional list of names to be used for columns of the view
+    pub columns: Vec<Ident>,
     /// The clause after `As` that defines the VIEW.
     /// Can only be either [Statement::Query] or [Statement::Tql].
     pub query: Box<Statement>,
@@ -405,6 +407,9 @@ impl Display for CreateView {
             write!(f, "IF NOT EXISTS ")?;
         }
         write!(f, "{} ", &self.name)?;
+        if !self.columns.is_empty() {
+            write!(f, "({}) ", format_list_comma!(self.columns))?;
+        }
         write!(f, "AS {}", &self.query)
     }
 }

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -187,6 +187,19 @@ impl Display for ShowCreateFlow {
     }
 }
 
+/// SQL structure for `SHOW CREATE VIEW`.
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
+pub struct ShowCreateView {
+    pub view_name: ObjectName,
+}
+
+impl Display for ShowCreateView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let view_name = &self.view_name;
+        write!(f, "SHOW CREATE VIEW {view_name}")
+    }
+}
+
 /// SQL structure for `SHOW VARIABLES xxx`.
 #[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
 pub struct ShowVariables {

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -31,8 +31,8 @@ use crate::statements::insert::Insert;
 use crate::statements::query::Query;
 use crate::statements::set_variables::SetVariables;
 use crate::statements::show::{
-    ShowColumns, ShowCreateFlow, ShowCreateTable, ShowDatabases, ShowIndex, ShowKind, ShowStatus,
-    ShowTableStatus, ShowTables, ShowVariables,
+    ShowColumns, ShowCreateFlow, ShowCreateTable, ShowCreateView, ShowDatabases, ShowIndex,
+    ShowKind, ShowStatus, ShowTableStatus, ShowTables, ShowVariables,
 };
 use crate::statements::tql::Tql;
 use crate::statements::truncate::TruncateTable;
@@ -85,6 +85,8 @@ pub enum Statement {
     ShowCreateTable(ShowCreateTable),
     // SHOW CREATE FLOW
     ShowCreateFlow(ShowCreateFlow),
+    // SHOW CREATE VIEW
+    ShowCreateView(ShowCreateView),
     // SHOW STATUS
     ShowStatus(ShowStatus),
     // DESCRIBE TABLE
@@ -126,6 +128,7 @@ impl Display for Statement {
             Statement::ShowIndex(s) => s.fmt(f),
             Statement::ShowCreateTable(s) => s.fmt(f),
             Statement::ShowCreateFlow(s) => s.fmt(f),
+            Statement::ShowCreateView(s) => s.fmt(f),
             Statement::ShowStatus(s) => s.fmt(f),
             Statement::DescribeTable(s) => s.fmt(f),
             Statement::Explain(s) => s.fmt(f),

--- a/tests/cases/standalone/common/view/columns.result
+++ b/tests/cases/standalone/common/view/columns.result
@@ -1,0 +1,248 @@
+CREATE DATABASE schema_for_view_test;
+
+Affected Rows: 1
+
+USE schema_for_view_test;
+
+Affected Rows: 0
+
+CREATE TABLE t1 (n INT, ts TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+INSERT INTO t1 VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+
+Affected Rows: 10
+
+CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT * FROM t1;
+
+Error: 1004(InvalidArguments), Expect 2 columns for view, but actual: 1
+
+CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT n FROM t1;
+
+Affected Rows: 0
+
+SHOW CREATE VIEW v1;
+
++------+------------------------------------------------------+
+| View | Create View                                          |
++------+------------------------------------------------------+
+| v1   | CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT n FROM t1 |
++------+------------------------------------------------------+
+
+SELECT * FROM v1;
+
++----+
+| a  |
++----+
+| 1  |
+| 2  |
+| 3  |
+| 4  |
+| 5  |
+| 6  |
+| 7  |
+| 8  |
+| 9  |
+| 10 |
++----+
+
+SELECT a FROM v1;
+
++----+
+| a  |
++----+
+| 1  |
+| 2  |
+| 3  |
+| 4  |
+| 5  |
+| 6  |
+| 7  |
+| 8  |
+| 9  |
+| 10 |
++----+
+
+SELECT n FROM v1;
+
+Error: 3000(PlanQuery), Failed to plan SQL: No field named n. Valid fields are v1.a.
+
+CREATE OR REPLACE VIEW v1 (a, b) AS SELECT n, n+1 FROM t1;
+
+Affected Rows: 0
+
+SHOW CREATE VIEW v1;
+
++------+-------------------------------------------------------------+
+| View | Create View                                                 |
++------+-------------------------------------------------------------+
+| v1   | CREATE OR REPLACE VIEW v1 (a, b) AS SELECT n, n + 1 FROM t1 |
++------+-------------------------------------------------------------+
+
+SELECT * FROM v1;
+
++----+----+
+| a  | b  |
++----+----+
+| 1  | 2  |
+| 2  | 3  |
+| 3  | 4  |
+| 4  | 5  |
+| 5  | 6  |
+| 6  | 7  |
+| 7  | 8  |
+| 8  | 9  |
+| 9  | 10 |
+| 10 | 11 |
++----+----+
+
+SELECT * FROM v1 WHERE a > 5;
+
++----+----+
+| a  | b  |
++----+----+
+| 6  | 7  |
+| 7  | 8  |
+| 8  | 9  |
+| 9  | 10 |
+| 10 | 11 |
++----+----+
+
+SELECT * FROM v1 WHERE b > 5;
+
++----+----+
+| a  | b  |
++----+----+
+| 5  | 6  |
+| 6  | 7  |
+| 7  | 8  |
+| 8  | 9  |
+| 9  | 10 |
+| 10 | 11 |
++----+----+
+
+SELECT a FROM v1;
+
++----+
+| a  |
++----+
+| 1  |
+| 2  |
+| 3  |
+| 4  |
+| 5  |
+| 6  |
+| 7  |
+| 8  |
+| 9  |
+| 10 |
++----+
+
+SELECT b FROM v1;
+
++----+
+| b  |
++----+
+| 2  |
+| 3  |
+| 4  |
+| 5  |
+| 6  |
+| 7  |
+| 8  |
+| 9  |
+| 10 |
+| 11 |
++----+
+
+SELECT a,b FROM v1;
+
++----+----+
+| a  | b  |
++----+----+
+| 1  | 2  |
+| 2  | 3  |
+| 3  | 4  |
+| 4  | 5  |
+| 5  | 6  |
+| 6  | 7  |
+| 7  | 8  |
+| 8  | 9  |
+| 9  | 10 |
+| 10 | 11 |
++----+----+
+
+SELECT n FROM v1;
+
+Error: 3000(PlanQuery), Failed to plan SQL: No field named n. Valid fields are v1.a, v1.b.
+
+SELECT * FROM v1 WHERE n > 5;
+
+Error: 3000(PlanQuery), Failed to plan SQL: No field named n. Valid fields are v1.a, v1.b.
+
+-- test view after altering table t1 --
+CREATE OR REPLACE VIEW v1 AS SELECT n, ts FROM t1 LIMIT 5;
+
+Affected Rows: 0
+
+SELECT * FROM v1;
+
++---+-------------------------+
+| n | ts                      |
++---+-------------------------+
+| 1 | 1970-01-01T00:00:00.001 |
+| 2 | 1970-01-01T00:00:00.002 |
+| 3 | 1970-01-01T00:00:00.003 |
+| 4 | 1970-01-01T00:00:00.004 |
+| 5 | 1970-01-01T00:00:00.005 |
++---+-------------------------+
+
+ALTER TABLE t1 ADD COLUMN s STRING DEFAULT '';
+
+Affected Rows: 0
+
+SELECT * FROM v1;
+
++---+-------------------------+
+| n | ts                      |
++---+-------------------------+
+| 1 | 1970-01-01T00:00:00.001 |
+| 2 | 1970-01-01T00:00:00.002 |
+| 3 | 1970-01-01T00:00:00.003 |
+| 4 | 1970-01-01T00:00:00.004 |
+| 5 | 1970-01-01T00:00:00.005 |
++---+-------------------------+
+
+ALTER TABLE t1 DROP COLUMN n;
+
+Affected Rows: 0
+
+-- FIXME(dennis): The result looks weird,
+-- Looks like substrait referes to columns only by their relative indices, so that’s name-independent.
+-- Limit: skip=0, fetch=5
+--  Projection: greptime.public.t1.ts, greptime.public.t1.s
+--    MergeScan [is_placeholder=false]
+-- Limit: skip=0, fetch=5
+--  MergeScan [is_placeholder=false]
+-- See https://github.com/apache/datafusion/issues/6489
+SELECT * FROM v1;
+
++-------------------------+---+
+| ts                      | s |
++-------------------------+---+
+| 1970-01-01T00:00:00.001 |   |
+| 1970-01-01T00:00:00.002 |   |
+| 1970-01-01T00:00:00.003 |   |
+| 1970-01-01T00:00:00.004 |   |
+| 1970-01-01T00:00:00.005 |   |
++-------------------------+---+
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE schema_for_view_test;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/view/columns.result
+++ b/tests/cases/standalone/common/view/columns.result
@@ -16,7 +16,7 @@ Affected Rows: 10
 
 CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT * FROM t1;
 
-Error: 1004(InvalidArguments), Expect 2 columns for view, but actual: 1
+Error: 1004(InvalidArguments), Expect 2 columns for view v1, but found 1
 
 CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT n FROM t1;
 

--- a/tests/cases/standalone/common/view/columns.sql
+++ b/tests/cases/standalone/common/view/columns.sql
@@ -1,0 +1,64 @@
+CREATE DATABASE schema_for_view_test;
+
+USE schema_for_view_test;
+
+CREATE TABLE t1 (n INT, ts TIMESTAMP TIME INDEX);
+
+INSERT INTO t1 VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10);
+
+CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT * FROM t1;
+
+CREATE VIEW IF NOT EXISTS v1 (a) AS SELECT n FROM t1;
+
+SHOW CREATE VIEW v1;
+
+SELECT * FROM v1;
+
+SELECT a FROM v1;
+
+SELECT n FROM v1;
+
+CREATE OR REPLACE VIEW v1 (a, b) AS SELECT n, n+1 FROM t1;
+
+SHOW CREATE VIEW v1;
+
+SELECT * FROM v1;
+
+SELECT * FROM v1 WHERE a > 5;
+
+SELECT * FROM v1 WHERE b > 5;
+
+SELECT a FROM v1;
+
+SELECT b FROM v1;
+
+SELECT a,b FROM v1;
+
+SELECT n FROM v1;
+
+SELECT * FROM v1 WHERE n > 5;
+
+-- test view after altering table t1 --
+CREATE OR REPLACE VIEW v1 AS SELECT n, ts FROM t1 LIMIT 5;
+
+SELECT * FROM v1;
+
+ALTER TABLE t1 ADD COLUMN s STRING DEFAULT '';
+
+SELECT * FROM v1;
+
+ALTER TABLE t1 DROP COLUMN n;
+
+-- FIXME(dennis): The result looks weird,
+-- Looks like substrait referes to columns only by their relative indices, so that’s name-independent.
+-- Limit: skip=0, fetch=5
+--  Projection: greptime.public.t1.ts, greptime.public.t1.s
+--    MergeScan [is_placeholder=false]
+-- Limit: skip=0, fetch=5
+--  MergeScan [is_placeholder=false]
+-- See https://github.com/apache/datafusion/issues/6489
+SELECT * FROM v1;
+
+USE public;
+
+DROP DATABASE schema_for_view_test;

--- a/tests/cases/standalone/common/view/show_create.result
+++ b/tests/cases/standalone/common/view/show_create.result
@@ -1,0 +1,136 @@
+CREATE DATABASE schema_for_view_test;
+
+Affected Rows: 1
+
+USE schema_for_view_test;
+
+Affected Rows: 0
+
+CREATE TABLE t1(a INT, b STRING, c TIMESTAMP TIME INDEX);
+
+Affected Rows: 0
+
+INSERT INTO t1 VALUES (41, "hello", 1), (42, "world", 2), (43, "greptime", 3);
+
+Affected Rows: 3
+
+CREATE VIEW v1 AS SELECT a, b FROM t1;
+
+Affected Rows: 0
+
+SELECT * FROM v1;
+
++----+----------+
+| a  | b        |
++----+----------+
+| 41 | hello    |
+| 42 | world    |
+| 43 | greptime |
++----+----------+
+
+SELECT a FROM v1;
+
++----+
+| a  |
++----+
+| 41 |
+| 42 |
+| 43 |
++----+
+
+INSERT INTO t1 VALUES (44, "greptimedb", 4);
+
+Affected Rows: 1
+
+SELECT * FROM v1;
+
++----+------------+
+| a  | b          |
++----+------------+
+| 41 | hello      |
+| 42 | world      |
+| 43 | greptime   |
+| 44 | greptimedb |
++----+------------+
+
+SHOW CREATE VIEW v1;
+
++------+---------------------------------------+
+| View | Create View                           |
++------+---------------------------------------+
+| v1   | CREATE VIEW v1 AS SELECT a, b FROM t1 |
++------+---------------------------------------+
+
+CREATE OR REPLACE VIEW v1 AS SELECT a, b, c FROM t1 WHERE a > 43;
+
+Affected Rows: 0
+
+SHOW CREATE VIEW v1;
+
++------+------------------------------------------------------------------+
+| View | Create View                                                      |
++------+------------------------------------------------------------------+
+| v1   | CREATE OR REPLACE VIEW v1 AS SELECT a, b, c FROM t1 WHERE a > 43 |
++------+------------------------------------------------------------------+
+
+SELECT * FROM v1;
+
++----+------------+-------------------------+
+| a  | b          | c                       |
++----+------------+-------------------------+
+| 44 | greptimedb | 1970-01-01T00:00:00.004 |
++----+------------+-------------------------+
+
+--- if not exists, so it doesn't change at all ---
+CREATE VIEW IF NOT EXISTS v1 AS SELECT c FROM t1;
+
+Affected Rows: 0
+
+SHOW CREATE VIEW v1;
+
++------+------------------------------------------------------------------+
+| View | Create View                                                      |
++------+------------------------------------------------------------------+
+| v1   | CREATE OR REPLACE VIEW v1 AS SELECT a, b, c FROM t1 WHERE a > 43 |
++------+------------------------------------------------------------------+
+
+SELECT * FROM v1;
+
++----+------------+-------------------------+
+| a  | b          | c                       |
++----+------------+-------------------------+
+| 44 | greptimedb | 1970-01-01T00:00:00.004 |
++----+------------+-------------------------+
+
+--- if not exists with replace, so it changes ---
+CREATE OR REPLACE VIEW IF NOT EXISTS v1 AS SELECT c FROM t1;
+
+Affected Rows: 0
+
+SHOW CREATE VIEW v1;
+
++------+-------------------------------------------------------------+
+| View | Create View                                                 |
++------+-------------------------------------------------------------+
+| v1   | CREATE OR REPLACE VIEW IF NOT EXISTS v1 AS SELECT c FROM t1 |
++------+-------------------------------------------------------------+
+
+SELECT * FROM v1;
+
++-------------------------+
+| c                       |
++-------------------------+
+| 1970-01-01T00:00:00.001 |
+| 1970-01-01T00:00:00.002 |
+| 1970-01-01T00:00:00.003 |
+| 1970-01-01T00:00:00.004 |
++-------------------------+
+
+USE public;
+
+Affected Rows: 0
+
+DROP DATABASE schema_for_view_test;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/view/show_create.sql
+++ b/tests/cases/standalone/common/view/show_create.sql
@@ -1,0 +1,44 @@
+CREATE DATABASE schema_for_view_test;
+
+USE schema_for_view_test;
+
+CREATE TABLE t1(a INT, b STRING, c TIMESTAMP TIME INDEX);
+
+INSERT INTO t1 VALUES (41, "hello", 1), (42, "world", 2), (43, "greptime", 3);
+
+CREATE VIEW v1 AS SELECT a, b FROM t1;
+
+SELECT * FROM v1;
+
+SELECT a FROM v1;
+
+INSERT INTO t1 VALUES (44, "greptimedb", 4);
+
+SELECT * FROM v1;
+
+SHOW CREATE VIEW v1;
+
+CREATE OR REPLACE VIEW v1 AS SELECT a, b, c FROM t1 WHERE a > 43;
+
+SHOW CREATE VIEW v1;
+
+SELECT * FROM v1;
+
+--- if not exists, so it doesn't change at all ---
+CREATE VIEW IF NOT EXISTS v1 AS SELECT c FROM t1;
+
+SHOW CREATE VIEW v1;
+
+SELECT * FROM v1;
+
+--- if not exists with replace, so it changes ---
+CREATE OR REPLACE VIEW IF NOT EXISTS v1 AS SELECT c FROM t1;
+
+SHOW CREATE VIEW v1;
+
+SELECT * FROM v1;
+
+
+USE public;
+
+DROP DATABASE schema_for_view_test;

--- a/tests/cases/standalone/common/view/view.result
+++ b/tests/cases/standalone/common/view/view.result
@@ -30,20 +30,28 @@ SELECT * FROM v1;
 | 1970-01-01T00:00:00.042 |
 +-------------------------+
 
--- CREATE VIEW v1 AS SELECT 'whatever'; --
+-- FIXME(dennis): Substrait doesn't support alias in projection --
+-- https://github.com/apache/datafusion/issues/6489 --
 SELECT j FROM v1 WHERE j > 41;
 
 Error: 3000(PlanQuery), Failed to plan SQL: No field named j. Valid fields are v1.i.
 
--- FIXME(dennis):: name alias in view, not supported yet --
---SELECT x FROM v1 t1(x) WHERE x > 41 --
+SELECT x FROM v1 t1(x) WHERE x > 41;
+
++-------------------------+
+| x                       |
++-------------------------+
+| 1970-01-01T00:00:00.042 |
++-------------------------+
+
 -- FIXME(dennis): DROP VIEW not supported yet--
 -- DROP VIEW v1 --
--- SELECT j FROM v1 WHERE j > 41 --
--- CREATE VIEW v1 AS SELECT 'whatever'; --
+-- substrait can't process such query currently
+-- CREATE VIEW v1 AS SELECT 'whatever';--
 -- SELECT * FROM v1; --
--- CREATE OR REPLACE VIEW v1 AS SELECT 42; --
--- SELECT * FROM v1; --
+-- substrait can't process such query currently
+--CREATE OR REPLACE VIEW v1 AS SELECT 42;--
+--SELECT * FROM v1;--
 INSERT INTO v1 VALUES (1);
 
 Error: 1004(InvalidArguments), Invalid SQL, error: column count mismatch, columns: 0, values: 1

--- a/tests/cases/standalone/common/view/view.sql
+++ b/tests/cases/standalone/common/view/view.sql
@@ -14,27 +14,22 @@ FROM t1 WHERE i < 43;
 
 SELECT * FROM v1;
 
--- CREATE VIEW v1 AS SELECT 'whatever'; --
-
+-- FIXME(dennis): Substrait doesn't support alias in projection --
+-- https://github.com/apache/datafusion/issues/6489 --
 SELECT j FROM v1 WHERE j > 41;
 
-
--- FIXME(dennis):: name alias in view, not supported yet --
---SELECT x FROM v1 t1(x) WHERE x > 41 --
+SELECT x FROM v1 t1(x) WHERE x > 41;
 
 -- FIXME(dennis): DROP VIEW not supported yet--
 -- DROP VIEW v1 --
 
--- SELECT j FROM v1 WHERE j > 41 --
-
--- CREATE VIEW v1 AS SELECT 'whatever'; --
-
+-- substrait can't process such query currently
+-- CREATE VIEW v1 AS SELECT 'whatever';--
 -- SELECT * FROM v1; --
 
-
--- CREATE OR REPLACE VIEW v1 AS SELECT 42; --
-
--- SELECT * FROM v1; --
+-- substrait can't process such query currently
+--CREATE OR REPLACE VIEW v1 AS SELECT 42;--
+--SELECT * FROM v1;--
 
 INSERT INTO v1 VALUES (1);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#3729 

## What's changed and what's your intention?

* Save the raw SQL `definition`, original plan columns, and view columns into `ViewInfoValue`.
* Impl `show create view`:

```sql
SHOW CREATE VIEW v1;

+------+------------------------------------------------------------------+
| View | Create View                                                      |
+------+------------------------------------------------------------------+
| v1   | CREATE OR REPLACE VIEW v1 AS SELECT a, b, c FROM t1 WHERE a > 43 |
+------+------------------------------------------------------------------+
```

* Impl view's columns projection:

```sql
CREATE OR REPLACE VIEW v1 (a, b) AS SELECT n, n+1 FROM t1;

SELECT * FROM v1;

+----+----+
| a  | b  |
+----+----+
| 1  | 2  |
| 2  | 3  |
| 3  | 4  |
| 4  | 5  |
| 5  | 6  |
| 6  | 7  |
| 7  | 8  |
| 8  | 9  |
| 9  | 10 |
| 10 | 11 |
+----+----+
```
* Fixed invalidating view info cache.

Remaining issues:

* [Substrait doesn't support alias in projection](https://github.com/apache/datafusion/issues/6489) causes the alias in original plan missing.
* Panic when the original plan's tables drop some columns.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functionality to create, alter, and query views in the database using SQL statements.
  - Introduced `SHOW CREATE VIEW` statement to display view creation details.
  - Added validation for view column names to prevent using SQL keywords.
  
- **Improvements**
  - Enhanced error handling for view creation and column projection changes.
  - Improved SQL parser with new methods for handling `CREATE VIEW` and column names.

- **Bug Fixes**
  - Resolved issues related to SQL alias handling in views and field name errors.

- **Tests**
  - Added comprehensive test coverage for `CREATE VIEW`, `SHOW CREATE VIEW`, and view manipulation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->