### PR TITLE
fix: remove path label for cache store

### DIFF
--- a/src/common/datasource/src/object_store/fs.rs
+++ b/src/common/datasource/src/object_store/fs.rs
@@ -31,7 +31,7 @@ pub fn build_fs_backend(root: &str) -> Result<ObjectStore> {
                 .expect("input error level must be valid"),
         )
         .layer(object_store::layers::TracingLayer)
-        .layer(object_store::layers::PrometheusMetricsLayer)
+        .layer(object_store::layers::PrometheusMetricsLayer::new(true))
         .finish();
     Ok(object_store)
 }

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -94,7 +94,7 @@ pub fn build_s3_backend(
                 .expect("input error level must be valid"),
         )
         .layer(object_store::layers::TracingLayer)
-        .layer(object_store::layers::PrometheusMetricsLayer)
+        .layer(object_store::layers::PrometheusMetricsLayer::new(true))
         .finish())
 }
 

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -60,7 +60,7 @@ pub(crate) async fn new_object_store(
         object_store
     };
 
-    let store = with_instrument_layers(object_store);
+    let store = with_instrument_layers(object_store, true);
     Ok(store)
 }
 

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -218,6 +218,7 @@ async fn new_fs_store(root: &str) -> Result<ObjectStore> {
 }
 
 /// Creates a fs object store with atomic write dir.
+#[allow(unused)]
 pub(crate) async fn new_fs_object_store(root: &str) -> Result<ObjectStore> {
     Ok(with_instrument_layers(new_fs_store(root).await?, true))
 }

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -208,23 +208,15 @@ pub(crate) struct SstWriteRequest {
     pub(crate) fulltext_index_config: FulltextIndexConfig,
 }
 
-async fn new_fs_store(root: &str) -> Result<ObjectStore> {
+pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {
     let atomic_write_dir = join_dir(root, ".tmp/");
     clean_dir(&atomic_write_dir).await?;
 
     let mut builder = Fs::default();
     builder.root(root).atomic_write_dir(&atomic_write_dir);
-    Ok(ObjectStore::new(builder).context(OpenDalSnafu)?.finish())
-}
+    let store = ObjectStore::new(builder).context(OpenDalSnafu)?.finish();
 
-/// Creates a fs object store with atomic write dir.
-#[allow(unused)]
-pub(crate) async fn new_fs_object_store(root: &str) -> Result<ObjectStore> {
-    Ok(with_instrument_layers(new_fs_store(root).await?, true))
-}
-
-pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {
-    Ok(with_instrument_layers(new_fs_store(root).await?, false))
+    Ok(with_instrument_layers(store, false))
 }
 
 /// Clean the directory.

--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -24,7 +24,7 @@ use object_store::manager::ObjectStoreManagerRef;
 use object_store::ObjectStore;
 use snafu::ResultExt;
 
-use crate::access_layer::{new_fs_object_store, SstWriteRequest};
+use crate::access_layer::{new_fs_cache_store, SstWriteRequest};
 use crate::cache::file_cache::{FileCache, FileCacheRef, FileType, IndexKey, IndexValue};
 use crate::error::{self, Result};
 use crate::metrics::{FLUSH_ELAPSED, UPLOAD_BYTES_TOTAL};
@@ -86,7 +86,7 @@ impl WriteCache {
     ) -> Result<Self> {
         info!("Init write cache on {cache_dir}, capacity: {cache_capacity}");
 
-        let local_store = new_fs_object_store(cache_dir).await?;
+        let local_store = new_fs_cache_store(cache_dir).await?;
         Self::new(
             local_store,
             object_store_manager,

--- a/src/mito2/src/sst/index/intermediate.rs
+++ b/src/mito2/src/sst/index/intermediate.rs
@@ -19,7 +19,7 @@ use object_store::util::{self, normalize_dir};
 use store_api::storage::{ColumnId, RegionId};
 use uuid::Uuid;
 
-use crate::access_layer::new_fs_object_store;
+use crate::access_layer::new_fs_cache_store;
 use crate::error::Result;
 use crate::sst::file::FileId;
 use crate::sst::index::store::InstrumentedStore;
@@ -37,7 +37,7 @@ impl IntermediateManager {
     /// Create a new `IntermediateManager` with the given root path.
     /// It will clean up all garbage intermediate files from previous runs.
     pub async fn init_fs(aux_path: impl AsRef<str>) -> Result<Self> {
-        let store = new_fs_object_store(&normalize_dir(aux_path.as_ref())).await?;
+        let store = new_fs_cache_store(&normalize_dir(aux_path.as_ref())).await?;
         let store = InstrumentedStore::new(store);
 
         // Remove all garbage intermediate files from previous runs.

--- a/src/object-store/src/util.rs
+++ b/src/object-store/src/util.rs
@@ -138,7 +138,7 @@ pub(crate) fn extract_parent_path(path: &str) -> &str {
 }
 
 /// Attaches instrument layers to the object store.
-pub fn with_instrument_layers(object_store: ObjectStore) -> ObjectStore {
+pub fn with_instrument_layers(object_store: ObjectStore, path_label: bool) -> ObjectStore {
     object_store
         .layer(
             LoggingLayer::default()
@@ -148,7 +148,7 @@ pub fn with_instrument_layers(object_store: ObjectStore) -> ObjectStore {
                 .expect("input error level must be valid"),
         )
         .layer(TracingLayer)
-        .layer(PrometheusMetricsLayer)
+        .layer(PrometheusMetricsLayer::new(path_label))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch fixes high cardinality on path label of opendal metrics. It's an issue introduce in #4277 . Because our file system cache shares same also uses this api, we get fragmented path label due to those usage. This path turns off path label for the cache.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed `new_fs_object_store` to `new_fs_cache_store` and adjusted its implementation to include additional instrumentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->