### PR TITLE
fix: panic while reading information_schema. KEY_COLUMN_USAGE

### DIFF
--- a/src/catalog/src/information_schema/key_column_usage.rs
+++ b/src/catalog/src/information_schema/key_column_usage.rs
@@ -256,7 +256,8 @@ impl InformationSchemaKeyColumnUsageBuilder {
                         // TODO(dimbtp): foreign key constraint not supported yet
                     }
                 } else {
-                    unreachable!();
+                    // The table might be dropped during iteration.
+                    continue;
                 }
             }
         }

--- a/src/catalog/src/information_schema/key_column_usage.rs
+++ b/src/catalog/src/information_schema/key_column_usage.rs
@@ -212,12 +212,12 @@ impl InformationSchemaKeyColumnUsageBuilder {
             .context(UpgradeWeakCatalogManagerRefSnafu)?;
         let predicates = Predicates::from_scan_request(&request);
 
-        let mut primary_constraints = vec![];
-
         for schema_name in catalog_manager.schema_names(&catalog_name).await? {
             let mut stream = catalog_manager.tables(&catalog_name, &schema_name);
 
             while let Some(table) = stream.try_next().await? {
+                let mut primary_constraints = vec![];
+
                 let table_info = table.table_info();
                 let table_name = &table_info.name;
                 let keys = &table_info.meta.primary_key_indices;
@@ -246,22 +246,22 @@ impl InformationSchemaKeyColumnUsageBuilder {
                     }
                     // TODO(dimbtp): foreign key constraint not supported yet
                 }
-            }
-        }
 
-        for (i, (catalog_name, schema_name, table_name, column_name)) in
-            primary_constraints.into_iter().enumerate()
-        {
-            self.add_key_column_usage(
-                &predicates,
-                &schema_name,
-                PRI_CONSTRAINT_NAME,
-                &catalog_name,
-                &schema_name,
-                &table_name,
-                &column_name,
-                i as u32 + 1,
-            );
+                for (i, (catalog_name, schema_name, table_name, column_name)) in
+                    primary_constraints.into_iter().enumerate()
+                {
+                    self.add_key_column_usage(
+                        &predicates,
+                        &schema_name,
+                        PRI_CONSTRAINT_NAME,
+                        &catalog_name,
+                        &schema_name,
+                        &table_name,
+                        &column_name,
+                        i as u32 + 1,
+                    );
+                }
+            }
         }
 
         self.finish()

--- a/tests/cases/standalone/common/show/show_index.result
+++ b/tests/cases/standalone/common/show/show_index.result
@@ -11,9 +11,30 @@ CREATE TABLE IF NOT EXISTS system_metrics (
 
 Affected Rows: 0
 
+CREATE TABLE IF NOT EXISTS test (
+    a STRING,
+    b STRING,
+    c DOUBLE,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(a, b),
+    TIME INDEX(ts)
+);
+
+Affected Rows: 0
+
 SHOW INDEX;
 
 Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: SHOW INDEX;, expected: '{FROM | IN} table', found: ;
+
+SHOW INDEX FROM test;
+
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
+| Table | Non_unique | Key_name   | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type                 | Comment | Index_comment | Visible | Expression |
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
+| test  | 1          | PRIMARY    | 1            | a           | A         |             |          |        | YES  | greptime-inverted-index-v1 |         |               | YES     |            |
+| test  | 1          | PRIMARY    | 2            | b           | A         |             |          |        | YES  | greptime-inverted-index-v1 |         |               | YES     |            |
+| test  | 1          | TIME INDEX | 1            | ts          | A         |             |          |        | NO   | greptime-inverted-index-v1 |         |               | YES     |            |
++-------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
 
 SHOW INDEX FROM system_metrics;
 
@@ -48,6 +69,10 @@ SHOW INDEX FROM system_metrics WHERE Key_name = 'TIME INDEX';
 +----------------+------------+------------+--------------+-------------+-----------+-------------+----------+--------+------+----------------------------+---------+---------------+---------+------------+
 
 DROP TABLE system_metrics;
+
+Affected Rows: 0
+
+DROP TABLE test;
 
 Affected Rows: 0
 

--- a/tests/cases/standalone/common/show/show_index.sql
+++ b/tests/cases/standalone/common/show/show_index.sql
@@ -9,7 +9,18 @@ CREATE TABLE IF NOT EXISTS system_metrics (
     TIME INDEX(ts)
 );
 
+CREATE TABLE IF NOT EXISTS test (
+    a STRING,
+    b STRING,
+    c DOUBLE,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(a, b),
+    TIME INDEX(ts)
+);
+
 SHOW INDEX;
+
+SHOW INDEX FROM test;
 
 SHOW INDEX FROM system_metrics;
 
@@ -20,3 +31,5 @@ SHOW INDEX FROM system_metrics like '%util%';
 SHOW INDEX FROM system_metrics WHERE Key_name = 'TIME INDEX';
 
 DROP TABLE system_metrics;
+
+DROP TABLE test;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4305 
## What's changed and what's your intention?

* Fixed panic while reading  `information_schema. KEY_COLUMN_USAGE `. #4305 
* Fixed the wrong `Seq_in_index`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added functionality to display indexes from tables, including new `test` and existing `system_metrics`.
  - Introduced a new table `test` with columns and indexes, and commands to show and drop these indexes.

- **Bug Fixes**
  - Adjusted control flow to handle cases where tables might be dropped during iteration, preventing potential crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->