### PR TITLE
fix: wrong frontend registration address

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -170,6 +170,7 @@
 | `http.body_limit` | String | `64MB` | HTTP request body limit.<br/>Support the following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:4001` | The address to bind the gRPC server. |
+| `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
 | `grpc.tls` | -- | -- | gRPC server TLS options, see `mysql.tls` section. |
 | `grpc.tls.mode` | String | `disable` | TLS mode. |
@@ -314,7 +315,7 @@
 | `rpc_max_send_message_size` | String | `None` | Deprecated, use `grpc.rpc_max_send_message_size` instead. |
 | `grpc` | -- | -- | The gRPC server options. |
 | `grpc.addr` | String | `127.0.0.1:3001` | The address to bind the gRPC server. |
-| `grpc.hostname` | String | `127.0.0.1` | The hostname to advertise to the metasrv. |
+| `grpc.hostname` | String | `127.0.0.1` | The hostname advertised to the metasrv,<br/>and used for connections from outside the host |
 | `grpc.runtime_size` | Integer | `8` | The number of server worker threads. |
 | `grpc.max_recv_message_size` | String | `512MB` | The maximum receive message size for gRPC server. |
 | `grpc.max_send_message_size` | String | `512MB` | The maximum send message size for gRPC server. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -43,7 +43,8 @@ rpc_max_send_message_size = "512MB"
 [grpc]
 ## The address to bind the gRPC server.
 addr = "127.0.0.1:3001"
-## The hostname to advertise to the metasrv.
+## The hostname advertised to the metasrv,
+## and used for connections from outside the host
 hostname = "127.0.0.1"
 ## The number of server worker threads.
 runtime_size = 8

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -36,6 +36,9 @@ body_limit = "64MB"
 [grpc]
 ## The address to bind the gRPC server.
 addr = "127.0.0.1:4001"
+## The hostname advertised to the metasrv,
+## and used for connections from outside the host
+hostname = "127.0.0.1"
 ## The number of server worker threads.
 runtime_size = 8
 

--- a/src/frontend/src/heartbeat.rs
+++ b/src/frontend/src/heartbeat.rs
@@ -22,6 +22,7 @@ use common_meta::heartbeat::mailbox::{HeartbeatMailbox, MailboxRef, OutgoingMess
 use common_meta::heartbeat::utils::outgoing_message_to_mailbox_message;
 use common_telemetry::{debug, error, info};
 use meta_client::client::{HeartbeatSender, HeartbeatStream, MetaClient};
+use servers::addrs;
 use servers::heartbeat_options::HeartbeatOptions;
 use snafu::ResultExt;
 use tokio::sync::mpsc;
@@ -37,7 +38,7 @@ pub mod handler;
 /// The frontend heartbeat task which sending `[HeartbeatRequest]` to Metasrv periodically in background.
 #[derive(Clone)]
 pub struct HeartbeatTask {
-    server_addr: String,
+    peer_addr: String,
     meta_client: Arc<MetaClient>,
     report_interval: u64,
     retry_interval: u64,
@@ -53,7 +54,7 @@ impl HeartbeatTask {
         resp_handler_executor: HeartbeatResponseHandlerExecutorRef,
     ) -> Self {
         HeartbeatTask {
-            server_addr: opts.grpc.addr.clone(),
+            peer_addr: addrs::resolve_addr(&opts.grpc.addr, Some(&opts.grpc.hostname)),
             meta_client,
             report_interval: heartbeat_opts.interval.as_millis() as u64,
             retry_interval: heartbeat_opts.retry_interval.as_millis() as u64,
@@ -129,7 +130,7 @@ impl HeartbeatTask {
         let self_peer = Some(Peer {
             // The peer id doesn't make sense for frontend, so we just set it 0.
             id: 0,
-            addr: self.server_addr.clone(),
+            addr: self.peer_addr.clone(),
         });
 
         common_runtime::spawn_hb(async move {

--- a/src/servers/src/addrs.rs
+++ b/src/servers/src/addrs.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use common_telemetry::warn;
+
 /// Resolves hostname:port address for meta registration.
 /// If `hostname_addr` is present, prefer to use it, `bind_addr` otherwise.
-///
 pub fn resolve_addr(bind_addr: &str, hostname_addr: Option<&str>) -> String {
     match hostname_addr {
         Some(hostname_addr) => {
@@ -28,7 +29,10 @@ pub fn resolve_addr(bind_addr: &str, hostname_addr: Option<&str>) -> String {
                 format!("{hostname_addr}:{port}")
             }
         }
-        None => bind_addr.to_string(),
+        None => {
+            warn!("hostname not set, using bind_addr: {bind_addr} instead.");
+            bind_addr.to_string()
+        }
     }
 }
 

--- a/src/servers/src/addrs.rs
+++ b/src/servers/src/addrs.rs
@@ -1,0 +1,40 @@
+/// Resolves hostname:port address for meta registration.
+/// If `hostname_addr` is present, prefer to use it, `bind_addr` otherwise.
+///
+pub fn resolve_addr(bind_addr: &str, hostname_addr: Option<&str>) -> String {
+    match hostname_addr {
+        Some(hostname_addr) => {
+            // it has port configured
+            if hostname_addr.contains(':') {
+                hostname_addr.to_string()
+            } else {
+                // otherwise, resolve port from bind_addr
+                // should be safe to unwrap here because bind_addr is already validated
+                let port = bind_addr.split(':').nth(1).unwrap();
+                format!("{hostname_addr}:{port}")
+            }
+        }
+        None => bind_addr.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_resolve_addr() {
+        assert_eq!(
+            "tomcat:3001",
+            super::resolve_addr("127.0.0.1:3001", Some("tomcat"))
+        );
+
+        assert_eq!(
+            "tomcat:3002",
+            super::resolve_addr("127.0.0.1:3001", Some("tomcat:3002"))
+        );
+
+        assert_eq!(
+            "127.0.0.1:3001",
+            super::resolve_addr("127.0.0.1:3001", None)
+        );
+    }
+}

--- a/src/servers/src/addrs.rs
+++ b/src/servers/src/addrs.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 /// Resolves hostname:port address for meta registration.
 /// If `hostname_addr` is present, prefer to use it, `bind_addr` otherwise.
 ///

--- a/src/servers/src/lib.rs
+++ b/src/servers/src/lib.rs
@@ -20,6 +20,7 @@
 use datatypes::schema::Schema;
 use query::plan::LogicalPlan;
 
+pub mod addrs;
 pub mod configurator;
 pub mod error;
 pub mod export_metrics;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4186 
## What's changed and what's your intention?

Fixed the wrong peer address that frontend registers.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new configuration parameter `grpc.hostname` to improve clarity and understanding of its usage for external connections.
  
- **Improvements**
  - Updated configuration files to provide clarification on the `hostname` field for gRPC servers, enhancing documentation for end-users.

- **Refactor**
  - Renamed `server_addr` to `peer_addr` in heartbeat components for consistency.
  - Improved address resolution logic for better handling of hostname and port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->