### PR TITLE
feat(index): distinguish different types of index metrics

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -209,26 +209,29 @@ lazy_static! {
     pub static ref INDEX_CREATE_ELAPSED: HistogramVec = register_histogram_vec!(
         "greptime_index_create_elapsed",
         "index create elapsed",
-        &[STAGE_LABEL],
+        &[STAGE_LABEL, TYPE_LABEL],
         vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
     /// Counter of rows indexed.
-    pub static ref INDEX_CREATE_ROWS_TOTAL: IntCounter = register_int_counter!(
+    pub static ref INDEX_CREATE_ROWS_TOTAL: IntCounterVec = register_int_counter_vec!(
         "greptime_index_create_rows_total",
         "index create rows total",
+        &[TYPE_LABEL],
     )
     .unwrap();
     /// Counter of created index bytes.
-    pub static ref INDEX_CREATE_BYTES_TOTAL: IntCounter = register_int_counter!(
+    pub static ref INDEX_CREATE_BYTES_TOTAL: IntCounterVec = register_int_counter_vec!(
         "greptime_index_create_bytes_total",
         "index create bytes total",
+        &[TYPE_LABEL],
     )
     .unwrap();
     /// Gauge of index create memory usage.
-    pub static ref INDEX_CREATE_MEMORY_USAGE: IntGauge = register_int_gauge!(
+    pub static ref INDEX_CREATE_MEMORY_USAGE: IntGaugeVec = register_int_gauge_vec!(
         "greptime_index_create_memory_usage",
         "index create memory usage",
+        &[TYPE_LABEL],
     ).unwrap();
     /// Counter of r/w bytes on index related IO operations.
     pub static ref INDEX_IO_BYTES_TOTAL: IntCounterVec = register_int_counter_vec!(

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -38,6 +38,9 @@ use crate::sst::index::fulltext_index::creator::SstIndexCreator as FulltextIndex
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::inverted_index::creator::SstIndexCreator as InvertedIndexer;
 
+pub(crate) const TYPE_INVERTED_INDEX: &str = "inverted_index";
+pub(crate) const TYPE_FULLTEXT_INDEX: &str = "fulltext_index";
+
 /// Output of the index creation.
 #[derive(Debug, Clone, Default)]
 pub struct IndexOutput {
@@ -89,11 +92,12 @@ pub struct Indexer {
     file_id: FileId,
     file_path: String,
     region_id: RegionId,
-    last_memory_usage: usize,
 
     puffin_manager: Option<SstPuffinManager>,
     inverted_indexer: Option<InvertedIndexer>,
+    last_mem_inverted_index: usize,
     fulltext_indexer: Option<FulltextIndexer>,
+    last_mem_fulltext_index: usize,
 }
 
 impl Indexer {
@@ -101,35 +105,42 @@ impl Indexer {
     pub async fn update(&mut self, batch: &Batch) {
         self.do_update(batch).await;
 
-        let memory_usage = self.memory_usage();
-        INDEX_CREATE_MEMORY_USAGE.add(memory_usage as i64 - self.last_memory_usage as i64);
-        self.last_memory_usage = memory_usage;
+        self.flush_mem_metrics();
     }
 
     /// Finalizes the index creation.
     pub async fn finish(&mut self) -> IndexOutput {
-        INDEX_CREATE_MEMORY_USAGE.sub(self.last_memory_usage as i64);
-        self.last_memory_usage = 0;
+        let output = self.do_finish().await;
 
-        self.do_finish().await
+        self.flush_mem_metrics();
+        output
     }
 
     /// Aborts the index creation.
     pub async fn abort(&mut self) {
-        INDEX_CREATE_MEMORY_USAGE.sub(self.last_memory_usage as i64);
-        self.last_memory_usage = 0;
-
         self.do_abort().await;
+
+        self.flush_mem_metrics();
     }
 
-    fn memory_usage(&self) -> usize {
-        self.inverted_indexer
+    fn flush_mem_metrics(&mut self) {
+        let inverted_mem = self
+            .inverted_indexer
             .as_ref()
-            .map_or(0, |creator| creator.memory_usage())
-            + self
-                .fulltext_indexer
-                .as_ref()
-                .map_or(0, |creator| creator.memory_usage())
+            .map_or(0, |creator| creator.memory_usage());
+        INDEX_CREATE_MEMORY_USAGE
+            .with_label_values(&[TYPE_INVERTED_INDEX])
+            .add(inverted_mem as i64 - self.last_mem_inverted_index as i64);
+        self.last_mem_inverted_index = inverted_mem;
+
+        let fulltext_mem = self
+            .fulltext_indexer
+            .as_ref()
+            .map_or(0, |creator| creator.memory_usage());
+        INDEX_CREATE_MEMORY_USAGE
+            .with_label_values(&[TYPE_FULLTEXT_INDEX])
+            .add(fulltext_mem as i64 - self.last_mem_fulltext_index as i64);
+        self.last_mem_fulltext_index = fulltext_mem;
     }
 }
 
@@ -153,7 +164,6 @@ impl<'a> IndexerBuilder<'a> {
             file_id: self.file_id,
             file_path: self.file_path.clone(),
             region_id: self.metadata.region_id,
-            last_memory_usage: 0,
 
             ..Default::default()
         };

--- a/src/mito2/src/sst/index/fulltext_index/creator.rs
+++ b/src/mito2/src/sst/index/fulltext_index/creator.rs
@@ -36,6 +36,7 @@ use crate::sst::index::fulltext_index::INDEX_BLOB_TYPE;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::SstPuffinWriter;
 use crate::sst::index::statistics::{ByteCount, RowCount, Statistics};
+use crate::sst::index::TYPE_FULLTEXT_INDEX;
 
 /// `SstIndexCreator` is responsible for creating fulltext indexes for SST files.
 pub struct SstIndexCreator {
@@ -104,7 +105,7 @@ impl SstIndexCreator {
         Ok(Self {
             creators,
             aborted: false,
-            stats: Statistics::default(),
+            stats: Statistics::new(TYPE_FULLTEXT_INDEX),
         })
     }
 

--- a/src/mito2/src/sst/index/inverted_index/creator.rs
+++ b/src/mito2/src/sst/index/inverted_index/creator.rs
@@ -44,6 +44,7 @@ use crate::sst::index::inverted_index::creator::temp_provider::TempFileProvider;
 use crate::sst::index::inverted_index::INDEX_BLOB_TYPE;
 use crate::sst::index::puffin_manager::SstPuffinWriter;
 use crate::sst::index::statistics::{ByteCount, RowCount, Statistics};
+use crate::sst::index::TYPE_INVERTED_INDEX;
 
 /// The minimum memory usage threshold for one column.
 const MIN_MEMORY_USAGE_THRESHOLD_PER_COLUMN: usize = 1024 * 1024; // 1MB
@@ -119,7 +120,7 @@ impl SstIndexCreator {
             index_creator,
             temp_file_provider,
             value_buf: vec![],
-            stats: Statistics::default(),
+            stats: Statistics::new(TYPE_INVERTED_INDEX),
             aborted: false,
             memory_usage,
             compress,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

AS STATED

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced metrics tracking with more granular data through new `IntCounterVec` and `IntGaugeVec`.

- **Improvements**
  - Added new constants and fields to support better indexing (`TYPE_INVERTED_INDEX`, `TYPE_FULLTEXT_INDEX`).
  - Improved memory usage tracking within the `Indexer` struct.
  - Custom initialization for statistics in `SstIndexCreator` to provide more detailed metrics.

- **Bug Fixes**
  - Updated methods to ensure accurate metrics collection, including `flush_mem_metrics`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->