### PR TITLE
perf(puffin): not to stage uncompressed blob

### DIFF
--- a/src/mito2/src/config.rs
+++ b/src/mito2/src/config.rs
@@ -371,9 +371,6 @@ pub struct InvertedIndexConfig {
     /// Memory threshold for performing an external sort during index creation.
     pub mem_threshold_on_create: MemoryThreshold,
 
-    /// Whether to compress the index data.
-    pub compress: bool,
-
     #[deprecated = "use [IndexConfig::aux_path] instead"]
     #[serde(skip_serializing)]
     pub intermediate_path: String,
@@ -396,7 +393,6 @@ impl Default for InvertedIndexConfig {
             create_on_compaction: Mode::Auto,
             apply_on_query: Mode::Auto,
             mem_threshold_on_create: MemoryThreshold::Auto,
-            compress: true,
             write_buffer_size: ReadableSize::mb(8),
             intermediate_path: String::new(),
             metadata_cache_size: ReadableSize::mb(32),

--- a/src/mito2/src/engine/basic_test.rs
+++ b/src/mito2/src/engine/basic_test.rs
@@ -580,7 +580,7 @@ async fn test_region_usage() {
     flush_region(&engine, region_id, None).await;
 
     let region_stat = region.region_usage();
-    assert_eq!(region_stat.sst_usage, 3026);
+    assert_eq!(region_stat.sst_usage, 3010);
 
     // region total usage
     // Some memtables may share items.

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -220,7 +220,6 @@ impl<'a> IndexerBuilder<'a> {
             self.intermediate_manager.clone(),
             self.inverted_index_config.mem_threshold_on_create(),
             segment_row_count,
-            self.inverted_index_config.compress,
             &self.index_options.inverted_index.ignore_column_ids,
         );
 

--- a/src/mito2/src/sst/index/puffin_manager.rs
+++ b/src/mito2/src/sst/index/puffin_manager.rs
@@ -21,8 +21,8 @@ use object_store::{FuturesAsyncReader, FuturesAsyncWriter, ObjectStore};
 use puffin::error::{self as puffin_error, Result as PuffinResult};
 use puffin::puffin_manager::file_accessor::PuffinFileAccessor;
 use puffin::puffin_manager::fs_puffin_manager::FsPuffinManager;
-use puffin::puffin_manager::stager::{BoundedStager, FsBlobGuard};
-use puffin::puffin_manager::{BlobGuard, PuffinManager};
+use puffin::puffin_manager::stager::BoundedStager;
+use puffin::puffin_manager::{BlobGuard, PuffinManager, PuffinReader};
 use snafu::ResultExt;
 
 use crate::error::{PuffinInitStagerSnafu, Result};
@@ -35,10 +35,11 @@ use crate::sst::index::store::{self, InstrumentedStore};
 type InstrumentedAsyncRead = store::InstrumentedAsyncRead<'static, FuturesAsyncReader>;
 type InstrumentedAsyncWrite = store::InstrumentedAsyncWrite<'static, FuturesAsyncWriter>;
 
-pub(crate) type BlobReader = <Arc<FsBlobGuard> as BlobGuard>::Reader;
-pub(crate) type SstPuffinWriter = <SstPuffinManager as PuffinManager>::Writer;
 pub(crate) type SstPuffinManager =
     FsPuffinManager<Arc<BoundedStager>, ObjectStorePuffinFileAccessor>;
+pub(crate) type SstPuffinReader = <SstPuffinManager as PuffinManager>::Reader;
+pub(crate) type SstPuffinWriter = <SstPuffinManager as PuffinManager>::Writer;
+pub(crate) type BlobReader = <<SstPuffinReader as PuffinReader>::Blob as BlobGuard>::Reader;
 
 const STAGING_DIR: &str = "staging";
 

--- a/src/puffin/src/file_format/reader/file.rs
+++ b/src/puffin/src/file_format/reader/file.rs
@@ -61,6 +61,15 @@ impl<R> PuffinFileReader<R> {
         );
         Ok(())
     }
+
+    /// Converts the reader into an owned blob reader.
+    pub fn into_blob_reader(self, blob_metadata: &BlobMetadata) -> PartialReader<R> {
+        PartialReader::new(
+            self.source,
+            blob_metadata.offset as _,
+            blob_metadata.length as _,
+        )
+    }
 }
 
 impl<'a, R: io::Read + io::Seek + 'a> SyncReader<'a> for PuffinFileReader<R> {

--- a/src/puffin/src/puffin_manager.rs
+++ b/src/puffin/src/puffin_manager.rs
@@ -22,7 +22,6 @@ mod tests;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use futures::future::BoxFuture;
 use futures::{AsyncRead, AsyncSeek};
 
 use crate::blob_metadata::CompressionCodec;
@@ -92,10 +91,11 @@ pub trait PuffinReader {
 
 /// `BlobGuard` is provided by the `PuffinReader` to access the blob data.
 /// Users should hold the `BlobGuard` until they are done with the blob data.
+#[async_trait]
 #[auto_impl::auto_impl(Arc)]
 pub trait BlobGuard {
     type Reader: AsyncRead + AsyncSeek + Unpin;
-    fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>>;
+    async fn reader(&self) -> Result<Self::Reader>;
 }
 
 /// `DirGuard` is provided by the `PuffinReader` to access the directory in the filesystem.

--- a/src/puffin/src/puffin_manager/file_accessor.rs
+++ b/src/puffin/src/puffin_manager/file_accessor.rs
@@ -21,7 +21,7 @@ use crate::error::Result;
 #[async_trait]
 #[auto_impl::auto_impl(Arc)]
 pub trait PuffinFileAccessor: Send + Sync + 'static {
-    type Reader: AsyncRead + AsyncSeek + Unpin + Send;
+    type Reader: AsyncRead + AsyncSeek + Unpin + Send + Sync;
     type Writer: AsyncWrite + Unpin + Send;
 
     /// Opens a reader for the given puffin file.

--- a/src/puffin/src/puffin_manager/fs_puffin_manager.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager.rs
@@ -46,7 +46,7 @@ impl<S, F> FsPuffinManager<S, F> {
 #[async_trait]
 impl<S, F> PuffinManager for FsPuffinManager<S, F>
 where
-    S: Stager + Clone,
+    S: Stager + Clone + 'static,
     F: PuffinFileAccessor + Clone,
 {
     type Reader = FsPuffinReader<S, F>;

--- a/src/puffin/src/puffin_manager/fs_puffin_manager/reader.rs
+++ b/src/puffin/src/puffin_manager/fs_puffin_manager/reader.rs
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use async_compression::futures::bufread::ZstdDecoder;
 use async_trait::async_trait;
-use futures::future::BoxFuture;
 use futures::io::BufReader;
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite};
+use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncWrite};
 use snafu::{ensure, OptionExt, ResultExt};
 
 use crate::blob_metadata::{BlobMetadata, CompressionCodec};
@@ -56,29 +58,51 @@ impl<S, F> FsPuffinReader<S, F> {
 #[async_trait]
 impl<S, F> PuffinReader for FsPuffinReader<S, F>
 where
-    S: Stager,
+    S: Stager + 'static,
     F: PuffinFileAccessor + Clone,
 {
-    type Blob = RandomReadBlob<F>;
+    type Blob = Either<RandomReadBlob<F>, S::Blob>;
     type Dir = S::Dir;
 
     async fn blob(&self, key: &str) -> Result<Self::Blob> {
-        let blob_metadata = self.blob_metadata(key).await?;
+        let reader = self
+            .puffin_file_accessor
+            .reader(&self.puffin_file_name)
+            .await?;
+        let mut file = PuffinFileReader::new(reader);
 
-        // If we choose to perform random reads directly on blobs
-        // within the puffin file, then they must not be compressed.
-        ensure!(
-            blob_metadata.compression_codec.is_none(),
-            UnsupportedDecompressionSnafu {
-                decompression: blob_metadata.compression_codec.unwrap().to_string()
-            }
-        );
+        // TODO(zhongzc): cache the metadata.
+        let metadata = file.metadata().await?;
+        let blob_metadata = metadata
+            .blobs
+            .into_iter()
+            .find(|m| m.blob_type == key)
+            .context(BlobNotFoundSnafu { blob: key })?;
 
-        Ok(RandomReadBlob {
-            file_name: self.puffin_file_name.clone(),
-            accessor: self.puffin_file_accessor.clone(),
-            blob_metadata: blob_metadata.clone(),
-        })
+        let blob = if blob_metadata.compression_codec.is_none() {
+            // If the blob is not compressed, we can directly read it from the puffin file.
+            Either::L(RandomReadBlob {
+                file_name: self.puffin_file_name.clone(),
+                accessor: self.puffin_file_accessor.clone(),
+                blob_metadata,
+            })
+        } else {
+            // If the blob is compressed, we need to decompress it into staging space before reading.
+            let staged_blob = self
+                .stager
+                .get_blob(
+                    self.puffin_file_name.as_str(),
+                    key,
+                    Box::new(|writer| {
+                        Box::pin(Self::init_blob_to_stager(file, blob_metadata, writer))
+                    }),
+                )
+                .await?;
+
+            Either::R(staged_blob)
+        };
+
+        Ok(blob)
     }
 
     async fn dir(&self, key: &str) -> Result<Self::Dir> {
@@ -90,7 +114,12 @@ where
                     let accessor = self.puffin_file_accessor.clone();
                     let puffin_file_name = self.puffin_file_name.clone();
                     let key = key.to_string();
-                    Self::init_dir_to_stager(puffin_file_name, key, writer_provider, accessor)
+                    Box::pin(Self::init_dir_to_stager(
+                        puffin_file_name,
+                        key,
+                        writer_provider,
+                        accessor,
+                    ))
                 }),
             )
             .await
@@ -102,99 +131,63 @@ where
     S: Stager,
     F: PuffinFileAccessor,
 {
-    // TODO(zhongzc): cache the metadata
-    async fn blob_metadata(&self, key: &str) -> Result<BlobMetadata> {
-        let reader = self
-            .puffin_file_accessor
-            .reader(&self.puffin_file_name)
-            .await?;
-        let mut file = PuffinFileReader::new(reader);
-
-        let metadata = file.metadata().await?;
-        let blob_metadata = metadata
-            .blobs
-            .into_iter()
-            .find(|m| m.blob_type == key)
-            .context(BlobNotFoundSnafu { blob: key })?;
-
-        Ok(blob_metadata)
-    }
-
-    // TODO(zhongzc): keep the function in case one day we need to stage the blob.
-    #[allow(dead_code)]
-    fn init_blob_to_stager(
-        puffin_file_name: String,
-        key: String,
+    async fn init_blob_to_stager(
+        mut reader: PuffinFileReader<F::Reader>,
+        blob_metadata: BlobMetadata,
         mut writer: BoxWriter,
-        accessor: F,
-    ) -> BoxFuture<'static, Result<u64>> {
-        Box::pin(async move {
-            let reader = accessor.reader(&puffin_file_name).await?;
-            let mut file = PuffinFileReader::new(reader);
-
-            let metadata = file.metadata().await?;
-            let blob_metadata = metadata
-                .blobs
-                .iter()
-                .find(|m| m.blob_type == key.as_str())
-                .context(BlobNotFoundSnafu { blob: key })?;
-            let reader = file.blob_reader(blob_metadata)?;
-
-            let compression = blob_metadata.compression_codec;
-            let size = Self::handle_decompress(reader, &mut writer, compression).await?;
-
-            Ok(size)
-        })
+    ) -> Result<u64> {
+        let reader = reader.blob_reader(&blob_metadata)?;
+        let compression = blob_metadata.compression_codec;
+        let size = Self::handle_decompress(reader, &mut writer, compression).await?;
+        Ok(size)
     }
 
-    fn init_dir_to_stager(
+    async fn init_dir_to_stager(
         puffin_file_name: String,
         key: String,
         writer_provider: DirWriterProviderRef,
         accessor: F,
-    ) -> BoxFuture<'static, Result<u64>> {
-        Box::pin(async move {
-            let reader = accessor.reader(&puffin_file_name).await?;
-            let mut file = PuffinFileReader::new(reader);
+    ) -> Result<u64> {
+        let reader = accessor.reader(&puffin_file_name).await?;
+        let mut file = PuffinFileReader::new(reader);
 
-            let puffin_metadata = file.metadata().await?;
-            let blob_metadata = puffin_metadata
-                .blobs
-                .iter()
-                .find(|m| m.blob_type == key.as_str())
-                .context(BlobNotFoundSnafu { blob: key })?;
+        let puffin_metadata = file.metadata().await?;
+        let blob_metadata = puffin_metadata
+            .blobs
+            .iter()
+            .find(|m| m.blob_type == key.as_str())
+            .context(BlobNotFoundSnafu { blob: key })?;
 
-            let mut reader = file.blob_reader(blob_metadata)?;
-            let mut buf = vec![];
-            reader.read_to_end(&mut buf).await.context(ReadSnafu)?;
-            let dir_meta: DirMetadata =
-                serde_json::from_slice(buf.as_slice()).context(DeserializeJsonSnafu)?;
+        let mut reader = file.blob_reader(blob_metadata)?;
+        let mut buf = vec![];
+        reader.read_to_end(&mut buf).await.context(ReadSnafu)?;
+        let dir_meta: DirMetadata =
+            serde_json::from_slice(buf.as_slice()).context(DeserializeJsonSnafu)?;
 
-            let mut size = 0;
-            for file_meta in dir_meta.files {
-                let blob_meta = puffin_metadata.blobs.get(file_meta.blob_index).context(
-                    BlobIndexOutOfBoundSnafu {
-                        index: file_meta.blob_index,
-                        max_index: puffin_metadata.blobs.len(),
-                    },
-                )?;
-                ensure!(
-                    blob_meta.blob_type == file_meta.key,
-                    FileKeyNotMatchSnafu {
-                        expected: file_meta.key,
-                        actual: &blob_meta.blob_type,
-                    }
-                );
+        let mut size = 0;
+        for file_meta in dir_meta.files {
+            let blob_meta = puffin_metadata.blobs.get(file_meta.blob_index).context(
+                BlobIndexOutOfBoundSnafu {
+                    index: file_meta.blob_index,
+                    max_index: puffin_metadata.blobs.len(),
+                },
+            )?;
+            ensure!(
+                blob_meta.blob_type == file_meta.key,
+                FileKeyNotMatchSnafu {
+                    expected: file_meta.key,
+                    actual: &blob_meta.blob_type,
+                }
+            );
 
-                let reader = file.blob_reader(blob_meta)?;
-                let writer = writer_provider.writer(&file_meta.relative_path).await?;
+            let reader = file.blob_reader(blob_meta)?;
+            let writer = writer_provider.writer(&file_meta.relative_path).await?;
 
-                let compression = blob_meta.compression_codec;
-                size += Self::handle_decompress(reader, writer, compression).await?;
-            }
+            let compression = blob_meta.compression_codec;
+            size += Self::handle_decompress(reader, writer, compression).await?;
+        }
 
-            Ok(size)
-        })
+        Ok(size)
     }
 
     /// Handles the decompression of the reader and writes the decompressed data to the writer.
@@ -229,27 +222,79 @@ pub struct RandomReadBlob<F> {
     blob_metadata: BlobMetadata,
 }
 
+#[async_trait]
 impl<F: PuffinFileAccessor + Clone> BlobGuard for RandomReadBlob<F> {
     type Reader = PartialReader<F::Reader>;
 
-    fn reader(&self) -> BoxFuture<'static, Result<Self::Reader>> {
-        let accessor = self.accessor.clone();
-        let file_name = self.file_name.clone();
-        let blob_metadata = self.blob_metadata.clone();
+    async fn reader(&self) -> Result<Self::Reader> {
+        ensure!(
+            self.blob_metadata.compression_codec.is_none(),
+            UnsupportedDecompressionSnafu {
+                decompression: self.blob_metadata.compression_codec.unwrap().to_string()
+            }
+        );
 
-        Box::pin(async move {
-            // If we choose to perform random reads directly on blobs
-            // within the puffin file, then they must not be compressed.
-            ensure!(
-                blob_metadata.compression_codec.is_none(),
-                UnsupportedDecompressionSnafu {
-                    decompression: blob_metadata.compression_codec.unwrap().to_string()
-                }
-            );
+        let reader = self.accessor.reader(&self.file_name).await?;
+        let blob_reader = PuffinFileReader::new(reader).into_blob_reader(&self.blob_metadata);
+        Ok(blob_reader)
+    }
+}
 
-            let reader = accessor.reader(&file_name).await?;
-            let blob_reader = PuffinFileReader::new(reader).into_blob_reader(&blob_metadata);
-            Ok(blob_reader)
-        })
+/// `Either` is a type that represents either `A` or `B`.
+///
+/// Used to:
+/// impl `AsyncRead + AsyncSeek` for `Either<A: AsyncRead + AsyncSeek, B: AsyncRead + AsyncSeek>`,
+/// impl `BlobGuard` for `Either<A: BlobGuard, B: BlobGuard>`.
+pub enum Either<A, B> {
+    L(A),
+    R(B),
+}
+
+impl<A, B> AsyncRead for Either<A, B>
+where
+    A: AsyncRead + Unpin,
+    B: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            Either::L(a) => Pin::new(a).poll_read(cx, buf),
+            Either::R(b) => Pin::new(b).poll_read(cx, buf),
+        }
+    }
+}
+
+impl<A, B> AsyncSeek for Either<A, B>
+where
+    A: AsyncSeek + Unpin,
+    B: AsyncSeek + Unpin,
+{
+    fn poll_seek(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        pos: std::io::SeekFrom,
+    ) -> Poll<std::io::Result<u64>> {
+        match self.get_mut() {
+            Either::L(a) => Pin::new(a).poll_seek(cx, pos),
+            Either::R(b) => Pin::new(b).poll_seek(cx, pos),
+        }
+    }
+}
+
+#[async_trait]
+impl<A, B> BlobGuard for Either<A, B>
+where
+    A: BlobGuard + Sync,
+    B: BlobGuard + Sync,
+{
+    type Reader = Either<A::Reader, B::Reader>;
+    async fn reader(&self) -> Result<Self::Reader> {
+        match self {
+            Either::L(a) => Ok(Either::L(a.reader().await?)),
+            Either::R(b) => Ok(Either::R(b.reader().await?)),
+        }
     }
 }

