### PR TITLE
chore: bump rust-postgres to 0.7.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,7 +4680,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -7928,11 +7928,11 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -7946,9 +7946,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
 dependencies = [
  "array-init",
  "bytes",
@@ -8455,7 +8455,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.1",
- "parking_lot 0.12.3",
+ "parking_lot 0.11.2",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -11919,9 +11919,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/tests-integration/tests/sql.rs
+++ b/tests-integration/tests/sql.rs
@@ -469,7 +469,7 @@ pub async fn test_postgres_bytea(store_type: StorageType) {
         .await
         .unwrap();
     let get_row = |mess: Vec<SimpleQueryMessage>| -> String {
-        match &mess[0] {
+        match &mess[1] {
             SimpleQueryMessage::Row(row) => row.get(0).unwrap().to_string(),
             _ => unreachable!(),
         }
@@ -595,9 +595,9 @@ pub async fn test_postgres_datestyle(store_type: StorageType) {
         .expect("INSERT INTO dt_test ERROR");
 
     let get_row = |mess: Vec<SimpleQueryMessage>| -> String {
-        match &mess[0] {
+        match &mess[1] {
             SimpleQueryMessage::Row(row) => row.get(0).unwrap().to_string(),
-            _ => unreachable!(),
+            _ => unreachable!("Unexpected messages: {:?}", mess),
         }
     };
 
@@ -759,7 +759,7 @@ pub async fn test_postgres_timezone(store_type: StorageType) {
     });
 
     let get_row = |mess: Vec<SimpleQueryMessage>| -> String {
-        match &mess[0] {
+        match &mess[1] {
             SimpleQueryMessage::Row(row) => row.get(0).unwrap().to_string(),
             _ => unreachable!(),
         }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fix #4503
## What's changed and what's your intention?

- Bump `postgres-protocol` to `0.6.7`
- Bump `tokio-postgres` to `0.7.11`
- Bump `postgres-types` to `0.2.7`

The `tokio-postgres@0.7.11` introduced a breaking change, the `simple_query` method returns
`SimpleQueryMessage::RowDescription` before the `SimpleQueryMessage::Row`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
