### PR TITLE
feat: support `text/plain` format for log ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,12 +739,9 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
-dependencies = [
- "bytemuck",
-]
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-waker"
@@ -6386,9 +6383,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "mur3"
@@ -6942,9 +6939,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.47.3"
+version = "0.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac4826fe3d5482a49b92955b0f6b06ce45b46ec84484176588209bfbf996870"
+checksum = "ff159a2da374ef2d64848a6547943cf1af7d2ceada5ae77be175e1389aa07ae3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12844,9 +12841,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "atomic",
  "getrandom",
@@ -12857,9 +12854,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.9.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ff64d5cde1e2cb5268bdb497235b6bd255ba8244f910dbc3574e59593de68c"
+checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -93,6 +93,19 @@ pub trait Processor: std::fmt::Debug + Send + Sync + 'static {
                 Value::Map(map) => {
                     values.push(self.exec_map(map)?);
                 }
+                Value::String(_) => {
+                    let fields = self.fields();
+                    if fields.len() != 1 {
+                        return Err(format!(
+                            "{} processor: expected fields length 1 when processing line input, but got {}",
+                            self.kind(),
+                            fields.len()
+                        ));
+                    }
+                    let field = fields.first().unwrap();
+
+                    values.push(self.exec_field(&val, field).map(Value::Map)?);
+                }
                 _ if self.ignore_processor_array_failure() => {
                     warn!("expected a map, but got {val}")
                 }

--- a/src/pipeline/src/manager/error.rs
+++ b/src/pipeline/src/manager/error.rs
@@ -81,6 +81,13 @@ pub enum Error {
         location: Location,
     },
 
