### PR TITLE
test: replace unstable output of last value test

### DIFF
--- a/tests/cases/standalone/optimizer/last_value.result
+++ b/tests/cases/standalone/optimizer/last_value.result
@@ -22,6 +22,8 @@ Affected Rows: 9
 
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE \-+
+-- SQLNESS REPLACE (\s\s+) _
 explain analyze
     select
         last_value(host order by ts),
@@ -30,22 +32,22 @@ explain analyze
     from t
     group by host;
 
-+-------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| stage | node | plan                                                                                                                                                                                                                                                                                                                                                                                                      |
-+-------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 0     | 0    |  MergeScanExec: peers=[5695126634496(1326, 0), ] REDACTED
-|       |      |                                                                                                                                                                                                                                                                                                                                                                                                           |
-| 1     | 0    |  ProjectionExec: expr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@1 as last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST]@2 as last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]@3 as last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|       |      |   AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|       |      |     CoalesceBatchesExec: target_batch_size=8192 REDACTED
-|       |      |       RepartitionExec: REDACTED
-|       |      |         CoalesceBatchesExec: target_batch_size=8192 REDACTED
-|       |      |           AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
-|       |      |             RepartitionExec: REDACTED
-|       |      |               SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges), selector=LastRow REDACTED
-|       |      |                                                                                                                                                                                                                                                                                                                                                                                                           |
-|       |      | Total rows: 4                                                                                                                                                                                                                                                                                                                                                                                             |
-+-------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+++++
+| stage | node | plan_|
+++++
+| 0_| 0_|_MergeScanExec: peers=[5695126634496(1326, 0), ] REDACTED
+|_|_|_|
+| 1_| 0_|_ProjectionExec: expr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST]@1 as last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST]@2 as last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]@3 as last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
+|_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
+|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
+|_|_|_RepartitionExec: REDACTED
+|_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
+|_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
+|_|_|_RepartitionExec: REDACTED
+|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges), selector=LastRow REDACTED
+|_|_|_|
+|_|_| Total rows: 4_|
+++++
 
 drop table t;
 

--- a/tests/cases/standalone/optimizer/last_value.sql
+++ b/tests/cases/standalone/optimizer/last_value.sql
@@ -18,6 +18,8 @@ insert into t values
 
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE \-+
+-- SQLNESS REPLACE (\s\s+) _
 explain analyze
     select
         last_value(host order by ts),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR replaces unstable output of the last value optimizer test

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated SQL test cases with new comments and formatting changes to improve readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->