### PR TITLE
fix: enable space string in yaml value

### DIFF
--- a/src/pipeline/src/etl/processor/mod.rs
+++ b/src/pipeline/src/etl/processor/mod.rs
@@ -182,7 +182,7 @@ fn parse_processor(doc: &yaml_rust::Yaml) -> Result<Arc<dyn Processor>, String> 
 
 pub(crate) fn yaml_string(v: &yaml_rust::Yaml, field: &str) -> Result<String, String> {
     v.as_str()
-        .map(|s| s.trim().to_string())
+        .map(|s| s.to_string())
         .ok_or(format!("'{field}' must be a string"))
 }
 

--- a/src/script/src/python/rspython/builtins/test.rs
+++ b/src/script/src/python/rspython/builtins/test.rs
@@ -39,7 +39,7 @@ use crate::python::utils::format_py_error;
 #[test]
 fn convert_scalar_to_py_obj_and_back() {
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
-        // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
+        // this can be in `.enter()` closure, but for clarity, put it in the `with_init()`
         let _ = PyVector::make_class(&vm.ctx);
     })
     .enter(|vm| {
@@ -422,7 +422,7 @@ fn test_vm() {
 
     rustpython_vm::Interpreter::with_init(Default::default(), |vm| {
         vm.add_native_module("udf_builtins", Box::new(greptime_builtin::make_module));
-        // this can be in `.enter()` closure, but for clearity, put it in the `with_init()`
+        // this can be in `.enter()` closure, but for clarity, put it in the `with_init()`
         let _ = PyVector::make_class(&vm.ctx);
     })
     .enter(|vm| {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Pipeline engine uses `yaml_rust` to parse raw yaml file. It already trims spaces in value as possible, but keeps spaces if deliberately included between quotes. For example
```Yaml
// gets "value"
name: value

// gets "value" too since spaces is auto trimed
name:   value

// gets " value"
name: " value"
```

In pipeline engine transformation there is a extra `trim()` that removes the space, which is neither necessary nor compatible with the origin behavior of yaml.

This pr mainly fixes this issue by removing the `trim()` invoke.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where whitespace was incorrectly trimmed from strings retrieved from YAML documents.

- **Documentation**
  - Improved comments in the Python script, enhancing code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->