### PR TITLE
feat: support gRPC cancellation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9644,6 +9644,7 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-stream",
  "tokio-test",
+ "tokio-util",
  "tonic 0.11.0",
  "tonic-reflection",
  "tower",

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -437,9 +437,11 @@ impl StartCommand {
         );
         let flownode = Arc::new(flow_builder.build().await);
 
-        let builder =
-            DatanodeBuilder::new(dn_opts, fe_plugins.clone()).with_kv_backend(kv_backend.clone());
-        let datanode = builder.build().await.context(StartDatanodeSnafu)?;
+        let datanode = DatanodeBuilder::new(dn_opts, fe_plugins.clone())
+            .with_kv_backend(kv_backend.clone())
+            .build()
+            .await
+            .context(StartDatanodeSnafu)?;
 
         let node_manager = Arc::new(StandaloneDatanodeManager {
             region_server: datanode.region_server(),

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use auth::UserProviderRef;
 use common_base::Plugins;
-use common_config::Configurable;
+use common_config::{Configurable, Mode};
 use common_runtime::Builder as RuntimeBuilder;
 use servers::grpc::builder::GrpcServerBuilder;
 use servers::grpc::greptime_handler::GreptimeRequestHandler;
@@ -140,11 +140,15 @@ where
         };
 
         let user_provider = self.plugins.get::<UserProviderRef>();
+        let runtime = match opts.mode {
+            Mode::Standalone => Some(builder.runtime().clone()),
+            _ => None,
+        };
 
         let greptime_request_handler = GreptimeRequestHandler::new(
             ServerGrpcQueryHandlerAdapter::arc(self.instance.clone()),
             user_provider.clone(),
-            builder.runtime().clone(),
+            runtime,
         );
 
         let grpc_server = builder

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -98,6 +98,7 @@ table.workspace = true
 tokio.workspace = true
 tokio-rustls = "0.25"
 tokio-stream = { workspace = true, features = ["net"] }
+tokio-util.workspace = true
 tonic.workspace = true
 tonic-reflection = "0.11"
 tower = { workspace = true, features = ["full"] }

--- a/src/servers/src/grpc.rs
+++ b/src/servers/src/grpc.rs
@@ -14,6 +14,7 @@
 
 mod authorize;
 pub mod builder;
+mod cancellation;
 mod database;
 pub mod flight;
 pub mod greptime_handler;

--- a/src/servers/src/grpc/cancellation.rs
+++ b/src/servers/src/grpc/cancellation.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::future::Future;
+
+use tokio::select;
+use tokio_util::sync::CancellationToken;
+
+type Result<T> = std::result::Result<tonic::Response<T>, tonic::Status>;
+
+pub(crate) async fn with_cancellation_handler<Request, Cancellation, Response>(
+    request: Request,
+    cancellation: Cancellation,
+) -> Result<Response>
+where
+    Request: Future<Output = Result<Response>> + Send + 'static,
+    Cancellation: Future<Output = Result<Response>> + Send + 'static,
+    Response: Send + 'static,
+{
+    let token = CancellationToken::new();
+    // Will call token.cancel() when the future is dropped, such as when the client cancels the request
+    let _drop_guard = token.clone().drop_guard();
+    let select_task = tokio::spawn(async move {
+        // Can select on token cancellation on any cancellable future while handling the request,
+        // allowing for custom cleanup code or monitoring
+        select! {
+            res = request => res,
+            _ = token.cancelled() => cancellation.await,
+        }
+    });
+
+    select_task.await.unwrap()
+}

--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -18,11 +18,12 @@ use api::v1::{AffectedRows, GreptimeRequest, GreptimeResponse, ResponseHeader};
 use async_trait::async_trait;
 use common_error::status_code::StatusCode;
 use common_query::OutputData;
+use common_telemetry::warn;
 use futures::StreamExt;
 use tonic::{Request, Response, Status, Streaming};
 
 use crate::grpc::greptime_handler::GreptimeRequestHandler;
-use crate::grpc::TonicResult;
+use crate::grpc::{cancellation, TonicResult};
 
 pub(crate) struct DatabaseService {
     handler: GreptimeRequestHandler,
@@ -40,55 +41,91 @@ impl GreptimeDatabase for DatabaseService {
         &self,
         request: Request<GreptimeRequest>,
     ) -> TonicResult<Response<GreptimeResponse>> {
-        let request = request.into_inner();
-        let output = self.handler.handle_request(request).await?;
-        let message = match output.data {
-            OutputData::AffectedRows(rows) => GreptimeResponse {
-                header: Some(ResponseHeader {
-                    status: Some(api::v1::Status {
-                        status_code: StatusCode::Success as _,
-                        ..Default::default()
+        let remote_addr = request.remote_addr();
+        let handler = self.handler.clone();
+        let request_future = async move {
+            let request = request.into_inner();
+            let output = handler.handle_request(request).await?;
+            let message = match output.data {
+                OutputData::AffectedRows(rows) => GreptimeResponse {
+                    header: Some(ResponseHeader {
+                        status: Some(api::v1::Status {
+                            status_code: StatusCode::Success as _,
+                            ..Default::default()
+                        }),
                     }),
-                }),
-                response: Some(RawResponse::AffectedRows(AffectedRows { value: rows as _ })),
-            },
-            OutputData::Stream(_) | OutputData::RecordBatches(_) => {
-                return Err(Status::unimplemented("GreptimeDatabase::Handle for query"));
-            }
+                    response: Some(RawResponse::AffectedRows(AffectedRows { value: rows as _ })),
+                },
+                OutputData::Stream(_) | OutputData::RecordBatches(_) => {
+                    return Err(Status::unimplemented("GreptimeDatabase::Handle for query"));
+                }
+            };
+
+            Ok(Response::new(message))
         };
-        Ok(Response::new(message))
+
+        let cancellation_future = async move {
+            warn!(
+                "GreptimeDatabase::Handle: request from {:?} cancelled by client",
+                remote_addr
+            );
+            // If this future is executed it means the request future was dropped,
+            // so it doesn't actually matter what is returned here
+            Err(Status::cancelled(
+                "GreptimeDatabase::Handle: request cancelled by client",
+            ))
+        };
+        cancellation::with_cancellation_handler(request_future, cancellation_future).await
     }
 
     async fn handle_requests(
         &self,
         request: Request<Streaming<GreptimeRequest>>,
     ) -> Result<Response<GreptimeResponse>, Status> {
-        let mut affected_rows = 0;
+        let remote_addr = request.remote_addr();
+        let handler = self.handler.clone();
+        let request_future = async move {
+            let mut affected_rows = 0;
 
-        let mut stream = request.into_inner();
-        while let Some(request) = stream.next().await {
-            let request = request?;
-            let output = self.handler.handle_request(request).await?;
-            match output.data {
-                OutputData::AffectedRows(rows) => affected_rows += rows,
-                OutputData::Stream(_) | OutputData::RecordBatches(_) => {
-                    return Err(Status::unimplemented(
-                        "GreptimeDatabase::HandleRequests for query",
-                    ));
+            let mut stream = request.into_inner();
+            while let Some(request) = stream.next().await {
+                let request = request?;
+                let output = handler.handle_request(request).await?;
+                match output.data {
+                    OutputData::AffectedRows(rows) => affected_rows += rows,
+                    OutputData::Stream(_) | OutputData::RecordBatches(_) => {
+                        return Err(Status::unimplemented(
+                            "GreptimeDatabase::HandleRequests for query",
+                        ));
+                    }
                 }
             }
-        }
-        let message = GreptimeResponse {
-            header: Some(ResponseHeader {
-                status: Some(api::v1::Status {
-                    status_code: StatusCode::Success as _,
-                    ..Default::default()
+            let message = GreptimeResponse {
+                header: Some(ResponseHeader {
+                    status: Some(api::v1::Status {
+                        status_code: StatusCode::Success as _,
+                        ..Default::default()
+                    }),
                 }),
-            }),
-            response: Some(RawResponse::AffectedRows(AffectedRows {
-                value: affected_rows as u32,
-            })),
+                response: Some(RawResponse::AffectedRows(AffectedRows {
+                    value: affected_rows as u32,
+                })),
+            };
+
+            Ok(Response::new(message))
         };
-        Ok(Response::new(message))
+
+        let cancellation_future = async move {
+            warn!(
+                "GreptimeDatabase::HandleRequests: request from {:?} cancelled by client",
+                remote_addr
+            );
+            // If this future is executed it means the request future was dropped,
+            // so it doesn't actually matter what is returned here
+            Err(Status::cancelled(
+                "GreptimeDatabase::HandleRequests: request cancelled by client",
+            ))
+        };
+        cancellation::with_cancellation_handler(request_future, cancellation_future).await
     }
 }

--- a/src/servers/tests/grpc/mod.rs
+++ b/src/servers/tests/grpc/mod.rs
@@ -60,7 +60,7 @@ impl MockGrpcServer {
         let service: FlightCraftWrapper<_> = GreptimeRequestHandler::new(
             self.query_handler.clone(),
             self.user_provider.clone(),
-            self.runtime.clone(),
+            Some(self.runtime.clone()),
         )
         .into();
         FlightServiceServer::new(service)

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -509,7 +509,7 @@ pub async fn setup_grpc_server_with(
     let greptime_request_handler = GreptimeRequestHandler::new(
         ServerGrpcQueryHandlerAdapter::arc(fe_instance_ref.clone()),
         user_provider.clone(),
-        runtime.clone(),
+        Some(runtime.clone()),
     );
 
     let flight_handler = Arc::new(greptime_request_handler.clone());


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR enables gRPC server cancellation support in `RegionServer` and `GreptimeService`.

Closes #3964 

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
