### PR TITLE
fix(fulltext-search): prune rows in row group forget to take remainder

### DIFF
--- a/src/mito2/src/sst/parquet/row_selection.rs
+++ b/src/mito2/src/sst/parquet/row_selection.rs
@@ -53,14 +53,14 @@ pub(crate) fn row_selection_from_row_ranges(
 /// Note: the input iterator must be sorted in ascending order and
 ///       contain unique row IDs in the range [0, total_row_count).
 pub(crate) fn row_selection_from_sorted_row_ids(
-    row_ids: impl Iterator<Item = u32>,
+    row_ids: impl Iterator<Item = usize>,
     total_row_count: usize,
 ) -> RowSelection {
     let mut selectors: Vec<RowSelector> = Vec::new();
     let mut last_processed_end = 0;
 
     for row_id in row_ids {
-        let start = row_id as usize;
+        let start = row_id;
         let end = start + 1;
 
         if start > last_processed_end {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Forgot to take the remainder before passing row ids to `prune_row_groups_by_rows`. Fixed it on this patch.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
