### PR TITLE
feat:  add PruneReader for optimized row filtering

### DIFF
--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -828,6 +828,20 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("SST file {} does not contain valid stats info", file_path))]
+    StatsNotPresent {
+        file_path: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display("Failed to decode stats of file {}", file_path))]
+    DecodeStats {
+        file_path: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -958,6 +972,7 @@ impl ErrorExt for Error {
             FulltextPushText { source, .. }
             | FulltextFinish { source, .. }
             | ApplyFulltextIndex { source, .. } => source.status_code(),
+            DecodeStats { .. } | StatsNotPresent { .. } => StatusCode::Internal,
         }
     }
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -19,6 +19,7 @@ pub mod dedup;
 pub(crate) mod last_row;
 pub mod merge;
 pub mod projection;
+pub(crate) mod prune;
 pub(crate) mod scan_region;
 pub(crate) mod seq_scan;
 pub(crate) mod unordered_scan;
@@ -54,7 +55,7 @@ use crate::error::{
 };
 use crate::memtable::BoxedBatchIterator;
 use crate::metrics::{READ_BATCHES_RETURN, READ_ROWS_RETURN, READ_STAGE_ELAPSED};
-use crate::sst::parquet::reader::RowGroupReader;
+use crate::read::prune::PruneReader;
 
 /// Storage internal representation of a batch of rows for a primary key (time series).
 ///
@@ -686,8 +687,8 @@ pub enum Source {
     Iter(BoxedBatchIterator),
     /// Source from a [BoxedBatchStream].
     Stream(BoxedBatchStream),
-    /// Source from a [RowGroupReader].
-    RowGroupReader(RowGroupReader),
+    /// Source from a [PruneReader].
+    PruneReader(PruneReader),
 }
 
 impl Source {
@@ -697,7 +698,7 @@ impl Source {
             Source::Reader(reader) => reader.next_batch().await,
             Source::Iter(iter) => iter.next().transpose(),
             Source::Stream(stream) => stream.try_next().await,
-            Source::RowGroupReader(reader) => reader.next_batch().await,
+            Source::PruneReader(reader) => reader.next_batch().await,
         }
     }
 }

--- a/src/mito2/src/read/prune.rs
+++ b/src/mito2/src/read/prune.rs
@@ -18,7 +18,7 @@ use crate::read::{Batch, BatchReader};
 use crate::sst::parquet::file_range::FileRangeContextRef;
 use crate::sst::parquet::reader::{ReaderMetrics, RowGroupReader};
 
