### PR TITLE
feat: introduce `FlownodePeerCache`

### DIFF
--- a/src/common/meta/src/cache.rs
+++ b/src/common/meta/src/cache.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cluster;
 mod container;
 mod flow;
 mod registry;
 mod table;
 
+pub use cluster::{new_flownode_peer_cache, FlownodePeerCache, FlownodePeerCacheRef};
 pub use container::{CacheContainer, Initializer, Invalidator, TokenFilter};
 pub use flow::{new_table_flownode_set_cache, TableFlownodeSetCache, TableFlownodeSetCacheRef};
 pub use registry::{

--- a/src/common/meta/src/cache/cluster.rs
+++ b/src/common/meta/src/cache/cluster.rs
@@ -1,0 +1,17 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod flownode;
+
+pub use flownode::{new_flownode_peer_cache, FlownodePeerCache, FlownodePeerCacheRef};

--- a/src/common/meta/src/cache/cluster/flownode.rs
+++ b/src/common/meta/src/cache/cluster/flownode.rs
@@ -1,0 +1,73 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use futures::future::BoxFuture;
+use moka::future::Cache;
+use snafu::{OptionExt, ResultExt};
+
+use crate::cache::{CacheContainer, Initializer};
+use crate::cluster::ClusterInfoRef;
+use crate::error::Result;
+use crate::instruction::CacheIdent;
+use crate::peer::Peer;
+use crate::{error, FlownodeId};
+
+/// [FlownodePeerCache] caches the [FlownodeId] to [Peer] mapping.
+pub type FlownodePeerCache = CacheContainer<FlownodeId, Arc<Peer>, CacheIdent>;
+
+pub type FlownodePeerCacheRef = Arc<FlownodePeerCache>;
+
+/// Constructs a [FlownodePeerCache].
+pub fn new_flownode_peer_cache(
+    name: String,
+    cache: Cache<FlownodeId, Arc<Peer>>,
+    cluster_info: ClusterInfoRef,
+) -> FlownodePeerCache {
+    let init = init_factory(cluster_info);
+
+    CacheContainer::new(name, cache, Box::new(invalidator), init, Box::new(filter))
+}
+
+fn init_factory(cluster_info: ClusterInfoRef) -> Initializer<FlownodeId, Arc<Peer>> {
+    Arc::new(move |flownode_id| {
+        let cluster_info = cluster_info.clone();
+        Box::pin(async move {
+            let peer = cluster_info
+                .get_flownode(*flownode_id)
+                .await
+                .context(error::GetClusterInfoSnafu)?
+                .context(error::ValueNotExistSnafu {})?;
+
+            Ok(Some(Arc::new(peer)))
+        })
+    })
+}
+
+fn invalidator<'a>(
+    cache: &'a Cache<FlownodeId, Arc<Peer>>,
+    ident: &'a CacheIdent,
+) -> BoxFuture<'a, Result<()>> {
+    Box::pin(async move {
+        if let CacheIdent::FlownodeId(flownode_id) = ident {
+            cache.invalidate(flownode_id).await
+        }
+        Ok(())
+    })
+}
+
+fn filter(ident: &CacheIdent) -> bool {
+    matches!(ident, CacheIdent::FlownodeId(_))
+}

--- a/src/common/meta/src/cache_invalidator.rs
+++ b/src/common/meta/src/cache_invalidator.rs
@@ -99,6 +99,10 @@ where
                     let key = FlowInfoKey::new(*flow_id);
                     self.invalidate_key(&key.to_bytes()).await;
                 }
+                CacheIdent::FlownodeId(_) => {
+                    // Do nothing.
+                    // The Flownode peer info won't be cached in the KvBackend.
+                }
             }
         }
         Ok(())

--- a/src/common/meta/src/cluster.rs
+++ b/src/common/meta/src/cluster.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use std::str::FromStr;
+use std::sync::Arc;
 
