### PR TITLE
perf(flow): Map&Reduce Operator use batch to reduce alloc

### DIFF
--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -28,7 +28,7 @@ use super::state::Scheduler;
 use crate::compute::state::DataflowState;
 use crate::compute::types::{Collection, CollectionBundle, ErrCollector, Toff};
 use crate::error::{Error, InvalidQuerySnafu, NotImplementedSnafu};
-use crate::expr::{self, GlobalId, LocalId};
+use crate::expr::{self, Batch, GlobalId, LocalId};
 use crate::plan::{Plan, TypedPlan};
 use crate::repr::{self, DiffRow};
 
@@ -87,9 +87,32 @@ impl<'referred, 'df> Context<'referred, 'df> {
 }
 
 impl<'referred, 'df> Context<'referred, 'df> {
-    /// Interpret and execute plan
+    /// Like `render_plan` but in Batch Mode
+    pub fn render_plan_batch(&mut self, plan: TypedPlan) -> Result<CollectionBundle<Batch>, Error> {
+        match plan.plan {
+            Plan::Constant { rows } => todo!(),
+            Plan::Get { id } => todo!(),
+            Plan::Let { id, value, body } => todo!(),
+            Plan::Mfp { input, mfp } => self.render_mfp_batch(input, mfp),
+            Plan::Reduce {
+                input,
+                key_val_plan,
+                reduce_plan,
+            } => todo!(),
+            Plan::Join { .. } => NotImplementedSnafu {
+                reason: "Join is still WIP",
+            }
+            .fail(),
+            Plan::Union { .. } => NotImplementedSnafu {
+                reason: "Union is still WIP",
+            }
+            .fail(),
+        }
+    }
+
+    /// Interpret plan to dataflow and prepare them for execution
     ///
-    /// return the output of this plan
+    /// return the output handler of this plan
     pub fn render_plan(&mut self, plan: TypedPlan) -> Result<CollectionBundle, Error> {
         match plan.plan {
             Plan::Constant { rows } => Ok(self.render_constant(rows)),

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -146,12 +146,11 @@ impl<'referred, 'df> Context<'referred, 'df> {
     /// Always assume input is sorted by timestamp
     pub fn render_constant_batch(&mut self, rows: Vec<DiffRow>) -> CollectionBundle<Batch> {
         let (send_port, recv_port) = self.df.make_edge::<_, Toff<Batch>>("constant_batch");
-        let mut per_time: BTreeMap<repr::Timestamp, Vec<DiffRow>> = rows
-            .into_iter()
-            .group_by(|(_row, ts, _diff)| *ts)
-            .into_iter()
-            .map(|(k, v)| (k, v.into_iter().collect_vec()))
-            .collect();
+        let mut per_time: BTreeMap<repr::Timestamp, Vec<DiffRow>> = Default::default();
+        for (key, group) in &rows.into_iter().group_by(|(_row, ts, _diff)| *ts) {
+            per_time.entry(key).or_default().extend(group);
+        }
+
         let now = self.compute_state.current_time_ref();
         // TODO(discord9): better way to schedule future run
         let scheduler = self.compute_state.get_scheduler();
@@ -192,12 +191,11 @@ impl<'referred, 'df> Context<'referred, 'df> {
     /// Always assume input is sorted by timestamp
     pub fn render_constant(&mut self, rows: Vec<DiffRow>) -> CollectionBundle {
         let (send_port, recv_port) = self.df.make_edge::<_, Toff>("constant");
-        let mut per_time: BTreeMap<repr::Timestamp, Vec<DiffRow>> = rows
-            .into_iter()
-            .group_by(|(_row, ts, _diff)| *ts)
-            .into_iter()
-            .map(|(k, v)| (k, v.into_iter().collect_vec()))
-            .collect();
+        let mut per_time: BTreeMap<repr::Timestamp, Vec<DiffRow>> = Default::default();
+        for (key, group) in &rows.into_iter().group_by(|(_row, ts, _diff)| *ts) {
+            per_time.entry(key).or_default().extend(group);
+        }
+
         let now = self.compute_state.current_time_ref();
         // TODO(discord9): better way to schedule future run
         let scheduler = self.compute_state.get_scheduler();

--- a/src/flow/src/compute/render.rs
+++ b/src/flow/src/compute/render.rs
@@ -142,7 +142,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
     }
 
     /// render Constant, take all rows that have a timestamp not greater than the current time
-    ///
+    /// This function is primarily used for testing
     /// Always assume input is sorted by timestamp
     pub fn render_constant_batch(&mut self, rows: Vec<DiffRow>) -> CollectionBundle<Batch> {
         let (send_port, recv_port) = self.df.make_edge::<_, Toff<Batch>>("constant_batch");
@@ -156,7 +156,6 @@ impl<'referred, 'df> Context<'referred, 'df> {
         // TODO(discord9): better way to schedule future run
         let scheduler = self.compute_state.get_scheduler();
         let scheduler_inner = scheduler.clone();
-
         let err_collector = self.err_collector.clone();
 
         let subgraph_id =

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -182,7 +182,9 @@ impl<'referred, 'df> Context<'referred, 'df> {
                         arrange.compact_to(now)
                     });
 
-                    // this output part is not supposed to be resource intensive, so we can do some costly operation here
+                    // this output part is not supposed to be resource intensive
+                    // (because for every batch there wouldn't usually be as many output row?), 
+                    // so we can do some costly operation here
                     let output_types = all_output_rows.first().map(|(row, _, _)| {
                         row.iter()
                             .map(|v| v.data_type())

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -1447,7 +1447,7 @@ mod test {
                     let now = *now_inner.borrow();
                     let data = recv.take_inner();
                     let res = data.into_iter().flat_map(|v| v.into_iter()).collect_vec();
-                    dbg!(&res);
+
                     if let Some(expected) = expected.get(&now) {
                         let batch = expected.iter().map(|v| Value::from(*v)).collect_vec();
                         let batch = Batch::try_from_rows(vec![batch.into()]).unwrap();

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -123,7 +123,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
 
                             for row_idx in 0..key_batch.row_count() {
                                 let key_row = key_batch.get_row(row_idx).unwrap();
-                                let val_row = val_batch.slice(row_idx, 1);
+                                let val_row = val_batch.slice(row_idx, 1)?;
                                 let val_batch =
                                     key_to_many_vals.entry(Row::new(key_row)).or_default();
                                 val_batch.append_batch(val_row)?;
@@ -224,7 +224,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
                                 .map(|mut b| b.to_vector())
                                 .collect_vec();
 
-                            let output_batch = Batch::new(output_columns, row_cnt);
+                            let output_batch = Batch::try_new(output_columns, row_cnt)?;
                             send.give(vec![output_batch]);
 
                             Ok(())

--- a/src/flow/src/compute/render/reduce.rs
+++ b/src/flow/src/compute/render/reduce.rs
@@ -98,7 +98,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
 
         let subgraph =
             self.df.add_subgraph_in_out(
-                Self::REDUCE,
+                Self::REDUCE_BATCH,
                 input.collection.into_inner(),
                 out_send_port,
                 move |_ctx, recv, send| {

--- a/src/flow/src/compute/render/src_sink.rs
+++ b/src/flow/src/compute/render/src_sink.rs
@@ -186,7 +186,7 @@ impl<'referred, 'df> Context<'referred, 'df> {
             move |_ctx, recv| {
                 let data = recv.take_inner();
                 for batch in data.into_iter().flat_map(|i| i.into_iter()) {
-                    // if the sender is closed unexpectly, stop sending
+                    // if the sender is closed unexpectedly, stop sending
                     if sender.is_closed() || sender.send(batch).is_err() {
                         common_telemetry::error!("UnboundedSinkBatch is closed");
                         break;

--- a/src/flow/src/compute/types.rs
+++ b/src/flow/src/compute/types.rs
@@ -105,11 +105,11 @@ impl Arranged {
 /// This type maintains the invariant that it does contain at least one(or both) valid
 /// source of data, either a collection or at least one arrangement. This is for convenience
 /// of reading the data from the collection.
-pub struct CollectionBundle {
+pub struct CollectionBundle<T: 'static = DiffRow> {
     /// This is useful for passively reading the new updates from the collection
     ///
     /// Invariant: the timestamp of the updates should always not greater than now, since future updates should be stored in the arrangement
-    pub collection: Collection<DiffRow>,
+    pub collection: Collection<T>,
     /// the key [`ScalarExpr`] indicate how the keys(also a [`Row`]) used in Arranged is extract from collection's [`Row`]
     /// So it is the "index" of the arrangement
     ///

--- a/src/flow/src/compute/types.rs
+++ b/src/flow/src/compute/types.rs
@@ -105,6 +105,8 @@ impl Arranged {
 /// This type maintains the invariant that it does contain at least one(or both) valid
 /// source of data, either a collection or at least one arrangement. This is for convenience
 /// of reading the data from the collection.
+///
+// TODO(discord9): make T default to Batch and obsolete the Row Mode
 pub struct CollectionBundle<T: 'static = DiffRow> {
     /// This is useful for passively reading the new updates from the collection
     ///

--- a/src/flow/src/compute/types.rs
+++ b/src/flow/src/compute/types.rs
@@ -121,13 +121,16 @@ pub struct CollectionBundle<T: 'static = DiffRow> {
     pub arranged: BTreeMap<Vec<ScalarExpr>, Arranged>,
 }
 
-impl CollectionBundle {
-    pub fn from_collection(collection: Collection<DiffRow>) -> Self {
+impl<T: 'static> CollectionBundle<T> {
+    pub fn from_collection(collection: Collection<T>) -> Self {
         Self {
             collection,
             arranged: BTreeMap::default(),
         }
     }
+}
+
+impl<T: 'static + Clone> CollectionBundle<T> {
     pub fn clone(&self, df: &mut Hydroflow) -> Self {
         Self {
             collection: self.collection.clone(df),

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -23,8 +23,7 @@ mod relation;
 mod scalar;
 mod signature;
 
-use arrow::array::BooleanArray;
-use datatypes::prelude::{ConcreteDataType, DataType};
+use datatypes::prelude::DataType;
 use datatypes::value::Value;
 use datatypes::vectors::VectorRef;
 pub(crate) use df_func::{DfScalarFunction, RawDfScalarFn};
@@ -35,9 +34,9 @@ use itertools::Itertools;
 pub(crate) use linear::{MapFilterProject, MfpPlan, SafeMfpPlan};
 pub(crate) use relation::{AggregateExpr, AggregateFunc};
 pub(crate) use scalar::{ScalarExpr, TypedExpr};
-use snafu::{ensure, OptionExt, ResultExt};
+use snafu::{ensure, ResultExt};
 
-use crate::expr::error::{DataTypeSnafu, TypeMismatchSnafu};
+use crate::expr::error::DataTypeSnafu;
 
 /// A batch of vectors with the same length but without schema, only useful in dataflow
 ///

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -23,9 +23,8 @@ mod relation;
 mod scalar;
 mod signature;
 
-use datatypes::prelude::DataType;
 use arrow::array::BooleanArray;
-use datatypes::prelude::ConcreteDataType;
+use datatypes::prelude::{ConcreteDataType, DataType};
 use datatypes::vectors::VectorRef;
 pub(crate) use df_func::{DfScalarFunction, RawDfScalarFn};
 pub(crate) use error::{EvalError, InvalidArgumentSnafu};
@@ -35,12 +34,9 @@ use itertools::Itertools;
 pub(crate) use linear::{MapFilterProject, MfpPlan, SafeMfpPlan};
 pub(crate) use relation::{AggregateExpr, AggregateFunc};
 pub(crate) use scalar::{ScalarExpr, TypedExpr};
-use snafu::{ensure, ResultExt};
+use snafu::{ensure, OptionExt, ResultExt};
 
-use crate::expr::error::DataTypeSnafu;
-use snafu::OptionExt;
-
-use crate::expr::error::TypeMismatchSnafu;
+use crate::expr::error::{DataTypeSnafu, TypeMismatchSnafu};
 
 /// A batch of vectors with the same length but without schema, only useful in dataflow
 pub struct Batch {

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -45,11 +45,24 @@ use crate::expr::error::{DataTypeSnafu, TypeMismatchSnafu};
 pub struct Batch {
     batch: Vec<VectorRef>,
     row_count: usize,
+    /// describe if corresponding rows in batch is insert or delete, None means all rows are insert
+    diffs: Option<VectorRef>,
 }
 
 impl Batch {
+    pub fn empty() -> Self {
+        Self {
+            batch: vec![],
+            row_count: 0,
+            diffs: None,
+        }
+    }
     pub fn new(batch: Vec<VectorRef>, row_count: usize) -> Self {
-        Self { batch, row_count }
+        Self {
+            batch,
+            row_count,
+            diffs: None,
+        }
     }
 
     pub fn batch(&self) -> &[VectorRef] {

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -138,7 +138,7 @@ impl Batch {
         })
     }
 
-    pub fn new(batch: Vec<VectorRef>, row_count: usize) -> Self {
+    pub fn new_unchecked(batch: Vec<VectorRef>, row_count: usize) -> Self {
         Self {
             batch,
             row_count,

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -39,6 +39,9 @@ use snafu::{ensure, OptionExt, ResultExt};
 use crate::expr::error::{DataTypeSnafu, TypeMismatchSnafu};
 
 /// A batch of vectors with the same length but without schema, only useful in dataflow
+///
+/// somewhere cheap to clone since it just contains a list of VectorRef(which is a `Arc`).
+#[derive(Debug, Clone)]
 pub struct Batch {
     batch: Vec<VectorRef>,
     row_count: usize,

--- a/src/flow/src/expr.rs
+++ b/src/flow/src/expr.rs
@@ -180,9 +180,6 @@ impl Batch {
     }
 
     /// Slices the `Batch`, returning a new `Batch`.
-    ///
-    /// # Panics
-    /// This function panics if `offset + length > self.row_count()`.
     pub fn slice(&self, offset: usize, length: usize) -> Result<Batch, EvalError> {
         let batch = self
             .batch()

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -18,15 +18,17 @@ use std::sync::OnceLock;
 
 use datatypes::prelude::ConcreteDataType;
 use datatypes::value::Value;
+use datatypes::vectors::VectorRef;
 use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
-use snafu::{IntoError, OptionExt};
+use snafu::{ensure, IntoError, OptionExt};
 use strum::{EnumIter, IntoEnumIterator};
 
 use crate::error::{DatafusionSnafu, Error, InvalidQuerySnafu};
 use crate::expr::error::EvalError;
 use crate::expr::relation::accum::{Accum, Accumulator};
 use crate::expr::signature::{GenericFn, Signature};
+use crate::expr::InvalidArgumentSnafu;
 use crate::repr::Diff;
 
 /// Aggregate functions that can be applied to a group of rows.
@@ -130,6 +132,96 @@ impl AggregateFunc {
         accum.update_batch(self, value_diffs)?;
         let res = accum.eval(self)?;
         Ok((res, accum.into_state()))
+    }
+
+    /// return output value and new accumulator state
+    pub fn eval_batch<A>(
+        &self,
+        accum: A,
+        vector: VectorRef,
+        diff: Option<VectorRef>,
+    ) -> Result<(Value, Vec<Value>), EvalError>
+    where
+        A: IntoIterator<Item = Value>,
+    {
+        let mut accum = accum.into_iter().peekable();
+
+        let mut accum = if accum.peek().is_none() {
+            Accum::new_accum(self)?
+        } else {
+            Accum::try_from_iter(self, &mut accum)?
+        };
+
+        let vector_diff = VectorDiff::try_new(vector, diff)?;
+
+        accum.update_batch(self, vector_diff)?;
+
+        let res = accum.eval(self)?;
+        Ok((res, accum.into_state()))
+    }
+}
+
+struct VectorDiff {
+    vector: VectorRef,
+    diff: Option<VectorRef>,
+}
+
+impl VectorDiff {
+    fn len(&self) -> usize {
+        self.vector.len()
+    }
+
+    fn try_new(vector: VectorRef, diff: Option<VectorRef>) -> Result<Self, EvalError> {
+        ensure!(
+            diff.as_ref()
+                .map_or(true, |diff| diff.len() == vector.len()),
+            InvalidArgumentSnafu {
+                reason: "Length of vector and diff should be the same"
+            }
+        );
+        Ok(Self { vector, diff })
+    }
+}
+
+impl IntoIterator for VectorDiff {
+    type Item = (Value, Diff);
+    type IntoIter = VectorDiffIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        VectorDiffIter {
+            vector: self.vector,
+            diff: self.diff,
+            idx: 0,
+        }
+    }
+}
+
+struct VectorDiffIter {
+    vector: VectorRef,
+    diff: Option<VectorRef>,
+    idx: usize,
+}
+
+impl std::iter::Iterator for VectorDiffIter {
+    type Item = (Value, Diff);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.idx >= self.vector.len() {
+            return None;
+        }
+        let value = self.vector.get(self.idx);
+        let diff = if let Some(diff) = self.diff.as_ref() {
+            if let Ok(diff_at) = diff.get(self.idx).try_into() {
+                diff_at
+            } else {
+                return None;
+            }
+        } else {
+            1
+        };
+
+        self.idx += 1;
+        Some((value, diff))
     }
 }
 

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -214,6 +214,7 @@ impl std::iter::Iterator for VectorDiffIter {
             if let Ok(diff_at) = diff.get(self.idx).try_into() {
                 diff_at
             } else {
+                common_telemetry::warn!("Invalid diff value at index {}", self.idx);
                 return None;
             }
         } else {

--- a/src/flow/src/expr/relation/func.rs
+++ b/src/flow/src/expr/relation/func.rs
@@ -210,6 +210,7 @@ impl std::iter::Iterator for VectorDiffIter {
             return None;
         }
         let value = self.vector.get(self.idx);
+        // +1 means insert, -1 means delete, and default to +1 insert when diff is not provided
         let diff = if let Some(diff) = self.diff.as_ref() {
             if let Ok(diff_at) = diff.get(self.idx).try_into() {
                 diff_at

--- a/src/flow/src/expr/scalar.rs
+++ b/src/flow/src/expr/scalar.rs
@@ -341,7 +341,7 @@ impl ScalarExpr {
                 // put a slice to corresponding batch
                 let slice_offset = prev_cond_idx;
                 let slice_length = idx - prev_cond_idx;
-                let to_be_append = batch.slice(slice_offset, slice_length);
+                let to_be_append = batch.slice(slice_offset, slice_length)?;
 
                 let to_put_back = match prev_cond {
                     Some(true) => (
@@ -364,7 +364,7 @@ impl ScalarExpr {
         if let Some(slice_offset) = prev_start_idx {
             let prev_cond = prev_cond.unwrap();
             let slice_length = bool_conds.len() - slice_offset;
-            let to_be_append = batch.slice(slice_offset, slice_length);
+            let to_be_append = batch.slice(slice_offset, slice_length)?;
             let to_put_back = match prev_cond {
                 Some(true) => (
                     Some(true),
@@ -876,7 +876,7 @@ mod test {
             let raw_len = raw.len();
             let vectors = vec![Int32Vector::from(raw).slice(0, raw_len)];
 
-            let batch = Batch::new(vectors, raw_len);
+            let batch = Batch::try_new(vectors, raw_len).unwrap();
             let expected = Int32Vector::from(vec![
                 None,
                 Some(42),
@@ -895,7 +895,7 @@ mod test {
             let raw_len = raw.len();
             let vectors = vec![Int32Vector::from(raw).slice(0, raw_len)];
 
-            let batch = Batch::new(vectors, raw_len);
+            let batch = Batch::try_new(vectors, raw_len).unwrap();
             let expected = Int32Vector::from(vec![Some(42)]).slice(0, raw_len);
             assert_eq!(expr.eval_batch(&batch).unwrap(), expected);
 
@@ -903,7 +903,7 @@ mod test {
             let raw_len = raw.len();
             let vectors = vec![Int32Vector::from(raw).slice(0, raw_len)];
 
-            let batch = Batch::new(vectors, raw_len);
+            let batch = Batch::try_new(vectors, raw_len).unwrap();
             let expected = NullVector::new(raw_len).slice(0, raw_len);
             assert_eq!(expr.eval_batch(&batch).unwrap(), expected);
         }

--- a/src/flow/src/lib.rs
+++ b/src/flow/src/lib.rs
@@ -20,6 +20,10 @@
 #![allow(dead_code)]
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(clippy::too_many_lines)]
+
+// TODO(discord9): enable this lint to handle out of bound access
+// #![cfg_attr(not(test), warn(clippy::indexing_slicing))]
+
 // allow unused for now because it should be use later
 mod adapter;
 mod compute;

--- a/src/flow/src/repr.rs
+++ b/src/flow/src/repr.rs
@@ -177,6 +177,12 @@ impl Row {
     }
 }
 
+impl From<Vec<Value>> for Row {
+    fn from(row: Vec<Value>) -> Self {
+        Row::new(row)
+    }
+}
+
 impl From<ProtoRow> for Row {
     fn from(row: ProtoRow) -> Self {
         Row::pack(

--- a/src/flow/src/utils.rs
+++ b/src/flow/src/utils.rs
@@ -513,7 +513,7 @@ pub type ArrangeReader<'a> = tokio::sync::RwLockReadGuard<'a, Arrangement>;
 pub type ArrangeWriter<'a> = tokio::sync::RwLockWriteGuard<'a, Arrangement>;
 
 /// A handler to the inner Arrangement, can be cloned and shared, useful for query it's inner state
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArrangeHandler {
     inner: Arc<RwLock<Arrangement>>,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

- add `render_*_batch` functions for flow's render(See `render/map/reduce/src_sink.rs` and `render.rs` files)
 - A major change is impl of `render_reduce_batch` which simpilfy impl and should improve performance(See `src/flow/src/compute/render/reduce.rs`)
- add `evaluate_inner/into_batch` for SafeMfpPlan to help with eval mfp with batch(See `src/flow/src/expr/linear.rs` file)
- other changes are minor and can be ignore

The PR is already too large too add functionality to actually use it, will do that in next PR

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced batch processing capabilities for dataflow plans, enhancing performance and efficiency.
	- Added methods for handling batch operations in various contexts, including rendering plans, processing source data, and managing outputs.
	- Enhanced the `Batch` struct to track row modifications and implemented new methods for improved error handling.

- **Bug Fixes**
	- Improved error handling within batch processing methods to ensure robust operation.

- **Documentation**
	- Updated method documentation for clarity regarding functionality and usage.

- **Tests**
	- New test cases introduced to validate batch processing functionality across various components. 

- **Chores**
	- Added comments for future code quality improvements regarding out-of-bounds access in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->