### PR TITLE
perf: optimize RecordBatch to HttpOutput conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
  "common-runtime",
  "common-telemetry",
  "common-time",
- "criterion",
+ "criterion 0.4.0",
  "dashmap",
  "datatypes",
  "flatbuffers",
@@ -2382,6 +2382,32 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.7",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
  "walkdir",
 ]
 
@@ -5973,7 +5999,7 @@ dependencies = [
  "common-time",
  "common-wal",
  "crc32fast",
- "criterion",
+ "criterion 0.4.0",
  "crossbeam-utils",
  "datafusion 38.0.0",
  "datafusion-common 38.0.0",
@@ -7633,6 +7659,7 @@ checksum = "ef5c97c51bd34c7e742402e216abdeb44d415fbe6ae41d56b114723e953711cb"
 dependencies = [
  "backtrace",
  "cfg-if",
+ "criterion 0.5.1",
  "findshlibs",
  "inferno",
  "libc",
@@ -9556,7 +9583,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "console",
- "criterion",
+ "criterion 0.4.0",
  "crossbeam-utils",
  "datafusion 38.0.0",
  "datafusion-common 38.0.0",
@@ -9844,7 +9871,7 @@ dependencies = [
  "common-test-util",
  "common-time",
  "common-version",
- "criterion",
+ "criterion 0.5.1",
  "dashmap",
  "datafusion 38.0.0",
  "datafusion-common 38.0.0",

--- a/src/common/base/src/bytes.rs
+++ b/src/common/base/src/bytes.rs
@@ -81,16 +81,17 @@ impl PartialEq<Bytes> for [u8] {
 /// Now this buffer is restricted to only hold valid UTF-8 string (only allow constructing `StringBytes`
 /// from String or str). We may support other encoding in the future.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct StringBytes(bytes::Bytes);
+pub struct StringBytes(String);
 
 impl StringBytes {
     /// View this string as UTF-8 string slice.
-    ///
-    /// # Safety
-    /// We only allow constructing `StringBytes` from String/str, so the inner
-    /// buffer must holds valid UTF-8.
     pub fn as_utf8(&self) -> &str {
-        unsafe { std::str::from_utf8_unchecked(&self.0) }
+        &self.0
+    }
+
+    /// Convert this string into owned UTF-8 string.
+    pub fn into_string(self) -> String {
+        self.0
     }
 
     pub fn len(&self) -> usize {
@@ -104,37 +105,37 @@ impl StringBytes {
 
 impl From<String> for StringBytes {
     fn from(string: String) -> StringBytes {
-        StringBytes(bytes::Bytes::from(string))
+        StringBytes(string)
     }
 }
 
 impl From<&str> for StringBytes {
     fn from(string: &str) -> StringBytes {
-        StringBytes(bytes::Bytes::copy_from_slice(string.as_bytes()))
+        StringBytes(string.to_string())
     }
 }
 
 impl PartialEq<String> for StringBytes {
     fn eq(&self, other: &String) -> bool {
-        self.0 == other.as_bytes()
+        &self.0 == other
     }
 }
 
 impl PartialEq<StringBytes> for String {
     fn eq(&self, other: &StringBytes) -> bool {
-        self.as_bytes() == other.0
+        self == &other.0
     }
 }
 
 impl PartialEq<str> for StringBytes {
     fn eq(&self, other: &str) -> bool {
-        self.0 == other.as_bytes()
+        self.0.as_str() == other
     }
 }
 
 impl PartialEq<StringBytes> for str {
     fn eq(&self, other: &StringBytes) -> bool {
-        self.as_bytes() == other.0
+        self == other.0
     }
 }
 

--- a/src/datatypes/src/value.rs
+++ b/src/datatypes/src/value.rs
@@ -29,7 +29,7 @@ use common_time::timestamp::{TimeUnit, Timestamp};
 use common_time::{Duration, Interval, Timezone};
 use datafusion_common::ScalarValue;
 pub use ordered_float::OrderedFloat;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use snafu::{ensure, ResultExt};
 
 use crate::error::{self, ConvertArrowArrayToScalarsSnafu, Error, Result, TryFromValueSnafu};
@@ -695,7 +695,7 @@ impl TryFrom<Value> for serde_json::Value {
             Value::Int64(v) => serde_json::Value::from(v),
             Value::Float32(v) => serde_json::Value::from(v.0),
             Value::Float64(v) => serde_json::Value::from(v.0),
-            Value::String(bytes) => serde_json::Value::String(bytes.as_utf8().to_string()),
+            Value::String(bytes) => serde_json::Value::String(bytes.into_string()),
             Value::Binary(bytes) => serde_json::to_value(bytes)?,
             Value::Date(v) => serde_json::Value::Number(v.val().into()),
             Value::DateTime(v) => serde_json::Value::Number(v.val().into()),
@@ -1165,6 +1165,39 @@ impl<'a> From<Option<ListValueRef<'a>>> for ValueRef<'a> {
     }
 }
 
+impl<'a> TryFrom<ValueRef<'a>> for serde_json::Value {
+    type Error = serde_json::Error;
+
+    fn try_from(value: ValueRef<'a>) -> serde_json::Result<serde_json::Value> {
+        let json_value = match value {
+            ValueRef::Null => serde_json::Value::Null,
+            ValueRef::Boolean(v) => serde_json::Value::Bool(v),
+            ValueRef::UInt8(v) => serde_json::Value::from(v),
+            ValueRef::UInt16(v) => serde_json::Value::from(v),
+            ValueRef::UInt32(v) => serde_json::Value::from(v),
+            ValueRef::UInt64(v) => serde_json::Value::from(v),
+            ValueRef::Int8(v) => serde_json::Value::from(v),
+            ValueRef::Int16(v) => serde_json::Value::from(v),
+            ValueRef::Int32(v) => serde_json::Value::from(v),
+            ValueRef::Int64(v) => serde_json::Value::from(v),
+            ValueRef::Float32(v) => serde_json::Value::from(v.0),
+            ValueRef::Float64(v) => serde_json::Value::from(v.0),
+            ValueRef::String(bytes) => serde_json::Value::String(bytes.to_string()),
+            ValueRef::Binary(bytes) => serde_json::to_value(bytes)?,
+            ValueRef::Date(v) => serde_json::Value::Number(v.val().into()),
+            ValueRef::DateTime(v) => serde_json::Value::Number(v.val().into()),
+            ValueRef::List(v) => serde_json::to_value(v)?,
+            ValueRef::Timestamp(v) => serde_json::to_value(v.value())?,
+            ValueRef::Time(v) => serde_json::to_value(v.value())?,
+            ValueRef::Interval(v) => serde_json::to_value(v.to_i128())?,
+            ValueRef::Duration(v) => serde_json::to_value(v.value())?,
+            ValueRef::Decimal128(v) => serde_json::to_value(v.to_string())?,
+        };
+
+        Ok(json_value)
+    }
+}
+
 /// Reference to a [ListValue].
 ///
 /// Now comparison still requires some allocation (call of `to_value()`) and
@@ -1191,6 +1224,18 @@ impl<'a> ListValueRef<'a> {
         match self {
             ListValueRef::Indexed { vector, .. } => vector.data_type(),
             ListValueRef::Ref { val } => val.datatype().clone(),
+        }
+    }
+}
+
+impl<'a> Serialize for ListValueRef<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            ListValueRef::Indexed { vector, idx } => match vector.get(*idx) {
+                Value::List(v) => v.serialize(serializer),
+                _ => unreachable!(),
+            },
+            ListValueRef::Ref { val } => val.serialize(serializer),
         }
     }
 }

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -116,11 +116,12 @@ catalog = { workspace = true, features = ["testing"] }
 client = { workspace = true, features = ["testing"] }
 common-base.workspace = true
 common-test-util.workspace = true
-criterion = "0.4"
+criterion = "0.5"
 mysql_async = { version = "0.33", default-features = false, features = [
     "default-rustls",
 ] }
 permutation = "0.4"
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 rand.workspace = true
 script = { workspace = true, features = ["python"] }
 serde_json.workspace = true

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -16,10 +16,10 @@ workspace = true
 [dependencies]
 aide = { version = "0.9", features = ["axum"] }
 api.workspace = true
-arrow.workspace = true
 arrow-flight.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
+arrow.workspace = true
 async-trait = "0.1"
 auth.workspace = true
 axum = { workspace = true, features = ["multipart"] }
@@ -44,8 +44,8 @@ common-telemetry.workspace = true
 common-time.workspace = true
 common-version = { workspace = true, features = ["codec"] }
 dashmap.workspace = true
-datafusion.workspace = true
 datafusion-common.workspace = true
+datafusion.workspace = true
 datatypes.workspace = true
 derive_builder.workspace = true
 futures = "0.3"
@@ -96,12 +96,12 @@ snap = "1"
 sql.workspace = true
 strum.workspace = true
 table.workspace = true
-tokio.workspace = true
 tokio-rustls = "0.25"
 tokio-stream = { workspace = true, features = ["net"] }
 tokio-util.workspace = true
-tonic.workspace = true
+tokio.workspace = true
 tonic-reflection = "0.11"
+tonic.workspace = true
 tower = { workspace = true, features = ["full"] }
 tower-http = { version = "0.4", features = ["full"] }
 urlencoding = "2.1"
@@ -136,4 +136,8 @@ common-version.workspace = true
 
 [[bench]]
 name = "bench_prom"
+harness = false
+
+[[bench]]
+name = "to_http_output"
 harness = false

--- a/src/servers/benches/to_http_output.rs
+++ b/src/servers/benches/to_http_output.rs
@@ -21,6 +21,7 @@ use common_recordbatch::RecordBatch;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datatypes::schema::SchemaRef;
 use datatypes::vectors::StringVector;
+use pprof::criterion::{Output, PProfProfiler};
 use servers::http::HttpRecordsOutput;
 
 fn mock_schema() -> SchemaRef {
@@ -70,5 +71,9 @@ fn bench_convert_record_batch_to_http_output(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_convert_record_batch_to_http_output,);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(101, Output::Flamegraph(None)));
+    targets = bench_convert_record_batch_to_http_output
+}
 criterion_main!(benches);

