### PR TITLE
refactor: add `RemoteCompaction` error

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -33,6 +33,7 @@ use store_api::storage::RegionId;
 
 use crate::cache::file_cache::FileType;
 use crate::region::RegionState;
+use crate::schedule::remote_job_scheduler::JobId;
 use crate::sst::file::FileId;
 use crate::worker::WorkerId;
 
@@ -768,6 +769,20 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display(
+        "Failed to remotely compact region {} by job {} due to {}",
+        region_id,
+        job_id,
+        reason
+    ))]
+    RemoteCompaction {
+        region_id: RegionId,
+        job_id: JobId,
+        reason: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -888,6 +903,7 @@ impl ErrorExt for Error {
             TimeRangePredicateOverflow { .. } => StatusCode::InvalidArguments,
             BuildTimeRangeFilter { .. } => StatusCode::Unexpected,
             UnsupportedOperation { .. } => StatusCode::Unsupported,
+            RemoteCompaction { .. } => StatusCode::Unexpected,
         }
     }
 

--- a/src/mito2/src/schedule/remote_job_scheduler.rs
+++ b/src/mito2/src/schedule/remote_job_scheduler.rs
@@ -66,7 +66,7 @@ pub trait RemoteJobScheduler: Send + Sync + 'static {
 #[snafu(display("Internal error occurred in remote job scheduler: {}", reason))]
 pub struct RemoteJobSchedulerError {
     #[snafu(implicit)]
-    location: Location,
+    pub location: Location,
     pub reason: String,
     // Keep the waiters in the error so that we can notify them when fallback to the local compaction.
     pub waiters: Vec<OutputTx>,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The `RemoteCompaction` will use for `CompactionJobResult` and [sends](https://github.com/GreptimeTeam/greptimedb/blob/main/src/mito2/src/schedule/remote_job_scheduler.rs#L158-L169) the notification to Mito.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new error handling mechanism for remote region compaction failures, providing detailed information about the `region_id`, `job_id`, `reason`, and `location` of the error.

- **Improvements**
  - Enhanced the accessibility of error information by making the `location` field public in the remote job scheduler errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->