### PR TITLE
chore: make mysql server version changable

### DIFF
--- a/src/servers/src/mysql/handler.rs
+++ b/src/servers/src/mysql/handler.rs
@@ -221,6 +221,10 @@ impl MysqlInstanceShim {
 impl<W: AsyncWrite + Send + Sync + Unpin> AsyncMysqlShim<W> for MysqlInstanceShim {
     type Error = error::Error;
 
+    fn version(&self) -> String {
+        std::env::var("GREPTIMEDB_MYSQL_SERVER_VERSION").unwrap_or_else(|_| "8.4.2".to_string())
+    }
+
     fn salt(&self) -> [u8; 20] {
         self.salt
     }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

because our customer might report some security issues just by the mysql server version. trying to make them happy. now the default returned 8.4.2 is the latest mysql lts version

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
