### PR TITLE
chore: support `pattern` as pipeline key name

### DIFF
--- a/src/pipeline/src/etl/processor/dissect.rs
+++ b/src/pipeline/src/etl/processor/dissect.rs
@@ -19,8 +19,8 @@ use itertools::Itertools;
 
 use crate::etl::field::{Field, Fields};
 use crate::etl::processor::{
-    yaml_bool, yaml_field, yaml_fields, yaml_parse_strings, yaml_string, Processor, FIELDS_NAME,
-    FIELD_NAME, IGNORE_MISSING_NAME, PATTERNS_NAME,
+    yaml_bool, yaml_field, yaml_fields, yaml_parse_string, yaml_parse_strings, yaml_string,
+    Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERNS_NAME, PATTERN_NAME,
 };
 use crate::etl::value::{Map, Value};
 
@@ -559,6 +559,10 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DissectProcessor {
             match key {
                 FIELD_NAME => processor.with_fields(Fields::one(yaml_field(v, FIELD_NAME)?)),
                 FIELDS_NAME => processor.with_fields(yaml_fields(v, FIELDS_NAME)?),
+                PATTERN_NAME => {
+                    let pattern: Pattern = yaml_parse_string(v, PATTERN_NAME)?;
+                    processor.with_patterns(vec![pattern]);
+                }
                 PATTERNS_NAME => {
                     let patterns = yaml_parse_strings(v, PATTERNS_NAME)?;
                     processor.with_patterns(patterns);

--- a/src/pipeline/tests/common.rs
+++ b/src/pipeline/tests/common.rs
@@ -33,12 +33,12 @@ pub fn parse_and_exec(input_str: &str, pipeline_yaml: &str) -> Rows {
 pub fn make_column_schema(
     column_name: String,
     datatype: ColumnDataType,
-    sematic_type: SemanticType,
+    semantic_type: SemanticType,
 ) -> ColumnSchema {
     ColumnSchema {
         column_name,
         datatype: datatype.into(),
-        semantic_type: sematic_type.into(),
+        semantic_type: semantic_type.into(),
         ..Default::default()
     }
 }

--- a/src/pipeline/tests/common.rs
+++ b/src/pipeline/tests/common.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use greptime_proto::v1::Rows;
+use greptime_proto::v1::{ColumnDataType, ColumnSchema, Rows, SemanticType};
 use pipeline::{parse, Content, GreptimeTransformer, Pipeline, Value};
 
 /// test util function to parse and execute pipeline
@@ -27,4 +27,18 @@ pub fn parse_and_exec(input_str: &str, pipeline_yaml: &str) -> Rows {
         parse(&yaml_content).expect("failed to parse pipeline");
 
     pipeline.exec(input_value).expect("failed to exec pipeline")
+}
+
+/// test util function to create column schema
+pub fn make_column_schema(
+    column_name: String,
+    datatype: ColumnDataType,
+    sematic_type: SemanticType,
+) -> ColumnSchema {
+    ColumnSchema {
+        column_name,
+        datatype: datatype.into(),
+        semantic_type: sematic_type.into(),
+        ..Default::default()
+    }
 }

--- a/src/pipeline/tests/dissect.rs
+++ b/src/pipeline/tests/dissect.rs
@@ -1,0 +1,113 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use greptime_proto::v1::value::ValueData::StringValue;
+use greptime_proto::v1::{ColumnDataType, SemanticType};
+
+#[test]
+fn test_dissect_pattern() {
+    let input_value_str = r#"
+    [
+      {
+        "str": "123 456"
+      }
+    ]
+"#;
+
+    let pipeline_yaml = r#"
+processors:
+  - dissect:
+      field: str
+      pattern: "%{a} %{b}"
+
+transform:
+  - fields:
+        - a
+        - b
+    type: string
+"#;
+
+    let output = common::parse_and_exec(input_value_str, pipeline_yaml);
+
+    let expected_schema = vec![
+        common::make_column_schema("a".to_string(), ColumnDataType::String, SemanticType::Field),
+        common::make_column_schema("b".to_string(), ColumnDataType::String, SemanticType::Field),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
+    ];
+
+    assert_eq!(output.schema, expected_schema);
+
+    assert_eq!(
+        output.rows[0].values[0].value_data,
+        Some(StringValue("123".to_string()))
+    );
+    assert_eq!(
+        output.rows[0].values[1].value_data,
+        Some(StringValue("456".to_string()))
+    );
+}
+
+#[test]
+fn test_dissect_patterns() {
+    let input_value_str = r#"
+    [
+      {
+        "str": "123 456"
+      }
+    ]
+"#;
+
+    let pipeline_yaml = r#"
+processors:
+  - dissect:
+      field: str
+      patterns: 
+        - "%{a} %{b}"
+
+transform:
+  - fields:
+        - a
+        - b
+    type: string
+"#;
+
+    let output = common::parse_and_exec(input_value_str, pipeline_yaml);
+
+    let expected_schema = vec![
+        common::make_column_schema("a".to_string(), ColumnDataType::String, SemanticType::Field),
+        common::make_column_schema("b".to_string(), ColumnDataType::String, SemanticType::Field),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
+    ];
+
+    assert_eq!(output.schema, expected_schema);
+
+    assert_eq!(
+        output.rows[0].values[0].value_data,
+        Some(StringValue("123".to_string()))
+    );
+    assert_eq!(
+        output.rows[0].values[1].value_data,
+        Some(StringValue("456".to_string()))
+    );
+}

--- a/src/pipeline/tests/gsub.rs
+++ b/src/pipeline/tests/gsub.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use greptime_proto::v1::value::ValueData::TimestampMillisecondValue;
-use greptime_proto::v1::{ColumnDataType, ColumnSchema, SemanticType};
+use greptime_proto::v1::{ColumnDataType, SemanticType};
 
 mod common;
 
@@ -49,13 +49,11 @@ transform:
 
     let output = common::parse_and_exec(input_value_str, pipeline_yaml);
 
-    let expected_schema = vec![ColumnSchema {
-        column_name: "reqTimeSec".to_string(),
-        datatype: ColumnDataType::TimestampMillisecond.into(),
-        semantic_type: SemanticType::Timestamp.into(),
-        datatype_extension: None,
-        options: None,
-    }];
+    let expected_schema = vec![common::make_column_schema(
+        "reqTimeSec".to_string(),
+        ColumnDataType::TimestampMillisecond,
+        SemanticType::Timestamp,
+    )];
 
     assert_eq!(output.schema, expected_schema);
     assert_eq!(

--- a/src/pipeline/tests/join.rs
+++ b/src/pipeline/tests/join.rs
@@ -32,20 +32,16 @@ transform:
 
 lazy_static! {
     pub static ref EXPECTED_SCHEMA: Vec<ColumnSchema> = vec![
-        ColumnSchema {
-            column_name: "join_test".to_string(),
-            datatype: ColumnDataType::String.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "greptime_timestamp".to_string(),
-            datatype: ColumnDataType::TimestampNanosecond.into(),
-            semantic_type: SemanticType::Timestamp.into(),
-            datatype_extension: None,
-            options: None,
-        },
+        common::make_column_schema(
+            "join_test".to_string(),
+            ColumnDataType::String,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
     ];
 }
 

--- a/src/pipeline/tests/on_failure.rs
+++ b/src/pipeline/tests/on_failure.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use greptime_proto::v1::value::ValueData::{U16Value, U8Value};
-use greptime_proto::v1::{ColumnDataType, ColumnSchema, SemanticType};
+use greptime_proto::v1::{ColumnDataType, SemanticType};
 
 mod common;
 
@@ -40,20 +40,16 @@ transform:
     let output = common::parse_and_exec(input_value_str, pipeline_yaml);
 
     let expected_schema = vec![
-        ColumnSchema {
-            column_name: "version".to_string(),
-            datatype: ColumnDataType::Uint8.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "greptime_timestamp".to_string(),
-            datatype: ColumnDataType::TimestampNanosecond.into(),
-            semantic_type: SemanticType::Timestamp.into(),
-            datatype_extension: None,
-            options: None,
-        },
+        common::make_column_schema(
+            "version".to_string(),
+            ColumnDataType::Uint8,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
     ];
 
     assert_eq!(output.schema, expected_schema);
@@ -85,20 +81,16 @@ transform:
     let output = common::parse_and_exec(input_value_str, pipeline_yaml);
 
     let expected_schema = vec![
-        ColumnSchema {
-            column_name: "version".to_string(),
-            datatype: ColumnDataType::Uint8.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "greptime_timestamp".to_string(),
-            datatype: ColumnDataType::TimestampNanosecond.into(),
-            semantic_type: SemanticType::Timestamp.into(),
-            datatype_extension: None,
-            options: None,
-        },
+        common::make_column_schema(
+            "version".to_string(),
+            ColumnDataType::Uint8,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
     ];
 
     assert_eq!(output.schema, expected_schema);
@@ -125,20 +117,16 @@ transform:
     let output = common::parse_and_exec(input_value_str, pipeline_yaml);
 
     let expected_schema = vec![
-        ColumnSchema {
-            column_name: "version".to_string(),
-            datatype: ColumnDataType::Uint8.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "greptime_timestamp".to_string(),
-            datatype: ColumnDataType::TimestampNanosecond.into(),
-            semantic_type: SemanticType::Timestamp.into(),
-            datatype_extension: None,
-            options: None,
-        },
+        common::make_column_schema(
+            "version".to_string(),
+            ColumnDataType::Uint8,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
     ];
 
     assert_eq!(output.schema, expected_schema);
@@ -176,27 +164,21 @@ transform:
     let output = common::parse_and_exec(input_value_str, pipeline_yaml);
 
     let expected_schema = vec![
-        ColumnSchema {
-            column_name: "version".to_string(),
-            datatype: ColumnDataType::Uint8.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "spec_version".to_string(),
-            datatype: ColumnDataType::Uint16.into(),
-            semantic_type: SemanticType::Field.into(),
-            datatype_extension: None,
-            options: None,
-        },
-        ColumnSchema {
-            column_name: "greptime_timestamp".to_string(),
-            datatype: ColumnDataType::TimestampNanosecond.into(),
-            semantic_type: SemanticType::Timestamp.into(),
-            datatype_extension: None,
-            options: None,
-        },
+        common::make_column_schema(
+            "version".to_string(),
+            ColumnDataType::Uint8,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "spec_version".to_string(),
+            ColumnDataType::Uint16,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
     ];
 
     assert_eq!(output.schema, expected_schema);

--- a/src/pipeline/tests/regex.rs
+++ b/src/pipeline/tests/regex.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod common;
+
+use greptime_proto::v1::value::ValueData::StringValue;
+use greptime_proto::v1::{ColumnDataType, SemanticType};
+
+#[test]
+fn test_regex_pattern() {
+    let input_value_str = r#"
+    [
+      {
+        "str": "123 456"
+      }
+    ]
+"#;
+
+    let pipeline_yaml = r#"
+processors:
+  - regex:
+      fields: 
+        - str
+      pattern: "(?<id>\\d+)"
+
+transform:
+  - field: str_id
+    type: string
+"#;
+
+    let output = common::parse_and_exec(input_value_str, pipeline_yaml);
+
+    let expected_schema = vec![
+        common::make_column_schema(
+            "str_id".to_string(),
+            ColumnDataType::String,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
+    ];
+
+    assert_eq!(output.schema, expected_schema);
+
+    assert_eq!(
+        output.rows[0].values[0].value_data,
+        Some(StringValue("123".to_string()))
+    );
+}
+
+#[test]
+fn test_regex_patterns() {
+    let input_value_str = r#"
+    [
+      {
+        "str": "123 456"
+      }
+    ]
+"#;
+
+    let pipeline_yaml = r#"
+processors:
+  - regex:
+      fields: 
+        - str
+      patterns:
+        - "(?<id>\\d+)"
+
+transform:
+  - field: str_id
+    type: string
+"#;
+
+    let output = common::parse_and_exec(input_value_str, pipeline_yaml);
+
+    let expected_schema = vec![
+        common::make_column_schema(
+            "str_id".to_string(),
+            ColumnDataType::String,
+            SemanticType::Field,
+        ),
+        common::make_column_schema(
+            "greptime_timestamp".to_string(),
+            ColumnDataType::TimestampNanosecond,
+            SemanticType::Timestamp,
+        ),
+    ];
+
+    assert_eq!(output.schema, expected_schema);
+
+    assert_eq!(
+        output.rows[0].values[0].value_data,
+        Some(StringValue("123".to_string()))
+    );
+}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr mainly
- supports `pattern` as field key name in pipeline yaml along with `patterns`
- adds some tests

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for parsing and handling patterns in the ETL processor, enhancing its ability to dissect and process data fields.

- **Tests**
  - Added new test cases for pattern processing, including dissecting patterns and regex pattern application.
  - Simplified the creation of expected schemas in test cases by introducing a common function for schema construction, improving code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->