### PR TITLE
feat: add postgres response for trasaction related statements

### DIFF
--- a/src/common/function/src/system.rs
+++ b/src/common/function/src/system.rs
@@ -22,7 +22,7 @@ mod version;
 use std::sync::Arc;
 
 use build::BuildFunction;
-use database::DatabaseFunction;
+use database::{CurrentSchemaFunction, DatabaseFunction};
 use pg_catalog::PGCatalogFunction;
 use procedure_state::ProcedureStateFunction;
 use timezone::TimezoneFunction;
@@ -37,6 +37,7 @@ impl SystemFunction {
         registry.register(Arc::new(BuildFunction));
         registry.register(Arc::new(VersionFunction));
         registry.register(Arc::new(DatabaseFunction));
+        registry.register(Arc::new(CurrentSchemaFunction));
         registry.register(Arc::new(TimezoneFunction));
         registry.register(Arc::new(ProcedureStateFunction));
         PGCatalogFunction::register(registry);

--- a/src/common/function/src/system/database.rs
+++ b/src/common/function/src/system/database.rs
@@ -26,11 +26,35 @@ use crate::function::{Function, FunctionContext};
 #[derive(Clone, Debug, Default)]
 pub struct DatabaseFunction;
 
-const NAME: &str = "database";
+#[derive(Clone, Debug, Default)]
+pub struct CurrentSchemaFunction;
+
+const DATABASE_FUNCTION_NAME: &str = "database";
+const CURRENT_SCHEMA_FUNCTION_NAME: &str = "current_schema";
 
 impl Function for DatabaseFunction {
     fn name(&self) -> &str {
-        NAME
+        DATABASE_FUNCTION_NAME
+    }
+
+    fn return_type(&self, _input_types: &[ConcreteDataType]) -> Result<ConcreteDataType> {
+        Ok(ConcreteDataType::string_datatype())
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::uniform(0, vec![], Volatility::Immutable)
+    }
+
+    fn eval(&self, func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
+        let db = func_ctx.query_ctx.current_schema();
+
+        Ok(Arc::new(StringVector::from_slice(&[&db])) as _)
+    }
+}
+
+impl Function for CurrentSchemaFunction {
+    fn name(&self) -> &str {
+        CURRENT_SCHEMA_FUNCTION_NAME
     }
 
     fn return_type(&self, _input_types: &[ConcreteDataType]) -> Result<ConcreteDataType> {
@@ -51,6 +75,12 @@ impl Function for DatabaseFunction {
 impl fmt::Display for DatabaseFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DATABASE")
+    }
+}
+
+impl fmt::Display for CurrentSchemaFunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CURRENT_SCHEMA")
     }
 }
 

--- a/src/common/function/src/system/pg_catalog.rs
+++ b/src/common/function/src/system/pg_catalog.rs
@@ -14,11 +14,13 @@
 
 mod pg_get_userbyid;
 mod table_is_visible;
+mod version;
 
 use std::sync::Arc;
 
 use pg_get_userbyid::PGGetUserByIdFunction;
 use table_is_visible::PGTableIsVisibleFunction;
+use version::PGVersionFunction;
 
 use crate::function_registry::FunctionRegistry;
 
@@ -35,5 +37,6 @@ impl PGCatalogFunction {
     pub fn register(registry: &FunctionRegistry) {
         registry.register(Arc::new(PGTableIsVisibleFunction));
         registry.register(Arc::new(PGGetUserByIdFunction));
+        registry.register(Arc::new(PGVersionFunction));
     }
 }

--- a/src/common/function/src/system/pg_catalog/version.rs
+++ b/src/common/function/src/system/pg_catalog/version.rs
@@ -1,0 +1,54 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+use std::{env, fmt};
+
+use common_query::error::Result;
+use common_query::prelude::{Signature, Volatility};
+use datatypes::data_type::ConcreteDataType;
+use datatypes::vectors::{StringVector, VectorRef};
+
+use crate::function::{Function, FunctionContext};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PGVersionFunction;
+
+impl fmt::Display for PGVersionFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, crate::pg_catalog_func_fullname!("VERSION"))
+    }
+}
+
+impl Function for PGVersionFunction {
+    fn name(&self) -> &str {
+        crate::pg_catalog_func_fullname!("version")
+    }
+
+    fn return_type(&self, _input_types: &[ConcreteDataType]) -> Result<ConcreteDataType> {
+        Ok(ConcreteDataType::string_datatype())
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::exact(vec![], Volatility::Immutable)
+    }
+
+    fn eval(&self, _func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
+        let result = StringVector::from(vec![format!(
+            "PostgreSQL 16.3 GreptimeDB {}",
+            env!("CARGO_PKG_VERSION")
+        )]);
+        Ok(Arc::new(result))
+    }
+}

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -42,13 +42,13 @@ use self::handler::DefaultQueryParser;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 
 pub(crate) struct GreptimeDBStartupParameters {
-    version: &'static str,
+    version: String,
 }
 
 impl GreptimeDBStartupParameters {
     fn new() -> GreptimeDBStartupParameters {
         GreptimeDBStartupParameters {
-            version: env!("CARGO_PKG_VERSION"),
+            version: format!("16.3-greptime-{}", env!("CARGO_PKG_VERSION")),
         }
     }
 }
