### PR TITLE
refactor: add `SerializedPickerOutput` and field modification of `CompactorRequest`

### DIFF
--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -32,6 +32,7 @@ use common_time::timestamp::TimeUnit;
 use common_time::Timestamp;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
+use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use store_api::metadata::RegionMetadataRef;
 use store_api::storage::RegionId;
@@ -57,7 +58,7 @@ use crate::region::version::{VersionControlRef, VersionRef};
 use crate::region::ManifestContextRef;
 use crate::request::{OptionOutputTx, OutputTx, WorkerRequest};
 use crate::schedule::scheduler::SchedulerRef;
-use crate::sst::file::{FileHandle, FileId, Level};
+use crate::sst::file::{FileHandle, FileId, FileMeta, Level};
 use crate::sst::version::LevelMeta;
 use crate::worker::WorkerListener;
 
@@ -440,6 +441,16 @@ pub struct CompactionOutput {
     pub filter_deleted: bool,
     /// Compaction output time range.
     pub output_time_range: Option<TimestampRange>,
+}
+
+/// SerializedCompactionOutput is a serialized version of [CompactionOutput] by replacing [FileHandle] with [FileMeta].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SerializedCompactionOutput {
+    output_file_id: FileId,
+    output_level: Level,
+    inputs: Vec<FileMeta>,
+    filter_deleted: bool,
+    output_time_range: Option<TimestampRange>,
 }
 
 /// Builds [BoxedBatchReader] that reads all SST files and yields batches in primary key order.

--- a/src/mito2/src/compaction.rs
+++ b/src/mito2/src/compaction.rs
@@ -284,6 +284,7 @@ impl CompactionScheduler {
             cache_manager: cache_manager.clone(),
             access_layer: access_layer.clone(),
             manifest_ctx: manifest_ctx.clone(),
+            file_purger: None,
         };
 
         let picker_output = {

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -61,6 +61,7 @@ pub struct CompactionRegion {
     pub(crate) access_layer: AccessLayerRef,
     pub(crate) manifest_ctx: Arc<ManifestContext>,
     pub(crate) current_version: VersionRef,
+    pub(crate) file_purger: Option<Arc<LocalFilePurger>>,
 }
 
 /// CompactorRequest represents the request to compact a region.
@@ -170,7 +171,14 @@ pub async fn open_compaction_region(
         access_layer,
         manifest_ctx,
         current_version,
+        file_purger: Some(file_purger),
     })
+}
+
+impl CompactionRegion {
+    pub fn file_purger(&self) -> Option<Arc<LocalFilePurger>> {
+        self.file_purger.clone()
+    }
 }
 
 /// `[MergeOutput]` represents the output of merging SST files.

--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -64,19 +64,18 @@ pub struct CompactionRegion {
     pub(crate) file_purger: Option<Arc<LocalFilePurger>>,
 }
 
-/// CompactorRequest represents the request to compact a region.
+/// OpenCompactionRegionRequest represents the request to open a compaction region.
 #[derive(Debug, Clone)]
