### PR TITLE
chore(ci): unset default gcc linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-
 [alias]
 sqlness = "run --bin sqlness-runner --"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #4363
## What's changed and what's your intention?

unset default gcc linker

wait for https://github.com/GreptimeTeam/greptimedb/actions/runs/9934707196/job/27439556826

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
