### PR TITLE
chore: bump version to v0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arrow",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "catalog",
  "common-error",
@@ -1226,7 +1226,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.3",
- "substrait 0.8.1",
+ "substrait 0.8.2",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arrow",
@@ -1535,7 +1535,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "client"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1565,7 +1565,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.3",
  "substrait 0.17.1",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "auth",
@@ -1651,7 +1651,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "temp-env",
  "tempfile",
@@ -1696,7 +1696,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "common-error",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "bigdecimal",
  "common-error",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "snafu 0.8.3",
  "strum 0.25.0",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "common-base",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "common-error",
  "common-macro",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anymap2",
  "api",
@@ -1995,11 +1995,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.8.1"
+version = "0.8.2"
 
 [[package]]
 name = "common-procedure"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "atty",
  "backtrace",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "client",
  "common-query",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "build-data",
  "schemars",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -3170,7 +3170,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3219,7 +3219,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "tokio",
  "toml 0.8.13",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
  "snafu 0.8.3",
  "store-api",
  "strum 0.25.0",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -3886,7 +3886,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -4768,7 +4768,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5335,7 +5335,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "log-store"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5632,7 +5632,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -6448,7 +6448,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6689,7 +6689,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6734,7 +6734,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "tokio",
  "tokio-util",
@@ -6979,7 +6979,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "auth",
  "common-base",
@@ -7603,7 +7603,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -7809,7 +7809,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "bitflags 2.5.0",
@@ -7920,7 +7920,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -7983,7 +7983,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "tokio",
  "tokio-stream",
@@ -9302,7 +9302,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -9575,7 +9575,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "aide",
  "api",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -9957,7 +9957,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "chrono",
@@ -10013,7 +10013,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "clap 4.5.4",
@@ -10240,7 +10240,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -10407,7 +10407,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10595,7 +10595,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "async-trait",
@@ -10706,7 +10706,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -10740,7 +10740,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -10799,7 +10799,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.8.1",
+ "substrait 0.8.2",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Bump version to v0.8.2

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
