### PR TITLE
fix: generate unique timestamp for inserting tests

### DIFF
--- a/tests-fuzz/targets/fuzz_insert.rs
+++ b/tests-fuzz/targets/fuzz_insert.rs
@@ -17,6 +17,7 @@
 use std::sync::Arc;
 
 use common_telemetry::info;
+use common_time::util::current_time_millis;
 use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use rand::{Rng, SeedableRng};
@@ -33,7 +34,7 @@ use tests_fuzz::generator::create_expr::CreateTableExprGeneratorBuilder;
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
 use tests_fuzz::ir::{
-    generate_random_timestamp_for_mysql, generate_random_value, replace_default,
+    generate_random_value, generate_unique_timestamp_for_mysql, replace_default,
     sort_by_primary_keys, CreateTableExpr, InsertIntoExpr, MySQLTsColumnTypeGenerator,
 };
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
@@ -107,7 +108,7 @@ fn generate_insert_expr<R: Rng + 'static>(
         .omit_column_list(omit_column_list)
         .rows(input.rows)
         .value_generator(Box::new(generate_random_value))
-        .ts_value_generator(Box::new(generate_random_timestamp_for_mysql))
+        .ts_value_generator(generate_unique_timestamp_for_mysql(current_time_millis()))
         .build()
         .unwrap();
     insert_generator.generate(rng)

--- a/tests-fuzz/targets/fuzz_insert_logical_table.rs
+++ b/tests-fuzz/targets/fuzz_insert_logical_table.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_telemetry::info;
+use common_time::util::current_time_millis;
 use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::fuzz_target;
 use rand::{Rng, SeedableRng};
@@ -36,7 +37,7 @@ use tests_fuzz::generator::create_expr::{
 use tests_fuzz::generator::insert_expr::InsertExprGeneratorBuilder;
 use tests_fuzz::generator::Generator;
 use tests_fuzz::ir::{
-    generate_random_timestamp_for_mysql, generate_random_value, replace_default,
+    generate_random_value, generate_unique_timestamp_for_mysql, replace_default,
     sort_by_primary_keys, CreateTableExpr, InsertIntoExpr,
 };
 use tests_fuzz::translator::mysql::create_expr::CreateTableExprTranslator;
@@ -119,7 +120,7 @@ fn generate_insert_expr<R: Rng + 'static>(
         .table_ctx(table_ctx)
         .rows(rows)
         .value_generator(Box::new(generate_random_value))
-        .ts_value_generator(Box::new(generate_random_timestamp_for_mysql))
+        .ts_value_generator(generate_unique_timestamp_for_mysql(current_time_millis()))
         .build()
         .unwrap();
     insert_generator.generate(rng)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #4388
## What's changed and what's your intention?

Generate unique timestamp for inserting tests

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