-pub struct CompactorRequest {
+pub struct OpenCompactionRegionRequest {
     pub region_id: RegionId,
     pub region_dir: String,
     pub region_options: RegionOptions,
-    pub picker_output: PickerOutput,
 }
 
 /// Open a compaction region from a compaction request.
 /// It's simple version of RegionOpener::open().
 pub async fn open_compaction_region(
-    req: &CompactorRequest,
+    req: &OpenCompactionRegionRequest,
     mito_config: &MitoConfig,
     object_store_manager: ObjectStoreManager,
 ) -> Result<CompactionRegion> {

--- a/src/mito2/src/compaction/picker.rs
+++ b/src/mito2/src/compaction/picker.rs
@@ -55,30 +55,24 @@ pub struct SerializedPickerOutput {
     pub time_window_size: i64,
 }
 
-impl From<PickerOutput> for SerializedPickerOutput {
-    fn from(input: PickerOutput) -> Self {
+impl From<&PickerOutput> for SerializedPickerOutput {
+    fn from(input: &PickerOutput) -> Self {
         let outputs = input
             .outputs
-            .into_iter()
+            .iter()
             .map(|output| SerializedCompactionOutput {
                 output_file_id: output.output_file_id,
                 output_level: output.output_level,
-                inputs: output
-                    .inputs
-                    .into_iter()
-                    .map(|s| s.meta_ref().clone())
-                    .collect(),
+                inputs: output.inputs.iter().map(|s| s.meta_ref().clone()).collect(),
                 filter_deleted: output.filter_deleted,
                 output_time_range: output.output_time_range,
             })
             .collect();
-
         let expired_ssts = input
             .expired_ssts
-            .into_iter()
+            .iter()
             .map(|s| s.meta_ref().clone())
             .collect();
-
         Self {
             outputs,
             expired_ssts,
@@ -187,7 +181,7 @@ mod tests {
         };
 
         let picker_output_str =
-            serde_json::to_string(&SerializedPickerOutput::from(picker_output.clone())).unwrap();
+            serde_json::to_string(&SerializedPickerOutput::from(&picker_output)).unwrap();
         let serialized_picker_output: SerializedPickerOutput =
             serde_json::from_str(&picker_output_str).unwrap();
         let picker_output_from_serialized =

--- a/src/mito2/src/compaction/picker.rs
+++ b/src/mito2/src/compaction/picker.rs
@@ -16,13 +16,15 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use api::v1::region::compact_request;
+use serde::{Deserialize, Serialize};
 
 use crate::compaction::compactor::CompactionRegion;
 use crate::compaction::twcs::TwcsPicker;
 use crate::compaction::window::WindowedCompactionPicker;
-use crate::compaction::CompactionOutput;
+use crate::compaction::{CompactionOutput, SerializedCompactionOutput};
 use crate::region::options::CompactionOptions;
-use crate::sst::file::FileHandle;
+use crate::sst::file::{FileHandle, FileMeta};
+use crate::sst::file_purger::FilePurger;
 
 #[async_trait::async_trait]
 pub(crate) trait CompactionTask: Debug + Send + Sync + 'static {
@@ -45,6 +47,82 @@ pub struct PickerOutput {
     pub time_window_size: i64,
 }
 
+/// SerializedPickerOutput is a serialized version of PickerOutput by replacing [CompactionOutput] and [FileHandle] with [SerializedCompactionOutput] and [FileMeta].
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+pub struct SerializedPickerOutput {
+    pub outputs: Vec<SerializedCompactionOutput>,
+    pub expired_ssts: Vec<FileMeta>,
+    pub time_window_size: i64,
+}
+
+impl From<PickerOutput> for SerializedPickerOutput {
+    fn from(input: PickerOutput) -> Self {
+        let outputs = input
+            .outputs
+            .into_iter()
+            .map(|output| SerializedCompactionOutput {
+                output_file_id: output.output_file_id,
+                output_level: output.output_level,
+                inputs: output
+                    .inputs
+                    .into_iter()
+                    .map(|s| s.meta_ref().clone())
+                    .collect(),
+                filter_deleted: output.filter_deleted,
+                output_time_range: output.output_time_range,
+            })
+            .collect();
+
+        let expired_ssts = input
+            .expired_ssts
+            .into_iter()
+            .map(|s| s.meta_ref().clone())
+            .collect();
+
+        Self {
+            outputs,
+            expired_ssts,
+            time_window_size: input.time_window_size,
+        }
+    }
+}
+
+impl PickerOutput {
+    /// Converts a [SerializedPickerOutput] to a [PickerOutput].
+    pub fn from_serialized(
+        input: SerializedPickerOutput,
+        file_purger: Arc<dyn FilePurger>,
+    ) -> Self {
+        let outputs = input
+            .outputs
+            .into_iter()
+            .map(|output| CompactionOutput {
+                output_file_id: output.output_file_id,
+                output_level: output.output_level,
+                inputs: output
+                    .inputs
+                    .into_iter()
+                    .map(|file_meta| FileHandle::new(file_meta, file_purger.clone()))
+                    .collect(),
+                filter_deleted: output.filter_deleted,
+                output_time_range: output.output_time_range,
+            })
+            .collect();
+
+        let expired_ssts = input
+            .expired_ssts
+            .into_iter()
+            .map(|file_meta| FileHandle::new(file_meta, file_purger.clone()))
+            .collect();
+
+        Self {
+            outputs,
+            expired_ssts,
+            time_window_size: input.time_window_size,
+        }
+    }
+}
+
 /// Create a new picker based on the compaction request options and compaction options.
 pub fn new_picker(
     compact_request_options: compact_request::Options,
@@ -65,5 +143,80 @@ pub fn new_picker(
                 twcs_opts.time_window_seconds(),
             )) as Arc<_>,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compaction::test_util::new_file_handle;
+    use crate::sst::file::FileId;
+    use crate::test_util::new_noop_file_purger;
+
+    #[test]
+    fn test_picker_output_serialization() {
+        let inputs_file_handle = vec![
+            new_file_handle(FileId::random(), 0, 999, 0),
+            new_file_handle(FileId::random(), 0, 999, 0),
+            new_file_handle(FileId::random(), 0, 999, 0),
+        ];
+        let expired_ssts_file_handle = vec![
+            new_file_handle(FileId::random(), 0, 999, 0),
+            new_file_handle(FileId::random(), 0, 999, 0),
+        ];
+
+        let picker_output = PickerOutput {
+            outputs: vec![
+                CompactionOutput {
+                    output_file_id: FileId::random(),
+                    output_level: 0,
+                    inputs: inputs_file_handle.clone(),
+                    filter_deleted: false,
+                    output_time_range: None,
+                },
+                CompactionOutput {
+                    output_file_id: FileId::random(),
+                    output_level: 0,
+                    inputs: inputs_file_handle.clone(),
+                    filter_deleted: false,
+                    output_time_range: None,
+                },
+            ],
+            expired_ssts: expired_ssts_file_handle.clone(),
+            time_window_size: 1000,
+        };
+
+        let picker_output_str =
+            serde_json::to_string(&SerializedPickerOutput::from(picker_output.clone())).unwrap();
+        let serialized_picker_output: SerializedPickerOutput =
+            serde_json::from_str(&picker_output_str).unwrap();
+        let picker_output_from_serialized =
+            PickerOutput::from_serialized(serialized_picker_output, new_noop_file_purger());
+
+        picker_output
+            .expired_ssts
+            .iter()
+            .zip(picker_output_from_serialized.expired_ssts.iter())
+            .for_each(|(expected, actual)| {
+                assert_eq!(expected.meta_ref(), actual.meta_ref());
+            });
+
+        picker_output
+            .outputs
+            .iter()
+            .zip(picker_output_from_serialized.outputs.iter())
+            .for_each(|(expected, actual)| {
+                assert_eq!(expected.output_file_id, actual.output_file_id);
+                assert_eq!(expected.output_level, actual.output_level);
+                expected
+                    .inputs
+                    .iter()
+                    .zip(actual.inputs.iter())
+                    .for_each(|(expected, actual)| {
+                        assert_eq!(expected.meta_ref(), actual.meta_ref());
+                    });
+                assert_eq!(expected.filter_deleted, actual.filter_deleted);
+                assert_eq!(expected.output_time_range, actual.output_time_range);
+            });
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Add the new struct `SerializedPickerOutput` to transmit `PickerOutput` through the network;
2. The modification of `CompactorRequest`:
   - Rename to `OpenCompactionRegionRequest`;
   - Remove `compaction_options`;
   - Use `RegionOptions` type for `region_options` instead of `HashMap`;
   - Remove `PickerOutput`;
3. Add `file_purger` field in `CompactionRegion`, and it will be helpful when covert `SerializedPickerOutput` from `PickerOutput`;

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded compaction output to include optional time range information.
  - Added serialization support for compaction output for enhanced data handling.

- **Refactor**
  - Renamed `CompactorRequest` to `OpenCompactionRegionRequest` for clearer intent.
  - Introduced `SerializedPickerOutput` to improve data structure consistency and support easier data conversion.

- **Tests**
  - Added test cases for serialization to ensure data integrity during compaction processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->