### PR TITLE
ci: fix windows temp path

### DIFF
--- a/.github/actions/build-windows-artifacts/action.yml
+++ b/.github/actions/build-windows-artifacts/action.yml
@@ -69,7 +69,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: sqlness-logs
-        path: C:\tmp\greptime-*.log
+        path: C:\Users\RUNNER~1\AppData\Local\Temp\sqlness*
         retention-days: 3
 
     - name: Build greptime binary

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sqlness-logs
-          path: C:\tmp\greptime-*.log
+          path: C:\Users\RUNNER~1\AppData\Local\Temp\sqlness*
           retention-days: 3
 
   test-on-windows:


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4514

## What's changed and what's your intention?
Fix sqlness log path

According to https://github.com/GreptimeTeam/greptimedb/actions/runs/10257291884/job/28378064525

The log directory is under `C:\Users\RUNNER~1\AppData\Local\Temp`.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
