### PR TITLE
feat: track channels with query context and w/rcu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,7 +4234,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e52fa3e63c77545618328781e11178eb2cfc45c5#e52fa3e63c77545618328781e11178eb2cfc45c5"
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=c437b55725b7f5224fe9d46db21072b4a682ee4b#c437b55725b7f5224fe9d46db21072b4a682ee4b"
 dependencies = [
  "prost 0.12.6",
  "serde",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "meter-core"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=488844b4702916cc6f7d04898fb0b837afce4ca7#488844b4702916cc6f7d04898fb0b837afce4ca7"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=049171eb16cb4249d8099751a0c46750d1fe88e7#049171eb16cb4249d8099751a0c46750d1fe88e7"
 dependencies = [
  "anymap",
  "once_cell",
@@ -6165,7 +6165,7 @@ dependencies = [
 [[package]]
 name = "meter-macros"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=488844b4702916cc6f7d04898fb0b837afce4ca7#488844b4702916cc6f7d04898fb0b837afce4ca7"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=049171eb16cb4249d8099751a0c46750d1fe88e7#049171eb16cb4249d8099751a0c46750d1fe88e7"
 dependencies = [
  "meter-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,11 +4234,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
-<<<<<<< HEAD
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=7ca323090b3ae8faf2c15036b7f41b7c5225cf5f#7ca323090b3ae8faf2c15036b7f41b7c5225cf5f"
-=======
-source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=fffd0b37cd258fa32677983cc36c5f1f2ef925b8#fffd0b37cd258fa32677983cc36c5f1f2ef925b8"
->>>>>>> 3a8cc2a62f (feat: add source channel to meter recorders)
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=e52fa3e63c77545618328781e11178eb2cfc45c5#e52fa3e63c77545618328781e11178eb2cfc45c5"
 dependencies = [
  "prost 0.12.6",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4234,7 +4234,11 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 [[package]]
 name = "greptime-proto"
 version = "0.1.0"
+<<<<<<< HEAD
 source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=7ca323090b3ae8faf2c15036b7f41b7c5225cf5f#7ca323090b3ae8faf2c15036b7f41b7c5225cf5f"
+=======
+source = "git+https://github.com/GreptimeTeam/greptime-proto.git?rev=fffd0b37cd258fa32677983cc36c5f1f2ef925b8#fffd0b37cd258fa32677983cc36c5f1f2ef925b8"
+>>>>>>> 3a8cc2a62f (feat: add source channel to meter recorders)
 dependencies = [
  "prost 0.12.6",
  "serde",
@@ -6155,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "meter-core"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=80b72716dcde47ec4161478416a5c6c21343364d#80b72716dcde47ec4161478416a5c6c21343364d"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=488844b4702916cc6f7d04898fb0b837afce4ca7#488844b4702916cc6f7d04898fb0b837afce4ca7"
 dependencies = [
  "anymap",
  "once_cell",
@@ -6165,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "meter-macros"
 version = "0.1.0"
-source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=80b72716dcde47ec4161478416a5c6c21343364d#80b72716dcde47ec4161478416a5c6c21343364d"
+source = "git+https://github.com/GreptimeTeam/greptime-meter.git?rev=488844b4702916cc6f7d04898fb0b837afce4ca7#488844b4702916cc6f7d04898fb0b837afce4ca7"
 dependencies = [
  "meter-core",
 ]
@@ -10326,6 +10330,7 @@ dependencies = [
  "common-telemetry",
  "common-time",
  "derive_builder 0.12.0",
+ "meter-core",
  "snafu 0.8.3",
  "sql",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,12 +119,12 @@ etcd-client = { version = "0.13" }
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e52fa3e63c77545618328781e11178eb2cfc45c5" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "c437b55725b7f5224fe9d46db21072b4a682ee4b" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"
-meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "488844b4702916cc6f7d04898fb0b837afce4ca7" }
+meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "049171eb16cb4249d8099751a0c46750d1fe88e7" }
 mockall = "0.11.4"
 moka = "0.12"
 notify = "6.1"
@@ -238,7 +238,7 @@ table = { path = "src/table" }
 
 [workspace.dependencies.meter-macros]
 git = "https://github.com/GreptimeTeam/greptime-meter.git"
-rev = "488844b4702916cc6f7d04898fb0b837afce4ca7"
+rev = "049171eb16cb4249d8099751a0c46750d1fe88e7"
 
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,12 +119,13 @@ etcd-client = { version = "0.13" }
 fst = "0.4.7"
 futures = "0.3"
 futures-util = "0.3"
-greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "7ca323090b3ae8faf2c15036b7f41b7c5225cf5f" }
+greptime-proto = { git = "https://github.com/GreptimeTeam/greptime-proto.git", rev = "e52fa3e63c77545618328781e11178eb2cfc45c5" }
 humantime = "2.1"
 humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"
-meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "80b72716dcde47ec4161478416a5c6c21343364d" }
+meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "488844b4702916cc6f7d04898fb0b837afce4ca7" }
+meter-macros = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "488844b4702916cc6f7d04898fb0b837afce4ca7" }
 mockall = "0.11.4"
 moka = "0.12"
 notify = "6.1"
@@ -235,10 +236,6 @@ sql = { path = "src/sql" }
 store-api = { path = "src/store-api" }
 substrait = { path = "src/common/substrait" }
 table = { path = "src/table" }
-
-[workspace.dependencies.meter-macros]
-git = "https://github.com/GreptimeTeam/greptime-meter.git"
-rev = "80b72716dcde47ec4161478416a5c6c21343364d"
 
 [profile.release]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ humantime-serde = "1.1"
 itertools = "0.10"
 lazy_static = "1.4"
 meter-core = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "488844b4702916cc6f7d04898fb0b837afce4ca7" }
-meter-macros = { git = "https://github.com/GreptimeTeam/greptime-meter.git", rev = "488844b4702916cc6f7d04898fb0b837afce4ca7" }
 mockall = "0.11.4"
 moka = "0.12"
 notify = "6.1"
@@ -236,6 +235,10 @@ sql = { path = "src/sql" }
 store-api = { path = "src/store-api" }
 substrait = { path = "src/common/substrait" }
 table = { path = "src/table" }
+
+[workspace.dependencies.meter-macros]
+git = "https://github.com/GreptimeTeam/greptime-meter.git"
+rev = "488844b4702916cc6f7d04898fb0b837afce4ca7"
 
 [profile.release]
 debug = 1

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1073,7 +1073,6 @@ impl From<DropFlowTask> for PbDropFlowTask {
     }
 }
 
