### PR TITLE
fix: explicitly set config instead of using changable default in tests

### DIFF
--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use cmd::options::GreptimeOptions;
 use cmd::standalone::StandaloneOptions;
+use common_base::readable_size::ReadableSize;
 use common_config::Configurable;
 use common_runtime::global::RuntimeOptions;
 use common_telemetry::logging::LoggingOptions;
@@ -70,6 +71,11 @@ fn test_load_datanode_example_config() {
                 num_workers: 8,
                 auto_flush_interval: Duration::from_secs(3600),
                 scan_parallelism: 0,
+                global_write_buffer_size: ReadableSize::gb(1),
+                global_write_buffer_reject_size: ReadableSize::gb(2),
+                sst_meta_cache_size: ReadableSize::mb(128),
+                vector_cache_size: ReadableSize::mb(512),
+                page_cache_size: ReadableSize::mb(512),
                 ..Default::default()
             })],
             logging: LoggingOptions {
@@ -194,6 +200,11 @@ fn test_load_standalone_example_config() {
                 num_workers: 8,
                 auto_flush_interval: Duration::from_secs(3600),
                 scan_parallelism: 0,
+                global_write_buffer_size: ReadableSize::gb(1),
+                global_write_buffer_reject_size: ReadableSize::gb(2),
+                sst_meta_cache_size: ReadableSize::mb(128),
+                vector_cache_size: ReadableSize::mb(512),
+                page_cache_size: ReadableSize::mb(512),
                 ..Default::default()
             })],
             storage: StorageConfig {

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -76,6 +76,7 @@ fn test_load_datanode_example_config() {
                 sst_meta_cache_size: ReadableSize::mb(128),
                 vector_cache_size: ReadableSize::mb(512),
                 page_cache_size: ReadableSize::mb(512),
+                max_background_jobs: 4,
                 ..Default::default()
             })],
             logging: LoggingOptions {
@@ -205,6 +206,7 @@ fn test_load_standalone_example_config() {
                 sst_meta_cache_size: ReadableSize::mb(128),
                 vector_cache_size: ReadableSize::mb(512),
                 page_cache_size: ReadableSize::mb(512),
+                max_background_jobs: 4,
                 ..Default::default()
             })],
             storage: StorageConfig {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

fix #4126 

## What's changed and what's your intention?

fix the test failure in #4126 

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
