### PR TITLE
fix: return empty path when extract function fails to extract

### DIFF
--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -123,18 +123,20 @@ pub fn normalize_path(path: &str) -> String {
     p
 }
 
-// This logical tries to extract parent path from the object storage operation
-// the function also relies on assumption that the region path is built from
-// pattern `<data|index>/catalog/schema/table_id/....`
-//
-// this implementation tries to extract at most 3 levels of parent path
+/// This logical tries to extract parent path from the object storage operation
+/// the function also relies on assumption that the region path is built from
+/// pattern `<data|index>/catalog/schema/table_id/....`
+///
+/// this implementation tries to extract at most 3 levels of parent path
+/// it returns empty string if there are less than 3 levels of path, to avoid
+/// invalid path extracted
 pub(crate) fn extract_parent_path(path: &str) -> &str {
     // split the path into `catalog`, `schema` and others
     path.char_indices()
         .filter(|&(_, c)| c == '/')
         // we get the data/catalog/schema from path, split at the 3rd /
         .nth(2)
-        .map_or(path, |(i, _)| &path[..i])
+        .map_or("", |(i, _)| &path[..i])
 }
 
 /// Attaches instrument layers to the object store.
@@ -208,13 +210,13 @@ mod tests {
 
         assert_eq!(
             "data/greptime/public",
-            extract_parent_path("data/greptime/public")
+            extract_parent_path("data/greptime/public/")
         );
 
-        assert_eq!("data/greptime/", extract_parent_path("data/greptime/"));
+        assert_eq!("", extract_parent_path("data/greptime/"));
 
-        assert_eq!("data/", extract_parent_path("data/"));
+        assert_eq!("", extract_parent_path("data/"));
 
-        assert_eq!("/", extract_parent_path("/"));
+        assert_eq!("", extract_parent_path("/"));
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

It turns out the cache layer shares same metrics mechanism, however its path pattern are totally different. This results as a explosion of our metrics cardinality. 

This patch can be seen as a temporary one that it ignores path pattern we don't want to measure. But this can still fail when have some other cache path pattern that accidentally matches the normal pattern.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path extraction logic to handle paths with less than 3 levels, ensuring more reliable operations and preventing potential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->