### PR TITLE
feat: hint options for gRPC insert

### DIFF
--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -144,7 +144,7 @@ impl Database {
         let mut request = tonic::Request::new(request);
         let metadata = request.metadata_mut();
         for (key, value) in hints {
-            let key = AsciiMetadataKey::from_bytes(format!("x-greptime-hint:{}", key).as_bytes())
+            let key = AsciiMetadataKey::from_bytes(format!("x-greptime-hint-{}", key).as_bytes())
                 .map_err(|_| {
                 InvalidAsciiSnafu {
                     value: key.to_string(),

--- a/src/client/src/database.rs
+++ b/src/client/src/database.rs
@@ -33,9 +33,12 @@ use common_telemetry::tracing_context::W3cTrace;
 use futures_util::StreamExt;
 use prost::Message;
 use snafu::{ensure, ResultExt};
+use tonic::metadata::AsciiMetadataKey;
 use tonic::transport::Channel;
 
-use crate::error::{ConvertFlightDataSnafu, Error, IllegalFlightMessagesSnafu, ServerSnafu};
+use crate::error::{
+    ConvertFlightDataSnafu, Error, IllegalFlightMessagesSnafu, InvalidAsciiSnafu, ServerSnafu,
+};
 use crate::{from_grpc_response, Client, Result};
 
 #[derive(Clone, Debug, Default)]
@@ -128,6 +131,36 @@ impl Database {
 
     pub async fn insert(&self, requests: InsertRequests) -> Result<u32> {
         self.handle(Request::Inserts(requests)).await
+    }
+
+    pub async fn insert_with_hints(
+        &self,
+        requests: InsertRequests,
+        hints: &[(&str, &str)],
+    ) -> Result<u32> {
+        let mut client = make_database_client(&self.client)?.inner;
+        let request = self.to_rpc_request(Request::Inserts(requests));
+
+        let mut request = tonic::Request::new(request);
+        let metadata = request.metadata_mut();
+        for (key, value) in hints {
+            let key = AsciiMetadataKey::from_bytes(format!("x-greptime-hint:{}", key).as_bytes())
+                .map_err(|_| {
+                InvalidAsciiSnafu {
+                    value: key.to_string(),
+                }
+                .build()
+            })?;
+            let value = value.parse().map_err(|_| {
+                InvalidAsciiSnafu {
+                    value: value.to_string(),
+                }
+                .build()
+            })?;
+            metadata.insert(key, value);
+        }
+        let response = client.handle(request).await?.into_inner();
+        from_grpc_response(response)
     }
 
     async fn handle(&self, request: Request) -> Result<u32> {

--- a/src/client/src/error.rs
+++ b/src/client/src/error.rs
@@ -122,6 +122,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Failed to parse ascii string: {}", value))]
+    InvalidAscii {
+        value: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -143,6 +150,8 @@ impl ErrorExt for Error {
             | Error::ConvertFlightData { source, .. }
             | Error::CreateTlsChannel { source, .. } => source.status_code(),
             Error::IllegalGrpcClientState { .. } => StatusCode::Unexpected,
+
+            Error::InvalidAscii { .. } => StatusCode::InvalidArguments,
         }
     }
 

--- a/src/operator/src/insert.rs
+++ b/src/operator/src/insert.rs
@@ -644,9 +644,18 @@ impl Inserter {
         statement_executor: &StatementExecutor,
         create_type: AutoCreateTableType,
     ) -> Result<TableRef> {
+        let mut hint_options = vec![];
         let options: &[(&str, &str)] = match create_type {
             AutoCreateTableType::Logical(_) => unreachable!(),
-            AutoCreateTableType::Physical => &[],
+            AutoCreateTableType::Physical => {
+                if let Some(append_mode) = ctx.extension(APPEND_MODE_KEY) {
+                    hint_options.push((APPEND_MODE_KEY, append_mode));
+                }
+                if let Some(merge_mode) = ctx.extension(MERGE_MODE_KEY) {
+                    hint_options.push((MERGE_MODE_KEY, merge_mode));
+                }
+                hint_options.as_slice()
+            }
             // Set append_mode to true for log table.
             // because log tables should keep rows with the same ts and tags.
             AutoCreateTableType::Log => &[(APPEND_MODE_KEY, "true")],

--- a/src/servers/src/grpc/database.rs
+++ b/src/servers/src/grpc/database.rs
@@ -26,7 +26,7 @@ use tonic::{Request, Response, Status, Streaming};
 use crate::grpc::greptime_handler::GreptimeRequestHandler;
 use crate::grpc::{cancellation, TonicResult};
 
-pub const GREPTIME_DB_HEADER_HINT_PREFIX: &str = "x-greptime-hint:";
+pub const GREPTIME_DB_HEADER_HINT_PREFIX: &str = "x-greptime-hint-";
 
 pub(crate) struct DatabaseService {
     handler: GreptimeRequestHandler,
@@ -177,7 +177,11 @@ mod tests {
     #[test]
     fn test_extract_hints() {
         let mut metadata = MetadataMap::new();
-        metadata.insert("x-greptime-hint:append_mode", "true".parse().unwrap());
+        let prev = metadata.insert(
+            "x-greptime-hint-append_mode",
+            MetadataValue::from_static("true"),
+        );
+        assert!(prev.is_none());
         let hints = extract_hints(&metadata);
         assert_eq!(hints, vec![("append_mode".to_string(), "true".to_string())]);
     }
@@ -186,7 +190,7 @@ mod tests {
     fn extract_hints_ignores_non_ascii_metadata() {
         let mut metadata = MetadataMap::new();
         metadata.insert_bin(
-            "x-greptime-hint:merge_mode",
+            "x-greptime-hint-merge_mode-bin",
             MetadataValue::from_bytes(b"last_non_null"),
         );
         let hints = extract_hints(&metadata);

--- a/src/servers/src/grpc/flight.rs
+++ b/src/servers/src/grpc/flight.rs
@@ -167,7 +167,7 @@ impl FlightCraft for GreptimeRequestHandler {
             request_type = get_request_type(&request)
         );
         async {
-            let output = self.handle_request(request).await?;
+            let output = self.handle_request(request, Default::default()).await?;
             let stream: Pin<Box<dyn Stream<Item = Result<FlightData, Status>> + Send + Sync>> =
                 to_flight_data_stream(output, TracingContext::from_current_span());
             Ok(Response::new(stream))

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -78,7 +78,7 @@ impl PrometheusGateway for PrometheusGatewayService {
         };
 
         let header = inner.header.as_ref();
-        let query_ctx = create_query_context(header);
+        let query_ctx = create_query_context(header, Default::default());
         let user_info = auth(self.user_provider.clone(), header, &query_ctx).await?;
         query_ctx.set_current_user(user_info);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR closes #4441 

# How to use:
For example, if you need to add a hint during the first write to automatically create a table with the option `merge_mode = "last_non_null"`, then we need to add a hint to the gRPC request header:

```
("x-greptime-hint-merge_mode", "last_non_null")
```

Note, you must use the prefix `x-greptime-hint-`; otherwise, it will not be parsed as a valid hint.

Taking the java ingester client as an example, we modify a line of code in this example to:

https://github.com/GreptimeTeam/greptimedb-ingester-java/blob/4fa729a537df3f49278aef58fa919315ad6a7f88/ingester-example/src/main/java/io/greptime/LowLevelApiWriteQuickStart.java#L76

```
CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(cpuMetric, memMetric);
```
->
```
Context ctx = Context.hint("merge_mode", "last_non_null");
CompletableFuture<Result<WriteOk, Err>> future = greptimeDB.write(Arrays.asList(cpuMetric, memMetric), WriteOp.Insert, ctx);
```

Currently, only two hint options are supported, which are append_mode and merge_mode.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
