### PR TITLE
refactor!: Remove `Mode` from `FrontendOptions`

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -166,7 +166,6 @@
 
 | Key | Type | Default | Descriptions |
 | --- | -----| ------- | ----------- |
-| `mode` | String | `standalone` | The running mode of the datanode. It can be `standalone` or `distributed`. |
 | `default_timezone` | String | `None` | The default timezone of the server. |
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.read_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |

--- a/config/frontend.example.toml
+++ b/config/frontend.example.toml
@@ -1,6 +1,3 @@
-## The running mode of the datanode. It can be `standalone` or `distributed`.
-mode = "standalone"
-
 ## The default timezone of the server.
 ## +toml2docs:none-default
 default_timezone = "UTC"

--- a/src/cmd/src/frontend.rs
+++ b/src/cmd/src/frontend.rs
@@ -243,7 +243,6 @@ impl StartCommand {
                 .get_or_insert_with(MetaClientOptions::default)
                 .metasrv_addrs
                 .clone_from(metasrv_addrs);
-            opts.mode = Mode::Distributed;
         }
 
         if let Some(user_provider) = &self.user_provider {
@@ -317,7 +316,7 @@ impl StartCommand {
         );
 
         let catalog_manager = KvBackendCatalogManager::new(
-            opts.mode,
+            Mode::Distributed,
             Some(meta_client.clone()),
             cached_meta_backend.clone(),
             layered_cache_registry.clone(),
@@ -448,7 +447,6 @@ mod tests {
 
         let fe_opts = command.load_options(&Default::default()).unwrap().component;
 
-        assert_eq!(Mode::Distributed, fe_opts.mode);
         assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http.addr);
         assert_eq!(Duration::from_secs(30), fe_opts.http.timeout);
 

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -182,7 +182,6 @@ impl StandaloneOptions {
     pub fn frontend_options(&self) -> FrontendOptions {
         let cloned_opts = self.clone();
         FrontendOptions {
-            mode: cloned_opts.mode,
             default_timezone: cloned_opts.default_timezone,
             http: cloned_opts.http,
             grpc: cloned_opts.grpc,
@@ -636,7 +635,6 @@ mod tests {
     use common_test_util::temp_dir::create_named_temp_file;
     use common_wal::config::DatanodeWalConfig;
     use datanode::config::{FileConfig, GcsConfig};
-    use servers::Mode;
 
     use super::*;
     use crate::options::GlobalOptions;
@@ -736,7 +734,6 @@ mod tests {
         let fe_opts = options.frontend_options();
         let dn_opts = options.datanode_options();
         let logging_opts = options.logging;
-        assert_eq!(Mode::Standalone, fe_opts.mode);
         assert_eq!("127.0.0.1:4000".to_string(), fe_opts.http.addr);
         assert_eq!(Duration::from_secs(33), fe_opts.http.timeout);
         assert_eq!(ReadableSize::mb(128), fe_opts.http.body_limit);

--- a/src/frontend/src/frontend.rs
+++ b/src/frontend/src/frontend.rs
@@ -20,7 +20,6 @@ use servers::export_metrics::ExportMetricsOption;
 use servers::grpc::GrpcOptions;
 use servers::heartbeat_options::HeartbeatOptions;
 use servers::http::HttpOptions;
-use servers::Mode;
 
 use crate::service_config::{
     DatanodeOptions, InfluxdbOptions, MysqlOptions, OpentsdbOptions, OtlpOptions, PostgresOptions,
@@ -30,7 +29,6 @@ use crate::service_config::{
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct FrontendOptions {
-    pub mode: Mode,
     pub node_id: Option<String>,
     pub default_timezone: Option<String>,
     pub heartbeat: HeartbeatOptions,
@@ -53,7 +51,6 @@ pub struct FrontendOptions {
 impl Default for FrontendOptions {
     fn default() -> Self {
         Self {
-            mode: Mode::Standalone,
             node_id: None,
             default_timezone: None,
             heartbeat: HeartbeatOptions::frontend_default(),

--- a/src/frontend/src/server.rs
+++ b/src/frontend/src/server.rs
@@ -143,7 +143,15 @@ where
         };
 
         let user_provider = self.plugins.get::<UserProviderRef>();
-        let runtime = match opts.mode {
+
+        // Determine whether it is Standalone or Distributed mode based on whether the meta client is configured.
+        let mode = if opts.meta_client.is_none() {
+            Mode::Standalone
+        } else {
+            Mode::Distributed
+        };
+
+        let runtime = match mode {
             Mode::Standalone => Some(builder.runtime().clone()),
             _ => None,
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Resolve https://github.com/GreptimeTeam/greptimedb/issues/4399.

Remove `Mode` from `FrontendOptions` and determine whether it is Standalone or Distributed mode based on whether the Meta Client is configured.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
