### PR TITLE
fix(flow): infer table schema correctly

### DIFF
--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -265,7 +265,7 @@ impl FlownodeManager {
             let ctx = Arc::new(QueryContext::with(&catalog, &schema));
             // TODO(discord9): instead of auto build table from request schema, actually build table
             // before `create flow` to be able to assign pk and ts etc.
-            let (primary_keys, schema, is_auto_create) = if let Some(table_id) = self
+            let (primary_keys, schema, is_ts_placeholder) = if let Some(table_id) = self
                 .table_info_source
                 .get_table_id_from_name(&table_name)
                 .await?
@@ -317,7 +317,12 @@ impl FlownodeManager {
                     .map(|v| {
                         v.column_indices
                             .iter()
-                            .map(|i| format!("Col_{i}"))
+                            .map(|i| {
+                                schema
+                                    .get_name(*i)
+                                    .clone()
+                                    .unwrap_or_else(|| format!("Col_{i}"))
+                            })
                             .collect_vec()
                     })
                     .unwrap_or_default();
@@ -326,13 +331,6 @@ impl FlownodeManager {
                     ConcreteDataType::timestamp_millisecond_datatype(),
                     true,
                 );
-                // TODO(discord9): bugged so we can't infer time index from flow plan, so we have to manually set one
-                let ts_col = ColumnSchema::new(
-                    AUTO_CREATED_PLACEHOLDER_TS_COL,
-                    ConcreteDataType::timestamp_millisecond_datatype(),
-                    true,
-                )
-                .with_time_index(true);
 
                 let wout_ts = schema
                     .typ()
@@ -347,15 +345,30 @@ impl FlownodeManager {
                             .cloned()
                             .flatten()
                             .unwrap_or(format!("Col_{}", idx));
-                        ColumnSchema::new(name, typ.scalar_type, typ.nullable)
+                        let ret = ColumnSchema::new(name, typ.scalar_type, typ.nullable);
+                        if schema.typ().time_index == Some(idx) {
+                            ret.with_time_index(true)
+                        } else {
+                            ret
+                        }
                     })
                     .collect_vec();
 
                 let mut with_ts = wout_ts.clone();
                 with_ts.push(update_at);
-                with_ts.push(ts_col);
 
-                (primary_keys, with_ts, true)
+                // if no time index, add one
+                if schema.typ().time_index.is_none() {
+                    let ts_col = ColumnSchema::new(
+                        AUTO_CREATED_PLACEHOLDER_TS_COL,
+                        ConcreteDataType::timestamp_millisecond_datatype(),
+                        true,
+                    )
+                    .with_time_index(true);
+                    with_ts.push(ts_col);
+                }
+
+                (primary_keys, with_ts, schema.typ().time_index.is_none())
             };
             let schema_len = schema.len();
             let proto_schema = column_schemas_to_proto(schema, &primary_keys)?;
@@ -378,7 +391,7 @@ impl FlownodeManager {
                                     now,
                                 ))]);
                                 // ts col, if auto create
