### PR TITLE
feat(servers): make http timeout and body limit optional

### DIFF
--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -26,10 +26,11 @@ retry_interval = "3s"
 [http]
 ## The address to bind the HTTP server.
 addr = "127.0.0.1:4000"
-## HTTP request timeout.
+## HTTP request timeout. Set to 0 to disable timeout.
 timeout = "30s"
 ## HTTP request body limit.
 ## Support the following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.
+## Set to 0 to disable limit.
 body_limit = "64MB"
 
 ## The gRPC server options.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -21,10 +21,11 @@ bg_rt_size = 4
 [http]
 ## The address to bind the HTTP server.
 addr = "127.0.0.1:4000"
-## HTTP request timeout.
+## HTTP request timeout. Set to 0 to disable timeout.
 timeout = "30s"
 ## HTTP request body limit.
 ## Support the following units are supported: `B`, `KB`, `KiB`, `MB`, `MiB`, `GB`, `GiB`, `TB`, `TiB`, `PB`, `PiB`.
+## Set to 0 to disable limit.
 body_limit = "64MB"
 
 ## The gRPC server options.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Set timeout or body limit to 0 to disable them.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to disable `timeout` and `body_limit` settings by setting them to 0 in configuration files, allowing more flexible customization.
- **Improvements**
  - Enhanced server configuration to dynamically adjust `timeout` and `body_limit` settings, including logging when these settings are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->