-// TODO(sunng87): refactor this to avoid duplication
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryContext {
     current_catalog: String,

--- a/src/common/meta/src/rpc/ddl.rs
+++ b/src/common/meta/src/rpc/ddl.rs
@@ -1073,12 +1073,14 @@ impl From<DropFlowTask> for PbDropFlowTask {
     }
 }
 
+// TODO(sunng87): refactor this to avoid duplication
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryContext {
     current_catalog: String,
     current_schema: String,
     timezone: String,
     extensions: HashMap<String, String>,
+    channel: u8,
 }
 
 impl From<QueryContextRef> for QueryContext {
@@ -1088,6 +1090,7 @@ impl From<QueryContextRef> for QueryContext {
             current_schema: query_context.current_schema().to_string(),
             timezone: query_context.timezone().to_string(),
             extensions: query_context.extensions(),
+            channel: query_context.channel() as u8,
         }
     }
 }
@@ -1099,6 +1102,7 @@ impl From<QueryContext> for PbQueryContext {
             current_schema,
             timezone,
             extensions,
+            channel,
         }: QueryContext,
     ) -> Self {
         PbQueryContext {
@@ -1106,6 +1110,7 @@ impl From<QueryContext> for PbQueryContext {
             current_schema,
             timezone,
             extensions,
+            channel: channel as u32,
         }
     }
 }

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -270,7 +270,12 @@ impl Inserter {
         requests: RegionInsertRequests,
         ctx: &QueryContextRef,
     ) -> Result<Output> {
-        let write_cost = write_meter!(ctx.current_catalog(), ctx.current_schema(), requests);
+        let write_cost = write_meter!(
+            ctx.current_catalog(),
+            ctx.current_schema(),
+            requests,
+            ctx.channel() as u8
+        );
         let request_factory = RegionRequestFactory::new(RegionRequestHeader {
             tracing_context: TracingContext::from_current_span().to_w3c(),
             dbname: ctx.get_db_string(),

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -194,6 +194,7 @@ impl MergeScanExec {
         let tracing_context = TracingContext::from_json(context.session_id().as_str());
         let current_catalog = self.query_ctx.current_catalog().to_string();
         let current_schema = self.query_ctx.current_schema().to_string();
+        let current_channel = self.query_ctx.channel();
         let timezone = self.query_ctx.timezone().to_string();
         let extensions = self.query_ctx.extensions();
         let target_partition = self.target_partition;
@@ -221,6 +222,7 @@ impl MergeScanExec {
                             current_schema: current_schema.clone(),
                             timezone: timezone.clone(),
                             extensions: extensions.clone(),
+                            channel: current_channel as u32,
                         }),
                     }),
                     region_id,
@@ -266,7 +268,8 @@ impl MergeScanExec {
                         ReadItem {
                             cpu_time: metrics.elapsed_compute as u64,
                             table_scan: metrics.memory_usage as u64
-                        }
+                        },
+                        current_channel as u8
                     );
                     metric.record_greptime_exec_cost(value as usize);
 

