### PR TITLE
refactor: add `&mut Plugins` argument in plugins setup api and remove unnecessary mut

### DIFF
--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use catalog::kvbackend::MetaKvBackend;
 use clap::Parser;
+use common_base::Plugins;
 use common_config::Configurable;
 use common_telemetry::logging::TracingOptions;
 use common_telemetry::{info, warn};
@@ -271,8 +272,9 @@ impl StartCommand {
         info!("Datanode start command: {:#?}", self);
         info!("Datanode options: {:#?}", opts);
 
-        let mut opts = opts.component;
-        let plugins = plugins::setup_datanode_plugins(&mut opts)
+        let opts = opts.component;
+        let mut plugins = Plugins::new();
+        plugins::setup_datanode_plugins(&mut plugins, &opts)
             .await
             .context(StartDatanodeSnafu)?;
 

--- a/src/cmd/src/metasrv.rs
+++ b/src/cmd/src/metasrv.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use clap::Parser;
+use common_base::Plugins;
 use common_config::Configurable;
 use common_telemetry::info;
 use common_telemetry::logging::TracingOptions;
@@ -238,8 +239,9 @@ impl StartCommand {
         info!("Metasrv start command: {:#?}", self);
         info!("Metasrv options: {:#?}", opts);
 
-        let mut opts = opts.component;
-        let plugins = plugins::setup_metasrv_plugins(&mut opts)
+        let opts = opts.component;
+        let mut plugins = Plugins::new();
+        plugins::setup_metasrv_plugins(&mut plugins, &opts)
             .await
             .context(StartMetaServerSnafu)?;
 

--- a/src/plugins/src/datanode.rs
+++ b/src/plugins/src/datanode.rs
@@ -16,8 +16,13 @@ use common_base::Plugins;
 use datanode::config::DatanodeOptions;
 use datanode::error::Result;
 
-pub async fn setup_datanode_plugins(_opts: &mut DatanodeOptions) -> Result<Plugins> {
-    Ok(Plugins::new())
+#[allow(unused_variables)]
+#[allow(unused_mut)]
+pub async fn setup_datanode_plugins(
+    plugins: &mut Plugins,
+    dn_opts: &DatanodeOptions,
+) -> Result<()> {
+    Ok(())
 }
 
 pub async fn start_datanode_plugins(_plugins: Plugins) -> Result<()> {

--- a/src/plugins/src/frontend.rs
+++ b/src/plugins/src/frontend.rs
@@ -18,16 +18,17 @@ use frontend::error::{IllegalAuthConfigSnafu, Result};
 use frontend::frontend::FrontendOptions;
 use snafu::ResultExt;
 
-pub async fn setup_frontend_plugins(opts: &FrontendOptions) -> Result<Plugins> {
-    let plugins = Plugins::new();
-
-    if let Some(user_provider) = opts.user_provider.as_ref() {
+#[allow(unused_mut)]
+pub async fn setup_frontend_plugins(
+    plugins: &mut Plugins,
+    fe_opts: &FrontendOptions,
+) -> Result<()> {
+    if let Some(user_provider) = fe_opts.user_provider.as_ref() {
         let provider =
             auth::user_provider_from_option(user_provider).context(IllegalAuthConfigSnafu)?;
         plugins.insert::<UserProviderRef>(provider);
     }
-
-    Ok(plugins)
+    Ok(())
 }
 
 pub async fn start_frontend_plugins(_plugins: Plugins) -> Result<()> {

--- a/src/plugins/src/meta_srv.rs
+++ b/src/plugins/src/meta_srv.rs
@@ -16,8 +16,12 @@ use common_base::Plugins;
 use meta_srv::error::Result;
 use meta_srv::metasrv::MetasrvOptions;
 
-pub async fn setup_metasrv_plugins(_opts: &mut MetasrvOptions) -> Result<Plugins> {
-    Ok(Plugins::new())
+#[allow(unused_variables)]
+pub async fn setup_metasrv_plugins(
+    _plugins: &mut Plugins,
+    metasrv_opts: &MetasrvOptions,
+) -> Result<()> {
+    Ok(())
 }
 
 pub async fn start_metasrv_plugins(_plugins: Plugins) -> Result<()> {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

**NOTE**: The PR will **break** the `setup_<role>_plugins()` API.

1. Add the `&mut Plugins` argument in the plugins setup API instead of creating `Plugins` inside since we need to add frontend and datanode plugins in standalone mode in one `Plugins`;

2. Remove unnecessary `mut` for `*Options`
   
   I think it's not a good practice to implicitly modify the `*Options` in the plugin setup API. We can modify the `*Options` from layered configuration, for example, environment variables, config file, etc;


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