@@ -59,7 +59,7 @@ impl ServerParameterProvider for GreptimeDBStartupParameters {
         C: ClientInfo,
     {
         Some(HashMap::from([
-            ("server_version".to_owned(), self.version.to_owned()),
+            ("server_version".to_owned(), self.version.clone()),
             ("server_encoding".to_owned(), "UTF8".to_owned()),
             ("client_encoding".to_owned(), "UTF8".to_owned()),
             ("DateStyle".to_owned(), "ISO YMD".to_owned()),

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod auth_handler;
+mod fixtures;
 mod handler;
 mod server;
 mod types;

--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -50,7 +50,7 @@ static VAR_VALUES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 
 static SHOW_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new("(?i)^SHOW (.*?);?$").unwrap());
 static SET_TRANSACTION_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new("(?i)^SET TRANSACTION (.*?);?").unwrap());
+    Lazy::new(|| Regex::new("(?i)^SET TRANSACTION (.*?);?$").unwrap());
 static TRANSACTION_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new("(?i)^(BEGIN|ROLLBACK|COMMIT);?").unwrap());
 

--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -1,0 +1,27 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pgwire::api::results::{
+    DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, QueryResponse, Response, Tag,
+};
+use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
+use session::context::QueryContextRef;
+
+/// Process unsupported SQL and return fixed result as a compatibility solution
+pub(crate) fn process<'a>(
+    query: &str,
+    query_ctx: QueryContextRef,
+) -> Option<PgWireResult<Vec<Response<'a>>>> {
+    None
+}

--- a/src/servers/src/postgres/fixtures.rs
+++ b/src/servers/src/postgres/fixtures.rs
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
+use futures::stream;
 use pgwire::api::results::{
-    DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, QueryResponse, Response, Tag,
+    DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat, FieldInfo,
+    QueryResponse, Response, Tag,
 };
+use pgwire::api::Type;
 use pgwire::error::{ErrorInfo, PgWireError, PgWireResult};
 use session::context::QueryContextRef;
 
@@ -23,5 +28,75 @@ pub(crate) fn process<'a>(
     query: &str,
     query_ctx: QueryContextRef,
 ) -> Option<PgWireResult<Vec<Response<'a>>>> {
