### PR TITLE
chore: add more metrics about parquet and cache

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -19,6 +19,7 @@ use prometheus::*;
 pub const STAGE_LABEL: &str = "stage";
 /// Type label.
 pub const TYPE_LABEL: &str = "type";
+const CACHE_EVICTION_CAUSE: &str = "cause";
 /// Reason to flush.
 pub const FLUSH_REASON: &str = "reason";
 /// File type label.
@@ -194,7 +195,7 @@ lazy_static! {
     pub static ref CACHE_EVICTION: IntGaugeVec = register_int_gauge_vec!(
         "greptime_mito_cache_eviction",
         "mito cache eviction",
-        &[TYPE_LABEL, "cause"]
+        &[TYPE_LABEL, CACHE_EVICTION_CAUSE]
     ).unwrap();
     // ------- End of cache metrics.
 

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -192,7 +192,7 @@ lazy_static! {
     )
     .unwrap();
     /// Cache eviction counter, labeled with cache type and eviction reason.
-    pub static ref CACHE_EVICTION: IntGaugeVec = register_int_gauge_vec!(
+    pub static ref CACHE_EVICTION: IntCounterVec = register_int_counter_vec!(
         "greptime_mito_cache_eviction",
         "mito cache eviction",
         &[TYPE_LABEL, CACHE_EVICTION_CAUSE]

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -323,12 +323,4 @@ lazy_static! {
         "mito manifest operation elapsed",
         &["op"]
     ).unwrap();
-
-    // Parquet related metrics:
-
-    /// Elapsed time of loading parquet metadata.
-    pub static ref PARQUET_METADATA_LOAD_ELAPSED: Histogram = register_histogram!(
-        "greptime_parquet_metadata_load_elapsed",
-        "parquet metadata load elapsed",
-    ).unwrap();
 }

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -190,6 +190,12 @@ lazy_static! {
         "mito upload bytes total",
     )
     .unwrap();
+    /// Cache eviction counter, labeled with cache type and eviction reason.
+    pub static ref CACHE_EVICTION: IntGaugeVec = register_int_gauge_vec!(
+        "greptime_mito_cache_eviction",
+        "mito cache eviction",
+        &[TYPE_LABEL, "cause"]
+    ).unwrap();
     // ------- End of cache metrics.
 
     // Index metrics.
@@ -315,5 +321,13 @@ lazy_static! {
         "greptime_manifest_op_elapsed",
         "mito manifest operation elapsed",
         &["op"]
+    ).unwrap();
+
+    // Parquet related metrics:
+
+    /// Elapsed time of loading parquet metadata.
+    pub static ref PARQUET_METADATA_LOAD_ELAPSED: Histogram = register_histogram!(
+        "greptime_parquet_metadata_load_elapsed",
+        "parquet metadata load elapsed",
     ).unwrap();
 }

--- a/src/mito2/src/sst/parquet/metadata.rs
+++ b/src/mito2/src/sst/parquet/metadata.rs
@@ -19,7 +19,6 @@ use parquet::file::FOOTER_SIZE;
 use snafu::ResultExt;
 
 use crate::error::{self, Result};
-use crate::metrics::PARQUET_METADATA_LOAD_ELAPSED;
 
 /// The estimated size of the footer and metadata need to read from the end of parquet file.
 const DEFAULT_PREFETCH_SIZE: u64 = 64 * 1024;
@@ -68,8 +67,6 @@ impl<'a> MetadataLoader<'a> {
     ///
     /// Refer to https://github.com/apache/arrow-rs/blob/093a10e46203be1a0e94ae117854701bf58d4c79/parquet/src/arrow/async_reader/metadata.rs#L55-L106
     pub async fn load(&self) -> Result<ParquetMetaData> {
-        let _t = PARQUET_METADATA_LOAD_ELAPSED.start_timer();
-
         let object_store = &self.object_store;
         let path = self.file_path;
         let file_size = self.get_file_size().await?;

--- a/src/mito2/src/sst/parquet/metadata.rs
+++ b/src/mito2/src/sst/parquet/metadata.rs
@@ -19,6 +19,7 @@ use parquet::file::FOOTER_SIZE;
 use snafu::ResultExt;
 
 use crate::error::{self, Result};
+use crate::metrics::PARQUET_METADATA_LOAD_ELAPSED;
 
 /// The estimated size of the footer and metadata need to read from the end of parquet file.
 const DEFAULT_PREFETCH_SIZE: u64 = 64 * 1024;
@@ -67,6 +68,8 @@ impl<'a> MetadataLoader<'a> {
     ///
     /// Refer to https://github.com/apache/arrow-rs/blob/093a10e46203be1a0e94ae117854701bf58d4c79/parquet/src/arrow/async_reader/metadata.rs#L55-L106
     pub async fn load(&self) -> Result<ParquetMetaData> {
+        let _t = PARQUET_METADATA_LOAD_ELAPSED.start_timer();
+
         let object_store = &self.object_store;
         let path = self.file_path;
         let file_size = self.get_file_size().await?;

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -302,6 +302,10 @@ impl ParquetReaderBuilder {
         file_path: &str,
         file_size: u64,
     ) -> Result<Arc<ParquetMetaData>> {
+        let _t = READ_STAGE_ELAPSED
+            .with_label_values(&["read_parquet_metadata"])
+            .start_timer();
+
         let region_id = self.file_handle.region_id();
         let file_id = self.file_handle.file_id();
         // Tries to get from global cache.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

as title

useful for diagnosing slow queries

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a cache eviction metric for improved monitoring of cache performance.
	- Added a histogram metric to measure the time taken for loading Parquet metadata.

- **Improvements**
	- Enhanced observability of cache eviction reasons for better diagnostics.
	- Implemented performance tracking in the MetadataLoader for metadata loading efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->