-                                if is_auto_create {
+                                if is_ts_placeholder {
                                     ensure!(
                                         row.len() == schema_len - 1,
                                         InternalSnafu {
@@ -509,12 +522,13 @@ impl FlownodeManager {
         debug!("Starting to run");
         loop {
             // TODO(discord9): only run when new inputs arrive or scheduled to
-            debug!("call run_available in run every second");
-            self.run_available(true).await.unwrap();
-            debug!("call send_writeback_requests in run every second");
+            if let Err(err) = self.run_available(true).await {
+                common_telemetry::error!("Run available errors: {:?}", err);
+            }
             // TODO(discord9): error handling
-            self.send_writeback_requests().await.unwrap();
-            debug!("call log_all_errors in run every second");
+            if let Err(err) = self.send_writeback_requests().await {
+                common_telemetry::error!("Send writeback request errors: {:?}", err);
+            };
             self.log_all_errors().await;
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
@@ -597,6 +611,7 @@ impl FlownodeManager {
                 break;
             }
         }
+        self.node_context.write().await.remove_flow(flow_id);
         Ok(())
     }
 
@@ -643,6 +658,7 @@ impl FlownodeManager {
         node_ctx.query_context = query_ctx.map(Arc::new);
         // construct a active dataflow state with it
         let flow_plan = sql_to_flow_plan(&mut node_ctx, &self.query_engine, &sql).await?;
+
         debug!("Flow {:?}'s Plan is {:?}", flow_id, flow_plan);
         node_ctx.assign_table_schema(&sink_table_name, flow_plan.schema.clone())?;
 

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -644,7 +644,7 @@ impl FlownodeManager {
         // construct a active dataflow state with it
         let flow_plan = sql_to_flow_plan(&mut node_ctx, &self.query_engine, &sql).await?;
         debug!("Flow {:?}'s Plan is {:?}", flow_id, flow_plan);
-        node_ctx.assign_table_schema(&sink_table_name, flow_plan.typ.clone())?;
+        node_ctx.assign_table_schema(&sink_table_name, flow_plan.schema.clone())?;
 
         let _ = comment;
         let _ = flow_options;

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -345,6 +345,7 @@ impl FlownodeManager {
                             .names
                             .get(idx)
                             .cloned()
+                            .flatten()
                             .unwrap_or(format!("Col_{}", idx));
                         ColumnSchema::new(name, typ.scalar_type, typ.nullable)
                     })

--- a/src/flow/src/adapter/node_context.rs
+++ b/src/flow/src/adapter/node_context.rs
@@ -27,7 +27,7 @@ use crate::adapter::error::{Error, EvalSnafu, TableNotFoundSnafu};
 use crate::adapter::{FlowId, TableName, TableSource};
 use crate::expr::error::InternalSnafu;
 use crate::expr::GlobalId;
-use crate::repr::{DiffRow, RelationDesc, RelationType, BROADCAST_CAP};
+use crate::repr::{DiffRow, RelationDesc, BROADCAST_CAP};
 
 /// A context that holds the information of the dataflow
 #[derive(Default, Debug)]
@@ -307,14 +307,14 @@ impl FlownodeContext {
     pub fn assign_table_schema(
         &mut self,
         table_name: &TableName,
-        schema: RelationType,
+        schema: RelationDesc,
     ) -> Result<(), Error> {
         let gid = self
             .table_repr
             .get_by_name(table_name)
             .map(|(_, gid)| gid)
             .unwrap();
-        self.schema.insert(gid, schema.into_unnamed());
+        self.schema.insert(gid, schema);
         Ok(())
     }
 

--- a/src/flow/src/adapter/node_context.rs
+++ b/src/flow/src/adapter/node_context.rs
@@ -27,7 +27,6 @@ use crate::adapter::error::{Error, EvalSnafu, TableNotFoundSnafu};
 use crate::adapter::{FlowId, TableName, TableSource};
 use crate::expr::error::InternalSnafu;
 use crate::expr::GlobalId;
-use crate::plan::TypedPlan;
 use crate::repr::{DiffRow, RelationDesc, BROADCAST_CAP};
 
 /// A context that holds the information of the dataflow

--- a/src/flow/src/adapter/table_source.rs
+++ b/src/flow/src/adapter/table_source.rs
@@ -132,7 +132,7 @@ impl TableSource {
                         nullable: col.is_nullable(),
                         scalar_type: col.data_type,
                     },
-                    col.name,
+                    Some(col.name),
                 )
             })
             .unzip();

--- a/src/flow/src/adapter/worker.rs
+++ b/src/flow/src/adapter/worker.rs
@@ -514,7 +514,7 @@ mod test {
                 plan: Plan::Get {
                     id: Id::Global(GlobalId::User(1)),
                 },
-                typ: RelationType::new(vec![]),
+                schema: RelationType::new(vec![]),
             },
         );
         let create_reqs = Request::Create {

--- a/src/flow/src/adapter/worker.rs
+++ b/src/flow/src/adapter/worker.rs
@@ -514,7 +514,7 @@ mod test {
                 plan: Plan::Get {
                     id: Id::Global(GlobalId::User(1)),
                 },
-                schema: RelationType::new(vec![]),
+                schema: RelationType::new(vec![]).into_unnamed(),
             },
         );
         let create_reqs = Request::Create {

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -111,7 +111,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
                 input,
                 key_val_plan,
                 reduce_plan,
-            } => self.render_reduce(input, key_val_plan, reduce_plan, plan.typ),
+            } => self.render_reduce(input, key_val_plan, reduce_plan, plan.schema),
             Plan::Join { .. } => NotImplementedSnafu {
                 reason: "Join is still WIP",
             }

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -111,7 +111,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
                 input,
                 key_val_plan,
                 reduce_plan,
-            } => self.render_reduce(input, key_val_plan, reduce_plan, plan.schema),
+            } => self.render_reduce(input, key_val_plan, reduce_plan, plan.schema.typ),
             Plan::Join { .. } => NotImplementedSnafu {
                 reason: "Join is still WIP",
             }

--- a/src/flow/src/compute/render/map.rs
+++ b/src/flow/src/compute/render/map.rs
@@ -252,7 +252,7 @@ mod test {
             .unwrap();
 
         let bundle = ctx
-            .render_mfp(Box::new(input_plan.with_types(typ)), mfp)
+            .render_mfp(Box::new(input_plan.with_types(typ.into_unnamed())), mfp)
             .unwrap();
         let output = get_output_handle(&mut ctx, bundle);
         // drop ctx here to simulate actual process of compile first, run later scenario
@@ -312,7 +312,7 @@ mod test {
             )])
             .unwrap();
         let bundle = ctx
-            .render_mfp(Box::new(input_plan.with_types(typ)), mfp)
+            .render_mfp(Box::new(input_plan.with_types(typ.into_unnamed())), mfp)
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);
@@ -348,7 +348,7 @@ mod test {
             )])
             .unwrap();
         let bundle = ctx