--- a/src/servers/benches/to_http_output.rs
+++ b/src/servers/benches/to_http_output.rs
@@ -1,0 +1,74 @@
+// Copyright 2024 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow::array::StringArray;
+use arrow_schema::{DataType, Field, Schema};
+use common_recordbatch::RecordBatch;
+use criterion::{criterion_group, criterion_main, Criterion};
+use datatypes::schema::SchemaRef;
+use datatypes::vectors::StringVector;
+use servers::http::HttpRecordsOutput;
+
+fn mock_schema() -> SchemaRef {
+    let mut fields = Vec::with_capacity(10);
+    for i in 0..10 {
+        fields.push(Field::new(format!("field{}", i), DataType::Utf8, true));
+    }
+    let arrow_schema = Arc::new(Schema::new(fields));
+    Arc::new(arrow_schema.try_into().unwrap())
+}
+
+fn mock_input_record_batch(batch_size: usize, num_batches: usize) -> Vec<RecordBatch> {
+    let mut result = Vec::with_capacity(num_batches);
+    for _ in 0..num_batches {
+        let mut vectors = Vec::with_capacity(10);
+        for _ in 0..10 {
+            let vector: StringVector = StringArray::from(
+                (0..batch_size)
+                    .map(|_| String::from("Copyright 2024 Greptime Team"))
+                    .collect::<Vec<_>>(),
+            )
+            .into();
+            vectors.push(Arc::new(vector) as _);
+        }
+
+        let schema = mock_schema();
+        let record_batch = RecordBatch::new(schema, vectors).unwrap();
+        result.push(record_batch);
+    }
+
+    result
+}
+
+fn bench_convert_record_batch_to_http_output(c: &mut Criterion) {
+    let record_batches = mock_input_record_batch(4096, 100);
+    c.bench_function("convert_record_batch_to_http_output", |b| {
+        b.iter_custom(|iters| {
+            let mut elapsed_sum = std::time::Duration::new(0, 0);
+            for _ in 0..iters {
+                let record_batches = record_batches.clone();
+                let start = Instant::now();
+                let _result = HttpRecordsOutput::try_new(mock_schema(), record_batches);
+                elapsed_sum += start.elapsed();
+            }
+            elapsed_sum
+        });
+    });
+}
+
+criterion_group!(benches, bench_convert_record_batch_to_http_output,);
+criterion_main!(benches);

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -221,7 +221,7 @@ impl HttpRecordsOutput {
 }
 
 impl HttpRecordsOutput {
-    pub(crate) fn try_new(
+    pub fn try_new(
         schema: SchemaRef,
         recordbatches: Vec<RecordBatch>,
     ) -> std::result::Result<HttpRecordsOutput, Error> {

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -242,7 +242,7 @@ impl HttpRecordsOutput {
             for recordbatch in recordbatches {
                 for col in recordbatch.columns() {
                     for row_idx in 0..recordbatch.num_rows() {
-                        let value = Value::try_from(col.get(row_idx)).context(ToJsonSnafu)?;
+                        let value = Value::try_from(col.get_ref(row_idx)).context(ToJsonSnafu)?;
                         rows[row_idx + finished_row_cursor].push(value);
                     }
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Optimize `HttpRecordsOutput::try_new()` method. Reduce the consumption of converting 409600 rows from ~400ms to ~120ms. Saves ~70% CPU.

This patch also adds a microbenchmark for that method.

Key optimizations are:
- Change the algorithm to do column-row conversion
- Change the underlying type of `Value::String` from `Bytes` to `String`
- Avoid all unnecessary `Clone`s

Now the entire conversion method only has one `clone` that takes data from the data vector, and one write that `writes` the serialized content to the result vector.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
