### PR TITLE
test: wait until checkpoint finish

### DIFF
--- a/src/mito2/src/manifest/tests/checkpoint.rs
+++ b/src/mito2/src/manifest/tests/checkpoint.rs
@@ -172,6 +172,11 @@ async fn test_corrupted_data_causing_checksum_error() {
         manager.update(nop_action()).await.unwrap();
     }
 
+    // Wait for the checkpoint to finish.
+    while manager.checkpointer().is_doing_checkpoint() {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
     // Check if there is a checkpoint
     assert!(manager
         .store()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4191

## What's changed and what's your intention?

The checkpoint is done in the background so the checkpoint test may not corrupt the latest checkpoint. This PR waits until the checkpoint is finished.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced test reliability by adding a mechanism to wait for a checkpoint to finish before proceeding with further operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->