### PR TITLE
fix: notify flush receiver after write buffer is released

### DIFF
--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -34,9 +34,13 @@ lazy_static! {
     /// Global memtable dictionary size in bytes.
     pub static ref MEMTABLE_DICT_BYTES: IntGauge =
         register_int_gauge!("greptime_mito_memtable_dict_bytes", "mito memtable dictionary size in bytes").unwrap();
-    /// Gauge for open regions
-    pub static ref REGION_COUNT: IntGauge =
-        register_int_gauge!("greptime_mito_region_count", "mito region count").unwrap();
+    /// Gauge for open regions in each worker.
+    pub static ref REGION_COUNT: IntGaugeVec =
+        register_int_gauge_vec!(
+            "greptime_mito_region_count",
+            "mito region count in each worker",
+            &[WORKER_LABEL],
+        ).unwrap();
     /// Elapsed time to handle requests.
     pub static ref HANDLE_REQUEST_ELAPSED: HistogramVec = register_histogram_vec!(
             "greptime_mito_handle_request_elapsed",

--- a/src/mito2/src/worker/handle_close.rs
+++ b/src/mito2/src/worker/handle_close.rs
@@ -19,7 +19,6 @@ use store_api::region_request::AffectedRows;
 use store_api::storage::RegionId;
 
 use crate::error::Result;
-use crate::metrics::REGION_COUNT;
 use crate::worker::RegionWorkerLoop;
 
 impl<S> RegionWorkerLoop<S> {
@@ -31,7 +30,7 @@ impl<S> RegionWorkerLoop<S> {
             return Ok(0);
         };
 
-        info!("Try to close region {}", region_id);
+        info!("Try to close region {}, worker: {}", region_id, self.id);
 
         region.stop().await;
         self.regions.remove_region(region_id);
@@ -40,9 +39,9 @@ impl<S> RegionWorkerLoop<S> {
         // Clean compaction status.
         self.compaction_scheduler.on_region_closed(region_id);
 
-        info!("Region {} closed", region_id);
+        info!("Region {} closed, worker: {}", region_id, self.id);
 
-        REGION_COUNT.dec();
+        self.region_count.dec();
 
         Ok(0)
     }

--- a/src/mito2/src/worker/handle_create.rs
+++ b/src/mito2/src/worker/handle_create.rs
@@ -24,7 +24,6 @@ use store_api::region_request::{AffectedRows, RegionCreateRequest};
 use store_api::storage::RegionId;
 
 use crate::error::{InvalidMetadataSnafu, Result};
-use crate::metrics::REGION_COUNT;
 use crate::region::opener::{check_recovered_region, RegionOpener};
 use crate::worker::RegionWorkerLoop;
 
@@ -70,9 +69,13 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         .create_or_open(&self.config, &self.wal)
         .await?;
 
-        info!("A new region created, region: {:?}", region.metadata());
+        info!(
+            "A new region created, worker: {}, region: {:?}",
+            self.id,
+            region.metadata()
+        );
 
-        REGION_COUNT.inc();
+        self.region_count.inc();
 
         // Insert the MitoRegion into the RegionMap.
         self.regions.insert_region(Arc::new(region));

--- a/src/mito2/src/worker/handle_drop.rs
+++ b/src/mito2/src/worker/handle_drop.rs
@@ -28,7 +28,6 @@ use store_api::storage::RegionId;
 use tokio::time::sleep;
 
 use crate::error::{OpenDalSnafu, Result};
-use crate::metrics::REGION_COUNT;
 use crate::region::{RegionMapRef, RegionState};
 use crate::worker::{RegionWorkerLoop, DROPPING_MARKER_FILE};
 
@@ -45,7 +44,7 @@ where
     ) -> Result<AffectedRows> {
         let region = self.regions.writable_region(region_id)?;
 
-        info!("Try to drop region: {}", region_id);
+        info!("Try to drop region: {}, worker: {}", region_id, self.id);
 
         // Marks the region as dropping.
         region.set_dropping()?;
@@ -93,7 +92,7 @@ where
             region_id
         );
 
-        REGION_COUNT.dec();
+        self.region_count.dec();
 
         // Detaches a background task to delete the region dir
         let region_dir = region.access_layer.region_dir().to_owned();

--- a/src/mito2/src/worker/handle_open.rs
+++ b/src/mito2/src/worker/handle_open.rs
@@ -26,7 +26,6 @@ use store_api::storage::RegionId;
 use crate::error::{
     ObjectStoreNotFoundSnafu, OpenDalSnafu, OpenRegionSnafu, RegionNotFoundSnafu, Result,
 };
-use crate::metrics::REGION_COUNT;
 use crate::region::opener::RegionOpener;
 use crate::request::OptionOutputTx;
 use crate::wal::entry_distributor::WalEntryReceiver;
@@ -56,7 +55,10 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                 .context(OpenDalSnafu)?
         {
             let result = remove_region_dir_once(&request.region_dir, object_store).await;
-            info!("Region {} is dropped, result: {:?}", region_id, result);
+            info!(
+                "Region {} is dropped, worker: {}, result: {:?}",
+                region_id, self.id, result
+            );
             return RegionNotFoundSnafu { region_id }.fail();
         }
 
@@ -84,7 +86,7 @@ impl<S: LogStore> RegionWorkerLoop<S> {
             sender.send(Err(err));
             return;
         }
-        info!("Try to open region {}", region_id);
+        info!("Try to open region {}, worker: {}", region_id, self.id);
 
         // Open region from specific region dir.
         let opener = match RegionOpener::new(
@@ -112,12 +114,14 @@ impl<S: LogStore> RegionWorkerLoop<S> {
         let wal = self.wal.clone();
         let config = self.config.clone();
         let opening_regions = self.opening_regions.clone();
+        let region_count = self.region_count.clone();
+        let worker_id = self.id;
         opening_regions.insert_sender(region_id, sender);
         common_runtime::spawn_global(async move {
             match opener.open(&config, &wal).await {
                 Ok(region) => {
-                    info!("Region {} is opened", region_id);
-                    REGION_COUNT.inc();
+                    info!("Region {} is opened, worker: {}", region_id, worker_id);
+                    region_count.inc();
 
                     // Insert the Region into the RegionMap.
                     regions.insert_region(Arc::new(region));


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/4475

## What's changed and what's your intention?
This PR notifies all workers once a write buffer (memtable) is released so workers can handle stalled requests.

It also adds worker id to some logs and metrics so we can know the relationship between regions and workers.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a notification system for memory management in the Write Buffer Manager, improving responsiveness.
	- Enhanced metrics tracking with REGION_COUNT now providing per-worker granularity.

- **Bug Fixes**
	- Improved logging to include worker IDs, aiding in better traceability during operations.

- **Refactor**
	- Shifted from global metrics to instance-based tracking for region counts, enhancing modularity and maintainability.

- **Tests**
	- Added a new test to validate the notifier functionality within the Write Buffer Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->