### PR TITLE
perf: set simple filter on primary key columns to exact filter

### DIFF
--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -182,7 +182,7 @@ impl TableProvider for DummyTableProvider {
         let supported = filters
             .iter()
             .map(|e| {
-                // Simple filter on primary key columns are percisely evaluated.
+                // Simple filter on primary key columns are precisely evaluated.
                 if let Some(simple_filter) = SimpleFilterEvaluator::try_new(e) {
                     if self
                         .metadata

--- a/src/query/src/dummy_catalog.rs
+++ b/src/query/src/dummy_catalog.rs
@@ -17,7 +17,9 @@
 use std::any::Any;
 use std::sync::{Arc, Mutex};
 
+use api::v1::SemanticType;
 use async_trait::async_trait;
+use common_recordbatch::filter::SimpleFilterEvaluator;
 use common_recordbatch::OrderOption;
 use datafusion::catalog::schema::SchemaProvider;
 use datafusion::catalog::{CatalogProvider, CatalogProviderList};
@@ -177,7 +179,27 @@ impl TableProvider for DummyTableProvider {
         &self,
         filters: &[&Expr],
     ) -> datafusion::error::Result<Vec<TableProviderFilterPushDown>> {
-        Ok(vec![TableProviderFilterPushDown::Inexact; filters.len()])
+        let supported = filters
+            .iter()
+            .map(|e| {
+                // Simple filter on primary key columns are percisely evaluated.
+                if let Some(simple_filter) = SimpleFilterEvaluator::try_new(e) {
+                    if self
+                        .metadata
+                        .column_by_name(simple_filter.column_name())
+                        .and_then(|c| (c.semantic_type == SemanticType::Tag).then_some(()))
+                        .is_some()
+                    {
+                        TableProviderFilterPushDown::Exact
+                    } else {
+                        TableProviderFilterPushDown::Inexact
+                    }
+                } else {
+                    TableProviderFilterPushDown::Inexact
+                }
+            })
+            .collect();
+        Ok(supported)
     }
 }
 

--- a/tests/cases/standalone/common/select/prune.result
+++ b/tests/cases/standalone/common/select/prune.result
@@ -77,6 +77,25 @@ select * from demo where collector='disk' order by ts;
 | 1970-01-01T00:00:00.002 | 3.0   | test2 | idc1 | disk      |
 +-------------------------+-------+-------+------+-----------+
 
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+explain analyze select * from demo where idc='idc1' order by ts;
+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_SortPreservingMergeExec: [ts@0 ASC NULLS LAST] REDACTED
+|_|_|_SortExec: expr=[ts@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_|
+|_|_| Total rows: 2_|
++-+-+-+
+
 drop table demo;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/select/prune.result
+++ b/tests/cases/standalone/common/select/prune.result
@@ -82,16 +82,14 @@ select * from demo where collector='disk' order by ts;
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
-explain analyze select * from demo where idc='idc1' order by ts;
+explain analyze select * from demo where idc='idc1';
 
 +-+-+-+
 | stage | node | plan_|
 +-+-+-+
 | 0_| 0_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SortPreservingMergeExec: [ts@0 ASC NULLS LAST] REDACTED
-|_|_|_SortExec: expr=[ts@0 ASC NULLS LAST], preserve_partitioning=[true] REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+

--- a/tests/cases/standalone/common/select/prune.sql
+++ b/tests/cases/standalone/common/select/prune.sql
@@ -25,6 +25,6 @@ select * from demo where collector='disk' order by ts;
 -- SQLNESS REPLACE (peers.*) REDACTED
 -- SQLNESS REPLACE (metrics.*) REDACTED
 -- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
-explain analyze select * from demo where idc='idc1' order by ts;
+explain analyze select * from demo where idc='idc1';
 
 drop table demo;

--- a/tests/cases/standalone/common/select/prune.sql
+++ b/tests/cases/standalone/common/select/prune.sql
@@ -20,4 +20,11 @@ select * from demo where idc='idc1' order by ts;
 
 select * from demo where collector='disk' order by ts;
 
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
+-- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
+explain analyze select * from demo where idc='idc1' order by ts;
+
 drop table demo;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Simple filter on primary key columns are precisely evaluated and need not to be evaluated again on Filter plan.

This patch has resulted in good performance improvement on my current test case. Before:
<img width="200" alt="image" src="https://github.com/user-attachments/assets/a6498dee-1fa9-4864-9a53-892e858d1c2b">


After:

<img width="217" alt="image" src="https://github.com/user-attachments/assets/975071ff-3b66-4bc7-a2da-cd7f939347b2">

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
