### PR TITLE
feat: inverted index cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -5148,6 +5151,7 @@ dependencies = [
  "futures",
  "greptime-proto",
  "mockall",
+ "moka",
  "pin-project",
  "prost 0.12.6",
  "rand",
@@ -5157,6 +5161,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+ "uuid",
 ]
 
 [[package]]
@@ -12822,9 +12827,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "atomic",
  "getrandom",
@@ -12835,9 +12840,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
+checksum = "a3ff64d5cde1e2cb5268bdb497235b6bd255ba8244f910dbc3574e59593de68c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,6 +5153,7 @@ dependencies = [
  "mockall",
  "moka",
  "pin-project",
+ "prometheus",
  "prost 0.12.6",
  "rand",
  "regex",

--- a/src/index/Cargo.toml
+++ b/src/index/Cargo.toml
@@ -20,11 +20,13 @@ fst.workspace = true
 futures.workspace = true
 greptime-proto.workspace = true
 mockall.workspace = true
+moka = { workspace = true, features = ["sync", "future"] }
 pin-project.workspace = true
 prost.workspace = true
 regex.workspace = true
 regex-automata.workspace = true
 snafu.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/src/index/Cargo.toml
+++ b/src/index/Cargo.toml
@@ -22,6 +22,7 @@ greptime-proto.workspace = true
 mockall.workspace = true
 moka = { workspace = true, features = ["sync", "future"] }
 pin-project.workspace = true
+prometheus.workspace = true
 prost.workspace = true
 regex.workspace = true
 regex-automata.workspace = true

--- a/src/index/src/inverted_index/format/reader.rs
+++ b/src/index/src/inverted_index/format/reader.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use common_base::BitVec;
 use greptime_proto::v1::index::InvertedIndexMetas;
