### PR TITLE
chore(log_store): remove redundant metrics

### DIFF
--- a/src/log-store/src/kafka/log_store.rs
+++ b/src/log-store/src/kafka/log_store.rs
@@ -130,7 +130,6 @@ impl LogStore for KafkaLogStore {
     /// Appends a batch of entries and returns a response containing a map where the key is a region id
     /// while the value is the id of the last successfully written entry of the region.
     async fn append_batch(&self, entries: Vec<Entry>) -> Result<AppendBatchResponse> {
-        metrics::METRIC_KAFKA_APPEND_BATCH_CALLS_TOTAL.inc();
         metrics::METRIC_KAFKA_APPEND_BATCH_BYTES_TOTAL.inc_by(
             entries
                 .iter()
@@ -209,7 +208,6 @@ impl LogStore for KafkaLogStore {
                 actual: provider.type_name(),
             })?;
 
-        metrics::METRIC_KAFKA_READ_CALLS_TOTAL.inc();
         let _timer = metrics::METRIC_KAFKA_READ_ELAPSED.start_timer();
 
         // Gets the client associated with the topic.
@@ -273,7 +271,7 @@ impl LogStore for KafkaLogStore {
                     })?;
                 let (kafka_record, offset) = (record_and_offset.record, record_and_offset.offset);
 
-                metrics::METRIC_KAFKA_READ_RECORD_BYTES_TOTAL
+                metrics::METRIC_KAFKA_READ_BYTES_TOTAL
                     .inc_by(kafka_record.approximate_size() as u64);
 
                 debug!(

--- a/src/log-store/src/metrics.rs
+++ b/src/log-store/src/metrics.rs
@@ -45,48 +45,6 @@ lazy_static! {
         &["raft-engine", "read"],
     );
 
-    /// Counter of bytes of the records read by the kafka logstore.
-    pub static ref METRIC_KAFKA_READ_RECORD_BYTES_TOTAL: IntCounter = register_int_counter!(
-        "greptime_kafka_read_record_bytes_total",
-        "kafka read record bytes total"
-    ).unwrap();
-
-    /// Counter of the numbers of the records produced by the kafka logstore.
-    pub static ref METRIC_KAFKA_PRODUCE_RECORD_COUNTS: IntCounter = register_int_counter!(
-        "greptime_kafka_produce_record_counts",
-        "kafka produce record counts",
-    ).unwrap();
-
-    /// Counter of bytes of the records produced by the kafka logstore.
-    pub static ref METRIC_KAFKA_PRODUCE_RECORD_BYTES_TOTAL: IntCounter = register_int_counter!(
-        "greptime_kafka_produce_record_bytes_total",
-        "kafka produce record bytes total"
-    ).unwrap();
-
-    /// Counters of calls of each operation on a logstore.
-    pub static ref METRIC_LOGSTORE_OP_CALLS_TOTAL: IntCounterVec = register_int_counter_vec!(
-        "greptime_logstore_op_calls_total",
-        "logstore operation calls total",
-        &[LOGSTORE_LABEL, OPTYPE_LABEL],
-    )
-    .unwrap();
-    /// Counter of calls of the append_batch operation on the kafka logstore.
-    pub static ref METRIC_KAFKA_APPEND_BATCH_CALLS_TOTAL: IntCounter = METRIC_LOGSTORE_OP_CALLS_TOTAL.with_label_values(
-        &["kafka", "append_batch"],
-    );
-    /// Counter of calls of the read operation on the kafka logstore.
-    pub static ref METRIC_KAFKA_READ_CALLS_TOTAL: IntCounter = METRIC_LOGSTORE_OP_CALLS_TOTAL.with_label_values(
-        &["kafka", "read"],
-    );
-    /// Counter of calls of the append_batch operation on the raft-engine logstore.
-    pub static ref METRIC_RAFT_ENGINE_APPEND_BATCH_CALLS_TOTAL: IntCounter = METRIC_LOGSTORE_OP_CALLS_TOTAL.with_label_values(
-        &["raft-engine", "append_batch"],
-    );
-    /// Counter of calls of the read operation on the raft-engine logstore.
-    pub static ref METRIC_RAFT_ENGINE_READ_CALLS_TOTAL: IntCounter = METRIC_LOGSTORE_OP_CALLS_TOTAL.with_label_values(
-        &["raft-engine", "read"],
-    );
-
     /// Timer of operations on a logstore.
     pub static ref METRIC_LOGSTORE_OP_ELAPSED: HistogramVec = register_histogram_vec!(
         "greptime_logstore_op_elapsed",

--- a/src/log-store/src/raft_engine/log_store.rs
+++ b/src/log-store/src/raft_engine/log_store.rs
@@ -213,7 +213,6 @@ impl LogStore for RaftEngineLogStore {
     /// Appends a batch of entries to logstore. `RaftEngineLogStore` assures the atomicity of
     /// batch append.
     async fn append_batch(&self, entries: Vec<Entry>) -> Result<AppendBatchResponse> {
-        metrics::METRIC_RAFT_ENGINE_APPEND_BATCH_CALLS_TOTAL.inc();
         metrics::METRIC_RAFT_ENGINE_APPEND_BATCH_BYTES_TOTAL.inc_by(
             entries
                 .iter()
@@ -261,7 +260,6 @@ impl LogStore for RaftEngineLogStore {
                 actual: provider.type_name(),
             })?;
         let namespace_id = ns.id;
-        metrics::METRIC_RAFT_ENGINE_READ_CALLS_TOTAL.inc();
         let _timer = metrics::METRIC_RAFT_ENGINE_READ_ELAPSED.start_timer();
 
         ensure!(self.started(), IllegalStateSnafu);


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Remove redundant metrics

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
