### PR TITLE
feat: store peer info in `TableFlowValue`

### DIFF
--- a/src/common/meta/src/cache/flow/table_flownode.rs
+++ b/src/common/meta/src/cache/flow/table_flownode.rs
@@ -71,7 +71,7 @@ async fn handle_create_flow(
     cache: &Cache<TableId, FlownodeSet>,
     CreateFlow {
         source_table_ids,
-        flownode_peers,
+        flownodes: flownode_peers,
     }: &CreateFlow,
 ) {
     for table_id in source_table_ids {
@@ -226,7 +226,7 @@ mod tests {
         let cache = new_table_flownode_set_cache("test".to_string(), cache, mem_kv);
         let ident = vec![CacheIdent::CreateFlow(CreateFlow {
             source_table_ids: vec![1024, 1025],
-            flownode_peers: (1..=5).map(Peer::empty).collect(),
+            flownodes: (1..=5).map(Peer::empty).collect(),
         })];
         cache.invalidate(&ident).await.unwrap();
         let set = cache.get(1024).await.unwrap().unwrap();
@@ -243,11 +243,11 @@ mod tests {
         let ident = vec![
             CacheIdent::CreateFlow(CreateFlow {
                 source_table_ids: vec![1024, 1025],
-                flownode_peers: (1..=5).map(Peer::empty).collect(),
+                flownodes: (1..=5).map(Peer::empty).collect(),
             }),
             CacheIdent::CreateFlow(CreateFlow {
                 source_table_ids: vec![1024, 1025],
-                flownode_peers: (11..=12).map(Peer::empty).collect(),
+                flownodes: (11..=12).map(Peer::empty).collect(),
             }),
         ];
         cache.invalidate(&ident).await.unwrap();

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -194,7 +194,7 @@ impl CreateFlowProcedure {
                 &ctx,
                 &[CacheIdent::CreateFlow(CreateFlow {
                     source_table_ids: self.data.source_table_ids.clone(),
-                    flownode_peers: self.data.peers.clone(),
+                    flownodes: self.data.peers.clone(),
                 })],
             )
             .await?;

--- a/src/common/meta/src/ddl/create_flow.rs
+++ b/src/common/meta/src/ddl/create_flow.rs
@@ -194,7 +194,7 @@ impl CreateFlowProcedure {
                 &ctx,
                 &[CacheIdent::CreateFlow(CreateFlow {
                     source_table_ids: self.data.source_table_ids.clone(),
-                    flownode_ids: self.data.peers.iter().map(|peer| peer.id).collect(),
+                    flownode_peers: self.data.peers.clone(),
                 })],
             )
             .await?;

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -25,6 +25,7 @@ use table::table_name::TableName;
 use crate::flow_name::FlowName;
 use crate::key::schema_name::SchemaName;
 use crate::key::FlowId;
+use crate::peer::Peer;
 use crate::{ClusterId, DatanodeId, FlownodeId};
 
 #[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
@@ -169,7 +170,7 @@ pub enum CacheIdent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateFlow {
     pub source_table_ids: Vec<TableId>,
-    pub flownode_ids: Vec<FlownodeId>,
+    pub flownode_peers: Vec<Peer>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/common/meta/src/instruction.rs
+++ b/src/common/meta/src/instruction.rs
@@ -170,7 +170,7 @@ pub enum CacheIdent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateFlow {
     pub source_table_ids: Vec<TableId>,
-    pub flownode_peers: Vec<Peer>,
+    pub flownodes: Vec<Peer>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/common/meta/src/key.rs
+++ b/src/common/meta/src/key.rs
@@ -112,6 +112,7 @@ use common_catalog::consts::{
 use common_telemetry::warn;
 use datanode_table::{DatanodeTableKey, DatanodeTableManager, DatanodeTableValue};
 use flow::flow_route::FlowRouteValue;
+use flow::table_flow::TableFlowValue;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::de::DeserializeOwned;
@@ -1193,7 +1194,8 @@ impl_table_meta_value! {
     DatanodeTableValue,
     FlowInfoValue,
     FlowNameValue,
-    FlowRouteValue
+    FlowRouteValue,
+    TableFlowValue
 }
 
 impl_optional_meta_value! {

--- a/src/common/meta/src/key/flow/flow_route.rs
+++ b/src/common/meta/src/key/flow/flow_route.rs
@@ -187,7 +187,7 @@ impl FlowRouteManager {
 
     /// Builds a create flow routes transaction.
     ///
-    /// Puts `__flow/route/{flownode_id}/{partitions}` keys.
+    /// Puts `__flow/route/{flow_id}/{partition_id}` keys.
     pub(crate) fn build_create_txn<I: IntoIterator<Item = (FlowPartitionId, FlowRouteValue)>>(
         &self,
         flow_id: FlowId,

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -341,8 +341,8 @@ impl Inserter {
                         .await
                         .context(RequestInsertsSnafu)?
                         .unwrap_or_default()
-                        .into_iter()
-                        .map(|id| Peer::new(id, ""))
+                        .values()
+                        .cloned()
                         .collect::<Vec<_>>();
 
                     if !peers.is_empty() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Storing peer info in `FlowTableValue` which reduce one query when mirror insertion.

The original steps:
1. Querying TableId -> `FlowId`s
2. Querying FlowId -> `Peer`s



## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced flow management to include peer information alongside flownode data.

- **Bug Fixes**
  - Corrected key format in `FlowRouteManager` to ensure accurate flow partition handling.

- **Performance Improvements**
  - Switched from `HashSet` to `Arc<HashMap>` for flownode storage, which improves data handling efficiency.

- **Developer Experience**
  - Simplified the creation of flow transactions with updated data structures and serialization support.
  - Improved test suite to align with the new data handling mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->