-use common_error::ext::ErrorExt;
+use common_error::ext::BoxedError;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -36,19 +37,19 @@ lazy_static! {
     .unwrap();
 }
 
+pub type ClusterInfoRef = Arc<dyn ClusterInfo>;
+
 /// [ClusterInfo] provides information about the cluster.
 #[async_trait::async_trait]
-pub trait ClusterInfo {
-    type Error: ErrorExt;
-
+pub trait ClusterInfo: Sync + Send {
     /// List all nodes by role in the cluster. If `role` is `None`, list all nodes.
     async fn list_nodes(
         &self,
         role: Option<Role>,
-    ) -> std::result::Result<Vec<NodeInfo>, Self::Error>;
+    ) -> std::result::Result<Vec<NodeInfo>, BoxedError>;
 
     /// Retrieves the [`Peer`] information of a flownode.
-    async fn get_flownode(&self, id: FlownodeId) -> std::result::Result<Option<Peer>, Self::Error>;
+    async fn get_flownode(&self, id: FlownodeId) -> std::result::Result<Option<Peer>, BoxedError>;
 
     // TODO(jeremy): Other info, like region status, etc.
 }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -636,7 +636,18 @@ pub enum Error {
     },
 
     #[snafu(display("Failed to get cache"))]
-    GetCache { source: Arc<Error> },
+    GetCache {
+        source: Arc<Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to get cluster info"))]
+    GetClusterInfo {
+        source: BoxedError,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -723,6 +734,7 @@ impl ErrorExt for Error {
             RetryLater { source, .. } => source.status_code(),
             InvalidCatalogValue { source, .. } => source.status_code(),
             ConvertAlterTableRequest { source, .. } => source.status_code(),
+            GetClusterInfo { source, .. } => source.status_code(),
 
             ParseProcedureId { .. }
             | InvalidNumTopics { .. }

--- a/src/common/meta/src/error.rs
+++ b/src/common/meta/src/error.rs
@@ -624,7 +624,7 @@ pub enum Error {
     FromUtf8 {
         name: String,
         #[snafu(source)]
-        error: std::string::FromUtf8Error,
+        error: std::str::Utf8Error,
         #[snafu(implicit)]
         location: Location,
     },

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -164,6 +164,7 @@ pub enum CacheIdent {
     SchemaName(SchemaName),
     CreateFlow(CreateFlow),
     DropFlow(DropFlow),
+    FlownodeId(FlownodeId),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -152,6 +152,7 @@ impl Instance {
         let mut meta_client = MetaClientBuilder::frontend_default_options(cluster_id)
             .channel_manager(channel_manager)
             .ddl_channel_manager(ddl_channel_manager)
+            .enable_access_cluster_info()
             .build();
         meta_client
             .start(&meta_client_options.metasrv_addrs)

--- a/src/frontend/src/instance/builder.rs
+++ b/src/frontend/src/instance/builder.rs
@@ -127,11 +127,13 @@ impl FrontendBuilder {
                 .context(error::CacheRequiredSnafu {
                     name: TABLE_FLOWNODE_SET_CACHE_NAME,
                 })?;
+        let flownode_peer_cache = self.layered_cache_registry.get();
         let inserter = Arc::new(Inserter::new(
             self.catalog_manager.clone(),
             partition_manager.clone(),
             node_manager.clone(),
             table_flownode_cache,
+            flownode_peer_cache,
         ));
         let deleter = Arc::new(Deleter::new(
             self.catalog_manager.clone(),

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -23,6 +23,7 @@ use common_base::Plugins;
 use common_config::Configurable;
 use common_greptimedb_telemetry::GreptimeDBTelemetryTask;
 use common_grpc::channel_manager;
+use common_meta::cache_invalidator::CacheInvalidatorRef;
 use common_meta::ddl::ProcedureExecutorRef;
 use common_meta::key::TableMetadataManagerRef;
 use common_meta::kv_backend::{KvBackendRef, ResettableKvBackend, ResettableKvBackendRef};
@@ -327,6 +328,8 @@ pub struct Metasrv {
     started: Arc<AtomicBool>,
     start_time_ms: u64,
     options: MetasrvOptions,
+    // Used to notify cluster members to invalidate the cache
+    cache_invalidator: CacheInvalidatorRef,
     // It is only valid at the leader node and is used to temporarily
     // store some data that will not be persisted.
     in_memory: ResettableKvBackendRef,
@@ -534,6 +537,10 @@ impl Metasrv {
 
     pub fn handler_group(&self) -> &HeartbeatHandlerGroup {
         &self.handler_group
+    }
+
+    pub fn cache_invalidator(&self) -> &CacheInvalidatorRef {
+        &self.cache_invalidator
     }
 
     pub fn election(&self) -> Option<&ElectionRef> {

--- a/src/meta-srv/src/metasrv/builder.rs
+++ b/src/meta-srv/src/metasrv/builder.rs
@@ -346,7 +346,7 @@ impl MetasrvBuilder {
             DdlManager::try_new(
                 DdlContext {
                     node_manager,
-                    cache_invalidator,
+                    cache_invalidator: cache_invalidator.clone(),
                     memory_region_keeper: memory_region_keeper.clone(),
                     table_metadata_manager: table_metadata_manager.clone(),
                     table_metadata_allocator: table_metadata_allocator.clone(),
@@ -410,6 +410,7 @@ impl MetasrvBuilder {
             started,
             start_time_ms: common_time::util::current_time_millis() as u64,
             options,
+            cache_invalidator,
             in_memory,
             kv_backend,
             leader_cached_kv_backend,

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -25,7 +25,7 @@ use catalog::CatalogManagerRef;
 use client::{OutputData, OutputMeta};
 use common_catalog::consts::default_engine;
 use common_grpc_expr::util::{extract_new_columns, ColumnExpr};
-use common_meta::cache::TableFlownodeSetCacheRef;
+use common_meta::cache::{FlownodePeerCacheRef, TableFlownodeSetCacheRef};
 use common_meta::node_manager::{AffectedRows, NodeManagerRef};
 use common_meta::peer::Peer;
 use common_query::prelude::{GREPTIME_TIMESTAMP, GREPTIME_VALUE};
@@ -62,6 +62,9 @@ pub struct Inserter {
     partition_manager: PartitionRuleManagerRef,
     node_manager: NodeManagerRef,
     table_flownode_set_cache: TableFlownodeSetCacheRef,
+    /// Only available in cluster mode, it not necessary to query peer info in standalone mode.
+    #[allow(dead_code)]
+    flownode_peer_cache: Option<FlownodePeerCacheRef>,
 }
 
 pub type InserterRef = Arc<Inserter>;
@@ -88,12 +91,14 @@ impl Inserter {
         partition_manager: PartitionRuleManagerRef,
         node_manager: NodeManagerRef,
         table_flownode_set_cache: TableFlownodeSetCacheRef,
+        flownode_peer_cache: Option<FlownodePeerCacheRef>,
     ) -> Self {
         Self {
             catalog_manager,
             partition_manager,
             node_manager,
             table_flownode_set_cache,
+            flownode_peer_cache,
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Add `get_flownode` method in `ClusterInfo` trait.
2. Implement the `FlownodePeerCache`
3. Broadcast cache invalidation message when a new flownode is registered
4. Add the `Option<FlownodePeerCache>` to `Inserter`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new caching mechanism for `FlownodeId` to `Peer` mappings.
  - Added methods to retrieve `Peer` information for Flownodes.
  - Enhanced cache handling functionality with new constructors and cache registry builders.

- **Improvements**
  - Updated error handling with new variants and better error context.
  - Adjusted function signatures for consistency and error management.

- **Refactor**
  - Refactored cache-related code for better modularity and clarity.
  - Reorganized imports and type definitions for improved readability and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->