### PR TITLE
fix(fuzz): generate valid string

### DIFF
--- a/tests-fuzz/src/ir.rs
+++ b/tests-fuzz/src/ir.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 
 use self::insert_expr::{RowValue, RowValues};
 use crate::context::TableContextRef;
+use crate::fake::WordGenerator;
 use crate::generator::{Random, TsValueGenerator};
 use crate::impl_random;
 use crate::ir::create_expr::ColumnOption;
@@ -450,7 +451,11 @@ pub fn partible_column_options_generator<R: Rng + 'static>(
         1 => vec![ColumnOption::PrimaryKey, ColumnOption::NotNull],
         2 => vec![
             ColumnOption::PrimaryKey,
-            ColumnOption::DefaultValue(generate_random_value(rng, column_type, None)),
+            ColumnOption::DefaultValue(generate_random_value(
+                rng,
+                column_type,
+                Some(&WordGenerator),
+            )),
         ],
         3 => vec![ColumnOption::PrimaryKey],
         _ => unreachable!(),

--- a/tests-fuzz/src/utils/migration.rs
+++ b/tests-fuzz/src/utils/migration.rs
@@ -69,7 +69,7 @@ pub async fn wait_for_region_distribution(
             })
         },
         move |region_distribution| {
-            info!("Region Distribution: {:?}", region_distribution);
+            info!("region distribution: {:?}", region_distribution);
             if expected_region_distribution.keys().len() != region_distribution.keys().len() {
                 return false;
             }

--- a/tests-fuzz/targets/migration/fuzz_migrate_mito_regions.rs
+++ b/tests-fuzz/targets/migration/fuzz_migrate_mito_regions.rs
@@ -222,18 +222,18 @@ async fn execute_region_migration(ctx: FuzzContext, input: FuzzInput) -> Result<
     }
     info!("Excepted new region distribution: {new_distribution:?}");
 
+    for procedure_id in procedure_ids {
+        wait_for_procedure_finish(&ctx.greptime, Duration::from_secs(120), procedure_id).await;
+    }
+
     // Waits for all region migrated
     wait_for_region_distribution(
         &ctx.greptime,
-        Duration::from_secs(120),
+        Duration::from_secs(60),
         table_ctx.name.clone(),
         new_distribution,
     )
     .await;
-
-    for procedure_id in procedure_ids {
-        wait_for_procedure_finish(&ctx.greptime, Duration::from_secs(120), procedure_id).await;
-    }
 
     // Values validation
     info!("Validating rows");


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Generate valid string for column default value

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Improved random value generation by utilizing `WordGenerator`.
	- Reduced wait time for region distribution checks from 120 to 60 seconds, enhancing test efficiency.
	- Updated log message for region distribution to improve consistency in output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->