### PR TITLE
ci: retry on error or timeout during installing operator

### DIFF
--- a/.github/actions/setup-greptimedb-cluster/action.yml
+++ b/.github/actions/setup-greptimedb-cluster/action.yml
@@ -35,7 +35,6 @@ runs:
     with: 
       timeout_minutes: 3
       max_attempts: 3
-      retry_on: error
       shell: bash
       command: |
         helm repo add greptime https://greptimeteam.github.io/helm-charts/ 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Make operator installation step retry on error or timeout 

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions configuration for setting up the GreptimeDB cluster to improve error handling behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->