### PR TITLE
fix: retry on unknown error

### DIFF
--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -192,6 +192,9 @@ impl Error {
             } | Self::RegionServer {
                 code: Code::Unavailable,
                 ..
+            } | Self::RegionServer {
+                code: Code::Unknown,
+                ..
             }
         )
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

It should retry on unknown error (e.g. incurring transport error)
```
2024-06-10T05:01:57.684978Z ERROR LocalManager::submit_root_procedure: common_procedure::local::runner: Failed to execute procedure metasrv-procedure::DropTable-4d04bd3d-3a0f-495c-819d-80b939475fa4, retry: false err=0: Failed to execute procedure due to external error
2024-06-10 13:01:57.685	
1: Failed to operate on datanode: peer-2(greptimedb-datanode-2.greptimedb-datanode.greptimedb:4001), at greptimedb/src/common/meta/src/ddl/utils.rs:33:27
2024-06-10 13:01:57.685	
2: External error, at greptimedb/src/client/src/region.rs:59:31
2024-06-10 13:01:57.685	
3: Failed to request RegionServer greptimedb-datanode-2.greptimedb-datanode.greptimedb:4001, code: Unknown error, at greptimedb/src/client/src/region.rs:193:31
2024-06-10 13:01:57.685	
4: transport error, at greptimedb/src/client/src/error.rs:176:23
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
