### PR TITLE
chore: bump opendal version to 0.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6967,9 +6967,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.47.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff159a2da374ef2d64848a6547943cf1af7d2ceada5ae77be175e1389aa07ae3"
+checksum = "615d41187deea0ea7fab5b48e9afef6ae8fc742fdcfa248846ee3d92ff71e986"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6986,7 +6986,7 @@ dependencies = [
  "md-5",
  "once_cell",
  "percent-encoding",
- "quick-xml 0.31.0",
+ "quick-xml 0.36.1",
  "reqsign",
  "reqwest",
  "serde",
@@ -8605,9 +8605,19 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "86e446ed58cef1bbfe847bc2fda0e2e4ea9f0e57b90c507d4781292590d72a4e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
  "serde",
@@ -8883,9 +8893,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8901,7 +8911,7 @@ dependencies = [
  "log",
  "once_cell",
  "percent-encoding",
- "quick-xml 0.31.0",
+ "quick-xml 0.35.0",
  "rand",
  "reqwest",
  "rsa 0.9.6",

--- a/src/common/datasource/src/object_store/fs.rs
+++ b/src/common/datasource/src/object_store/fs.rs
@@ -19,9 +19,8 @@ use snafu::ResultExt;
 use crate::error::{BuildBackendSnafu, Result};
 
 pub fn build_fs_backend(root: &str) -> Result<ObjectStore> {
-    let mut builder = Fs::default();
-    let _ = builder.root(root);
-    let object_store = ObjectStore::new(builder)
+    let builder = Fs::default();
+    let object_store = ObjectStore::new(builder.root(root))
         .context(BuildBackendSnafu)?
         .layer(
             object_store::layers::LoggingLayer::default()

--- a/src/common/datasource/src/object_store/s3.rs
+++ b/src/common/datasource/src/object_store/s3.rs
@@ -44,28 +44,26 @@ pub fn build_s3_backend(
     path: &str,
     connection: &HashMap<String, String>,
 ) -> Result<ObjectStore> {
-    let mut builder = S3::default();
-
-    let _ = builder.root(path).bucket(host);
+    let mut builder = S3::default().root(path).bucket(host);
 
     if let Some(endpoint) = connection.get(ENDPOINT) {
-        let _ = builder.endpoint(endpoint);
+        builder = builder.endpoint(endpoint);
     }
 
     if let Some(region) = connection.get(REGION) {
-        let _ = builder.region(region);
+        builder = builder.region(region);
     }
 
     if let Some(key_id) = connection.get(ACCESS_KEY_ID) {
-        let _ = builder.access_key_id(key_id);
+        builder = builder.access_key_id(key_id);
     }
 
     if let Some(key) = connection.get(SECRET_ACCESS_KEY) {
-        let _ = builder.secret_access_key(key);
+        builder = builder.secret_access_key(key);
     }
 
     if let Some(session_token) = connection.get(SESSION_TOKEN) {
-        let _ = builder.security_token(session_token);
+        builder = builder.session_token(session_token);
     }
 
     if let Some(enable_str) = connection.get(ENABLE_VIRTUAL_HOST_STYLE) {
@@ -79,7 +77,7 @@ pub fn build_s3_backend(
             .build()
         })?;
         if enable {
-            let _ = builder.enable_virtual_host_style();
+            builder = builder.enable_virtual_host_style();
         }
     }
 

--- a/src/common/datasource/src/test_util.rs
+++ b/src/common/datasource/src/test_util.rs
@@ -47,19 +47,15 @@ pub fn format_schema(schema: Schema) -> Vec<String> {
 }
 
 pub fn test_store(root: &str) -> ObjectStore {
-    let mut builder = Fs::default();
-    let _ = builder.root(root);
-
-    ObjectStore::new(builder).unwrap().finish()
+    let builder = Fs::default();
+    ObjectStore::new(builder.root(root)).unwrap().finish()
 }
 
 pub fn test_tmp_store(root: &str) -> (ObjectStore, TempDir) {
     let dir = create_temp_dir(root);
 
-    let mut builder = Fs::default();
-    let _ = builder.root("/");
-
-    (ObjectStore::new(builder).unwrap().finish(), dir)
+    let builder = Fs::default();
+    (ObjectStore::new(builder.root("/")).unwrap().finish(), dir)
 }
 
 pub fn test_basic_schema() -> SchemaRef {

--- a/src/common/procedure/src/local.rs
+++ b/src/common/procedure/src/local.rs
@@ -680,9 +680,8 @@ pub(crate) mod test_util {
 
     pub(crate) fn new_object_store(dir: &TempDir) -> ObjectStore {
         let store_dir = dir.path().to_str().unwrap();
-        let mut builder = Builder::default();
-        let _ = builder.root(store_dir);
-        ObjectStore::new(builder).unwrap().finish()
+        let builder = Builder::default();
+        ObjectStore::new(builder.root(store_dir)).unwrap().finish()
     }
 }
 

--- a/src/common/procedure/src/store.rs
+++ b/src/common/procedure/src/store.rs
@@ -361,8 +361,7 @@ mod tests {
 
     fn procedure_store_for_test(dir: &TempDir) -> ProcedureStore {
         let store_dir = dir.path().to_str().unwrap();
-        let mut builder = Builder::default();
-        let _ = builder.root(store_dir);
+        let builder = Builder::default().root(store_dir);
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
         ProcedureStore::from_object_store(object_store)

--- a/src/common/procedure/src/store/state_store.rs
+++ b/src/common/procedure/src/store/state_store.rs
@@ -220,8 +220,7 @@ mod tests {
     async fn test_object_state_store() {
         let dir = create_temp_dir("state_store");
         let store_dir = dir.path().to_str().unwrap();
-        let mut builder = Builder::default();
-        let _ = builder.root(store_dir);
+        let builder = Builder::default().root(store_dir);
 
         let object_store = ObjectStore::new(builder).unwrap().finish();
         let state_store = ObjectStateStore::new(object_store);
@@ -291,8 +290,7 @@ mod tests {
     async fn test_object_state_store_delete() {
         let dir = create_temp_dir("state_store_list");
         let store_dir = dir.path().to_str().unwrap();
-        let mut builder = Builder::default();
-        let _ = builder.root(store_dir);
+        let builder = Builder::default().root(store_dir);
 
         let object_store = ObjectStore::new(builder).unwrap().finish();
         let state_store = ObjectStateStore::new(object_store);

--- a/src/datanode/src/store.rs
+++ b/src/datanode/src/store.rs
@@ -112,11 +112,11 @@ async fn create_object_store_with_cache(
         let atomic_temp_dir = join_dir(path, ".tmp/");
         clean_temp_dir(&atomic_temp_dir)?;
 
-        let cache_store = {
-            let mut builder = Fs::default();
-            builder.root(path).atomic_write_dir(&atomic_temp_dir);
-            builder.build().context(error::InitBackendSnafu)?
-        };
+        let cache_store = Fs::default()
+            .root(path)
+            .atomic_write_dir(&atomic_temp_dir)
+            .build()
+            .context(error::InitBackendSnafu)?;
 
         let cache_layer = LruCacheLayer::new(Arc::new(cache_store), cache_capacity.0 as usize)
             .await

--- a/src/datanode/src/store/azblob.rs
+++ b/src/datanode/src/store/azblob.rs
@@ -30,8 +30,7 @@ pub(crate) async fn new_azblob_object_store(azblob_config: &AzblobConfig) -> Res
         azblob_config.container, &root
     );
 
-    let mut builder = Azblob::default();
-    let _ = builder
+    let mut builder = Azblob::default()
         .root(&root)
         .container(&azblob_config.container)
         .endpoint(&azblob_config.endpoint)
@@ -40,8 +39,8 @@ pub(crate) async fn new_azblob_object_store(azblob_config: &AzblobConfig) -> Res
         .http_client(build_http_client()?);
 
     if let Some(token) = &azblob_config.sas_token {
-        let _ = builder.sas_token(token);
-    }
+        builder = builder.sas_token(token);
+    };
 
     Ok(ObjectStore::new(builder)
         .context(error::InitBackendSnafu)?

--- a/src/datanode/src/store/fs.rs
+++ b/src/datanode/src/store/fs.rs
@@ -35,8 +35,9 @@ pub(crate) async fn new_fs_object_store(
     let atomic_write_dir = join_dir(data_home, ".tmp/");
     store::clean_temp_dir(&atomic_write_dir)?;
 
-    let mut builder = Fs::default();
-    let _ = builder.root(data_home).atomic_write_dir(&atomic_write_dir);
+    let builder = Fs::default()
+        .root(data_home)
+        .atomic_write_dir(&atomic_write_dir);
 
     let object_store = ObjectStore::new(builder)
         .context(error::InitBackendSnafu)?

--- a/src/datanode/src/store/gcs.rs
+++ b/src/datanode/src/store/gcs.rs
@@ -29,8 +29,7 @@ pub(crate) async fn new_gcs_object_store(gcs_config: &GcsConfig) -> Result<Objec
         gcs_config.bucket, &root
     );
 
-    let mut builder = Gcs::default();
-    builder
+    let builder = Gcs::default()
         .root(&root)
         .bucket(&gcs_config.bucket)
         .scope(&gcs_config.scope)

--- a/src/datanode/src/store/oss.rs
+++ b/src/datanode/src/store/oss.rs
@@ -29,8 +29,7 @@ pub(crate) async fn new_oss_object_store(oss_config: &OssConfig) -> Result<Objec
         oss_config.bucket, &root
     );
 
-    let mut builder = Oss::default();
-    let _ = builder
+    let builder = Oss::default()
         .root(&root)
         .bucket(&oss_config.bucket)
         .endpoint(&oss_config.endpoint)

--- a/src/datanode/src/store/s3.rs
+++ b/src/datanode/src/store/s3.rs
@@ -30,8 +30,7 @@ pub(crate) async fn new_s3_object_store(s3_config: &S3Config) -> Result<ObjectSt
         s3_config.bucket, &root
     );
 
-    let mut builder = S3::default();
-    let _ = builder
+    let mut builder = S3::default()
         .root(&root)
         .bucket(&s3_config.bucket)
         .access_key_id(s3_config.access_key_id.expose_secret())
@@ -39,11 +38,11 @@ pub(crate) async fn new_s3_object_store(s3_config: &S3Config) -> Result<ObjectSt
         .http_client(build_http_client()?);
 
     if s3_config.endpoint.is_some() {
-        let _ = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
-    }
+        builder = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
+    };
     if s3_config.region.is_some() {
-        let _ = builder.region(s3_config.region.as_ref().unwrap());
-    }
+        builder = builder.region(s3_config.region.as_ref().unwrap());
+    };
 
     Ok(ObjectStore::new(builder)
         .context(error::InitBackendSnafu)?

--- a/src/file-engine/src/test_util.rs
+++ b/src/file-engine/src/test_util.rs
@@ -26,8 +26,7 @@ use store_api::metadata::ColumnMetadata;
 pub fn new_test_object_store(prefix: &str) -> (TempDir, ObjectStore) {
     let dir = create_temp_dir(prefix);
     let store_dir = dir.path().to_string_lossy();
-    let mut builder = Fs::default();
-    let _ = builder.root(&store_dir);
+    let builder = Fs::default().root(&store_dir);
     (dir, ObjectStore::new(builder).unwrap().finish())
 }
 

--- a/src/metric-engine/src/test_util.rs
+++ b/src/metric-engine/src/test_util.rs
@@ -307,8 +307,7 @@ mod test {
         env.init_metric_region().await;
         let region_id = to_metadata_region_id(env.default_physical_region_id());
 
-        let mut builder = Fs::default();
-        builder.root(&env.data_home());
+        let builder = Fs::default().root(&env.data_home());
         let object_store = ObjectStore::new(builder).unwrap().finish();
 
         let region_dir = "test_metric_region";

--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -212,8 +212,7 @@ pub(crate) async fn new_fs_cache_store(root: &str) -> Result<ObjectStore> {
     let atomic_write_dir = join_dir(root, ".tmp/");
     clean_dir(&atomic_write_dir).await?;
 
-    let mut builder = Fs::default();
-    builder.root(root).atomic_write_dir(&atomic_write_dir);
+    let builder = Fs::default().root(root).atomic_write_dir(&atomic_write_dir);
     let store = ObjectStore::new(builder).context(OpenDalSnafu)?.finish();
 
     Ok(with_instrument_layers(store, false))

--- a/src/mito2/src/cache/file_cache.rs
+++ b/src/mito2/src/cache/file_cache.rs
@@ -382,8 +382,7 @@ mod tests {
     use super::*;
 
     fn new_fs_store(path: &str) -> ObjectStore {
-        let mut builder = Fs::default();
-        builder.root(path);
+        let builder = Fs::default().root(path);
         ObjectStore::new(builder).unwrap().finish()
     }
 

--- a/src/mito2/src/cache/test_util.rs
+++ b/src/mito2/src/cache/test_util.rs
@@ -46,7 +46,6 @@ fn parquet_file_data() -> Vec<u8> {
 }
 
 pub(crate) fn new_fs_store(path: &str) -> ObjectStore {
-    let mut builder = Fs::default();
-    builder.root(path);
-    ObjectStore::new(builder).unwrap().finish()
+    let builder = Fs::default();
+    ObjectStore::new(builder.root(path)).unwrap().finish()
 }

--- a/src/mito2/src/manifest/storage.rs
+++ b/src/mito2/src/manifest/storage.rs
@@ -642,8 +642,7 @@ mod tests {
     fn new_test_manifest_store() -> ManifestObjectStore {
         common_telemetry::init_default_ut_logging();
         let tmp_dir = create_temp_dir("test_manifest_log_store");
-        let mut builder = Fs::default();
-        let _ = builder.root(&tmp_dir.path().to_string_lossy());
+        let builder = Fs::default().root(&tmp_dir.path().to_string_lossy());
         let object_store = ObjectStore::new(builder).unwrap().finish();
         ManifestObjectStore::new(
             "/",

--- a/src/mito2/src/sst/file_purger.rs
+++ b/src/mito2/src/sst/file_purger.rs
@@ -114,8 +114,7 @@ mod tests {
 
         let dir = create_temp_dir("file-purge");
         let dir_path = dir.path().display().to_string();
-        let mut builder = Fs::default();
-        builder.root(&dir_path);
+        let builder = Fs::default().root(&dir_path);
         let sst_file_id = FileId::random();
         let sst_dir = "table1";
         let path = location::sst_file_path(sst_dir, sst_file_id);
@@ -171,8 +170,7 @@ mod tests {
 
         let dir = create_temp_dir("file-purge");
         let dir_path = dir.path().display().to_string();
-        let mut builder = Fs::default();
-        builder.root(&dir_path);
+        let builder = Fs::default().root(&dir_path);
         let sst_file_id = FileId::random();
         let sst_dir = "table1";
 

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -365,8 +365,7 @@ impl TestEnv {
                 .display()
                 .to_string();
             let mut builder = Fs::default();
-            builder.root(&data_path);
-            let object_store = ObjectStore::new(builder).unwrap().finish();
+            let object_store = ObjectStore::new(builder.root(&data_path)).unwrap().finish();
             object_store_manager.add(storage_name, object_store);
         }
         let object_store_manager = Arc::new(object_store_manager);
@@ -553,8 +552,7 @@ impl TestEnv {
     fn create_object_store_manager(&self) -> ObjectStoreManager {
         let data_home = self.data_home.path();
         let data_path = data_home.join("data").as_path().display().to_string();
-        let mut builder = Fs::default();
-        builder.root(&data_path);
+        let builder = Fs::default().root(&data_path);
         let object_store = ObjectStore::new(builder).unwrap().finish();
         ObjectStoreManager::new("default", object_store)
     }
@@ -570,9 +568,10 @@ impl TestEnv {
         let data_home = self.data_home.path();
         let manifest_dir = data_home.join("manifest").as_path().display().to_string();
 
-        let mut builder = Fs::default();
-        builder.root(&manifest_dir);
-        let object_store = ObjectStore::new(builder).unwrap().finish();
+        let builder = Fs::default();
+        let object_store = ObjectStore::new(builder.root(&manifest_dir))
+            .unwrap()
+            .finish();
 
         // The "manifest_dir" here should be the relative path from the `object_store`'s root.
         // Otherwise the OpenDal's list operation would fail with "StripPrefixError". This is

--- a/src/mito2/src/test_util/scheduler_util.rs
+++ b/src/mito2/src/test_util/scheduler_util.rs
@@ -52,8 +52,7 @@ impl SchedulerEnv {
     pub(crate) async fn new() -> SchedulerEnv {
         let path = create_temp_dir("");
         let path_str = path.path().display().to_string();
-        let mut builder = Fs::default();
-        builder.root(&path_str);
+        let builder = Fs::default().root(&path_str);
 
         let index_aux_path = path.path().join("index_aux");
         let puffin_mgr = PuffinManagerFactory::new(&index_aux_path, 4096, None)

--- a/src/object-store/Cargo.toml
+++ b/src/object-store/Cargo.toml
@@ -17,7 +17,7 @@ futures.workspace = true
 lazy_static.workspace = true
 md5 = "0.7"
 moka = { workspace = true, features = ["future"] }
-opendal = { version = "0.47", features = [
+opendal = { version = "0.48", features = [
     "layers-tracing",
     "services-azblob",
     "services-fs",

--- a/src/object-store/src/layers/lru_cache.rs
+++ b/src/object-store/src/layers/lru_cache.rs
@@ -25,10 +25,17 @@ use common_telemetry::info;
 use read_cache::ReadCache;
 
 /// An opendal layer with local LRU file cache supporting.
-#[derive(Clone)]
 pub struct LruCacheLayer<C: Access> {
     // The read cache
     read_cache: ReadCache<C>,
+}
+
+impl<C: Access> Clone for LruCacheLayer<C> {
+    fn clone(&self) -> Self {
+        Self {
+            read_cache: self.read_cache.clone(),
+        }
+    }
 }
 
 impl<C: Access> LruCacheLayer<C> {

--- a/src/object-store/src/manager.rs
+++ b/src/object-store/src/manager.rs
@@ -61,8 +61,7 @@ mod tests {
 
     fn new_object_store(dir: &TempDir) -> ObjectStore {
         let store_dir = dir.path().to_str().unwrap();
-        let mut builder = Builder::default();
-        let _ = builder.root(store_dir);
+        let builder = Builder::default().root(store_dir);
         ObjectStore::new(builder).unwrap().finish()
     }
 

--- a/src/object-store/tests/object_store_test.rs
+++ b/src/object-store/tests/object_store_test.rs
@@ -95,8 +95,7 @@ async fn test_object_list(store: &ObjectStore) -> Result<()> {
 async fn test_fs_backend() -> Result<()> {
     let data_dir = create_temp_dir("test_fs_backend");
     let tmp_dir = create_temp_dir("test_fs_backend");
-    let mut builder = Fs::default();
-    let _ = builder
+    let builder = Fs::default()
         .root(&data_dir.path().to_string_lossy())
         .atomic_write_dir(&tmp_dir.path().to_string_lossy());
 
@@ -117,8 +116,7 @@ async fn test_s3_backend() -> Result<()> {
 
             let root = uuid::Uuid::new_v4().to_string();
 
-            let mut builder = S3::default();
-            let _ = builder
+            let builder = S3::default()
                 .root(&root)
                 .access_key_id(&env::var("GT_S3_ACCESS_KEY_ID")?)
                 .secret_access_key(&env::var("GT_S3_ACCESS_KEY")?)
@@ -146,8 +144,7 @@ async fn test_oss_backend() -> Result<()> {
 
             let root = uuid::Uuid::new_v4().to_string();
 
-            let mut builder = Oss::default();
-            let _ = builder
+            let builder = Oss::default()
                 .root(&root)
                 .access_key_id(&env::var("GT_OSS_ACCESS_KEY_ID")?)
                 .access_key_secret(&env::var("GT_OSS_ACCESS_KEY")?)
@@ -174,8 +171,7 @@ async fn test_azblob_backend() -> Result<()> {
 
             let root = uuid::Uuid::new_v4().to_string();
 
-            let mut builder = Azblob::default();
-            let _ = builder
+            let builder = Azblob::default()
                 .root(&root)
                 .account_name(&env::var("GT_AZBLOB_ACCOUNT_NAME")?)
                 .account_key(&env::var("GT_AZBLOB_ACCOUNT_KEY")?)
@@ -199,8 +195,7 @@ async fn test_gcs_backend() -> Result<()> {
         if !container.is_empty() {
             info!("Running azblob test.");
 
-            let mut builder = Gcs::default();
-            builder
+            let builder = Gcs::default()
                 .root(&uuid::Uuid::new_v4().to_string())
                 .bucket(&env::var("GT_GCS_BUCKET").unwrap())
                 .scope(&env::var("GT_GCS_SCOPE").unwrap())
@@ -224,8 +219,7 @@ async fn test_file_backend_with_lru_cache() -> Result<()> {
 
     let data_dir = create_temp_dir("test_file_backend_with_lru_cache");
     let tmp_dir = create_temp_dir("test_file_backend_with_lru_cache");
-    let mut builder = Fs::default();
-    let _ = builder
+    let builder = Fs::default()
         .root(&data_dir.path().to_string_lossy())
         .atomic_write_dir(&tmp_dir.path().to_string_lossy());
 
@@ -233,8 +227,7 @@ async fn test_file_backend_with_lru_cache() -> Result<()> {
 
     let cache_dir = create_temp_dir("test_file_backend_with_lru_cache");
     let cache_layer = {
-        let mut builder = Fs::default();
-        let _ = builder
+        let builder = Fs::default()
             .root(&cache_dir.path().to_string_lossy())
             .atomic_write_dir(&cache_dir.path().to_string_lossy());
         let file_cache = Arc::new(builder.build().unwrap());
@@ -307,8 +300,7 @@ async fn test_object_store_cache_policy() -> Result<()> {
     // create file cache layer
     let cache_dir = create_temp_dir("test_object_store_cache_policy_cache");
     let atomic_temp_dir = create_temp_dir("test_object_store_cache_policy_cache_tmp");
-    let mut builder = Fs::default();
-    let _ = builder
+    let builder = Fs::default()
         .root(&cache_dir.path().to_string_lossy())
         .atomic_write_dir(&atomic_temp_dir.path().to_string_lossy());
     let file_cache = Arc::new(builder.build().unwrap());

--- a/src/operator/src/statement/copy_database.rs
+++ b/src/operator/src/statement/copy_database.rs
@@ -244,8 +244,7 @@ mod tests {
     async fn test_list_files_and_parse_table_name() {
         let dir = common_test_util::temp_dir::create_temp_dir("test_list_files_to_copy");
         let store_dir = normalize_dir(dir.path().to_str().unwrap());
-        let mut builder = Fs::default();
-        let _ = builder.root(&store_dir);
+        let builder = Fs::default().root(&store_dir);
         let object_store = ObjectStore::new(builder).unwrap().finish();
         object_store.write("a.parquet", "").await.unwrap();
         object_store.write("b.parquet", "").await.unwrap();

--- a/tests-integration/src/test_util.rs
+++ b/tests-integration/src/test_util.rs
@@ -164,8 +164,7 @@ pub fn get_test_store_config(store_type: &StorageType) -> (ObjectStoreConfig, Te
                 ..Default::default()
             };
 
-            let mut builder = Gcs::default();
-            builder
+            let builder = Gcs::default()
                 .root(&gcs_config.root)
                 .bucket(&gcs_config.bucket)
                 .scope(&gcs_config.scope)
@@ -186,8 +185,7 @@ pub fn get_test_store_config(store_type: &StorageType) -> (ObjectStoreConfig, Te
                 ..Default::default()
             };
 
-            let mut builder = Azblob::default();
-            let _ = builder
+            let mut builder = Azblob::default()
                 .root(&azblob_config.root)
                 .endpoint(&azblob_config.endpoint)
                 .account_name(azblob_config.account_name.expose_secret())
@@ -195,8 +193,8 @@ pub fn get_test_store_config(store_type: &StorageType) -> (ObjectStoreConfig, Te
                 .container(&azblob_config.container);
 
             if let Ok(sas_token) = env::var("GT_AZBLOB_SAS_TOKEN") {
-                let _ = builder.sas_token(&sas_token);
-            }
+                builder = builder.sas_token(&sas_token);
+            };
 
             let config = ObjectStoreConfig::Azblob(azblob_config);
 
@@ -214,8 +212,7 @@ pub fn get_test_store_config(store_type: &StorageType) -> (ObjectStoreConfig, Te
                 ..Default::default()
             };
 
-            let mut builder = Oss::default();
-            let _ = builder
+            let builder = Oss::default()
                 .root(&oss_config.root)
                 .endpoint(&oss_config.endpoint)
                 .access_key_id(oss_config.access_key_id.expose_secret())
@@ -235,19 +232,18 @@ pub fn get_test_store_config(store_type: &StorageType) -> (ObjectStoreConfig, Te
                 s3_config.cache.cache_path = Some("/tmp/greptimedb_cache".to_string());
             }
 
-            let mut builder = S3::default();
-            let _ = builder
+            let mut builder = S3::default()
                 .root(&s3_config.root)
                 .access_key_id(s3_config.access_key_id.expose_secret())
                 .secret_access_key(s3_config.secret_access_key.expose_secret())
                 .bucket(&s3_config.bucket);
 
             if s3_config.endpoint.is_some() {
-                let _ = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
-            }
+                builder = builder.endpoint(s3_config.endpoint.as_ref().unwrap());
+            };
             if s3_config.region.is_some() {
-                let _ = builder.region(s3_config.region.as_ref().unwrap());
-            }
+                builder = builder.region(s3_config.region.as_ref().unwrap());
+            };
 
             let config = ObjectStoreConfig::S3(s3_config);
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

bump opendal version to 0.48

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