--- a/src/puffin/src/puffin_manager/stager.rs
+++ b/src/puffin/src/puffin_manager/stager.rs
@@ -42,19 +42,19 @@ pub type DirWriterProviderRef = Box<dyn DirWriterProvider + Send>;
 ///
 /// `Stager` will provide a `BoxWriter` that the caller of `get_blob`
 /// can use to write the blob into the staging area.
-pub trait InitBlobFn = Fn(BoxWriter) -> WriteResult;
+pub trait InitBlobFn = FnOnce(BoxWriter) -> WriteResult;
 
 /// Function that initializes a directory.
 ///
 /// `Stager` will provide a `DirWriterProvider` that the caller of `get_dir`
 /// can use to write files inside the directory into the staging area.
-pub trait InitDirFn = Fn(DirWriterProviderRef) -> WriteResult;
+pub trait InitDirFn = FnOnce(DirWriterProviderRef) -> WriteResult;
 
 /// `Stager` manages the staging area for the puffin files.
 #[async_trait]
 #[auto_impl::auto_impl(Arc)]
 pub trait Stager: Send + Sync {
-    type Blob: BlobGuard;
+    type Blob: BlobGuard + Sync;
     type Dir: DirGuard;
 
     /// Retrieves a blob, initializing it if necessary using the provided `init_fn`.

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -838,7 +838,6 @@ create_on_flush = "auto"
 create_on_compaction = "auto"
 apply_on_query = "auto"
 mem_threshold_on_create = "auto"
-compress = true
 metadata_cache_size = "32MiB"
 content_cache_size = "32MiB"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* Remove compress support for inverted index
* Directly read uncompressed blob within puffin file instead of staging it first

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted test assertion in `test_region_usage` for improved accuracy.

- **Documentation**
  - Updated integration tests to remove unnecessary `compress = true` configuration.

- **Refactor**
  - Simplified and streamlined blob handling logic in test functions for better readability and efficiency.
  - Removed explicit compression parameters and fields, defaulting to compression where applicable.

**Note:** These changes enhance the performance and maintainability of the application without altering the user interface or user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->