### PR TITLE
fix: permission denied is 403

### DIFF
--- a/src/servers/src/http/error_result.rs
+++ b/src/servers/src/http/error_result.rs
@@ -100,15 +100,14 @@ impl IntoResponse for ErrorResponse {
             | StatusCode::FlowNotFound
             | StatusCode::FlowAlreadyExists => HttpStatusCode::BAD_REQUEST,
 
-            StatusCode::PermissionDenied
-            | StatusCode::AuthHeaderNotFound
+            StatusCode::AuthHeaderNotFound
             | StatusCode::InvalidAuthHeader
             | StatusCode::UserNotFound
             | StatusCode::UnsupportedPasswordType
             | StatusCode::UserPasswordMismatch
             | StatusCode::RegionReadonly => HttpStatusCode::UNAUTHORIZED,
 
-            StatusCode::AccessDenied => HttpStatusCode::FORBIDDEN,
+            StatusCode::PermissionDenied | StatusCode::AccessDenied => HttpStatusCode::FORBIDDEN,
 
             StatusCode::RateLimited => HttpStatusCode::TOO_MANY_REQUESTS,
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Fix http code for permission denied.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted error handling to correctly map `Permission Denied` to `403 Forbidden` and `Auth Header Not Found` to `401 Unauthorized`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->