### PR TITLE
fix: append table stats

### DIFF
--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -20,7 +20,6 @@ use std::time::Instant;
 
 use common_error::ext::BoxedError;
 use common_recordbatch::{DfRecordBatch, DfSendableRecordBatchStream, SendableRecordBatchStream};
-use common_telemetry::info;
 use common_telemetry::tracing::Span;
 use common_telemetry::tracing_context::TracingContext;
 use datafusion::error::Result as DfResult;

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 
 use common_error::ext::BoxedError;
 use common_recordbatch::{DfRecordBatch, DfSendableRecordBatchStream, SendableRecordBatchStream};
+use common_telemetry::info;
 use common_telemetry::tracing::Span;
 use common_telemetry::tracing_context::TracingContext;
 use datafusion::error::Result as DfResult;
@@ -168,6 +169,7 @@ impl ExecutionPlan for RegionScanExec {
                 .iter()
                 .map(|_| ColumnStatistics {
                     distinct_count: Precision::Exact(self.total_rows),
+                    null_count: Precision::Exact(0), // all null rows are counted for append-only table
                     ..Default::default()
                 })
                 .collect();

--- a/tests/cases/distributed/explain/analyze_append_table_count.result
+++ b/tests/cases/distributed/explain/analyze_append_table_count.result
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS `test_table` (
+  `bytes` BIGINT NULL,
+  `http_version` STRING NULL,
+  `ip` STRING NULL,
+  `method` STRING NULL,
+  `path` STRING NULL,
+  `status` SMALLINT UNSIGNED NULL,
+  `user` STRING NULL,
+  `timestamp` TIMESTAMP(3) NOT NULL,
+  TIME INDEX (`timestamp`),
+  PRIMARY KEY (`user`, `path`, `status`)
+)
+ENGINE=mito
+WITH(
+  append_mode = 'true'
+);
+
+Affected Rows: 0
+
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+EXPLAIN ANALYZE SELECT count(*) FROM test_table;
+
++-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| stage | node | plan                                                                                                                                                                               |
++-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 0     | 0    |  MergeScanExec: REDACTED
+|       |      |                                                                                                                                                                                    |
+| 1     | 0    |  ProjectionExec: expr=[0 as COUNT(test_table.timestamp)] REDACTED
+|       |      |   common_recordbatch::adapter::MetricCollector REDACTED
+|       |      |                                                                                                                                                                                    |
+|       |      | Total rows: 1                                                                                                                                                                      |
++-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+

--- a/tests/cases/distributed/explain/analyze_append_table_count.sql
+++ b/tests/cases/distributed/explain/analyze_append_table_count.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS `test_table` (
+  `bytes` BIGINT NULL,
+  `http_version` STRING NULL,
+  `ip` STRING NULL,
+  `method` STRING NULL,
+  `path` STRING NULL,
+  `status` SMALLINT UNSIGNED NULL,
+  `user` STRING NULL,
+  `timestamp` TIMESTAMP(3) NOT NULL,
+  TIME INDEX (`timestamp`),
+  PRIMARY KEY (`user`, `path`, `status`)
+)
+
+ENGINE=mito
+WITH(
+  append_mode = 'true'
+);
+
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (peers.*) REDACTED
+EXPLAIN ANALYZE SELECT count(*) FROM test_table;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR fixes the issue where null count is not initialized in column stats.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
