### PR TITLE
feat: expose merge_mode option

### DIFF
--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -46,6 +46,8 @@ pub enum MergeMode {
     LastNonNull,
 }
 
+// Note: We need to update [store_api::mito_engine_options::is_mito_engine_option_key()]
+// if we want expose the option to table options.
 /// Options that affect the entire region.
 ///
 /// Users need to specify the options while creating/opening a region.

--- a/src/store-api/src/mito_engine_options.rs
+++ b/src/store-api/src/mito_engine_options.rs
@@ -35,6 +35,7 @@ pub fn is_mito_engine_option_key(key: &str) -> bool {
         "memtable.partition_tree.data_freeze_threshold",
         "memtable.partition_tree.fork_dictionary_bytes",
         "append_mode",
+        "merge_mode",
     ]
     .contains(&key)
 }

--- a/tests/cases/standalone/common/insert/merge_mode.result
+++ b/tests/cases/standalone/common/insert/merge_mode.result
@@ -1,0 +1,120 @@
+create table if not exists last_non_null_table(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_non_null');
+
+Affected Rows: 0
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, 0, NULL), ('host2', 1, NULL, 1);
+
+Affected Rows: 2
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, NULL, 10), ('host2', 1, 11, NULL);
+
+Affected Rows: 2
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
++-------+-------------------------+------+--------+
+| host  | ts                      | cpu  | memory |
++-------+-------------------------+------+--------+
+| host1 | 1970-01-01T00:00:00     | 0.0  | 10.0   |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 | 1.0    |
++-------+-------------------------+------+--------+
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, 20, NULL);
+
+Affected Rows: 1
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
++-------+-------------------------+------+--------+
+| host  | ts                      | cpu  | memory |
++-------+-------------------------+------+--------+
+| host1 | 1970-01-01T00:00:00     | 20.0 | 10.0   |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 | 1.0    |
++-------+-------------------------+------+--------+
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, NULL, NULL);
+
+Affected Rows: 1
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
++-------+-------------------------+------+--------+
+| host  | ts                      | cpu  | memory |
++-------+-------------------------+------+--------+
+| host1 | 1970-01-01T00:00:00     | 20.0 | 10.0   |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 | 1.0    |
++-------+-------------------------+------+--------+
+
+DROP TABLE last_non_null_table;
+
+Affected Rows: 0
+
+create table if not exists last_row_table(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_row');
+
+Affected Rows: 0
+
+INSERT INTO last_row_table VALUES ('host1', 0, 0, NULL), ('host2', 1, NULL, 1);
+
+Affected Rows: 2
+
+INSERT INTO last_row_table VALUES ('host1', 0, NULL, 10), ('host2', 1, 11, NULL);
+
+Affected Rows: 2
+
+SELECT * from last_row_table ORDER BY host, ts;
+
++-------+-------------------------+------+--------+
+| host  | ts                      | cpu  | memory |
++-------+-------------------------+------+--------+
+| host1 | 1970-01-01T00:00:00     |      | 10.0   |
+| host2 | 1970-01-01T00:00:00.001 | 11.0 |        |
++-------+-------------------------+------+--------+
+
+DROP TABLE last_row_table;
+
+Affected Rows: 0
+
+create table if not exists invalid_merge_mode(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='first_row');
+
+Error: 1004(InvalidArguments), Invalid options: Matching variant not found at line 1 column 25
+
+create table if not exists invalid_merge_mode(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_non_null', 'append_mode'='true');
+
+Error: 1004(InvalidArguments), Invalid region options, merge_mode is not allowed when append_mode is enabled
+

--- a/tests/cases/standalone/common/insert/merge_mode.sql
+++ b/tests/cases/standalone/common/insert/merge_mode.sql
@@ -1,0 +1,67 @@
+create table if not exists last_non_null_table(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_non_null');
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, 0, NULL), ('host2', 1, NULL, 1);
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, NULL, 10), ('host2', 1, 11, NULL);
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, 20, NULL);
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
+INSERT INTO last_non_null_table VALUES ('host1', 0, NULL, NULL);
+
+SELECT * from last_non_null_table ORDER BY host, ts;
+
+DROP TABLE last_non_null_table;
+
+create table if not exists last_row_table(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_row');
+
+INSERT INTO last_row_table VALUES ('host1', 0, 0, NULL), ('host2', 1, NULL, 1);
+
+INSERT INTO last_row_table VALUES ('host1', 0, NULL, 10), ('host2', 1, 11, NULL);
+
+SELECT * from last_row_table ORDER BY host, ts;
+
+DROP TABLE last_row_table;
+
+create table if not exists invalid_merge_mode(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='first_row');
+
+create table if not exists invalid_merge_mode(
+    host string,
+    ts timestamp,
+    cpu double,
+    memory double,
+    TIME INDEX (ts),
+    PRIMARY KEY(host)
+)
+engine=mito
+with('merge_mode'='last_non_null', 'append_mode'='true');


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR exposes the merge_mode table options and adds sqlness tests for it.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new "merge_mode" option for handling data insertion into tables.
	- Added support for different merge modes such as `last_non_null` and `last_row` during table creation and data insertion.

- **Tests**
	- Added SQL tests demonstrating the behavior of new merge modes and handling of NULL values during data insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->