### PR TITLE
refactor: use ObjectStoreManagerRef type in open_compaction_region() and add related unit test

### DIFF
--- a/src/mito2/src/compaction/compactor.rs
+++ b/src/mito2/src/compaction/compactor.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use api::v1::region::compact_request;
 use common_telemetry::info;
-use object_store::manager::ObjectStoreManager;
+use object_store::manager::ObjectStoreManagerRef;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use snafu::{OptionExt, ResultExt};
@@ -77,7 +77,7 @@ pub struct OpenCompactionRegionRequest {
 pub async fn open_compaction_region(
     req: &OpenCompactionRegionRequest,
     mito_config: &MitoConfig,
-    object_store_manager: ObjectStoreManager,
+    object_store_manager: ObjectStoreManagerRef,
 ) -> Result<CompactionRegion> {
     let object_store = {
         let name = &req.region_options.storage;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Use `ObjectStoreManagerRef` type in `open_compaction_region()` and add related unit test

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal handling of storage management by updating parameter types in functions.
- **Tests**
	- Enhanced test coverage for storage engine and region compaction functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->