### PR TITLE
ci: download the latest stable released version by default and do some small refactoring

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,62 +1,72 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -ue
 
 OS_TYPE=
 ARCH_TYPE=
+
+# Set the GitHub token to avoid GitHub API rate limit.
+# You can run with `GITHUB_TOKEN`:
+#  GITHUB_TOKEN=<your_token> ./scripts/install.sh
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+
 VERSION=${1:-latest}
 GITHUB_ORG=GreptimeTeam
 GITHUB_REPO=greptimedb
 BIN=greptime
 
-get_os_type() {
-    os_type="$(uname -s)"
+function get_os_type() {
+  os_type="$(uname -s)"
 
-    case "$os_type" in
+  case "$os_type" in
     Darwin)
-        OS_TYPE=darwin
-        ;;
+      OS_TYPE=darwin
+      ;;
     Linux)
-        OS_TYPE=linux
-        ;;
+      OS_TYPE=linux
+      ;;
     *)
-        echo "Error: Unknown OS type: $os_type"
-        exit 1
-    esac
+      echo "Error: Unknown OS type: $os_type"
+      exit 1
+  esac
 }
 
-get_arch_type() {
-    arch_type="$(uname -m)"
+function get_arch_type() {
+  arch_type="$(uname -m)"
 
-    case "$arch_type" in
+  case "$arch_type" in
     arm64)
-        ARCH_TYPE=arm64
-        ;;
+      ARCH_TYPE=arm64
+      ;;
     aarch64)
-        ARCH_TYPE=arm64
-        ;;
+      ARCH_TYPE=arm64
+      ;;
     x86_64)
-        ARCH_TYPE=amd64
-        ;;
+      ARCH_TYPE=amd64
+      ;;
     amd64)
-        ARCH_TYPE=amd64
-        ;;
+      ARCH_TYPE=amd64
+      ;;
     *)
-        echo "Error: Unknown CPU type: $arch_type"
-        exit 1
-    esac
+      echo "Error: Unknown CPU type: $arch_type"
+      exit 1
+  esac
 }
 
-get_os_type
-get_arch_type
-
-if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
-    # Use the latest nightly version.
+function download_artifact() {
+  if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
+    # Use the latest stable released version.
+    # GitHub API reference: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release.
     if [ "${VERSION}" = "latest" ]; then
-        VERSION=$(curl -s -XGET "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases" | grep tag_name | grep nightly | cut -d: -f 2 | sed 's/.*"\(.*\)".*/\1/' | uniq | sort -rV | head -n 1)
-        if [ -z "${VERSION}" ]; then
-            echo "Failed to get the latest version."
-            exit 1
+      # To avoid other tools dependency, we choose to use `curl` to get the version metadata and parsed by `sed`.
+      VERSION=$(curl -sL \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        ${GITHUB_TOKEN:+-H "Authorization: Bearer $GITHUB_TOKEN"} \
+        "https://api.github.com/repos/${GITHUB_ORG}/${GITHUB_REPO}/releases/latest" | sed -n 's/.*"tag_name": "\([^"]*\)".*/\1/p')
+      if [ -z "${VERSION}" ]; then
+        echo "Failed to get the latest stable released version."
+        exit 1
         fi
     fi
 
@@ -73,4 +83,9 @@ if [ -n "${OS_TYPE}" ] && [ -n "${ARCH_TYPE}" ]; then
       rm -r "${PACKAGE_NAME%.tar.gz}" && \
       echo "Run './${BIN} --help' to get started"
     fi
-fi
+  fi
+}
+
+get_os_type
+get_arch_type
+download_artifact


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

1. Download the latest stable released version by default;
2. Do some small refactoring:

   - Add `GITHUB_TOKEN`;
   - Code format;
   - Add `download_artifact()`;
   
## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
