### PR TITLE
fix: prometheus api only returns 200

### DIFF
--- a/src/servers/src/error.rs
+++ b/src/servers/src/error.rs
@@ -752,7 +752,7 @@ fn log_error_if_necessary(error: &Error) {
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         let error_msg = self.output_msg();
-        let status = status_code_to_http_status(self.status_code());
+        let status = status_code_to_http_status(&self.status_code());
 
         log_error_if_necessary(&self);
 

--- a/src/servers/src/grpc/prom_query_gateway.rs
+++ b/src/servers/src/grpc/prom_query_gateway.rs
@@ -124,10 +124,7 @@ impl PrometheusGatewayService {
             match retrieve_metric_name_and_result_type(&query.query) {
                 Ok((metric_name, result_type)) => (metric_name.unwrap_or_default(), result_type),
                 Err(err) => {
-                    return PrometheusJsonResponse::error(
-                        err.status_code().to_string(),
-                        err.output_msg(),
-                    )
+                    return PrometheusJsonResponse::error(err.status_code(), err.output_msg())
                 }
             };
         // range query only returns matrix

--- a/src/servers/src/http/error_result.rs
+++ b/src/servers/src/http/error_result.rs
@@ -82,13 +82,13 @@ impl IntoResponse for ErrorResponse {
             HeaderValue::from(execution_time),
         );
         let status = StatusCode::from_u32(code).unwrap_or(StatusCode::Unknown);
-        let status_code = status_code_to_http_status(status);
+        let status_code = status_code_to_http_status(&status);
 
         (status_code, resp).into_response()
     }
 }
 
-pub fn status_code_to_http_status(status_code: StatusCode) -> HttpStatusCode {
+pub fn status_code_to_http_status(status_code: &StatusCode) -> HttpStatusCode {
     match status_code {
         StatusCode::Success | StatusCode::Cancelled => HttpStatusCode::OK,
 

--- a/src/servers/src/http/prometheus.rs
+++ b/src/servers/src/http/prometheus.rs
@@ -133,7 +133,7 @@ pub async fn format_query(
         }
         Err(reason) => {
             let err = InvalidQuerySnafu { reason }.build();
-            PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg())
+            PrometheusJsonResponse::error(err.status_code(), err.output_msg())
         }
     }
 }
@@ -200,9 +200,7 @@ pub async fn instant_query(
     let result = handler.do_query(&prom_query, query_ctx).await;
     let (metric_name, result_type) = match retrieve_metric_name_and_result_type(&prom_query.query) {
         Ok((metric_name, result_type)) => (metric_name.unwrap_or_default(), result_type),
-        Err(err) => {
-            return PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg())
-        }
+        Err(err) => return PrometheusJsonResponse::error(err.status_code(), err.output_msg()),
     };
     PrometheusJsonResponse::from_query_result(result, metric_name, result_type).await
 }
@@ -252,9 +250,7 @@ pub async fn range_query(
 
     let result = handler.do_query(&prom_query, query_ctx).await;
     let metric_name = match retrieve_metric_name_and_result_type(&prom_query.query) {
-        Err(err) => {
-            return PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg())
-        }
+        Err(err) => return PrometheusJsonResponse::error(err.status_code(), err.output_msg()),
         Ok((metric_name, _)) => metric_name.unwrap_or_default(),
     };
     PrometheusJsonResponse::from_query_result(result, metric_name, ValueType::Matrix).await
@@ -332,9 +328,7 @@ pub async fn labels_query(
     let mut labels = match get_all_column_names(&catalog, &schema, &handler.catalog_manager()).await
     {
         Ok(labels) => labels,
-        Err(e) => {
-            return PrometheusJsonResponse::error(e.status_code().to_string(), e.output_msg())
-        }
+        Err(e) => return PrometheusJsonResponse::error(e.status_code(), e.output_msg()),
     };
     // insert the special metric name label
     let _ = labels.insert(METRIC_NAME.to_string());
@@ -382,10 +376,7 @@ pub async fn labels_query(
             if err.status_code() != StatusCode::TableNotFound
                 && err.status_code() != StatusCode::TableColumnNotFound
             {
-                return PrometheusJsonResponse::error(
-                    err.status_code().to_string(),
-                    err.output_msg(),
-                );
+                return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
             }
         }
     }