@@ -29,11 +31,14 @@ mod footer;
 #[mockall::automock]
 #[async_trait]
 pub trait InvertedIndexReader: Send {
+    /// Seeks to given offset and reads all data to dest.
+    async fn read_all(&mut self, dest: &mut Vec<u8>) -> Result<usize>;
+
     /// Seeks to given offset and reads data with exact size as provided.
     async fn seek_read(&mut self, offset: u64, size: u32) -> Result<Vec<u8>>;
 
     /// Retrieves metadata of all inverted indices stored within the blob.
-    async fn metadata(&mut self) -> Result<InvertedIndexMetas>;
+    async fn metadata(&mut self) -> Result<Arc<InvertedIndexMetas>>;
 
     /// Retrieves the finite state transducer (FST) map from the given offset and size.
     async fn fst(&mut self, offset: u64, size: u32) -> Result<FstMap> {

--- a/src/index/src/inverted_index/format/reader.rs
+++ b/src/index/src/inverted_index/format/reader.rs
@@ -12,28 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod blob;
-pub mod cache;
-mod footer;
-
 use async_trait::async_trait;
 use common_base::BitVec;
 use greptime_proto::v1::index::InvertedIndexMetas;
+use snafu::ResultExt;
 
-use crate::inverted_index::error::Result;
+use crate::inverted_index::error::{DecodeFstSnafu, Result};
 pub use crate::inverted_index::format::reader::blob::InvertedIndexBlobReader;
 use crate::inverted_index::FstMap;
+
+mod blob;
+pub mod cache;
+mod footer;
 
 /// InvertedIndexReader defines an asynchronous reader of inverted index data
 #[mockall::automock]
 #[async_trait]
 pub trait InvertedIndexReader: Send {
-    /// Retrieve metadata of all inverted indices stored within the blob.
+    /// Seeks to given offset and reads data with exact size as provided.
+    async fn seek_read(&mut self, offset: u64, size: u32) -> Result<Vec<u8>>;
+
+    /// Retrieves metadata of all inverted indices stored within the blob.
     async fn metadata(&mut self) -> Result<InvertedIndexMetas>;
 
-    /// Retrieve the finite state transducer (FST) map from the given offset and size.
-    async fn fst(&mut self, offset: u64, size: u32) -> Result<FstMap>;
+    /// Retrieves the finite state transducer (FST) map from the given offset and size.
+    async fn fst(&mut self, offset: u64, size: u32) -> Result<FstMap> {
+        let fst_data = self.seek_read(offset, size).await?;
+        FstMap::new(fst_data).context(DecodeFstSnafu)
+    }
 
-    /// Retrieve the bitmap from the given offset and size.
-    async fn bitmap(&mut self, offset: u64, size: u32) -> Result<BitVec>;
+    /// Retrieves the bitmap from the given offset and size.
+    async fn bitmap(&mut self, offset: u64, size: u32) -> Result<BitVec> {
+        self.seek_read(offset, size).await.map(BitVec::from_vec)
+    }
 }

--- a/src/index/src/inverted_index/format/reader.rs
+++ b/src/index/src/inverted_index/format/reader.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod blob;
+pub mod cache;
 mod footer;
 
 use async_trait::async_trait;

--- a/src/index/src/inverted_index/format/reader.rs
+++ b/src/index/src/inverted_index/format/reader.rs
@@ -17,7 +17,7 @@ mod footer;
 
 use async_trait::async_trait;
 use common_base::BitVec;
-use greptime_proto::v1::index::{InvertedIndexMeta, InvertedIndexMetas};
+use greptime_proto::v1::index::InvertedIndexMetas;
 
 use crate::inverted_index::error::Result;
 pub use crate::inverted_index::format::reader::blob::InvertedIndexBlobReader;
@@ -30,14 +30,9 @@ pub trait InvertedIndexReader: Send {
     /// Retrieve metadata of all inverted indices stored within the blob.
     async fn metadata(&mut self) -> Result<InvertedIndexMetas>;
 
-    /// Retrieve the finite state transducer (FST) map for a given inverted index metadata entry.
-    async fn fst(&mut self, meta: &InvertedIndexMeta) -> Result<FstMap>;
+    /// Retrieve the finite state transducer (FST) map from the given offset and size.
+    async fn fst(&mut self, offset: u64, size: u32) -> Result<FstMap>;
 
-    /// Retrieve the bitmap for a given inverted index metadata entry at the specified offset and size.
-    async fn bitmap(
-        &mut self,
-        meta: &InvertedIndexMeta,
-        relative_offset: u32,
-        size: u32,
-    ) -> Result<BitVec>;
+    /// Retrieve the bitmap from the given offset and size.
+    async fn bitmap(&mut self, offset: u64, size: u32) -> Result<BitVec>;
 }

--- a/src/index/src/inverted_index/format/reader/blob.rs
+++ b/src/index/src/inverted_index/format/reader/blob.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::io::SeekFrom;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
@@ -49,6 +50,14 @@ impl<R> InvertedIndexBlobReader<R> {
 
 #[async_trait]
 impl<R: AsyncRead + AsyncSeek + Unpin + Send> InvertedIndexReader for InvertedIndexBlobReader<R> {
+    async fn read_all(&mut self, dest: &mut Vec<u8>) -> Result<usize> {
+        self.source
+            .seek(SeekFrom::Start(0))
+            .await
+            .context(SeekSnafu)?;
+        self.source.read_to_end(dest).await.context(ReadSnafu)
+    }
+
     async fn seek_read(&mut self, offset: u64, size: u32) -> Result<Vec<u8>> {
         self.source
             .seek(SeekFrom::Start(offset))
@@ -59,13 +68,13 @@ impl<R: AsyncRead + AsyncSeek + Unpin + Send> InvertedIndexReader for InvertedIn
         Ok(buf)
     }
 
-    async fn metadata(&mut self) -> Result<InvertedIndexMetas> {
+    async fn metadata(&mut self) -> Result<Arc<InvertedIndexMetas>> {
         let end = SeekFrom::End(0);
         let blob_size = self.source.seek(end).await.context(SeekSnafu)?;
         Self::validate_blob_size(blob_size)?;
 
         let mut footer_reader = InvertedIndeFooterReader::new(&mut self.source, blob_size);
-        footer_reader.metadata().await
+        footer_reader.metadata().await.map(Arc::new)
     }
 }
 

--- a/src/index/src/inverted_index/format/reader/cache.rs
+++ b/src/index/src/inverted_index/format/reader/cache.rs
@@ -1,0 +1,155 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_base::BitVec;
+use futures::{AsyncRead, AsyncSeek};
+use greptime_proto::v1::index::{InvertedIndexMeta, InvertedIndexMetas};
+use snafu::ResultExt;
+use uuid::Uuid;
+
+use crate::inverted_index::error::DecodeFstSnafu;
+use crate::inverted_index::format::reader::{InvertedIndexBlobReader, InvertedIndexReader};
+use crate::inverted_index::FstMap;
+
+pub struct CachedInvertedIndexBlobReader<R> {
+    file_id: Uuid,
+    inner: InvertedIndexBlobReader<R>,
+    cache: Arc<InvertedIndexCache>,
+}
+
+impl<R> CachedInvertedIndexBlobReader<R> {
+    pub fn new(
+        file_id: Uuid,
+        inner: InvertedIndexBlobReader<R>,
+        cache: Arc<InvertedIndexCache>,
+    ) -> Self {
+        Self {
+            file_id,
+            inner,
+            cache,
+        }
+    }
+}
+
+impl<R> CachedInvertedIndexBlobReader<R>
+where
+    R: AsyncRead + AsyncSeek + Unpin + Send,
+{
+    async fn get_or_load(
+        &mut self,
+        offset: u64,
+        size: u32,
+    ) -> crate::inverted_index::error::Result<Vec<u8>> {
+        if let Some(cached) = self.cache.get_index(IndexKey {
+            file_id: self.file_id,
+            offset,
+            size,
+        }) {
+            Ok(cached)
+        } else {
+            let data = self.inner.seek_read(offset, size).await?;
+            self.cache.put_index(
+                IndexKey {
+                    file_id: self.file_id,
+                    offset,
+                    size,
+                },
+                data.clone(),
+            );
+            Ok(data)
+        }
+    }
+}
+
+#[async_trait]
+impl<R: AsyncRead + AsyncSeek + Unpin + Send> InvertedIndexReader
+    for CachedInvertedIndexBlobReader<R>
+{
+    async fn metadata(&mut self) -> crate::inverted_index::error::Result<InvertedIndexMetas> {
+        self.inner.metadata().await
+    }
+
+    async fn fst(
+        &mut self,
+        offset: u64,
+        size: u32,
+    ) -> crate::inverted_index::error::Result<FstMap> {
+        self.get_or_load(offset, size)
+            .await
+            .and_then(|r| FstMap::new(r).context(DecodeFstSnafu))
+    }
+
+    async fn bitmap(
+        &mut self,
+        offset: u64,
+        size: u32,
+    ) -> crate::inverted_index::error::Result<BitVec> {
+        self.get_or_load(offset, size).await.map(BitVec::from_vec)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MetadataKey {
+    file_id: Uuid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexKey {
+    file_id: Uuid,
+    offset: u64,
+    size: u32,
+}
+
+pub struct InvertedIndexCache {
+    metadata: moka::sync::Cache<MetadataKey, Arc<InvertedIndexMeta>>,
+    index: moka::sync::Cache<IndexKey, Vec<u8>>,
+}
+
+impl InvertedIndexCache {
+    pub fn new(metadata_cap: u64, index_cap: u64) -> Self {
+        let metadata_cache = moka::sync::CacheBuilder::new(metadata_cap)
+            .name("inverted_index_metadata")
+            .build();
+        let index_cache = moka::sync::CacheBuilder::new(index_cap)
+            .name("inverted_index_content")
+            .build();
+        Self {
+            metadata: metadata_cache,
+            index: index_cache,
+        }
+    }
+}
+
+impl InvertedIndexCache {
+    pub fn get_metadata(&self, file_id: Uuid) -> Option<Arc<InvertedIndexMeta>> {
+        self.metadata.get(&MetadataKey { file_id })
+    }
+
+    pub fn put_metadata(&self, file_id: Uuid, metadata: Arc<InvertedIndexMeta>) {
+        self.metadata.insert(MetadataKey { file_id }, metadata)
+    }
+
+    // todo(hl): align index file content to pages with size like 4096 bytes so that we won't
+    // have too many cache entries.
+    pub fn get_index(&self, key: IndexKey) -> Option<Vec<u8>> {
+        self.index.get(&key)
+    }
+
+    pub fn put_index(&self, key: IndexKey, value: Vec<u8>) {
+        self.index.insert(key, value);
+    }
+}

--- a/src/index/src/inverted_index/format/writer/blob.rs
+++ b/src/index/src/inverted_index/format/writer/blob.rs
@@ -174,16 +174,31 @@ mod tests {
         assert_eq!(stats0.null_count, 1);
         assert_eq!(stats0.min_value, Bytes::from("a"));
         assert_eq!(stats0.max_value, Bytes::from("c"));
-        let fst0 = reader.fst(tag0).await.unwrap();
+        let fst0 = reader
+            .fst(
+                tag0.base_offset + tag0.relative_fst_offset as u64,
+                tag0.fst_size,
+            )
+            .await
+            .unwrap();
         assert_eq!(fst0.len(), 3);
         let [offset, size] = unpack(fst0.get(b"a").unwrap());
-        let bitmap = reader.bitmap(tag0, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag0.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0000_0001]));
         let [offset, size] = unpack(fst0.get(b"b").unwrap());
-        let bitmap = reader.bitmap(tag0, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag0.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0010_0000]));
         let [offset, size] = unpack(fst0.get(b"c").unwrap());
-        let bitmap = reader.bitmap(tag0, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag0.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0000_0001]));
 
         // tag1
@@ -193,16 +208,31 @@ mod tests {
         assert_eq!(stats1.null_count, 1);
         assert_eq!(stats1.min_value, Bytes::from("x"));
         assert_eq!(stats1.max_value, Bytes::from("z"));
-        let fst1 = reader.fst(tag1).await.unwrap();
+        let fst1 = reader
+            .fst(
+                tag1.base_offset + tag1.relative_fst_offset as u64,
+                tag1.fst_size,
+            )
+            .await
+            .unwrap();
         assert_eq!(fst1.len(), 3);
         let [offset, size] = unpack(fst1.get(b"x").unwrap());
-        let bitmap = reader.bitmap(tag1, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag1.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0000_0001]));
         let [offset, size] = unpack(fst1.get(b"y").unwrap());
-        let bitmap = reader.bitmap(tag1, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag1.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0010_0000]));
         let [offset, size] = unpack(fst1.get(b"z").unwrap());
