### PR TITLE
feat: Dedup strategy that keeps the last not null field

### DIFF
--- a/src/mito2/src/read/dedup.rs
+++ b/src/mito2/src/read/dedup.rs
@@ -393,6 +393,7 @@ pub(crate) struct LastNotNull {
 
 impl LastNotNull {
     /// Creates a new strategy with the given `filter_deleted` flag.
+    #[allow(dead_code)]
     pub(crate) fn new(filter_deleted: bool) -> Self {
         Self {
             buffer: None,

--- a/src/mito2/src/read/dedup.rs
+++ b/src/mito2/src/read/dedup.rs
@@ -361,12 +361,12 @@ impl LastFieldsBuilder {
             }
         };
 
+        // Resets itself. `self.builders` already reset in `to_vector()`.
+        self.clear();
+
         if self.filter_deleted {
             filter_deleted_from_batch(&mut output, metrics)?;
         }
-
-        // Resets itself. `self.builders` already reset in `to_vector()`.
-        self.clear();
 
         if output.is_empty() {
             Ok(None)

--- a/src/mito2/src/read/dedup.rs
+++ b/src/mito2/src/read/dedup.rs
@@ -357,7 +357,7 @@ impl LastFieldsBuilder {
             }
         };
 
-        // Resets itself. `self.builders` already reset in `to_vector()`.
+        // Resets itself. `self.builders` is already reset in `to_vector()`.
         self.clear();
 
         if self.filter_deleted {

--- a/src/mito2/src/read/merge.rs
+++ b/src/mito2/src/read/merge.rs
@@ -33,6 +33,10 @@ use crate::read::{Batch, BatchReader, BoxedBatchReader, Source};
 /// 1. Batch is ordered by primary key, time index, sequence desc, op type desc (we can
 /// ignore op type as sequence is already unique).
 /// 2. Batches from sources **must** not be empty.
+///
+/// The reader won't concatenate batches. Each batch returned by the reader also doesn't
+/// contain duplicate rows. But the last (primary key, timestamp) of a batch may be the same
+/// as the first one in the next batch.
 pub struct MergeReader {
     /// Holds [Node]s whose key range of current batch **is** overlapped with the merge window.
     /// Each node yields batches from a `source`.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR implements a new dedup strategy `LastNotNull`. This strategy merges the rows with the same key together and uses the latest not null value as the final value for each field.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhancements for deduplication of sorted batches, improving the filtering of deleted rows and handling of duplicate rows.

- **Bug Fixes**
  - Improved deduplication strategies to ensure better data integrity and more accurate results.

- **Documentation**
  - Added comments to clarify the deduplication process and the behavior of batch readers, improving code readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->