### PR TITLE
fix(sqlness): relax start time regex to match various precisions

### DIFF
--- a/tests/cases/distributed/information_schema/cluster_info.result
+++ b/tests/cases/distributed/information_schema/cluster_info.result
@@ -20,52 +20,52 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|127.0.0.1:4101|Version|Hash|Start_time|Duration|Duration||2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|127.0.0.1:6800|Version|Hash|Start_time|Duration|Duration||1|FRONTEND|127.0.0.1:4001|Version|Hash|Start_time|Duration|Duration||1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|Start_time|Version|Hash|Start_time|Duration|Duration||1|FRONTEND|Start_time|Version|Hash|Start_time|Duration|Duration||1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|FRONTEND|127.0.0.1:4001|Version|Hash|Start_time|Duration|Duration|+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|FRONTEND|Start_time|Version|Hash|Start_time|Duration|Duration|+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|127.0.0.1:4101|Version|Hash|Start_time|Duration|Duration||2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|127.0.0.1:6800|Version|Hash|Start_time|Duration|Duration||1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|Start_time|Version|Hash|Start_time|Duration|Duration||1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration|+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration|+++++++++
 
 USE PUBLIC;
 

--- a/tests/cases/distributed/information_schema/cluster_info.result
+++ b/tests/cases/distributed/information_schema/cluster_info.result
@@ -20,52 +20,52 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|Start_time|Version|Hash|Start_time|Duration|Duration||1|FRONTEND|Start_time|Version|Hash|Start_time|Duration|Duration||1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|127.0.0.1:4101|Version|Hash|Start_time|Duration|Duration||2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|127.0.0.1:6800|Version|Hash|Start_time|Duration|Duration||1|FRONTEND|127.0.0.1:4001|Version|Hash|Start_time|Duration|Duration||1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|FRONTEND|Start_time|Version|Hash|Start_time|Duration|Duration|+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|FRONTEND|127.0.0.1:4001|Version|Hash|Start_time|Duration|Duration|+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|Start_time|Version|Hash|Start_time|Duration|Duration||1|METASRV|Start_time|Version|Hash|Start_time|Duration||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|1|DATANODE|127.0.0.1:4101|Version|Hash|Start_time|Duration|Duration||2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration||0|FLOWNODE|127.0.0.1:6800|Version|Hash|Start_time|Duration|Duration||1|METASRV|127.0.0.1:3002|Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|2|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration||3|DATANODE|Start_time|Version|Hash|Start_time|Duration|Duration|+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|2|DATANODE|127.0.0.1:4102|Version|Hash|Start_time|Duration|Duration||3|DATANODE|127.0.0.1:4103|Version|Hash|Start_time|Duration|Duration|+++++++++
 
 USE PUBLIC;
 

--- a/tests/cases/distributed/information_schema/cluster_info.sql
+++ b/tests/cases/distributed/information_schema/cluster_info.sql
@@ -5,7 +5,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
@@ -21,7 +21,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
@@ -29,7 +29,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
@@ -37,7 +37,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;

--- a/tests/cases/distributed/information_schema/cluster_info.sql
+++ b/tests/cases/distributed/information_schema/cluster_info.sql
@@ -5,7 +5,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
@@ -21,7 +21,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'METASRV' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
@@ -29,7 +29,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
@@ -37,7 +37,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'FRONTEND' ORDER BY peer_type;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\s\d\.\d\.\d\s) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[0-9T:\.]{17}|\s[\-0-9T:\.]{23}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID > 1 ORDER BY peer_type;

--- a/tests/cases/standalone/information_schema/cluster_info.result
+++ b/tests/cases/standalone/information_schema/cluster_info.result
@@ -20,7 +20,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO;
@@ -30,7 +30,7 @@ SELECT * FROM CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'STANDALONE';
@@ -45,7 +45,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID = 0;

--- a/tests/cases/standalone/information_schema/cluster_info.result
+++ b/tests/cases/standalone/information_schema/cluster_info.result
@@ -20,22 +20,22 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO;
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|Start_time|STANDALONE||Version|Hash|Start_time|Start_timems||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|0|STANDALONE||Version|Hash|Start_time|Duration||+++++++++
 
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'STANDALONE';
 
-+++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|Start_time|STANDALONE||Version|Hash|Start_time|Start_timems||+++++++++
++++++++++|peer_id|peer_type|peer_addr|node_version|git_commit|start_time|uptime|active_time|+++++++++|0|STANDALONE||Version|Hash|Start_time|Duration||+++++++++
 
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 
@@ -45,7 +45,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID = 0;

--- a/tests/cases/standalone/information_schema/cluster_info.sql
+++ b/tests/cases/standalone/information_schema/cluster_info.sql
@@ -5,7 +5,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO;
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'STANDALONE';
@@ -23,7 +23,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{15,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID = 0;

--- a/tests/cases/standalone/information_schema/cluster_info.sql
+++ b/tests/cases/standalone/information_schema/cluster_info.sql
@@ -5,7 +5,7 @@ DESC TABLE CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO;
@@ -13,7 +13,7 @@ SELECT * FROM CLUSTER_INFO;
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE = 'STANDALONE';
@@ -23,7 +23,7 @@ SELECT * FROM CLUSTER_INFO WHERE PEER_TYPE != 'STANDALONE';
 -- SQLNESS REPLACE version node_version
 -- SQLNESS REPLACE (\d\.\d\.\d) Version
 -- SQLNESS REPLACE (\s[a-z0-9]{7}\s) Hash
--- SQLNESS REPLACE (\s[\-0-9T:\.]+) Start_time
+-- SQLNESS REPLACE (\s[\-0-9T:\.]{10,}) Start_time
 -- SQLNESS REPLACE ((\d+(s|ms|m)\s)+) Duration
 -- SQLNESS REPLACE [\s\-]+
 SELECT * FROM CLUSTER_INFO WHERE PEER_ID = 0;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The default display format detects the timestamp precision automatically. So the result is not quite stable before regex.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `Start_time` field in `CLUSTER_INFO` queries to support a wider range of date formats.
  - Adjusted filtering and ordering of `CLUSTER_INFO` results by `PEER_TYPE` and `PEER_ID`.

- **Refactor**
  - Changed the result set in specific queries to replace `Start_timems` with `Duration` for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->