### PR TITLE
refactor(puffin): adjust generic parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,6 +8615,7 @@ dependencies = [
  "async-compression 0.4.11",
  "async-trait",
  "async-walkdir",
+ "auto_impl",
  "base64 0.21.7",
  "bitflags 2.5.0",
  "common-error",

--- a/src/puffin/Cargo.toml
+++ b/src/puffin/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 async-compression = { version = "0.4", features = ["futures-io", "zstd"] }
 async-trait.workspace = true
 async-walkdir = "2.0.0"
+auto_impl = "1.2.0"
 base64.workspace = true
 bitflags.workspace = true
 common-error.workspace = true

--- a/src/puffin/src/puffin_manager.rs
+++ b/src/puffin/src/puffin_manager.rs
@@ -72,7 +72,7 @@ pub struct PutOptions {
 
 /// The `PuffinReader` trait provides methods for reading blobs and directories from a Puffin file.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Arc)]
+#[auto_impl::auto_impl(Arc)]
 pub trait PuffinReader {
     type Blob: BlobGuard;
     type Dir: DirGuard;
@@ -92,7 +92,7 @@ pub trait PuffinReader {
 
 /// `BlobGuard` is provided by the `PuffinReader` to access the blob data.
 /// Users should hold the `BlobGuard` until they are done with the blob data.
-#[auto_impl::auto_impl(Box, Arc)]
+#[auto_impl::auto_impl(Arc)]
 pub trait BlobGuard {
     type Reader: AsyncRead + AsyncSeek + Unpin;
     fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>>;
@@ -100,7 +100,7 @@ pub trait BlobGuard {
 
 /// `DirGuard` is provided by the `PuffinReader` to access the directory in the filesystem.
 /// Users should hold the `DirGuard` until they are done with the directory.
-#[auto_impl::auto_impl(Box, Arc)]
+#[auto_impl::auto_impl(Arc)]
 pub trait DirGuard {
     fn path(&self) -> &PathBuf;
 }

--- a/src/puffin/src/puffin_manager.rs
+++ b/src/puffin/src/puffin_manager.rs
@@ -72,6 +72,7 @@ pub struct PutOptions {
 
 /// The `PuffinReader` trait provides methods for reading blobs and directories from a Puffin file.
 #[async_trait]
+#[auto_impl::auto_impl(Box, Rc, Arc)]
 pub trait PuffinReader {
     type Blob: BlobGuard;
     type Dir: DirGuard;
@@ -91,6 +92,7 @@ pub trait PuffinReader {
 
 /// `BlobGuard` is provided by the `PuffinReader` to access the blob data.
 /// Users should hold the `BlobGuard` until they are done with the blob data.
+#[auto_impl::auto_impl(Box, Rc, Arc)]
 pub trait BlobGuard {
     type Reader: AsyncRead + AsyncSeek + Unpin;
     fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>>;
@@ -98,6 +100,7 @@ pub trait BlobGuard {
 
 /// `DirGuard` is provided by the `PuffinReader` to access the directory in the filesystem.
 /// Users should hold the `DirGuard` until they are done with the directory.
+#[auto_impl::auto_impl(Box, Rc, Arc)]
 pub trait DirGuard {
     fn path(&self) -> &PathBuf;
 }

--- a/src/puffin/src/puffin_manager.rs
+++ b/src/puffin/src/puffin_manager.rs
@@ -72,7 +72,7 @@ pub struct PutOptions {
 
 /// The `PuffinReader` trait provides methods for reading blobs and directories from a Puffin file.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Rc, Arc)]
+#[auto_impl::auto_impl(Box, Arc)]
 pub trait PuffinReader {
     type Blob: BlobGuard;
     type Dir: DirGuard;
@@ -92,7 +92,7 @@ pub trait PuffinReader {
 
 /// `BlobGuard` is provided by the `PuffinReader` to access the blob data.
 /// Users should hold the `BlobGuard` until they are done with the blob data.
-#[auto_impl::auto_impl(Box, Rc, Arc)]
+#[auto_impl::auto_impl(Box, Arc)]
 pub trait BlobGuard {
     type Reader: AsyncRead + AsyncSeek + Unpin;
     fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>>;
@@ -100,7 +100,7 @@ pub trait BlobGuard {
 
 /// `DirGuard` is provided by the `PuffinReader` to access the directory in the filesystem.
 /// Users should hold the `DirGuard` until they are done with the directory.
-#[auto_impl::auto_impl(Box, Rc, Arc)]
+#[auto_impl::auto_impl(Box, Arc)]
 pub trait DirGuard {
     fn path(&self) -> &PathBuf;
 }

--- a/src/puffin/src/puffin_manager/file_accessor.rs
+++ b/src/puffin/src/puffin_manager/file_accessor.rs
@@ -19,7 +19,7 @@ use crate::error::Result;
 
 /// `PuffinFileAccessor` is for opening readers and writers for puffin files.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Rc, Arc)]
+#[auto_impl::auto_impl(Box, Arc)]
 pub trait PuffinFileAccessor: Send + Sync + 'static {
     type Reader: AsyncRead + AsyncSeek + Unpin + Send;
     type Writer: AsyncWrite + Unpin + Send;

--- a/src/puffin/src/puffin_manager/file_accessor.rs
+++ b/src/puffin/src/puffin_manager/file_accessor.rs
@@ -19,7 +19,7 @@ use crate::error::Result;
 
 /// `PuffinFileAccessor` is for opening readers and writers for puffin files.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Arc)]
+#[auto_impl::auto_impl(Arc)]
 pub trait PuffinFileAccessor: Send + Sync + 'static {
     type Reader: AsyncRead + AsyncSeek + Unpin + Send;
     type Writer: AsyncWrite + Unpin + Send;

--- a/src/puffin/src/puffin_manager/file_accessor.rs
+++ b/src/puffin/src/puffin_manager/file_accessor.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use futures::{AsyncRead, AsyncSeek, AsyncWrite};
 
@@ -21,9 +19,10 @@ use crate::error::Result;
 
 /// `PuffinFileAccessor` is for opening readers and writers for puffin files.
 #[async_trait]
-pub trait PuffinFileAccessor {
-    type Reader: AsyncRead + AsyncSeek;
-    type Writer: AsyncWrite;
+#[auto_impl::auto_impl(Box, Rc, Arc)]
+pub trait PuffinFileAccessor: Send + Sync + 'static {
+    type Reader: AsyncRead + AsyncSeek + Unpin + Send;
+    type Writer: AsyncWrite + Unpin + Send;
 
     /// Opens a reader for the given puffin file.
     async fn reader(&self, puffin_file_name: &str) -> Result<Self::Reader>;
@@ -31,6 +30,3 @@ pub trait PuffinFileAccessor {
     /// Creates a writer for the given puffin file.
     async fn writer(&self, puffin_file_name: &str) -> Result<Self::Writer>;
 }
-
-pub type PuffinFileAccessorRef<R, W> =
-    Arc<dyn PuffinFileAccessor<Reader = R, Writer = W> + Send + Sync>;

--- a/src/puffin/src/puffin_manager/stager.rs
+++ b/src/puffin/src/puffin_manager/stager.rs
@@ -52,7 +52,7 @@ pub trait InitDirFn = Fn(DirWriterProviderRef) -> WriteResult;
 
 /// `Stager` manages the staging area for the puffin files.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Arc)]
+#[auto_impl::auto_impl(Arc)]
 pub trait Stager: Send + Sync {
     type Blob: BlobGuard;
     type Dir: DirGuard;

--- a/src/puffin/src/puffin_manager/stager.rs
+++ b/src/puffin/src/puffin_manager/stager.rs
@@ -15,7 +15,6 @@
 mod bounded_stager;
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 pub use bounded_stager::{BoundedStager, FsBlobGuard, FsDirGuard};
@@ -53,7 +52,8 @@ pub trait InitDirFn = Fn(DirWriterProviderRef) -> WriteResult;
 
 /// `Stager` manages the staging area for the puffin files.
 #[async_trait]
-pub trait Stager {
+#[auto_impl::auto_impl(Box, Rc, Arc)]
+pub trait Stager: Send + Sync {
     type Blob: BlobGuard;
     type Dir: DirGuard;
 
@@ -88,5 +88,3 @@ pub trait Stager {
         dir_size: u64,
     ) -> Result<()>;
 }
-
-pub type StagerRef<B, D> = Arc<dyn Stager<Blob = B, Dir = D> + Send + Sync>;

--- a/src/puffin/src/puffin_manager/stager.rs
+++ b/src/puffin/src/puffin_manager/stager.rs
@@ -52,7 +52,7 @@ pub trait InitDirFn = Fn(DirWriterProviderRef) -> WriteResult;
 
 /// `Stager` manages the staging area for the puffin files.
 #[async_trait]
-#[auto_impl::auto_impl(Box, Rc, Arc)]
+#[auto_impl::auto_impl(Box, Arc)]
 pub trait Stager: Send + Sync {
     type Blob: BlobGuard;
     type Dir: DirGuard;

--- a/src/puffin/src/puffin_manager/stager/bounded_stager.rs
+++ b/src/puffin/src/puffin_manager/stager/bounded_stager.rs
@@ -425,7 +425,7 @@ pub struct FsBlobGuard {
     delete_queue: Sender<DeleteTask>,
 }
 
-impl BlobGuard for Arc<FsBlobGuard> {
+impl BlobGuard for FsBlobGuard {
     type Reader = Compat<fs::File>;
 
     fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>> {
@@ -460,7 +460,7 @@ pub struct FsDirGuard {
     delete_queue: Sender<DeleteTask>,
 }
 
-impl DirGuard for Arc<FsDirGuard> {
+impl DirGuard for FsDirGuard {
     fn path(&self) -> &PathBuf {
         &self.path
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/pull/4266#discussion_r1665121324

## What's changed and what's your intention?

reduce generic parameters for `FsPuffinManager`


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the `SstPuffinManager` and related components for better type handling and efficiency.
  - Updated `PuffinReader`, `BlobGuard`, `DirGuard`, and `Stager` traits with `auto_impl` to support automatic implementation for `Arc` types.
  - Improved trait bounds for `PuffinFileAccessor` to enhance compatibility and performance.

- **Dependencies**
  - Added `auto_impl` version 1.2.0 to the project dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->