### PR TITLE
build(deps): switch to upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "prost 0.12.6",
  "serde_json",
  "snafu 0.8.3",
- "tonic-build 0.9.2",
+ "tonic-build",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -3564,15 +3564,16 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.12.4"
-source = "git+https://github.com/MichaelScofield/etcd-client.git?rev=4c371e9b3ea8e0a8ee2f9cbd7ded26e54a45df3b#4c371e9b3ea8e0a8ee2f9cbd7ded26e54a45df3b"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b915bb9b1e143ab7062e0067ed663e3dfeffc69ce0ceb9e93b35fecfc158d28"
 dependencies = [
  "http 0.2.12",
  "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
- "tonic-build 0.10.2",
+ "tonic-build",
  "tower",
  "tower-service",
 ]
@@ -4203,7 +4204,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/zhongzc/greptime-proto.git?branch=zhongzc/fulltext-options#6923c24096f9e8dedca9dff38a3c343c1a7cfc0c"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=b83f00958fe4cbc77b85b7407bca206e98bdc845#b83f00958fe4cbc77b85b7407bca206e98bdc845"
 dependencies = [
  "prost 0.12.6",
  "serde",
@@ -4211,7 +4212,7 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "tonic 0.11.0",
- "tonic-build 0.11.0",
+ "tonic-build",
 ]
 
 [[package]]
@@ -4617,7 +4618,7 @@ dependencies = [
  "clap 4.5.7",
  "data-encoding",
  "itertools 0.10.5",
- "prettyplease 0.2.20",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -7494,7 +7495,7 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "serde",
 ]
 
@@ -7950,7 +7951,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "prost-derive 0.12.6",
  "protobuf",
  "sha2",
@@ -8020,16 +8021,6 @@ checksum = "8ff1fec61082821f8236cf6c0c14e8172b62ce8a72a0eedc30d3b247bb68dc11"
 dependencies = [
  "ansi_term",
  "pad",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8207,40 +8198,18 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease 0.1.25",
- "prost 0.11.9",
- "prost-types 0.11.9",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.20",
+ "prettyplease",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
@@ -8268,7 +8237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.66",
@@ -8406,7 +8375,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.3",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -11041,9 +11010,9 @@ checksum = "f1e8440a1c9b95a7c9a00a19f78b980749e8c945eb880687a5d673cea83729c5"
 dependencies = [
  "git2",
  "heck 0.4.1",
- "prettyplease 0.2.20",
+ "prettyplease",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "prost-types 0.12.6",
  "schemars",
  "semver",
@@ -11065,9 +11034,9 @@ dependencies = [
  "pbjson",
  "pbjson-build",
  "pbjson-types",
- "prettyplease 0.2.20",
+ "prettyplease",
  "prost 0.12.6",
- "prost-build 0.12.6",
+ "prost-build",
  "prost-types 0.12.6",
  "schemars",
  "semver",
@@ -12111,39 +12080,13 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
-dependencies = [
- "prettyplease 0.1.25",
- "proc-macro2",
- "prost-build 0.11.9",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
-dependencies = [
- "prettyplease 0.2.20",
- "proc-macro2",
- "prost-build 0.12.6",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4ef6dd70a610078cb4e338a0f79d06bc759ff1b22d2120c2ff02ae264ba9c2"
 dependencies = [
- "prettyplease 0.2.20",
+ "prettyplease",
  "proc-macro2",
- "prost-build 0.12.6",
+ "prost-build",
  "quote",
  "syn 2.0.66",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,12 +115,11 @@ datafusion-sql = { git = "https://github.com/apache/datafusion.git", rev = "729b
 datafusion-substrait = { git = "https://github.com/apache/datafusion.git", rev = "729b356ef543ffcda6813c7b5373507a04ae0109" }
 derive_builder = "0.12"
 dotenv = "0.15"
-# TODO(LFC): Wait for https://github.com/etcdv3/etcd-client/pull/76
-etcd-client = { git = "https://github.com/MichaelScofield/etcd-client.git", rev = "4c371e9b3ea8e0a8ee2f9cbd7ded26e54a45df3b" }
+etcd-client = { version = "0.13" }
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/zhongzc/greptime-proto.git", branch = "zhongzc/fulltext-options" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "b83f00958fe4cbc77b85b7407bca206e98bdc845" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -21,7 +21,7 @@ serde_json.workspace = true
 snafu.workspace = true
 
 [build-dependencies]
-tonic-build = "0.9"
+tonic-build = "0.11"
 
 [dev-dependencies]
 paste = "1.0"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

TRIVIAL AS IS

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated `etcd-client` to version `0.13` for improved compatibility.
	- Changed `greptime-proto` dependency to a new repository for better reliability.
	- Upgraded `tonic-build` from version "0.9" to "0.11" for enhanced build performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->