### PR TITLE
chore(ci): retry on error during installing operator

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/action.yml
+++ b/.github/actions/setup-greptimedb-cluster/action.yml
@@ -31,17 +31,22 @@ runs:
   using: composite
   steps:
   - name: Install GreptimeDB operator
-    shell: bash
-    run: |
-      helm repo add greptime https://greptimeteam.github.io/helm-charts/ 
-      helm repo update
-      helm upgrade \
-        --install \
-        --create-namespace \
-        greptimedb-operator greptime/greptimedb-operator \
-        -n greptimedb-admin \
-        --wait \
-        --wait-for-jobs
+    uses: nick-fields/retry@v3
+    with: 
+      timeout_minutes: 3
+      max_attempts: 3
+      retry_on: error
+      shell: bash
+      command: |
+        helm repo add greptime https://greptimeteam.github.io/helm-charts/ 
+        helm repo update
+        helm upgrade \
+          --install \
+          --create-namespace \
+          greptimedb-operator greptime/greptimedb-operator \
+          -n greptimedb-admin \
+          --wait \
+          --wait-for-jobs
   - name: Install GreptimeDB cluster
     shell: bash
     run: | 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Retry on error during installing operator

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
