### PR TITLE
feat: support inserting into binary value through string

### DIFF
--- a/src/datatypes/src/data_type.rs
+++ b/src/datatypes/src/data_type.rs
@@ -161,6 +161,7 @@ impl ConcreteDataType {
                 | ConcreteDataType::Interval(_)
                 | ConcreteDataType::Duration(_)
                 | ConcreteDataType::Decimal128(_)
+                | ConcreteDataType::Binary(_)
         )
     }
 
@@ -717,6 +718,7 @@ mod tests {
         assert!(!ConcreteDataType::int32_datatype().is_stringifiable());
         assert!(!ConcreteDataType::float32_datatype().is_stringifiable());
         assert!(ConcreteDataType::string_datatype().is_stringifiable());
+        assert!(ConcreteDataType::binary_datatype().is_stringifiable());
         assert!(ConcreteDataType::date_datatype().is_stringifiable());
         assert!(ConcreteDataType::datetime_datatype().is_stringifiable());
         assert!(ConcreteDataType::timestamp_second_datatype().is_stringifiable());

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -120,6 +120,7 @@ fn parse_string_to_value(
                 .fail()
             }
         }
+        ConcreteDataType::Binary(_) => Ok(Value::Binary(s.as_bytes().into())),
         _ => {
             unreachable!()
         }
@@ -709,6 +710,14 @@ mod tests {
         let v =
             sql_value_to_value("a", &ConcreteDataType::binary_datatype(), &sql_val, None).unwrap();
         assert_eq!(Value::Binary(Bytes::from(b"Hello world!".as_slice())), v);
+
+        let sql_val = SqlValue::DoubleQuotedString("MorningMyFriends".to_string());
+        let v =
+            sql_value_to_value("a", &ConcreteDataType::binary_datatype(), &sql_val, None).unwrap();
+        assert_eq!(
+            Value::Binary(Bytes::from(b"MorningMyFriends".as_slice())),
+            v
+        );
 
         let sql_val = SqlValue::HexStringLiteral("9AF".to_string());
         let v = sql_value_to_value("a", &ConcreteDataType::binary_datatype(), &sql_val, None);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Introduce a similar behavior from MySQL to GreptimeDB:
```SQL
# In MySQL
mysql> create table test(a int, b blob);
mysql> insert into test values(1, "123");
mysql> select * from test;
+------+------------+
| a    | b          |
+------+------------+
|    1 | 0x313233   |
+------+------------+
1 row in set (0.00 sec)
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for a new `Binary` data type.

- **Bug Fixes**
  - Enhanced data type handling by properly accounting for binary values in string conversions.

- **Tests**
  - Added comprehensive test cases to ensure the correct handling and stringification of the new `Binary` data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->