### PR TITLE
feat: Implement memtable range

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -297,18 +297,18 @@ pub trait IterBuilder: Send + Sync {
 pub type BoxedIterBuilder = Box<dyn IterBuilder>;
 
 /// Context shared by ranges of the same memtable.
-pub(crate) struct MemRangeContext {
+pub struct MemRangeContext {
     /// Id of the memtable.
     id: MemtableId,
     /// Iterator builder.
     builder: BoxedIterBuilder,
 }
 
-pub(crate) type MemRangeContextRef = Arc<MemRangeContext>;
+pub type MemRangeContextRef = Arc<MemRangeContext>;
 
 impl MemRangeContext {
     /// Creates a new [MemRangeContext].
-    pub(crate) fn new(id: MemtableId, builder: BoxedIterBuilder) -> Self {
+    pub fn new(id: MemtableId, builder: BoxedIterBuilder) -> Self {
         Self { id, builder }
     }
 }
@@ -323,17 +323,17 @@ pub struct MemRange {
 
 impl MemRange {
     /// Creates a new range from context.
-    pub(crate) fn new(context: MemRangeContextRef) -> Self {
+    pub fn new(context: MemRangeContextRef) -> Self {
         Self { context }
     }
 
     /// Returns the id of the memtable to read.
-    pub(crate) fn id(&self) -> MemtableId {
+    pub fn id(&self) -> MemtableId {
         self.context.id
     }
 
     /// Builds an iterator to read the range.
-    pub(crate) fn build_iter(&self) -> Result<BoxedBatchIterator> {
+    pub fn build_iter(&self) -> Result<BoxedBatchIterator> {
         self.context.builder.build()
     }
 }

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -115,12 +115,9 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     /// Returns the ranges in the memtable.
     fn ranges(
         &self,
-        _projection: Option<&[ColumnId]>,
-        _predicate: Option<Predicate>,
-    ) -> Vec<MemRange> {
-        // FIXME(yingwen): remove the default implementaton.
-        todo!()
-    }
+        projection: Option<&[ColumnId]>,
+        predicate: Option<Predicate>,
+    ) -> Vec<MemRange>;
 
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -110,8 +110,6 @@ pub trait Memtable: Send + Sync + fmt::Debug {
         predicate: Option<Predicate>,
     ) -> Result<BoxedBatchIterator>;
 
-    // TODO(yingwen): Shared the predicate by Arc.
-    // TODO(yingwen): Should we pass Vec as argument?
     /// Returns the ranges in the memtable.
     fn ranges(
         &self,

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -115,7 +115,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemRange>;
+    ) -> Vec<MemtableRange>;
 
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;
@@ -295,17 +295,17 @@ pub trait IterBuilder: Send + Sync {
 pub type BoxedIterBuilder = Box<dyn IterBuilder>;
 
 /// Context shared by ranges of the same memtable.
-pub struct MemRangeContext {
+pub struct MemtableRangeContext {
     /// Id of the memtable.
     id: MemtableId,
     /// Iterator builder.
     builder: BoxedIterBuilder,
 }
 
-pub type MemRangeContextRef = Arc<MemRangeContext>;
+pub type MemtableRangeContextRef = Arc<MemtableRangeContext>;
 
-impl MemRangeContext {
-    /// Creates a new [MemRangeContext].
+impl MemtableRangeContext {
+    /// Creates a new [MemtableRangeContext].
     pub fn new(id: MemtableId, builder: BoxedIterBuilder) -> Self {
         Self { id, builder }
     }
@@ -313,15 +313,15 @@ impl MemRangeContext {
 
 /// A range in the memtable.
 #[derive(Clone)]
-pub struct MemRange {
+pub struct MemtableRange {
     /// Shared context.
-    context: MemRangeContextRef,
+    context: MemtableRangeContextRef,
     // TODO(yingwen): Id to identify the range in the memtable.
 }
 
-impl MemRange {
+impl MemtableRange {
     /// Creates a new range from context.
-    pub fn new(context: MemRangeContextRef) -> Self {
+    pub fn new(context: MemtableRangeContextRef) -> Self {
         Self { context }
     }
 

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -40,8 +40,8 @@ use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::tree::PartitionTree;
 use crate::memtable::{
-    AllocTracker, BoxedBatchIterator, KeyValues, Memtable, MemtableBuilder, MemtableId,
-    MemtableRef, MemtableStats,
+    AllocTracker, BoxedBatchIterator, IterBuilder, KeyValues, MemRange, MemRangeContext, Memtable,
+    MemtableBuilder, MemtableId, MemtableRef, MemtableStats,
 };
 
 /// Use `1/DICTIONARY_SIZE_FACTOR` of OS memory as dictionary size.
@@ -105,7 +105,7 @@ impl Default for PartitionTreeConfig {
 /// Memtable based on a partition tree.
 pub struct PartitionTreeMemtable {
     id: MemtableId,
-    tree: PartitionTree,
+    tree: Arc<PartitionTree>,
     alloc_tracker: AllocTracker,
     max_timestamp: AtomicI64,
     min_timestamp: AtomicI64,
@@ -154,6 +154,22 @@ impl Memtable for PartitionTreeMemtable {
         predicate: Option<Predicate>,
     ) -> Result<BoxedBatchIterator> {
         self.tree.read(projection, predicate)
+    }
+
+    fn ranges(
+        &self,
+        projection: Option<&[ColumnId]>,
+        predicate: Option<Predicate>,
+    ) -> Vec<MemRange> {
+        let projection = projection.map(|ids| ids.to_vec());
+        let builder = Box::new(PartitionTreeIterBuilder {
+            tree: self.tree.clone(),
+            projection,
+            predicate,
+        });
+        let context = Arc::new(MemRangeContext::new(self.id, builder));
+
+        vec![MemRange::new(context)]
     }
 
     fn is_empty(&self) -> bool {
@@ -224,7 +240,7 @@ impl PartitionTreeMemtable {
 
         Self {
             id,
-            tree,
+            tree: Arc::new(tree),
             alloc_tracker,
             max_timestamp: AtomicI64::new(i64::MIN),
             min_timestamp: AtomicI64::new(i64::MAX),
@@ -306,6 +322,19 @@ impl MemtableBuilder for PartitionTreeMemtableBuilder {
             self.write_buffer_manager.clone(),
             &self.config,
         ))
+    }
+}
+
+struct PartitionTreeIterBuilder {
+    tree: Arc<PartitionTree>,
+    projection: Option<Vec<ColumnId>>,
+    predicate: Option<Predicate>,
+}
+
+impl IterBuilder for PartitionTreeIterBuilder {
+    fn build(&self) -> Result<BoxedBatchIterator> {
+        self.tree
+            .read(self.projection.as_deref(), self.predicate.clone())
     }
 }
 

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -40,8 +40,8 @@ use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::metrics::WriteMetrics;
 use crate::memtable::partition_tree::tree::PartitionTree;
 use crate::memtable::{
-    AllocTracker, BoxedBatchIterator, IterBuilder, KeyValues, MemRange, MemRangeContext, Memtable,
-    MemtableBuilder, MemtableId, MemtableRef, MemtableStats,
+    AllocTracker, BoxedBatchIterator, IterBuilder, KeyValues, Memtable, MemtableBuilder,
+    MemtableId, MemtableRange, MemtableRangeContext, MemtableRef, MemtableStats,
 };
 
 /// Use `1/DICTIONARY_SIZE_FACTOR` of OS memory as dictionary size.
@@ -160,16 +160,16 @@ impl Memtable for PartitionTreeMemtable {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemRange> {
+    ) -> Vec<MemtableRange> {
         let projection = projection.map(|ids| ids.to_vec());
         let builder = Box::new(PartitionTreeIterBuilder {
             tree: self.tree.clone(),
             projection,
             predicate,
         });
-        let context = Arc::new(MemRangeContext::new(self.id, builder));
+        let context = Arc::new(MemtableRangeContext::new(self.id, builder));
 
-        vec![MemRange::new(context)]
+        vec![MemtableRange::new(context)]
     }
 
     fn is_empty(&self) -> bool {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -40,8 +40,8 @@ use crate::error::{ComputeArrowSnafu, ConvertVectorSnafu, PrimaryKeyLengthMismat
 use crate::flush::WriteBufferManagerRef;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::{
-    AllocTracker, BoxedBatchIterator, IterBuilder, KeyValues, MemRange, MemRangeContext, Memtable,
-    MemtableBuilder, MemtableId, MemtableRef, MemtableStats,
+    AllocTracker, BoxedBatchIterator, IterBuilder, KeyValues, Memtable, MemtableBuilder,
+    MemtableId, MemtableRange, MemtableRangeContext, MemtableRef, MemtableStats,
 };
 use crate::metrics::{READ_ROWS_TOTAL, READ_STAGE_ELAPSED};
 use crate::read::{Batch, BatchBuilder, BatchColumn};
@@ -248,7 +248,7 @@ impl Memtable for TimeSeriesMemtable {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemRange> {
+    ) -> Vec<MemtableRange> {
         let projection = if let Some(projection) = projection {
             projection.iter().copied().collect()
         } else {
@@ -263,9 +263,9 @@ impl Memtable for TimeSeriesMemtable {
             predicate,
             dedup: self.dedup,
         });
-        let context = Arc::new(MemRangeContext::new(self.id, builder));
+        let context = Arc::new(MemtableRangeContext::new(self.id, builder));
 
-        vec![MemRange::new(context)]
+        vec![MemtableRange::new(context)]
     }
 
     fn is_empty(&self) -> bool {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -35,7 +35,7 @@ use crate::access_layer::AccessLayerRef;
 use crate::cache::file_cache::FileCacheRef;
 use crate::cache::CacheManagerRef;
 use crate::error::Result;
-use crate::memtable::MemtableRef;
+use crate::memtable::{MemRange, MemtableRef};
 use crate::metrics::READ_SST_COUNT;
 use crate::read::compat::{self, CompatBatch};
 use crate::read::projection::ProjectionMapper;
@@ -632,8 +632,7 @@ pub(crate) type FileRangesGroup = SmallVec<[Vec<FileRange>; 4]>;
 #[derive(Default)]
 pub(crate) struct ScanPart {
     /// Memtables to scan.
-    /// We scan the whole memtable now. We might scan a range of the memtable in the future.
-    pub(crate) memtables: Vec<MemtableRef>,
+    pub(crate) mem_ranges: Vec<MemRange>,
     /// File ranges to scan.
     pub(crate) file_ranges: FileRangesGroup,
     /// Optional time range of the part (inclusive).
@@ -644,8 +643,8 @@ impl fmt::Debug for ScanPart {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "ScanPart({} memtables, {} file ranges",
-            self.memtables.len(),
+            "ScanPart({} mem ranges, {} file ranges",
+            self.mem_ranges.len(),
             self.file_ranges
                 .iter()
                 .map(|ranges| ranges.len())
@@ -671,7 +670,7 @@ impl ScanPart {
 
     /// Merges given `part` to this part.
     pub(crate) fn merge(&mut self, mut part: ScanPart) {
-        self.memtables.append(&mut part.memtables);
+        self.mem_ranges.append(&mut part.mem_ranges);
         self.file_ranges.append(&mut part.file_ranges);
         let Some(part_range) = part.time_range else {
             return;
@@ -688,7 +687,7 @@ impl ScanPart {
     /// Returns true if the we can split the part into multiple parts
     /// and preserving order.
     pub(crate) fn can_split_preserve_order(&self) -> bool {
-        self.memtables.is_empty() && self.file_ranges.len() == 1 && self.file_ranges[0].len() > 1
+        self.mem_ranges.is_empty() && self.file_ranges.len() == 1 && self.file_ranges[0].len() > 1
     }
 }
 
@@ -739,10 +738,10 @@ impl ScanPartList {
         self.0.as_ref().map_or(0, |parts| parts.len())
     }
 
-    /// Returns the number of memtables.
-    pub(crate) fn num_memtables(&self) -> usize {
+    /// Returns the number of mem ranges.
+    pub(crate) fn num_mem_ranges(&self) -> usize {
         self.0.as_ref().map_or(0, |parts| {
-            parts.iter().map(|part| part.memtables.len()).sum()
+            parts.iter().map(|part| part.mem_ranges.len()).sum()
         })
     }
 
@@ -792,9 +791,9 @@ impl StreamContext {
             Ok(inner) => match t {
                 DisplayFormatType::Default => write!(
                     f,
-                    "partition_count={} ({} memtables, {} file ranges)",
+                    "partition_count={} ({} mem ranges, {} file ranges)",
                     inner.len(),
-                    inner.num_memtables(),
+                    inner.num_mem_ranges(),
                     inner.num_file_ranges()
                 ),
                 DisplayFormatType::Verbose => write!(f, "{:?}", &*inner),

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -358,6 +358,9 @@ impl SeqDistributor {
         for mem in memtables {
             let stats = mem.stats();
             let mem_ranges = mem.ranges(projection, predicate.clone());
+            if mem_ranges.is_empty() {
+                continue;
+            }
             let part = ScanPart {
                 mem_ranges,
                 file_ranges: smallvec![],

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -29,10 +29,12 @@ use futures::StreamExt;
 use smallvec::smallvec;
 use snafu::ResultExt;
 use store_api::region_engine::{RegionScanner, ScannerPartitioning, ScannerProperties};
+use store_api::storage::ColumnId;
+use table::predicate::Predicate;
 
 use crate::cache::CacheManager;
 use crate::error::Result;
-use crate::memtable::MemtableRef;
+use crate::memtable::{MemRange, MemtableRef};
 use crate::read::compat::CompatBatch;
 use crate::read::projection::ProjectionMapper;
 use crate::read::scan_region::{
@@ -151,13 +153,10 @@ impl RegionScanner for UnorderedScan {
 
             let mapper = &stream_ctx.input.mapper;
             let memtable_sources = part
-                .memtables
+                .mem_ranges
                 .iter()
                 .map(|mem| {
-                    let iter = mem.iter(
-                        Some(mapper.column_ids()),
-                        stream_ctx.input.predicate.clone(),
-                    )?;
+                    let iter = mem.build_iter()?;
                     Ok(Source::Iter(iter))
                 })
                 .collect::<Result<Vec<_>>>()
@@ -240,8 +239,12 @@ async fn maybe_init_parts(
         let now = Instant::now();
         let mut distributor = UnorderedDistributor::default();
         input.prune_file_ranges(&mut distributor).await?;
-        part_list
-            .set_parts(distributor.build_parts(&input.memtables, input.parallelism.parallelism));
+        distributor.append_mem_ranges(
+            &input.memtables,
+            Some(input.mapper.column_ids()),
+            input.predicate.clone(),
+        );
+        part_list.set_parts(distributor.build_parts(input.parallelism.parallelism));
 
         metrics.observe_init_part(now.elapsed());
     }
@@ -253,6 +256,7 @@ async fn maybe_init_parts(
 /// is no output ordering guarantee of each partition.
 #[derive(Default)]
 struct UnorderedDistributor {
+    mem_ranges: Vec<MemRange>,
     file_ranges: Vec<FileRange>,
 }
 
@@ -267,35 +271,49 @@ impl FileRangeCollector for UnorderedDistributor {
 }
 
 impl UnorderedDistributor {
+    /// Appends memtable ranges to the distributor.
+    fn append_mem_ranges(
+        &mut self,
+        memtables: &[MemtableRef],
+        projection: Option<&[ColumnId]>,
+        predicate: Option<Predicate>,
+    ) {
+        for mem in memtables {
+            let mut mem_ranges = mem.ranges(projection, predicate.clone());
+            self.mem_ranges.append(&mut mem_ranges);
+        }
+    }
+
     /// Distributes file ranges and memtables across partitions according to the `parallelism`.
     /// The output number of parts may be `<= parallelism`.
     ///
     /// [ScanPart] created by this distributor only contains one group of file ranges.
-    fn build_parts(self, memtables: &[MemtableRef], parallelism: usize) -> Vec<ScanPart> {
+    fn build_parts(self, parallelism: usize) -> Vec<ScanPart> {
         if parallelism <= 1 {
             // Returns a single part.
             let part = ScanPart {
-                memtables: memtables.to_vec(),
+                mem_ranges: self.mem_ranges.clone(),
                 file_ranges: smallvec![self.file_ranges],
                 time_range: None,
             };
             return vec![part];
         }
 
-        let mems_per_part = ((memtables.len() + parallelism - 1) / parallelism).max(1);
+        let mems_per_part = ((self.mem_ranges.len() + parallelism - 1) / parallelism).max(1);
         let ranges_per_part = ((self.file_ranges.len() + parallelism - 1) / parallelism).max(1);
         common_telemetry::debug!(
-                "Parallel scan is enabled, parallelism: {}, {} memtables, {} file_ranges, mems_per_part: {}, ranges_per_part: {}",
+                "Parallel scan is enabled, parallelism: {}, {} mem_ranges, {} file_ranges, mems_per_part: {}, ranges_per_part: {}",
                 parallelism,
-                memtables.len(),
+                self.mem_ranges.len(),
                 self.file_ranges.len(),
                 mems_per_part,
                 ranges_per_part
             );
-        let mut scan_parts = memtables
+        let mut scan_parts = self
+            .mem_ranges
             .chunks(mems_per_part)
             .map(|mems| ScanPart {
-                memtables: mems.to_vec(),
+                mem_ranges: mems.to_vec(),
                 file_ranges: smallvec![Vec::new()], // Ensures there is always one group.
                 time_range: None,
             })
@@ -303,7 +321,7 @@ impl UnorderedDistributor {
         for (i, ranges) in self.file_ranges.chunks(ranges_per_part).enumerate() {
             if i == scan_parts.len() {
                 scan_parts.push(ScanPart {
-                    memtables: Vec::new(),
+                    mem_ranges: Vec::new(),
                     file_ranges: smallvec![ranges.to_vec()],
                     time_range: None,
                 });

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -280,6 +280,9 @@ impl UnorderedDistributor {
     ) {
         for mem in memtables {
             let mut mem_ranges = mem.ranges(projection, predicate.clone());
+            if mem_ranges.is_empty() {
+                continue;
+            }
             self.mem_ranges.append(&mut mem_ranges);
         }
     }

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -23,7 +23,7 @@ use crate::sst::file::FileTimeRange;
 use crate::sst::DEFAULT_WRITE_BUFFER_SIZE;
 
 pub(crate) mod file_range;
-mod format;
+pub(crate) mod format;
 pub(crate) mod helper;
 pub(crate) mod metadata;
 mod page_reader;

--- a/src/mito2/src/sst/parquet/file_range.rs
+++ b/src/mito2/src/sst/parquet/file_range.rs
@@ -82,16 +82,10 @@ impl FileRange {
 
 /// Context shared by ranges of the same parquet SST.
 pub(crate) struct FileRangeContext {
-    // Row group reader builder for the file.
+    /// Row group reader builder for the file.
     reader_builder: RowGroupReaderBuilder,
-    /// Filters pushed down.
-    filters: Vec<SimpleFilterContext>,
-    /// Helper to read the SST.
-    read_format: ReadFormat,
-    /// Decoder for primary keys
-    codec: McmpRowCodec,
-    /// Optional helper to compat batches.
-    compat_batch: Option<CompatBatch>,
+    /// Base of the context.
+    base: RangeBase,
 }
 
 pub(crate) type FileRangeContextRef = Arc<FileRangeContext>;
@@ -106,10 +100,12 @@ impl FileRangeContext {
     ) -> Self {
         Self {
             reader_builder,
-            filters,
-            read_format,
-            codec,
-            compat_batch: None,
+            base: RangeBase {
+                filters,
+                read_format,
+                codec,
+                compat_batch: None,
+            },
         }
     }
 
@@ -120,12 +116,12 @@ impl FileRangeContext {
 
     /// Returns filters pushed down.
     pub(crate) fn filters(&self) -> &[SimpleFilterContext] {
-        &self.filters
+        &self.base.filters
     }
 
     /// Returns the format helper.
     pub(crate) fn read_format(&self) -> &ReadFormat {
-        &self.read_format
+        &self.base.read_format
     }
 
     /// Returns the reader builder.
@@ -135,14 +131,34 @@ impl FileRangeContext {
 
     /// Returns the helper to compat batches.
     pub(crate) fn compat_batch(&self) -> Option<&CompatBatch> {
-        self.compat_batch.as_ref()
+        self.base.compat_batch.as_ref()
     }
 
     /// Sets the `CompatBatch` to the context.
     pub(crate) fn set_compat_batch(&mut self, compat: Option<CompatBatch>) {
-        self.compat_batch = compat;
+        self.base.compat_batch = compat;
     }
 
+    /// TRY THE BEST to perform pushed down predicate precisely on the input batch.
+    /// Return the filtered batch. If the entire batch is filtered out, return None.
+    pub(crate) fn precise_filter(&self, input: Batch) -> Result<Option<Batch>> {
+        self.base.precise_filter(input)
+    }
+}
+
+/// Common fields for a range to read and filter batches.
+pub(crate) struct RangeBase {
+    /// Filters pushed down.
+    pub(crate) filters: Vec<SimpleFilterContext>,
+    /// Helper to read the SST.
+    pub(crate) read_format: ReadFormat,
+    /// Decoder for primary keys
+    pub(crate) codec: McmpRowCodec,
+    /// Optional helper to compat batches.
+    pub(crate) compat_batch: Option<CompatBatch>,
+}
+
+impl RangeBase {
     /// TRY THE BEST to perform pushed down predicate precisely on the input batch.
     /// Return the filtered batch. If the entire batch is filtered out, return None.
     ///

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -37,11 +37,10 @@ use crate::memtable::{
     MemtableRange, MemtableRangeContext, MemtableRef, MemtableStats,
 };
 use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
-use crate::sst::parquet::format::ReadFormat;
 
 /// Empty memtable for test.
 #[derive(Debug, Default)]
-pub(crate) struct EmptyMemtable {
+pub struct EmptyMemtable {
     /// Id of this memtable.
     id: MemtableId,
     /// Time range to return.
@@ -50,7 +49,7 @@ pub(crate) struct EmptyMemtable {
 
 impl EmptyMemtable {
     /// Returns a new memtable with specific `id`.
-    pub(crate) fn new(id: MemtableId) -> EmptyMemtable {
+    pub fn new(id: MemtableId) -> EmptyMemtable {
         EmptyMemtable {
             id,
             time_range: None,
@@ -58,10 +57,7 @@ impl EmptyMemtable {
     }
 
     /// Attaches the time range to the memtable.
-    pub(crate) fn with_time_range(
-        mut self,
-        time_range: Option<(Timestamp, Timestamp)>,
-    ) -> EmptyMemtable {
+    pub fn with_time_range(mut self, time_range: Option<(Timestamp, Timestamp)>) -> EmptyMemtable {
         self.time_range = time_range;
         self
     }

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -364,16 +364,7 @@ pub(crate) fn collect_iter_timestamps(iter: BoxedBatchIterator) -> Vec<i64> {
 /// Builds a memtable range for test.
 pub(crate) fn mem_range_for_test(id: MemtableId) -> MemRange {
     let builder = Box::new(EmptyIterBuilder::default());
-    let metadata = metadata_for_test();
-    let read_format = ReadFormat::new(metadata.clone(), 0..5);
-    let codec = McmpRowCodec::new(
-        read_format
-            .metadata()
-            .primary_key_columns()
-            .map(|c| SortField::new(c.column_schema.data_type.clone()))
-            .collect(),
-    );
 
-    let context = MemRangeContext::new(id, builder, vec![], read_format, codec);
-    MemRange::new(Arc::new(context))
+    let context = Arc::new(MemRangeContext::new(id, builder));
+    MemRange::new(context)
 }

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -33,8 +33,8 @@ use crate::error::Result;
 use crate::memtable::key_values::KeyValue;
 use crate::memtable::partition_tree::data::{timestamp_array_to_i64_slice, DataBatch, DataBuffer};
 use crate::memtable::{
-    BoxedBatchIterator, IterBuilder, KeyValues, MemRange, MemRangeContext, Memtable,
-    MemtableBuilder, MemtableId, MemtableRef, MemtableStats,
+    BoxedBatchIterator, IterBuilder, KeyValues, Memtable, MemtableBuilder, MemtableId,
+    MemtableRange, MemtableRangeContext, MemtableRef, MemtableStats,
 };
 use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
 use crate::sst::parquet::format::ReadFormat;
@@ -92,7 +92,7 @@ impl Memtable for EmptyMemtable {
         &self,
         _projection: Option<&[ColumnId]>,
         _predicate: Option<Predicate>,
-    ) -> Vec<MemRange> {
+    ) -> Vec<MemtableRange> {
         vec![]
     }
 
@@ -362,9 +362,9 @@ pub(crate) fn collect_iter_timestamps(iter: BoxedBatchIterator) -> Vec<i64> {
 }
 
 /// Builds a memtable range for test.
-pub(crate) fn mem_range_for_test(id: MemtableId) -> MemRange {
+pub(crate) fn mem_range_for_test(id: MemtableId) -> MemtableRange {
     let builder = Box::new(EmptyIterBuilder::default());
 
-    let context = Arc::new(MemRangeContext::new(id, builder));
-    MemRange::new(context)
+    let context = Arc::new(MemtableRangeContext::new(id, builder));
+    MemtableRange::new(context)
 }

--- a/src/table/src/predicate.rs
+++ b/src/table/src/predicate.rs
@@ -50,10 +50,11 @@ macro_rules! return_none_if_utf8 {
     };
 }
 
+/// Reference-counted pointer to a list of logical exprs.
 #[derive(Debug, Clone)]
 pub struct Predicate {
     /// logical exprs
-    exprs: Vec<Expr>,
+    exprs: Arc<Vec<Expr>>,
 }
 
 impl Predicate {
@@ -61,7 +62,9 @@ impl Predicate {
     /// evaluated against record batches.
     /// Returns error when failed to convert exprs.
     pub fn new(exprs: Vec<Expr>) -> Self {
-        Self { exprs }
+        Self {
+            exprs: Arc::new(exprs),
+        }
     }
 
     /// Returns the logical exprs.

--- a/tests/cases/distributed/explain/analyze.result
+++ b/tests/cases/distributed/explain/analyze.result
@@ -35,7 +35,7 @@ explain analyze SELECT count(*) FROM system_metrics;
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[COUNT(system_REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -74,7 +74,7 @@ EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 | 0_| 0_|_RangeSelectExec: range_expr=[MIN(host.val) RANGE 5s], align=5000ms, align_to=0ms, align_by=[host@1], time_index=ts REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 10_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/analyze.result
@@ -30,7 +30,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -59,7 +59,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -2000 AND j@1 <= 12000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -87,7 +87,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -117,7 +117,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtables, 0 file ranges) REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR implements `MemtableRange` to represent a partition (range) of a memtable. This allows iterating the memtable concurrently. The memtable range keeps an `IterBuilder` to build an iterator to read that range.

The `Memtable` trait has a new method `ranges()` to return the list of ranges to read. Both `time_series` and `partition_tree` memtables return just 1 range.

The `ScanPart` now keeps a list of `MemtableRange` instead of `Memtable`.

It also refactors the `FileRange` and extracts a struct `RangeBase` so we can reuse it in other places. The `RangeBase` contains fields to prune batches from a file.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
