### PR TITLE
refactor: add `region_dir` in CompactionRegion

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -276,6 +276,7 @@ impl CompactionScheduler {
 
         let compaction_region = CompactionRegion {
             region_id,
+            region_dir: access_layer.region_dir().to_string(),
             current_version: current_version.clone(),
             region_options: current_version.options.clone(),
             engine_config: engine_config.clone(),

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -53,6 +53,7 @@ use crate::sst::parquet::WriteOptions;
 pub struct CompactionRegion {
     pub region_id: RegionId,
     pub region_options: RegionOptions,
+    pub region_dir: String,
 
     pub(crate) engine_config: Arc<MitoConfig>,
     pub(crate) region_metadata: RegionMetadataRef,
@@ -162,14 +163,15 @@ pub async fn open_compaction_region(
     };
 
     Ok(CompactionRegion {
-        region_options: region_options.clone(),
-        manifest_ctx,
-        access_layer,
-        current_version,
         region_id: req.region_id,
-        cache_manager: Arc::new(CacheManager::default()),
+        region_options: region_options.clone(),
+        region_dir: req.region_dir.clone(),
         engine_config: Arc::new(mito_config.clone()),
         region_metadata: region_metadata.clone(),
+        cache_manager: Arc::new(CacheManager::default()),
+        access_layer,
+        manifest_ctx,
+        current_version,
     })
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add `region_dir` in CompactionRegion.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Improved compaction process by adding `region_dir` field to better manage region directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->