### PR TITLE
fix: align pre-commit config with make file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     hooks:
     -    id: fmt
     -    id: clippy
-         args: ["--workspace", "--all-targets", "--", "-D", "warnings", "-D", "clippy::print_stdout", "-D", "clippy::print_stderr"]
+         args: ["--workspace", "--all-targets", "--all-features", "--", "-D", "warnings"]
          stages: [push]
     -    id: cargo-check
+         args: ["--workspace", "--all-targets", "--all-features"]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Align pre-commit config with our `Makefile` so that it won't check twice when commit and push

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated pre-commit hooks to include `--all-features` for `clippy` and `cargo-check` to ensure comprehensive code checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->