### PR TITLE
perf: reduce lock scope and improve log

### DIFF
--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -766,16 +766,13 @@ impl ScannerMetrics {
         READ_STAGE_ELAPSED
             .with_label_values(&["build_parts"])
             .observe(self.build_parts_cost.as_secs_f64());
-        if !self.build_reader_cost.is_zero() {
-            // Not all scanner has this cost.
-            READ_STAGE_ELAPSED
-                .with_label_values(&["build_reader"])
-                .observe(self.build_reader_cost.as_secs_f64());
-        }
     }
 
     /// Observes metrics on scanner finish.
     fn observe_metrics_on_finish(&self) {
+        READ_STAGE_ELAPSED
+            .with_label_values(&["build_reader"])
+            .observe(self.build_reader_cost.as_secs_f64());
         READ_STAGE_ELAPSED
             .with_label_values(&["convert_rb"])
             .observe(self.convert_cost.as_secs_f64());
@@ -783,11 +780,11 @@ impl ScannerMetrics {
             .with_label_values(&["scan"])
             .observe(self.scan_cost.as_secs_f64());
         READ_STAGE_ELAPSED
-            .with_label_values(&["total"])
-            .observe(self.total_cost.as_secs_f64());
-        READ_STAGE_ELAPSED
             .with_label_values(&["yield"])
             .observe(self.yield_cost.as_secs_f64());
+        READ_STAGE_ELAPSED
+            .with_label_values(&["total"])
+            .observe(self.total_cost.as_secs_f64());
         READ_ROWS_RETURN.observe(self.num_rows as f64);
         READ_BATCHES_RETURN.observe(self.num_batches as f64);
     }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -723,7 +723,7 @@ pub(crate) type FileRangesGroup = SmallVec<[Vec<FileRange>; 4]>;
 
 /// A partition of a scanner to read.
 /// It contains memtables and file ranges to scan.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct ScanPart {
     /// Memtable ranges to scan.
     pub(crate) memtable_ranges: Vec<MemtableRange>,

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -408,7 +408,7 @@ impl SeqScan {
                 metrics.total_cost = stream_ctx.query_start.elapsed();
                 metrics.observe_metrics_on_finish();
 
-                common_telemetry::info!(
+                common_telemetry::debug!(
                     "Seq scan finished, region_id: {}, partition: {}, id: {}, metrics: {:?}, first_poll: {:?}",
                     stream_ctx.input.mapper.metadata().region_id,
                     partition,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -155,7 +155,7 @@ impl RegionScanner for UnorderedScan {
                     .map_err(BoxedError::new)
                     .context(ExternalSnafu)?;
                 // Clone the part and releases the lock.
-                // We might wrap the part in an Arc in the future if cloning is too expensive.
+                // TODO(yingwen): We might wrap the part in an Arc in the future if cloning is too expensive.
                 let Some(part) = parts.0.get_part(partition).cloned() else {
                     return;
                 };

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -16,7 +16,7 @@
 
 use std::fmt;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_stream::{stream, try_stream};
 use common_error::ext::BoxedError;
@@ -115,11 +115,11 @@ impl UnorderedScan {
                 .map_err(BoxedError::new)
                 .context(ExternalSnafu)?;
         }
+        metrics.scan_cost += start.elapsed();
 
         let convert_start = Instant::now();
         let record_batch = mapper.convert(&batch, cache)?;
         metrics.convert_cost += convert_start.elapsed();
-        metrics.scan_cost += start.elapsed();
 
         Ok(Some(record_batch))
     }
@@ -149,14 +149,15 @@ impl RegionScanner for UnorderedScan {
             let first_poll = stream_ctx.query_start.elapsed();
 
             let mut parts = stream_ctx.parts.lock().await;
-            maybe_init_parts(&mut parts, &stream_ctx.input, &mut metrics)
+            maybe_init_parts(&stream_ctx.input, &mut parts, &mut metrics)
                 .await
                 .map_err(BoxedError::new)
                 .context(ExternalSnafu)?;
-            let Some(part) = parts.get_part(partition) else {
+            let Some(part) = parts.0.get_part(partition) else {
                 return;
             };
 
+            let build_reader_start = Instant::now();
             let mapper = &stream_ctx.input.mapper;
             let memtable_sources = part
                 .memtable_ranges
@@ -168,6 +169,7 @@ impl RegionScanner for UnorderedScan {
                 .collect::<Result<Vec<_>>>()
                 .map_err(BoxedError::new)
                 .context(ExternalSnafu)?;
+            metrics.build_reader_cost = build_reader_start.elapsed();
             let query_start = stream_ctx.query_start;
             let cache = stream_ctx.input.cache_manager.as_deref();
             // Scans memtables first.
@@ -175,20 +177,26 @@ impl RegionScanner for UnorderedScan {
                 while let Some(batch) = Self::fetch_from_source(&mut source, mapper, cache, None, &mut metrics).await? {
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
+                    let yield_start = Instant::now();
                     yield batch;
+                    metrics.yield_cost += yield_start.elapsed();
                 }
             }
             // Then scans file ranges.
             let mut reader_metrics = ReaderMetrics::default();
             // Safety: UnorderedDistributor::build_parts() ensures this.
             for file_range in &part.file_ranges[0] {
+                let build_reader_start = Instant::now();
                 let reader = file_range.reader(None).await.map_err(BoxedError::new).context(ExternalSnafu)?;
+                metrics.build_reader_cost += build_reader_start.elapsed();
                 let compat_batch = file_range.compat_batch();
                 let mut source = Source::PruneReader(reader);
                 while let Some(batch) = Self::fetch_from_source(&mut source, mapper, cache, compat_batch, &mut metrics).await? {
                     metrics.num_batches += 1;
                     metrics.num_rows += batch.num_rows();
+                    let yield_start = Instant::now();
                     yield batch;
+                    metrics.yield_cost += yield_start.elapsed();
                 }
                 if let Source::PruneReader(mut reader) = source {
                     reader_metrics.merge_from(reader.metrics());
@@ -213,7 +221,11 @@ impl RegionScanner for UnorderedScan {
 
 impl DisplayAs for UnorderedScan {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UnorderedScan: ")?;
+        write!(
+            f,
+            "UnorderedScan: region={}, ",
+            self.stream_ctx.input.mapper.metadata().region_id
+        )?;
         self.stream_ctx.format_for_explain(t, f)
     }
 }
@@ -236,11 +248,11 @@ impl UnorderedScan {
 
 /// Initializes parts if they are not built yet.
 async fn maybe_init_parts(
-    part_list: &mut ScanPartList,
     input: &ScanInput,
+    part_list: &mut (ScanPartList, Duration),
     metrics: &mut ScannerMetrics,
 ) -> Result<()> {
-    if part_list.is_none() {
+    if part_list.0.is_none() {
         let now = Instant::now();
         let mut distributor = UnorderedDistributor::default();
         input.prune_file_ranges(&mut distributor).await?;
@@ -249,9 +261,16 @@ async fn maybe_init_parts(
             Some(input.mapper.column_ids()),
             input.predicate.clone(),
         );
-        part_list.set_parts(distributor.build_parts(input.parallelism.parallelism));
+        part_list
+            .0
+            .set_parts(distributor.build_parts(input.parallelism.parallelism));
+        let build_part_cost = now.elapsed();
+        part_list.1 = build_part_cost;
 
-        metrics.observe_init_part(now.elapsed());
+        metrics.observe_init_part(build_part_cost);
+    } else {
+        // Updates the cost of building parts.
+        metrics.build_parts_cost = part_list.1;
     }
     Ok(())
 }

--- a/src/query/src/dist_plan/merge_scan.rs
+++ b/src/query/src/dist_plan/merge_scan.rs
@@ -198,7 +198,7 @@ impl MergeScanExec {
         let extensions = self.query_ctx.extensions();
         let target_partition = self.target_partition;
 
-        let sub_sgate_metrics_moved = self.sub_stage_metrics.clone();
+        let sub_stage_metrics_moved = self.sub_stage_metrics.clone();
         let plan = self.plan.clone();
         let stream = Box::pin(stream!({
             MERGE_SCAN_REGIONS.observe(regions.len() as f64);
@@ -226,6 +226,7 @@ impl MergeScanExec {
                     region_id,
                     plan: plan.clone(),
                 };
+                let do_get_start = Instant::now();
                 let mut stream = region_query_handler
                     .do_get(request)
                     .await
@@ -234,11 +235,11 @@ impl MergeScanExec {
                         BoxedError::new(e)
                     })
                     .context(ExternalSnafu)?;
+                let do_get_cost = do_get_start.elapsed();
 
                 ready_timer.stop();
 
-                let mut poll_duration = Duration::new(0, 0);
-
+                let mut poll_duration = Duration::ZERO;
                 let mut poll_timer = Instant::now();
                 while let Some(batch) = stream.next().await {
                     let poll_elapsed = poll_timer.elapsed();
@@ -249,13 +250,17 @@ impl MergeScanExec {
                     // to remove metadata and correct column name
                     let batch = RecordBatch::new(schema.clone(), batch.columns().iter().cloned())?;
                     metric.record_output_batch_rows(batch.num_rows());
-                    if let Some(first_consume_timer) = first_consume_timer.as_mut().take() {
+                    if let Some(mut first_consume_timer) = first_consume_timer.take() {
                         first_consume_timer.stop();
                     }
                     yield Ok(batch);
                     // reset poll timer
                     poll_timer = Instant::now();
                 }
+                common_telemetry::debug!(
+                    "Merge scan stop poll stream, partition: {}, region_id: {}, poll_duration: {:?}, first_consume: {}, do_get_cost: {:?}",
+                    partition, region_id, poll_duration, metric.first_consume_time(), do_get_cost
+                );
 
                 // process metrics after all data is drained.
                 if let Some(metrics) = stream.metrics() {
@@ -271,7 +276,7 @@ impl MergeScanExec {
                     metric.record_greptime_exec_cost(value as usize);
 
                     // record metrics from sub sgates
-                    sub_sgate_metrics_moved.lock().unwrap().push(metrics);
+                    sub_stage_metrics_moved.lock().unwrap().push(metrics);
                 }
 
                 MERGE_SCAN_POLL_ELAPSED.observe(poll_duration.as_secs_f64());

--- a/tests/cases/distributed/explain/analyze.result
+++ b/tests/cases/distributed/explain/analyze.result
@@ -24,6 +24,7 @@ Affected Rows: 3
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze SELECT count(*) FROM system_metrics;
 
 +-+-+-+
@@ -35,7 +36,7 @@ explain analyze SELECT count(*) FROM system_metrics;
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[COUNT(system_REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/distributed/explain/analyze.sql
+++ b/tests/cases/distributed/explain/analyze.sql
@@ -20,6 +20,7 @@ VALUES
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze SELECT count(*) FROM system_metrics;
 
 drop table system_metrics;

--- a/tests/cases/standalone/common/aggregate/multi_regions.result
+++ b/tests/cases/standalone/common/aggregate/multi_regions.result
@@ -18,6 +18,7 @@ Affected Rows: 0
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t group by host;
 
@@ -33,7 +34,7 @@ select sum(val) from t group by host;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[SUM(t.val)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[SUM(t.val)@1 as SUM(t.val)] REDACTED
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[SUM(t.val)] REDACTED
@@ -42,7 +43,7 @@ select sum(val) from t group by host;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[SUM(t.val)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -52,6 +53,7 @@ select sum(val) from t group by host;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t;
 
@@ -64,9 +66,9 @@ select sum(val) from t;
 |_|_|_ProjectionExec: expr=[val@1 as val] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -77,6 +79,7 @@ select sum(val) from t;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t group by idc;
 
@@ -92,9 +95,9 @@ select sum(val) from t group by idc;
 |_|_|_ProjectionExec: expr=[val@1 as val, idc@3 as idc] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/aggregate/multi_regions.sql
+++ b/tests/cases/standalone/common/aggregate/multi_regions.sql
@@ -16,6 +16,7 @@ partition on columns (host) (
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t group by host;
 
@@ -24,6 +25,7 @@ select sum(val) from t group by host;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t;
 
@@ -33,6 +35,7 @@ select sum(val) from t;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
 select sum(val) from t group by idc;
 

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -67,6 +67,7 @@ EXPLAIN SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 
 +-+-+-+
@@ -76,7 +77,7 @@ EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 10_|
 +-+-+-+

--- a/tests/cases/standalone/common/range/nest.sql
+++ b/tests/cases/standalone/common/range/nest.sql
@@ -35,6 +35,7 @@ EXPLAIN SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 
 DROP TABLE host;

--- a/tests/cases/standalone/common/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/analyze.result
@@ -13,6 +13,7 @@ Affected Rows: 3
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE (0, 10, '5s') test;
 
 +-+-+-+
@@ -31,7 +32,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -43,6 +44,7 @@ TQL ANALYZE (0, 10, '5s') test;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE (0, 10, '1s', '2s') test;
 
 +-+-+-+
@@ -61,7 +63,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -2000 AND j@1 <= 12000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -72,6 +74,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp + '10 seconds'::interval, '5s') test;
 
 +-+-+-+
@@ -90,7 +93,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -103,6 +106,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (Duration.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE VERBOSE (0, 10, '5s') test;
 
 +-+-+-+
@@ -121,7 +125,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql-explain-analyze/analyze.sql
+++ b/tests/cases/standalone/common/tql-explain-analyze/analyze.sql
@@ -9,6 +9,7 @@ INSERT INTO test VALUES (1, 1, "a"), (1, 1, "b"), (2, 2, "a");
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE (0, 10, '5s') test;
 
 -- 'lookback' parameter is not fully supported, the test has to be updated
@@ -18,6 +19,7 @@ TQL ANALYZE (0, 10, '5s') test;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE (0, 10, '1s', '2s') test;
 
 -- analyze at 0s, 5s and 10s. No point at 0s.
@@ -26,6 +28,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 -- SQLNESS REPLACE (-+) -
 -- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp + '10 seconds'::interval, '5s') test;
 
 -- analyze verbose at 0s, 5s and 10s. No point at 0s.
@@ -36,6 +39,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (Duration.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 TQL ANALYZE VERBOSE (0, 10, '5s') test;
 
 DROP TABLE test;

--- a/tests/cases/standalone/optimizer/last_value.result
+++ b/tests/cases/standalone/optimizer/last_value.result
@@ -27,6 +27,7 @@ Affected Rows: 9
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
     select
         last_value(host order by ts),
@@ -47,7 +48,7 @@ explain analyze
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
-|_|_|_SeqScan: partition_count=1 (1 memtable ranges, 0 file ranges), selector=LastRow REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges), selector=LastRow REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/last_value.sql
+++ b/tests/cases/standalone/optimizer/last_value.sql
@@ -23,6 +23,7 @@ insert into t values
 -- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE (partitioning.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 explain analyze
     select
         last_value(host order by ts),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR reduces the parts lock scope. This prevents different streams from blocking each other for too long. Under append mode, this lock prevents part parallelism.

It also improves the scan log.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
