### PR TITLE
feat: update default size of bgworkers, add hbworkers

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -16,8 +16,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
-| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
+| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
 | `http` | -- | -- | The HTTP server options. |
 | `http.addr` | String | `127.0.0.1:4000` | The address to bind the HTTP server. |
 | `http.timeout` | String | `30s` | HTTP request timeout. |
@@ -162,8 +161,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
-| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
+| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `18s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |
@@ -253,8 +251,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
-| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
+| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `12` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
@@ -319,8 +316,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
-| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
+| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `3s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |

--- a/config/config.md
+++ b/config/config.md
@@ -16,7 +16,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
 | `http` | -- | -- | The HTTP server options. |
 | `http.addr` | String | `127.0.0.1:4000` | The address to bind the HTTP server. |
 | `http.timeout` | String | `30s` | HTTP request timeout. |
@@ -161,7 +161,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `18s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |
@@ -251,7 +251,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `12` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
@@ -316,7 +316,7 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `3s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |

--- a/config/config.md
+++ b/config/config.md
@@ -16,7 +16,8 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
+| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
 | `http` | -- | -- | The HTTP server options. |
 | `http.addr` | String | `127.0.0.1:4000` | The address to bind the HTTP server. |
 | `http.timeout` | String | `30s` | HTTP request timeout. |
@@ -161,7 +162,8 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
+| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `18s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |
@@ -251,7 +253,8 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
+| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
 | `procedure` | -- | -- | Procedure storage options. |
 | `procedure.max_retry_times` | Integer | `12` | Procedure max retry time. |
 | `procedure.retry_delay` | String | `500ms` | Initial retry delay of procedures, increases exponentially |
@@ -316,7 +319,8 @@
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.write_rt_size` | Integer | `8` | The number of threads to execute the runtime for global write operations. |
-| `runtime.bg_rt_size` | Integer | `8` | The number of threads to execute the runtime for global background operations. |
+| `runtime.bg_rt_size` | Integer | `4` | The number of threads to execute the runtime for global background operations. |
+| `runtime.hb_rt_size` | Integer | `2` | The number of threads to execute the runtime for heartbeat operations. |
 | `heartbeat` | -- | -- | The heartbeat options. |
 | `heartbeat.interval` | String | `3s` | Interval for sending heartbeat messages to the metasrv. |
 | `heartbeat.retry_interval` | String | `3s` | Interval for retrying to send heartbeat messages to the metasrv. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -42,9 +42,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 4
-## The number of threads to execute the runtime for heartbeat operations.
-hb_rt_size = 2
+bg_rt_size = 8
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -42,7 +42,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -42,7 +42,9 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
+## The number of threads to execute the runtime for heartbeat operations.
+hb_rt_size = 2
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -12,7 +12,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -12,7 +12,9 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
+## The number of threads to execute the runtime for heartbeat operations.
+hb_rt_size = 2
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -12,9 +12,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 4
-## The number of threads to execute the runtime for heartbeat operations.
-hb_rt_size = 2
+bg_rt_size = 8
 
 ## The heartbeat options.
 [heartbeat]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -32,7 +32,9 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
+## The number of threads to execute the runtime for heartbeat operations.
+hb_rt_size = 2
 
 ## Procedure storage options.
 [procedure]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -32,9 +32,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 4
-## The number of threads to execute the runtime for heartbeat operations.
-hb_rt_size = 2
+bg_rt_size = 8
 
 ## Procedure storage options.
 [procedure]

--- a/config/metasrv.example.toml
+++ b/config/metasrv.example.toml
@@ -32,7 +32,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
 
 ## Procedure storage options.
 [procedure]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -15,9 +15,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 4
-## The number of threads to execute the runtime for heartbeat operations.
-hb_rt_size = 2
+bg_rt_size = 8
 
 ## The HTTP server options.
 [http]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -15,7 +15,9 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
+## The number of threads to execute the runtime for heartbeat operations.
+hb_rt_size = 2
 
 ## The HTTP server options.
 [http]

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -15,7 +15,7 @@ read_rt_size = 8
 ## The number of threads to execute the runtime for global write operations.
 write_rt_size = 8
 ## The number of threads to execute the runtime for global background operations.
