### PR TITLE
fix: ensure keep alive is completed in time

### DIFF
--- a/.github/actions/setup-etcd-cluster/action.yml
+++ b/.github/actions/setup-etcd-cluster/action.yml
@@ -2,7 +2,7 @@ name: Setup Etcd cluster
 description: Deploy Etcd cluster on Kubernetes
 inputs:
   etcd-replicas:
-    default: 3
+    default: 1
     description: "Etcd replicas"
   namespace:
     default: "etcd-cluster"

--- a/src/common/meta/src/distributed_time_constants.rs
+++ b/src/common/meta/src/distributed_time_constants.rs
@@ -33,7 +33,7 @@ pub const DATANODE_LEASE_SECS: u64 = REGION_LEASE_SECS;
 pub const FLOWNODE_LEASE_SECS: u64 = DATANODE_LEASE_SECS;
 
 /// The lease seconds of metasrv leader.
-pub const META_LEASE_SECS: u64 = 3;
+pub const META_LEASE_SECS: u64 = 5;
 
 /// In a lease, there are two opportunities for renewal.
 pub const META_KEEP_ALIVE_INTERVAL_SECS: u64 = META_LEASE_SECS / 2;

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -18,11 +18,12 @@ use std::time::Duration;
 
 use common_meta::distributed_time_constants::{META_KEEP_ALIVE_INTERVAL_SECS, META_LEASE_SECS};
 use common_telemetry::{error, info, warn};
-use etcd_client::{Client, GetOptions, PutOptions};
+use etcd_client::{Client, GetOptions, LeaderKey, LeaseKeepAliveStream, LeaseKeeper, PutOptions};
 use snafu::{OptionExt, ResultExt};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
+use tokio::time::timeout;
 
 use crate::election::{Election, LeaderChangeMessage, CANDIDATES_ROOT, ELECTION_KEY};
 use crate::error;
