### PR TITLE
chore: remove gc before running fuzz tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -174,12 +174,6 @@ jobs:
       - name: Run GreptimeDB
         run: |
           ./bins/greptime standalone start&
-      - name: Build Fuzz Test
-        shell: bash
-        run: |
-          cd tests-fuzz && \
-          cargo gc && \
-          cd ..
       - name: Fuzz Test
         uses: ./.github/actions/fuzz-test
         env:
@@ -191,7 +185,7 @@ jobs:
 
   unstable-fuzztest:
     name: Unstable Fuzz Test
-    needs: build
+    needs: build-greptime-ci
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -215,27 +209,21 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y libfuzzer-14-dev
           cargo install cargo-fuzz cargo-gc-bin
-      - name: Download pre-built binaries
+      - name: Download pre-built binariy
         uses: actions/download-artifact@v4
         with:
-          name: bins
+          name: bin
           path: .
-      - name: Unzip binaries
+      - name: Unzip bianry
         run: |
-          tar -xvf ./bins.tar.gz
-          rm ./bins.tar.gz
-      - name: Build Fuzz Test
-        shell: bash
-        run: |
-          cd tests-fuzz && \
-          cargo gc && \
-          cd ..
+          tar -xvf ./bin.tar.gz
+          rm ./bin.tar.gz
       - name: Run Fuzz Test
         uses: ./.github/actions/fuzz-test
         env:
           CUSTOM_LIBFUZZER_PATH: /usr/lib/llvm-14/lib/libFuzzer.a
           GT_MYSQL_ADDR: 127.0.0.1:4002
-          GT_FUZZ_BINARY_PATH: ./bins/greptime
+          GT_FUZZ_BINARY_PATH: ./bin/greptime
           GT_FUZZ_INSTANCE_ROOT_DIR: /tmp/unstable-greptime/
         with:
           target: ${{ matrix.target }}
@@ -350,12 +338,6 @@ jobs:
       - name: Port forward (mysql)
         run: |
           kubectl port-forward service/my-greptimedb-frontend 4002:4002 -n my-greptimedb&
-      - name: Build Fuzz Test
-        shell: bash
-        run: |
-          cd tests-fuzz && \
-          cargo gc && \
-          cd ..
       - name: Fuzz Test
         uses: ./.github/actions/fuzz-test
         env:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

remove gc before running fuzz tests

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
