### PR TITLE
fix: overflow when parsing default value with negative numbers

### DIFF
--- a/tests/cases/standalone/common/create/create.result
+++ b/tests/cases/standalone/common/create/create.result
@@ -54,6 +54,23 @@ CREATE TABLE 'N.~' (i TIMESTAMP TIME INDEX);
 
 Error: 1004(InvalidArguments), Invalid table name: N.~
 
+CREATE TABLE neg_default_value_min(i TIMESTAMP TIME INDEX, j SMALLINT DEFAULT -32768);
+
+Affected Rows: 0
+
+DESC TABLE neg_default_value_min;
+
++--------+----------------------+-----+------+---------+---------------+
+| Column | Type                 | Key | Null | Default | Semantic Type |
++--------+----------------------+-----+------+---------+---------------+
+| i      | TimestampMillisecond | PRI | NO   |         | TIMESTAMP     |
+| j      | Int16                |     | YES  | -32768  | FIELD         |
++--------+----------------------+-----+------+---------+---------------+
+
+DROP TABLE neg_default_value_min;
+
+Affected Rows: 0
+
 DESC TABLE integers;
 
 +--------+----------------------+-----+------+---------+---------------+

--- a/tests/cases/standalone/common/create/create.sql
+++ b/tests/cases/standalone/common/create/create.sql
@@ -26,6 +26,12 @@ CREATE TABLE test2 (i INTEGER, j TIMESTAMP TIME INDEX);
 
 CREATE TABLE 'N.~' (i TIMESTAMP TIME INDEX);
 
+CREATE TABLE neg_default_value_min(i TIMESTAMP TIME INDEX, j SMALLINT DEFAULT -32768);
+
+DESC TABLE neg_default_value_min;
+
+DROP TABLE neg_default_value_min;
+
 DESC TABLE integers;
 
 DESC TABLE test1;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4351

## What's changed and what's your intention?

Fixed overflow when parsing default constraints with negative numbers.

Close #4351 

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