--- a/src/servers/src/grpc/authorize.rs
+++ b/src/servers/src/grpc/authorize.rs
@@ -138,7 +138,7 @@ mod tests {
     use base64::Engine;
     use headers::Header;
     use hyper::{Body, Request};
-    use session::context::QueryContextRef;
+    use session::context::QueryContext;
 
     use crate::grpc::authorize::do_auth;
     use crate::http::header::GreptimeDbName;
@@ -196,7 +196,7 @@ mod tests {
         expected_schema: &str,
         expected_user_name: &str,
     ) {
-        let ctx = req.extensions().get::<QueryContextRef>().unwrap();
+        let ctx = req.extensions().get::<QueryContext>().unwrap();
         assert_eq!(expected_catalog, ctx.current_catalog());
         assert_eq!(expected_schema, ctx.current_schema());
 

--- a/src/servers/src/grpc/authorize.rs
+++ b/src/servers/src/grpc/authorize.rs
@@ -14,12 +14,11 @@
 
 use std::pin::Pin;
 use std::result::Result as StdResult;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use auth::UserProviderRef;
 use hyper::Body;
-use session::context::QueryContext;
+use session::context::{Channel, QueryContext};
 use tonic::body::BoxBody;
 use tonic::server::NamedService;
 use tower::{Layer, Service};
@@ -105,7 +104,7 @@ async fn do_auth<T>(
 ) -> Result<(), tonic::Status> {
     let (catalog, schema) = extract_catalog_and_schema(req);
 
-    let query_ctx = Arc::new(QueryContext::with(&catalog, &schema));
+    let query_ctx = QueryContext::with_channel(&catalog, &schema, Channel::Grpc);
 
     let Some(user_provider) = user_provider else {
         query_ctx.set_current_user(auth::userinfo_by_name(None));

--- a/src/servers/src/http/authorize.rs
+++ b/src/servers/src/http/authorize.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use ::auth::UserProviderRef;
 use axum::extract::State;
 use axum::http::{self, Request, StatusCode};
@@ -68,7 +66,7 @@ pub async fn inner_auth<B>(
         .current_schema(schema.clone())
         .timezone(timezone);
 
-    let query_ctx = Arc::new(query_ctx_builder.build());
+    let query_ctx = query_ctx_builder.build();
     let need_auth = need_auth(&req);
 
     // 2. check if auth is needed

--- a/src/servers/src/http/influxdb.rs
+++ b/src/servers/src/http/influxdb.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -21,7 +22,7 @@ use axum::Extension;
 use common_catalog::consts::DEFAULT_SCHEMA_NAME;
 use common_grpc::precision::Precision;
 use common_telemetry::tracing;
-use session::context::QueryContextRef;
+use session::context::{Channel, QueryContext, QueryContextRef};
 
 use super::header::write_cost_header_map;
 use crate::error::{Result, TimePrecisionSnafu};
@@ -45,12 +46,14 @@ pub async fn influxdb_health() -> Result<impl IntoResponse> {
 pub async fn influxdb_write_v1(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    Extension(query_ctx): Extension<QueryContextRef>,
+    Extension(mut query_ctx): Extension<QueryContext>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = params
         .remove("db")
         .unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_string());
+    query_ctx.set_channel(Channel::Influx);
+    let query_ctx = Arc::new(query_ctx);
 
     let precision = params
         .get("precision")
@@ -65,7 +68,7 @@ pub async fn influxdb_write_v1(
 pub async fn influxdb_write_v2(
     State(handler): State<InfluxdbLineProtocolHandlerRef>,
     Query(mut params): Query<HashMap<String, String>>,
-    Extension(query_ctx): Extension<QueryContextRef>,
+    Extension(mut query_ctx): Extension<QueryContext>,
     lines: String,
 ) -> Result<impl IntoResponse> {
     let db = match (params.remove("db"), params.remove("bucket")) {
@@ -73,6 +76,8 @@ pub async fn influxdb_write_v2(
         (Some(db), None) => db.clone(),
         _ => DEFAULT_SCHEMA_NAME.to_string(),
     };
+    query_ctx.set_channel(Channel::Influx);
+    let query_ctx = Arc::new(query_ctx);
 
     let precision = params
         .get("precision")

--- a/src/servers/tests/http/authorize.rs
+++ b/src/servers/tests/http/authorize.rs
@@ -20,14 +20,14 @@ use axum::http;
 use http_body::Body;
 use hyper::{Request, StatusCode};
 use servers::http::authorize::inner_auth;
-use session::context::QueryContextRef;
+use session::context::QueryContext;
 
 #[tokio::test]
 async fn test_http_auth() {
     // base64encode("username:password") == "dXNlcm5hbWU6cGFzc3dvcmQ="
     let req = mock_http_request(Some("Basic dXNlcm5hbWU6cGFzc3dvcmQ="), None).unwrap();
     let req = inner_auth(None, req).await.unwrap();
-    let ctx: &QueryContextRef = req.extensions().get().unwrap();
+    let ctx: &QueryContext = req.extensions().get().unwrap();
     let user_info = ctx.current_user();
     let default = auth::userinfo_by_name(None);
     assert_eq!(default.username(), user_info.username());
@@ -38,7 +38,7 @@ async fn test_http_auth() {
     // base64encode("greptime:greptime") == "Z3JlcHRpbWU6Z3JlcHRpbWU="
     let req = mock_http_request(Some("Basic Z3JlcHRpbWU6Z3JlcHRpbWU="), None).unwrap();
     let req = inner_auth(mock_user_provider.clone(), req).await.unwrap();
-    let ctx: &QueryContextRef = req.extensions().get().unwrap();
+    let ctx: &QueryContext = req.extensions().get().unwrap();
     let user_info = ctx.current_user();
     let default = auth::userinfo_by_name(None);
     assert_eq!(default.username(), user_info.username());
@@ -79,7 +79,7 @@ async fn test_schema_validating() {
     )
     .unwrap();
     let req = inner_auth(mock_user_provider.clone(), req).await.unwrap();
-    let ctx: &QueryContextRef = req.extensions().get().unwrap();
+    let ctx: &QueryContext = req.extensions().get().unwrap();
     let user_info = ctx.current_user();
     let default = auth::userinfo_by_name(None);
     assert_eq!(default.username(), user_info.username());

--- a/src/servers/tests/http/http_handler_test.rs
+++ b/src/servers/tests/http/http_handler_test.rs
@@ -40,7 +40,7 @@ use crate::{
 #[tokio::test]
 async fn test_sql_not_provided() {
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
-    let ctx = QueryContext::arc();
+    let ctx = QueryContext::with_db_name(None);
     ctx.set_current_user(auth::userinfo_by_name(None));
     let api_state = ApiState {
         sql_handler,
@@ -74,7 +74,7 @@ async fn test_sql_output_rows() {
 
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
-    let ctx = QueryContext::arc();
+    let ctx = QueryContext::with_db_name(None);
     ctx.set_current_user(auth::userinfo_by_name(None));
     let api_state = ApiState {
         sql_handler,
@@ -180,7 +180,7 @@ async fn test_sql_output_rows() {
 #[tokio::test]
 async fn test_dashboard_sql_limit() {
     let sql_handler = create_testing_sql_query_handler(MemTable::specified_numbers_table(2000));
-    let ctx = QueryContext::arc();
+    let ctx = QueryContext::with_db_name(None);
     ctx.set_current_user(auth::userinfo_by_name(None));
     let api_state = ApiState {
         sql_handler,
@@ -226,7 +226,7 @@ async fn test_sql_form() {
 
     let sql_handler = create_testing_sql_query_handler(MemTable::default_numbers_table());
 
-    let ctx = QueryContext::arc();
+    let ctx = QueryContext::with_db_name(None);
     ctx.set_current_user(auth::userinfo_by_name(None));
     let api_state = ApiState {
         sql_handler,

--- a/src/session/Cargo.toml
+++ b/src/session/Cargo.toml
@@ -20,5 +20,6 @@ common-macro.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
 derive_builder.workspace = true
+meter-core.workspace = true
 snafu.workspace = true
 sql.workspace = true

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -149,6 +149,14 @@ impl QueryContext {
             .build()
     }
 
+    pub fn with_channel(catalog: &str, schema: &str, channel: Channel) -> QueryContext {
+        QueryContextBuilder::default()
+            .current_catalog(catalog.to_string())
+            .current_schema(schema.to_string())
+            .channel(channel)
+            .build()
+    }
+
     pub fn with_db_name(db_name: Option<&str>) -> QueryContext {
         let (catalog, schema) = db_name
             .map(|db| {
@@ -253,7 +261,7 @@ impl QueryContextBuilder {
                 .unwrap_or_else(|| Arc::new(GreptimeDbDialect {})),
             extensions: self.extensions.unwrap_or_default(),
             configuration_parameter: self.configuration_parameter.unwrap_or_default(),
-            channel: self.channel.unwrap_or_default().into(),
+            channel: self.channel.unwrap_or_default(),
         }
     }
 

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -310,7 +310,7 @@ impl ConnInfo {
 #[repr(u8)]
 pub enum Channel {
     #[default]
-    Other = 0,
+    Unknown = 0,
 
     Mysql = 1,
     Postgres = 2,
@@ -334,7 +334,7 @@ impl From<u32> for Channel {
             7 => Self::Influx,
             8 => Self::Opentsdb,
 
-            _ => Self::Other,
+            _ => Self::Unknown,
         }
     }
 }
@@ -360,7 +360,7 @@ impl Display for Channel {
             Channel::Grpc => write!(f, "grpc"),
             Channel::Influx => write!(f, "influx"),
             Channel::Opentsdb => write!(f, "opentsdb"),
-            Channel::Other => write!(f, "other"),
+            Channel::Unknown => write!(f, "unknown"),
         }
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -25,7 +25,7 @@ use common_catalog::{build_db_string, parse_catalog_and_schema_from_db_string};
 use common_time::timezone::parse_timezone;
 use common_time::Timezone;
 use derive_builder::Builder;
-use sql::dialect::{Dialect, GreptimeDbDialect, MySqlDialect, PostgreSqlDialect};
+use sql::dialect::{Dialect, GenericDialect, GreptimeDbDialect, MySqlDialect, PostgreSqlDialect};
 
 use crate::session_config::{PGByteaOutputValue, PGDateOrder, PGDateTimeStyle};
 use crate::MutableInner;
@@ -47,6 +47,9 @@ pub struct QueryContext {
     // The configuration parameter are used to store the parameters that are set by the user
     #[builder(default)]
     configuration_parameter: Arc<ConfigurationVariables>,
+    // Track which protocol the query comes from.
+    #[builder(default)]
+    channel: Channel,
 }
 
 impl Display for QueryContext {
@@ -94,7 +97,8 @@ impl From<&RegionRequestHeader> for QueryContext {
                 .current_catalog(ctx.current_catalog.clone())
                 .current_schema(ctx.current_schema.clone())
                 .timezone(parse_timezone(Some(&ctx.timezone)))
-                .extensions(ctx.extensions.clone());
+                .extensions(ctx.extensions.clone())
+                .channel(ctx.channel.into());
         }
         builder.build()
     }
@@ -107,6 +111,7 @@ impl From<api::v1::QueryContext> for QueryContext {
             .current_schema(ctx.current_schema)
             .timezone(parse_timezone(Some(&ctx.timezone)))
             .extensions(ctx.extensions)
+            .channel(ctx.channel.into())
             .build()
     }
 }
@@ -117,6 +122,7 @@ impl From<QueryContext> for api::v1::QueryContext {
             current_catalog,
             mutable_inner,
             extensions,
+            channel,
             ..
         }: QueryContext,
     ) -> Self {
@@ -126,6 +132,7 @@ impl From<QueryContext> for api::v1::QueryContext {
             current_schema: mutable_inner.schema.clone(),
             timezone: mutable_inner.timezone.to_string(),
             extensions,
+            channel: channel as u32,
         }
     }
 }
@@ -224,6 +231,14 @@ impl QueryContext {
     pub fn configuration_parameter(&self) -> &ConfigurationVariables {
         &self.configuration_parameter
     }
+
+    pub fn channel(&self) -> Channel {
+        self.channel
+    }
+
+    pub fn set_channel(&mut self, channel: Channel) {
+        self.channel = channel;
+    }
 }
 
 impl QueryContextBuilder {
@@ -238,6 +253,7 @@ impl QueryContextBuilder {
                 .unwrap_or_else(|| Arc::new(GreptimeDbDialect {})),
             extensions: self.extensions.unwrap_or_default(),
             configuration_parameter: self.configuration_parameter.unwrap_or_default(),
+            channel: self.channel.unwrap_or_default().into(),
         }
     }
 
@@ -256,6 +272,7 @@ impl QueryContextBuilder {
             sql_dialect: Some(context.sql_dialect.clone()),
             extensions: Some(context.extensions.clone()),
             configuration_parameter: Some(context.configuration_parameter.clone()),
+            channel: Some(context.channel),
         }
     }
 }
@@ -289,10 +306,35 @@ impl ConnInfo {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default, Clone, Copy)]
+#[repr(u8)]
 pub enum Channel {
-    Mysql,
-    Postgres,
+    #[default]
+    Other = 0,
+
+    Mysql = 1,
+    Postgres = 2,
+    Http = 3,
+    Prometheus = 4,
+    Otlp = 5,
+    Grpc = 6,
+    Influx = 7,
+}
+
+impl From<u32> for Channel {
+    fn from(value: u32) -> Self {
+        match value {
+            1 => Self::Mysql,
+            2 => Self::Postgres,
+            3 => Self::Http,
+            4 => Self::Prometheus,
+            5 => Self::Otlp,
+            6 => Self::Grpc,
+            7 => Self::Influx,
+
+            _ => Self::Other,
+        }
+    }
 }
 
 impl Channel {
@@ -300,6 +342,7 @@ impl Channel {
         match self {
             Channel::Mysql => Arc::new(MySqlDialect {}),
             Channel::Postgres => Arc::new(PostgreSqlDialect {}),
+            _ => Arc::new(GenericDialect {}),
         }
     }
 }
@@ -309,6 +352,12 @@ impl Display for Channel {
         match self {
             Channel::Mysql => write!(f, "mysql"),
             Channel::Postgres => write!(f, "postgres"),
+            Channel::Http => write!(f, "http"),
+            Channel::Prometheus => write!(f, "prometheus"),
+            Channel::Otlp => write!(f, "otlp"),
+            Channel::Grpc => write!(f, "grpc"),
+            Channel::Influx => write!(f, "influx"),
+            Channel::Other => write!(f, "other"),
         }
     }
 }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -187,6 +187,10 @@ impl QueryContext {
         &self.current_catalog
     }
 
+    pub fn set_current_catalog(&mut self, new_catalog: &str) {
+        self.current_catalog = new_catalog.to_string();
+    }
+
     pub fn sql_dialect(&self) -> &(dyn Dialect + Send + Sync) {
         &*self.sql_dialect
     }
@@ -270,18 +274,6 @@ impl QueryContextBuilder {
             .get_or_insert_with(HashMap::new)
             .insert(key, value);
         self
-    }
-
-    pub fn from_existing(context: &QueryContext) -> QueryContextBuilder {
-        QueryContextBuilder {
-            current_catalog: Some(context.current_catalog.clone()),
-            // note that this is a shallow copy
-            mutable_inner: Some(context.mutable_inner.clone()),
-            sql_dialect: Some(context.sql_dialect.clone()),
-            extensions: Some(context.extensions.clone()),
-            configuration_parameter: Some(context.configuration_parameter.clone()),
-            channel: Some(context.channel),
-        }
     }
 }
 

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -327,6 +327,7 @@ pub enum Channel {
     Otlp = 5,
     Grpc = 6,
     Influx = 7,
+    Opentsdb = 8,
 }
 
 impl From<u32> for Channel {
@@ -339,6 +340,7 @@ impl From<u32> for Channel {
             5 => Self::Otlp,
             6 => Self::Grpc,
             7 => Self::Influx,
+            8 => Self::Opentsdb,
 
             _ => Self::Other,
         }
@@ -365,6 +367,7 @@ impl Display for Channel {
             Channel::Otlp => write!(f, "otlp"),
             Channel::Grpc => write!(f, "grpc"),
             Channel::Influx => write!(f, "influx"),
+            Channel::Opentsdb => write!(f, "opentsdb"),
             Channel::Other => write!(f, "other"),
         }
     }

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -79,6 +79,7 @@ impl Session {
             .mutable_inner(self.mutable_inner.clone())
             .sql_dialect(self.conn_info.channel.dialect())
             .configuration_parameter(self.configuration_variables.clone())
+            .channel(self.conn_info.channel)
             .build()
             .into()
     }

--- a/src/sql/src/dialect.rs
+++ b/src/sql/src/dialect.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub use sqlparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect};
+pub use sqlparser::dialect::{Dialect, GenericDialect, MySqlDialect, PostgreSqlDialect};
 
 /// GreptimeDb dialect
 #[derive(Debug, Clone)]


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch adds a new field `channel` in query context so the execution path now knows which source the query comes from. It also add this channel to meter, by which we can add statistics for w/rcus of each channel.

Upstream changes that has to be merged before this:

- https://github.com/GreptimeTeam/greptime-proto/pull/183
- https://github.com/GreptimeTeam/greptime-meter/pull/24

**Note that** this patch changes QueryContext extension type in axum, from `QueryContextRef` to plain `QueryContext` so that we can modify it in http handlers, to set `channel` field based on different handler.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
