### PR TITLE
fix(fulltext-index): clean up 0-value timer

### DIFF
--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -263,15 +263,13 @@ impl<'a> IndexerBuilder<'a> {
 
         let err = match creator {
             Ok(creator) => {
-                if creator.is_empty() {
+                if creator.is_none() {
                     debug!(
                         "Skip creating full-text index due to no columns require indexing, region_id: {}, file_id: {}",
                         self.metadata.region_id, self.file_id,
                     );
-                    return None;
-                } else {
-                    return Some(creator);
                 }
+                return creator;
             }
             Err(err) => err,
         };


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Metric `greptime_index_create_elapsed_bucket` reports non-zero values even though no index needs to be built.

![image](https://github.com/user-attachments/assets/b349e111-a0b0-4878-930d-1882dcd2d82c)

This patch fixes it.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
