### PR TITLE
fix: use status code to http status mapping in error IntoResponse

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -16,7 +16,6 @@ use std::any::Any;
 use std::net::SocketAddr;
 use std::string::FromUtf8Error;
 
-use axum::http::StatusCode as HttpStatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::{http, Json};
 use base64::DecodeError;
@@ -31,6 +30,8 @@ use headers::ContentType;
 use query::parser::PromQuery;
 use serde_json::json;
 use snafu::{Location, Snafu};
+
+use crate::http::error_result::status_code_to_http_status;
 
 #[derive(Snafu)]
 #[snafu(visibility(pub))]
@@ -750,28 +751,8 @@ fn log_error_if_necessary(error: &Error) {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        use pipeline::error::Error as PipelineError;
         let error_msg = self.output_msg();
-        let status = match self {
-            Error::InfluxdbLineProtocol { .. }
-            | Error::RowWriter { .. }
-            | Error::PromSeriesWrite { .. }
-            | Error::InvalidOpentsdbJsonRequest { .. }
-            | Error::DecodePromRemoteRequest { .. }
-            | Error::DecodeOtlpRequest { .. }
-            | Error::DecompressSnappyPromRemoteRequest { .. }
-            | Error::DecompressZstdPromRemoteRequest { .. }
-            | Error::InvalidPromRemoteRequest { .. }
-            | Error::InvalidQuery { .. }
-            | Error::TimePrecision { .. } => HttpStatusCode::BAD_REQUEST,
-            Error::Pipeline { ref source, .. } => match source {
-                PipelineError::CompilePipeline { .. }
-                | PipelineError::InvalidPipelineVersion { .. }
-                | PipelineError::PipelineNotFound { .. } => HttpStatusCode::BAD_REQUEST,
-                _ => HttpStatusCode::INTERNAL_SERVER_ERROR,
-            },
-            _ => HttpStatusCode::INTERNAL_SERVER_ERROR,
-        };
+        let status = status_code_to_http_status(self.status_code());
 
         log_error_if_necessary(&self);
 

--- a/src/servers/src/http/error_result.rs
+++ b/src/servers/src/http/error_result.rs
@@ -82,48 +82,53 @@ impl IntoResponse for ErrorResponse {
             HeaderValue::from(execution_time),
         );
         let status = StatusCode::from_u32(code).unwrap_or(StatusCode::Unknown);
-        let status_code = match status {
-            StatusCode::Success | StatusCode::Cancelled => HttpStatusCode::OK,
+        let status_code = status_code_to_http_status(status);
 
-            StatusCode::Unsupported
-            | StatusCode::InvalidArguments
-            | StatusCode::InvalidSyntax
-            | StatusCode::RequestOutdated
-            | StatusCode::RegionAlreadyExists
-            | StatusCode::TableColumnExists
-            | StatusCode::TableAlreadyExists
-            | StatusCode::RegionNotFound
-            | StatusCode::DatabaseNotFound
-            | StatusCode::TableNotFound
-            | StatusCode::TableColumnNotFound
-            | StatusCode::PlanQuery
-            | StatusCode::DatabaseAlreadyExists
-            | StatusCode::FlowNotFound
-            | StatusCode::FlowAlreadyExists => HttpStatusCode::BAD_REQUEST,
-
-            StatusCode::AuthHeaderNotFound
-            | StatusCode::InvalidAuthHeader
-            | StatusCode::UserNotFound
-            | StatusCode::UnsupportedPasswordType
-            | StatusCode::UserPasswordMismatch
-            | StatusCode::RegionReadonly => HttpStatusCode::UNAUTHORIZED,
-
-            StatusCode::PermissionDenied | StatusCode::AccessDenied => HttpStatusCode::FORBIDDEN,
-
-            StatusCode::RateLimited => HttpStatusCode::TOO_MANY_REQUESTS,
-
-            StatusCode::RegionNotReady
-            | StatusCode::TableUnavailable
-            | StatusCode::RegionBusy
-            | StatusCode::StorageUnavailable => HttpStatusCode::SERVICE_UNAVAILABLE,
-
-            StatusCode::Internal
-            | StatusCode::Unexpected
-            | StatusCode::IllegalState
-            | StatusCode::Unknown
-            | StatusCode::RuntimeResourcesExhausted
-            | StatusCode::EngineExecuteQuery => HttpStatusCode::INTERNAL_SERVER_ERROR,
-        };
         (status_code, resp).into_response()
+    }
+}
+
+pub fn status_code_to_http_status(status_code: StatusCode) -> HttpStatusCode {
+    match status_code {
+        StatusCode::Success | StatusCode::Cancelled => HttpStatusCode::OK,
+
+        StatusCode::Unsupported
+        | StatusCode::InvalidArguments
+        | StatusCode::InvalidSyntax
+        | StatusCode::RequestOutdated
+        | StatusCode::RegionAlreadyExists
+        | StatusCode::TableColumnExists
+        | StatusCode::TableAlreadyExists
+        | StatusCode::RegionNotFound
+        | StatusCode::DatabaseNotFound
+        | StatusCode::TableNotFound
+        | StatusCode::TableColumnNotFound
+        | StatusCode::PlanQuery
+        | StatusCode::DatabaseAlreadyExists
+        | StatusCode::FlowNotFound
+        | StatusCode::FlowAlreadyExists => HttpStatusCode::BAD_REQUEST,
+
+        StatusCode::AuthHeaderNotFound
+        | StatusCode::InvalidAuthHeader
+        | StatusCode::UserNotFound
+        | StatusCode::UnsupportedPasswordType
+        | StatusCode::UserPasswordMismatch
+        | StatusCode::RegionReadonly => HttpStatusCode::UNAUTHORIZED,
+
+        StatusCode::PermissionDenied | StatusCode::AccessDenied => HttpStatusCode::FORBIDDEN,
+
+        StatusCode::RateLimited => HttpStatusCode::TOO_MANY_REQUESTS,
+
+        StatusCode::RegionNotReady
+        | StatusCode::TableUnavailable
+        | StatusCode::RegionBusy
+        | StatusCode::StorageUnavailable => HttpStatusCode::SERVICE_UNAVAILABLE,
+
+        StatusCode::Internal
+        | StatusCode::Unexpected
+        | StatusCode::IllegalState
+        | StatusCode::Unknown
+        | StatusCode::RuntimeResourcesExhausted
+        | StatusCode::EngineExecuteQuery => HttpStatusCode::INTERNAL_SERVER_ERROR,
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr extracts the greptimedb status code to HTTP status mapping in `impl IntoResponse for ErrorResponse` and reuses it in `impl IntoResponse for Error` so that HTTP handler returning `Result` now shows the correct HTTP status code and msg.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
