### PR TITLE
fix(puffin): fix dependency

### DIFF
--- a/src/puffin/Cargo.toml
+++ b/src/puffin/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-async-compression = "0.4.11"
+async-compression = { version = "0.4", features = ["futures-io", "zstd"] }
 async-trait.workspace = true
 async-walkdir = "2.0.0"
 base64.workspace = true
@@ -20,7 +20,7 @@ common-telemetry.workspace = true
 derive_builder.workspace = true
 futures.workspace = true
 lz4_flex = "0.11"
-moka.workspace = true
+moka = { workspace = true, features = ["future", "sync"] }
 pin-project.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
Fixes dependency of puffin crate so that `cargo build -p puffin` won't fail like:

```
error: At least one of the crate features `sync` or `future` must be enabled for `moka` crate. Please update your dependencies in Cargo.toml
  --> /home/lei/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/moka-0.12.7/src/lib.rs:89:1
   |
89 | / compile_error!(
90 | |     "At least one of the crate features `sync` or `future` must be enabled for \
91 | |     `moka` crate. Please update your dependencies in Cargo.toml"
92 | | );
   | |_^


error[E0433]: failed to resolve: could not find `futures` in `async_compression`
   --> src/puffin/src/puffin_manager/fs_puffin_manager/reader.rs:15:24
    |
15  | use async_compression::futures::bufread::ZstdDecoder;
    |                        ^^^^^^^ could not find `futures` in `async_compression`
    |
note: found an item that was configured out
   --> /home/lei/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/async-compression-0.4.11/src/lib.rs:150:9
    |
150 | pub mod futures;
    |         ^^^^^^^
    = note: the item is gated behind the `futures-io` feature

error[E0433]: failed to resolve: could not find `futures` in `async_compression`
   --> src/puffin/src/puffin_manager/fs_puffin_manager/writer.rs:18:24
    |
18  | use async_compression::futures::bufread::ZstdEncoder;
    |                        ^^^^^^^ could not find `futures` in `async_compression`
    |
note: found an item that was configured out
   --> /home/lei/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/async-compression-0.4.11/src/lib.rs:150:9
    |
150 | pub mod futures;
    |         ^^^^^^^
    = note: the item is gated behind the `futures-io` feature

For more information about this error, try `rustc --explain E0433`.
error: could not compile `puffin` (lib) due to 2 previous errors

```


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies for improved performance and feature support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->