@@ -711,7 +702,7 @@ pub async fn label_values_query(
         {
             Ok(table_names) => table_names,
             Err(e) => {
-                return PrometheusJsonResponse::error(e.status_code().to_string(), e.output_msg());
+                return PrometheusJsonResponse::error(e.status_code(), e.output_msg());
             }
         };
         table_names.sort_unstable();
@@ -723,10 +714,7 @@ pub async fn label_values_query(
             {
                 Ok(table_names) => table_names,
                 Err(e) => {
-                    return PrometheusJsonResponse::error(
-                        e.status_code().to_string(),
-                        e.output_msg(),
-                    );
+                    return PrometheusJsonResponse::error(e.status_code(), e.output_msg());
                 }
             };
         let mut field_columns = field_columns.into_iter().collect::<Vec<_>>();
@@ -736,7 +724,10 @@ pub async fn label_values_query(
 
     let queries = params.matches.0;
     if queries.is_empty() {
-        return PrometheusJsonResponse::error("Invalid argument", "match[] parameter is required");
+        return PrometheusJsonResponse::error(
+            StatusCode::InvalidArguments,
+            "match[] parameter is required",
+        );
     }
 
     let start = params.start.unwrap_or_else(yesterday_rfc3339);
@@ -764,10 +755,7 @@ pub async fn label_values_query(
             if err.status_code() != StatusCode::TableNotFound
                 && err.status_code() != StatusCode::TableColumnNotFound
             {
-                return PrometheusJsonResponse::error(
-                    err.status_code().to_string(),
-                    err.output_msg(),
-                );
+                return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
             }
         }
     }
@@ -963,7 +951,10 @@ pub async fn series_query(
         queries = form_params.matches.0;
     }
     if queries.is_empty() {
-        return PrometheusJsonResponse::error("Unsupported", "match[] parameter is required");
+        return PrometheusJsonResponse::error(
+            StatusCode::Unsupported,
+            "match[] parameter is required",
+        );
     }
     let start = params
         .start
@@ -1012,7 +1003,7 @@ pub async fn series_query(
         )
         .await
         {
-            return PrometheusJsonResponse::error(err.status_code().to_string(), err.output_msg());
+            return PrometheusJsonResponse::error(err.status_code(), err.output_msg());
         }
     }
     let merge_map = merge_map

--- a/tests-integration/tests/grpc.rs
+++ b/tests-integration/tests/grpc.rs
@@ -577,6 +577,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
         error_type: None,
         warnings: None,
         resp_metrics: Default::default(),
+        status_code: None,
     };
     assert_eq!(instant_query_result, expected);
 
@@ -628,6 +629,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
         error_type: None,
         warnings: None,
         resp_metrics: Default::default(),
+        status_code: None,
     };
     assert_eq!(range_query_result, expected);
 
@@ -660,6 +662,7 @@ pub async fn test_prom_gateway_query(store_type: StorageType) {
         error_type: None,
         warnings: None,
         resp_metrics: Default::default(),
+        status_code: None,
     };
     assert_eq!(range_query_result, expected);
 

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -520,7 +520,15 @@ pub async fn test_prom_http_api(store_type: StorageType) {
         .header("Content-Type", "application/x-www-form-urlencoded")
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    let prom_resp = res.json::<PrometheusJsonResponse>().await;
+    assert_eq!(prom_resp.status, "error");
+    assert!(prom_resp
+        .error_type
+        .is_some_and(|err| err.eq_ignore_ascii_case("TableNotFound")));
+    assert!(prom_resp
+        .error
+        .is_some_and(|err| err.eq_ignore_ascii_case("Table not found: greptime.public.up")));
 
     // label values
     // should return error if there is no match[]
@@ -528,11 +536,15 @@ pub async fn test_prom_http_api(store_type: StorageType) {
         .get("/v1/prometheus/api/v1/label/instance/values")
         .send()
         .await;
-    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
     let prom_resp = res.json::<PrometheusJsonResponse>().await;
     assert_eq!(prom_resp.status, "error");
-    assert!(prom_resp.error.is_some_and(|err| !err.is_empty()));
-    assert!(prom_resp.error_type.is_some_and(|err| !err.is_empty()));
+    assert!(prom_resp
+        .error
+        .is_some_and(|err| err.eq_ignore_ascii_case("match[] parameter is required")));
+    assert!(prom_resp
+        .error_type
+        .is_some_and(|err| err.eq_ignore_ascii_case("InvalidArguments")));
 
     // single match[]
     let res = client


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr mainly fixes the case where prometheus api returns 200 even if an error is encountered.

Note: `Invalid argument` is now `InvalidArguments`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
