### PR TITLE
refactor: add RetryInterceptor to print detailed error

### DIFF
--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -25,11 +25,11 @@ use std::time::Duration;
 use std::{env, path};
 
 use common_base::readable_size::ReadableSize;
-use common_telemetry::info;
-use object_store::layers::{LruCacheLayer, RetryLayer};
+use common_telemetry::{info, warn};
+use object_store::layers::{LruCacheLayer, RetryInterceptor, RetryLayer};
 use object_store::services::Fs;
 use object_store::util::{join_dir, normalize_dir, with_instrument_layers};
-use object_store::{HttpClient, ObjectStore, ObjectStoreBuilder};
+use object_store::{Error, HttpClient, ObjectStore, ObjectStoreBuilder};
 use snafu::prelude::*;
 
 use crate::config::{ObjectStoreConfig, DEFAULT_OBJECT_STORE_CACHE_SIZE};
@@ -55,7 +55,11 @@ pub(crate) async fn new_object_store(
     // Enable retry layer and cache layer for non-fs object storages
     let object_store = if !matches!(store, ObjectStoreConfig::File(..)) {
         let object_store = create_object_store_with_cache(object_store, &store).await?;
-        object_store.layer(RetryLayer::new().with_jitter())
+        object_store.layer(
+            RetryLayer::new()
+                .with_jitter()
+                .with_notify(PrintDetailedError),
+        )
     } else {
         object_store
     };
@@ -170,4 +174,13 @@ pub(crate) fn build_http_client() -> Result<HttpClient> {
     };
 
     HttpClient::build(http_builder).context(error::InitBackendSnafu)
+}
+
+struct PrintDetailedError;
+
+// PrintDetailedError is a retry interceptor that prints error in Debug format in retrying.
+impl RetryInterceptor for PrintDetailedError {
+    fn intercept(&self, err: &Error, dur: Duration) {
+        warn!("Retry after {}s, error: {:#?}", dur.as_secs_f64(), err);
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

As the [issue](https://github.com/apache/opendal/issues/4918) mentions, we want to print detailed messages when an error occurs to help us troubleshoot.

The PR adds the `PrintDetailedError`, which implements `RetryInterceptor` to print `Error` in `Debug` format in retrying.

@evenyag Do we need a configuration to control whether we add the `RetryInterceptor`?

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