@@ -235,34 +236,32 @@ impl Election for EtcdElection {
                 tokio::time::interval(Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS));
             loop {
                 let _ = keep_alive_interval.tick().await;
-                keeper.keep_alive().await.context(error::EtcdFailedSnafu)?;
 
-                if let Some(res) = receiver.message().await.context(error::EtcdFailedSnafu)? {
-                    if res.ttl() > 0 {
-                        // Only after a successful `keep_alive` is the leader considered official.
-                        if self
-                            .is_leader
-                            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-                            .is_ok()
-                        {
-                            self.infancy.store(true, Ordering::Relaxed);
-
-                            if let Err(e) = self
-                                .leader_watcher
-                                .send(LeaderChangeMessage::Elected(Arc::new(leader.clone())))
-                            {
-                                error!(e; "Failed to send leader change message");
-                            }
-                        }
-                    } else {
+                // The keep alive operation MUST be done in `META_KEEP_ALIVE_INTERVAL_SECS`.
+                match timeout(
+                    Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS),
+                    self.keep_alive(&mut keeper, &mut receiver, leader),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        // Do nothing
+                    }
+                    Ok(Err(err)) => {
+                        error!(err; "Failed to keep alive");
+                        break;
+                    }
+                    Err(_) => {
+                        error!("Refresh lease timeout");
                         if self.is_leader.load(Ordering::Relaxed) {
                             if let Err(e) = self
                                 .leader_watcher
                                 .send(LeaderChangeMessage::StepDown(Arc::new(leader.clone())))
                             {
-                                error!("Failed to send leader change message, error: {e}");
+                                error!(e; "Failed to send leader change message");
                             }
                         }
+
                         break;
                     }
                 }
@@ -295,5 +294,50 @@ impl Election for EtcdElection {
 
     fn subscribe_leader_change(&self) -> Receiver<LeaderChangeMessage> {
         self.leader_watcher.subscribe()
+    }
+}
+
+impl EtcdElection {
+    async fn keep_alive(
+        &self,
+        keeper: &mut LeaseKeeper,
+        receiver: &mut LeaseKeepAliveStream,
+        leader: &LeaderKey,
+    ) -> Result<()> {
+        keeper.keep_alive().await.context(error::EtcdFailedSnafu)?;
+        if let Some(res) = receiver.message().await.context(error::EtcdFailedSnafu)? {
+            if res.ttl() > 0 {
+                // Only after a successful `keep_alive` is the leader considered official.
+                if self
+                    .is_leader
+                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    self.infancy.store(true, Ordering::Relaxed);
+
+                    if let Err(e) = self
+                        .leader_watcher
+                        .send(LeaderChangeMessage::Elected(Arc::new(leader.clone())))
+                    {
+                        error!(e; "Failed to send leader change message");
+                    }
+                }
+            } else {
+                if self.is_leader.load(Ordering::Relaxed) {
+                    if let Err(e) = self
+                        .leader_watcher
+                        .send(LeaderChangeMessage::StepDown(Arc::new(leader.clone())))
+                    {
+                        error!(e; "Failed to send leader change message");
+                    }
+                }
+                return error::UnexpectedSnafu {
+                    violated: "Failed to refresh the lease",
+                }
+                .fail();
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -235,8 +235,6 @@ impl Election for EtcdElection {
             let mut keep_alive_interval =
                 tokio::time::interval(Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS));
             loop {
-                let _ = keep_alive_interval.tick().await;
-
                 // The keep alive operation MUST be done in `META_KEEP_ALIVE_INTERVAL_SECS`.
                 match timeout(
                     Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS),
@@ -245,7 +243,7 @@ impl Election for EtcdElection {
                 .await
                 {
                     Ok(Ok(())) => {
-                        // Do nothing
+                        let _ = keep_alive_interval.tick().await;
                     }
                     Ok(Err(err)) => {
                         error!(err; "Failed to keep alive");

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -23,7 +23,7 @@ use snafu::{ensure, OptionExt, ResultExt};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
-use tokio::time::timeout;
+use tokio::time::{timeout, MissedTickBehavior};
 
 use crate::election::{Election, LeaderChangeMessage, CANDIDATES_ROOT, ELECTION_KEY};
 use crate::error;
@@ -234,6 +234,7 @@ impl Election for EtcdElection {
 
             let mut keep_alive_interval =
                 tokio::time::interval(Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS));
+            keep_alive_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 // The keep alive operation MUST be done in `META_KEEP_ALIVE_INTERVAL_SECS`.
                 match timeout(

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -256,7 +256,11 @@ impl Election for EtcdElection {
                 }
             }
 
-            if self.is_leader.load(Ordering::Relaxed) {
+            if self
+                .is_leader
+                .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
                 if let Err(e) = self
                     .leader_watcher
                     .send(LeaderChangeMessage::StepDown(Arc::new(leader.clone())))
@@ -264,7 +268,6 @@ impl Election for EtcdElection {
                     error!(e; "Failed to send leader change message");
                 }
             }
-            self.is_leader.store(false, Ordering::Relaxed);
         }
 
         Ok(())

--- a/src/meta-srv/src/election/etcd.rs
+++ b/src/meta-srv/src/election/etcd.rs
@@ -232,13 +232,13 @@ impl Election for EtcdElection {
                 .await
                 .context(error::EtcdFailedSnafu)?;
 
-            let mut keep_alive_interval =
-                tokio::time::interval(Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS));
+            let keep_lease_duration = Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS);
+            let mut keep_alive_interval = tokio::time::interval(keep_lease_duration);
             keep_alive_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 // The keep alive operation MUST be done in `META_KEEP_ALIVE_INTERVAL_SECS`.
                 match timeout(
-                    Duration::from_secs(META_KEEP_ALIVE_INTERVAL_SECS),
+                    keep_lease_duration,
                     self.keep_alive(&mut keeper, &mut receiver, leader),
                 )
                 .await

--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -450,7 +450,7 @@ impl Metasrv {
             {
                 let election = election.clone();
                 let started = self.started.clone();
-                let _handle = common_runtime::spawn_bg(async move {
+                let _handle = common_runtime::spawn_write(async move {
                     while started.load(Ordering::Relaxed) {
                         let res = election.campaign().await;
                         if let Err(e) = res {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

ensure keep alive is completed in time

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved lease management and leader handling in the election process with enhanced timeout error handling.

- **Bug Fixes**
  - Adjusted default replica values for Greptimedb and Etcd clusters from 3 to 1, improving resource efficiency.

- **Refactor**
  - Switched function call from `common_runtime::spawn_bg` to `common_runtime::spawn_write` for better asynchronous operation handling.

- **Performance Improvements**
  - Extended lease duration for the metasrv leader from 3 to 5 seconds, enhancing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->