### PR TITLE
feat: able to handle concurrent region edit requests

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -33,6 +33,8 @@ mod create_test;
 #[cfg(test)]
 mod drop_test;
 #[cfg(test)]
+mod edit_region_test;
+#[cfg(test)]
 mod filter_deleted_test;
 #[cfg(test)]
 mod flush_test;
@@ -88,7 +90,7 @@ use crate::manifest::action::RegionEdit;
 use crate::metrics::HANDLE_REQUEST_ELAPSED;
 use crate::read::scan_region::{ScanParallism, ScanRegion, Scanner};
 use crate::region::RegionUsage;
-use crate::request::WorkerRequest;
+use crate::request::{RegionEditRequest, WorkerRequest};
 use crate::wal::entry_distributor::{
     build_wal_entry_distributor_and_receivers, DEFAULT_ENTRY_RECEIVER_BUFFER_SIZE,
 };
@@ -196,11 +198,11 @@ impl MitoEngine {
         );
 
         let (tx, rx) = oneshot::channel();
-        let request = WorkerRequest::EditRegion {
+        let request = WorkerRequest::EditRegion(RegionEditRequest {
             region_id,
             edit,
             tx,
-        };
+        });
         self.inner
             .workers
             .submit_to_worker(region_id, request)

--- a/src/mito2/src/engine/edit_region_test.rs
+++ b/src/mito2/src/engine/edit_region_test.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+use store_api::region_engine::RegionEngine;
+use store_api::region_request::RegionRequest;
+use store_api::storage::RegionId;
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use crate::config::MitoConfig;
+use crate::engine::MitoEngine;
+use crate::manifest::action::RegionEdit;
+use crate::region::MitoRegionRef;
+use crate::sst::file::{FileId, FileMeta};
+use crate::test_util::{CreateRequestBuilder, TestEnv};
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_edit_region_concurrently() {
+    const EDITS_PER_TASK: usize = 10;
+    let tasks_count = 10;
+
+    // A task that creates SST files and edits the region with them.
+    struct Task {
+        region: MitoRegionRef,
+        ssts: Vec<FileMeta>,
+    }
+
+    impl Task {
+        async fn create_ssts(&mut self, object_store: &ObjectStore) {
+            for _ in 0..EDITS_PER_TASK {
+                let file = FileMeta {
+                    region_id: self.region.region_id,
+                    file_id: FileId::random(),
+                    level: 0,
+                    ..Default::default()
+                };
+                object_store
+                    .write(
+                        &format!("{}/{}.parquet", self.region.region_dir(), file.file_id),
+                        b"x".as_slice(),
+                    )
+                    .await
+                    .unwrap();
+                self.ssts.push(file);
+            }
+        }
+
+        async fn edit_region(self, engine: MitoEngine) {
+            for sst in self.ssts {
+                let edit = RegionEdit {
+                    files_to_add: vec![sst],
+                    files_to_remove: vec![],
+                    compaction_time_window: None,
+                    flushed_entry_id: None,
+                    flushed_sequence: None,
+                };
+                engine
+                    .edit_region(self.region.region_id, edit)
+                    .await
+                    .unwrap();
+            }
+        }
+    }
+
+    let mut env = TestEnv::new();
+    let engine = env.create_engine(MitoConfig::default()).await;
+
+    let region_id = RegionId::new(1, 1);
+    engine
+        .handle_request(
+            region_id,
+            RegionRequest::Create(CreateRequestBuilder::new().build()),
+        )
+        .await
+        .unwrap();
+    let region = engine.get_region(region_id).unwrap();
+
+    let mut tasks = Vec::with_capacity(tasks_count);
+    let object_store = env.get_object_store().unwrap();
+    for _ in 0..tasks_count {
+        let mut task = Task {
+            region: region.clone(),
+            ssts: Vec::new(),
+        };
+        task.create_ssts(&object_store).await;
+        tasks.push(task);
+    }
+
+    let mut join_set = JoinSet::new();
+    // This semaphore is used to coordinate the tasks, making them started at roughly the same time.
+    let s = Arc::new(Semaphore::new(0));
+    for task in tasks {
+        join_set.spawn({
+            let s = s.clone();
+            let engine = engine.clone();
+            async move {
+                let _permit = s.acquire().await.unwrap();
+                task.edit_region(engine).await;
+            }
+        });
+    }
+    s.add_permits(tasks_count);
+    while join_set.join_next().await.is_some() {}
+
+    assert_eq!(
+        region.version().ssts.levels()[0].files.len(),
+        tasks_count * EDITS_PER_TASK
+    );
+}

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -842,6 +842,13 @@ pub enum Error {
         #[snafu(implicit)]
         location: Location,
     },
+
+    #[snafu(display("Region {} is busy", region_id))]
+    RegionBusy {
+        region_id: RegionId,
+        #[snafu(implicit)]
+        location: Location,
+    },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -973,6 +980,7 @@ impl ErrorExt for Error {
             | FulltextFinish { source, .. }
             | ApplyFulltextIndex { source, .. } => source.status_code(),
             DecodeStats { .. } | StatsNotPresent { .. } => StatusCode::Internal,
+            RegionBusy { .. } => StatusCode::RegionBusy,
         }
     }
 

--- a/src/mito2/src/request.rs
+++ b/src/mito2/src/request.rs
@@ -494,11 +494,7 @@ pub(crate) enum WorkerRequest {
     Stop,
 
     /// Use [RegionEdit] to edit a region directly.
-    EditRegion {
-        region_id: RegionId,
-        edit: RegionEdit,
-        tx: Sender<Result<()>>,
-    },
+    EditRegion(RegionEditRequest),
 }
 
 impl WorkerRequest {
@@ -760,6 +756,15 @@ pub(crate) struct RegionChangeResult {
     pub(crate) sender: OptionOutputTx,
     /// Result from the manifest manager.
     pub(crate) result: Result<()>,
+}
+
+/// Request to edit a region directly.
+#[derive(Debug)]
+pub(crate) struct RegionEditRequest {
+    pub(crate) region_id: RegionId,
+    pub(crate) edit: RegionEdit,
+    /// The sender to notify the result to the region engine.
+    pub(crate) tx: Sender<Result<()>>,
 }
 
 /// Notifies the regin the result of editing region.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Currently the region edit requests can only be handled one by one. This is because once a region is processing the request, it's set to the "Editing" state, which rejects other concurrent edit requests (require "Writable" state). 

This PR adds a "region edit queue" for temporarily storing the concurrent region edit requests. When concurrent requests come in, and the worker loop finds the region is in "Editing" state, it stores the requests in the queue. Once the current edit request is done, the worker loop checks the queue for a remaining edit request and handles it.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