-bg_rt_size = 8
+bg_rt_size = 4
 
 ## The HTTP server options.
 [http]

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -41,7 +41,8 @@ fn test_load_datanode_example_config() {
         runtime: RuntimeOptions {
             read_rt_size: 8,
             write_rt_size: 8,
-            bg_rt_size: 8,
+            bg_rt_size: 4,
+            hb_rt_size: 1,
         },
         component: DatanodeOptions {
             node_id: Some(42),
@@ -100,7 +101,8 @@ fn test_load_frontend_example_config() {
         runtime: RuntimeOptions {
             read_rt_size: 8,
             write_rt_size: 8,
-            bg_rt_size: 8,
+            bg_rt_size: 4,
+            hb_rt_size: 1,
         },
         component: FrontendOptions {
             default_timezone: Some("UTC".to_string()),
@@ -148,7 +150,8 @@ fn test_load_metasrv_example_config() {
         runtime: RuntimeOptions {
             read_rt_size: 8,
             write_rt_size: 8,
-            bg_rt_size: 8,
+            bg_rt_size: 4,
+            hb_rt_size: 1,
         },
         component: MetasrvOptions {
             selector: SelectorType::LeaseBased,
@@ -181,7 +184,8 @@ fn test_load_standalone_example_config() {
         runtime: RuntimeOptions {
             read_rt_size: 8,
             write_rt_size: 8,
-            bg_rt_size: 8,
+            bg_rt_size: 4,
+            hb_rt_size: 1,
         },
         component: StandaloneOptions {
             default_timezone: Some("UTC".to_string()),

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -42,7 +42,7 @@ fn test_load_datanode_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
+            hb_rt_size: 2,
         },
         component: DatanodeOptions {
             node_id: Some(42),
@@ -102,7 +102,7 @@ fn test_load_frontend_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
+            hb_rt_size: 2,
         },
         component: FrontendOptions {
             default_timezone: Some("UTC".to_string()),
@@ -151,7 +151,7 @@ fn test_load_metasrv_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
+            hb_rt_size: 2,
         },
         component: MetasrvOptions {
             selector: SelectorType::LeaseBased,
@@ -185,7 +185,7 @@ fn test_load_standalone_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
+            hb_rt_size: 2,
         },
         component: StandaloneOptions {
             default_timezone: Some("UTC".to_string()),

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -42,7 +42,7 @@ fn test_load_datanode_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 2,
+            hb_rt_size: 1,
         },
         component: DatanodeOptions {
             node_id: Some(42),
@@ -102,7 +102,7 @@ fn test_load_frontend_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 2,
+            hb_rt_size: 1,
         },
         component: FrontendOptions {
             default_timezone: Some("UTC".to_string()),
@@ -151,7 +151,7 @@ fn test_load_metasrv_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 2,
+            hb_rt_size: 1,
         },
         component: MetasrvOptions {
             selector: SelectorType::LeaseBased,
@@ -185,7 +185,7 @@ fn test_load_standalone_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 2,
+            hb_rt_size: 1,
         },
         component: StandaloneOptions {
             default_timezone: Some("UTC".to_string()),

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -42,7 +42,6 @@ fn test_load_datanode_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
         },
         component: DatanodeOptions {
             node_id: Some(42),
@@ -102,7 +101,6 @@ fn test_load_frontend_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
         },
         component: FrontendOptions {
             default_timezone: Some("UTC".to_string()),
@@ -151,7 +149,6 @@ fn test_load_metasrv_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
         },
         component: MetasrvOptions {
             selector: SelectorType::LeaseBased,
@@ -185,7 +182,6 @@ fn test_load_standalone_example_config() {
             read_rt_size: 8,
             write_rt_size: 8,
             bg_rt_size: 4,
-            hb_rt_size: 1,
         },
         component: StandaloneOptions {
             default_timezone: Some("UTC".to_string()),

--- a/src/common/runtime/src/global.rs
+++ b/src/common/runtime/src/global.rs
@@ -26,7 +26,7 @@ use crate::{Builder, JoinHandle, Runtime};
 const READ_WORKERS: usize = 8;
 const WRITE_WORKERS: usize = 8;
 const BG_WORKERS: usize = 4;
-const HB_WORKERS: usize = 1;
+const HB_WORKERS: usize = 2;
 
 /// The options for the global runtimes.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -49,7 +49,7 @@ impl Default for RuntimeOptions {
             read_rt_size: cpus,
             write_rt_size: cpus,
             bg_rt_size: usize::max(cpus / 2, 1),
-            hb_rt_size: 1,
+            hb_rt_size: HB_WORKERS,
         }
     }
 }

--- a/src/common/runtime/src/global.rs
+++ b/src/common/runtime/src/global.rs
@@ -26,7 +26,7 @@ use crate::{Builder, JoinHandle, Runtime};
 const READ_WORKERS: usize = 8;
 const WRITE_WORKERS: usize = 8;
 const BG_WORKERS: usize = 4;
-const HB_WORKERS: usize = 2;
+const HB_WORKERS: usize = 1;
 
 /// The options for the global runtimes.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -49,7 +49,7 @@ impl Default for RuntimeOptions {
             read_rt_size: cpus,
             write_rt_size: cpus,
             bg_rt_size: usize::max(cpus / 2, 1),
-            hb_rt_size: HB_WORKERS,
+            hb_rt_size: 1,
         }
     }
 }

--- a/src/common/runtime/src/global.rs
+++ b/src/common/runtime/src/global.rs
@@ -26,7 +26,7 @@ use crate::{Builder, JoinHandle, Runtime};
 const READ_WORKERS: usize = 8;
 const WRITE_WORKERS: usize = 8;
 const BG_WORKERS: usize = 4;
-const HB_WORKERS: usize = 1;
+const HB_WORKERS: usize = 2;
 
 /// The options for the global runtimes.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -37,9 +37,6 @@ pub struct RuntimeOptions {
     pub write_rt_size: usize,
     /// The number of threads to execute the runtime for global background operations.
     pub bg_rt_size: usize,
-    /// The number of threads to execute the runtime for heartbeat between meta
-    /// and this node
-    pub hb_rt_size: usize,
 }
 
 impl Default for RuntimeOptions {
@@ -49,7 +46,6 @@ impl Default for RuntimeOptions {
             read_rt_size: cpus,
             write_rt_size: cpus,
             bg_rt_size: usize::max(cpus / 2, 1),
-            hb_rt_size: 1,
         }
     }
 }
@@ -171,11 +167,7 @@ pub fn init_global_runtimes(options: &RuntimeOptions) {
             "global-bg-worker",
             options.bg_rt_size,
         ));
