### PR TITLE
refactor: simplify parquet writer

### DIFF
--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -20,8 +20,8 @@ use arrow_schema::Schema;
 use async_trait::async_trait;
 use datafusion::datasource::physical_plan::{FileMeta, ParquetFileReaderFactory};
 use datafusion::error::Result as DatafusionResult;
-use datafusion::parquet::arrow::{ArrowWriter, parquet_to_arrow_schema};
 use datafusion::parquet::arrow::async_reader::AsyncFileReader;
+use datafusion::parquet::arrow::{parquet_to_arrow_schema, ArrowWriter};
 use datafusion::parquet::errors::{ParquetError, Result as ParquetResult};
 use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::parquet::format::FileMetaData;
@@ -29,19 +29,18 @@ use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::future::BoxFuture;
 use futures::StreamExt;
+use object_store::{FuturesAsyncReader, ObjectStore};
 use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use snafu::ResultExt;
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
-use object_store::{FuturesAsyncReader, ObjectStore};
-
 use crate::buffered_writer::{ArrowWriterCloser, DfRecordBatchEncoder};
-use crate::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::error::{self, Result, WriteObjectSnafu, WriteParquetSnafu};
 use crate::file_format::FileFormat;
 use crate::share_buffer::SharedBuffer;
+use crate::DEFAULT_WRITE_BUFFER_SIZE;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ParquetFormat {}
@@ -217,9 +216,8 @@ pub async fn stream_to_parquet(
 mod tests {
     use common_test_util::find_workspace_path;
 
-    use crate::test_util::{format_schema, test_store};
-
     use super::*;
+    use crate::test_util::{format_schema, test_store};
 
     fn test_data_root() -> String {
         find_workspace_path("/src/common/datasource/tests/parquet")

--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -20,8 +20,8 @@ use arrow_schema::Schema;
 use async_trait::async_trait;
 use datafusion::datasource::physical_plan::{FileMeta, ParquetFileReaderFactory};
 use datafusion::error::Result as DatafusionResult;
+use datafusion::parquet::arrow::{ArrowWriter, parquet_to_arrow_schema};
 use datafusion::parquet::arrow::async_reader::AsyncFileReader;
-use datafusion::parquet::arrow::{parquet_to_arrow_schema, ArrowWriter};
 use datafusion::parquet::errors::{ParquetError, Result as ParquetResult};
 use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::parquet::format::FileMetaData;
@@ -29,14 +29,16 @@ use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::future::BoxFuture;
 use futures::StreamExt;
-use object_store::{FuturesAsyncReader, ObjectStore};
 use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use snafu::ResultExt;
 use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
+use object_store::{FuturesAsyncReader, ObjectStore};
+
 use crate::buffered_writer::{ArrowWriterCloser, DfRecordBatchEncoder};
+use crate::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::error::{self, Result, WriteObjectSnafu, WriteParquetSnafu};
 use crate::file_format::FileFormat;
 use crate::share_buffer::SharedBuffer;
@@ -190,6 +192,7 @@ pub async fn stream_to_parquet(
     let inner_writer = store
         .writer_with(path)
         .concurrent(concurrency)
+        .chunk(DEFAULT_WRITE_BUFFER_SIZE.as_bytes() as usize)
         .await
         .map(|w| w.into_futures_async_write().compat_write())
         .context(WriteObjectSnafu { path })?;
@@ -214,8 +217,9 @@ pub async fn stream_to_parquet(
 mod tests {
     use common_test_util::find_workspace_path;
 
-    use super::*;
     use crate::test_util::{format_schema, test_store};
+
+    use super::*;
 
     fn test_data_root() -> String {
         find_workspace_path("/src/common/datasource/tests/parquet")

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -30,8 +30,8 @@ use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::IndexerBuilder;
 use crate::sst::location;
 use crate::sst::parquet::reader::ParquetReaderBuilder;
-use crate::sst::parquet::{SstInfo, WriteOptions};
 use crate::sst::parquet::writer::ParquetWriter;
+use crate::sst::parquet::{SstInfo, WriteOptions};
 
 pub type AccessLayerRef = Arc<AccessLayer>;
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -18,8 +18,8 @@ use object_store::services::Fs;
 use object_store::util::{join_dir, with_instrument_layers};
 use object_store::ObjectStore;
 use snafu::ResultExt;
-use tokio_util::compat::FuturesAsyncWriteCompatExt;
 use store_api::metadata::RegionMetadataRef;
+use tokio_util::compat::FuturesAsyncWriteCompatExt;
 
 use crate::cache::write_cache::SstUploadRequest;
 use crate::cache::CacheManagerRef;
@@ -29,10 +29,10 @@ use crate::region::options::IndexOptions;
 use crate::sst::file::{FileHandle, FileId, FileMeta};
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::IndexerBuilder;
-use crate::sst::{DEFAULT_WRITE_CONCURRENCY, location};
 use crate::sst::parquet::reader::ParquetReaderBuilder;
 use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
+use crate::sst::{location, DEFAULT_WRITE_CONCURRENCY};
 
 pub type AccessLayerRef = Arc<AccessLayer>;
 
@@ -148,16 +148,15 @@ impl AccessLayer {
             }
             .build();
             let mut writer = ParquetWriter::new(
-                ||async{
-                    Ok(self.object_store
+                || async {
+                    self.object_store
                         .writer_with(&file_path)
                         .concurrent(DEFAULT_WRITE_CONCURRENCY)
                         .await
                         .map(|v| v.into_futures_async_write().compat_write())
-                        .unwrap())
+                        .context(OpenDalSnafu)
                 },
                 request.metadata,
-
                 indexer,
             );
             writer.write_all(request.source, write_opts).await?

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -32,7 +32,7 @@ use crate::sst::index::IndexerBuilder;
 use crate::sst::parquet::reader::ParquetReaderBuilder;
 use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
-use crate::sst::{location, DEFAULT_WRITE_CONCURRENCY};
+use crate::sst::{location, DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
 
 pub type AccessLayerRef = Arc<AccessLayer>;
 
@@ -151,6 +151,7 @@ impl AccessLayer {
                 || async {
                     self.object_store
                         .writer_with(&file_path)
+                        .chunk(DEFAULT_WRITE_BUFFER_SIZE.as_bytes() as usize)
                         .concurrent(DEFAULT_WRITE_CONCURRENCY)
                         .await
                         .map(|v| v.into_futures_async_write().compat_write())

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -133,6 +133,7 @@ impl WriteCache {
                 self.file_cache
                     .local_store()
                     .writer_with(&self.file_cache.cache_file_path(parquet_key))
+                    .chunk(DEFAULT_WRITE_BUFFER_SIZE.as_bytes() as usize)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
                     .map(|v| v.into_futures_async_write().compat_write())

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -17,23 +17,22 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::AsyncWriteExt;
-use snafu::ResultExt;
-
 use common_base::readable_size::ReadableSize;
 use common_telemetry::{debug, info};
+use futures::AsyncWriteExt;
 use object_store::manager::ObjectStoreManagerRef;
 use object_store::ObjectStore;
+use snafu::ResultExt;
 
 use crate::access_layer::{new_fs_object_store, SstWriteRequest};
 use crate::cache::file_cache::{FileCache, FileCacheRef, FileType, IndexKey, IndexValue};
-use crate::error::{self,  Result};
+use crate::error::{self, Result};
 use crate::metrics::{FLUSH_ELAPSED, UPLOAD_BYTES_TOTAL};
-use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
-use crate::sst::index::IndexerBuilder;
 use crate::sst::index::intermediate::IntermediateManager;
+use crate::sst::index::IndexerBuilder;
+use crate::sst::parquet::writer::ParquetWriter;
 use crate::sst::parquet::{SstInfo, WriteOptions};
-use crate::sst::parquet::writer::{ ParquetWriter};
+use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
 
 /// A cache for uploading files to remote object stores.
 ///
@@ -249,8 +248,9 @@ pub struct SstUploadRequest {
 mod tests {
     use common_test_util::temp_dir::create_temp_dir;
 
-    use crate::cache::CacheManager;
+    use super::*;
     use crate::cache::test_util::new_fs_store;
+    use crate::cache::CacheManager;
     use crate::region::options::IndexOptions;
     use crate::sst::file::FileId;
     use crate::sst::location::{index_file_path, sst_file_path};
@@ -260,8 +260,6 @@ mod tests {
         sst_region_metadata,
     };
     use crate::test_util::TestEnv;
-
-    use super::*;
 
     #[tokio::test]
     async fn test_write_and_upload_sst() {

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -151,16 +151,17 @@ pub enum Error {
         error: ArrowError,
     },
 
-    #[snafu(display("Failed to write to buffer"))]
-    WriteBuffer {
-        #[snafu(implicit)]
-        location: Location,
-        source: common_datasource::error::Error,
-    },
-
     #[snafu(display("Failed to read parquet file, path: {}", path))]
     ReadParquet {
         path: String,
+        #[snafu(source)]
+        error: parquet::errors::ParquetError,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to write parquet file"))]
+    WriteParquet {
         #[snafu(source)]
         error: parquet::errors::ParquetError,
         #[snafu(implicit)]
@@ -808,7 +809,7 @@ impl ErrorExt for Error {
             | BuildEntry { .. } => StatusCode::Internal,
             OpenRegion { source, .. } => source.status_code(),
 
-            WriteBuffer { source, .. } => source.status_code(),
+            WriteParquet {..}=>StatusCode::Internal,
             WriteGroup { source, .. } => source.status_code(),
             FieldTypeMismatch { source, .. } => source.status_code(),
             SerializeField { .. } => StatusCode::Internal,

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -809,7 +809,7 @@ impl ErrorExt for Error {
             | BuildEntry { .. } => StatusCode::Internal,
             OpenRegion { source, .. } => source.status_code(),
 
-            WriteParquet {..}=>StatusCode::Internal,
+            WriteParquet { .. } => StatusCode::Internal,
             WriteGroup { source, .. } => source.status_code(),
             FieldTypeMismatch { source, .. } => source.status_code(),
             SerializeField { .. } => StatusCode::Internal,

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -16,12 +16,11 @@
 
 use std::sync::Arc;
 
+use common_base::readable_size::ReadableSize;
 use parquet::file::metadata::ParquetMetaData;
 
-use common_base::readable_size::ReadableSize;
-
-use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::sst::file::FileTimeRange;
+use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 
 pub(crate) mod file_range;
 mod format;
@@ -80,33 +79,31 @@ pub struct SstInfo {
 mod tests {
     use std::sync::Arc;
 
-    use datafusion_common::{Column, ScalarValue};
-    use datafusion_expr::{BinaryExpr, Expr, Operator};
-    use parquet::basic::{Compression, Encoding, ZstdLevel};
-    use parquet::file::metadata::KeyValue;
-    use parquet::file::properties::WriterProperties;
-    use tokio_util::compat::FuturesAsyncWriteCompatExt;
-
     use common_datasource::file_format::parquet::BufferedWriter;
     use common_time::Timestamp;
+    use datafusion_common::{Column, ScalarValue};
+    use datafusion_expr::{BinaryExpr, Expr, Operator};
     use datatypes::arrow;
     use datatypes::arrow::array::RecordBatch;
     use datatypes::arrow::datatypes::{DataType, Field, Schema};
+    use parquet::basic::{Compression, Encoding, ZstdLevel};
+    use parquet::file::metadata::KeyValue;
+    use parquet::file::properties::WriterProperties;
     use table::predicate::Predicate;
+    use tokio_util::compat::FuturesAsyncWriteCompatExt;
 
+    use super::*;
     use crate::cache::{CacheManager, PageKey};
-    use crate::sst::DEFAULT_WRITE_CONCURRENCY;
     use crate::sst::index::Indexer;
     use crate::sst::parquet::format::WriteFormat;
     use crate::sst::parquet::reader::ParquetReaderBuilder;
     use crate::sst::parquet::writer::ParquetWriter;
-    use crate::test_util::{check_reader_result, TestEnv};
+    use crate::sst::DEFAULT_WRITE_CONCURRENCY;
     use crate::test_util::sst_util::{
         assert_parquet_metadata_eq, build_test_binary_test_region_metadata, new_batch_by_range,
         new_batch_with_binary, new_source, sst_file_handle, sst_region_metadata,
     };
-
-    use super::*;
+    use crate::test_util::{check_reader_result, TestEnv};
 
     const FILE_DIR: &str = "/";
 
@@ -194,7 +191,7 @@ mod tests {
                     .writer_with(&file_path)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
-                    .map(|w|w.into_futures_async_write().compat_write())
+                    .map(|w| w.into_futures_async_write().compat_write())
                     .unwrap())
             },
             metadata.clone(),
@@ -269,8 +266,9 @@ mod tests {
         // write the sst file and get sst info
         // sst info contains the parquet metadata, which is converted from FileMetaData
         let mut writer = ParquetWriter::new(
-            ||async {
-                Ok(object_store.writer_with(&file_path)
+            || async {
+                Ok(object_store
+                    .writer_with(&file_path)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
                     .map(|v| v.into_futures_async_write().compat_write())
@@ -313,8 +311,9 @@ mod tests {
         };
         // Prepare data.
         let mut writer = ParquetWriter::new(
-            ||async {
-                Ok(object_store.writer_with(&file_path)
+            || async {
+                Ok(object_store
+                    .writer_with(&file_path)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
                     .map(|v| v.into_futures_async_write().compat_write())
@@ -371,8 +370,9 @@ mod tests {
         };
         // Prepare data.
         let mut writer = ParquetWriter::new(
-            ||async {
-                Ok(object_store.writer_with(&file_path)
+            || async {
+                Ok(object_store
+                    .writer_with(&file_path)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
                     .map(|v| v.into_futures_async_write().compat_write())
@@ -411,8 +411,9 @@ mod tests {
         };
         // Prepare data.
         let mut writer = ParquetWriter::new(
-            ||async {
-                Ok(object_store.writer_with(&file_path)
+            || async {
+                Ok(object_store
+                    .writer_with(&file_path)
                     .concurrent(DEFAULT_WRITE_CONCURRENCY)
                     .await
                     .map(|v| v.into_futures_async_write().compat_write())

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -16,12 +16,11 @@
 
 use std::sync::Arc;
 
+use common_base::readable_size::ReadableSize;
 use parquet::file::metadata::ParquetMetaData;
 
-use common_base::readable_size::ReadableSize;
-
-use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 use crate::sst::file::FileTimeRange;
+use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 
 pub(crate) mod file_range;
 mod format;
@@ -80,33 +79,31 @@ pub struct SstInfo {
 mod tests {
     use std::sync::Arc;
 
+    use common_time::Timestamp;
     use datafusion_common::{Column, ScalarValue};
     use datafusion_expr::{BinaryExpr, Expr, Operator};
+    use datatypes::arrow;
+    use datatypes::arrow::array::RecordBatch;
+    use datatypes::arrow::datatypes::{DataType, Field, Schema};
     use parquet::arrow::AsyncArrowWriter;
     use parquet::basic::{Compression, Encoding, ZstdLevel};
     use parquet::file::metadata::KeyValue;
     use parquet::file::properties::WriterProperties;
+    use table::predicate::Predicate;
     use tokio_util::compat::FuturesAsyncWriteCompatExt;
 
-    use common_time::Timestamp;
-    use datatypes::arrow;
-    use datatypes::arrow::array::RecordBatch;
-    use datatypes::arrow::datatypes::{DataType, Field, Schema};
-    use table::predicate::Predicate;
-
+    use super::*;
     use crate::cache::{CacheManager, PageKey};
-    use crate::sst::DEFAULT_WRITE_CONCURRENCY;
     use crate::sst::index::Indexer;
     use crate::sst::parquet::format::WriteFormat;
     use crate::sst::parquet::reader::ParquetReaderBuilder;
-    use crate::sst::parquet::writer::{ParquetWriter};
-    use crate::test_util::{check_reader_result, TestEnv};
+    use crate::sst::parquet::writer::ParquetWriter;
+    use crate::sst::DEFAULT_WRITE_CONCURRENCY;
     use crate::test_util::sst_util::{
         assert_parquet_metadata_eq, build_test_binary_test_region_metadata, new_batch_by_range,
         new_batch_with_binary, new_source, sst_file_handle, sst_region_metadata,
     };
-
-    use super::*;
+    use crate::test_util::{check_reader_result, TestEnv};
 
     const FILE_DIR: &str = "/";
 

--- a/src/mito2/src/sst/parquet/format.rs
+++ b/src/mito2/src/sst/parquet/format.rs
@@ -77,8 +77,8 @@ impl WriteFormat {
     }
 
     /// Gets the arrow schema to store in parquet.
-    pub(crate) fn arrow_schema(&self) -> SchemaRef {
-        self.arrow_schema.clone()
+    pub(crate) fn arrow_schema(&self) -> &SchemaRef {
+        &self.arrow_schema
     }
 
     /// Convert `batch` to a arrow record batch to store in parquet.
@@ -700,7 +700,7 @@ mod tests {
     fn test_to_sst_arrow_schema() {
         let metadata = build_test_region_metadata();
         let write_format = WriteFormat::new(metadata);
-        assert_eq!(build_test_arrow_schema(), write_format.arrow_schema());
+        assert_eq!(&build_test_arrow_schema(), write_format.arrow_schema());
     }
 
     #[test]

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -14,52 +14,52 @@
 
 //! Parquet writer.
 
-use std::sync::Arc;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
-use common_datasource::file_format::parquet::BufferedWriter;
-use common_telemetry::debug;
-use common_time::Timestamp;
-use futures::TryFutureExt;
-use object_store::ObjectStore;
+use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::{Compression, Encoding, ZstdLevel};
 use parquet::file::metadata::KeyValue;
 use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 use parquet::schema::types::ColumnPath;
 use snafu::ResultExt;
+use tokio::io::AsyncWrite;
+
+use common_time::Timestamp;
+use datatypes::arrow::datatypes::SchemaRef;
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::consts::SEQUENCE_COLUMN_NAME;
 
-use crate::error::{InvalidMetadataSnafu, Result, WriteBufferSnafu};
+use crate::error::{InvalidMetadataSnafu, Result, WriteParquetSnafu};
 use crate::read::{Batch, Source};
 use crate::sst::index::Indexer;
+use crate::sst::parquet::{PARQUET_METADATA_KEY, SstInfo, WriteOptions};
 use crate::sst::parquet::format::WriteFormat;
 use crate::sst::parquet::helper::parse_parquet_metadata;
-use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
-use crate::sst::DEFAULT_WRITE_CONCURRENCY;
 
 /// Parquet SST writer.
-pub struct ParquetWriter {
-    /// SST output file path.
-    file_path: String,
+pub struct ParquetWriter<W, F> {
+    writer: Option<AsyncArrowWriter<SizeAwareWriter<W>>>,
+    writer_factory: F,
     /// Region metadata of the source and the target SST.
     metadata: RegionMetadataRef,
-    object_store: ObjectStore,
     indexer: Indexer,
+    bytes_written: Arc<Mutex<usize>>,
 }
 
-impl ParquetWriter {
+impl<W: AsyncWrite + Send + Unpin, Fut: Future<Output = Result<W>>, F: FnMut() -> Fut>
+    ParquetWriter<W, F>
+{
     /// Creates a new parquet SST writer.
-    pub fn new(
-        file_path: String,
-        metadata: RegionMetadataRef,
-        object_store: ObjectStore,
-        indexer: Indexer,
-    ) -> ParquetWriter {
+    pub fn new(factory: F, metadata: RegionMetadataRef, indexer: Indexer) -> ParquetWriter<W, F> {
         ParquetWriter {
-            file_path,
+            writer: None,
+            writer_factory: factory,
             metadata,
-            object_store,
             indexer,
+            bytes_written: Arc::new(Mutex::new(0)),
         }
     }
 
@@ -71,42 +71,24 @@ impl ParquetWriter {
         mut source: Source,
         opts: &WriteOptions,
     ) -> Result<Option<SstInfo>> {
-        let json = self.metadata.to_json().context(InvalidMetadataSnafu)?;
-        let key_value_meta = KeyValue::new(PARQUET_METADATA_KEY.to_string(), json);
-
-        // TODO(yingwen): Find and set proper column encoding for internal columns: op type and tsid.
-        let props_builder = WriterProperties::builder()
-            .set_key_value_metadata(Some(vec![key_value_meta]))
-            .set_compression(Compression::ZSTD(ZstdLevel::default()))
-            .set_encoding(Encoding::PLAIN)
-            .set_max_row_group_size(opts.row_group_size);
-
-        let props_builder = Self::customize_column_config(props_builder, &self.metadata);
-        let writer_props = props_builder.build();
-
         let write_format = WriteFormat::new(self.metadata.clone());
-        let mut buffered_writer = BufferedWriter::try_new(
-            self.file_path.clone(),
-            self.object_store.clone(),
-            write_format.arrow_schema(),
-            Some(writer_props),
-            opts.write_buffer_size.as_bytes() as usize,
-            DEFAULT_WRITE_CONCURRENCY,
-        )
-        .await
-        .context(WriteBufferSnafu)?;
-
         let mut stats = SourceStats::default();
-        while let Some(batch) = write_next_batch(&mut source, &write_format, &mut buffered_writer)
-            .or_else(|err| async {
-                // abort index creation if error occurs.
-                self.indexer.abort().await;
-                Err(err)
-            })
-            .await?
+
+        while let Some(res) = self
+            .write_next_batch(&mut source, &write_format, opts)
+            .await
+            .transpose()
         {
-            stats.update(&batch);
-            self.indexer.update(&batch).await;
+            match res {
+                Ok(batch) => {
+                    stats.update(&batch);
+                    self.indexer.update(&batch).await;
+                }
+                Err(e) => {
+                    self.indexer.abort().await;
+                    return Err(e);
+                }
+            }
         }
 
         let index_size = self.indexer.finish().await;
@@ -114,16 +96,18 @@ impl ParquetWriter {
         let index_file_size = index_size.unwrap_or(0) as u64;
 
         if stats.num_rows == 0 {
-            debug!(
-                "No data written, try to stop the writer: {}",
-                self.file_path
-            );
-
-            buffered_writer.close().await.context(WriteBufferSnafu)?;
             return Ok(None);
         }
 
-        let (file_meta, file_size) = buffered_writer.close().await.context(WriteBufferSnafu)?;
+        let Some(mut arrow_writer) = self.writer.take()else {
+            // No batch actually written.
+            return Ok(None);
+        };
+
+        arrow_writer.flush().await.context(WriteParquetSnafu)?;
+
+        let file_meta = arrow_writer.close().await.context(WriteParquetSnafu)?;
+        let file_size = *self.bytes_written.lock().unwrap() as u64;
 
         // Safety: num rows > 0 so we must have min/max.
         let time_range = stats.time_range.unwrap();
@@ -160,24 +144,56 @@ impl ParquetWriter {
             .set_column_encoding(ts_col.clone(), Encoding::DELTA_BINARY_PACKED)
             .set_column_dictionary_enabled(ts_col, false)
     }
-}
 
-async fn write_next_batch(
-    source: &mut Source,
-    write_format: &WriteFormat,
-    buffered_writer: &mut BufferedWriter,
-) -> Result<Option<Batch>> {
-    let Some(batch) = source.next_batch().await? else {
-        return Ok(None);
-    };
+    async fn write_next_batch(
+        &mut self,
+        source: &mut Source,
+        write_format: &WriteFormat,
+        opts: &WriteOptions,
+    ) -> Result<Option<Batch>> {
+        let Some(batch) = source.next_batch().await? else {
+            return Ok(None);
+        };
 
-    let arrow_batch = write_format.convert_batch(&batch)?;
-    buffered_writer
-        .write(&arrow_batch)
-        .await
-        .context(WriteBufferSnafu)?;
+        let arrow_batch = write_format.convert_batch(&batch)?;
+        self.maybe_init_writer(write_format.arrow_schema(), opts)
+            .await?
+            .write(&arrow_batch)
+            .await
+            .context(WriteParquetSnafu)?;
+        Ok(Some(batch))
+    }
 
-    Ok(Some(batch))
+    async fn maybe_init_writer(
+        &mut self,
+        schema: &SchemaRef,
+        opts: &WriteOptions,
+    ) -> Result<&mut AsyncArrowWriter<SizeAwareWriter<W>>> {
+        if let Some(ref mut w) = self.writer {
+            return Ok(w);
+        } else {
+            let json = self.metadata.to_json().context(InvalidMetadataSnafu)?;
+            let key_value_meta = KeyValue::new(PARQUET_METADATA_KEY.to_string(), json);
+
+            // TODO(yingwen): Find and set proper column encoding for internal columns: op type and tsid.
+            let props_builder = WriterProperties::builder()
+                .set_key_value_metadata(Some(vec![key_value_meta]))
+                .set_compression(Compression::ZSTD(ZstdLevel::default()))
+                .set_encoding(Encoding::PLAIN)
+                .set_max_row_group_size(opts.row_group_size);
+
+            let props_builder = Self::customize_column_config(props_builder, &self.metadata);
+            let writer_props = props_builder.build();
+
+            let writer =
+                SizeAwareWriter::new((self.writer_factory)().await?, self.bytes_written.clone());
+            let arrow_writer =
+                AsyncArrowWriter::try_new(writer, schema.clone(), Some(writer_props)).context(WriteParquetSnafu)?;
+            self.writer = Some(arrow_writer);
+            // safety: self.writer is assigned above
+            Ok(self.writer.as_mut().unwrap())
+        }
+    }
 }
 
 #[derive(Default)]
@@ -206,5 +222,57 @@ impl SourceStats {
         } else {
             self.time_range = Some((min_in_batch, max_in_batch));
         }
+    }
+}
+
+/// Workaround for [AsyncArrowWriter] does not provide a method to
+/// get total bytes written after close.
+struct SizeAwareWriter<W> {
+    inner: W,
+    size: Arc<Mutex<usize>>,
+}
+
+impl<W> SizeAwareWriter<W> {
+    fn new(inner: W, size: Arc<Mutex<usize>>) -> Self {
+        Self {
+            inner,
+            size: size.clone(),
+        }
+    }
+}
+
+impl<W> AsyncWrite for SizeAwareWriter<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        let this = self.as_mut().get_mut();
+
+        match Pin::new(&mut this.inner).poll_write(cx, buf) {
+            Poll::Ready(Ok(bytes_written)) => {
+                let mut size = this.size.lock().unwrap();
+                *size = *size + bytes_written;
+                Poll::Ready(Ok(bytes_written))
+            }
+            other => other,
+        }
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -53,7 +53,7 @@ pub struct ParquetWriter<W, F> {
 }
 
 pub trait WriterFactory<W> {
-    fn create(&mut self) -> impl Future<Output=Result<W>>;
+    fn create(&mut self) -> impl Future<Output = Result<W>>;
 }
 
 pub struct ObjectStoreWriterFactory {
@@ -62,7 +62,7 @@ pub struct ObjectStoreWriterFactory {
 }
 
 impl WriterFactory<Compat<FuturesAsyncWriter>> for ObjectStoreWriterFactory {
-    fn create(&mut self) -> impl Future<Output=Result<Compat<FuturesAsyncWriter>>> {
+    fn create(&mut self) -> impl Future<Output = Result<Compat<FuturesAsyncWriter>>> {
         async {
             self.object_store
                 .writer_with(&self.path)

--- a/src/mito2/src/sst/parquet/writer.rs
+++ b/src/mito2/src/sst/parquet/writer.rs
@@ -35,11 +35,11 @@ use tokio_util::compat::{Compat, FuturesAsyncWriteCompatExt};
 
 use crate::error::{InvalidMetadataSnafu, OpenDalSnafu, Result, WriteParquetSnafu};
 use crate::read::{Batch, Source};
-use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
 use crate::sst::index::Indexer;
 use crate::sst::parquet::format::WriteFormat;
 use crate::sst::parquet::helper::parse_parquet_metadata;
 use crate::sst::parquet::{SstInfo, WriteOptions, PARQUET_METADATA_KEY};
+use crate::sst::{DEFAULT_WRITE_BUFFER_SIZE, DEFAULT_WRITE_CONCURRENCY};
 
 /// Parquet SST writer.
 pub struct ParquetWriter<W, F> {
@@ -82,10 +82,7 @@ impl ParquetWriter<Compat<FuturesAsyncWriter>, ObjectStoreWriterFactory> {
         indexer: Indexer,
     ) -> ParquetWriter<Compat<FuturesAsyncWriter>, ObjectStoreWriterFactory> {
         ParquetWriter::new(
-            ObjectStoreWriterFactory {
-                path,
-                object_store,
-            },
+            ObjectStoreWriterFactory { path, object_store },
             metadata,
             indexer,
         )
@@ -95,10 +92,8 @@ impl ParquetWriter<Compat<FuturesAsyncWriter>, ObjectStoreWriterFactory> {
 impl<W, F> ParquetWriter<W, F>
 where
     W: AsyncWrite + Send + Unpin,
-    F: WriterFactory<W>
+    F: WriterFactory<W>,
 {
-
-
     /// Creates a new parquet SST writer.
     pub fn new(factory: F, metadata: RegionMetadataRef, indexer: Indexer) -> ParquetWriter<W, F> {
         ParquetWriter {
@@ -232,8 +227,10 @@ where
             let props_builder = Self::customize_column_config(props_builder, &self.metadata);
             let writer_props = props_builder.build();
 
-            let writer =
-                SizeAwareWriter::new(self.writer_factory.create().await?, self.bytes_written.clone());
+            let writer = SizeAwareWriter::new(
+                self.writer_factory.create().await?,
+                self.bytes_written.clone(),
+            );
             let arrow_writer =
                 AsyncArrowWriter::try_new(writer, schema.clone(), Some(writer_props))
                     .context(WriteParquetSnafu)?;

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -79,7 +79,6 @@ impl StatementExecutor {
                 Box::pin(DfRecordBatchStreamAdapter::new(stream)),
                 object_store,
                 path,
-                threshold,
                 WRITE_CONCURRENCY,
             )
             .await


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR simplifies SST writing process by removing the `BufferedWriter`.

The `BufferedWriter` came to solve the problem that arrow's paruqet writer requires `std::io::Write` while opendal only provides async S3 writer that implements `tokio::io::AsyncWrite`.  Now arrow provides `AsyncArrowWriter` so we can remove those structs.

## Performance

Writing an parquet file with size 1.2GB,
- before: 11143163us
- after: 10507815us

A slight improvement of 6%.



## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
