### PR TITLE
feat(puffin): support lz4 compression for footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8359,6 +8359,7 @@ dependencies = [
  "common-macro",
  "derive_builder 0.12.0",
  "futures",
+ "lz4_flex 0.11.3",
  "pin-project",
  "serde",
  "serde_json",

--- a/src/puffin/Cargo.toml
+++ b/src/puffin/Cargo.toml
@@ -14,6 +14,7 @@ common-error.workspace = true
 common-macro.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
+lz4_flex = "0.11"
 pin-project.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/puffin/src/error.rs
+++ b/src/puffin/src/error.rs
@@ -141,6 +141,24 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to compress lz4"))]
+    Lz4Compression {
+        #[snafu(source)]
+        error: std::io::Error,
+
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to decompress lz4"))]
+    Lz4Decompression {
+        #[snafu(source)]
+        error: serde_json::Error,
+
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 impl ErrorExt for Error {
@@ -160,7 +178,9 @@ impl ErrorExt for Error {
             | UnexpectedFooterPayloadSize { .. }
             | UnexpectedPuffinFileSize { .. }
             | InvalidBlobOffset { .. }
-            | InvalidBlobAreaEnd { .. } => StatusCode::Unexpected,
+            | InvalidBlobAreaEnd { .. }
+            | Lz4Compression { .. }
+            | Lz4Decompression { .. } => StatusCode::Unexpected,
 
             UnsupportedDecompression { .. } => StatusCode::Unsupported,
         }

--- a/src/puffin/src/file_format/writer.rs
+++ b/src/puffin/src/file_format/writer.rs
@@ -41,6 +41,9 @@ pub trait PuffinSyncWriter {
     /// Set the properties of the Puffin file
     fn set_properties(&mut self, properties: HashMap<String, String>);
 
+    /// Sets whether the footer payload should be LZ4 compressed.
+    fn set_footer_lz4_compressed(&mut self, lz4_compressed: bool);
+
     /// Add a blob to the Puffin file
     fn add_blob<R: std::io::Read>(&mut self, blob: Blob<R>) -> Result<()>;
 
@@ -53,6 +56,9 @@ pub trait PuffinSyncWriter {
 pub trait PuffinAsyncWriter {
     /// Set the properties of the Puffin file
     fn set_properties(&mut self, properties: HashMap<String, String>);
+
+    /// Sets whether the footer payload should be LZ4 compressed.
+    fn set_footer_lz4_compressed(&mut self, lz4_compressed: bool);
 
     /// Add a blob to the Puffin file
     async fn add_blob<R: futures::AsyncRead + Send>(&mut self, blob: Blob<R>) -> Result<()>;

--- a/src/puffin/src/file_format/writer/footer.rs
+++ b/src/puffin/src/file_format/writer/footer.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::mem;
 
 use snafu::ResultExt;
 
 use crate::blob_metadata::BlobMetadata;
-use crate::error::{Result, SerializeJsonSnafu};
+use crate::error::{Lz4CompressionSnafu, Result, SerializeJsonSnafu};
 use crate::file_format::{Flags, MAGIC, MIN_FOOTER_SIZE};
 use crate::file_metadata::FileMetadataBuilder;
 
@@ -31,13 +32,19 @@ use crate::file_metadata::FileMetadataBuilder;
 pub struct FooterWriter {
     blob_metadata: Vec<BlobMetadata>,
     file_properties: HashMap<String, String>,
+    lz4_compressed: bool,
 }
 
 impl FooterWriter {
-    pub fn new(blob_metadata: Vec<BlobMetadata>, file_properties: HashMap<String, String>) -> Self {
+    pub fn new(
+        blob_metadata: Vec<BlobMetadata>,
+        file_properties: HashMap<String, String>,
+        lz4_compressed: bool,
+    ) -> Self {
         Self {
             blob_metadata,
             file_properties,
+            lz4_compressed,
         }
     }
 
@@ -70,10 +77,13 @@ impl FooterWriter {
     }
 
     /// Appends reserved flags (currently zero-initialized) to the given buffer.
-    ///
-    /// TODO(zhongzc): support compression
     fn write_flags(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(&Flags::DEFAULT.bits().to_le_bytes());
+        let mut flags = Flags::DEFAULT;
+        if self.lz4_compressed {
+            flags |= Flags::FOOTER_PAYLOAD_COMPRESSED_LZ4;
+        }
+
+        buf.extend_from_slice(&flags.bits().to_le_bytes());
     }
 
     fn footer_payload(&mut self) -> Result<Vec<u8>> {
@@ -83,6 +93,19 @@ impl FooterWriter {
             .build()
             .expect("Required fields are not set");
 
-        serde_json::to_vec(&file_metadata).context(SerializeJsonSnafu)
+        if self.lz4_compressed {
+            let mut buf = vec![];
+            let mut encoder = lz4_flex::frame::FrameEncoder::new(&mut buf);
+
+            let serialized = serde_json::to_vec(&file_metadata).context(SerializeJsonSnafu)?;
+            encoder
+                .write_all(&serialized)
+                .context(Lz4CompressionSnafu)?;
+
+            encoder.flush().context(Lz4CompressionSnafu)?;
+            Ok(buf)
+        } else {
+            serde_json::to_vec(&file_metadata).context(SerializeJsonSnafu)
+        }
     }
 }

--- a/src/puffin/src/tests.rs
+++ b/src/puffin/src/tests.rs
@@ -117,178 +117,202 @@ async fn test_sample_metric_data_puffin_async() {
 
 #[test]
 fn test_writer_reader_with_empty_sync() {
-    let mut buf = Cursor::new(vec![]);
+    fn test_writer_reader_with_empty_sync(footer_compressed: bool) {
+        let mut buf = Cursor::new(vec![]);
 
-    let mut writer = PuffinFileWriter::new(&mut buf);
-    writer.set_properties(HashMap::from([(
-        "created-by".to_string(),
-        "Test 1234".to_string(),
-    )]));
+        let mut writer = PuffinFileWriter::new(&mut buf);
+        writer.set_properties(HashMap::from([(
+            "created-by".to_string(),
+            "Test 1234".to_string(),
+        )]));
 
-    let written_bytes = writer.finish().unwrap();
-    assert!(written_bytes > 0);
+        writer.set_footer_lz4_compressed(footer_compressed);
+        let written_bytes = writer.finish().unwrap();
+        assert!(written_bytes > 0);
 
-    let mut buf = Cursor::new(buf.into_inner());
-    let mut reader = PuffinFileReader::new(&mut buf);
-    let metadata = reader.metadata().unwrap();
+        let mut buf = Cursor::new(buf.into_inner());
+        let mut reader = PuffinFileReader::new(&mut buf);
+        let metadata = reader.metadata().unwrap();
 
-    assert_eq!(metadata.properties.len(), 1);
-    assert_eq!(
-        metadata.properties.get("created-by"),
-        Some(&"Test 1234".to_string())
-    );
+        assert_eq!(metadata.properties.len(), 1);
+        assert_eq!(
+            metadata.properties.get("created-by"),
+            Some(&"Test 1234".to_string())
+        );
 
-    assert_eq!(metadata.blobs.len(), 0);
+        assert_eq!(metadata.blobs.len(), 0);
+    }
+
+    test_writer_reader_with_empty_sync(false);
+    test_writer_reader_with_empty_sync(true);
 }
 
 #[tokio::test]
 async fn test_writer_reader_empty_async() {
-    let mut buf = AsyncCursor::new(vec![]);
+    async fn test_writer_reader_empty_async(footer_compressed: bool) {
+        let mut buf = AsyncCursor::new(vec![]);
 
-    let mut writer = PuffinFileWriter::new(&mut buf);
-    writer.set_properties(HashMap::from([(
-        "created-by".to_string(),
-        "Test 1234".to_string(),
-    )]));
+        let mut writer = PuffinFileWriter::new(&mut buf);
+        writer.set_properties(HashMap::from([(
+            "created-by".to_string(),
+            "Test 1234".to_string(),
+        )]));
 
-    let written_bytes = writer.finish().await.unwrap();
-    assert!(written_bytes > 0);
+        writer.set_footer_lz4_compressed(footer_compressed);
+        let written_bytes = writer.finish().await.unwrap();
+        assert!(written_bytes > 0);
 
-    let mut buf = AsyncCursor::new(buf.into_inner());
-    let mut reader = PuffinFileReader::new(&mut buf);
-    let metadata = reader.metadata().await.unwrap();
+        let mut buf = AsyncCursor::new(buf.into_inner());
+        let mut reader = PuffinFileReader::new(&mut buf);
+        let metadata = reader.metadata().await.unwrap();
 
-    assert_eq!(metadata.properties.len(), 1);
-    assert_eq!(
-        metadata.properties.get("created-by"),
-        Some(&"Test 1234".to_string())
-    );
+        assert_eq!(metadata.properties.len(), 1);
+        assert_eq!(
+            metadata.properties.get("created-by"),
+            Some(&"Test 1234".to_string())
+        );
 
-    assert_eq!(metadata.blobs.len(), 0);
+        assert_eq!(metadata.blobs.len(), 0);
+    }
+
+    test_writer_reader_empty_async(false).await;
+    test_writer_reader_empty_async(true).await;
 }
 
 #[test]
 fn test_writer_reader_sync() {
-    let mut buf = Cursor::new(vec![]);
+    fn test_writer_reader_sync(footer_compressed: bool) {
+        let mut buf = Cursor::new(vec![]);
 
-    let mut writer = PuffinFileWriter::new(&mut buf);
+        let mut writer = PuffinFileWriter::new(&mut buf);
 
-    let blob1 = "abcdefghi";
-    writer
-        .add_blob(Blob {
-            data: Cursor::new(&blob1),
-            blob_type: "some-blob".to_string(),
-            properties: Default::default(),
-        })
-        .unwrap();
+        let blob1 = "abcdefghi";
+        writer
+            .add_blob(Blob {
+                data: Cursor::new(&blob1),
+                blob_type: "some-blob".to_string(),
+                properties: Default::default(),
+            })
+            .unwrap();
 
-    let blob2 = include_bytes!("tests/resources/sample-metric-data.blob");
-    writer
-        .add_blob(Blob {
-            data: Cursor::new(&blob2),
-            blob_type: "some-other-blob".to_string(),
-            properties: Default::default(),
-        })
-        .unwrap();
+        let blob2 = include_bytes!("tests/resources/sample-metric-data.blob");
+        writer
+            .add_blob(Blob {
+                data: Cursor::new(&blob2),
+                blob_type: "some-other-blob".to_string(),
+                properties: Default::default(),
+            })
+            .unwrap();
 
-    writer.set_properties(HashMap::from([(
-        "created-by".to_string(),
-        "Test 1234".to_string(),
-    )]));
+        writer.set_properties(HashMap::from([(
+            "created-by".to_string(),
+            "Test 1234".to_string(),
+        )]));
 
-    let written_bytes = writer.finish().unwrap();
-    assert!(written_bytes > 0);
+        writer.set_footer_lz4_compressed(footer_compressed);
+        let written_bytes = writer.finish().unwrap();
+        assert!(written_bytes > 0);
 
-    let mut buf = Cursor::new(buf.into_inner());
-    let mut reader = PuffinFileReader::new(&mut buf);
-    let metadata = reader.metadata().unwrap();
+        let mut buf = Cursor::new(buf.into_inner());
+        let mut reader = PuffinFileReader::new(&mut buf);
+        let metadata = reader.metadata().unwrap();
 
-    assert_eq!(metadata.properties.len(), 1);
-    assert_eq!(
-        metadata.properties.get("created-by"),
-        Some(&"Test 1234".to_string())
-    );
+        assert_eq!(metadata.properties.len(), 1);
+        assert_eq!(
+            metadata.properties.get("created-by"),
+            Some(&"Test 1234".to_string())
+        );
 
-    assert_eq!(metadata.blobs.len(), 2);
-    assert_eq!(metadata.blobs[0].blob_type, "some-blob");
-    assert_eq!(metadata.blobs[0].offset, 4);
-    assert_eq!(metadata.blobs[0].length, 9);
+        assert_eq!(metadata.blobs.len(), 2);
+        assert_eq!(metadata.blobs[0].blob_type, "some-blob");
+        assert_eq!(metadata.blobs[0].offset, 4);
+        assert_eq!(metadata.blobs[0].length, 9);
 
-    assert_eq!(metadata.blobs[1].blob_type, "some-other-blob");
-    assert_eq!(metadata.blobs[1].offset, 13);
-    assert_eq!(metadata.blobs[1].length, 83);
+        assert_eq!(metadata.blobs[1].blob_type, "some-other-blob");
+        assert_eq!(metadata.blobs[1].offset, 13);
+        assert_eq!(metadata.blobs[1].length, 83);
 
-    let mut some_blob = reader.blob_reader(&metadata.blobs[0]).unwrap();
-    let mut buf = String::new();
-    some_blob.read_to_string(&mut buf).unwrap();
-    assert_eq!(buf, blob1);
+        let mut some_blob = reader.blob_reader(&metadata.blobs[0]).unwrap();
+        let mut buf = String::new();
+        some_blob.read_to_string(&mut buf).unwrap();
+        assert_eq!(buf, blob1);
 
-    let mut some_other_blob = reader.blob_reader(&metadata.blobs[1]).unwrap();
-    let mut buf = Vec::new();
-    some_other_blob.read_to_end(&mut buf).unwrap();
-    assert_eq!(buf, blob2);
+        let mut some_other_blob = reader.blob_reader(&metadata.blobs[1]).unwrap();
+        let mut buf = Vec::new();
+        some_other_blob.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, blob2);
+    }
+
+    test_writer_reader_sync(false);
+    test_writer_reader_sync(true);
 }
 
 #[tokio::test]
 async fn test_writer_reader_async() {
-    let mut buf = AsyncCursor::new(vec![]);
+    async fn test_writer_reader_async(footer_compressed: bool) {
+        let mut buf = AsyncCursor::new(vec![]);
 
-    let mut writer = PuffinFileWriter::new(&mut buf);
+        let mut writer = PuffinFileWriter::new(&mut buf);
 
-    let blob1 = "abcdefghi".as_bytes();
-    writer
-        .add_blob(Blob {
-            data: AsyncCursor::new(blob1),
-            blob_type: "some-blob".to_string(),
-            properties: Default::default(),
-        })
-        .await
-        .unwrap();
+        let blob1 = "abcdefghi".as_bytes();
+        writer
+            .add_blob(Blob {
+                data: AsyncCursor::new(blob1),
+                blob_type: "some-blob".to_string(),
+                properties: Default::default(),
+            })
+            .await
+            .unwrap();
 
-    let blob2 = include_bytes!("tests/resources/sample-metric-data.blob");
-    writer
-        .add_blob(Blob {
-            data: AsyncCursor::new(&blob2),
-            blob_type: "some-other-blob".to_string(),
-            properties: Default::default(),
-        })
-        .await
-        .unwrap();
+        let blob2 = include_bytes!("tests/resources/sample-metric-data.blob");
+        writer
+            .add_blob(Blob {
+                data: AsyncCursor::new(&blob2),
+                blob_type: "some-other-blob".to_string(),
+                properties: Default::default(),
+            })
+            .await
+            .unwrap();
 
-    writer.set_properties(HashMap::from([(
-        "created-by".to_string(),
-        "Test 1234".to_string(),
-    )]));
+        writer.set_properties(HashMap::from([(
+            "created-by".to_string(),
+            "Test 1234".to_string(),
+        )]));
 
-    let written_bytes = writer.finish().await.unwrap();
-    assert!(written_bytes > 0);
+        writer.set_footer_lz4_compressed(footer_compressed);
+        let written_bytes = writer.finish().await.unwrap();
+        assert!(written_bytes > 0);
 
-    let mut buf = AsyncCursor::new(buf.into_inner());
-    let mut reader = PuffinFileReader::new(&mut buf);
-    let metadata = reader.metadata().await.unwrap();
+        let mut buf = AsyncCursor::new(buf.into_inner());
+        let mut reader = PuffinFileReader::new(&mut buf);
+        let metadata = reader.metadata().await.unwrap();
 
-    assert_eq!(metadata.properties.len(), 1);
-    assert_eq!(
-        metadata.properties.get("created-by"),
-        Some(&"Test 1234".to_string())
-    );
+        assert_eq!(metadata.properties.len(), 1);
+        assert_eq!(
+            metadata.properties.get("created-by"),
+            Some(&"Test 1234".to_string())
+        );
 
-    assert_eq!(metadata.blobs.len(), 2);
-    assert_eq!(metadata.blobs[0].blob_type, "some-blob");
-    assert_eq!(metadata.blobs[0].offset, 4);
-    assert_eq!(metadata.blobs[0].length, 9);
+        assert_eq!(metadata.blobs.len(), 2);
+        assert_eq!(metadata.blobs[0].blob_type, "some-blob");
+        assert_eq!(metadata.blobs[0].offset, 4);
+        assert_eq!(metadata.blobs[0].length, 9);
 
-    assert_eq!(metadata.blobs[1].blob_type, "some-other-blob");
-    assert_eq!(metadata.blobs[1].offset, 13);
-    assert_eq!(metadata.blobs[1].length, 83);
+        assert_eq!(metadata.blobs[1].blob_type, "some-other-blob");
+        assert_eq!(metadata.blobs[1].offset, 13);
+        assert_eq!(metadata.blobs[1].length, 83);
 
-    let mut some_blob = reader.blob_reader(&metadata.blobs[0]).unwrap();
-    let mut buf = Vec::new();
-    some_blob.read_to_end(&mut buf).await.unwrap();
-    assert_eq!(buf, blob1);
+        let mut some_blob = reader.blob_reader(&metadata.blobs[0]).unwrap();
+        let mut buf = Vec::new();
+        some_blob.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, blob1);
 
-    let mut some_other_blob = reader.blob_reader(&metadata.blobs[1]).unwrap();
-    let mut buf = Vec::new();
-    some_other_blob.read_to_end(&mut buf).await.unwrap();
-    assert_eq!(buf, blob2);
+        let mut some_other_blob = reader.blob_reader(&metadata.blobs[1]).unwrap();
+        let mut buf = Vec::new();
+        some_other_blob.read_to_end(&mut buf).await.unwrap();
+        assert_eq!(buf, blob2);
+    }
+
+    test_writer_reader_async(false).await;
+    test_writer_reader_async(true).await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4193

## What's changed and what's your intention?

add `lz4_flex` as the dependency to get things done.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for LZ4 compression and decompression for the footer payload.
  - Introduced methods to enable LZ4 compression for footer payloads in both synchronous and asynchronous writers.

- **Bug Fixes**
  - Updated error handling with new variants for LZ4 compression and decompression errors.

- **Tests**
  - Expanded tests to cover scenarios with both compressed and uncompressed footer payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->