### PR TITLE
chore: set topic to 3 for sqlness test

### DIFF
--- a/tests/conf/metasrv-test.toml.template
+++ b/tests/conf/metasrv-test.toml.template
@@ -4,7 +4,7 @@ provider = "raft_engine"
 {{ else }}
 provider = "kafka"
 broker_endpoints = {kafka_wal_broker_endpoints | unescaped}
-num_topics = 64
+num_topics = 3
 selector_type = "round_robin"
 topic_name_prefix = "distributed_test_greptimedb_wal_topic"
 {{ endif }}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

set topic to 3 for sqlness test since it seems CI machine is too slow on opening topic when run `cargo sqlness` and sometimes can't start db in 10s hence failing sqlness Remote WAL test like this:
https://github.com/GreptimeTeam/greptimedb/actions/runs/10380872089/job/28741742298


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
