### PR TITLE
feat: customize copy to parquet parameter

### DIFF
--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -225,14 +225,8 @@ fn column_wise_config(
     mut props: WriterPropertiesBuilder,
     schema: SchemaRef,
 ) -> WriterPropertiesBuilder {
-    // Disable dictionary for timestamp column.
-    if let Some(ts_col) = schema.timestamp_column() {
-        let path = ColumnPath::new(vec![ts_col.name.clone()]);
-        props = props
-            .set_column_dictionary_enabled(path.clone(), false)
-            .set_column_encoding(path, Encoding::DELTA_BINARY_PACKED)
-    }
-
+    // Disable dictionary for timestamp column, since for increasing timestamp column,
+    // the dictionary pages will be larger than data pages.
     for col in schema.column_schemas() {
         if col.data_type.is_timestamp() {
             let path = ColumnPath::new(vec![col.name.clone()]);

--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -232,6 +232,15 @@ fn column_wise_config(
             .set_column_dictionary_enabled(path.clone(), false)
             .set_column_encoding(path, Encoding::DELTA_BINARY_PACKED)
     }
+
+    for col in schema.column_schemas() {
+        if col.data_type.is_timestamp() {
+            let path = ColumnPath::new(vec![col.name.clone()]);
+            props = props
+                .set_column_dictionary_enabled(path.clone(), false)
+                .set_column_encoding(path, Encoding::DELTA_BINARY_PACKED)
+        }
+    }
     props
 }
 

--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -27,6 +27,7 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::parquet::format::FileMetaData;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
+use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::SchemaRef;
 use futures::future::BoxFuture;
 use futures::StreamExt;
@@ -231,10 +232,12 @@ fn column_wise_config(
         props = props.set_column_dictionary_enabled(path, false);
     }
 
-    // Use delta binary packed encoding for all numeric columns.
+    // Use delta binary packed encoding for int32/int64 columns.
     for column in schema.column_schemas() {
         let data_type = &column.data_type;
-        if data_type.is_numeric() {
+        if data_type == &ConcreteDataType::int64_datatype()
+            || data_type == &ConcreteDataType::int32_datatype()
+        {
             let path = ColumnPath::new(vec![column.name.clone()]);
             props = props.set_column_encoding(path, Encoding::DELTA_BINARY_PACKED);
         }

--- a/src/common/datasource/src/file_format/parquet.rs
+++ b/src/common/datasource/src/file_format/parquet.rs
@@ -27,7 +27,6 @@ use datafusion::parquet::file::metadata::ParquetMetaData;
 use datafusion::parquet::format::FileMetaData;
 use datafusion::physical_plan::metrics::ExecutionPlanMetricsSet;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use datatypes::prelude::ConcreteDataType;
 use datatypes::schema::SchemaRef;
 use futures::future::BoxFuture;
 use futures::StreamExt;
@@ -229,20 +228,10 @@ fn column_wise_config(
     // Disable dictionary for timestamp column.
     if let Some(ts_col) = schema.timestamp_column() {
         let path = ColumnPath::new(vec![ts_col.name.clone()]);
-        props = props.set_column_dictionary_enabled(path, false);
+        props = props
+            .set_column_dictionary_enabled(path.clone(), false)
+            .set_column_encoding(path, Encoding::DELTA_BINARY_PACKED)
     }
-
-    // Use delta binary packed encoding for int32/int64 columns.
-    for column in schema.column_schemas() {
-        let data_type = &column.data_type;
-        if data_type == &ConcreteDataType::int64_datatype()
-            || data_type == &ConcreteDataType::int32_datatype()
-        {
-            let path = ColumnPath::new(vec![column.name.clone()]);
-            props = props.set_column_encoding(path, Encoding::DELTA_BINARY_PACKED);
-        }
-    }
-
     props
 }
 

--- a/src/mito2/src/engine/compaction_test.rs
+++ b/src/mito2/src/engine/compaction_test.rs
@@ -112,7 +112,11 @@ async fn test_compaction_region() {
     let engine = env.create_engine(MitoConfig::default()).await;
 
     let region_id = RegionId::new(1, 1);
-    let request = CreateRequestBuilder::new().build();
+    let request = CreateRequestBuilder::new()
+        .insert_option("compaction.type", "twcs")
+        .insert_option("compaction.twcs.max_active_window_runs", "1")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "1")
+        .build();
 
     let column_schemas = request
         .column_metadatas

--- a/src/mito2/src/engine/merge_mode_test.rs
+++ b/src/mito2/src/engine/merge_mode_test.rs
@@ -101,8 +101,8 @@ async fn test_merge_mode_compaction() {
     let request = CreateRequestBuilder::new()
         .field_num(2)
         .insert_option("compaction.type", "twcs")
-        .insert_option("compaction.twcs.max_active_window_files", "2")
-        .insert_option("compaction.twcs.max_inactive_window_files", "2")
+        .insert_option("compaction.twcs.max_active_window_runs", "1")
+        .insert_option("compaction.twcs.max_inactive_window_runs", "1")
         .insert_option("merge_mode", "last_non_null")
         .build();
     let region_dir = request.region_dir.clone();

--- a/src/mito2/src/region/options.rs
+++ b/src/mito2/src/region/options.rs
@@ -216,7 +216,7 @@ impl TwcsOptions {
 impl Default for TwcsOptions {
     fn default() -> Self {
         Self {
-            max_active_window_runs: 1,
+            max_active_window_runs: 4,
             max_inactive_window_runs: 1,
             time_window: None,
             remote_compaction: false,

--- a/src/operator/src/statement/copy_table_to.rs
+++ b/src/operator/src/statement/copy_table_to.rs
@@ -75,14 +75,18 @@ impl StatementExecutor {
             )
             .await
             .context(error::WriteStreamToFileSnafu { path }),
-            Format::Parquet(_) => stream_to_parquet(
-                Box::pin(DfRecordBatchStreamAdapter::new(stream)),
-                object_store,
-                path,
-                WRITE_CONCURRENCY,
-            )
-            .await
-            .context(error::WriteStreamToFileSnafu { path }),
+            Format::Parquet(_) => {
+                let schema = stream.schema();
+                stream_to_parquet(
+                    Box::pin(DfRecordBatchStreamAdapter::new(stream)),
+                    schema,
+                    object_store,
+                    path,
+                    WRITE_CONCURRENCY,
+                )
+                .await
+                .context(error::WriteStreamToFileSnafu { path })
+            }
             _ => error::UnsupportedFormatSnafu { format: *format }.fail(),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds customized column config for parquet writer while copying table data to parquet files.

733->524

## Checklist

- [X] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced Parquet file writing with customizable column properties and improved compression settings.
  
- **Improvements**
  - Increased the default value of `max_active_window_runs` from 1 to 4, improving performance in specific scenarios.
  - Updated compaction test configurations to include detailed options for compaction type and settings.

- **Tests**
  - Adjusted test scenarios to reflect new compaction and merge mode settings, ensuring consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->