### PR TITLE
fix: region logical regions after catching up

### DIFF
--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -536,19 +536,7 @@ impl RegionServerInner {
                 },
                 None => return Ok(CurrentEngine::EarlyReturn(0)),
             },
-            RegionChange::None => match current_region_status {
-                Some(status) => match status.clone() {
-                    RegionEngineWithStatus::Registering(_) => {
-                        return error::RegionNotReadySnafu { region_id }.fail()
-                    }
-                    RegionEngineWithStatus::Deregistering(_) => {
-                        return error::RegionNotFoundSnafu { region_id }.fail()
-                    }
-                    RegionEngineWithStatus::Ready(engine) => engine,
-                },
-                None => return error::RegionNotFoundSnafu { region_id }.fail(),
-            },
-            RegionChange::Catchup => match current_region_status {
+            RegionChange::None | RegionChange::Catchup => match current_region_status {
                 Some(status) => match status.clone() {
                     RegionEngineWithStatus::Registering(_) => {
                         return error::RegionNotReadySnafu { region_id }.fail()

--- a/src/datanode/src/region_server.rs
+++ b/src/datanode/src/region_server.rs
@@ -548,6 +548,18 @@ impl RegionServerInner {
                 },
                 None => return error::RegionNotFoundSnafu { region_id }.fail(),
             },
+            RegionChange::Catchup => match current_region_status {
+                Some(status) => match status.clone() {
+                    RegionEngineWithStatus::Registering(_) => {
+                        return error::RegionNotReadySnafu { region_id }.fail()
+                    }
+                    RegionEngineWithStatus::Deregistering(_) => {
+                        return error::RegionNotFoundSnafu { region_id }.fail()
+                    }
+                    RegionEngineWithStatus::Ready(engine) => engine,
+                },
+                None => return error::RegionNotFoundSnafu { region_id }.fail(),
+            },
         };
 
         Ok(CurrentEngine::Engine(engine))
@@ -685,8 +697,8 @@ impl RegionServerInner {
             | RegionRequest::Alter(_)
             | RegionRequest::Flush(_)
             | RegionRequest::Compact(_)
-            | RegionRequest::Truncate(_)
-            | RegionRequest::Catchup(_) => RegionChange::None,
+            | RegionRequest::Truncate(_) => RegionChange::None,
+            RegionRequest::Catchup(_) => RegionChange::Catchup,
         };
 
         let engine = match self.get_engine(region_id, &region_change)? {
@@ -748,6 +760,7 @@ impl RegionServerInner {
             RegionChange::Register(_) | RegionChange::Deregisters => {
                 self.region_map.remove(&region_id);
             }
+            RegionChange::Catchup => {}
         }
     }
 
@@ -789,6 +802,12 @@ impl RegionServerInner {
                     .remove(&region_id)
                     .map(|(id, engine)| engine.set_writable(id, false));
                 self.event_listener.on_region_deregistered(region_id);
+            }
+            RegionChange::Catchup => {
+                if is_metric_engine(engine.name()) {
+                    // Registers the logical regions belong to the physical region (`region_id`).
+                    self.register_logical_regions(&engine, region_id).await?;
+                }
             }
         }
         Ok(())
@@ -891,6 +910,11 @@ enum RegionChange {
     None,
     Register(RegionAttribute),
     Deregisters,
+    Catchup,
+}
+
+fn is_metric_engine(engine: &str) -> bool {
+    engine == METRIC_ENGINE_NAME
 }
 
 fn parse_region_attribute(

--- a/src/metric-engine/src/engine/catchup.rs
+++ b/src/metric-engine/src/engine/catchup.rs
@@ -56,6 +56,9 @@ impl MetricEngineInner {
             )
             .await
             .context(MitoCatchupOperationSnafu)
-            .map(|response| response.affected_rows)
+            .map(|response| response.affected_rows)?;
+
+        self.recover_states(region_id).await?;
+        Ok(0)
     }
 }

--- a/src/metric-engine/src/engine/open.rs
+++ b/src/metric-engine/src/engine/open.rs
@@ -122,7 +122,7 @@ impl MetricEngineInner {
     /// Includes:
     /// - Record physical region's column names
     /// - Record the mapping between logical region id and physical region id
-    async fn recover_states(&self, physical_region_id: RegionId) -> Result<()> {
+    pub(crate) async fn recover_states(&self, physical_region_id: RegionId) -> Result<()> {
         // load logical regions and physical column names
         let logical_regions = self
             .metadata_region


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR registers metric logical regions after invoking catchup and fixes metric logical regions not found issues after migrating a physical region.

After replaying the WAL of a metric metadata region, there are two places required to register logical regions manually:
- Metric engine
- RegionServer



## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