-        let bitmap = reader.bitmap(tag1, offset, size).await.unwrap();
+        let bitmap = reader
+            .bitmap(tag1.base_offset + offset as u64, size)
+            .await
+            .unwrap();
         assert_eq!(bitmap, BitVec::from_slice(&[0b0000_0001]));
     }
 }

--- a/src/index/src/inverted_index/metrics.rs
+++ b/src/index/src/inverted_index/metrics.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod create;
-pub mod error;
-pub mod format;
-mod metrics;
-pub mod search;
+use mockall::lazy_static;
+use prometheus::{register_int_counter_vec, IntCounterVec};
 
-pub type FstMap = fst::Map<Vec<u8>>;
-pub type Bytes = Vec<u8>;
-pub type BytesRef<'a> = &'a [u8];
+lazy_static! {
+    pub static ref INDEX_CACHE_STATS: IntCounterVec = register_int_counter_vec!(
+        "greptime_index_cache",
+        "greptime index cache stats",
+        &["cache_type", "op_type"]
+    )
+    .unwrap();
+}

--- a/src/index/src/inverted_index/search/fst_values_mapper.rs
+++ b/src/index/src/inverted_index/search/fst_values_mapper.rs
@@ -48,7 +48,7 @@ impl<'a> FstValuesMapper<'a> {
 
             let bm = self
                 .reader
-                .bitmap(self.metadata, relative_offset, size)
+                .bitmap(self.metadata.base_offset + relative_offset as u64, size)
                 .await?;
 
             // Ensure the longest BitVec is the left operand to prevent truncation during OR.
@@ -79,7 +79,7 @@ mod tests {
         let mut mock_reader = MockInvertedIndexReader::new();
         mock_reader
             .expect_bitmap()
-            .returning(|_, offset, size| match (offset, size) {
+            .returning(|offset, size| match (offset, size) {
                 (1, 1) => Ok(bitvec![u8, Lsb0; 1, 0, 1, 0, 1, 0, 1]),
                 (2, 1) => Ok(bitvec![u8, Lsb0; 0, 1, 0, 1, 0, 1, 0, 1]),
                 _ => unreachable!(),

--- a/src/index/src/inverted_index/search/index_apply/predicates_apply.rs
+++ b/src/index/src/inverted_index/search/index_apply/predicates_apply.rs
@@ -164,6 +164,8 @@ impl TryFrom<Vec<(String, Vec<Predicate>)>> for PredicatesIndexApplier {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use common_base::bit_vec::prelude::*;
     use greptime_proto::v1::index::InvertedIndexMeta;
 
@@ -177,7 +179,7 @@ mod tests {
         s.to_owned()
     }
 
-    fn mock_metas(tags: impl IntoIterator<Item = (&'static str, u32)>) -> InvertedIndexMetas {
+    fn mock_metas(tags: impl IntoIterator<Item = (&'static str, u32)>) -> Arc<InvertedIndexMetas> {
         let mut metas = InvertedIndexMetas {
             total_row_count: 8,
             segment_row_count: 1,
@@ -191,7 +193,7 @@ mod tests {
             };
             metas.metas.insert(s(tag), meta);
         }
-        metas
+        Arc::new(metas)
     }
 
     fn key_fst_applier(value: &'static str) -> Box<dyn FstApplier> {
@@ -316,11 +318,11 @@ mod tests {
     async fn test_index_applier_with_empty_index() {
         let mut mock_reader = MockInvertedIndexReader::new();
         mock_reader.expect_metadata().returning(move || {
-            Ok(InvertedIndexMetas {
+            Ok(Arc::new(InvertedIndexMetas {
                 total_row_count: 0, // No rows
                 segment_row_count: 1,
                 ..Default::default()
-            })
+            }))
         });
 
         let mut mock_fst_applier = MockFstApplier::new();

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -246,7 +246,8 @@ impl CacheManagerBuilder {
                 .build()
         });
 
-        let inverted_index_cache = InvertedIndexCache::new(1024, 1024);
+        // todo(hl): make it configurable.
+        let inverted_index_cache = InvertedIndexCache::new(1024 * 16, 1024 * 16);
         CacheManager {
             sst_meta_cache,
             vector_cache,

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -330,10 +330,13 @@ impl ScanRegion {
             Some(file_cache)
         }();
 
+        let index_cache = self.cache_manager.as_ref().map(|c| c.index_cache());
+
         SstIndexApplierBuilder::new(
             self.access_layer.region_dir().to_string(),
             self.access_layer.object_store().clone(),
             file_cache,
+            index_cache,
             self.version.metadata.as_ref(),
             self.version
                 .options

--- a/src/mito2/src/sst/file.rs
+++ b/src/mito2/src/sst/file.rs
@@ -65,6 +65,12 @@ impl FileId {
     }
 }
 
+impl From<FileId> for Uuid {
+    fn from(value: FileId) -> Self {
+        value.0
+    }
+}
+
 impl fmt::Display for FileId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)

--- a/src/mito2/src/sst/index/applier/builder/between.rs
+++ b/src/mito2/src/sst/index/applier/builder/between.rs
@@ -74,6 +74,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -113,6 +114,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -134,6 +136,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),
@@ -157,6 +160,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -179,6 +183,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),

--- a/src/mito2/src/sst/index/applier/builder/comparison.rs
+++ b/src/mito2/src/sst/index/applier/builder/comparison.rs
@@ -229,6 +229,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -254,6 +255,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -269,6 +271,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),
@@ -286,6 +289,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),

--- a/src/mito2/src/sst/index/applier/builder/eq_list.rs
+++ b/src/mito2/src/sst/index/applier/builder/eq_list.rs
@@ -136,6 +136,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -170,6 +171,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -187,6 +189,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -203,6 +206,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -218,6 +222,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),
@@ -274,6 +279,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -307,6 +313,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),

--- a/src/mito2/src/sst/index/applier/builder/in_list.rs
+++ b/src/mito2/src/sst/index/applier/builder/in_list.rs
@@ -67,6 +67,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -96,6 +97,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -116,6 +118,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),
@@ -138,6 +141,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -159,6 +163,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),

--- a/src/mito2/src/sst/index/applier/builder/regex_match.rs
+++ b/src/mito2/src/sst/index/applier/builder/regex_match.rs
@@ -61,6 +61,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -86,6 +87,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -104,6 +106,7 @@ mod tests {
             "test".to_string(),
             test_object_store(),
             None,
+            None,
             &metadata,
             HashSet::default(),
         );
@@ -121,6 +124,7 @@ mod tests {
         let mut builder = SstIndexApplierBuilder::new(
             "test".to_string(),
             test_object_store(),
+            None,
             None,
             &metadata,
             HashSet::default(),

--- a/src/mito2/src/sst/index/creator.rs
+++ b/src/mito2/src/sst/index/creator.rs
@@ -325,6 +325,7 @@ mod tests {
     use datatypes::value::ValueRef;
     use datatypes::vectors::{UInt64Vector, UInt8Vector};
     use futures::future::BoxFuture;
+    use index::inverted_index::format::reader::cache::InvertedIndexCache;
     use object_store::services::Memory;
     use store_api::metadata::{ColumnMetadata, RegionMetadataBuilder};
     use store_api::storage::RegionId;
@@ -433,10 +434,12 @@ mod tests {
         assert_eq!(row_count, tags.len() * segment_row_count);
 
         move |expr| {
+            let cache = Arc::new(InvertedIndexCache::new(10, 10));
             let applier = SstIndexApplierBuilder::new(
                 region_dir.clone(),
                 object_store.clone(),
                 None,
+                Some(cache),
                 &region_metadata,
                 Default::default(),
             )

--- a/src/puffin/Cargo.toml
+++ b/src/puffin/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-compression = "0.4.11"
+async-compression = { version = "0.4.11", features = ["futures-io", "zstd"] }
 async-trait.workspace = true
 async-walkdir = "2.0.0"
 bitflags.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Add iverted index cache

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced caching mechanism to improve performance of inverted index data retrieval.
  - Added Prometheus metrics for tracking index cache statistics.

- **Enhancements**
  - Improved `InvertedIndexReader` and `InvertedIndexBlobReader` with new methods for better data handling.
  - Updated cache management in `CacheManager` to include inverted index caching.
  - Enhanced `SstIndexApplier` to use cached index data conditionally.

- **Dependency Updates**
  - Added `moka`, `prometheus`, and `uuid` as workspace dependencies.
  - Updated `async-compression` to include "futures-io" and "zstd" features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->