### PR TITLE
fix(tql): avoid unwrap on parsing tql query 

### DIFF
--- a/src/sql/src/parsers/error.rs
+++ b/src/sql/src/parsers/error.rs
@@ -31,4 +31,12 @@ pub enum TQLError {
 
     #[snafu(display("Failed to evaluate TQL expression: {}", msg))]
     Evaluation { msg: String },
+
+    #[snafu(display("Failed to convert TQL expression to logical expression"))]
+    ConvertToLogicalExpression {
+        #[snafu(source)]
+        error: Box<crate::error::Error>,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }

--- a/src/sql/src/parsers/tql_parser.rs
+++ b/src/sql/src/parsers/tql_parser.rs
@@ -273,6 +273,11 @@ mod tests {
             }
             _ => unreachable!(),
         }
+
+        let sql = "TQL EVAL (now(), now()-'5m', '30s') http_requests_total";
+        let result =
+            ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/sql/src/parsers/tql_parser.rs
+++ b/src/sql/src/parsers/tql_parser.rs
@@ -31,6 +31,7 @@ const VERBOSE: &str = "VERBOSE";
 
 use sqlparser::parser::Parser;
 
+use super::error::ConvertToLogicalExpressionSnafu;
 use crate::dialect::GreptimeDbDialect;
 use crate::parsers::error::{EvaluationSnafu, ParserSnafu, TQLError};
 
@@ -182,7 +183,9 @@ impl<'a> ParserContext<'a> {
 
     fn parse_tokens(tokens: Vec<Token>) -> std::result::Result<String, TQLError> {
         let parser_expr = Self::parse_to_expr(tokens)?;
-        let lit = utils::parser_expr_to_scalar_value(parser_expr).unwrap();
+        let lit = utils::parser_expr_to_scalar_value(parser_expr)
+            .map_err(Box::new)
+            .context(ConvertToLogicalExpressionSnafu)?;
 
         let second = match lit {
             ScalarValue::TimestampNanosecond(ts_nanos, _)


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


Avoid `.unwrap()` and panic on invalid tql queries.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
