### PR TITLE
feat(flow): support datafusion scalar function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3812,6 +3812,7 @@ dependencies = [
  "api",
  "arrow-schema",
  "async-trait",
+ "bytes",
  "catalog",
  "common-base",
  "common-catalog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,6 +3810,7 @@ name = "flow"
 version = "0.8.1"
 dependencies = [
  "api",
+ "arrow-schema",
  "async-trait",
  "catalog",
  "common-base",
@@ -3825,6 +3826,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-time",
+ "datafusion 38.0.0",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
  "datafusion-physical-expr 38.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "common-time",
  "datafusion-common 38.0.0",
  "datafusion-expr 38.0.0",
+ "datafusion-physical-expr 38.0.0",
  "datatypes",
  "enum-as-inner",
  "enum_dispatch",

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 api.workspace = true
+bytes.workspace = true
 catalog.workspace = true
 common-base.workspace = true
 common-decimal.workspace = true

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -30,6 +30,7 @@ common-function.workspace = true
 common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
+datafusion-physical-expr.workspace = true
 enum-as-inner = "0.6.0"
 greptime-proto.workspace = true
 hydroflow = { git = "https://github.com/GreptimeTeam/hydroflow.git", branch = "main" }

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -30,6 +30,7 @@ common-function.workspace = true
 common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
+datafusion.workspace = true
 datafusion-physical-expr.workspace = true
 enum-as-inner = "0.6.0"
 greptime-proto.workspace = true
@@ -52,6 +53,7 @@ table.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 
+arrow-schema.workspace = true
 [dev-dependencies]
 catalog.workspace = true
 common-catalog.workspace = true

--- a/src/flow/Cargo.toml
+++ b/src/flow/Cargo.toml
@@ -9,32 +9,33 @@ workspace = true
 
 [dependencies]
 api.workspace = true
+arrow-schema.workspace = true
+async-trait.workspace = true
 bytes.workspace = true
 catalog.workspace = true
 common-base.workspace = true
 common-decimal.workspace = true
 common-error.workspace = true
 common-frontend.workspace = true
-common-macro.workspace = true
-common-runtime.workspace = true
-common-telemetry.workspace = true
-common-time.workspace = true
-datafusion-common.workspace = true
-datafusion-expr.workspace = true
-datatypes.workspace = true
-enum_dispatch = "0.3"
-futures = "0.3"
-# This fork is simply for keeping our dependency in our org, and pin the version
-# it is the same with upstream repo
-async-trait.workspace = true
 common-function.workspace = true
+common-macro.workspace = true
 common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
+common-runtime.workspace = true
+common-telemetry.workspace = true
+common-time.workspace = true
 datafusion.workspace = true
+datafusion-common.workspace = true
+datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
+datatypes.workspace = true
 enum-as-inner = "0.6.0"
+enum_dispatch = "0.3"
+futures = "0.3"
 greptime-proto.workspace = true
+# This fork of hydroflow is simply for keeping our dependency in our org, and pin the version
+# otherwise it is the same with upstream repo
 hydroflow = { git = "https://github.com/GreptimeTeam/hydroflow.git", branch = "main" }
 itertools.workspace = true
 minstant = "0.1.7"
@@ -54,7 +55,6 @@ table.workspace = true
 tokio.workspace = true
 tonic.workspace = true
 
-arrow-schema.workspace = true
 [dev-dependencies]
 catalog.workspace = true
 common-catalog.workspace = true

--- a/src/flow/src/adapter.rs
+++ b/src/flow/src/adapter.rs
@@ -64,12 +64,12 @@ mod table_source;
 
 use error::Error;
 
-// TODO: replace this with `GREPTIME_TIMESTAMP` before v0.9
+// TODO(discord9): replace this with `GREPTIME_TIMESTAMP` before v0.9
 pub const AUTO_CREATED_PLACEHOLDER_TS_COL: &str = "__ts_placeholder";
 
 pub const UPDATE_AT_TS_COL: &str = "update_at";
 
-// TODO: refactor common types for flow to a separate module
+// TODO(discord9): refactor common types for flow to a separate module
 /// FlowId is a unique identifier for a flow task
 pub type FlowId = u64;
 pub type TableName = [String; 3];

--- a/src/flow/src/adapter/node_context.rs
+++ b/src/flow/src/adapter/node_context.rs
@@ -79,7 +79,6 @@ impl Default for SourceSender {
     }
 }
 
-// TODO: make all send operation immut
 impl SourceSender {
     pub fn get_receiver(&self) -> broadcast::Receiver<DiffRow> {
         self.sender.subscribe()

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -27,4 +27,4 @@ pub(crate) use func::{BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc}
 pub(crate) use id::{GlobalId, Id, LocalId};
 pub(crate) use linear::{MapFilterProject, MfpPlan, SafeMfpPlan};
 pub(crate) use relation::{AggregateExpr, AggregateFunc};
-pub(crate) use scalar::{ScalarExpr, TypedExpr};
+pub(crate) use scalar::{DfScalarFunction, RawDfScalarFn, ScalarExpr, TypedExpr};

--- a/src/flow/src/expr/error.rs
+++ b/src/flow/src/expr/error.rs
@@ -16,12 +16,15 @@
 
 use std::any::Any;
 
+use arrow_schema::ArrowError;
+use common_error::ext::BoxedError;
 use common_macro::stack_trace_debug;
 use common_telemetry::common_error::ext::ErrorExt;
 use common_telemetry::common_error::status_code::StatusCode;
+use datafusion_common::DataFusionError;
 use datatypes::data_type::ConcreteDataType;
 use serde::{Deserialize, Serialize};
-use snafu::{Location, Snafu};
+use snafu::{Location, ResultExt, Snafu};
 
 fn is_send_sync() {
     fn check<T: Send + Sync>() {}
@@ -106,5 +109,28 @@ pub enum EvalError {
         expired_by: i64,
         #[snafu(implicit)]
         location: Location,
+    },
+
+    #[snafu(display("Arrow error: {raw:?}, context: {context}"))]
+    Arrow {
+        raw: ArrowError,
+        context: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("DataFusion error: {raw:?}, context: {context}"))]
+    Datafusion {
+        raw: DataFusionError,
+        context: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("External error"))]
+    External {
+        #[snafu(implicit)]
+        location: Location,
+        source: BoxedError,
     },
 }

--- a/src/flow/src/expr/func.rs
+++ b/src/flow/src/expr/func.rs
@@ -814,7 +814,7 @@ impl VariadicFunc {
         name: &str,
         arg_types: &[Option<ConcreteDataType>],
     ) -> Result<Self, Error> {
-        // TODO: future variadic funcs to be added might need to check arg_types
+        // TODO(discord9): future variadic funcs to be added might need to check arg_types
         let _ = arg_types;
         match name {
             "and" => Ok(Self::And),

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -15,7 +15,9 @@
 //! Scalar expressions.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
+use datafusion_physical_expr::PhysicalExpr;
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::Value;
 use serde::{Deserialize, Serialize};
@@ -149,6 +151,38 @@ pub enum ScalarExpr {
         then: Box<ScalarExpr>,
         els: Box<ScalarExpr>,
     },
+}
+
+/// a way to represent a scalar function that is implemented in Data Fusion
+#[derive(Debug, Clone)]
+pub struct CallDfScalarFunction {
+    fn_name: String,
+    // TODO(discord9): directly from datafusion expr
+    fn_impl: Arc<dyn PhysicalExpr>,
+}
+
+impl std::cmp::PartialEq for CallDfScalarFunction {
+    fn eq(&self, other: &Self) -> bool {
+        self.fn_name.eq(&other.fn_name)
+    }
+}
+
+impl std::cmp::Eq for CallDfScalarFunction {}
+
+impl std::cmp::PartialOrd for CallDfScalarFunction {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl std::cmp::Ord for CallDfScalarFunction {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.fn_name.cmp(&other.fn_name)
+    }
+}
+impl std::hash::Hash for CallDfScalarFunction {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.fn_name.hash(state);
+    }
 }
 
 impl ScalarExpr {

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -157,27 +157,32 @@ pub enum ScalarExpr {
 
 /// a way to represent a scalar function that is implemented in Data Fusion
 #[derive(Debug, Clone, Serialize)]
-pub struct CallDfScalarFunction {
+pub struct DfScalarFunction {
     raw_fn: RawDfScalarFn,
     // TODO(discord9): directly from datafusion expr
     #[serde(skip)]
     fn_impl: Arc<dyn PhysicalExpr>,
 }
 
-impl CallDfScalarFunction {
+impl DfScalarFunction {
     pub fn new(raw_fn: RawDfScalarFn, fn_impl: Arc<dyn PhysicalExpr>) -> Result<Self, Error> {
         Ok(Self { raw_fn, fn_impl })
     }
+
+    pub fn eval(&self, values: &[Value]) -> Result<Value, EvalError> {
+        // TODO(discord9): make cols all array length of one
+        todo!()
+    }
 }
 
-impl<'de> serde::de::Deserialize<'de> for CallDfScalarFunction {
+impl<'de> serde::de::Deserialize<'de> for DfScalarFunction {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
         let raw_fn = RawDfScalarFn::deserialize(deserializer)?;
         let fn_impl = raw_fn.get_fn_impl().map_err(serde::de::Error::custom)?;
-        CallDfScalarFunction::new(raw_fn, fn_impl).map_err(serde::de::Error::custom)
+        DfScalarFunction::new(raw_fn, fn_impl).map_err(serde::de::Error::custom)
     }
 }
 
@@ -201,25 +206,25 @@ impl RawDfScalarFn {
     }
 }
 
-impl std::cmp::PartialEq for CallDfScalarFunction {
+impl std::cmp::PartialEq for DfScalarFunction {
     fn eq(&self, other: &Self) -> bool {
         self.raw_fn.eq(&other.raw_fn)
     }
 }
 
-impl std::cmp::Eq for CallDfScalarFunction {}
+impl std::cmp::Eq for DfScalarFunction {}
 
-impl std::cmp::PartialOrd for CallDfScalarFunction {
+impl std::cmp::PartialOrd for DfScalarFunction {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
-impl std::cmp::Ord for CallDfScalarFunction {
+impl std::cmp::Ord for DfScalarFunction {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.raw_fn.cmp(&other.raw_fn)
     }
 }
-impl std::hash::Hash for CallDfScalarFunction {
+impl std::hash::Hash for DfScalarFunction {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.raw_fn.hash(state);
     }

--- a/src/flow/src/repr/relation.rs
+++ b/src/flow/src/repr/relation.rs
@@ -364,7 +364,7 @@ impl RelationDesc {
 
     /// apply mfp, and also project col names for the projected columns
     pub fn apply_mfp(&self, mfp: &SafeMfpPlan) -> Result<Self> {
-        // TODO: find a way to deduce name at best effect
+        // TODO(discord9): find a way to deduce name at best effect
         let names = {
             let mfp = &mfp.mfp;
             let mut names = self.names.clone();

--- a/src/flow/src/transform.rs
+++ b/src/flow/src/transform.rs
@@ -79,9 +79,9 @@ pub struct FunctionExtensions {
 }
 
 impl FunctionExtensions {
-    pub fn from_iter(inner: impl IntoIterator<Item = (u32, String)>) -> Self {
+    pub fn from_iter(inner: impl IntoIterator<Item = (u32, impl ToString)>) -> Self {
         Self {
-            anchor_to_name: inner.into_iter().collect(),
+            anchor_to_name: inner.into_iter().map(|(k, s)| (k, s.to_string())).collect(),
         }
     }
 

--- a/src/flow/src/transform.rs
+++ b/src/flow/src/transform.rs
@@ -71,7 +71,7 @@ mod plan;
 ///
 /// So in substrait plan, a ref to a function can be a single u32 anchor instead of a full name in string
 pub struct FunctionExtensions {
-    anchor_to_name: HashMap<u32, String>,
+    pub anchor_to_name: HashMap<u32, String>,
 }
 
 impl FunctionExtensions {
@@ -95,6 +95,10 @@ impl FunctionExtensions {
     /// Get the name of a function by it's anchor
     pub fn get(&self, anchor: &u32) -> Option<&String> {
         self.anchor_to_name.get(anchor)
+    }
+
+    pub fn inner_ref(&self) -> HashMap<u32, &String> {
+        self.anchor_to_name.iter().map(|(k, v)| (*k, v)).collect()
     }
 }
 

--- a/src/flow/src/transform/aggr.rs
+++ b/src/flow/src/transform/aggr.rs
@@ -53,14 +53,14 @@ use crate::expr::{
     TypedExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc,
 };
 use crate::plan::{AccumulablePlan, AggrWithIndex, KeyValPlan, Plan, ReducePlan, TypedPlan};
-use crate::repr::{self, ColumnType, RelationType};
+use crate::repr::{self, ColumnType, RelationDesc, RelationType};
 use crate::transform::{substrait_proto, FlownodeContext, FunctionExtensions};
 
 impl TypedExpr {
     fn from_substrait_agg_grouping(
         ctx: &mut FlownodeContext,
         groupings: &[Grouping],
-        typ: &RelationType,
+        typ: &RelationDesc,
         extensions: &FunctionExtensions,
     ) -> Result<Vec<TypedExpr>, Error> {
         let _ = ctx;
@@ -89,7 +89,7 @@ impl AggregateExpr {
     fn from_substrait_agg_measures(
         ctx: &mut FlownodeContext,
         measures: &[Measure],
-        typ: &RelationType,
+        typ: &RelationDesc,
         extensions: &FunctionExtensions,
     ) -> Result<(Vec<AggregateExpr>, MapFilterProject), Error> {
         let _ = ctx;
@@ -143,7 +143,7 @@ impl AggregateExpr {
     /// since aggr functions like `avg` need to be transform to `sum(x)/cast(count(x) as x_type)`
     pub fn from_substrait_agg_func(
         f: &proto::AggregateFunction,
-        input_schema: &RelationType,
+        input_schema: &RelationDesc,
         extensions: &FunctionExtensions,
         filter: &Option<TypedExpr>,
         order_by: &Option<Vec<TypedExpr>>,
@@ -320,7 +320,7 @@ impl TypedPlan {
             let group_exprs = TypedExpr::from_substrait_agg_grouping(
                 ctx,
                 &agg.groupings,
-                &input.schema.typ,
+                &input.schema,
                 extensions,
             )?;
 
@@ -332,7 +332,7 @@ impl TypedPlan {
         let (mut aggr_exprs, post_mfp) = AggregateExpr::from_substrait_agg_measures(
             ctx,
             &agg.measures,
-            &input.schema.typ,
+            &input.schema,
             extensions,
         )?;
 

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -55,6 +55,23 @@ fn typename_to_cdt(name: &str) -> CDT {
 }
 
 impl TypedExpr {
+    pub async fn from_substrait_to_datafusion_scalar_func(
+        f: &ScalarFunction,
+        input_schema: &RelationType,
+        extensions: &FunctionExtensions,
+    ) -> Result<TypedExpr, Error> {
+        let e = Expression {
+            rex_type: Some(RexType::ScalarFunction(f.clone())),
+        };
+        /*substrait::df_logical_plan::consumer::from_substrait_rex(
+            &datafusion::prelude::SessionContext::new(),
+            &e,
+            input_schema,
+            &extensions.inner_ref(),
+        )
+        .await;*/
+        todo!()
+    }
     /// Convert ScalarFunction into Flow's ScalarExpr
     pub fn from_substrait_scalar_func(
         f: &ScalarFunction,

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -29,7 +29,7 @@ use crate::adapter::error::{
 use crate::expr::{
     BinaryFunc, ScalarExpr, TypedExpr, UnaryFunc, UnmaterializableFunc, VariadicFunc,
 };
-use crate::repr::{ColumnType, RelationType};
+use crate::repr::{ColumnType, RelationDesc, RelationType};
 use crate::transform::literal::{from_substrait_literal, from_substrait_type};
 use crate::transform::{substrait_proto, FunctionExtensions};
 // TODO: found proper place for this
@@ -75,7 +75,7 @@ impl TypedExpr {
     /// Convert ScalarFunction into Flow's ScalarExpr
     pub fn from_substrait_scalar_func(
         f: &ScalarFunction,
-        input_schema: &RelationType,
+        input_schema: &RelationDesc,
         extensions: &FunctionExtensions,
     ) -> Result<TypedExpr, Error> {
         let fn_name =
@@ -208,7 +208,7 @@ impl TypedExpr {
     /// Convert IfThen into Flow's ScalarExpr
     pub fn from_substrait_ifthen_rex(
         if_then: &IfThen,
-        input_schema: &RelationType,
+        input_schema: &RelationDesc,
         extensions: &FunctionExtensions,
     ) -> Result<TypedExpr, Error> {
         let ifs: Vec<_> = if_then
@@ -263,7 +263,7 @@ impl TypedExpr {
     /// Convert Substrait Rex into Flow's ScalarExpr
     pub fn from_substrait_rex(
         e: &Expression,
-        input_schema: &RelationType,
+        input_schema: &RelationDesc,
         extensions: &FunctionExtensions,
     ) -> Result<TypedExpr, Error> {
         match &e.rex_type {
@@ -294,7 +294,7 @@ impl TypedExpr {
                         }
                         None => {
                             let column = x.field as usize;
-                            let column_type = input_schema.column_types[column].clone();
+                            let column_type = input_schema.typ().column_types[column].clone();
                             Ok(TypedExpr::new(ScalarExpr::Column(column), column_type))
                         }
                     },
@@ -601,7 +601,8 @@ mod test {
             output_type: None,
             ..Default::default()
         };
-        let input_schema = RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]);
+        let input_schema =
+            RelationType::new(vec![ColumnType::new(CDT::uint32_datatype(), false)]).into_unnamed();
         let extensions = FunctionExtensions {
             anchor_to_name: HashMap::from([(0, "is_null".to_string())]),
         };
@@ -628,7 +629,8 @@ mod test {
         let input_schema = RelationType::new(vec![
             ColumnType::new(CDT::uint32_datatype(), false),
             ColumnType::new(CDT::uint32_datatype(), false),
-        ]);
+        ])
+        .into_unnamed();
         let extensions = FunctionExtensions {
             anchor_to_name: HashMap::from([(0, "add".to_string())]),
         };
@@ -656,7 +658,8 @@ mod test {
         let input_schema = RelationType::new(vec![
             ColumnType::new(CDT::timestamp_nanosecond_datatype(), false),
             ColumnType::new(CDT::string_datatype(), false),
-        ]);
+        ])
+        .into_unnamed();
         let extensions = FunctionExtensions {
             anchor_to_name: HashMap::from([(0, "tumble".to_string())]),
         };
@@ -685,7 +688,8 @@ mod test {
         let input_schema = RelationType::new(vec![
             ColumnType::new(CDT::timestamp_nanosecond_datatype(), false),
             ColumnType::new(CDT::string_datatype(), false),
-        ]);
+        ])
+        .into_unnamed();
         let extensions = FunctionExtensions {
             anchor_to_name: HashMap::from([(0, "tumble".to_string())]),
         };

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -58,7 +58,7 @@ fn typename_to_cdt(name: &str) -> CDT {
     }
 }
 
-/// Convert ScalarFunction to corrseponding Datafusion's PhysicalExpr
+/// Convert ScalarFunction to corresponding Datafusion's PhysicalExpr
 pub(crate) fn from_scalar_fn_to_df_fn_impl(
     f: &ScalarFunction,
     input_schema: &RelationDesc,

--- a/src/flow/src/transform/expr.rs
+++ b/src/flow/src/transform/expr.rs
@@ -374,8 +374,6 @@ impl TypedExpr {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use common_time::{DateTime, Interval};
     use datatypes::prelude::ConcreteDataType;
     use datatypes::value::Value;

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -80,7 +80,7 @@ impl TypedPlan {
 
                 let mut exprs: Vec<TypedExpr> = vec![];
                 for e in &p.expressions {
-                    let expr = TypedExpr::from_substrait_rex(e, &input.schema.typ, extensions)?;
+                    let expr = TypedExpr::from_substrait_rex(e, &input.schema, extensions)?;
                     exprs.push(expr);
                 }
                 let is_literal = exprs.iter().all(|expr| expr.expr.is_literal());
@@ -133,7 +133,7 @@ impl TypedPlan {
                 };
 
                 let expr = if let Some(condition) = filter.condition.as_ref() {
-                    TypedExpr::from_substrait_rex(condition, &input.schema.typ, extensions)?
+                    TypedExpr::from_substrait_rex(condition, &input.schema, extensions)?
                 } else {
                     return not_impl_err!("Filter without an condition is not valid");
                 };

--- a/src/flow/src/transform/plan.rs
+++ b/src/flow/src/transform/plan.rs
@@ -64,7 +64,7 @@ impl TypedPlan {
     }
 
     /// Convert Substrait Rel into Flow's TypedPlan
-    /// TODO: SELECT DISTINCT(does it get compile with something else?)
+    /// TODO(discord9): SELECT DISTINCT(does it get compile with something else?)
     pub fn from_substrait_rel(
         ctx: &mut FlownodeContext,
         rel: &Rel,
@@ -213,7 +213,7 @@ fn rewrite_projection_after_reduce(
     reduce_output_type: &RelationDesc,
     proj_exprs: &mut Vec<TypedExpr>,
 ) -> Result<(), Error> {
-    // TODO: get keys correctly
+    // TODO(discord9): get keys correctly
     let key_exprs = key_val_plan
         .key_plan
         .projection

--- a/src/flow/src/utils.rs
+++ b/src/flow/src/utils.rs
@@ -177,7 +177,7 @@ pub struct Arrangement {
     ///
     /// Since updates typically occur as a delete followed by an insert, a small vector of size 2 is used to store updates for efficiency.
     ///
-    /// TODO: Consider balancing the batch size?
+    /// TODO(discord9): Consider balancing the batch size?
     spine: Spine,
 
     /// Indicates whether the arrangement maintains a complete history of updates.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

support datafusion scalar function

Please explain IN DETAIL what the changes are in this PR and why they are needed:

support datafusion scalar function by let datafusion decode substrait proto, and hence build df `PhysicalExpr` to evaluate function

- added `DfScalarFunction` which hold both impl of that scalar function and necessary data to ser/de it
- added path in transform module to translate scalar function to df scalar function when no other functions are available

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
