### PR TITLE
feat: impl show table status

### DIFF
--- a/src/catalog/src/information_schema/tables.rs
+++ b/src/catalog/src/information_schema/tables.rs
@@ -64,7 +64,7 @@ pub const TABLE_COMMENT: &str = "table_comment";
 pub const MAX_INDEX_LENGTH: &str = "max_index_length";
 pub const TEMPORARY: &str = "temporary";
 const TABLE_ID: &str = "table_id";
-const ENGINE: &str = "engine";
+pub const ENGINE: &str = "engine";
 const INIT_CAPACITY: usize = 42;
 
 pub(super) struct InformationSchemaTables {

--- a/src/common/wal/src/config.rs
+++ b/src/common/wal/src/config.rs
@@ -207,7 +207,7 @@ mod tests {
         let datanode_wal_config: DatanodeWalConfig = toml::from_str(toml_str).unwrap();
         let expected = DatanodeKafkaConfig {
             broker_endpoints: vec!["127.0.0.1:9092".to_string()],
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),
             backoff: BackoffConfig {
@@ -229,7 +229,7 @@ mod tests {
             num_partitions: 1,
             replication_factor: 1,
             create_topic_timeout: Duration::from_secs(30),
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),
             backoff: BackoffConfig {

--- a/src/common/wal/src/config/kafka/datanode.rs
+++ b/src/common/wal/src/config/kafka/datanode.rs
@@ -46,7 +46,7 @@ impl Default for DatanodeKafkaConfig {
     fn default() -> Self {
         Self {
             broker_endpoints: vec![BROKER_ENDPOINT.to_string()],
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             // Warning: Kafka has a default limit of 1MB per message in a topic.
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),

--- a/src/common/wal/src/config/kafka/standalone.rs
+++ b/src/common/wal/src/config/kafka/standalone.rs
@@ -67,7 +67,7 @@ impl Default for StandaloneKafkaConfig {
             num_partitions: 1,
             replication_factor,
             create_topic_timeout: Duration::from_secs(30),
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             // Warning: Kafka has a default limit of 1MB per message in a topic.
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),

--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -520,6 +520,9 @@ pub fn check_permission(
         Statement::ShowTables(stmt) => {
             validate_db_permission!(stmt, query_ctx);
         }
+        Statement::ShowTableStatus(stmt) => {
+            validate_db_permission!(stmt, query_ctx);
+        }
         Statement::ShowColumns(stmt) => {
             validate_db_permission!(stmt, query_ctx);
         }

--- a/src/operator/src/statement.rs
+++ b/src/operator/src/statement.rs
@@ -126,6 +126,8 @@ impl StatementExecutor {
 
             Statement::ShowTables(stmt) => self.show_tables(stmt, query_ctx).await,
 
+            Statement::ShowTableStatus(stmt) => self.show_table_status(stmt, query_ctx).await,
+
             Statement::ShowCollation(kind) => self.show_collation(kind, query_ctx).await,
 
             Statement::ShowCharset(kind) => self.show_charset(kind, query_ctx).await,

--- a/src/operator/src/statement/show.rs
+++ b/src/operator/src/statement/show.rs
@@ -22,7 +22,7 @@ use snafu::ResultExt;
 use sql::ast::Ident;
 use sql::statements::create::Partitions;
 use sql::statements::show::{
-    ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTables, ShowVariables,
+    ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTableStatus, ShowTables, ShowVariables,
 };
 use sqlparser::ast::ObjectName;
 use table::metadata::TableType;
@@ -51,6 +51,17 @@ impl StatementExecutor {
         query_ctx: QueryContextRef,
     ) -> Result<Output> {
         query::sql::show_tables(stmt, &self.query_engine, &self.catalog_manager, query_ctx)
+            .await
+            .context(ExecuteStatementSnafu)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub(super) async fn show_table_status(
+        &self,
+        stmt: ShowTableStatus,
+        query_ctx: QueryContextRef,
+    ) -> Result<Output> {
+        query::sql::show_table_status(stmt, &self.query_engine, &self.catalog_manager, query_ctx)
             .await
             .context(ExecuteStatementSnafu)
     }

--- a/src/query/src/sql.rs
+++ b/src/query/src/sql.rs
@@ -54,7 +54,7 @@ use sql::ast::Ident;
 use sql::parser::ParserContext;
 use sql::statements::create::{CreateFlow, Partitions};
 use sql::statements::show::{
-    ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTables, ShowVariables,
+    ShowColumns, ShowDatabases, ShowIndex, ShowKind, ShowTableStatus, ShowTables, ShowVariables,
 };
 use sqlparser::ast::ObjectName;
 use table::requests::{FILE_TABLE_LOCATION_KEY, FILE_TABLE_PATTERN_KEY};
@@ -445,6 +445,7 @@ pub async fn show_index(
     .await
 }
 
+/// Execute [`ShowTables`] statement and return the [`Output`] if success.
 pub async fn show_tables(
     stmt: ShowTables,
     query_engine: &QueryEngineRef,
@@ -467,6 +468,63 @@ pub async fn show_tables(
     } else {
         vec![(tables::TABLE_NAME, TABLES_COLUMN)]
     };
+    let filters = vec![
+        col(tables::TABLE_SCHEMA).eq(lit(schema_name.clone())),
+        col(tables::TABLE_CATALOG).eq(lit(query_ctx.current_catalog())),
+    ];
+    let like_field = Some(tables::TABLE_NAME);
+    let sort = vec![col(tables::TABLE_NAME).sort(true, true)];
+
+    query_from_information_schema_table(
+        query_engine,
+        catalog_manager,
+        query_ctx,
+        TABLES,
+        vec![],
+        projects,
+        filters,
+        like_field,
+        sort,
+        stmt.kind,
+    )
+    .await
+}
+
+/// Execute [`ShowTableStatus`] statement and return the [`Output`] if success.
+pub async fn show_table_status(
+    stmt: ShowTableStatus,
+    query_engine: &QueryEngineRef,
+    catalog_manager: &CatalogManagerRef,
+    query_ctx: QueryContextRef,
+) -> Result<Output> {
+    let schema_name = if let Some(database) = stmt.database {
+        database
+    } else {
+        query_ctx.current_schema()
+    };
+
+    // Refer to https://dev.mysql.com/doc/refman/8.4/en/show-table-status.html
+    let projects = vec![
+        (tables::TABLE_NAME, "Name"),
+        (tables::ENGINE, "Engine"),
+        (tables::VERSION, "Version"),
+        (tables::ROW_FORMAT, "Row_format"),
+        (tables::TABLE_ROWS, "Rows"),
+        (tables::AVG_ROW_LENGTH, "Avg_row_length"),
+        (tables::DATA_LENGTH, "Data_length"),
+        (tables::MAX_DATA_LENGTH, "Max_data_length"),
+        (tables::INDEX_LENGTH, "Index_length"),
+        (tables::DATA_FREE, "Data_free"),
+        (tables::AUTO_INCREMENT, "Auto_increment"),
+        (tables::CREATE_TIME, "Create_time"),
+        (tables::UPDATE_TIME, "Update_time"),
+        (tables::CHECK_TIME, "Check_time"),
+        (tables::TABLE_COLLATION, "Collation"),
+        (tables::CHECKSUM, "Checksum"),
+        (tables::CREATE_OPTIONS, "Create_options"),
+        (tables::TABLE_COMMENT, "Comment"),
+    ];
+
     let filters = vec![
         col(tables::TABLE_SCHEMA).eq(lit(schema_name.clone())),
         col(tables::TABLE_CATALOG).eq(lit(query_ctx.current_catalog())),

--- a/src/sql/src/parsers/show_parser.rs
+++ b/src/sql/src/parsers/show_parser.rs
@@ -359,7 +359,7 @@ impl<'a> ParserContext<'a> {
                 }));
             }
 
-            // SHOW TABLES [in | FROM] [DATABASE]
+            // SHOW TABLE STATUS [in | FROM] [DATABASE]
             Token::Word(w) => match w.keyword {
                 Keyword::IN | Keyword::FROM => self.parse_db_name()?,
 

--- a/src/sql/src/parsers/show_parser.rs
+++ b/src/sql/src/parsers/show_parser.rs
@@ -22,7 +22,7 @@ use crate::error::{
 use crate::parser::ParserContext;
 use crate::statements::show::{
     ShowColumns, ShowCreateFlow, ShowCreateTable, ShowDatabases, ShowIndex, ShowKind, ShowStatus,
-    ShowTables, ShowVariables,
+    ShowTableStatus, ShowTables, ShowVariables,
 };
 use crate::statements::statement::Statement;
 
@@ -36,6 +36,14 @@ impl<'a> ParserContext<'a> {
         } else if self.matches_keyword(Keyword::TABLES) {
             self.parser.next_token();
             self.parse_show_tables(false)
+        } else if self.matches_keyword(Keyword::TABLE) {
+            self.parser.next_token();
+            if self.matches_keyword(Keyword::STATUS) {
+                self.parser.next_token();
+                self.parse_show_table_status()
+            } else {
+                self.unsupported(self.peek_token_as_string())
+            }
         } else if self.matches_keyword(Keyword::CHARSET) {
             self.parser.next_token();
             Ok(Statement::ShowCharset(self.parse_show_kind()?))
@@ -339,6 +347,32 @@ impl<'a> ParserContext<'a> {
             kind,
             database,
             full,
+        }))
+    }
+
+    fn parse_show_table_status(&mut self) -> Result<Statement> {
+        let database = match self.parser.peek_token().token {
+            Token::EOF | Token::SemiColon => {
+                return Ok(Statement::ShowTableStatus(ShowTableStatus {
+                    kind: ShowKind::All,
+                    database: None,
+                }));
+            }
+
+            // SHOW TABLES [in | FROM] [DATABASE]
+            Token::Word(w) => match w.keyword {
+                Keyword::IN | Keyword::FROM => self.parse_db_name()?,
+
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let kind = self.parse_show_kind()?;
+
+        Ok(Statement::ShowTableStatus(ShowTableStatus {
+            kind,
+            database,
         }))
     }
 
@@ -834,5 +868,42 @@ mod tests {
             result.unwrap()[0],
             Statement::ShowCharset(ShowKind::Like(_))
         ));
+    }
+
+    fn parse_show_table_status(sql: &str) -> ShowTableStatus {
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        let mut stmts = result.unwrap();
+        assert_eq!(1, stmts.len());
+
+        match stmts.remove(0) {
+            Statement::ShowTableStatus(stmt) => stmt,
+            _ => panic!("Failed to parse show table status"),
+        }
+    }
+
+    #[test]
+    pub fn test_show_table_status() {
+        let sql = "SHOW TABLE STATUS";
+        let stmt = parse_show_table_status(sql);
+        assert!(stmt.database.is_none());
+        assert_eq!(sql, stmt.to_string());
+
+        let sql = "SHOW TABLE STATUS IN test";
+        let stmt = parse_show_table_status(sql);
+        assert_eq!("test", stmt.database.as_ref().unwrap());
+        assert_eq!(sql, stmt.to_string());
+
+        let sql = "SHOW TABLE STATUS LIKE '%monitor'";
+        let stmt = parse_show_table_status(sql);
+        assert!(stmt.database.is_none());
+        assert!(matches!(stmt.kind, ShowKind::Like(_)));
+        assert_eq!(sql, stmt.to_string());
+
+        let sql = "SHOW TABLE STATUS IN test WHERE Name = 'monitor'";
+        let stmt = parse_show_table_status(sql);
+        assert_eq!("test", stmt.database.as_ref().unwrap());
+        assert!(matches!(stmt.kind, ShowKind::Where(_)));
+        assert_eq!(sql, stmt.to_string());
     }
 }

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -38,7 +38,7 @@ impl Display for ShowKind {
 }
 
 macro_rules! format_kind {
-    ($self: expr,$f: expr) => {
+    ($self: expr, $f: expr) => {
         if $self.kind != ShowKind::All {
             write!($f, " {}", &$self.kind)?;
         }

--- a/src/sql/src/statements/show.rs
+++ b/src/sql/src/statements/show.rs
@@ -29,11 +29,20 @@ pub enum ShowKind {
 impl Display for ShowKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ShowKind::All => write!(f, "ALL"),
+            // The `All` is the default kind placeholder, not a valid statement.
+            ShowKind::All => write!(f, ""),
             ShowKind::Like(ident) => write!(f, "LIKE {ident}"),
             ShowKind::Where(expr) => write!(f, "WHERE {expr}"),
         }
     }
+}
+
+macro_rules! format_kind {
+    ($self: expr,$f: expr) => {
+        if $self.kind != ShowKind::All {
+            write!($f, " {}", &$self.kind)?;
+        }
+    };
 }
 
 /// SQL structure for `SHOW DATABASES`.
@@ -58,11 +67,12 @@ impl Display for ShowColumns {
         if self.full {
             write!(f, "FULL ")?;
         }
-        write!(f, "COLUMNS IN {} ", &self.table)?;
+        write!(f, "COLUMNS IN {}", &self.table)?;
         if let Some(database) = &self.database {
-            write!(f, "IN {database} ")?;
+            write!(f, " IN {database}")?;
         }
-        write!(f, "{}", &self.kind)
+        format_kind!(self, f);
+        Ok(())
     }
 }
 
@@ -76,11 +86,13 @@ pub struct ShowIndex {
 
 impl Display for ShowIndex {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SHOW INDEX IN {} ", &self.table)?;
+        write!(f, "SHOW INDEX IN {}", &self.table)?;
         if let Some(database) = &self.database {
-            write!(f, "IN {database} ")?;
+            write!(f, " IN {database}")?;
         }
-        write!(f, "{}", &self.kind)
+        format_kind!(self, f);
+
+        Ok(())
     }
 }
 
@@ -93,13 +105,15 @@ impl ShowDatabases {
 
 impl Display for ShowDatabases {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let kind = &self.kind;
-
         if self.full {
-            write!(f, r#"SHOW FULL DATABASES {kind}"#)
+            write!(f, "SHOW FULL DATABASES")?;
         } else {
-            write!(f, r#"SHOW DATABASES {kind}"#)
+            write!(f, "SHOW DATABASES")?;
         }
+
+        format_kind!(self, f);
+
+        Ok(())
     }
 }
 
@@ -117,11 +131,33 @@ impl Display for ShowTables {
         if self.full {
             write!(f, "FULL ")?;
         }
-        write!(f, "TABLES ")?;
+        write!(f, "TABLES")?;
         if let Some(database) = &self.database {
-            write!(f, "IN {database} ")?;
+            write!(f, " IN {database}")?;
         }
-        write!(f, "{}", &self.kind)
+        format_kind!(self, f);
+
+        Ok(())
+    }
+}
+
+/// SQL structure for `SHOW TABLE STATUS`.
+#[derive(Debug, Clone, PartialEq, Eq, Visit, VisitMut)]
+pub struct ShowTableStatus {
+    pub kind: ShowKind,
+    pub database: Option<String>,
+}
+
+impl Display for ShowTableStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SHOW TABLE STATUS")?;
+        if let Some(database) = &self.database {
+            write!(f, " IN {database}")?;
+        }
+
+        format_kind!(self, f);
+
+        Ok(())
     }
 }
 
@@ -187,7 +223,7 @@ mod tests {
 
     #[test]
     fn test_kind_display() {
-        assert_eq!("ALL", format!("{}", ShowKind::All));
+        assert_eq!("", format!("{}", ShowKind::All));
         assert_eq!(
             "LIKE test",
             format!(
@@ -348,7 +384,7 @@ SHOW CREATE TABLE monitor"#,
                 let new_sql = format!("\n{}", show);
                 assert_eq!(
                     r#"
-SHOW INDEX IN t1 IN d1 ALL"#,
+SHOW INDEX IN t1 IN d1"#,
                     &new_sql
                 );
             }
@@ -371,7 +407,7 @@ SHOW INDEX IN t1 IN d1 ALL"#,
                 let new_sql = format!("\n{}", show);
                 assert_eq!(
                     r#"
-SHOW FULL COLUMNS IN t1 IN d1 ALL"#,
+SHOW FULL COLUMNS IN t1 IN d1"#,
                     &new_sql
                 );
             }
@@ -394,7 +430,7 @@ SHOW FULL COLUMNS IN t1 IN d1 ALL"#,
                 let new_sql = format!("\n{}", show);
                 assert_eq!(
                     r#"
-SHOW FULL TABLES IN d1 ALL"#,
+SHOW FULL TABLES IN d1"#,
                     &new_sql
                 );
             }
@@ -414,7 +450,7 @@ SHOW FULL TABLES IN d1 ALL"#,
                 let new_sql = format!("\n{}", show);
                 assert_eq!(
                     r#"
-SHOW FULL TABLES ALL"#,
+SHOW FULL TABLES"#,
                     &new_sql
                 );
             }
@@ -437,7 +473,7 @@ SHOW FULL TABLES ALL"#,
                 let new_sql = format!("\n{}", show);
                 assert_eq!(
                     r#"
-SHOW DATABASES ALL"#,
+SHOW DATABASES"#,
                     &new_sql
                 );
             }

--- a/src/sql/src/statements/statement.rs
+++ b/src/sql/src/statements/statement.rs
@@ -32,7 +32,7 @@ use crate::statements::query::Query;
 use crate::statements::set_variables::SetVariables;
 use crate::statements::show::{
     ShowColumns, ShowCreateFlow, ShowCreateTable, ShowDatabases, ShowIndex, ShowKind, ShowStatus,
-    ShowTables, ShowVariables,
+    ShowTableStatus, ShowTables, ShowVariables,
 };
 use crate::statements::tql::Tql;
 use crate::statements::truncate::TruncateTable;
@@ -71,6 +71,8 @@ pub enum Statement {
     ShowDatabases(ShowDatabases),
     // SHOW TABLES
     ShowTables(ShowTables),
+    // SHOW TABLE STATUS
+    ShowTableStatus(ShowTableStatus),
     // SHOW COLUMNS
     ShowColumns(ShowColumns),
     // SHOW CHARSET or SHOW CHARACTER SET
@@ -119,6 +121,7 @@ impl Display for Statement {
             Statement::Alter(s) => s.fmt(f),
             Statement::ShowDatabases(s) => s.fmt(f),
             Statement::ShowTables(s) => s.fmt(f),
+            Statement::ShowTableStatus(s) => s.fmt(f),
             Statement::ShowColumns(s) => s.fmt(f),
             Statement::ShowIndex(s) => s.fmt(f),
             Statement::ShowCreateTable(s) => s.fmt(f),

--- a/tests/cases/standalone/common/show/show_databases_tables.result
+++ b/tests/cases/standalone/common/show/show_databases_tables.result
@@ -58,6 +58,114 @@ SHOW TABLES;
 | triggers                              |
 +---------------------------------------+
 
+SHOW TABLES LIKE 'tables';
+
++--------+
+| Tables |
++--------+
+| tables |
++--------+
+
+SHOW FULL TABLES;
+
++---------------------------------------+-----------------+
+| Tables                                | Table_type      |
++---------------------------------------+-----------------+
+| build_info                            | LOCAL TEMPORARY |
+| character_sets                        | LOCAL TEMPORARY |
+| check_constraints                     | LOCAL TEMPORARY |
+| cluster_info                          | LOCAL TEMPORARY |
+| collation_character_set_applicability | LOCAL TEMPORARY |
+| collations                            | LOCAL TEMPORARY |
+| column_privileges                     | LOCAL TEMPORARY |
+| column_statistics                     | LOCAL TEMPORARY |
+| columns                               | LOCAL TEMPORARY |
+| engines                               | LOCAL TEMPORARY |
+| events                                | LOCAL TEMPORARY |
+| files                                 | LOCAL TEMPORARY |
+| global_status                         | LOCAL TEMPORARY |
+| key_column_usage                      | LOCAL TEMPORARY |
+| optimizer_trace                       | LOCAL TEMPORARY |
+| parameters                            | LOCAL TEMPORARY |
+| partitions                            | LOCAL TEMPORARY |
+| profiling                             | LOCAL TEMPORARY |
+| referential_constraints               | LOCAL TEMPORARY |
+| region_peers                          | LOCAL TEMPORARY |
+| routines                              | LOCAL TEMPORARY |
+| runtime_metrics                       | LOCAL TEMPORARY |
+| schema_privileges                     | LOCAL TEMPORARY |
+| schemata                              | LOCAL TEMPORARY |
+| session_status                        | LOCAL TEMPORARY |
+| table_constraints                     | LOCAL TEMPORARY |
+| table_privileges                      | LOCAL TEMPORARY |
+| tables                                | LOCAL TEMPORARY |
+| triggers                              | LOCAL TEMPORARY |
++---------------------------------------+-----------------+
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS;
+
++---------------------------------------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| Name                                  | Engine | Version | Row_format | Rows | Avg_row_length | Data_length | Max_data_length | Index_length | Data_free | Auto_increment | Create_time             | Update_time | Check_time | Collation | Checksum | Create_options | Comment |
++---------------------------------------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| build_info                            |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| character_sets                        |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| check_constraints                     |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| cluster_info                          |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| collation_character_set_applicability |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| collations                            |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| column_privileges                     |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| column_statistics                     |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| columns                               |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| engines                               |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| events                                |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| files                                 |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| global_status                         |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| key_column_usage                      |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| optimizer_trace                       |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| parameters                            |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| partitions                            |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| profiling                             |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| referential_constraints               |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| region_peers                          |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| routines                              |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| runtime_metrics                       |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| schema_privileges                     |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| schemata                              |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| session_status                        |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| table_constraints                     |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| table_privileges                      |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| tables                                |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
+| triggers                              |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
++---------------------------------------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS LIKE 'tables';
+
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| Name   | Engine | Version | Row_format | Rows | Avg_row_length | Data_length | Max_data_length | Index_length | Data_free | Auto_increment | Create_time             | Update_time | Check_time | Collation | Checksum | Create_options | Comment |
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| tables |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS WHERE Name = 'tables';
+
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| Name   | Engine | Version | Row_format | Rows | Avg_row_length | Data_length | Max_data_length | Index_length | Data_free | Auto_increment | Create_time             | Update_time | Check_time | Collation | Checksum | Create_options | Comment |
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| tables |        | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
++--------+--------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS from public;
+
++---------+-------------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| Name    | Engine      | Version | Row_format | Rows | Avg_row_length | Data_length | Max_data_length | Index_length | Data_free | Auto_increment | Create_time             | Update_time | Check_time | Collation | Checksum | Create_options | Comment |
++---------+-------------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+| numbers | test_engine | 11      | Fixed      | 0    | 0              | 0           | 0               | 0            | 0         | 0              | DATETIME |             |            |           | 0        |                |         |
++---------+-------------+---------+------------+------+----------------+-------------+-----------------+--------------+-----------+----------------+-------------------------+-------------+------------+-----------+----------+----------------+---------+
+
 USE public;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/show/show_databases_tables.sql
+++ b/tests/cases/standalone/common/show/show_databases_tables.sql
@@ -6,4 +6,20 @@ USE information_schema;
 
 SHOW TABLES;
 
+SHOW TABLES LIKE 'tables';
+
+SHOW FULL TABLES;
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS;
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS LIKE 'tables';
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS WHERE Name = 'tables';
+
+-- SQLNESS REPLACE (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}) DATETIME
+SHOW TABLE STATUS from public;
+
 USE public;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4017 #3354 

## What's changed and what's your intention?

* Impl `show table status [IN database] [LIKE name | WHERE ..]`.

```sql
mysql> show table status\G;
*************************** 1. row ***************************
           Name: numbers
         Engine: test_engine
        Version: 11
     Row_format: Fixed
           Rows: 0
 Avg_row_length: 0
    Data_length: 0
Max_data_length: 0
   Index_length: 0
      Data_free: 0
 Auto_increment: 0
    Create_time: 2024-07-05 23:20:47.992000
    Update_time: NULL
     Check_time: NULL
      Collation: NULL
       Checksum: 0
 Create_options:
        Comment: NULL
1 row in set (0.20 sec)
```

* Fixed the `ShowKind` display, the `All` should not display, it's just a placeholder.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `SHOW TABLE STATUS` command to retrieve information about table statuses within the database.

- **Enhancements**
  - Improved display logic for various `SHOW` commands to provide more consistent and clearer output.

- **Configuration Changes**
  - Changed default Kafka compression setting from `Lz4` to `NoCompression` for both Datanode and Standalone configurations.

- **Tests**
  - Added new test cases for `SHOW TABLES LIKE`, `SHOW FULL TABLES`, and `SHOW TABLE STATUS` commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->