### PR TITLE
feat(index): add puffin metadata cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5155,6 +5155,7 @@ dependencies = [
  "pin-project",
  "prometheus",
  "prost 0.12.6",
+ "puffin",
  "rand",
  "regex",
  "regex-automata 0.4.7",

--- a/src/index/Cargo.toml
+++ b/src/index/Cargo.toml
@@ -24,6 +24,7 @@ moka = { workspace = true, features = ["sync", "future"] }
 pin-project.workspace = true
 prometheus.workspace = true
 prost.workspace = true
+puffin.workspace = true
 regex.workspace = true
 regex-automata.workspace = true
 snafu.workspace = true

--- a/src/index/src/inverted_index.rs
+++ b/src/index/src/inverted_index.rs
@@ -15,7 +15,7 @@
 pub mod create;
 pub mod error;
 pub mod format;
-mod metrics;
+pub mod metrics;
 pub mod search;
 
 pub type FstMap = fst::Map<Vec<u8>>;

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -263,7 +263,7 @@ impl CacheManagerBuilder {
         let top_cache = Some(Cache::builder().max_capacity(10000).build());
 
         // todo(hl): make it configurable.
-        let inverted_index_cache = InvertedIndexCache::new(1024 * 16, 1024 * 16);
+        let inverted_index_cache = InvertedIndexCache::new(1024 * 16, 1024 * 16, 1024 * 16);
         CacheManager {
             sst_meta_cache,
             vector_cache,

--- a/src/mito2/src/sst/index/creator.rs
+++ b/src/mito2/src/sst/index/creator.rs
@@ -434,7 +434,7 @@ mod tests {
         assert_eq!(row_count, tags.len() * segment_row_count);
 
         move |expr| {
-            let cache = Arc::new(InvertedIndexCache::new(10, 10));
+            let cache = Arc::new(InvertedIndexCache::new(10, 10, 10));
             let applier = SstIndexApplierBuilder::new(
                 region_dir.clone(),
                 object_store.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- Added puffin as a dependency.
- Modified the `InvertedIndexCache` to include a cache for puffin metadata.
- Updated functions to handle the new puffin metadata cache, including adjustments to the `InvertedIndexCache` struct and related methods.
- Adjusted the `SstIndexApplier` and other related components to utilize the new puffin metadata cache.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