-            .render_mfp(Box::new(input_plan.with_types(typ)), mfp)
+            .render_mfp(Box::new(input_plan.with_types(typ.into_unnamed())), mfp)
             .unwrap();
 
         let output = get_output_handle(&mut ctx, bundle);

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -817,7 +817,8 @@ mod test {
                 ColumnType::new(CDT::uint64_datatype(), true), // sum(number)
                 ColumnType::new(CDT::datetime_datatype(), false), // window start
                 ColumnType::new(CDT::datetime_datatype(), false), // window end
-            ]),
+            ])
+            .into_unnamed(),
             // TODO(discord9): mfp indirectly ref to key columns
             /*
             .with_key(vec![1])
@@ -829,10 +830,13 @@ mod test {
                             Plan::Get {
                                 id: crate::expr::Id::Global(GlobalId::User(1)),
                             }
-                            .with_types(RelationType::new(vec![
-                                ColumnType::new(ConcreteDataType::uint32_datatype(), false),
-                                ColumnType::new(ConcreteDataType::datetime_datatype(), false),
-                            ])),
+                            .with_types(
+                                RelationType::new(vec![
+                                    ColumnType::new(ConcreteDataType::uint32_datatype(), false),
+                                    ColumnType::new(ConcreteDataType::datetime_datatype(), false),
+                                ])
+                                .into_unnamed(),
+                            ),
                         ),
                         key_val_plan: KeyValPlan {
                             key_plan: MapFilterProject::new(2)
@@ -880,7 +884,8 @@ mod test {
                             ColumnType::new(CDT::uint64_datatype(), true),    //sum(number)
                         ])
                         .with_key(vec![1])
-                        .with_time_index(Some(0)),
+                        .with_time_index(Some(0))
+                        .into_unnamed(),
                     ),
                 ),
                 mfp: MapFilterProject::new(3)
@@ -977,7 +982,8 @@ mod test {
             els: Box::new(ScalarExpr::Literal(Value::Null, CDT::uint64_datatype())),
         };
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::uint64_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint64_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Reduce {
@@ -985,9 +991,13 @@ mod test {
                             Plan::Get {
                                 id: crate::expr::Id::Global(GlobalId::User(1)),
                             }
-                            .with_types(RelationType::new(vec![
-                                ColumnType::new(ConcreteDataType::int64_datatype(), false),
-                            ])),
+                            .with_types(
+                                RelationType::new(vec![ColumnType::new(
+                                    ConcreteDataType::int64_datatype(),
+                                    false,
+                                )])
+                                .into_unnamed(),
+                            ),
                         ),
                         key_val_plan: KeyValPlan {
                             key_plan: MapFilterProject::new(1)
@@ -1008,10 +1018,13 @@ mod test {
                             distinct_aggrs: vec![],
                         }),
                     }
-                    .with_types(RelationType::new(vec![
-                        ColumnType::new(ConcreteDataType::uint32_datatype(), true),
-                        ColumnType::new(ConcreteDataType::int64_datatype(), true),
-                    ])),
+                    .with_types(
+                        RelationType::new(vec![
+                            ColumnType::new(ConcreteDataType::uint32_datatype(), true),
+                            ColumnType::new(ConcreteDataType::int64_datatype(), true),
+                        ])
+                        .into_unnamed(),
+                    ),
                 ),
                 mfp: MapFilterProject::new(2)
                     .map(vec![
@@ -1068,7 +1081,7 @@ mod test {
         let reduce_plan = ReducePlan::Distinct;
         let bundle = ctx
             .render_reduce(
-                Box::new(input_plan.with_types(typ)),
+                Box::new(input_plan.with_types(typ.into_unnamed())),
                 key_val_plan,
                 reduce_plan,
                 RelationType::empty(),
@@ -1143,7 +1156,7 @@ mod test {
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
             .render_reduce(
-                Box::new(input_plan.with_types(typ)),
+                Box::new(input_plan.with_types(typ.into_unnamed())),
                 key_val_plan,
                 reduce_plan,
                 RelationType::empty(),
@@ -1224,7 +1237,7 @@ mod test {
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
             .render_reduce(
-                Box::new(input_plan.with_types(typ)),
+                Box::new(input_plan.with_types(typ.into_unnamed())),
                 key_val_plan,
                 reduce_plan,
                 RelationType::empty(),
@@ -1301,7 +1314,7 @@ mod test {
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
             .render_reduce(
-                Box::new(input_plan.with_types(typ)),
+                Box::new(input_plan.with_types(typ.into_unnamed())),
                 key_val_plan,
                 reduce_plan,
                 RelationType::empty(),
@@ -1393,7 +1406,7 @@ mod test {
         let reduce_plan = ReducePlan::Accumulable(accum_plan);
         let bundle = ctx
             .render_reduce(
-                Box::new(input_plan.with_types(typ)),
+                Box::new(input_plan.with_types(typ.into_unnamed())),
                 key_val_plan,
                 reduce_plan,
                 RelationType::empty(),

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -813,7 +813,7 @@ mod test {
             distinct: false,
         };
         let expected = TypedPlan {
-            typ: RelationType::new(vec![
+            schema: RelationType::new(vec![
                 ColumnType::new(CDT::uint64_datatype(), true), // sum(number)
                 ColumnType::new(CDT::datetime_datatype(), false), // window start
                 ColumnType::new(CDT::datetime_datatype(), false), // window end
@@ -977,7 +977,7 @@ mod test {
             els: Box::new(ScalarExpr::Literal(Value::Null, CDT::uint64_datatype())),
         };
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::uint64_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint64_datatype(), true)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Reduce {

--- a/src/flow/src/compute/render/src_sink.rs
+++ b/src/flow/src/compute/render/src_sink.rs
@@ -62,7 +62,6 @@ impl<'referred, 'df> Context<'referred, 'df> {
                 let arr = arranged.get_updates_in_range(..=now);
                 err_collector.run(|| arranged.compact_to(now));
 
-                debug!("Call source");
                 let prev_avail = arr.into_iter().map(|((k, _), t, d)| (k, t, d));
                 let mut to_send = Vec::new();
                 let mut to_arrange = Vec::new();

--- a/src/flow/src/plan.rs
+++ b/src/flow/src/plan.rs
@@ -43,8 +43,9 @@ pub struct TypedPlan {
 
 impl TypedPlan {
     /// directly apply a mfp to the plan
-    pub fn mfp(self, mfp: MapFilterProject) -> Result<Self, Error> {
+    pub fn mfp(self, mfp: SafeMfpPlan) -> Result<Self, Error> {
         let new_type = self.typ.apply_mfp(&mfp)?;
+        let mfp = mfp.mfp;
         let plan = match self.plan {
             Plan::Mfp {
                 input,
@@ -74,8 +75,10 @@ impl TypedPlan {
             .unzip();
         let mfp = MapFilterProject::new(input_arity)
             .map(exprs)?
-            .project(input_arity..input_arity + output_arity)?;
+            .project(input_arity..input_arity + output_arity)?
+            .into_safe();
         let out_typ = self.typ.apply_mfp(&mfp)?;
+        let mfp = mfp.mfp;
         // special case for mfp to compose when the plan is already mfp
         let plan = match self.plan {
             Plan::Mfp {

--- a/src/flow/src/plan.rs
+++ b/src/flow/src/plan.rs
@@ -36,7 +36,7 @@ use crate::repr::{ColumnType, DiffRow, RelationType};
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 pub struct TypedPlan {
     /// output type of the relation
-    pub typ: RelationType,
+    pub schema: RelationType,
     /// The untyped plan.
     pub plan: Plan,
 }
@@ -44,7 +44,7 @@ pub struct TypedPlan {
 impl TypedPlan {
     /// directly apply a mfp to the plan
     pub fn mfp(self, mfp: SafeMfpPlan) -> Result<Self, Error> {
-        let new_type = self.typ.apply_mfp(&mfp)?;
+        let new_type = self.schema.apply_mfp(&mfp)?;
         let mfp = mfp.mfp;
         let plan = match self.plan {
             Plan::Mfp {
@@ -60,14 +60,14 @@ impl TypedPlan {
             },
         };
         Ok(TypedPlan {
-            typ: new_type,
+            schema: new_type,
             plan,
         })
     }
 
     /// project the plan to the given expressions
     pub fn projection(self, exprs: Vec<TypedExpr>) -> Result<Self, Error> {
-        let input_arity = self.typ.column_types.len();
+        let input_arity = self.schema.column_types.len();
         let output_arity = exprs.len();
         let (exprs, _expr_typs): (Vec<_>, Vec<_>) = exprs
             .into_iter()
@@ -77,7 +77,7 @@ impl TypedPlan {
             .map(exprs)?
             .project(input_arity..input_arity + output_arity)?
             .into_safe();
-        let out_typ = self.typ.apply_mfp(&mfp)?;
+        let out_typ = self.schema.apply_mfp(&mfp)?;
         let mfp = mfp.mfp;
         // special case for mfp to compose when the plan is already mfp
         let plan = match self.plan {
@@ -93,12 +93,15 @@ impl TypedPlan {
                 mfp,
             },
         };
-        Ok(TypedPlan { typ: out_typ, plan })
+        Ok(TypedPlan {
+            schema: out_typ,
+            plan,
+        })
     }
 
     /// Add a new filter to the plan, will filter out the records that do not satisfy the filter
     pub fn filter(self, filter: TypedExpr) -> Result<Self, Error> {
-        let typ = self.typ.clone();
+        let typ = self.schema.clone();
         let plan = match self.plan {
             Plan::Mfp {
                 input,
@@ -112,7 +115,7 @@ impl TypedPlan {
                 mfp: MapFilterProject::new(typ.column_types.len()).filter(vec![filter.expr])?,
             },
         };
-        Ok(TypedPlan { typ, plan })
+        Ok(TypedPlan { schema: typ, plan })
     }
 }
 
@@ -231,6 +234,9 @@ impl Plan {
 
 impl Plan {
     pub fn with_types(self, typ: RelationType) -> TypedPlan {
-        TypedPlan { typ, plan: self }
+        TypedPlan {
+            schema: typ,
+            plan: self,
+        }
     }
 }

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt};
 
 use crate::adapter::error::{InvalidQuerySnafu, Result, UnexpectedSnafu};
-use crate::expr::MapFilterProject;
+use crate::expr::{MapFilterProject, SafeMfpPlan};
 
 /// a set of column indices that are "keys" for the collection.
 #[derive(Default, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
@@ -111,7 +111,8 @@ impl RelationType {
     /// then new key=`[1]`, new time index=`[0]`
     ///
     /// note that this function will remove empty keys like key=`[]` will be removed
-    pub fn apply_mfp(&self, mfp: &MapFilterProject) -> Result<Self> {
+    pub fn apply_mfp(&self, mfp: &SafeMfpPlan) -> Result<Self> {
+        let mfp = &mfp.mfp;
         let mut all_types = self.column_types.clone();
         for expr in &mfp.expressions {
             let expr_typ = expr.typ(&self.column_types)?;
@@ -264,7 +265,7 @@ impl RelationType {
     }
 
     /// Return relation describe with column names
-    pub fn into_named(self, names: Vec<ColumnName>) -> RelationDesc {
+    pub fn into_named(self, names: Vec<Option<ColumnName>>) -> RelationDesc {
         RelationDesc { typ: self, names }
     }
 
@@ -339,7 +340,7 @@ fn return_true() -> bool {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct RelationDesc {
     pub typ: RelationType,
-    pub names: Vec<ColumnName>,
+    pub names: Vec<Option<ColumnName>>,
 }
 
 impl RelationDesc {
@@ -358,7 +359,7 @@ impl RelationDesc {
     pub fn try_new<I, N>(typ: RelationType, names: I) -> Result<Self>
     where
         I: IntoIterator<Item = N>,
-        N: Into<ColumnName>,
+        N: Into<Option<ColumnName>>,
     {
         let names: Vec<_> = names.into_iter().map(|name| name.into()).collect();
         ensure!(
@@ -383,7 +384,7 @@ impl RelationDesc {
     pub fn new_unchecked<I, N>(typ: RelationType, names: I) -> Self
     where
         I: IntoIterator<Item = N>,
-        N: Into<ColumnName>,
+        N: Into<Option<ColumnName>>,
     {
         let names: Vec<_> = names.into_iter().map(|name| name.into()).collect();
         assert_eq!(typ.arity(), names.len());
@@ -394,7 +395,7 @@ impl RelationDesc {
     where
         I: IntoIterator<Item = (N, T)>,
         T: Into<ColumnType>,
-        N: Into<ColumnName>,
+        N: Into<Option<ColumnName>>,
     {
         let (names, types): (Vec<_>, Vec<_>) = iter.into_iter().unzip();
         let types = types.into_iter().map(Into::into).collect();
@@ -420,7 +421,7 @@ impl RelationDesc {
     /// Appends a column with the specified name and type.
     pub fn with_column<N>(mut self, name: N, column_type: ColumnType) -> Self
     where
-        N: Into<ColumnName>,
+        N: Into<Option<ColumnName>>,
     {
         self.typ.column_types.push(column_type);
         self.names.push(name.into());
@@ -445,7 +446,7 @@ impl RelationDesc {
     pub fn try_with_names<I, N>(self, names: I) -> Result<Self>
     where
         I: IntoIterator<Item = N>,
-        N: Into<ColumnName>,
+        N: Into<Option<ColumnName>>,
     {
         Self::try_new(self.typ, names)
     }
@@ -461,7 +462,7 @@ impl RelationDesc {
     }
 
     /// Returns an iterator over the columns in this relation.
-    pub fn iter(&self) -> impl Iterator<Item = (&ColumnName, &ColumnType)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Option<ColumnName>, &ColumnType)> {
         self.iter_names().zip(self.iter_types())
     }
 
@@ -471,7 +472,7 @@ impl RelationDesc {
     }
 
     /// Returns an iterator over the names of the columns in this relation.
-    pub fn iter_names(&self) -> impl Iterator<Item = &ColumnName> {
+    pub fn iter_names(&self) -> impl Iterator<Item = &Option<ColumnName>> {
         self.names.iter()
     }
 
@@ -482,7 +483,7 @@ impl RelationDesc {
     /// specified name, the leftmost column is returned.
     pub fn get_by_name(&self, name: &ColumnName) -> Option<(usize, &ColumnType)> {
         self.iter_names()
-            .position(|n| n == name)
+            .position(|n| n.as_ref() == Some(name))
             .map(|i| (i, &self.typ.column_types[i]))
     }
 
@@ -491,7 +492,7 @@ impl RelationDesc {
     /// # Panics
     ///
     /// Panics if `i` is not a valid column index.
-    pub fn get_name(&self, i: usize) -> &ColumnName {
+    pub fn get_name(&self, i: usize) -> &Option<ColumnName> {
         &self.names[i]
     }
 
@@ -500,7 +501,7 @@ impl RelationDesc {
     /// # Panics
     ///
     /// Panics if `i` is not a valid column index.
-    pub fn get_name_mut(&mut self, i: usize) -> &mut ColumnName {
+    pub fn get_name_mut(&mut self, i: usize) -> &mut Option<ColumnName> {
         &mut self.names[i]
     }
 
@@ -515,7 +516,7 @@ impl RelationDesc {
     pub fn get_unambiguous_name(&self, i: usize) -> Option<&ColumnName> {
         let name = &self.names[i];
         if self.iter_names().filter(|n| *n == name).count() == 1 {
-            Some(name)
+            name.as_ref()
         } else {
             None
         }

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -272,8 +272,8 @@ impl RelationType {
     /// Return relation describe without column names
     pub fn into_unnamed(self) -> RelationDesc {
         RelationDesc {
+            names: vec![None; self.column_types.len()],
             typ: self,
-            names: vec![],
         }
     }
 }
@@ -337,7 +337,7 @@ fn return_true() -> bool {
 ///
 /// It bundles a [`RelationType`] with the name of each column in the relation.
 /// Individual column names are optional.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash)]
 pub struct RelationDesc {
     pub typ: RelationType,
     pub names: Vec<Option<ColumnName>>,
@@ -352,7 +352,7 @@ impl RelationDesc {
             let mut names = self.names.clone();
             for expr in &mfp.expressions {
                 if let ScalarExpr::Column(i) = expr {
-                    names.push(self.names[*i].clone());
+                    names.push(self.names.get(*i).cloned().flatten());
                 } else {
                     names.push(None);
                 }

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -133,24 +133,7 @@ impl RelationType {
             })
             .try_collect()?;
 
-        let old_to_new_col =
-            BTreeMap::from_iter(mfp.projection.clone().into_iter().enumerate().map(
-                |(new, old)| {
-                    let mut old = old;
-                    // trace back to the original column
-                    while let Some(ScalarExpr::Column(prev)) = if old >= mfp.input_arity {
-                        mfp.expressions.get(old - mfp.input_arity)
-                    } else {
-                        None
-                    } {
-                        old = *prev;
-                        if old < mfp.input_arity {
-                            break;
-                        }
-                    }
-                    (old, new)
-                },
-            ));
+        let old_to_new_col = mfp.get_old_to_new_mapping();
 
         // since it's just a mfp, we also try to preserve keys&time index information, if they survive mfp transform
         let keys = self

--- a/src/flow/src/transform.rs
+++ b/src/flow/src/transform.rs
@@ -212,7 +212,7 @@ mod test {
             let schema = RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]);
 
             tri_map.insert(Some(name.clone()), Some(1024), gid);
-            schemas.insert(gid, schema.into_unnamed());
+            schemas.insert(gid, schema.into_named(vec![Some("number".to_string())]));
         }
 
         {
@@ -226,7 +226,10 @@ mod test {
                 ColumnType::new(CDT::uint32_datatype(), false),
                 ColumnType::new(CDT::datetime_datatype(), false),
             ]);
-            schemas.insert(gid, schema.into_unnamed());
+            schemas.insert(
+                gid,
+                schema.into_named(vec![Some("number".to_string()), Some("ts".to_string())]),
+            );
             tri_map.insert(Some(name.clone()), Some(1025), gid);
         }
 

--- a/src/flow/src/transform/aggr.rs
+++ b/src/flow/src/transform/aggr.rs
@@ -456,7 +456,16 @@ mod test {
     use crate::plan::{Plan, TypedPlan};
     use crate::repr::{self, ColumnType, RelationType};
     use crate::transform::test::{create_test_ctx, create_test_query_engine, sql_to_substrait};
+    /// TODO(discord9): add more illegal sql tests
+    #[tokio::test]
+    async fn tes_missing_key_check() {
+        let engine = create_test_query_engine();
+        let sql = "SELECT avg(number) FROM numbers_with_ts GROUP BY tumble(ts, '1 hour'), number";
+        let plan = sql_to_substrait(engine.clone(), sql).await;
 
+        let mut ctx = create_test_ctx();
+        assert!(TypedPlan::from_substrait_plan(&mut ctx, &plan).is_err());
+    }
     /// TODO(discord9): add more illegal sql tests
     #[tokio::test]
     async fn test_tumble_composite() {

--- a/src/flow/src/transform/aggr.rs
+++ b/src/flow/src/transform/aggr.rs
@@ -414,7 +414,7 @@ impl TypedPlan {
                 .filter(f)?
                 .project(p)?;
             Ok(TypedPlan {
-                typ: output_type.apply_mfp(&post_mfp)?,
+                typ: output_type.apply_mfp(&post_mfp.clone().into_safe())?,
                 plan: Plan::Mfp {
                     input: Box::new(input),
                     mfp: post_mfp,

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -364,7 +364,7 @@ mod test {
         };
         let expected = TypedPlan {
             schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)])
-                .into_unnamed(),
+                .into_named(vec![Some("number".to_string())]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
@@ -375,7 +375,7 @@ mod test {
                             ConcreteDataType::uint32_datatype(),
                             false,
                         )])
-                        .into_unnamed(),
+                        .into_named(vec![Some("number".to_string())]),
                     ),
                 ),
                 mfp: MapFilterProject::new(1)
@@ -438,7 +438,7 @@ mod test {
                             ConcreteDataType::uint32_datatype(),
                             false,
                         )])
-                        .into_unnamed(),
+                        .into_named(vec![Some("number".to_string())]),
                     ),
                 ),
                 mfp: MapFilterProject::new(1)
@@ -476,7 +476,7 @@ mod test {
                             ConcreteDataType::uint32_datatype(),
                             false,
                         )])
-                        .into_unnamed(),
+                        .into_named(vec![Some("number".to_string())]),
                     ),
                 ),
                 mfp: MapFilterProject::new(1)
@@ -515,7 +515,7 @@ mod test {
                             ConcreteDataType::uint32_datatype(),
                             false,
                         )])
-                        .into_unnamed(),
+                        .into_named(vec![Some("number".to_string())]),
                     ),
                 ),
                 mfp: MapFilterProject::new(1)

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -363,7 +363,7 @@ mod test {
             ],
         };
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
@@ -397,7 +397,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::boolean_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::boolean_datatype(), true)]),
             plan: Plan::Constant {
                 rows: vec![(
                     repr::Row::new(vec![Value::from(true)]),
@@ -421,7 +421,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
@@ -455,7 +455,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::int16_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::int16_datatype(), true)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
@@ -490,7 +490,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -363,16 +363,20 @@ mod test {
             ],
         };
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)])
+                .into_unnamed(),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
                         id: crate::expr::Id::Global(GlobalId::User(0)),
                     }
-                    .with_types(RelationType::new(vec![ColumnType::new(
-                        ConcreteDataType::uint32_datatype(),
-                        false,
-                    )])),
+                    .with_types(
+                        RelationType::new(vec![ColumnType::new(
+                            ConcreteDataType::uint32_datatype(),
+                            false,
+                        )])
+                        .into_unnamed(),
+                    ),
                 ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0)])
@@ -397,7 +401,8 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::boolean_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::boolean_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Constant {
                 rows: vec![(
                     repr::Row::new(vec![Value::from(true)]),
@@ -421,16 +426,20 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
                         id: crate::expr::Id::Global(GlobalId::User(0)),
                     }
-                    .with_types(RelationType::new(vec![ColumnType::new(
-                        ConcreteDataType::uint32_datatype(),
-                        false,
-                    )])),
+                    .with_types(
+                        RelationType::new(vec![ColumnType::new(
+                            ConcreteDataType::uint32_datatype(),
+                            false,
+                        )])
+                        .into_unnamed(),
+                    ),
                 ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0).call_binary(
@@ -455,16 +464,20 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::int16_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::int16_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
                         id: crate::expr::Id::Global(GlobalId::User(0)),
                     }
-                    .with_types(RelationType::new(vec![ColumnType::new(
-                        ConcreteDataType::uint32_datatype(),
-                        false,
-                    )])),
+                    .with_types(
+                        RelationType::new(vec![ColumnType::new(
+                            ConcreteDataType::uint32_datatype(),
+                            false,
+                        )])
+                        .into_unnamed(),
+                    ),
                 ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Literal(
@@ -490,16 +503,20 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
                         id: crate::expr::Id::Global(GlobalId::User(0)),
                     }
-                    .with_types(RelationType::new(vec![ColumnType::new(
-                        ConcreteDataType::uint32_datatype(),
-                        false,
-                    )])),
+                    .with_types(
+                        RelationType::new(vec![ColumnType::new(
+                            ConcreteDataType::uint32_datatype(),
+                            false,
+                        )])
+                        .into_unnamed(),
+                    ),
                 ),
                 mfp: MapFilterProject::new(1)
                     .map(vec![ScalarExpr::Column(0)

--- a/src/flow/src/transform/literal.rs
+++ b/src/flow/src/transform/literal.rs
@@ -175,7 +175,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::int64_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::int64_datatype(), true)]),
             plan: Plan::Constant {
                 rows: vec![(
                     repr::Row::new(vec![Value::Int64(1)]),

--- a/src/flow/src/transform/literal.rs
+++ b/src/flow/src/transform/literal.rs
@@ -175,7 +175,8 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            schema: RelationType::new(vec![ColumnType::new(CDT::int64_datatype(), true)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::int64_datatype(), true)])
+                .into_unnamed(),
             plan: Plan::Constant {
                 rows: vec![(
                     repr::Row::new(vec![Value::Int64(1)]),

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -286,7 +286,7 @@ impl TypedPlan {
                         let input_arity = get_table.typ.column_types.len();
                         let mfp =
                             MapFilterProject::new(input_arity).project(column_indices.clone())?;
-                        get_table.mfp(mfp)
+                        get_table.mfp(mfp.into_safe())
                     } else {
                         Ok(get_table)
                     }

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -293,9 +293,16 @@ fn rewrite_projection_after_reduce(
     for (key_idx, key_expr) in key_exprs.iter().enumerate() {
         if let ScalarExpr::Column(_) = key_expr {
             if !all_cols_ref_in_proj.contains(&key_idx) {
-                return InvalidQuerySnafu{
-                    reason: format!("Expect normal column in group by also appear in projection, but column {}(name is {}) is missing", key_idx, reduce_output_type.get_name(key_idx).clone().map(|s|format!("'{}'",s)).unwrap_or("unknown".to_string()))
-                }.fail();
+                let err_msg = format!(
+                    "Expect normal column in group by also appear in projection, but column {}(name is {}) is missing", 
+                    key_idx,
+                    reduce_output_type
+                        .get_name(key_idx)
+                        .clone()
+                        .map(|s|format!("'{}'",s))
+                        .unwrap_or("unknown".to_string())
+            );
+                return InvalidQuerySnafu { reason: err_msg }.fail();
             }
         }
     }

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -308,6 +308,7 @@ impl TypedPlan {
 #[cfg(test)]
 mod test {
     use datatypes::prelude::ConcreteDataType;
+    use pretty_assertions::assert_eq;
 
     use super::*;
     use crate::expr::{GlobalId, ScalarExpr};
@@ -327,7 +328,7 @@ mod test {
 
         let expected = TypedPlan {
             schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)])
-                .into_unnamed(),
+                .into_named(vec![Some("number".to_string())]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {
@@ -338,7 +339,7 @@ mod test {
                             ConcreteDataType::uint32_datatype(),
                             false,
                         )])
-                        .into_unnamed(),
+                        .into_named(vec![Some("number".to_string())]),
                     ),
                 ),
                 mfp: MapFilterProject::new(1)

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -80,7 +80,7 @@ impl TypedPlan {
 
                 let mut exprs: Vec<TypedExpr> = vec![];
                 for e in &p.expressions {
-                    let expr = TypedExpr::from_substrait_rex(e, &input.typ, extensions)?;
+                    let expr = TypedExpr::from_substrait_rex(e, &input.schema, extensions)?;
                     exprs.push(expr);
                 }
                 let is_literal = exprs.iter().all(|expr| expr.expr.is_literal());
@@ -98,7 +98,7 @@ impl TypedPlan {
                     let plan = Plan::Constant {
                         rows: vec![(row, repr::Timestamp::MIN, 1)],
                     };
-                    Ok(TypedPlan { typ, plan })
+                    Ok(TypedPlan { schema: typ, plan })
                 } else {
                     /// if reduce_plan contains the special function like tumble floor/ceiling, add them to the proj_exprs
                     fn rewrite_projection_after_reduce(
@@ -200,7 +200,7 @@ impl TypedPlan {
                             rewrite_projection_after_reduce(
                                 key_val_plan,
                                 reduce_plan,
-                                &input.typ,
+                                &input.schema,
                                 &mut exprs,
                             )?;
                         }
@@ -214,7 +214,7 @@ impl TypedPlan {
                                 rewrite_projection_after_reduce(
                                     key_val_plan,
                                     reduce_plan,
-                                    &input.typ,
+                                    &input.schema,
                                     &mut exprs,
                                 )?;
                             }
@@ -232,7 +232,7 @@ impl TypedPlan {
                 };
 
                 let expr = if let Some(condition) = filter.condition.as_ref() {
-                    TypedExpr::from_substrait_rex(condition, &input.typ, extensions)?
+                    TypedExpr::from_substrait_rex(condition, &input.schema, extensions)?
                 } else {
                     return not_impl_err!("Filter without an condition is not valid");
                 };
@@ -269,7 +269,7 @@ impl TypedPlan {
                         id: crate::expr::Id::Global(table.0),
                     };
                     let get_table = TypedPlan {
-                        typ: table.1.typ().clone(),
+                        schema: table.1.typ().clone(),
                         plan: get_table,
                     };
 
@@ -283,7 +283,7 @@ impl TypedPlan {
                             .iter()
                             .map(|item| item.field as usize)
                             .collect();
-                        let input_arity = get_table.typ.column_types.len();
+                        let input_arity = get_table.schema.column_types.len();
                         let mfp =
                             MapFilterProject::new(input_arity).project(column_indices.clone())?;
                         get_table.mfp(mfp.into_safe())
@@ -323,7 +323,7 @@ mod test {
         let flow_plan = TypedPlan::from_substrait_plan(&mut ctx, &plan);
 
         let expected = TypedPlan {
-            typ: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
+            schema: RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]),
             plan: Plan::Mfp {
                 input: Box::new(
                     Plan::Get {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
- fix infer table schema for flow

Please explain IN DETAIL what the changes are in this PR and why they are needed:

previously, flow can't correctly infer pk&time index for query with `GROUP BY`& `tumble`, now function to infer those &related tests are added

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
