### PR TITLE
ci: add the github actions of pushing image to aws public ecr

### DIFF
--- a/.github/actions/build-dev-builder-images/action.yml
+++ b/.github/actions/build-dev-builder-images/action.yml
@@ -31,6 +31,21 @@ inputs:
     description: Build dev-builder-android image
     required: false
     default: "true"
+  aws-access-key-id:
+    description: AWS access key id
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key
+    required: true
+  aws-ecr-region:
+    description: AWS ecr region
+    required: true
+  aws-image-registry:
+    description: AWS ecr registry
+    required: true
+  image-namespace:
+    description: The namespace of the image registry to store the images
+    required: true
 runs:
   using: composite
   steps:
@@ -41,7 +56,19 @@ runs:
         username: ${{ inputs.dockerhub-image-registry-username }}
         password: ${{ inputs.dockerhub-image-registry-token }}
 
-    - name: Build and push dev-builder-ubuntu image
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-ecr-region }}
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+
+    - name: Build and push dev-builder-ubuntu image to dockerhub
       shell: bash
       if: ${{ inputs.build-dev-builder-ubuntu == 'true' }}
       run: |
@@ -52,7 +79,22 @@ runs:
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }}
 
-    - name: Build and push dev-builder-centos image
+        docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
+
+    - name: Build and push dev-builder-ubuntu image to ecr
+      shell: bash
+      if: ${{ inputs.build-dev-builder-ubuntu == 'true' }}
+      run: |
+        make dev-builder \
+          BASE_IMAGE=ubuntu \
+          BUILDX_MULTI_PLATFORM_BUILD=all \
+          IMAGE_REGISTRY=${{ inputs.aws-image-registry }} \
+          IMAGE_NAMESPACE=${{ inputs.image-namespace }} \
+          IMAGE_TAG=${{ inputs.version }}
+
+        docker push ${{ inputs.aws-image-registry }}/${{ inputs.image-namespace }}/dev-builder-ubuntu:${{ inputs.version }}
+
+    - name: Build and push dev-builder-centos image to dockerhub
       shell: bash
       if: ${{ inputs.build-dev-builder-centos == 'true' }}
       run: |
@@ -63,7 +105,22 @@ runs:
           IMAGE_NAMESPACE=${{ inputs.dockerhub-image-namespace }} \
           IMAGE_TAG=${{ inputs.version }}
 
-    - name: Build and push dev-builder-android image # Only build image for amd64 platform.
+        docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-centos:${{ inputs.version }}
+
+    - name: Build and push dev-builder-centos image to ecr
+      shell: bash
+      if: ${{ inputs.build-dev-builder-centos == 'true' }}
+      run: |
+        make dev-builder \
+          BASE_IMAGE=centos \
+          BUILDX_MULTI_PLATFORM_BUILD=amd64 \
+          IMAGE_REGISTRY=${{ inputs.aws-image-registry }} \
+          IMAGE_NAMESPACE=${{ inputs.image-namespace }} \
+          IMAGE_TAG=${{ inputs.version }}
+
+        docker push ${{ inputs.aws-image-registry }}/${{ inputs.image-namespace }}/dev-builder-centos:${{ inputs.version }}
+
+    - name: Build and push dev-builder-android image to dockerhub # Only build image for amd64 platform.
       shell: bash
       if: ${{ inputs.build-dev-builder-android == 'true' }}
       run: |
@@ -74,3 +131,15 @@ runs:
           IMAGE_TAG=${{ inputs.version }} && \
 
         docker push ${{ inputs.dockerhub-image-registry }}/${{ inputs.dockerhub-image-namespace }}/dev-builder-android:${{ inputs.version }}
+
+    - name: Build and push dev-builder-android image to ecr
+      shell: bash
+      if: ${{ inputs.build-dev-builder-android == 'true' }}
+      run: |
+        make dev-builder \
+          BASE_IMAGE=android \
+          IMAGE_REGISTRY=${{ inputs.aws-image-registry }} \
+          IMAGE_NAMESPACE=${{ inputs.image-namespace }} \
+          IMAGE_TAG=${{ inputs.version }} && \
+
+        docker push ${{ inputs.aws-image-registry }}/${{ inputs.image-namespace }}/dev-builder-android:${{ inputs.version }}

