### PR TITLE
fix: larger stack size in debug mode

### DIFF
--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -72,17 +72,13 @@ fn main() -> Result<()> {
         .name("main_spawn".to_string())
         .stack_size(8 * 1024 * 1024)
         .spawn(|| {
-            let body = async {
-                setup_human_panic();
-                start(Command::parse()).await
-            };
             {
                 tokio::runtime::Builder::new_multi_thread()
                     .thread_stack_size(8 * 1024 * 1024)
                     .enable_all()
                     .build()
                     .expect("Failed building the Runtime")
-                    .block_on(body)
+                    .block_on(main_body())
             }
         })
         .context(cmd::error::SpawnThreadSnafu)?
@@ -93,6 +89,10 @@ fn main() -> Result<()> {
 #[cfg(not(debug_assertions))]
 #[tokio::main]
 async fn main() -> Result<()> {
+    main_body().await
+}
+
+async fn main_body() -> Result<()> {
     setup_human_panic();
     start(Command::parse()).await
 }

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -80,7 +80,7 @@ fn main() -> Result<()> {
                 let builder = tokio::runtime::Builder::new_multi_thread().enable_all();
 
                 #[cfg(debug_assertions)]
-                let builder = builder..thread_stack_size(8 * 1024 * 1024);
+                let builder = builder.thread_stack_size(8 * 1024 * 1024);
 
                 return builder
                     .build()

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -64,7 +64,7 @@ enum SubCommand {
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn main() -> Result<()> {
-    // Set the stack size to 8MB for the thread so it wouldn't crash on large stack usage in debug mode
+    // Set the stack size to 8MB for the thread so it wouldn't overflow on large stack usage in debug mode
     // see https://github.com/GreptimeTeam/greptimedb/pull/4317
     // and https://github.com/rust-lang/rust/issues/34283
     let builder = std::thread::Builder::new().name("main_spawn".to_string());
@@ -83,11 +83,11 @@ fn main() -> Result<()> {
                 #[cfg(debug_assertions)]
                 let builder = builder.thread_stack_size(8 * 1024 * 1024);
 
-                return builder
+                builder
                     .enable_all()
                     .build()
                     .expect("Failed building the Runtime")
-                    .block_on(body);
+                    .block_on(body)
             }
         })
         .context(SpawnThreadSnafu)?

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -77,12 +77,13 @@ fn main() -> Result<()> {
             };
             #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
             {
-                let builder = tokio::runtime::Builder::new_multi_thread().enable_all();
+                let mut builder = tokio::runtime::Builder::new_multi_thread();
 
                 #[cfg(debug_assertions)]
                 let builder = builder.thread_stack_size(8 * 1024 * 1024);
 
                 return builder
+                    .enable_all()
                     .build()
                     .expect("Failed building the Runtime")
                     .block_on(body);

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -15,10 +15,11 @@
 #![doc = include_str!("../../../../README.md")]
 
 use clap::{Parser, Subcommand};
-use cmd::error::Result;
+use cmd::error::{Result, SpawnThreadSnafu};
 use cmd::options::GlobalOptions;
 use cmd::{cli, datanode, flownode, frontend, metasrv, standalone, App};
 use common_version::version;
+use snafu::ResultExt;
 
 #[derive(Parser)]
 #[command(name = "greptime", author, version, long_version = version(), about)]
@@ -89,9 +90,9 @@ fn main() -> Result<()> {
                     .block_on(body);
             }
         })
-        .unwrap()
+        .context(SpawnThreadSnafu)?
         .join()
-        .unwrap()
+        .expect("Couldn't join on the associated thread")
 }
 
 async fn start(cli: Command) -> Result<()> {

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
     // Set the stack size to 8MB for the thread so it wouldn't crash on large stack usage in debug mode
     // see https://github.com/GreptimeTeam/greptimedb/pull/4317
     // and https://github.com/rust-lang/rust/issues/34283
-    let builder = std::thread::Builder::new().name("main_larger_stack".to_string());
+    let builder = std::thread::Builder::new().name("main_spawn".to_string());
     #[cfg(debug_assertions)]
     let builder = builder.stack_size(8 * 1024 * 1024);
     builder

--- a/src/cmd/src/error.rs
+++ b/src/cmd/src/error.rs
@@ -305,6 +305,12 @@ pub enum Error {
         error: std::io::Error,
     },
 
+    #[snafu(display("Failed to spawn thread"))]
+    SpawnThread {
+        #[snafu(source)]
+        error: std::io::Error,
+    },
+
     #[snafu(display("Other error"))]
     Other {
         source: BoxedError,
@@ -395,7 +401,9 @@ impl ErrorExt for Error {
             Error::SubstraitEncodeLogicalPlan { source, .. } => source.status_code(),
             Error::StartCatalogManager { source, .. } => source.status_code(),
 
-            Error::SerdeJson { .. } | Error::FileIo { .. } => StatusCode::Unexpected,
+            Error::SerdeJson { .. } | Error::FileIo { .. } | Error::SpawnThread { .. } => {
+                StatusCode::Unexpected
+            }
 
             Error::Other { source, .. } => source.status_code(),
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

set larger stack size for debug mode, so it doesn't overflow for deep recursive functions. After setting this, `cargo sqlness` doesn't overflow in windows(it can relably reproduce overflow before this fix)

https://github.com/GreptimeTeam/greptimedb/actions/runs/10261340360/job/28388920598

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
