### PR TITLE
fix(config): enable file engine by default

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -139,6 +139,7 @@
 | `region_engine.mito.memtable.index_max_keys_per_shard` | Integer | `8192` | The max number of keys in one shard.<br/>Only available for `partition_tree` memtable. |
 | `region_engine.mito.memtable.data_freeze_threshold` | Integer | `32768` | The max rows of data inside the actively writing buffer in one shard.<br/>Only available for `partition_tree` memtable. |
 | `region_engine.mito.memtable.fork_dictionary_bytes` | String | `1GiB` | Max dictionary bytes.<br/>Only available for `partition_tree` memtable. |
+| `region_engine.file` | -- | -- | Enable the file engine. |
 | `logging` | -- | -- | The logging options. |
 | `logging.dir` | String | `/tmp/greptimedb/logs` | The directory to store the log files. |
 | `logging.level` | String | `None` | The log level. Can be `info`/`debug`/`warn`/`error`. |
@@ -428,6 +429,7 @@
 | `region_engine.mito.memtable.index_max_keys_per_shard` | Integer | `8192` | The max number of keys in one shard.<br/>Only available for `partition_tree` memtable. |
 | `region_engine.mito.memtable.data_freeze_threshold` | Integer | `32768` | The max rows of data inside the actively writing buffer in one shard.<br/>Only available for `partition_tree` memtable. |
 | `region_engine.mito.memtable.fork_dictionary_bytes` | String | `1GiB` | Max dictionary bytes.<br/>Only available for `partition_tree` memtable. |
+| `region_engine.file` | -- | -- | Enable the file engine. |
 | `logging` | -- | -- | The logging options. |
 | `logging.dir` | String | `/tmp/greptimedb/logs` | The directory to store the log files. |
 | `logging.level` | String | `None` | The log level. Can be `info`/`debug`/`warn`/`error`. |

--- a/config/datanode.example.toml
+++ b/config/datanode.example.toml
@@ -478,6 +478,10 @@ data_freeze_threshold = 32768
 ## Only available for `partition_tree` memtable.
 fork_dictionary_bytes = "1GiB"
 
+[[region_engine]]
+## Enable the file engine.
+[region_engine.file]
+
 ## The logging options.
 [logging]
 ## The directory to store the log files.

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -501,6 +501,10 @@ data_freeze_threshold = 32768
 ## Only available for `partition_tree` memtable.
 fork_dictionary_bytes = "1GiB"
 
+[[region_engine]]
+## Enable the file engine.
+[region_engine.file]
+
 ## The logging options.
 [logging]
 ## The directory to store the log files.

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -26,6 +26,7 @@ use common_telemetry::logging::LoggingOptions;
 use common_wal::config::raft_engine::RaftEngineConfig;
 use common_wal::config::{DatanodeWalConfig, StandaloneWalConfig};
 use datanode::config::{DatanodeOptions, RegionEngineConfig, StorageConfig};
+use file_engine::config::EngineConfig;
 use frontend::frontend::FrontendOptions;
 use frontend::service_config::datanode::DatanodeClientOptions;
 use meta_client::MetaClientOptions;
@@ -71,18 +72,21 @@ fn test_load_datanode_example_config() {
                 data_home: "/tmp/greptimedb/".to_string(),
                 ..Default::default()
             },
-            region_engine: vec![RegionEngineConfig::Mito(MitoConfig {
-                num_workers: 8,
-                auto_flush_interval: Duration::from_secs(3600),
-                scan_parallelism: 0,
-                global_write_buffer_size: ReadableSize::gb(1),
-                global_write_buffer_reject_size: ReadableSize::gb(2),
-                sst_meta_cache_size: ReadableSize::mb(128),
-                vector_cache_size: ReadableSize::mb(512),
-                page_cache_size: ReadableSize::mb(512),
-                max_background_jobs: 4,
-                ..Default::default()
-            })],
+            region_engine: vec![
+                RegionEngineConfig::Mito(MitoConfig {
+                    num_workers: 8,
+                    auto_flush_interval: Duration::from_secs(3600),
+                    scan_parallelism: 0,
+                    global_write_buffer_size: ReadableSize::gb(1),
+                    global_write_buffer_reject_size: ReadableSize::gb(2),
+                    sst_meta_cache_size: ReadableSize::mb(128),
+                    vector_cache_size: ReadableSize::mb(512),
+                    page_cache_size: ReadableSize::mb(512),
+                    max_background_jobs: 4,
+                    ..Default::default()
+                }),
+                RegionEngineConfig::File(EngineConfig {}),
+            ],
             logging: LoggingOptions {
                 level: Some("info".to_string()),
                 otlp_endpoint: Some("".to_string()),
@@ -207,18 +211,21 @@ fn test_load_standalone_example_config() {
                 sync_period: Some(Duration::from_secs(10)),
                 ..Default::default()
             }),
-            region_engine: vec![RegionEngineConfig::Mito(MitoConfig {
-                num_workers: 8,
-                auto_flush_interval: Duration::from_secs(3600),
-                scan_parallelism: 0,
-                global_write_buffer_size: ReadableSize::gb(1),
-                global_write_buffer_reject_size: ReadableSize::gb(2),
-                sst_meta_cache_size: ReadableSize::mb(128),
-                vector_cache_size: ReadableSize::mb(512),
-                page_cache_size: ReadableSize::mb(512),
-                max_background_jobs: 4,
-                ..Default::default()
-            })],
+            region_engine: vec![
+                RegionEngineConfig::Mito(MitoConfig {
+                    num_workers: 8,
+                    auto_flush_interval: Duration::from_secs(3600),
+                    scan_parallelism: 0,
+                    global_write_buffer_size: ReadableSize::gb(1),
+                    global_write_buffer_reject_size: ReadableSize::gb(2),
+                    sst_meta_cache_size: ReadableSize::mb(128),
+                    vector_cache_size: ReadableSize::mb(512),
+                    page_cache_size: ReadableSize::mb(512),
+                    max_background_jobs: 4,
+                    ..Default::default()
+                }),
+                RegionEngineConfig::File(EngineConfig {}),
+            ],
             storage: StorageConfig {
                 data_home: "/tmp/greptimedb/".to_string(),
                 ..Default::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
close #4341
## What's changed and what's your intention?

Enable the file engine in `*.example.toml`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to enable the file engine in various configuration files (`config.md`, `datanode.example.toml`, `standalone.example.toml`).

- **Tests**
  - Enhanced configuration loading tests to include the new file engine configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->