+    #[snafu(display("Failed to create dataframe"))]
+    DataFrame {
+        source: query::error::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
     #[snafu(display("General catalog error"))]
     Catalog {
         source: catalog::error::Error,
@@ -126,6 +133,7 @@ impl ErrorExt for Error {
             | InvalidPipelineVersion { .. } => StatusCode::InvalidArguments,
             BuildDfLogicalPlan { .. } => StatusCode::Internal,
             ExecuteInternalStatement { source, .. } => source.status_code(),
+            DataFrame { source, .. } => source.status_code(),
             Catalog { source, .. } => source.status_code(),
             CreateTable { source, .. } => source.status_code(),
         }

--- a/src/pipeline/src/manager/table.rs
+++ b/src/pipeline/src/manager/table.rs
@@ -24,33 +24,32 @@ use common_query::OutputData;
 use common_recordbatch::util as record_util;
 use common_telemetry::{debug, info};
 use common_time::timestamp::{TimeUnit, Timestamp};
-use datafusion::datasource::DefaultTableSource;
 use datafusion::logical_expr::col;
 use datafusion_common::{TableReference, ToDFSchema};
-use datafusion_expr::{DmlStatement, LogicalPlan as DfLogicalPlan, LogicalPlanBuilder};
+use datafusion_expr::{DmlStatement, LogicalPlan as DfLogicalPlan};
 use datatypes::prelude::ScalarVector;
 use datatypes::timestamp::TimestampNanosecond;
 use datatypes::vectors::{StringVector, TimestampNanosecondVector, Vector};
 use moka::sync::Cache;
 use operator::insert::InserterRef;
 use operator::statement::StatementExecutorRef;
+use query::dataframe::DataFrame;
 use query::plan::LogicalPlan;
 use query::QueryEngineRef;
 use session::context::{QueryContextBuilder, QueryContextRef};
 use snafu::{ensure, OptionExt, ResultExt};
 use table::metadata::TableInfo;
-use table::table::adapter::DfTableProviderAdapter;
 use table::TableRef;
 
 use crate::error::{
     BuildDfLogicalPlanSnafu, CastTypeSnafu, CollectRecordsSnafu, CompilePipelineSnafu,
-    ExecuteInternalStatementSnafu, InsertPipelineSnafu, InvalidPipelineVersionSnafu,
-    PipelineNotFoundSnafu, Result,
+    DataFrameSnafu, ExecuteInternalStatementSnafu, InsertPipelineSnafu,
+    InvalidPipelineVersionSnafu, PipelineNotFoundSnafu, Result,
 };
 use crate::etl::transform::GreptimeTransformer;
 use crate::etl::{parse, Content, Pipeline};
 use crate::manager::{PipelineInfo, PipelineVersion};
-use crate::util::{build_plan_filter, generate_pipeline_cache_key};
+use crate::util::{generate_pipeline_cache_key, prepare_dataframe_conditions};
 
 pub(crate) const PIPELINE_TABLE_NAME: &str = "pipelines";
 pub(crate) const PIPELINE_TABLE_PIPELINE_NAME_COLUMN_NAME: &str = "name";
@@ -337,15 +336,24 @@ impl PipelineTable {
             return Ok(None);
         }
 
-        // 2. do delete
+        // 2. prepare dataframe
+        let dataframe = self
+            .query_engine
+            .read_table(self.table.clone())
+            .context(DataFrameSnafu)?;
+        let DataFrame::DataFusion(dataframe) = dataframe;
+
+        let dataframe = dataframe
+            .filter(prepare_dataframe_conditions(schema, name, version))
+            .context(BuildDfLogicalPlanSnafu)?;
+
+        // 3. prepare dml stmt
         let table_info = self.table.table_info();
         let table_name = TableReference::full(
             table_info.catalog_name.clone(),
             table_info.schema_name.clone(),
             table_info.name.clone(),
         );
-        let table_provider = Arc::new(DfTableProviderAdapter::new(self.table.clone()));
-        let table_source = Arc::new(DefaultTableSource::new(table_provider));
 
         let df_schema = Arc::new(
             table_info
@@ -357,24 +365,17 @@ impl PipelineTable {
                 .context(BuildDfLogicalPlanSnafu)?,
         );
 
-        // create scan plan
-        let logical_plan = LogicalPlanBuilder::scan(table_name.clone(), table_source, None)
-            .context(BuildDfLogicalPlanSnafu)?
-            .filter(build_plan_filter(schema, name, version))
-            .context(BuildDfLogicalPlanSnafu)?
-            .build()
-            .context(BuildDfLogicalPlanSnafu)?;
-
         // create dml stmt
         let stmt = DmlStatement::new(
             table_name,
             df_schema,
             datafusion_expr::WriteOp::Delete,
-            Arc::new(logical_plan),
+            Arc::new(dataframe.into_parts().1),
         );
 
         let plan = LogicalPlan::DfPlan(DfLogicalPlan::Dml(stmt));
 
+        // 4. execute dml stmt
         let output = self
             .query_engine
             .execute(plan, Self::query_ctx(&table_info))
@@ -404,24 +405,19 @@ impl PipelineTable {
         name: &str,
         version: PipelineVersion,
     ) -> Result<Option<(String, TimestampNanosecond)>> {
-        let table_info = self.table.table_info();
+        // 1. prepare dataframe
+        let dataframe = self
+            .query_engine
+            .read_table(self.table.clone())
+            .context(DataFrameSnafu)?;
+        let DataFrame::DataFusion(dataframe) = dataframe;
 
-        let table_name = TableReference::full(
-            table_info.catalog_name.clone(),
-            table_info.schema_name.clone(),
-            table_info.name.clone(),
-        );
-
-        let table_provider = Arc::new(DfTableProviderAdapter::new(self.table.clone()));
-        let table_source = Arc::new(DefaultTableSource::new(table_provider));
-
-        let plan = LogicalPlanBuilder::scan(table_name, table_source, None)
+        let dataframe = dataframe
+            .filter(prepare_dataframe_conditions(schema, name, version))
             .context(BuildDfLogicalPlanSnafu)?
-            .filter(build_plan_filter(schema, name, version))
-            .context(BuildDfLogicalPlanSnafu)?
-            .project(vec![
-                col(PIPELINE_TABLE_PIPELINE_CONTENT_COLUMN_NAME),
-                col(PIPELINE_TABLE_CREATED_AT_COLUMN_NAME),
+            .select_columns(&[
+                PIPELINE_TABLE_PIPELINE_CONTENT_COLUMN_NAME,
+                PIPELINE_TABLE_CREATED_AT_COLUMN_NAME,
             ])
             .context(BuildDfLogicalPlanSnafu)?
             .sort(vec![
@@ -429,15 +425,18 @@ impl PipelineTable {
             ])
             .context(BuildDfLogicalPlanSnafu)?
             .limit(0, Some(1))
-            .context(BuildDfLogicalPlanSnafu)?
-            .build()
             .context(BuildDfLogicalPlanSnafu)?;
+
+        let plan = LogicalPlan::DfPlan(dataframe.into_parts().1);
+
+        let table_info = self.table.table_info();
 
         debug!("find_pipeline_by_name: plan: {:?}", plan);
 
+        // 2. execute plan
         let output = self
             .query_engine
-            .execute(LogicalPlan::DfPlan(plan), Self::query_ctx(&table_info))
+            .execute(plan, Self::query_ctx(&table_info))
             .await
             .context(ExecuteInternalStatementSnafu)?;
         let stream = match output.data {
@@ -446,6 +445,7 @@ impl PipelineTable {
             _ => unreachable!(),
         };
 
+        // 3. construct result
         let records = record_util::collect(stream)
             .await
             .context(CollectRecordsSnafu)?;

--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -254,14 +254,13 @@ pub async fn log_ingester(
             Deserializer::from_str(&payload).into_iter(),
             ignore_errors,
         )?,
-        ct if ct == ContentType::text() || ct == ContentType::text_utf8() => {
-            let a = payload
+        ct if ct == ContentType::text() || ct == ContentType::text_utf8() => Value::Array(
+            payload
                 .lines()
                 .filter(|line| !line.is_empty())
                 .map(|line| json!({ "line": line }))
-                .collect::<Vec<Value>>();
-            Value::Array(a)
-        }
+                .collect::<Vec<Value>>(),
+        ),
         _ => UnsupportedContentTypeSnafu { content_type }.fail()?,
     };
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -78,6 +78,7 @@ macro_rules! http_tests {
                 test_vm_proto_remote_write,
 
                 test_pipeline_api,
+                test_plain_text_ingestion,
             );
         )*
     };
@@ -1125,6 +1126,106 @@ transform:
         .await;
     // todo(shuiyisong): refactor http error handling
     assert_ne!(res.status(), StatusCode::OK);
+
+    guard.remove_all().await;
+}
+
+pub async fn test_plain_text_ingestion(store_type: StorageType) {
+    common_telemetry::init_default_ut_logging();
+    let (app, mut guard) = setup_test_http_app_with_frontend(store_type, "test_pipeline_api").await;
+
+    // handshake
+    let client = TestClient::new(app);
+
+    let body = r#"
+processors:
+  - dissect:
+      fields:
+        - line
+      patterns: 
+        - "%{+ts} %{+ts} %{content}"
+  - date:
+      fields: 
+        - ts
+      formats:
+        - "%Y-%m-%d %H:%M:%S%.3f"
+
+transform:
+  - fields:
+      - content
+    type: string
+  - field: ts
+    type: time
+    index: timestamp
+"#;
+
+    // 1. create pipeline
+    let res = client
+        .post("/v1/events/pipelines/test")
+        .header("Content-Type", "application/x-yaml")
+        .body(body)
+        .send()
+        .await;
+
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let content = res.text().await;
+
+    let content = serde_json::from_str(&content);
+    assert!(content.is_ok());
+    //  {"execution_time_ms":13,"pipelines":[{"name":"test","version":"2024-07-04 08:31:00.987136"}]}
+    let content: Value = content.unwrap();
+
+    let version_str = content
+        .get("pipelines")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .first()
+        .unwrap()
+        .get("version")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(!version_str.is_empty());
+
+    // 2. write data
+    let data_body = r#"
+2024-05-25 20:16:37.217 hello
+2024-05-25 20:16:37.218 hello world
+"#;
+    let res = client
+        .post("/v1/events/logs?db=public&table=logs1&pipeline_name=test")
+        .header("Content-Type", "text/plain")
+        .body(data_body)
+        .send()
+        .await;
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // 3. select data
+    let res = client.get("/v1/sql?sql=select * from logs1").send().await;
+    assert_eq!(res.status(), StatusCode::OK);
+    let resp = res.text().await;
+
+    let resp: Value = serde_json::from_str(&resp).unwrap();
+    let v = resp
+        .get("output")
+        .unwrap()
+        .as_array()
+        .unwrap()
+        .first()
+        .unwrap()
+        .get("records")
+        .unwrap()
+        .get("rows")
+        .unwrap()
+        .to_string();
+
+    assert_eq!(
+        v,
+        r#"[["hello",1716668197217000000],["hello world",1716668197218000000]]"#,
+    );
 
     guard.remove_all().await;
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr 
 - adds support for `text/plain` and `text/plain; charset=utf-8` on log ingestion
 - refactors pipeline find and delete api using `dataframe` api

now you can use plain text logs to ingest log data, for example:
```
url="http://localhost:4000/v1/events/logs?table=$table_name&pipeline_name=$pipeline_name"
curl -X POST "$url" -H "Content-Type: text/plain" \
 -d '
2024-05-25 20:16:37.217 hello
2024-05-25 20:16:37.218 hello world
'
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new error type, `DataFrame`, for more detailed error reporting related to data frames.
  - Added `TimestampNanosecondValue` support to handle more precise timestamp data in tests.
  - Added plaintext ingestion test for HTTP pipelines.

- **Refactor**
  - Improved data frame preparation and filtering logic in the `PipelineTable` module.
  - Updated content type processing methods in HTTP event handling.

- **Bug Fixes**
  - Enhanced error handling to include new data frame-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->