### PR TITLE
chore: add metrics for log ingestion

### DIFF
--- a/src/servers/src/http/event.rs
+++ b/src/servers/src/http/event.rs
@@ -40,6 +40,7 @@ use crate::error::{
 use crate::http::greptime_manage_resp::GreptimedbManageResponse;
 use crate::http::greptime_result_v1::GreptimedbV1Response;
 use crate::http::HttpResponse;
+use crate::metrics::METRIC_HTTP_LOGS_INGESTION_ELAPSED;
 use crate::query_handler::LogHandlerRef;
 
 #[derive(Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -298,6 +299,11 @@ async fn ingest_logs_inner(
     pipeline_data: PipelineValue,
     query_ctx: QueryContextRef,
 ) -> Result<HttpResponse> {
+    let db = query_ctx.get_db_string();
+    let _timer = METRIC_HTTP_LOGS_INGESTION_ELAPSED
+        .with_label_values(&[db.as_str()])
+        .start_timer();
+
     let start = std::time::Instant::now();
 
     let pipeline = state

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -44,6 +44,10 @@ pub(crate) const METRIC_POSTGRES_SIMPLE_QUERY: &str = "simple";
 pub(crate) const METRIC_POSTGRES_EXTENDED_QUERY: &str = "extended";
 pub(crate) const METRIC_METHOD_LABEL: &str = "method";
 pub(crate) const METRIC_PATH_LABEL: &str = "path";
+pub(crate) const METRIC_RESULT_LABEL: &str = "result";
+
+pub(crate) const METRIC_SUCCESS_VALUE: &str = "success";
+pub(crate) const METRIC_FAILURE_VALUE: &str = "failure";
 
 lazy_static! {
     pub static ref METRIC_ERROR_COUNTER: IntCounterVec = register_int_counter_vec!(
@@ -130,11 +134,24 @@ lazy_static! {
             &[METRIC_DB_LABEL]
         )
         .unwrap();
+    pub static ref METRIC_HTTP_LOGS_INGESTION_COUNTER: IntCounterVec = register_int_counter_vec!(
+        "greptime_servers_http_logs_ingestion_counter",
+        "servers http logs ingestion counter",
+        &[METRIC_DB_LABEL]
+    )
+    .unwrap();
     pub static ref METRIC_HTTP_LOGS_INGESTION_ELAPSED: HistogramVec =
         register_histogram_vec!(
             "greptime_servers_http_logs_ingestion_elapsed",
             "servers http logs ingestion elapsed",
-            &[METRIC_DB_LABEL]
+            &[METRIC_DB_LABEL, METRIC_RESULT_LABEL]
+        )
+        .unwrap();
+    pub static ref METRIC_HTTP_LOGS_TRANSFORM_ELAPSED: HistogramVec =
+        register_histogram_vec!(
+            "greptime_servers_http_logs_transform_elapsed",
+            "servers http logs transform elapsed",
+            &[METRIC_DB_LABEL, METRIC_RESULT_LABEL]
         )
         .unwrap();
     pub static ref METRIC_MYSQL_CONNECTIONS: IntGauge = register_int_gauge!(

--- a/src/servers/src/metrics.rs
+++ b/src/servers/src/metrics.rs
@@ -130,6 +130,13 @@ lazy_static! {
             &[METRIC_DB_LABEL]
         )
         .unwrap();
+    pub static ref METRIC_HTTP_LOGS_INGESTION_ELAPSED: HistogramVec =
+        register_histogram_vec!(
+            "greptime_servers_http_logs_ingestion_elapsed",
+            "servers http logs ingestion elapsed",
+            &[METRIC_DB_LABEL]
+        )
+        .unwrap();
     pub static ref METRIC_MYSQL_CONNECTIONS: IntGauge = register_int_gauge!(
         "greptime_servers_mysql_connection_count",
         "servers mysql connection count"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr mainly adds three metrics for monitoring log ingestion
- ingestion elapsed
- ingestion counter
- transform (pipeline engine execution) elapsed

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
