### PR TITLE
chore: bump version v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "catalog",
  "common-error",
@@ -1285,7 +1285,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.3",
- "substrait 0.9.0",
+ "substrait 0.9.1",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow",
@@ -1637,7 +1637,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1667,7 +1667,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.3",
  "substrait 0.37.3",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "auth",
@@ -1753,7 +1753,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "temp-env",
  "tempfile",
@@ -1799,7 +1799,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "common-error",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bigdecimal",
  "common-error",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "snafu 0.8.3",
  "strum 0.25.0",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "common-base",
@@ -2018,7 +2018,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2045,7 +2045,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anymap2",
  "api",
@@ -2100,11 +2100,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.9.0"
+version = "0.9.1"
 
 [[package]]
 name = "common-procedure"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -2163,7 +2163,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2204,7 +2204,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "atty",
  "backtrace",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "client",
  "common-query",
@@ -2243,7 +2243,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2259,7 +2259,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "build-data",
  "const_format",
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "common-base",
  "common-error",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3115,7 +3115,7 @@ dependencies = [
  "session",
  "snafu 0.8.3",
  "store-api",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "tokio",
  "toml 0.8.14",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3685,7 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow-schema",
@@ -3835,7 +3835,7 @@ dependencies = [
  "snafu 0.8.3",
  "store-api",
  "strum 0.25.0",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -3882,7 +3882,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5763,7 +5763,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "log-store"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -6096,7 +6096,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -7202,7 +7202,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "tokio",
  "tokio-util",
@@ -7452,7 +7452,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -7741,7 +7741,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow",
@@ -7899,7 +7899,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "auth",
  "common-base",
@@ -8168,7 +8168,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8403,7 +8403,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-compression 0.4.11",
  "async-trait",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8588,7 +8588,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "tokio",
  "tokio-stream",
@@ -9916,7 +9916,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -10209,7 +10209,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aide",
  "api",
@@ -10315,7 +10315,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arc-swap",
@@ -10616,7 +10616,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "chrono",
@@ -10676,7 +10676,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "clap 4.5.7",
@@ -10893,7 +10893,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "aquamarine",
@@ -11062,7 +11062,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11263,7 +11263,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "async-trait",
@@ -11528,7 +11528,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -11570,7 +11570,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "api",
  "arrow-flight",
@@ -11630,7 +11630,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.9.0",
+ "substrait 0.9.1",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
 - Bump version for multiple packages from 0.9.0 to 0.9.1 in Cargo.lock

I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Bump GreptimeDB version v0.9.1

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
