### PR TITLE
chore: add a compile cfg for python in cmd package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ datanode = { path = "src/datanode" }
 datatypes = { path = "src/datatypes" }
 file-engine = { path = "src/file-engine" }
 flow = { path = "src/flow" }
-frontend = { path = "src/frontend" }
+frontend = { path = "src/frontend", default-features = false }
 index = { path = "src/index" }
 log-store = { path = "src/log-store" }
 meta-client = { path = "src/meta-client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ auth = { path = "src/auth" }
 cache = { path = "src/cache" }
 catalog = { path = "src/catalog" }
 client = { path = "src/client" }
-cmd = { path = "src/cmd" }
+cmd = { path = "src/cmd", default-features = false }
 common-base = { path = "src/common/base" }
 common-catalog = { path = "src/common/catalog" }
 common-config = { path = "src/common/config" }

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -10,7 +10,9 @@ name = "greptime"
 path = "src/bin/greptime.rs"
 
 [features]
+default = ["python"]
 tokio-console = ["common-telemetry/tokio-console"]
+python = ["frontend/python"]
 
 [lints]
 workspace = true
@@ -47,7 +49,7 @@ either = "1.8"
 etcd-client.workspace = true
 file-engine.workspace = true
 flow.workspace = true
-frontend.workspace = true
+frontend = { workspace = true, default-features = false }
 futures.workspace = true
 human-panic = "1.2.2"
 lazy_static.workspace = true

--- a/src/frontend/src/error.rs
+++ b/src/frontend/src/error.rs
@@ -274,6 +274,7 @@ pub enum Error {
         location: Location,
     },
 
+    #[cfg(feature = "python")]
     #[snafu(display("Failed to start script manager"))]
     StartScriptManager {
         #[snafu(implicit)]
@@ -438,6 +439,7 @@ impl ErrorExt for Error {
             Error::External { source, .. } => source.status_code(),
             Error::FindTableRoute { source, .. } => source.status_code(),
 
+            #[cfg(feature = "python")]
             Error::StartScriptManager { source, .. } => source.status_code(),
 
             Error::TableOperation { source, .. } => source.status_code(),

--- a/src/frontend/src/script.rs
+++ b/src/frontend/src/script.rs
@@ -13,19 +13,14 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use catalog::CatalogManagerRef;
-use common_error::ext::ErrorExt;
 use common_query::Output;
 use query::QueryEngineRef;
-use servers::query_handler::grpc::GrpcQueryHandler;
 use session::context::QueryContextRef;
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::instance::Instance;
-
-type FrontendGrpcQueryHandlerRef = Arc<dyn GrpcQueryHandler<Error = Error> + Send + Sync>;
 
 #[cfg(not(feature = "python"))]
 mod dummy {
@@ -41,7 +36,7 @@ mod dummy {
             Ok(Self {})
         }
 
-        pub fn start(&self, instance: &Instance) -> Result<()> {
+        pub fn start(&self, _instance: &Instance) -> Result<()> {
             Ok(())
         }
 
@@ -67,12 +62,14 @@ mod dummy {
 
 #[cfg(feature = "python")]
 mod python {
+    use std::sync::Arc;
+
     use api::v1::ddl_request::Expr;
     use api::v1::greptime_request::Request;
     use api::v1::DdlRequest;
     use arc_swap::ArcSwap;
     use catalog::RegisterSystemTableRequest;
-    use common_error::ext::BoxedError;
+    use common_error::ext::{BoxedError, ErrorExt};
     use common_telemetry::{error, info};
     use script::manager::ScriptManager;
     use servers::query_handler::grpc::GrpcQueryHandler;
@@ -81,7 +78,9 @@ mod python {
     use table::table_name::TableName;
 
     use super::*;
-    use crate::error::{CatalogSnafu, TableNotFoundSnafu};
+    use crate::error::{CatalogSnafu, Error, TableNotFoundSnafu};
+
+    type FrontendGrpcQueryHandlerRef = Arc<dyn GrpcQueryHandler<Error = Error> + Send + Sync>;
 
     /// A placeholder for the real gRPC handler.
     /// It is temporary and will be replaced soon.

--- a/src/frontend/src/script.rs
+++ b/src/frontend/src/script.rs
@@ -23,6 +23,7 @@ use servers::query_handler::grpc::GrpcQueryHandler;
 use session::context::QueryContextRef;
 
 use crate::error::{Error, Result};
+use crate::instance::Instance;
 
 type FrontendGrpcQueryHandlerRef = Arc<dyn GrpcQueryHandler<Error = Error> + Send + Sync>;
 
@@ -81,7 +82,6 @@ mod python {
 
     use super::*;
     use crate::error::{CatalogSnafu, TableNotFoundSnafu};
-    use crate::instance::Instance;
 
     /// A placeholder for the real gRPC handler.
     /// It is temporary and will be replaced soon.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add a "python" flag in `cmd` package so can turn off `python` feature when building `greptime` binary
i.e. `cargo build --release --bin greptime --no-default-feature`, note the `--no-default-feature` which turn off default features which in turn turn off `python` featue, since the only default features in `cmd` is `python`

LIMITATION: user who want to turn off `python` features might need to also figure out is there any features they want to keep because they need to pass `--no-default-features` first to turn off all default features

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
