### PR TITLE
ci: push latest greptimedb nigthly build image

### DIFF
--- a/.github/actions/release-cn-artifacts/action.yaml
+++ b/.github/actions/release-cn-artifacts/action.yaml
@@ -123,10 +123,10 @@ runs:
         DST_REGISTRY_PASSWORD: ${{ inputs.dst-image-registry-password }}
       run: |
         ./.github/scripts/copy-image.sh \
-         ${{ inputs.src-image-registry }}/${{ inputs.src-image-namespace }}/${{ inputs.src-image-name }}-centos:latest \
+         ${{ inputs.src-image-registry }}/${{ inputs.src-image-namespace }}/${{ inputs.src-image-name }}-centos:${{ inputs.version }} \
          ${{ inputs.dst-image-registry }}/${{ inputs.dst-image-namespace }}
 
-    - name: Push greptimedb-centos image from DockerHub to ACR
+    - name: Push latest greptimedb-centos image from DockerHub to ACR
       shell: bash
       if: ${{ inputs.dev-mode == 'false' && inputs.push-latest-tag == 'true' }}
       env:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -199,7 +199,7 @@ jobs:
           image-registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           image-registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
           version: ${{ needs.allocate-runners.outputs.version }}
-          push-latest-tag: false # Don't push the latest tag to registry.
+          push-latest-tag: true
 
       - name: Set nightly build result
         id: set-nightly-build-result
@@ -240,7 +240,7 @@ jobs:
           aws-cn-region: ${{ vars.AWS_RELEASE_BUCKET_REGION }}
           dev-mode: false
           update-version-info: false  # Don't update version info in S3.
-          push-latest-tag: false      # Don't push the latest tag to registry.
+          push-latest-tag: true
 
   stop-linux-amd64-runner: # It's always run as the last job in the workflow to make sure that the runner is released.
     name: Stop linux-amd64 runner


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Since we use a new namespace for the nightly build image(not the scheduled released version), we can push the latest tag for those images.

Also, it resolves the issue of failing to push nightly images to ACR.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
