### PR TITLE
refactor: do not print error log on PlanQuery error

### DIFF
--- a/src/common/error/src/status_code.rs
+++ b/src/common/error/src/status_code.rs
@@ -159,7 +159,6 @@ impl StatusCode {
             | StatusCode::Unexpected
             | StatusCode::Internal
             | StatusCode::Cancelled
-            | StatusCode::PlanQuery
             | StatusCode::EngineExecuteQuery
             | StatusCode::StorageUnavailable
             | StatusCode::RuntimeResourcesExhausted => true,
@@ -171,6 +170,7 @@ impl StatusCode {
             | StatusCode::TableNotFound
             | StatusCode::RegionAlreadyExists
             | StatusCode::RegionNotFound
+            | StatusCode::PlanQuery
             | StatusCode::FlowAlreadyExists
             | StatusCode::FlowNotFound
             | StatusCode::RegionNotReady


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

We get a lot of error logs for "table not found" query on the production. Here I moved PlanQuery code to non error log section to avoid this. I also want to confirm if `PlanQuery` is all caused by user input errors, which is safe to do so.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted internal handling of `StatusCode::PlanQuery` to improve error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->