### PR TITLE
feat!: remove alias `metasrv-addr`

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -125,7 +125,7 @@ struct StartCommand {
     rpc_addr: Option<String>,
     #[clap(long)]
     rpc_hostname: Option<String>,
-    #[clap(long, aliases = ["metasrv-addr"], value_delimiter = ',', num_args = 1..)]
+    #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addrs: Option<Vec<String>>,
     #[clap(short, long)]
     config_file: Option<String>,

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -147,7 +147,7 @@ pub struct StartCommand {
     config_file: Option<String>,
     #[clap(short, long)]
     influxdb_enable: Option<bool>,
-    #[clap(long, aliases = ["metasrv-addr"], value_delimiter = ',', num_args = 1..)]
+    #[clap(long, value_delimiter = ',', num_args = 1..)]
     metasrv_addrs: Option<Vec<String>>,
     #[clap(long)]
     tls_mode: Option<TlsMode>,

--- a/tests/runner/src/env.rs
+++ b/tests/runner/src/env.rs
@@ -227,7 +227,7 @@ impl Env {
                     DEFAULT_LOG_LEVEL.to_string(),
                     subcommand.to_string(),
                     "start".to_string(),
-                    "--metasrv-addr=127.0.0.1:3002".to_string(),
+                    "--metasrv-addrs=127.0.0.1:3002".to_string(),
                     "--http-addr=127.0.0.1:5003".to_string(),
                 ];
                 (args, SERVER_ADDR.to_string())
@@ -303,7 +303,7 @@ impl Env {
         args.push(format!("--node-id={id}"));
         args.push("-c".to_string());
         args.push(self.generate_config_file(subcommand, db_ctx));
-        args.push("--metasrv-addr=127.0.0.1:3002".to_string());
+        args.push("--metasrv-addrs=127.0.0.1:3002".to_string());
         (args, format!("127.0.0.1:410{id}"))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb-operator/pull/156
https://github.com/GreptimeTeam/docs/pull/1030
cherry-pick from https://github.com/GreptimeTeam/greptimedb/pull/4226

## What's changed and what's your intention?

remove alias `metasrv-addr` for `metasrv-addrs`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated command-line argument names from `--metasrv-addr` to `--metasrv-addrs` for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->