### PR TITLE
feat: validate partition rule on create table

### DIFF
--- a/src/operator/src/error.rs
+++ b/src/operator/src/error.rs
@@ -156,6 +156,13 @@ pub enum Error {
         source: common_meta::error::Error,
     },
 
+    #[snafu(display("Invalid partition"))]
+    InvalidPartition {
+        #[snafu(implicit)]
+        location: Location,
+        source: partition::error::Error,
+    },
+
     #[snafu(display("Invalid SQL, error: {}", err_msg))]
     InvalidSql {
         err_msg: String,
@@ -727,7 +734,8 @@ impl ErrorExt for Error {
             | Error::InvalidViewName { .. }
             | Error::InvalidExpr { .. }
             | Error::InvalidViewStmt { .. }
-            | Error::ConvertIdentifier { .. } => StatusCode::InvalidArguments,
+            | Error::ConvertIdentifier { .. }
+            | Error::InvalidPartition { .. } => StatusCode::InvalidArguments,
 
             Error::TableAlreadyExists { .. } | Error::ViewAlreadyExists { .. } => {
                 StatusCode::TableAlreadyExists

--- a/src/partition/src/multi_dim.rs
+++ b/src/partition/src/multi_dim.rs
@@ -66,7 +66,7 @@ impl MultiDimPartitionRule {
         };
 
         let mut checker = RuleChecker::new(&rule);
-        checker.check(&rule)?;
+        checker.check()?;
 
         Ok(rule)
     }
@@ -189,8 +189,8 @@ impl<'a> RuleChecker<'a> {
         }
     }
 
-    pub fn check(&mut self, rule: &MultiDimPartitionRule) -> Result<()> {
-        for expr in &rule.exprs {
+    pub fn check(&mut self) -> Result<()> {
+        for expr in &self.rule.exprs {
             self.walk_expr(expr)?
         }
 

--- a/tests/cases/standalone/common/partition.result
+++ b/tests/cases/standalone/common/partition.result
@@ -167,3 +167,17 @@ DROP TABLE my_table;
 
 Affected Rows: 0
 
+-- incorrect partition rule
+CREATE TABLE invalid_rule (
+  a INT PRIMARY KEY,
+  b STRING,
+  ts TIMESTAMP TIME INDEX,
+)
+PARTITION ON COLUMNS (a) (
+  a < 10,
+  a > 10 AND a < 20,
+  a >= 20
+);
+
+Error: 1004(InvalidArguments), Unclosed value Int32(10) on column a
+

--- a/tests/cases/standalone/common/partition.sql
+++ b/tests/cases/standalone/common/partition.sql
@@ -69,3 +69,15 @@ INSERT INTO my_table VALUES
 SELECT * FROM my_table;
 
 DROP TABLE my_table;
+
+-- incorrect partition rule
+CREATE TABLE invalid_rule (
+  a INT PRIMARY KEY,
+  b STRING,
+  ts TIMESTAMP TIME INDEX,
+)
+PARTITION ON COLUMNS (a) (
+  a < 10,
+  a > 10 AND a < 20,
+  a >= 20
+);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Validate partition rule on `CREATE TABLE`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved error handling with a new `InvalidPartition` error variant, providing more specific error messages for invalid partition rules.
  
- **Bug Fixes**
  - Enhanced validation for partition rules, ensuring errors are correctly flagged when rules are improperly defined.

- **Refactor**
  - Streamlined method signatures for partition rule checking, simplifying the code and improving maintainability.

- **Tests**
  - Added tests to check for appropriate error handling when creating tables with invalid partition rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->