### PR TITLE
fix: use heartbeat runtime instead of background runtime

### DIFF
--- a/src/datanode/src/alive_keeper.rs
+++ b/src/datanode/src/alive_keeper.rs
@@ -286,7 +286,7 @@ impl CountdownTaskHandle {
             region_id,
             rx,
         };
-        let handler = common_runtime::spawn_bg(async move {
+        let handler = common_runtime::spawn_hb(async move {
             countdown_task.run().await;
         });
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

use heartbeat runtime instead of background runtime

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