-        c.hb_runtime = Some(create_runtime(
-            "global-hb",
-            "global-hb-worker",
-            options.hb_rt_size,
-        ));
+        c.hb_runtime = Some(create_runtime("global-hb", "global-hb-worker", HB_WORKERS));
     });
 }
 

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -20,8 +20,8 @@ pub mod runtime;
 
 pub use global::{
     bg_runtime, block_on_bg, block_on_read, block_on_write, create_runtime, init_global_runtimes,
-    read_runtime, spawn_bg, spawn_blocking_bg, spawn_blocking_read, spawn_blocking_write,
-    spawn_read, spawn_write, write_runtime,
+    read_runtime, spawn_bg, spawn_blocking_bg, spawn_blocking_hb, spawn_blocking_read,
+    spawn_blocking_write, spawn_hb, spawn_read, spawn_write, write_runtime,
 };
 
 pub use crate::repeated_task::{BoxedTaskFunction, RepeatedTask, TaskFunction};

--- a/src/datanode/src/heartbeat.rs
+++ b/src/datanode/src/heartbeat.rs
@@ -108,7 +108,7 @@ impl HeartbeatTask {
 
         let mut last_received_lease = Instant::now();
 
-        let _handle = common_runtime::spawn_bg(async move {
+        let _handle = common_runtime::spawn_hb(async move {
             while let Some(res) = rx.message().await.unwrap_or_else(|e| {
                 error!(e; "Error while reading heartbeat response");
                 None
@@ -215,7 +215,7 @@ impl HeartbeatTask {
         self.region_alive_keeper.start(Some(event_receiver)).await?;
         let mut last_sent = Instant::now();
 
-        common_runtime::spawn_bg(async move {
+        common_runtime::spawn_hb(async move {
             let sleep = tokio::time::sleep(Duration::from_millis(0));
             tokio::pin!(sleep);
             loop {

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -85,7 +85,7 @@ impl HeartbeatTask {
         let capture_self = self.clone();
         let retry_interval = self.retry_interval;
 
-        let _handle = common_runtime::spawn_bg(async move {
+        let _handle = common_runtime::spawn_hb(async move {
             loop {
                 match resp_stream.message().await {
                     Ok(Some(resp)) => {
@@ -132,7 +132,7 @@ impl HeartbeatTask {
             addr: self.server_addr.clone(),
         });
 
-        common_runtime::spawn_bg(async move {
+        common_runtime::spawn_hb(async move {
             let sleep = tokio::time::sleep(Duration::from_millis(0));
             tokio::pin!(sleep);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4128 

## What's changed and what's your intention?

This patch changes default bg_worker runtime to half of cpu_num, to avoid cpu-intensive tasks to fill up all compute resources

It also use dedicated runtime to host heartbeat tasks, which is of higher priority.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
