### PR TITLE
test: more sleep when flow insert makes it serial

### DIFF
--- a/tests/cases/standalone/common/flow/basic.result
+++ b/tests/cases/standalone/common/flow/basic.result
@@ -14,6 +14,7 @@ SELECT sum(number) FROM numbers_input GROUP BY tumble(ts, '1 second', '2021-07-0
 
 Affected Rows: 0
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
@@ -21,7 +22,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
 +-------+---------------------+---------------------+
@@ -30,6 +31,7 @@ SELECT col_0, window_start, window_end FROM out_num_cnt;
 | 42    | 2021-07-01T00:00:00 | 2021-07-01T00:00:01 |
 +-------+---------------------+---------------------+
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),

--- a/tests/cases/standalone/common/flow/basic.result
+++ b/tests/cases/standalone/common/flow/basic.result
@@ -22,7 +22,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
 +-------+---------------------+---------------------+
@@ -39,7 +39,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
 +-------+---------------------+---------------------+

--- a/tests/cases/standalone/common/flow/basic.sql
+++ b/tests/cases/standalone/common/flow/basic.sql
@@ -16,7 +16,7 @@ VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
 -- SQLNESS SLEEP 500ms
@@ -25,7 +25,7 @@ VALUES
     (23,"2021-07-01 00:00:01.000"),
     (24,"2021-07-01 00:00:01.500");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
 DROP FLOW test_numbers;

--- a/tests/cases/standalone/common/flow/basic.sql
+++ b/tests/cases/standalone/common/flow/basic.sql
@@ -10,14 +10,16 @@ SINK TO out_num_cnt
 AS 
 SELECT sum(number) FROM numbers_input GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt;
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),

--- a/tests/cases/standalone/common/flow/df_func.result
+++ b/tests/cases/standalone/common/flow/df_func.result
@@ -24,7 +24,7 @@ VALUES
 Affected Rows: 2
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -41,7 +41,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -89,7 +89,7 @@ VALUES
 Affected Rows: 2
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -106,7 +106,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -153,7 +153,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +-------+---------------------+
@@ -170,7 +170,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +-------+---------------------+
@@ -217,7 +217,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +---------------------+-------+
@@ -234,7 +234,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +---------------------+-------+

