### PR TITLE
revert: set default compresion to LZ4

### DIFF
--- a/src/common/meta/src/wal_options_allocator/kafka/topic_manager.rs
+++ b/src/common/meta/src/wal_options_allocator/kafka/topic_manager.rs
@@ -173,7 +173,7 @@ impl TopicManager {
                     timestamp: chrono::Utc::now(),
                     headers: Default::default(),
                 }],
-                Compression::Lz4,
+                Compression::NoCompression,
             )
             .await
             .context(ProduceRecordSnafu { topic })?;

--- a/src/common/wal/src/config.rs
+++ b/src/common/wal/src/config.rs
@@ -207,7 +207,7 @@ mod tests {
         let datanode_wal_config: DatanodeWalConfig = toml::from_str(toml_str).unwrap();
         let expected = DatanodeKafkaConfig {
             broker_endpoints: vec!["127.0.0.1:9092".to_string()],
-            compression: Compression::Lz4,
+            compression: Compression::default(),
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),
             backoff: BackoffConfig {
@@ -229,7 +229,7 @@ mod tests {
             num_partitions: 1,
             replication_factor: 1,
             create_topic_timeout: Duration::from_secs(30),
-            compression: Compression::Lz4,
+            compression: Compression::default(),
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),
             backoff: BackoffConfig {

--- a/src/common/wal/src/config/kafka/datanode.rs
+++ b/src/common/wal/src/config/kafka/datanode.rs
@@ -46,7 +46,7 @@ impl Default for DatanodeKafkaConfig {
     fn default() -> Self {
         Self {
             broker_endpoints: vec![BROKER_ENDPOINT.to_string()],
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             // Warning: Kafka has a default limit of 1MB per message in a topic.
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),

--- a/src/common/wal/src/config/kafka/standalone.rs
+++ b/src/common/wal/src/config/kafka/standalone.rs
@@ -67,7 +67,7 @@ impl Default for StandaloneKafkaConfig {
             num_partitions: 1,
             replication_factor,
             create_topic_timeout: Duration::from_secs(30),
-            compression: Compression::Lz4,
+            compression: Compression::NoCompression,
             // Warning: Kafka has a default limit of 1MB per message in a topic.
             max_batch_bytes: ReadableSize::mb(1),
             consumer_wait_timeout: Duration::from_millis(100),


### PR DESCRIPTION

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Due to #4304
Reverts GreptimeTeam/greptimedb#4294

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
  - Updated Kafka compression settings from `Lz4` to `NoCompression` for topic management and various configurations.

These changes aim to standardize compression settings across the application, potentially improving consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->