### PR TITLE
fix(ci): use `ld_classic` on macOS

### DIFF
--- a/.github/actions/build-macos-artifacts/action.yml
+++ b/.github/actions/build-macos-artifacts/action.yml
@@ -59,9 +59,15 @@ runs:
       if: ${{ inputs.disable-run-tests == 'false' }}
       uses: taiki-e/install-action@nextest
 
+    # Get proper backtraces in mac Sonoma. Currently there's an issue with the new
+    # linker that prevents backtraces from getting printed correctly.
+    #
+    # <https://github.com/rust-lang/rust/issues/113783> 
     - name: Run integration tests
       if: ${{ inputs.disable-run-tests == 'false' }}
       shell: bash
+      env: 
+        CARGO_BUILD_RUSTFLAGS: "-Clink-arg=-Wl,-ld_classic"
       run: |
         make test sqlness-test
 
@@ -75,6 +81,8 @@ runs:
 
     - name: Build greptime binary
       shell: bash
+      env: 
+        CARGO_BUILD_RUSTFLAGS: "-Clink-arg=-Wl,-ld_classic"
       run: |
         make build \
         CARGO_PROFILE=${{ inputs.cargo-profile }} \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/rust-lang/rust/issues/113783

## What's changed and what's your intention?

The PR use `ld_classic` on macOS when releasing macOS artifact.

The latest macOS CI runner image(https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240611.1), its default linker can't get the backtraces properly, which will lead release failed.

```
thread 'selector::weighted_choose::tests::test_random_reverse_weighted_choose_should_panic' panicked at src/meta-srv/src/selector/weighted_choose.rs:173:41:
called `Result::unwrap()` on an `Err` value: 0: Failed to set weight array, at src/meta-srv/src/selector/weighted_choose.rs:87:18
1: NoItem
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
