### PR TITLE
ci: update centos yum source and specify cargo-binstall version

### DIFF
--- a/docker/ci/centos/Dockerfile
+++ b/docker/ci/centos/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:7
 
+# Note: CentOS 7 has reached EOL since 2024-07-01 thus `mirror.centos.org` is no longer available and we need to use `vault.centos.org` instead.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y epel-release \
     openssl \
     openssl-devel  \

--- a/docker/dev-builder/centos/Dockerfile
+++ b/docker/dev-builder/centos/Dockerfile
@@ -2,6 +2,10 @@ FROM centos:7 as builder
 
 ENV LANG en_US.utf8
 
+# Note: CentOS 7 has reached EOL since 2024-07-01 thus `mirror.centos.org` is no longer available and we need to use `vault.centos.org` instead.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+
 # Install dependencies
 RUN ulimit -n 1024000 && yum groupinstall -y 'Development Tools'
 RUN yum install -y epel-release  \

--- a/docker/dev-builder/centos/Dockerfile
+++ b/docker/dev-builder/centos/Dockerfile
@@ -29,6 +29,10 @@ ENV PATH /opt/rh/rh-python38/root/usr/bin:/usr/local/bin:/root/.cargo/bin/:$PATH
 ARG RUST_TOOLCHAIN
 RUN rustup toolchain install ${RUST_TOOLCHAIN}
 
-# Install nextest.
+
+# Install cargo-binstall with a specific version to adapt the current rust toolchain.
+# Note: if we use the latest version, we may encounter the following `use of unstable library feature 'io_error_downcast'` error.
 RUN cargo install cargo-binstall --version 1.6.6 --locked
+
+# Install nextest.
 RUN cargo binstall cargo-nextest --no-confirm

--- a/docker/dev-builder/centos/Dockerfile
+++ b/docker/dev-builder/centos/Dockerfile
@@ -30,5 +30,5 @@ ARG RUST_TOOLCHAIN
 RUN rustup toolchain install ${RUST_TOOLCHAIN}
 
 # Install nextest.
-RUN cargo install cargo-binstall --locked
+RUN cargo install cargo-binstall --version 1.6.6 --locked
 RUN cargo binstall cargo-nextest --no-confirm

--- a/docker/dev-builder/ubuntu/Dockerfile
+++ b/docker/dev-builder/ubuntu/Dockerfile
@@ -55,6 +55,9 @@ ENV PATH /root/.cargo/bin/:$PATH
 ARG RUST_TOOLCHAIN
 RUN rustup toolchain install ${RUST_TOOLCHAIN}
 
+# Install cargo-binstall with a specific version to adapt the current rust toolchain.
+# Note: if we use the latest version, we may encounter the following `use of unstable library feature 'io_error_downcast'` error.
+RUN cargo install cargo-binstall --version 1.6.6 --locked
+
 # Install nextest.
-RUN cargo install cargo-binstall --locked
 RUN cargo binstall cargo-nextest --no-confirm

--- a/docker/dev-builder/ubuntu/Dockerfile-18.10
+++ b/docker/dev-builder/ubuntu/Dockerfile-18.10
@@ -43,6 +43,9 @@ ENV PATH /root/.cargo/bin/:$PATH
 ARG RUST_TOOLCHAIN
 RUN rustup toolchain install ${RUST_TOOLCHAIN}
 
+# Install cargo-binstall with a specific version to adapt the current rust toolchain.
+# Note: if we use the latest version, we may encounter the following `use of unstable library feature 'io_error_downcast'` error.
+RUN cargo install cargo-binstall --version 1.6.6 --locked
+
 # Install nextest.
-RUN cargo install cargo-binstall --locked
 RUN cargo binstall cargo-nextest --no-confirm


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Resolve https://github.com/GreptimeTeam/greptimedb/issues/4242

1. Use `vault.centos.org` as default yum for `centos:7` image since CentOS 7 has reached EOL since 2024-07-01 thus `mirror.centos.org` is no longer available;
2. Specify the installed version of `cargo-binstall` to adapt current rust toolchain;

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CentOS 7 Dockerfiles to use `vault.centos.org` due to EOL of CentOS 7.
  - Updated Ubuntu Dockerfiles to install `cargo-binstall` with version 1.6.6 to ensure compatibility with the current Rust toolchain and prevent errors related to unstable library features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->