### PR TITLE
refactor: make region manifest checkpoint ran in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,6 +5862,7 @@ dependencies = [
  "rskafka",
  "rstest",
  "rstest_reuse",
+ "scopeguard",
  "serde",
  "serde_json",
  "serde_with",

--- a/src/mito2/Cargo.toml
+++ b/src/mito2/Cargo.toml
@@ -58,6 +58,7 @@ regex = "1.5"
 rskafka = { workspace = true, optional = true }
 rstest = { workspace = true, optional = true }
 rstest_reuse = { workspace = true, optional = true }
+scopeguard = "1.2"
 serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true

--- a/src/mito2/src/manifest.rs
+++ b/src/mito2/src/manifest.rs
@@ -15,6 +15,7 @@
 //! manifest storage
 
 pub mod action;
+mod checkpointer;
 pub mod manager;
 pub mod storage;
 #[cfg(test)]

--- a/src/mito2/src/manifest/checkpointer.rs
+++ b/src/mito2/src/manifest/checkpointer.rs
@@ -71,7 +71,7 @@ impl Checkpointer {
         }
 
         // We can simply check whether there's a running checkpoint task like this, all because of
-        // the caller of this function is ran single threaded: it's in the region's worker loop.
+        // the caller of this function is ran single threaded, inside the lock of RegionManifestManager.
         if self.is_doing_checkpoint.load(Ordering::Relaxed) {
             return;
         }

--- a/src/mito2/src/manifest/checkpointer.rs
+++ b/src/mito2/src/manifest/checkpointer.rs
@@ -1,0 +1,150 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use common_telemetry::{error, info};
+use store_api::manifest::{ManifestVersion, MIN_VERSION};
+use store_api::storage::RegionId;
+
+use crate::manifest::action::{RegionCheckpoint, RegionManifest};
+use crate::manifest::manager::RegionManifestOptions;
+use crate::manifest::storage::ManifestObjectStore;
+use crate::metrics::MANIFEST_OP_ELAPSED;
+
+/// [`Checkpointer`] is responsible for doing checkpoint for a region, in an asynchronous way.
+#[derive(Debug)]
+pub(crate) struct Checkpointer {
+    region_id: RegionId,
+    manifest_options: RegionManifestOptions,
+    manifest_store: Arc<ManifestObjectStore>,
+    last_checkpoint_version: Arc<AtomicU64>,
+    is_doing_checkpoint: Arc<AtomicBool>,
+}
+
+impl Checkpointer {
+    pub(crate) fn new(
+        region_id: RegionId,
+        manifest_options: RegionManifestOptions,
+        manifest_store: Arc<ManifestObjectStore>,
+        last_checkpoint_version: ManifestVersion,
+    ) -> Self {
+        Self {
+            region_id,
+            manifest_options,
+            manifest_store,
+            last_checkpoint_version: Arc::new(AtomicU64::new(last_checkpoint_version)),
+            is_doing_checkpoint: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub(crate) fn last_checkpoint_version(&self) -> ManifestVersion {
+        self.last_checkpoint_version.load(Ordering::Relaxed)
+    }
+
+    /// Check if it's needed to do checkpoint for the region by the checkpoint distance.
+    /// If needed, and there's no currently running checkpoint task, it will start a new checkpoint
+    /// task running in the background.
+    pub(crate) fn maybe_do_checkpoint(&self, manifest: &RegionManifest) {
+        if self.manifest_options.checkpoint_distance == 0 {
+            return;
+        }
+
+        let last_checkpoint_version = self.last_checkpoint_version();
+        if manifest.manifest_version - last_checkpoint_version
+            < self.manifest_options.checkpoint_distance
+        {
+            return;
+        }
+
+        // We can simply check whether there's a running checkpoint task like this, all because of
+        // the caller of this function is ran single threaded: it's in the region's worker loop.
+        if self.is_doing_checkpoint.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let start_version = if last_checkpoint_version == 0 {
+            // Checkpoint version can't be zero by implementation.
+            // So last checkpoint version is zero means no last checkpoint.
+            MIN_VERSION
+        } else {
+            last_checkpoint_version + 1
+        };
+        let end_version = manifest.manifest_version;
+        info!(
+            "Start doing checkpoint for region {}, compacted version: [{}, {}]",
+            self.region_id, start_version, end_version,
+        );
+
+        let checkpoint = RegionCheckpoint {
+            last_version: end_version,
+            compacted_actions: (end_version - start_version + 1) as usize,
+            checkpoint: Some(manifest.clone()),
+        };
+        self.do_checkpoint(checkpoint);
+    }
+
+    fn do_checkpoint(&self, checkpoint: RegionCheckpoint) {
+        let is_doing_checkpoint = self.is_doing_checkpoint.clone();
+        is_doing_checkpoint.store(true, Ordering::Relaxed);
+        let guard = scopeguard::guard(is_doing_checkpoint, |x| {
+            x.store(false, Ordering::Relaxed);
+        });
+
+        let manifest_store = self.manifest_store.clone();
+        let region_id = self.region_id;
+        let last_checkpoint_version = self.last_checkpoint_version.clone();
+        common_runtime::spawn_bg(async move {
+            let _guard = guard;
+
+            let _t = MANIFEST_OP_ELAPSED
+                .with_label_values(&["checkpoint"])
+                .start_timer();
+
+            let version = checkpoint.last_version();
+
+            let checkpoint = match checkpoint.encode() {
+                Ok(checkpoint) => checkpoint,
+                Err(e) => {
+                    error!(e; "Failed to encode checkpoint {:?}", checkpoint);
+                    return;
+                }
+            };
+
+            if let Err(e) = manifest_store.save_checkpoint(version, &checkpoint).await {
+                error!(e; "Failed to save checkpoint for region {}", region_id);
+                return;
+            }
+
+            if let Err(e) = manifest_store.delete_until(version, true).await {
+                error!(e; "Failed to delete manifest actions until version {} for region {}", version, region_id);
+                return;
+            }
+
+            last_checkpoint_version.store(version, Ordering::Relaxed);
+
+            info!(
+                "Checkpoint for region {} success, version: {}",
+                region_id, version
+            );
+        });
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_doing_checkpoint(&self) -> bool {
+        self.is_doing_checkpoint.load(Ordering::Relaxed)
+    }
+}

--- a/src/mito2/src/manifest/manager.rs
+++ b/src/mito2/src/manifest/manager.rs
@@ -161,8 +161,7 @@ impl RegionManifestManager {
             RegionMetaActionList::with_action(RegionMetaAction::Change(RegionChange { metadata }));
         store.save(version, &action_list.encode()?).await?;
 
-        let checkpointer =
-            Checkpointer::new(region_id, options, Arc::new(store.clone()), MIN_VERSION);
+        let checkpointer = Checkpointer::new(region_id, options, store.clone(), MIN_VERSION);
         Ok(Self {
             store,
             last_version: version,
@@ -259,7 +258,7 @@ impl RegionManifestManager {
         let checkpointer = Checkpointer::new(
             manifest.metadata.region_id,
             options,
-            Arc::new(store.clone()),
+            store.clone(),
             last_checkpoint_version,
         );
         Ok(Some(Self {

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -14,6 +14,7 @@
 
 use std::assert_matches::assert_matches;
 use std::sync::Arc;
+use std::time::Duration;
 
 use common_datasource::compression::CompressionType;
 use store_api::storage::RegionId;
@@ -113,6 +114,10 @@ async fn manager_with_checkpoint_distance_1() {
     // apply 10 actions
     for _ in 0..10 {
         manager.update(nop_action()).await.unwrap();
+
+        while manager.checkpointer().is_doing_checkpoint() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     // has checkpoint
@@ -240,6 +245,10 @@ async fn generate_checkpoint_with_compression_types(
 
     for action in actions {
         manager.update(action).await.unwrap();
+
+        while manager.checkpointer().is_doing_checkpoint() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     RegionManifestManager::last_checkpoint(&mut manager.store())

--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -126,9 +126,8 @@ async fn manager_with_checkpoint_distance_1() {
     // check files
     let mut expected = vec![
         "00000000000000000009.checkpoint",
+        "00000000000000000010.checkpoint",
         "00000000000000000010.json",
-        "00000000000000000008.checkpoint",
-        "00000000000000000009.json",
         "_last_checkpoint",
     ];
     expected.sort_unstable();
@@ -148,7 +147,7 @@ async fn manager_with_checkpoint_distance_1() {
         .unwrap();
     let raw_json = std::str::from_utf8(&raw_bytes).unwrap();
     let expected_json =
-        "{\"size\":846,\"version\":9,\"checksum\":1218259706,\"extend_metadata\":{}}";
+        "{\"size\":848,\"version\":10,\"checksum\":4186457347,\"extend_metadata\":{}}";
     assert_eq!(expected_json, raw_json);
 
     // reopen the manager


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Region manifest checkpoint currently requires many object store reads and writes. The checkpoint is performed synchronously in the region manifest update. When the object store is slow, it could easily cause the region manifest update method executes too long. This PR makes the checkpoint ran in the background (performed asynchronously) to solve the problem.

This PR also makes some changes to how the checkpoint is done. Originally the current checkpoint is the last checkpoint merged with all the incremental files. This process has to scan the object store. However, since the checkpoint is actually a snapshot of the current region manifest, which is already present in the memory, stick to the old ways seems unnecessary. So this PR directly use the region manifest snapshot to make current checkpoint, and delete the obsolete incremental files.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
