### PR TITLE
fix(sqlness): catch different format timestamp

### DIFF
--- a/tests/cases/distributed/information_schema/cluster_info.result
+++ b/tests/cases/distributed/information_schema/cluster_info.result
@@ -20,7 +20,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
@@ -30,7 +30,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
@@ -40,7 +40,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
@@ -50,7 +50,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
@@ -60,7 +60,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;

--- a/tests/cases/distributed/information_schema/cluster_info.sql
+++ b/tests/cases/distributed/information_schema/cluster_info.sql
@@ -5,7 +5,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
@@ -21,7 +21,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
@@ -29,7 +29,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
@@ -37,7 +37,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #4148

## What's changed and what's your intention?

This PR tries to catch different format timestamps in the sqlness case(introduced in #3832); The format of output timestamps may behave inconsistently on different platforms. (e.g., `20240615T04:24:18`, `2024-04-30T06:40:02.074`)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
