### PR TITLE
fix: enhance ColumnOption::DefaultValue formatting for string values

### DIFF
--- a/tests-fuzz/src/ir/create_expr.rs
+++ b/tests-fuzz/src/ir/create_expr.rs
@@ -39,7 +39,12 @@ impl Display for ColumnOption {
             ColumnOption::Null => write!(f, "NULL"),
             ColumnOption::NotNull => write!(f, "NOT NULL"),
             ColumnOption::DefaultFn(s) => write!(f, "DEFAULT {}", s),
-            ColumnOption::DefaultValue(s) => write!(f, "DEFAULT {}", s),
+            ColumnOption::DefaultValue(s) => match s {
+                Value::String(value) => {
+                    write!(f, "DEFAULT \'{}\'", value.as_utf8())
+                }
+                _ => write!(f, "DEFAULT {}", s),
+            },
             ColumnOption::TimeIndex => write!(f, "TIME INDEX"),
             ColumnOption::PrimaryKey => write!(f, "PRIMARY KEY"),
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Enhance ColumnOption::DefaultValue formatting for string values, to fix incorrect CreateTableExpr generation🥲

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved formatting of default column values to correctly handle string variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->