### PR TITLE
fix: too large shadow-rs consts

### DIFF
--- a/src/common/version/build.rs
+++ b/src/common/version/build.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeSet;
 use std::env;
 
 use build_data::{format_timestamp, get_source_time};
+use shadow_rs::{CARGO_METADATA, CARGO_TREE};
 
 fn main() -> shadow_rs::SdResult<()> {
     println!("cargo:rerun-if-changed=.git/refs/heads");
@@ -33,6 +35,10 @@ fn main() -> shadow_rs::SdResult<()> {
     // made as a submodule in another repo.
     let src_path = env::var("CARGO_WORKSPACE_DIR").or_else(|_| env::var("CARGO_MANIFEST_DIR"))?;
     let out_path = env::var("OUT_DIR")?;
-    let _ = shadow_rs::Shadow::build_with(src_path, out_path, Default::default())?;
+    let _ = shadow_rs::Shadow::build_with(
+        src_path,
+        out_path,
+        BTreeSet::from([CARGO_METADATA, CARGO_TREE]),
+    )?;
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The change in https://github.com/GreptimeTeam/greptimedb/pull/4494 cause the final generated "shadow.rs" file too large(over 26MB). This PR cancels generating the two largest consts in that file, of which are no use to us. After this PR, the file is small(~14KB) again.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
