### PR TITLE
fix: recover memtable options when opening physical regions

### DIFF
--- a/src/metric-engine/src/engine/create.rs
+++ b/src/metric-engine/src/engine/create.rs
@@ -38,9 +38,7 @@ use store_api::region_request::{AffectedRows, RegionCreateRequest, RegionRequest
 use store_api::storage::consts::ReservedColumnId;
 use store_api::storage::RegionId;
 
-use crate::engine::options::{
-    set_index_options_for_data_region, set_memtable_options_for_data_region,
-};
+use crate::engine::options::set_data_region_options;
 use crate::engine::MetricEngineInner;
 use crate::error::{
     AddingFieldColumnSnafu, ColumnNotFoundSnafu, ColumnTypeMismatchSnafu,
@@ -478,11 +476,8 @@ impl MetricEngineInner {
         data_region_request.column_metadatas.push(tsid_col);
         data_region_request.primary_key = primary_key;
 
-        // set index options
-        set_index_options_for_data_region(&mut data_region_request.options);
-
-        // Set memtable options.
-        set_memtable_options_for_data_region(&mut data_region_request.options);
+        // set data region options
+        set_data_region_options(&mut data_region_request.options);
 
         data_region_request
     }

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -26,7 +26,7 @@ use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use super::MetricEngineInner;
-use crate::engine::options::set_index_options_for_data_region;
+use crate::engine::options::{set_index_options_for_data_region, set_memtable_options_for_data_region};
 use crate::error::{OpenMitoRegionSnafu, Result};
 use crate::metrics::{LOGICAL_REGION_COUNT, PHYSICAL_REGION_COUNT};
 use crate::utils;
@@ -81,6 +81,7 @@ impl MetricEngineInner {
 
         let mut data_region_options = request.options;
         set_index_options_for_data_region(&mut data_region_options);
+        set_memtable_options_for_data_region(&mut data_region_options);
         let open_data_region_request = RegionOpenRequest {
             region_dir: data_region_dir,
             options: data_region_options,

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -26,7 +26,9 @@ use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use super::MetricEngineInner;
-use crate::engine::options::{set_index_options_for_data_region, set_memtable_options_for_data_region};
+use crate::engine::options::{
+    set_index_options_for_data_region, set_memtable_options_for_data_region,
+};
 use crate::error::{OpenMitoRegionSnafu, Result};
 use crate::metrics::{LOGICAL_REGION_COUNT, PHYSICAL_REGION_COUNT};
 use crate::utils;

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -26,9 +26,7 @@ use store_api::region_request::{AffectedRows, RegionOpenRequest, RegionRequest};
 use store_api::storage::RegionId;
 
 use super::MetricEngineInner;
-use crate::engine::options::{
-    set_index_options_for_data_region, set_memtable_options_for_data_region,
-};
+use crate::engine::options::set_data_region_options;
 use crate::error::{OpenMitoRegionSnafu, Result};
 use crate::metrics::{LOGICAL_REGION_COUNT, PHYSICAL_REGION_COUNT};
 use crate::utils;
@@ -82,8 +80,7 @@ impl MetricEngineInner {
         };
 
         let mut data_region_options = request.options;
-        set_index_options_for_data_region(&mut data_region_options);
-        set_memtable_options_for_data_region(&mut data_region_options);
+        set_data_region_options(&mut data_region_options);
         let open_data_region_request = RegionOpenRequest {
             region_dir: data_region_dir,
             options: data_region_options,

--- a/src/metric-engine/src/engine/options.rs
+++ b/src/metric-engine/src/engine/options.rs
@@ -30,20 +30,17 @@ const IGNORE_COLUMN_IDS_FOR_DATA_REGION: [ColumnId; 1] = [ReservedColumnId::tsid
 /// value and appropriately increasing the size of the index, it results in an improved indexing effect.
 const SEG_ROW_COUNT_FOR_DATA_REGION: u32 = 256;
 
-/// Set the index options for the data region.
-pub fn set_index_options_for_data_region(options: &mut HashMap<String, String>) {
+/// Sets data region specific options.
+pub fn set_data_region_options(options: &mut HashMap<String, String>) {
+    // Set the index options for the data region.
     options.insert(
         "index.inverted_index.ignore_column_ids".to_string(),
         IGNORE_COLUMN_IDS_FOR_DATA_REGION.iter().join(","),
     );
-
     options.insert(
         "index.inverted_index.segment_row_count".to_string(),
         SEG_ROW_COUNT_FOR_DATA_REGION.to_string(),
     );
-}
-
-/// Set memtable options for the data region.
-pub fn set_memtable_options_for_data_region(options: &mut HashMap<String, String>) {
+    // Set memtable options for the data region.
     options.insert("memtable.type".to_string(), "partition_tree".to_string());
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

During creating physical regions for metric engine, index and memtable options are set manually:
https://github.com/GreptimeTeam/greptimedb/blob/df01ac05a1ec5f7c3c4630eca7b58e8f0b39f8fe/src/metric-engine/src/engine/create.rs#L482-L485

But when open physical regions, only index options are set:

https://github.com/GreptimeTeam/greptimedb/blob/d1838fb28de054c5f4c82ea07683f28acd4871db/src/metric-engine/src/engine/open.rs#L83

### Memory usage

<img width="916" alt="image" src="https://github.com/GreptimeTeam/greptimedb/assets/6406592/cd063a50-61b9-494d-b3ea-d62bfa54a570">






## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