-    None
+    dbg!(query);
+    if query.trim().starts_with("BEGIN") {
+        Some(Ok(vec![Response::Execution(Tag::new("BEGIN"))]))
+    } else if query.trim().starts_with("ROLLBACK") {
+        Some(Ok(vec![Response::Execution(Tag::new("ROLLBACK"))]))
+    } else if query.trim().starts_with("COMMIT") {
+        Some(Ok(vec![Response::Execution(Tag::new("COMMIT"))]))
+    } else if query.trim().starts_with("SET") {
+        Some(Ok(vec![Response::Execution(Tag::new("SET"))]))
+    } else if query == "SELECT t.oid, NULL\nFROM pg_type t JOIN pg_namespace ns\n    ON typnamespace = ns.oid\nWHERE typname = 'hstore';\n"{
+        let f1 = FieldInfo::new("t.oid".into(), None, None, Type::OID, FieldFormat::Text);
+        let f2 = FieldInfo::new("?coulmn?".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+
+        Some(Ok(vec![Response::Query(QueryResponse::new(Arc::new(vec![f1, f2]), stream::iter(vec![])))]))
+    } else if query == "show transaction isolation level"{
+        let f1 = FieldInfo::new("transaction_isolation".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+        let schema = Arc::new(vec![f1]);
+        let data = stream::iter(vec![
+            {
+                let mut encoder = DataRowEncoder::new(schema.clone());
+                let _ = encoder.encode_field(&Some("read committed"));
+                encoder.finish()
+            }
+
+        ]);
+
+        Some(Ok(vec![ Response::Query(QueryResponse::new(schema, data))]))
+    } else if query == "show standard_conforming_strings"{
+        let f1 = FieldInfo::new("standard_conforming_strings".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+        let schema = Arc::new(vec![f1]);
+        let data = stream::iter(vec![
+            {
+                let mut encoder = DataRowEncoder::new(schema.clone());
+                let _ = encoder.encode_field(&Some("on"));
+                encoder.finish()
+            }
+
+        ]);
+
+        Some(Ok(vec![ Response::Query(QueryResponse::new(schema, data))]))
+    } else if query == "SELECT nspname FROM pg_namespace WHERE nspname NOT LIKE 'pg_%' ORDER BY nspname" {
+        let f1 = FieldInfo::new("nspname".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+        let schema = Arc::new(vec![f1]);
+        let data = stream::iter(vec![
+            {
+                let mut encoder = DataRowEncoder::new(schema.clone());
+                let _ = encoder.encode_field(&Some(query_ctx.current_schema()));
+                encoder.finish()
+            }
+
+        ]);
+
+        Some(Ok(vec![ Response::Query(QueryResponse::new(schema, data))]))
+    } else {
+        None
+    }
 }
+
+// else if query == "select pg_catalog.version()"{
+//         let f1 = FieldInfo::new("version".into(), None, None, Type::VARCHAR, FieldFormat::Text);
+//         let schema = Arc::new(vec![f1]);
+//         let data = stream::iter(vec![
+//             {
+//                 let mut encoder = DataRowEncoder::new(schema.clone());
+//                 encoder.encode_field(&Some("PostgreSQL 16.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 14.1.1 20240720, 64-bit"));
+//                 encoder.finish()
+//             }
+
+//         ]);
+
+//         Some(Ok(vec![ Response::Query(QueryResponse::new(schema, data))]))
+//     }

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -37,7 +37,7 @@ use sql::dialect::PostgreSqlDialect;
 use sql::parser::{ParseOptions, ParserContext};
 
 use super::types::*;
-use super::PostgresServerHandler;
+use super::{fixtures, PostgresServerHandler};
 use crate::error::Result;
 use crate::query_handler::sql::ServerSqlQueryHandlerRef;
 use crate::SqlPlan;
@@ -58,16 +58,22 @@ impl SimpleQueryHandler for PostgresServerHandler {
         let _timer = crate::metrics::METRIC_POSTGRES_QUERY_TIMER
             .with_label_values(&[crate::metrics::METRIC_POSTGRES_SIMPLE_QUERY, db.as_str()])
             .start_timer();
-        let outputs = self.query_handler.do_query(query, query_ctx.clone()).await;
 
-        let mut results = Vec::with_capacity(outputs.len());
+        if let Some(resps) = fixtures::process(query, query_ctx.clone()) {
+            resps
+        } else {
+            let outputs = self.query_handler.do_query(query, query_ctx.clone()).await;
 
-        for output in outputs {
-            let resp = output_to_query_response(query_ctx.clone(), output, &Format::UnifiedText)?;
-            results.push(resp);
+            let mut results = Vec::with_capacity(outputs.len());
+
+            for output in outputs {
+                let resp =
+                    output_to_query_response(query_ctx.clone(), output, &Format::UnifiedText)?;
+                results.push(resp);
+            }
+
+            Ok(results)
         }
-
-        Ok(results)
     }
 }
 

--- a/src/servers/src/postgres/handler.rs
+++ b/src/servers/src/postgres/handler.rs
@@ -77,7 +77,7 @@ impl SimpleQueryHandler for PostgresServerHandler {
     }
 }
 
-fn output_to_query_response<'a>(
+pub(crate) fn output_to_query_response<'a>(
     query_ctx: QueryContextRef,
     output: Result<Output>,
     field_format: &Format,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Fixes #4553 

## What's changed and what's your intention?

This patch partially improved our compatibility with Superset and Metabase postgres source. Note that we still need hidden table support and more for full compatibility 

- Respond transaction related statements: BEGIN/ROLLBACK/COMMIT/SET TRANSATION .../SHOW TRANSACTION ...
- Add some fixed response for `SHOW ...`
- Add built in function `current_schema()`
- Add built in function `pg_catalog.version()`
- Updated version in postgres startup

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
