### PR TITLE
fix: avoid total size overflow

### DIFF
--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -199,7 +199,9 @@ impl FileCache {
             .metakey(Metakey::ContentLength)
             .await
             .context(OpenDalSnafu)?;
-        let (mut total_size, mut total_keys) = (0, 0);
+        // Use i64 for total_size to reduce the risk of overflow.
+        // It is possible that the total size of the cache is larger than i32::MAX.
+        let (mut total_size, mut total_keys) = (0i64, 0);
         while let Some(entry) = lister.try_next().await.context(OpenDalSnafu)? {
             let meta = entry.metadata();
             if !meta.is_file() {
@@ -212,13 +214,11 @@ impl FileCache {
             self.memory_index
                 .insert(key, IndexValue { file_size })
                 .await;
-            total_size += file_size;
+            total_size += i64::from(file_size);
             total_keys += 1;
         }
         // The metrics is a signed int gauge so we can updates it finally.
-        CACHE_BYTES
-            .with_label_values(&[FILE_TYPE])
-            .add(total_size.into());
+        CACHE_BYTES.with_label_values(&[FILE_TYPE]).add(total_size);
 
         info!(
             "Recovered file cache, num_keys: {}, num_bytes: {}, cost: {:?}",


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/4435

## What's changed and what's your intention?

This PR casts the file size to i64 to avoid the recovered total size overflow while the total cache directory is greater than 4GB.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced cache management by allowing support for larger file sizes, improving reliability.
  
- **Bug Fixes**
  - Fixed potential overflow issues in total size calculations for cached files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->