### PR TITLE
ci: add flownode in docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,13 @@ run-it-in-container: start-etcd ## Run integration tests in dev-builder.
 	-w /greptimedb ${IMAGE_REGISTRY}/${IMAGE_NAMESPACE}/dev-builder-${BASE_IMAGE}:latest \
 	make test sqlness-test BUILD_JOBS=${BUILD_JOBS}
 
-.PHONY: run-cluster-with-etcd
-run-cluster-with-etcd: ## Run greptime cluster with etcd in docker-compose.
+.PHONY: start-cluster
+start-cluster: ## Start the greptimedb cluster with etcd by using docker compose.
 	 docker compose -f ./docker/docker-compose/cluster-with-etcd.yaml up
+
+.PHONY: stop-cluster
+stop-cluster: ## Stop the greptimedb cluster that created by docker compose.
+	docker compose -f ./docker/docker-compose/cluster-with-etcd.yaml stop
 
 ##@ Docs
 config-docs: ## Generate configuration documentation from toml files.

--- a/docker/docker-compose/cluster-with-etcd.yaml
+++ b/docker/docker-compose/cluster-with-etcd.yaml
@@ -1,12 +1,13 @@
 x-custom:
-  initial_cluster_token: &initial_cluster_token "--initial-cluster-token=etcd-cluster"
-  common_settings: &common_settings
+  etcd_initial_cluster_token: &etcd_initial_cluster_token "--initial-cluster-token=etcd-cluster"
+  etcd_common_settings: &etcd_common_settings
     image: quay.io/coreos/etcd:v3.5.10
     entrypoint: /usr/local/bin/etcd
+  greptimedb_image: &greptimedb_image docker.io/greptimedb/greptimedb:latest
 
 services:
   etcd0:
-    <<: *common_settings
+    <<: *etcd_common_settings
     container_name: etcd0
     ports:
       - 2379:2379
@@ -22,7 +23,7 @@ services:
       - --election-timeout=1250
       - --initial-cluster=etcd0=http://etcd0:2380
       - --initial-cluster-state=new
-      - *initial_cluster_token
+      - *etcd_initial_cluster_token
     volumes:
       - /tmp/greptimedb-cluster-docker-compose/etcd0:/var/lib/etcd
     healthcheck:
@@ -34,7 +35,7 @@ services:
       - greptimedb
 
   metasrv:
-    image: docker.io/greptime/greptimedb:latest
+    image: *greptimedb_image
     container_name: metasrv
     ports:
       - 3002:3002
@@ -56,10 +57,11 @@ services:
       - greptimedb
 
   datanode0:
-    image: docker.io/greptime/greptimedb:latest
+    image: *greptimedb_image
     container_name: datanode0
     ports:
       - 3001:3001
+      - 5000:5000
     command:
       - datanode
       - start
@@ -67,8 +69,14 @@ services:
       - --rpc-addr=0.0.0.0:3001
       - --rpc-hostname=datanode0:3001
       - --metasrv-addrs=metasrv:3002
+      - --http-addr=0.0.0.0:5000
     volumes:
       - /tmp/greptimedb-cluster-docker-compose/datanode0:/tmp/greptimedb
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://datanode0:5000/health" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     depends_on:
       metasrv:
         condition: service_healthy
@@ -76,7 +84,7 @@ services:
       - greptimedb
 
   frontend0:
-    image: docker.io/greptime/greptimedb:latest
+    image: *greptimedb_image
     container_name: frontend0
     ports:
       - 4000:4000
@@ -91,8 +99,31 @@ services:
       - --rpc-addr=0.0.0.0:4001
       - --mysql-addr=0.0.0.0:4002
       - --postgres-addr=0.0.0.0:4003
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://frontend0:4000/health" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
     depends_on:
-      metasrv:
+      datanode0:
+        condition: service_healthy
+    networks:
+      - greptimedb
+
+  flownode0:
+    image: *greptimedb_image
+    container_name: flownode0
+    ports:
+      - 4004:4004
+    command:
+      - flownode
+      - start
+      - --node-id=0
+      - --metasrv-addrs=metasrv:3002
+      - --rpc-addr=0.0.0.0:4004
+      - --rpc-hostname=flownode0:4004
+    depends_on:
+      frontend0:
         condition: service_healthy
     networks:
       - greptimedb


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**NOTE**: Wait for the latest nightly release.

1. Add flownode in cluster that created by docker compose.
2. Refactor the Makefile target naming:

   - `make start-cluster`: Create the greptimedb cluster by using docker compose;
   - `make stop-cluster`: Stop the greptimedb cluster that created by the docker compose;

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new target to stop the `greptimedb` cluster using Docker Compose.

- **Improvements**
  - Renamed the target for starting the `greptimedb` cluster to `start-cluster`.
  - Enhanced Docker Compose configurations with new health checks and port configurations for `datanode0`, `frontend0`, and `flownode0`.

- **Configuration Changes**
  - Updated ETCD-related variable names for better clarity.
  - Introduced a new image reference for `greptimedb`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->