### PR TITLE
feat: show create table only for base table

### DIFF
--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -22,6 +22,7 @@ use datafusion::parquet;
 use datatypes::arrow::error::ArrowError;
 use servers::define_into_tonic_status;
 use snafu::{Location, Snafu};
+use table::metadata::TableType;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
@@ -697,6 +698,18 @@ pub enum Error {
         location: Location,
         source: substrait::error::Error,
     },
+
+    #[snafu(display(
+        "Show create table only for base table. {} is {}",
+        table_name,
+        table_type
+    ))]
+    ShowCreateTableBaseOnly {
+        table_name: String,
+        table_type: TableType,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -734,7 +747,9 @@ impl ErrorExt for Error {
                 StatusCode::TableAlreadyExists
             }
 
-            Error::NotSupported { .. } => StatusCode::Unsupported,
+            Error::NotSupported { .. } | Error::ShowCreateTableBaseOnly { .. } => {
+                StatusCode::Unsupported
+            }
 
             Error::TableMetadataManager { source, .. } => source.status_code(),
 

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -188,7 +188,7 @@ impl StatementExecutor {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(stmt.table_name(), &query_ctx)
                         .map_err(BoxedError::new)
-                        .context(error::ExternalSnafu)?;
+                        .context(ExternalSnafu)?;
                 let table_name = TableName::new(catalog, schema, table);
                 self.drop_table(table_name, stmt.drop_if_exists(), query_ctx)
                     .await
@@ -206,7 +206,7 @@ impl StatementExecutor {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(stmt.table_name(), &query_ctx)
                         .map_err(BoxedError::new)
-                        .context(error::ExternalSnafu)?;
+                        .context(ExternalSnafu)?;
                 let table_name = TableName::new(catalog, schema, table);
                 self.truncate_table(table_name, query_ctx).await
             }
@@ -223,14 +223,14 @@ impl StatementExecutor {
                 let (catalog, schema, table) =
                     table_idents_to_full_name(&show.table_name, &query_ctx)
                         .map_err(BoxedError::new)
-                        .context(error::ExternalSnafu)?;
+                        .context(ExternalSnafu)?;
 
                 let table_ref = self
                     .catalog_manager
                     .table(&catalog, &schema, &table)
                     .await
-                    .context(error::CatalogSnafu)?
-                    .context(error::TableNotFoundSnafu { table_name: &table })?;
+                    .context(CatalogSnafu)?
+                    .context(TableNotFoundSnafu { table_name: &table })?;
                 let table_name = TableName::new(catalog, schema, table);
 
                 self.show_create_table(table_name, table_ref, query_ctx)

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -23,6 +23,7 @@ use sql::statements::create::Partitions;
 use sql::statements::show::{
     ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTables, ShowVariables,
 };
+use table::metadata::TableType;
 use table::table_name::TableName;
 use table::TableRef;
 
@@ -81,6 +82,15 @@ impl StatementExecutor {
         table: TableRef,
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
+        let table_info = table.table_info();
+        if table_info.table_type != TableType::Base {
+            return error::ShowCreateTableBaseOnlySnafu {
+                table_name: table_name.to_string(),
+                table_type: table_info.table_type,
+            }
+            .fail();
+        }
+
         let partitions = self
             .partition_manager
             .find_table_partitions(table.table_info().table_id())

--- a/tests/cases/standalone/common/show/show_create.result
+++ b/tests/cases/standalone/common/show/show_create.result
@@ -192,3 +192,11 @@ drop table phy;
 
 Affected Rows: 0
 
+show create table numbers;
+
+Error: 1001(Unsupported), Show create table only for base table. greptime.public.numbers is TEMPORARY
+
+show create table information_schema.columns;
+
+Error: 1001(Unsupported), Show create table only for base table. greptime.information_schema.columns is TEMPORARY
+

--- a/tests/cases/standalone/common/show/show_create.sql
+++ b/tests/cases/standalone/common/show/show_create.sql
@@ -79,3 +79,7 @@ WITH(
 show create table phy;
 
 drop table phy;
+
+show create table numbers;
+
+show create table information_schema.columns;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This closes #3980.

Display:

```
$ curl -i -XPOST -H 'Content-Type: application/x-www-form-urlencoded' -d 'sql=SHOW CREATE TABLE numbers' http://localhost:4000/v1/sql
HTTP/1.1 400 Bad Request
Content-Length: 121
Connection: keep-alive
Content-Type: application/json
Date: Mon, 03 Jun 2024 15:04:04 GMT
Keep-Alive: timeout=4
Proxy-Connection: keep-alive
X-Greptime-Err-Code: 1001
X-Greptime-Execution-Time: 0

{"code":1001,"error":"Show create table only for base table. greptime.public.numbers is TEMPORARY","execution_time_ms":0}
```

and

```
mysql> SHOW CREATE TABLE information_schema.columns;
ERROR 1815 (HY000): Show create table only for base table. greptime.information_schema.columns is TEMPORARY
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
