### PR TITLE
chore: add missing s for `--metasrv-addr`

### DIFF
--- a/docker/docker-compose/cluster-with-etcd.yaml
+++ b/docker/docker-compose/cluster-with-etcd.yaml
@@ -66,7 +66,7 @@ services:
       - --node-id=0
       - --rpc-addr=0.0.0.0:3001
       - --rpc-hostname=datanode0:3001
-      - --metasrv-addr=metasrv:3002
+      - --metasrv-addrs=metasrv:3002
     volumes:
       - /tmp/greptimedb-cluster-docker-compose/datanode0:/tmp/greptimedb
     depends_on:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

per the bot

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the configuration flag from `--metasrv-addr` to `--metasrv-addrs` in Docker Compose file to ensure proper service communication.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->