### PR TITLE
chore: bump version to v0.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - "v*.*.*"
   schedule:
     # At 00:00 on Monday.
-    - cron: "0 0 * * 1"
+    - cron: '0 0 * * 1'
   workflow_dispatch: # Allows you to run this workflow manually.
     # Notes: The GitHub Actions ONLY support 10 inputs, and it's already used up.
     inputs:
@@ -168,7 +168,9 @@ jobs:
   build-linux-amd64-artifacts:
     name: Build linux-amd64 artifacts
     if: ${{ inputs.build_linux_amd64_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [allocate-runners]
+    needs: [
+      allocate-runners,
+    ]
     runs-on: ${{ needs.allocate-runners.outputs.linux-amd64-runner }}
     steps:
       - uses: actions/checkout@v4
@@ -185,7 +187,9 @@ jobs:
   build-linux-arm64-artifacts:
     name: Build linux-arm64 artifacts
     if: ${{ inputs.build_linux_arm64_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [allocate-runners]
+    needs: [
+      allocate-runners,
+    ]
     runs-on: ${{ needs.allocate-runners.outputs.linux-arm64-runner }}
     steps:
       - uses: actions/checkout@v4
@@ -224,7 +228,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       build-macos-result: ${{ steps.set-build-macos-result.outputs.build-macos-result }}
-    needs: [allocate-runners]
+    needs: [
+      allocate-runners,
+    ]
     if: ${{ inputs.build_macos_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
     steps:
       - uses: actions/checkout@v4
@@ -263,7 +269,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       build-windows-result: ${{ steps.set-build-windows-result.outputs.build-windows-result }}
-    needs: [allocate-runners]
+    needs: [
+      allocate-runners,
+    ]
     if: ${{ inputs.build_windows_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
     steps:
       - run: git config --global core.autocrlf false
@@ -290,12 +298,11 @@ jobs:
   release-images-to-dockerhub:
     name: Build and push images to DockerHub
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs:
-      [
-        allocate-runners,
-        build-linux-amd64-artifacts,
-        build-linux-arm64-artifacts,
-      ]
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+    ]
     runs-on: ubuntu-2004-16-cores
     outputs:
       build-image-result: ${{ steps.set-build-image-result.outputs.build-image-result }}
@@ -321,15 +328,14 @@ jobs:
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: # The job have to wait for all the artifacts are built.
-      [
-        allocate-runners,
-        build-linux-amd64-artifacts,
-        build-linux-arm64-artifacts,
-        build-macos-artifacts,
-        build-windows-artifacts,
-        release-images-to-dockerhub,
-      ]
+    needs: [ # The job have to wait for all the artifacts are built.
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+      build-macos-artifacts,
+      build-windows-artifacts,
+      release-images-to-dockerhub,
+    ]
     runs-on: ubuntu-20.04
     # When we push to ACR, it's easy to fail due to some unknown network issues.
     # However, we don't want to fail the whole workflow because of this.
@@ -362,15 +368,14 @@ jobs:
   publish-github-release:
     name: Create GitHub release and upload artifacts
     if: ${{ inputs.publish_github_release || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: # The job have to wait for all the artifacts are built.
-      [
-        allocate-runners,
-        build-linux-amd64-artifacts,
-        build-linux-arm64-artifacts,
-        build-macos-artifacts,
-        build-windows-artifacts,
-        release-images-to-dockerhub,
-      ]
+    needs: [ # The job have to wait for all the artifacts are built.
+      allocate-runners,
+      build-linux-amd64-artifacts,
+      build-linux-arm64-artifacts,
+      build-macos-artifacts,
+      build-windows-artifacts,
+      release-images-to-dockerhub,
+    ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -390,7 +395,10 @@ jobs:
     # Only run this job when the runner is allocated.
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: [allocate-runners, build-linux-amd64-artifacts]
+    needs: [
+      allocate-runners,
+      build-linux-amd64-artifacts,
+    ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -412,7 +420,10 @@ jobs:
     # Only run this job when the runner is allocated.
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: [allocate-runners, build-linux-arm64-artifacts]
+    needs: [
+      allocate-runners,
+      build-linux-arm64-artifacts,
+    ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -432,12 +443,11 @@ jobs:
   notification:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'push' || github.event_name == 'schedule') && always() }}
     name: Send notification to Greptime team
-    needs:
-      [
-        release-images-to-dockerhub,
-        build-macos-artifacts,
-        build-windows-artifacts,
-      ]
+    needs: [
+      release-images-to-dockerhub,
+      build-macos-artifacts,
+      build-windows-artifacts,
+    ]
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - "v*.*.*"
   schedule:
     # At 00:00 on Monday.
-    - cron: '0 0 * * 1'
+    - cron: "0 0 * * 1"
   workflow_dispatch: # Allows you to run this workflow manually.
     # Notes: The GitHub Actions ONLY support 10 inputs, and it's already used up.
     inputs:
@@ -91,7 +91,7 @@ env:
   # The scheduled version is '${{ env.NEXT_RELEASE_VERSION }}-nightly-YYYYMMDD', like v0.2.0-nigthly-20230313;
   NIGHTLY_RELEASE_PREFIX: nightly
   # Note: The NEXT_RELEASE_VERSION should be modified manually by every formal release.
-  NEXT_RELEASE_VERSION: v0.9.0
+  NEXT_RELEASE_VERSION: v0.10.0
 
 # Permission reference: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
 permissions:
@@ -168,9 +168,7 @@ jobs:
   build-linux-amd64-artifacts:
     name: Build linux-amd64 artifacts
     if: ${{ inputs.build_linux_amd64_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
-      allocate-runners,
-    ]
+    needs: [allocate-runners]
     runs-on: ${{ needs.allocate-runners.outputs.linux-amd64-runner }}
     steps:
       - uses: actions/checkout@v4
@@ -187,9 +185,7 @@ jobs:
   build-linux-arm64-artifacts:
     name: Build linux-arm64 artifacts
     if: ${{ inputs.build_linux_arm64_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
-      allocate-runners,
-    ]
+    needs: [allocate-runners]
     runs-on: ${{ needs.allocate-runners.outputs.linux-arm64-runner }}
     steps:
       - uses: actions/checkout@v4
@@ -228,9 +224,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       build-macos-result: ${{ steps.set-build-macos-result.outputs.build-macos-result }}
-    needs: [
-      allocate-runners,
-    ]
+    needs: [allocate-runners]
     if: ${{ inputs.build_macos_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
     steps:
       - uses: actions/checkout@v4
@@ -269,9 +263,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     outputs:
       build-windows-result: ${{ steps.set-build-windows-result.outputs.build-windows-result }}
-    needs: [
-      allocate-runners,
-    ]
+    needs: [allocate-runners]
     if: ${{ inputs.build_windows_artifacts || github.event_name == 'push' || github.event_name == 'schedule' }}
     steps:
       - run: git config --global core.autocrlf false
@@ -298,11 +290,12 @@ jobs:
   release-images-to-dockerhub:
     name: Build and push images to DockerHub
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [
-      allocate-runners,
-      build-linux-amd64-artifacts,
-      build-linux-arm64-artifacts,
-    ]
+    needs:
+      [
+        allocate-runners,
+        build-linux-amd64-artifacts,
+        build-linux-arm64-artifacts,
+      ]
     runs-on: ubuntu-2004-16-cores
     outputs:
       build-image-result: ${{ steps.set-build-image-result.outputs.build-image-result }}
@@ -328,14 +321,15 @@ jobs:
   release-cn-artifacts:
     name: Release artifacts to CN region
     if: ${{ inputs.release_images || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ # The job have to wait for all the artifacts are built.
-      allocate-runners,
-      build-linux-amd64-artifacts,
-      build-linux-arm64-artifacts,
-      build-macos-artifacts,
-      build-windows-artifacts,
-      release-images-to-dockerhub,
-    ]
+    needs: # The job have to wait for all the artifacts are built.
+      [
+        allocate-runners,
+        build-linux-amd64-artifacts,
+        build-linux-arm64-artifacts,
+        build-macos-artifacts,
+        build-windows-artifacts,
+        release-images-to-dockerhub,
+      ]
     runs-on: ubuntu-20.04
     # When we push to ACR, it's easy to fail due to some unknown network issues.
     # However, we don't want to fail the whole workflow because of this.
@@ -368,14 +362,15 @@ jobs:
   publish-github-release:
     name: Create GitHub release and upload artifacts
     if: ${{ inputs.publish_github_release || github.event_name == 'push' || github.event_name == 'schedule' }}
-    needs: [ # The job have to wait for all the artifacts are built.
-      allocate-runners,
-      build-linux-amd64-artifacts,
-      build-linux-arm64-artifacts,
-      build-macos-artifacts,
-      build-windows-artifacts,
-      release-images-to-dockerhub,
-    ]
+    needs: # The job have to wait for all the artifacts are built.
+      [
+        allocate-runners,
+        build-linux-amd64-artifacts,
+        build-linux-arm64-artifacts,
+        build-macos-artifacts,
+        build-windows-artifacts,
+        release-images-to-dockerhub,
+      ]
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -395,10 +390,7 @@ jobs:
     # Only run this job when the runner is allocated.
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: [
-      allocate-runners,
-      build-linux-amd64-artifacts,
-    ]
+    needs: [allocate-runners, build-linux-amd64-artifacts]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -420,10 +412,7 @@ jobs:
     # Only run this job when the runner is allocated.
     if: ${{ always() }}
     runs-on: ubuntu-20.04
-    needs: [
-      allocate-runners,
-      build-linux-arm64-artifacts,
-    ]
+    needs: [allocate-runners, build-linux-arm64-artifacts]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -443,11 +432,12 @@ jobs:
   notification:
     if: ${{ github.repository == 'GreptimeTeam/greptimedb' && (github.event_name == 'push' || github.event_name == 'schedule') && always() }}
     name: Send notification to Greptime team
-    needs: [
-      release-images-to-dockerhub,
-      build-macos-artifacts,
-      build-windows-artifacts,
-    ]
+    needs:
+      [
+        release-images-to-dockerhub,
+        build-macos-artifacts,
+        build-windows-artifacts,
+      ]
     runs-on: ubuntu-20.04
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DEVELOP_CHANNEL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "catalog",
  "common-error",
@@ -1285,7 +1285,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.3",
- "substrait 0.8.2",
+ "substrait 0.9.0",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow",
@@ -1637,7 +1637,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1667,7 +1667,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.3",
  "substrait 0.37.3",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "auth",
@@ -1753,7 +1753,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "temp-env",
  "tempfile",
@@ -1799,7 +1799,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "common-error",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "bigdecimal",
  "common-error",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "snafu 0.8.3",
  "strum 0.25.0",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "common-base",
@@ -2017,7 +2017,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anymap2",
  "api",
@@ -2099,11 +2099,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.8.2"
+version = "0.9.0"
 
 [[package]]
 name = "common-procedure"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2129,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "atty",
  "backtrace",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "client",
  "common-query",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "build-data",
  "const_format",
@@ -2269,7 +2269,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "common-base",
  "common-error",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3114,7 +3114,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "tokio",
  "toml 0.8.14",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow-schema",
@@ -3834,7 +3834,7 @@ dependencies = [
  "snafu 0.8.3",
  "store-api",
  "strum 0.25.0",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -3881,7 +3881,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5761,7 +5761,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "log-store"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6068,7 +6068,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6094,7 +6094,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -6261,7 +6261,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7155,7 +7155,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7200,7 +7200,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "tokio",
  "tokio-util",
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -7739,7 +7739,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow",
@@ -7897,7 +7897,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "auth",
  "common-base",
@@ -8166,7 +8166,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8401,7 +8401,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-compression 0.4.11",
  "async-trait",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8586,7 +8586,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "tokio",
  "tokio-stream",
@@ -9914,7 +9914,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -10207,7 +10207,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "aide",
  "api",
@@ -10313,7 +10313,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arc-swap",
@@ -10613,7 +10613,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "chrono",
@@ -10673,7 +10673,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "clap 4.5.7",
@@ -10890,7 +10890,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "aquamarine",
@@ -11058,7 +11058,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11259,7 +11259,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "async-trait",
@@ -11524,7 +11524,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -11566,7 +11566,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "api",
  "arrow-flight",
@@ -11626,7 +11626,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.8.2",
+ "substrait 0.9.0",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4364

## What's changed and what's your intention?
Bump version to v0.9.0

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project version to 0.9.0 in `Cargo.toml`.
  - Updated workflow configuration for the next release version to 0.10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->