### PR TITLE
chore: bump `shadow-rs` version to set the path to find the correct git repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10376,9 +10376,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a600f795d0894cda22235b44eea4b85c2a35b405f65523645ac8e35b306817a"
+checksum = "66caf2de9b7e61293c00006cd2807d6c4e4b31018c5ea21d008f44f4852b93c3"
 dependencies = [
  "const_format",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_with = "3"
+shadow-rs = "0.31"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
 sysinfo = "0.30"

--- a/src/common/version/Cargo.toml
+++ b/src/common/version/Cargo.toml
@@ -14,8 +14,8 @@ codec = ["dep:serde", "dep:schemars"]
 const_format = "0.2"
 schemars = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-shadow-rs = "0.29"
+shadow-rs.workspace = true
 
 [build-dependencies]
 build-data = "0.2"
-shadow-rs = "0.29"
+shadow-rs.workspace = true

--- a/src/common/version/build.rs
+++ b/src/common/version/build.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
+
 use build_data::{format_timestamp, get_source_time};
 
 fn main() -> shadow_rs::SdResult<()> {
@@ -25,5 +27,12 @@ fn main() -> shadow_rs::SdResult<()> {
         }
     );
     build_data::set_BUILD_TIMESTAMP();
-    shadow_rs::new()
+
+    // The "CARGO_WORKSPACE_DIR" is set manually (not by Rust itself) in Cargo config file, to
+    // solve the problem where the "CARGO_MANIFEST_DIR" is not what we want when this repo is
+    // made as a submodule in another repo.
+    let src_path = env::var("CARGO_WORKSPACE_DIR").or_else(|_| env::var("CARGO_MANIFEST_DIR"))?;
+    let out_path = env::var("OUT_DIR")?;
+    let _ = shadow_rs::Shadow::build_with(src_path, out_path, Default::default())?;
+    Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In our another project with "greptimedb" as its submodule, the git info fetched in building is wrong. This is because the git repo finding ends within the submodule, which should have been the outside repo that owns the submodule.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