-enum Source {
+pub enum Source {
     RowGroup(RowGroupReader),
     LastRow(LastRowReader),
 }
@@ -60,6 +60,10 @@ impl PruneReader {
             source: Source::LastRow(reader),
             metrics: Default::default(),
         }
+    }
+
+    pub(crate) fn reset_source(&mut self, source: Source) {
+        self.source = source;
     }
 
     pub(crate) fn metrics(&mut self) -> &ReaderMetrics {

--- a/src/mito2/src/read/prune.rs
+++ b/src/mito2/src/read/prune.rs
@@ -1,0 +1,110 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::Result;
+use crate::read::last_row::LastRowReader;
+use crate::read::{Batch, BatchReader};
+use crate::sst::parquet::file_range::FileRangeContextRef;
+use crate::sst::parquet::reader::{ReaderMetrics, RowGroupReader};
+
+enum Source {
+    RowGroup(RowGroupReader),
+    LastRow(LastRowReader),
+}
+
+impl Source {
+    async fn next_batch(&mut self) -> Result<Option<Batch>> {
+        match self {
+            Source::RowGroup(r) => r.next_batch().await,
+            Source::LastRow(r) => r.next_batch().await,
+        }
+    }
+}
+
+pub struct PruneReader {
+    /// Context for file ranges.
+    context: FileRangeContextRef,
+    source: Source,
+    metrics: ReaderMetrics,
+}
+
+impl PruneReader {
+    pub(crate) fn new_with_row_group_reader(
+        ctx: FileRangeContextRef,
+        reader: RowGroupReader,
+    ) -> Self {
+        Self {
+            context: ctx,
+            source: Source::RowGroup(reader),
+            metrics: Default::default(),
+        }
+    }
+
+    pub(crate) fn new_with_last_row_reader(
+        ctx: FileRangeContextRef,
+        reader: LastRowReader,
+    ) -> Self {
+        Self {
+            context: ctx,
+            source: Source::LastRow(reader),
+            metrics: Default::default(),
+        }
+    }
+
+    pub(crate) fn metrics(&mut self) -> &ReaderMetrics {
+        match &self.source {
+            Source::RowGroup(r) => r.metrics(),
+            Source::LastRow(_) => &self.metrics,
+        }
+    }
+
+    pub(crate) async fn next_batch(&mut self) -> Result<Option<Batch>> {
+        while let Some(b) = self.source.next_batch().await? {
+            match self.prune(b)? {
+                Some(b) => {
+                    return Ok(Some(b));
+                }
+                None => {
+                    continue;
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Prunes batches by the pushed down predicate.
+    fn prune(&mut self, batch: Batch) -> Result<Option<Batch>> {
+        // fast path
+        if self.context.filters().is_empty() {
+            return Ok(Some(batch));
+        }
+
+        let num_rows_before_filter = batch.num_rows();
+        let Some(batch_filtered) = self.context.precise_filter(batch)? else {
+            // the entire batch is filtered out
+            self.metrics.num_rows_precise_filtered += num_rows_before_filter;
+            return Ok(None);
+        };
+
+        // update metric
+        let filtered_rows = num_rows_before_filter - batch_filtered.num_rows();
+        self.metrics.num_rows_precise_filtered += filtered_rows;
+
+        if !batch_filtered.is_empty() {
+            Ok(Some(batch_filtered))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -313,7 +313,7 @@ impl ScanRegion {
             .with_append_mode(self.version.options.append_mode)
             .with_filter_deleted(filter_deleted)
             .with_merge_mode(self.version.options.merge_mode())
-            .with_series_row_selector(self.request.series_row_selector.clone());
+            .with_series_row_selector(self.request.series_row_selector);
         Ok(input)
     }
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -103,7 +103,11 @@ impl SeqScan {
     }
 
     /// Builds sources from a [ScanPart].
-    fn build_part_sources(part: &ScanPart, sources: &mut Vec<Source>) -> Result<()> {
+    fn build_part_sources(
+        part: &ScanPart,
+        sources: &mut Vec<Source>,
+        row_selector: Option<TimeSeriesRowSelector>,
+    ) -> Result<()> {
         sources.reserve(part.memtable_ranges.len() + part.file_ranges.len());
         // Read memtables.
         for mem in &part.memtable_ranges {
@@ -125,7 +129,7 @@ impl SeqScan {
                 let region_id = ranges[0].file_handle().region_id();
                 let range_num = ranges.len();
                 for range in ranges {
-                    let mut reader = range.reader().await?;
+                    let mut reader = range.reader(row_selector).await?;
                     let compat_batch = range.compat_batch();
                     while let Some(mut batch) = reader.next_batch().await? {
                         if let Some(compat) = compat_batch {
@@ -166,7 +170,7 @@ impl SeqScan {
                 return Ok(None);
             };
 
-            Self::build_part_sources(part, &mut sources)?;
+            Self::build_part_sources(part, &mut sources, None)?;
         }
 
         Self::build_reader_from_sources(stream_ctx, sources, semaphore).await
@@ -189,7 +193,7 @@ impl SeqScan {
             return Ok(None);
         };
 
-        Self::build_part_sources(part, &mut sources)?;
+        Self::build_part_sources(part, &mut sources, stream_ctx.input.series_row_selector)?;
 
         Self::build_reader_from_sources(stream_ctx, sources, semaphore).await
     }

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -182,7 +182,7 @@ impl RegionScanner for UnorderedScan {
             let mut reader_metrics = ReaderMetrics::default();
             // Safety: UnorderedDistributor::build_parts() ensures this.
             for file_range in &part.file_ranges[0] {
-                let reader = file_range.reader().await.map_err(BoxedError::new).context(ExternalSnafu)?;
+                let reader = file_range.reader(None).await.map_err(BoxedError::new).context(ExternalSnafu)?;
                 let compat_batch = file_range.compat_batch();
                 let mut source = Source::PruneReader(reader);
                 while let Some(batch) = Self::fetch_from_source(&mut source, mapper, cache, compat_batch, &mut metrics).await? {

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -184,13 +184,13 @@ impl RegionScanner for UnorderedScan {
             for file_range in &part.file_ranges[0] {
                 let reader = file_range.reader().await.map_err(BoxedError::new).context(ExternalSnafu)?;
                 let compat_batch = file_range.compat_batch();
-                let mut source = Source::RowGroupReader(reader);
+                let mut source = Source::PruneReader(reader);
                 while let Some(batch) = Self::fetch_from_source(&mut source, mapper, cache, compat_batch, &mut metrics).await? {
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
                     yield batch;
                 }
-                if let Source::RowGroupReader(reader) = source {
+                if let Source::PruneReader(mut reader) = source {
                     reader_metrics.merge_from(reader.metrics());
                 }
             }

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -1083,8 +1083,6 @@ impl RowGroupReader {
     }
 
     /// Tries to fetch next [RecordBatch] from the reader.
-    ///
-    /// If the reader is exhausted, reads next row group.
     fn fetch_next_record_batch(&mut self) -> Result<Option<RecordBatch>> {
         self.reader.next().transpose().context(ArrowReaderSnafu {
             path: self.context.file_path(),

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -697,31 +697,31 @@ fn time_range_to_predicate(
 #[derive(Debug, Default)]
 pub(crate) struct ReaderMetrics {
     /// Number of row groups before filtering.
-    num_row_groups_before_filtering: usize,
+    pub(crate) num_row_groups_before_filtering: usize,
     /// Number of row groups filtered by fulltext index.
-    num_row_groups_fulltext_index_filtered: usize,
+    pub(crate) num_row_groups_fulltext_index_filtered: usize,
     /// Number of row groups filtered by inverted index.
-    num_row_groups_inverted_index_filtered: usize,
+    pub(crate) num_row_groups_inverted_index_filtered: usize,
     /// Number of row groups filtered by min-max index.
-    num_row_groups_min_max_filtered: usize,
+    pub(crate) num_row_groups_min_max_filtered: usize,
     /// Number of rows filtered by precise filter.
-    num_rows_precise_filtered: usize,
+    pub(crate) num_rows_precise_filtered: usize,
     /// Number of rows in row group before filtering.
-    num_rows_in_row_group_before_filtering: usize,
+    pub(crate) num_rows_in_row_group_before_filtering: usize,
     /// Number of rows in row group filtered by fulltext index.
-    num_rows_in_row_group_fulltext_index_filtered: usize,
+    pub(crate) num_rows_in_row_group_fulltext_index_filtered: usize,
     /// Number of rows in row group filtered by inverted index.
-    num_rows_in_row_group_inverted_index_filtered: usize,
+    pub(crate) num_rows_in_row_group_inverted_index_filtered: usize,
     /// Duration to build the parquet reader.
-    build_cost: Duration,
+    pub(crate) build_cost: Duration,
     /// Duration to scan the reader.
-    scan_cost: Duration,
+    pub(crate) scan_cost: Duration,
     /// Number of record batches read.
-    num_record_batches: usize,
+    pub(crate) num_record_batches: usize,
     /// Number of batches decoded.
-    num_batches: usize,
+    pub(crate) num_batches: usize,
     /// Number of rows read.
-    num_rows: usize,
+    pub(crate) num_rows: usize,
 }
 
 impl ReaderMetrics {

--- a/src/store-api/src/storage/requests.rs
+++ b/src/store-api/src/storage/requests.rs
@@ -17,7 +17,7 @@ use datafusion_expr::expr::Expr;
 use strum::Display;
 
 /// A hint on how to select rows from a time-series.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display)]
 pub enum TimeSeriesRowSelector {
     /// Only keep the last row of each time-series.
     LastRow,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR refactors the SST readers, adding a `PruneReader` to prune batches yielded, and use `LastRowReader` if row group only contains PUT operations.

The readers now are like:
![image](https://github.com/user-attachments/assets/ca21e13e-c67a-4453-b0ac-da62437d86bc)


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error handling for missing or undecodable stats information in SST files.
  - Introduced the `PruneReader` module to enable data pruning and provide metrics during reading processes.

- **Improvements**
  - Enhanced the `SeqScan` and `UnorderedScan` functionalities with more flexible row selection and pruning capabilities.
  - Improved `ReaderMetrics` visibility and functionality to offer detailed filtering metrics.

- **Bug Fixes**
  - Fixed potential issues with row selection and decoding metadata in the file range operations.

- **Refactor**
  - Renamed and updated various internal reader and batch handling methods for consistency and clarity.

- **Performance**
  - Improved data reading efficiency by applying pruning and detailed metrics tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->