--- a/.github/actions/build-greptime-images/action.yml
+++ b/.github/actions/build-greptime-images/action.yml
@@ -36,6 +36,18 @@ inputs:
     description: Whether to push the latest tag
     required: false
     default: 'true'
+  aws-access-key-id:
+    description: AWS access key id
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key
+    required: true
+  aws-ecr-region:
+    description: AWS ecr region
+    required: true
+  aws-image-registry:
+    description: AWS ecr registry
+    required: true
 runs:
   using: composite
   steps:
@@ -45,6 +57,18 @@ runs:
         registry: ${{ inputs.image-registry }}
         username: ${{ inputs.image-registry-username }}
         password: ${{ inputs.image-registry-password }}
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ inputs.aws-ecr-region }}
+
+    - name: Login to Amazon ECR
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
 
     - name: Set up qemu for multi-platform builds
       uses: docker/setup-qemu-action@v2
@@ -102,3 +126,5 @@ runs:
         tags: |
           ${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:latest
           ${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+          ${{ inputs.aws-image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:latest
+          ${{ inputs.aws-image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.image-tag }}

--- a/.github/actions/build-images/action.yml
+++ b/.github/actions/build-images/action.yml
@@ -28,6 +28,18 @@ inputs:
     description: Enable dev mode, only build standard greptime
     required: false
     default: 'false'
+  aws-access-key-id:
+    description: AWS access key id
+    required: true
+  aws-secret-access-key:
+    description: AWS secret access key
+    required: true
+  aws-ecr-region:
+    description: AWS ecr region
+    required: true
+  aws-image-registry:
+    description: AWS ecr registry
+    required: true
 runs:
   using: composite
   steps:
@@ -54,6 +66,38 @@ runs:
         image-namespace: ${{ inputs.image-namespace }}
         image-registry-username: ${{ inputs.image-registry-username }}
         image-registry-password: ${{ inputs.image-registry-password }}
+        image-name: ${{ inputs.image-name }}-centos
+        image-tag: ${{ inputs.version }}
+        docker-file: docker/ci/centos/Dockerfile
+        amd64-artifact-name: greptime-linux-amd64-centos-${{ inputs.version }}
+        platforms: linux/amd64
+        push-latest-tag: ${{ inputs.push-latest-tag }}
+
+    - name: Build and push standard images to ecr
+      uses: ./.github/actions/build-greptime-images
+      with: # The image will be used as '${{ inputs.image-registry }}/${{ inputs.image-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}'
+        image-registry: ${{ inputs.image-registry }}
+        image-namespace: ${{ inputs.image-namespace }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-ecr-region: ${{ inputs.aws-ecr-region }}
+        image-name: ${{ inputs.image-name }}
+        image-tag: ${{ inputs.version }}
+        docker-file: docker/ci/ubuntu/Dockerfile
+        amd64-artifact-name: greptime-linux-amd64-pyo3-${{ inputs.version }}
+        arm64-artifact-name: greptime-linux-arm64-pyo3-${{ inputs.version }}
+        platforms: linux/amd64,linux/arm64
+        push-latest-tag: ${{ inputs.push-latest-tag }}
+
+    - name: Build and push centos images to ecr
+      if: ${{ inputs.dev-mode == 'false' }}
+      uses: ./.github/actions/build-greptime-images
+      with:
+        image-registry: ${{ inputs.image-registry }}
+        image-namespace: ${{ inputs.image-namespace }}
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-ecr-region: ${{ inputs.aws-ecr-region }}
         image-name: ${{ inputs.image-name }}-centos
         image-tag: ${{ inputs.version }}
         docker-file: docker/ci/centos/Dockerfile

--- a/.github/actions/build-linux-artifacts/action.yml
+++ b/.github/actions/build-linux-artifacts/action.yml
@@ -31,8 +31,8 @@ runs:
       run: |
         cd ${{ inputs.working-dir }} && \
         make run-it-in-container BUILD_JOBS=4 \
-        IMAGE_NAMESPACE=i8k6a5e1/greptime \
-        IMAGE_REGISTRY=public.ecr.aws
+        IMAGE_NAMESPACE=${{ vars.IMAGE_NAMESPACE }} \
+        IMAGE_REGISTRY=${{ vars.aws-image-registry }}
 
     - name: Upload sqlness logs
       if: ${{ failure() && inputs.disable-run-tests == 'false' }} # Only upload logs when the integration tests failed.
@@ -51,8 +51,8 @@ runs:
         artifacts-dir: greptime-linux-${{ inputs.arch }}-pyo3-${{ inputs.version }}
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
-        image-registry: public.ecr.aws
-        image-namespace: i8k6a5e1/greptime        
+        image-registry: ${{ vars.aws-image-registry }}
+        image-namespace: ${{ vars.IMAGE_NAMESPACE }}
 
     - name: Build greptime without pyo3
       if: ${{ inputs.dev-mode == 'false' }}
@@ -64,8 +64,8 @@ runs:
         artifacts-dir: greptime-linux-${{ inputs.arch }}-${{ inputs.version }}
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
-        image-registry: public.ecr.aws
-        image-namespace: i8k6a5e1/greptime
+        image-registry: ${{ vars.aws-image-registry }}
+        image-namespace: ${{ vars.IMAGE_NAMESPACE }}
 
     - name: Clean up the target directory # Clean up the target directory for the centos7 base image, or it will still use the objects of last build.
       shell: bash
@@ -82,8 +82,8 @@ runs:
         artifacts-dir: greptime-linux-${{ inputs.arch }}-centos-${{ inputs.version }}
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
-        image-registry: public.ecr.aws
-        image-namespace: i8k6a5e1/greptime
+        image-registry: ${{ vars.aws-image-registry }}
+        image-namespace: ${{ vars.IMAGE_NAMESPACE }}
 
     - name: Build greptime on android base image
       uses: ./.github/actions/build-greptime-binary
@@ -94,5 +94,5 @@ runs:
         version: ${{ inputs.version }}
         working-dir: ${{ inputs.working-dir }}
         build-android-artifacts: true
-        image-registry: public.ecr.aws
-        image-namespace: i8k6a5e1/greptime
+        image-registry: ${{ vars.aws-image-registry }}
+        image-namespace: ${{ vars.IMAGE_NAMESPACE }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -240,12 +240,44 @@ jobs:
         run: |
           echo "build-result=success" >> $GITHUB_OUTPUT
 
+  release-images-to-ecr:
+    name: Build and push images to aws ecr
+    if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+    ]
+    runs-on: ubuntu-2004-16-cores
+    outputs:
+      build-result: ${{ steps.set-build-result.outputs.build-result }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and push images to ecr
+        uses: ./.github/actions/build-images
+        with:
+          aws-image-registry: ${{ vars.aws-image-registry }}
+          image-namespace: ${{ vars.IMAGE_NAMESPACE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          version: ${{ needs.allocate-runners.outputs.version }}
+          aws-ecr-region: ${{ vars.AWS_ECR_REGION }}
+
+      - name: Set build result
+        id: set-build-result
+        run: |
+          echo "build-result=success" >> $GITHUB_OUTPUT
+
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'schedule' }}
     needs: [
       allocate-runners,
       release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     continue-on-error: true
@@ -327,7 +359,8 @@ jobs:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' && always() }} # Not requiring successful dependent jobs, always run.
     name: Send notification to Greptime team
     needs: [
-      release-images-to-dockerhub
+      release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     env:
@@ -341,17 +374,17 @@ jobs:
         run: pnpm tsx bin/report-ci-failure.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.build-result == 'success' }}
+          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.build-result == 'success' && needs.release-images-to-ecr.outputs.build-result == 'success' }}
       - name: Notify dev build successful result
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.build-result == 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.build-result == 'success' && needs.release-images-to-ecr.outputs.build-result == 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's ${{ env.NEXT_RELEASE_VERSION }} build has completed successfully."}
 
       - name: Notify dev build failed result
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.build-result != 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.build-result != 'success' || needs.release-images-to-ecr.outputs.build-result != 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's ${{ env.NEXT_RELEASE_VERSION }} build has failed, please check ${{ steps.report-ci-status.outputs.html_url }}."}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -206,12 +206,44 @@ jobs:
         run: |
           echo "nightly-build-result=success" >> $GITHUB_OUTPUT
 
+  release-images-to-ecr:
+    name: Build and push images to aws ecr
+    if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+    ]
+    runs-on: ubuntu-2004-16-cores
+    outputs:
+      nightly-build-result: ${{ steps.set-nightly-build-result.outputs.nightly-build-result }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and push images to ecr
+        uses: ./.github/actions/build-images
+        with:
+          aws-image-registry: ${{ vars.aws-image-registry }}
+          image-namespace: ${{ vars.IMAGE_NAMESPACE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          version: ${{ needs.allocate-runners.outputs.version }}
+          aws-ecr-region: ${{ vars.AWS_ECR_REGION }}
+
+      - name: Set nightly build result
+        id: set-nightly-build-result
+        run: |
+          echo "nightly-build-result=success" >> $GITHUB_OUTPUT
+
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'schedule' }}
     needs: [
       allocate-runners,
       release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     # When we push to ACR, it's easy to fail due to some unknown network issues.
@@ -296,7 +328,8 @@ jobs:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' && always() }} # Not requiring successful dependent jobs, always run.
     name: Send notification to Greptime team
     needs: [
-      release-images-to-dockerhub
+      release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     env:
@@ -310,17 +343,17 @@ jobs:
         run: pnpm tsx bin/report-ci-failure.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result == 'success' }}
+          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result == 'success' && needs.release-images-to-ecr.outputs.nightly-build-result == 'success' }}
       - name: Notify nightly build successful result
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result == 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result == 'success' && needs.release-images-to-ecr.outputs.nightly-build-result == 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's ${{ env.NEXT_RELEASE_VERSION }} build has completed successfully."}
 
       - name: Notify nightly build failed result
         uses: slackapi/slack-github-action@v1.23.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result != 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.nightly-build-result != 'success' || needs.release-images-to-ecr.outputs.nightly-build-result != 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's ${{ env.NEXT_RELEASE_VERSION }} build has failed, please check ${{ steps.report-ci-status.outputs.html_url }}."}

--- a/.github/workflows/release-dev-builder-images.yaml
+++ b/.github/workflows/release-dev-builder-images.yaml
@@ -43,6 +43,11 @@ jobs:
           build-dev-builder-ubuntu: ${{ inputs.release_dev_builder_ubuntu_image }}
           build-dev-builder-centos: ${{ inputs.release_dev_builder_centos_image }}
           build-dev-builder-android: ${{ inputs.release_dev_builder_android_image }}
+          aws-image-registry: ${{ vars.aws-image-registry }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-ecr-region: ${{ vars.AWS_ECR_REGION }}
+          image-namespace: ${{ vars.IMAGE_NAMESPACE }}
 
   release-dev-builder-images-cn: # Note: Be careful issue: https://github.com/containers/skopeo/issues/1874 and we decide to use the latest stable skopeo container.
     name: Release dev builder images to CN region

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,37 @@ jobs:
         run: |
           echo "build-image-result=success" >> $GITHUB_OUTPUT
 
+  release-images-to-ecr:
+    name: Build and push images to aws ecr
+    if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+    ]
+    runs-on: ubuntu-2004-16-cores
+    outputs:
+      build-image-result: ${{ steps.set-build-image-result.outputs.build-image-result }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build and push images to ecr
+        uses: ./.github/actions/build-images
+        with:
+          aws-image-registry: ${{ vars.aws-image-registry }} # public.ecr.aws/i8k6a5e1
+          image-namespace: ${{ vars.IMAGE_NAMESPACE }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          version: ${{ needs.allocate-runners.outputs.version }}
+          aws-ecr-region: ${{ vars.AWS_ECR_REGION }} # us-east-1
+
+      - name: Set build image result
+        id: set-build-image-result
+        run: |
+          echo "build-image-result=success" >> $GITHUB_OUTPUT
+
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
@@ -335,6 +366,7 @@ jobs:
       build-macos-artifacts,
       build-windows-artifacts,
       release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     # When we push to ACR, it's easy to fail due to some unknown network issues.
@@ -375,6 +407,7 @@ jobs:
       build-macos-artifacts,
       build-windows-artifacts,
       release-images-to-dockerhub,
+      release-images-to-ecr,
     ]
     runs-on: ubuntu-20.04
     steps:
@@ -445,6 +478,7 @@ jobs:
     name: Send notification to Greptime team
     needs: [
       release-images-to-dockerhub,
+      release-images-to-ecr,
       build-macos-artifacts,
       build-windows-artifacts,
     ]
@@ -460,17 +494,17 @@ jobs:
         run: pnpm tsx bin/report-ci-failure.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.build-image-result == 'success' && needs.build-windows-artifacts.outputs.build-windows-result == 'success' && needs.build-macos-artifacts.outputs.build-macos-result == 'success' }}
+          CI_REPORT_STATUS: ${{ needs.release-images-to-dockerhub.outputs.build-image-result == 'success' && needs.release-images-to-ecr.outputs.build-image-result == 'success' &&  needs.build-windows-artifacts.outputs.build-windows-result == 'success' && needs.build-macos-artifacts.outputs.build-macos-result == 'success' }}
       - name: Notify release successful result
         uses: slackapi/slack-github-action@v1.25.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.build-image-result == 'success' && needs.build-windows-artifacts.outputs.build-windows-result == 'success' && needs.build-macos-artifacts.outputs.build-macos-result == 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.build-image-result == 'success' && needs.release-images-to-ecr.outputs.build-image-result == 'success' && needs.build-windows-artifacts.outputs.build-windows-result == 'success' && needs.build-macos-artifacts.outputs.build-macos-result == 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's release version has completed successfully."}
 
       - name: Notify release failed result
         uses: slackapi/slack-github-action@v1.25.0
-        if: ${{ needs.release-images-to-dockerhub.outputs.build-image-result != 'success' || needs.build-windows-artifacts.outputs.build-windows-result != 'success' || needs.build-macos-artifacts.outputs.build-macos-result != 'success' }}
+        if: ${{ needs.release-images-to-dockerhub.outputs.build-image-result != 'success' || needs.release-images-to-ecr.outputs.build-image-result != 'success' || needs.build-windows-artifacts.outputs.build-windows-result != 'success' || needs.build-macos-artifacts.outputs.build-macos-result != 'success' }}
         with:
           payload: |
             {"text": "GreptimeDB's release version has failed, please check ${{ steps.report-ci-status.outputs.html_url }}."}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,12 +344,12 @@ jobs:
       - name: Build and push images to ecr
         uses: ./.github/actions/build-images
         with:
-          aws-image-registry: ${{ vars.aws-image-registry }} # public.ecr.aws/i8k6a5e1
+          aws-image-registry: ${{ vars.aws-image-registry }}
           image-namespace: ${{ vars.IMAGE_NAMESPACE }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           version: ${{ needs.allocate-runners.outputs.version }}
-          aws-ecr-region: ${{ vars.AWS_ECR_REGION }} # us-east-1
+          aws-ecr-region: ${{ vars.AWS_ECR_REGION }}
 
       - name: Set build image result
         id: set-build-image-result


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Same as this: https://github.com/GreptimeTeam/greptimedb-operator/pull/155

## What's changed and what's your intention?
Add push image to aws container image registry. 

Need to add two repositoriy variables：
`aws-image-registry`: `public.ecr.aws/i8k6a5e1`
`AWS_ECR_REGION`: `us-east-1`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added functionality to push Docker images to AWS ECR in addition to DockerHub.
  - Introduced new job `release-images-to-ecr` for building and pushing images to AWS ECR.

- **Chores**
  - Updated workflows to include AWS credentials and ECR configuration.
  - Added AWS-related variables and input parameters across multiple workflow files.

- **Documentation**
  - Enhanced notification logic to reflect the results of image releases to both DockerHub and AWS ECR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->