--- a/tests/cases/standalone/common/flow/df_func.result
+++ b/tests/cases/standalone/common/flow/df_func.result
@@ -15,6 +15,7 @@ SELECT sum(abs(number)) FROM numbers_input_df_func GROUP BY tumble(ts, '1 second
 
 Affected Rows: 0
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (-20, "2021-07-01 00:00:00.200"),
@@ -23,7 +24,7 @@ VALUES
 Affected Rows: 2
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -32,6 +33,7 @@ SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 | 42    | 2021-07-01T00:00:00 | 2021-07-01T00:00:01 |
 +-------+---------------------+---------------------+
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -78,6 +80,7 @@ SELECT abs(sum(number)) FROM numbers_input_df_func GROUP BY tumble(ts, '1 second
 
 Affected Rows: 0
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (-20, "2021-07-01 00:00:00.200"),
@@ -86,7 +89,7 @@ VALUES
 Affected Rows: 2
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 +-------+---------------------+---------------------+
@@ -95,6 +98,7 @@ SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 | 2     | 2021-07-01T00:00:00 | 2021-07-01T00:00:01 |
 +-------+---------------------+---------------------+
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -141,6 +145,7 @@ SELECT max(number) - min(number), date_bin(INTERVAL '1 second', ts, '2021-07-01 
 
 Affected Rows: 0
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
@@ -148,7 +153,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +-------+---------------------+
@@ -157,6 +162,7 @@ SELECT col_0, col_1 FROM out_num_cnt;
 | 2     | 2021-07-01T00:00:00 |
 +-------+---------------------+
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -203,6 +209,7 @@ SELECT date_trunc('second', ts), sum(number) FROM numbers_input GROUP BY date_tr
 
 Affected Rows: 0
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
@@ -210,7 +217,7 @@ VALUES
 
 Affected Rows: 2
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 +---------------------+-------+
@@ -219,6 +226,7 @@ SELECT col_0, col_1 FROM out_num_cnt;
 | 2021-07-01T00:00:00 | 42    |
 +---------------------+-------+
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),

--- a/tests/cases/standalone/common/flow/df_func.sql
+++ b/tests/cases/standalone/common/flow/df_func.sql
@@ -11,15 +11,17 @@ SINK TO out_num_cnt_df_func
 AS 
 SELECT sum(abs(number)) FROM numbers_input_df_func GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (-20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -45,15 +47,17 @@ SINK TO out_num_cnt_df_func
 AS 
 SELECT abs(sum(number)) FROM numbers_input_df_func GROUP BY tumble(ts, '1 second', '2021-07-01 00:00:00');
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (-20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input_df_func 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -79,14 +83,16 @@ SINK TO out_num_cnt
 AS 
 SELECT max(number) - min(number), date_bin(INTERVAL '1 second', ts, '2021-07-01 00:00:00'::TimestampNanosecond) FROM numbers_input GROUP BY date_bin(INTERVAL '1 second', ts, '2021-07-01 00:00:00'::TimestampNanosecond);
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, col_1 FROM out_num_cnt;
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),
@@ -113,14 +119,16 @@ SINK TO out_num_cnt
 AS 
 SELECT date_trunc('second', ts), sum(number) FROM numbers_input GROUP BY date_trunc('second', ts);
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 3s
+-- SQLNESS SLEEP 2s
 SELECT col_0, col_1 FROM out_num_cnt;
 
+-- SQLNESS SLEEP 500ms
 INSERT INTO numbers_input 
 VALUES
     (23,"2021-07-01 00:00:01.000"),

--- a/tests/cases/standalone/common/flow/df_func.sql
+++ b/tests/cases/standalone/common/flow/df_func.sql
@@ -18,7 +18,7 @@ VALUES
     (22, "2021-07-01 00:00:00.600");
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 -- SQLNESS SLEEP 500ms
@@ -27,7 +27,7 @@ VALUES
     (23,"2021-07-01 00:00:01.000"),
     (-24,"2021-07-01 00:00:01.500");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 DROP FLOW test_numbers_df_func;
@@ -54,7 +54,7 @@ VALUES
     (22, "2021-07-01 00:00:00.600");
 
 -- sleep a little bit longer to make sure that table is created and data is inserted
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 -- SQLNESS SLEEP 500ms
@@ -63,7 +63,7 @@ VALUES
     (23,"2021-07-01 00:00:01.000"),
     (-24,"2021-07-01 00:00:01.500");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, window_start, window_end FROM out_num_cnt_df_func;
 
 DROP FLOW test_numbers_df_func;
@@ -89,7 +89,7 @@ VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 -- SQLNESS SLEEP 500ms
@@ -98,7 +98,7 @@ VALUES
     (23,"2021-07-01 00:00:01.000"),
     (24,"2021-07-01 00:00:01.500");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 DROP FLOW test_numbers;
@@ -125,7 +125,7 @@ VALUES
     (20, "2021-07-01 00:00:00.200"),
     (22, "2021-07-01 00:00:00.600");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 -- SQLNESS SLEEP 500ms
@@ -134,7 +134,7 @@ VALUES
     (23,"2021-07-01 00:00:01.000"),
     (24,"2021-07-01 00:00:01.500");
 
--- SQLNESS SLEEP 2s
+-- SQLNESS SLEEP 3s
 SELECT col_0, col_1 FROM out_num_cnt;
 
 DROP FLOW test_numbers;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add more sleep intrinsic in flow's sqlness test, so to make it more serial and prevent getting wrong result by preventing query to happen out of order

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Adjusted the timing of SQL operations for improved test efficiency.
  - Modified sleep durations in SQL scripts from 3 seconds to 2 seconds.
  - Introduced additional 500ms sleep commands to certain SQL queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->