### PR TITLE
refactor!: add processor builder and transform buidler

### DIFF
--- a/src/pipeline/benches/processor.rs
+++ b/src/pipeline/benches/processor.rs
@@ -237,10 +237,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.sample_size(50);
     group.bench_function("processor mut", |b| {
         b.iter(|| {
-            let result = processor_mut(black_box(&pipeline), black_box(input_value.clone()));
-            if result.is_err() {
-                panic!("Error: {:?}", result);
-            }
+            processor_mut(black_box(&pipeline), black_box(input_value.clone())).unwrap();
         })
     });
     group.finish();

--- a/src/pipeline/benches/processor.rs
+++ b/src/pipeline/benches/processor.rs
@@ -13,22 +13,8 @@
 // limitations under the License.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pipeline::{parse, Array, Content, GreptimeTransformer, Pipeline, Value as PipelineValue};
+use pipeline::{parse, Content, GreptimeTransformer, Pipeline};
 use serde_json::{Deserializer, Value};
-
-fn processor_map(
-    pipeline: &Pipeline<GreptimeTransformer>,
-    input_values: Vec<Value>,
-) -> impl IntoIterator<Item = greptime_proto::v1::Rows> {
-    let pipeline_data = input_values
-        .into_iter()
-        .map(|v| PipelineValue::try_from(v).unwrap())
-        .collect::<Vec<_>>();
-
-    pipeline.exec(PipelineValue::Array(Array {
-        values: pipeline_data,
-    }))
-}
 
 fn processor_mut(
     pipeline: &Pipeline<GreptimeTransformer>,
@@ -249,9 +235,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     let pipeline = prepare_pipeline();
     let mut group = c.benchmark_group("pipeline");
     group.sample_size(50);
-    group.bench_function("processor map", |b| {
-        b.iter(|| processor_map(black_box(&pipeline), black_box(input_value.clone())))
-    });
     group.bench_function("processor mut", |b| {
         b.iter(|| processor_mut(black_box(&pipeline), black_box(input_value.clone())))
     });

--- a/src/pipeline/benches/processor.rs
+++ b/src/pipeline/benches/processor.rs
@@ -19,7 +19,7 @@ use serde_json::{Deserializer, Value};
 fn processor_mut(
     pipeline: &Pipeline<GreptimeTransformer>,
     input_values: Vec<Value>,
-) -> impl IntoIterator<Item = Vec<greptime_proto::v1::Row>> {
+) -> Result<Vec<greptime_proto::v1::Row>, String> {
     let mut payload = pipeline.init_intermediate_state();
     let mut result = Vec::with_capacity(input_values.len());
 
@@ -236,7 +236,12 @@ fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("pipeline");
     group.sample_size(50);
     group.bench_function("processor mut", |b| {
-        b.iter(|| processor_mut(black_box(&pipeline), black_box(input_value.clone())))
+        b.iter(|| {
+            let result = processor_mut(black_box(&pipeline), black_box(input_value.clone()));
+            if result.is_err() {
+                panic!("Error: {:?}", result);
+            }
+        })
     });
     group.finish();
 }

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -122,7 +122,7 @@ where
                 .processor_builders
                 .into_iter()
                 .map(|builder| builder.build(&final_intermediate_keys))
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, _>>()?;
             let processors = Processors {
                 processors: processors_kind_list,
                 required_keys: processors_required_keys.clone(),
@@ -134,7 +134,7 @@ where
                 .builders
                 .into_iter()
                 .map(|builder| builder.build(&final_intermediate_keys, &output_keys))
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, String>>()?;
 
             let transformers = Transforms {
                 transforms: transfor_list,

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -87,7 +87,6 @@ where
 
             required_keys.append(&mut tr_keys);
             required_keys.sort();
-            let required_keys = required_keys;
 
             debug!("required_keys: {:?}", required_keys);
 

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -37,74 +37,74 @@ pub enum Content {
     Yaml(String),
 }
 
-/// set the index for the processor keys
-/// the index is the position of the key in the final intermediate keys
-fn set_processor_keys_index(
-    processors: &mut processor::Processors,
-    final_intermediate_keys: &Vec<String>,
-) -> Result<(), String> {
-    let final_intermediate_key_index = final_intermediate_keys
-        .iter()
-        .enumerate()
-        .map(|(i, k)| (k.as_str(), i))
-        .collect::<HashMap<_, _>>();
-    for processor in processors.iter_mut() {
-        for field in processor.fields_mut().iter_mut() {
-            let index = final_intermediate_key_index.get(field.input_field.name.as_str()).ok_or(format!(
-                    "input field {} is not found in intermediate keys: {final_intermediate_keys:?} when set processor keys index",
-                    field.input_field.name
-                ))?;
-            field.set_input_index(*index);
-            for (k, v) in field.output_fields_index_mapping.iter_mut() {
-                let index = final_intermediate_key_index.get(k.as_str());
-                match index {
-                    Some(index) => {
-                        *v = *index;
-                    }
-                    None => {
-                        warn!(
-                            "output field {k} is not found in intermediate keys: {final_intermediate_keys:?} when set processor keys index"
-                        );
-                    }
-                }
-            }
-        }
-    }
-    Ok(())
-}
+// /// set the index for the processor keys
+// /// the index is the position of the key in the final intermediate keys
+// fn set_processor_keys_index(
+//     processors: &mut processor::Processors,
+//     final_intermediate_keys: &Vec<String>,
+// ) -> Result<(), String> {
+//     let final_intermediate_key_index = final_intermediate_keys
+//         .iter()
+//         .enumerate()
+//         .map(|(i, k)| (k.as_str(), i))
+//         .collect::<HashMap<_, _>>();
+//     for processor in processors.iter_mut() {
+//         for field in processor.fields_mut().iter_mut() {
+//             let index = final_intermediate_key_index.get(field.input_field.name.as_str()).ok_or(format!(
+//                     "input field {} is not found in intermediate keys: {final_intermediate_keys:?} when set processor keys index",
+//                     field.input_field.name
+//                 ))?;
+//             field.set_input_index(*index);
+//             for (k, v) in field.output_fields_index_mapping.iter_mut() {
+//                 let index = final_intermediate_key_index.get(k.as_str());
+//                 match index {
+//                     Some(index) => {
+//                         *v = *index;
+//                     }
+//                     None => {
+//                         warn!(
+//                             "output field {k} is not found in intermediate keys: {final_intermediate_keys:?} when set processor keys index"
+//                         );
+//                     }
+//                 }
+//             }
+//         }
+//     }
+//     Ok(())
+// }
 
-fn set_transform_keys_index(
-    transforms: &mut Transforms,
-    final_intermediate_keys: &[String],
-    output_keys: &[String],
-) -> Result<(), String> {
-    let final_intermediate_key_index = final_intermediate_keys
-        .iter()
-        .enumerate()
-        .map(|(i, k)| (k.as_str(), i))
-        .collect::<HashMap<_, _>>();
-    let output_key_index = output_keys
-        .iter()
-        .enumerate()
-        .map(|(i, k)| (k.as_str(), i))
-        .collect::<HashMap<_, _>>();
-    for transform in transforms.iter_mut() {
-        for field in transform.fields.iter_mut() {
-            let index = final_intermediate_key_index.get(field.input_field.name.as_str()).ok_or(format!(
-                    "input field {} is not found in intermediate keys: {final_intermediate_keys:?} when set transform keys index",
-                    field.input_field.name
-                ))?;
-            field.set_input_index(*index);
-            for (k, v) in field.output_fields_index_mapping.iter_mut() {
-                let index = output_key_index.get(k.as_str()).ok_or(format!(
-                    "output field {k} is not found in output keys: {final_intermediate_keys:?} when set transform keys index"
-                ))?;
-                *v = *index;
-            }
-        }
-    }
-    Ok(())
-}
+// fn set_transform_keys_index(
+//     transforms: &mut Transforms,
+//     final_intermediate_keys: &[String],
+//     output_keys: &[String],
+// ) -> Result<(), String> {
+//     let final_intermediate_key_index = final_intermediate_keys
+//         .iter()
+//         .enumerate()
+//         .map(|(i, k)| (k.as_str(), i))
+//         .collect::<HashMap<_, _>>();
+//     let output_key_index = output_keys
+//         .iter()
+//         .enumerate()
+//         .map(|(i, k)| (k.as_str(), i))
+//         .collect::<HashMap<_, _>>();
+//     for transform in transforms.iter_mut() {
+//         for field in transform.fields.iter_mut() {
+//             let index = final_intermediate_key_index.get(field.input_field.name.as_str()).ok_or(format!(
+//                     "input field {} is not found in intermediate keys: {final_intermediate_keys:?} when set transform keys index",
+//                     field.input_field.name
+//                 ))?;
+//             field.set_input_index(*index);
+//             for (k, v) in field.output_fields_index_mapping.iter_mut() {
+//                 let index = output_key_index.get(k.as_str()).ok_or(format!(
+//                     "output field {k} is not found in output keys: {final_intermediate_keys:?} when set transform keys index"
+//                 ))?;
+//                 *v = *index;
+//             }
+//         }
+//     }
+//     Ok(())
+// }
 
 pub fn parse<T>(input: &Content) -> Result<Pipeline<T>, String>
 where
@@ -268,11 +268,12 @@ where
     T: Transformer,
 {
     fn exec_map(&self, map: &mut Map) -> Result<(), String> {
-        let v = map;
-        for processor in self.processors.iter() {
-            processor.exec_map(v)?;
-        }
-        Ok(())
+        todo!()
+        // let v = map;
+        // for processor in self.processors.iter() {
+        //     processor.exec_map(v)?;
+        // }
+        // Ok(())
     }
 
     pub fn exec(&self, mut val: Value) -> Result<T::Output, String> {
@@ -379,6 +380,7 @@ where
 #[cfg(test)]
 mod tests {
 
+    use api::v1::Rows;
     use greptime_proto::v1::value::ValueData;
     use greptime_proto::v1::{self, ColumnDataType, SemanticType};
 
@@ -386,100 +388,58 @@ mod tests {
     use crate::etl::{parse, Content, Pipeline};
     use crate::Value;
 
-    #[test]
-    fn test_pipeline_prepare() {
-        {
-            let input_value_str = r#"
-            {
-                "my_field": "1,2",
-                "foo": "bar"
-            }
-        "#;
-            let input_value: serde_json::Value = serde_json::from_str(input_value_str).unwrap();
+    //     #[test]
+    //     fn test_pipeline_prepare() {
+    //         let input_value_str = r#"
+    //             {
+    //                 "my_field": "1,2",
+    //                 "foo": "bar"
+    //             }
+    //         "#;
+    //         let input_value: serde_json::Value = serde_json::from_str(input_value_str).unwrap();
 
-            let pipeline_yaml = r#"
----
-description: Pipeline for Apache Tomcat
+    //         let pipeline_yaml = r#"
+    // ---
+    // description: Pipeline for Apache Tomcat
 
-processors:
-  - csv:
-      field: my_field, my_field,field1, field2
+    // processors:
+    //   - csv:
+    //       field: my_field, my_field,field1, field2
 
-transform:
-  - field: field1
-    type: uint32
-  - field: field2
-    type: uint32
-"#;
-            let pipeline: Pipeline<GreptimeTransformer> =
-                parse(&Content::Yaml(pipeline_yaml.into())).unwrap();
-            let mut payload = pipeline.init_intermediate_state();
-            pipeline.prepare(input_value, &mut payload).unwrap();
-            assert_eq!(
-                &["greptime_timestamp", "my_field"].to_vec(),
-                pipeline.required_keys()
-            );
-            assert_eq!(
-                payload,
-                vec![
-                    Value::Null,
-                    Value::String("1,2".to_string()),
-                    Value::Null,
-                    Value::Null
-                ]
-            );
-            let result = pipeline.exec_mut(&mut payload).unwrap();
+    // transform:
+    //   - field: field1
+    //     type: uint32
+    //   - field: field2
+    //     type: uint32
+    // "#;
+    //         let pipeline: Pipeline<GreptimeTransformer> =
+    //             parse(&Content::Yaml(pipeline_yaml.into())).unwrap();
+    //         let mut payload = pipeline.init_intermediate_state();
+    //         pipeline.prepare(input_value, &mut payload).unwrap();
+    //         assert_eq!(
+    //             &["greptime_timestamp", "my_field"].to_vec(),
+    //             pipeline.required_keys()
+    //         );
+    //         assert_eq!(
+    //             payload,
+    //             vec![
+    //                 Value::Null,
+    //                 Value::String("1,2".to_string()),
+    //                 Value::Null,
+    //                 Value::Null
+    //             ]
+    //         );
+    //         let result = pipeline.exec_mut(&mut payload).unwrap();
 
-            assert_eq!(result.values[0].value_data, Some(ValueData::U32Value(1)));
-            assert_eq!(result.values[1].value_data, Some(ValueData::U32Value(2)));
-            match &result.values[2].value_data {
-                Some(ValueData::TimestampNanosecondValue(v)) => {
-                    assert_ne!(*v, 0);
-                }
-                _ => panic!("expect null value"),
-            }
-        }
-        {
-            let input_value_str = r#"
-          {
-            "reqTimeSec": "1573840000.000"
-          }
-    "#;
-
-            let pipeline_yaml = r#"
----
-description: Pipeline for Demo Log
-
-processors:
-  - gsub:
-      field: reqTimeSec
-      pattern: "\\."
-      replacement: ""
-  - epoch:
-      field: reqTimeSec
-      resolution: millisecond
-      ignore_missing: true
-
-transform:
-  - field: reqTimeSec
-    type: epoch, millisecond
-    index: timestamp
-"#;
-            let input_value: serde_json::Value = serde_json::from_str(input_value_str).unwrap();
-            let pipeline: Pipeline<GreptimeTransformer> =
-                parse(&Content::Yaml(pipeline_yaml.into())).unwrap();
-            let mut payload = pipeline.init_intermediate_state();
-            pipeline.prepare(input_value, &mut payload).unwrap();
-            assert_eq!(&["reqTimeSec"].to_vec(), pipeline.required_keys());
-            assert_eq!(payload, vec![Value::String("1573840000.000".to_string())]);
-            let result = pipeline.exec_mut(&mut payload).unwrap();
-
-            assert_eq!(
-                result.values[0].value_data,
-                Some(ValueData::TimestampMillisecondValue(1573840000000))
-            );
-        }
-    }
+    //         assert_eq!(result.values[0].value_data, Some(ValueData::U32Value(1)));
+    //         assert_eq!(result.values[1].value_data, Some(ValueData::U32Value(2)));
+    //         match &result.values[2].value_data {
+    //             Some(ValueData::TimestampNanosecondValue(v)) => {
+    //                 assert_ne!(*v, 0);
+    //             }
+    //             _ => panic!("expect null value"),
+    //         }
+    //     }
 
     #[test]
     fn test_dissect_pipeline() {
@@ -625,7 +585,14 @@ transform:
 
         let pipeline: Pipeline<GreptimeTransformer> =
             parse(&Content::Yaml(pipeline_yaml.into())).unwrap();
-        let output = pipeline.exec(input_value.try_into().unwrap()).unwrap();
+        let schema = pipeline.schemas().clone();
+        let mut result = pipeline.init_intermediate_state();
+        pipeline.prepare(input_value, &mut result).unwrap();
+        let row = pipeline.exec_mut(&mut result).unwrap();
+        let output = Rows {
+            schema,
+            rows: vec![row],
+        };
         let schemas = output.schema;
 
         assert_eq!(schemas.len(), 1);

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -269,6 +269,20 @@ where
     }
 }
 
+pub(crate) fn find_key_index(
+    intermediate_keys: &[String],
+    key: &str,
+    kind: &str,
+) -> Result<usize, String> {
+    intermediate_keys
+        .iter()
+        .position(|k| k == key)
+        .ok_or(format!(
+            "{} processor.{} not found in intermediate keys",
+            kind, key
+        ))
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/pipeline/src/etl.rs
+++ b/src/pipeline/src/etl.rs
@@ -62,8 +62,6 @@ where
                     TransformBuilders::default()
                 };
 
-            // let mut transformer = T::new(transforms)?;
-            // let transforms = transformer.transforms_mut();
             let processors_required_keys = &processor_builder_list.input_keys;
             let processors_output_keys = &processor_builder_list.output_keys;
             let processors_required_original_keys = &processor_builder_list.original_input_keys;

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -21,31 +21,24 @@ enum IndexInfo {
     NotSet,
 }
 
+/// Information about the input field including the name and index in intermediate keys.
 #[derive(Debug, Default, Clone)]
 pub struct InputFieldInfo {
     pub(crate) name: String,
     pub(crate) index: usize,
 }
 
-struct InputFieldInfoBuilder {
-    name: String,
-}
-
 impl InputFieldInfo {
+    /// Create a new input field info with the given field name and index.
     pub(crate) fn new(field: impl Into<String>, index: usize) -> Self {
         InputFieldInfo {
             name: field.into(),
             index,
         }
     }
-
-    pub(crate) fn name(field: impl Into<String>) -> Self {
-        InputFieldInfo {
-            name: field.into(),
-            index: 0,
-        }
-    }
 }
+
+/// Information about a field that has one input and one output.
 #[derive(Debug, Default, Clone)]
 pub struct OneInputOneOutPutField {
     input: InputFieldInfo,
@@ -53,6 +46,7 @@ pub struct OneInputOneOutPutField {
 }
 
 impl OneInputOneOutPutField {
+    /// Create a new field with the given input and output.
     pub(crate) fn new(input: InputFieldInfo, output: (String, usize)) -> Self {
         OneInputOneOutPutField {
             input,
@@ -60,6 +54,7 @@ impl OneInputOneOutPutField {
         }
     }
 
+    /// Build a new field with the given processor kind, intermediate keys, input field, and target field.
     pub(crate) fn build(
         processor_kind: &str,
         intermediate_keys: &[String],
@@ -76,26 +71,32 @@ impl OneInputOneOutPutField {
         ))
     }
 
+    /// Get the input field information.
     pub(crate) fn input(&self) -> &InputFieldInfo {
         &self.input
     }
 
+    /// Get the index of the input field.
     pub(crate) fn input_index(&self) -> usize {
         self.input.index
     }
 
+    /// Get the name of the input field.
     pub(crate) fn input_name(&self) -> &str {
         &self.input.name
     }
 
+    /// Get the index of the output field.
     pub(crate) fn output_index(&self) -> usize {
         *self.output().1
     }
 
+    /// Get the name of the output field.
     pub(crate) fn output_name(&self) -> &str {
         self.output().0
     }
 
+    /// Get the output field information.
     pub(crate) fn output(&self) -> (&String, &usize) {
         if let Some((name, index)) = &self.output {
             (name, index)
@@ -105,34 +106,42 @@ impl OneInputOneOutPutField {
     }
 }
 
+/// Information about a field that has one input and multiple outputs.
 #[derive(Debug, Default, Clone)]
 pub struct OneInputMultiOutputField {
     input: InputFieldInfo,
+    /// Typically, processors that output multiple keys need to be distinguished by splicing the keys together.
     prefix: Option<String>,
 }
 
 impl OneInputMultiOutputField {
+    /// Create a new field with the given input and prefix.
     pub(crate) fn new(input: InputFieldInfo, prefix: Option<String>) -> Self {
         OneInputMultiOutputField { input, prefix }
     }
 
+    /// Get the input field information.
     pub(crate) fn input(&self) -> &InputFieldInfo {
         &self.input
     }
 
+    /// Get the index of the input field.
     pub(crate) fn input_index(&self) -> usize {
         self.input.index
     }
 
+    /// Get the name of the input field.
     pub(crate) fn input_name(&self) -> &str {
         &self.input.name
     }
 
+    /// Get the prefix for the output fields.
     pub(crate) fn target_prefix(&self) -> &str {
         self.prefix.as_deref().unwrap_or(&self.input.name)
     }
 }
 
+/// Raw processor-defined inputs and outputs
 #[derive(Debug, Default, Clone)]
 pub struct Field {
     pub(crate) input_field: String,
@@ -163,6 +172,7 @@ impl FromStr for Field {
 }
 
 impl Field {
+    /// Create a new field with the given input and target fields.
     pub(crate) fn new(input_field: impl Into<String>, target_field: Option<String>) -> Self {
         Field {
             input_field: input_field.into(),
@@ -170,19 +180,23 @@ impl Field {
         }
     }
 
+    /// Get the input field.
     pub(crate) fn input_field(&self) -> &str {
         &self.input_field
     }
 
+    /// Get the target field.
     pub(crate) fn target_field(&self) -> Option<&str> {
         self.target_field.as_deref()
     }
 
+    /// Get the target field or the input field if the target field is not set.
     pub(crate) fn target_or_input_field(&self) -> &str {
         self.target_field.as_deref().unwrap_or(&self.input_field)
     }
 }
 
+/// A collection of fields.
 #[derive(Debug, Default, Clone)]
 pub struct Fields(Vec<Field>);
 

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 use std::str::FromStr;
 
-use super::processor::find_key_index;
+use crate::etl::find_key_index;
 
 /// Information about the input field including the name and index in intermediate keys.
 #[derive(Debug, Default, Clone)]

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -125,6 +125,22 @@ impl OneInputOneOutPutField {
         &self.input
     }
 
+    pub(crate) fn input_index(&self) -> usize {
+        self.input.index
+    }
+
+    pub(crate) fn input_name(&self) -> &str {
+        &self.input.name
+    }
+
+    pub(crate) fn output_index(&self) -> usize {
+        *self.output().1
+    }
+
+    pub(crate) fn output_name(&self) -> &str {
+        self.output().0
+    }
+
     pub(crate) fn output(&self) -> (&String, &usize) {
         if let Some((name, index)) = &self.output {
             (name, index)
@@ -150,6 +166,14 @@ impl OneInputMultiOutputField {
 
     pub(crate) fn input(&self) -> &InputFieldInfo {
         &self.input
+    }
+
+    pub(crate) fn input_index(&self) -> usize {
+        self.input.index
+    }
+
+    pub(crate) fn input_name(&self) -> &str {
+        &self.input.name
     }
 
     pub(crate) fn outputs(&self) -> BTreeMap<&String, &usize> {
@@ -230,11 +254,12 @@ impl Deref for NewFields {
     }
 }
 
-impl Iterator for NewFields {
+impl IntoIterator for NewFields {
     type Item = NewField;
+    type IntoIter = std::vec::IntoIter<NewField>;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.pop()
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -14,6 +14,8 @@
 
 use std::ops::Deref;
 use std::str::FromStr;
+
+use super::processor::find_key_index;
 enum IndexInfo {
     Index(usize),
     NotSet,
@@ -56,6 +58,22 @@ impl OneInputOneOutPutField {
             input,
             output: Some(output),
         }
+    }
+
+    pub(crate) fn build(
+        processor_kind: &str,
+        intermediate_keys: &[String],
+        input_field: &str,
+        target_field: &str,
+    ) -> Result<Self, String> {
+        let input_index = find_key_index(intermediate_keys, input_field, processor_kind)?;
+
+        let input_field_info = InputFieldInfo::new(input_field, input_index);
+        let output_index = find_key_index(intermediate_keys, target_field, processor_kind)?;
+        Ok(OneInputOneOutPutField::new(
+            input_field_info,
+            (target_field.to_string(), output_index),
+        ))
     }
 
     pub(crate) fn input(&self) -> &InputFieldInfo {

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -16,10 +16,6 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use super::processor::find_key_index;
-enum IndexInfo {
-    Index(usize),
-    NotSet,
-}
 
 /// Information about the input field including the name and index in intermediate keys.
 #[derive(Debug, Default, Clone)]
@@ -40,15 +36,15 @@ impl InputFieldInfo {
 
 /// Information about a field that has one input and one output.
 #[derive(Debug, Default, Clone)]
-pub struct OneInputOneOutPutField {
+pub struct OneInputOneOutputField {
     input: InputFieldInfo,
     output: Option<(String, usize)>,
 }
 
-impl OneInputOneOutPutField {
+impl OneInputOneOutputField {
     /// Create a new field with the given input and output.
     pub(crate) fn new(input: InputFieldInfo, output: (String, usize)) -> Self {
-        OneInputOneOutPutField {
+        OneInputOneOutputField {
             input,
             output: Some(output),
         }
@@ -65,7 +61,7 @@ impl OneInputOneOutPutField {
 
         let input_field_info = InputFieldInfo::new(input_field, input_index);
         let output_index = find_key_index(intermediate_keys, target_field, processor_kind)?;
-        Ok(OneInputOneOutPutField::new(
+        Ok(OneInputOneOutputField::new(
             input_field_info,
             (target_field.to_string(), output_index),
         ))

--- a/src/pipeline/src/etl/field.rs
+++ b/src/pipeline/src/etl/field.rs
@@ -153,15 +153,12 @@ impl OneInputOneOutPutField {
 #[derive(Debug, Default, Clone)]
 pub struct OneInputMultiOutputField {
     input: InputFieldInfo,
-    outputs: Option<BTreeMap<String, usize>>,
+    prefix: Option<String>,
 }
 
 impl OneInputMultiOutputField {
-    pub(crate) fn new(input: InputFieldInfo, outputs: BTreeMap<String, usize>) -> Self {
-        OneInputMultiOutputField {
-            input,
-            outputs: Some(outputs),
-        }
+    pub(crate) fn new(input: InputFieldInfo, prefix: Option<String>) -> Self {
+        OneInputMultiOutputField { input, prefix }
     }
 
     pub(crate) fn input(&self) -> &InputFieldInfo {
@@ -176,21 +173,15 @@ impl OneInputMultiOutputField {
         &self.input.name
     }
 
-    pub(crate) fn outputs(&self) -> BTreeMap<&String, &usize> {
-        if let Some(outputs) = &self.outputs {
-            outputs.iter().collect()
-        } else {
-            let mut map = BTreeMap::new();
-            map.insert(&self.input.name, &self.input.index);
-            map
-        }
+    pub(crate) fn target_prefix(&self) -> &str {
+        self.prefix.as_deref().unwrap_or(&self.input.name)
     }
 }
 
 #[derive(Debug, Default, Clone)]
 pub struct NewField {
-    input_field: String,
-    target_field: Option<String>,
+    pub(crate) input_field: String,
+    pub(crate) target_field: Option<String>,
 }
 
 impl FromStr for NewField {

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -89,10 +89,15 @@ pub enum ProcessorKind {
     Date(DateProcessor),
 }
 
+/// ProcessorBuilder trait defines the interface for all processor builders
+/// A processor builder is used to create a processor
 #[enum_dispatch(ProcessorBuilders)]
 pub trait ProcessorBuilder: std::fmt::Debug + Send + Sync + 'static {
+    /// Get the processor's output keys
     fn output_keys(&self) -> HashSet<&str>;
+    /// Get the processor's input keys
     fn input_keys(&self) -> HashSet<&str>;
+    /// Build the processor
     fn build(self, intermediate_keys: &[String]) -> Result<ProcessorKind, String>;
 }
 

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -63,56 +63,14 @@ const SEPARATOR_NAME: &str = "separator";
 /// The output of a processor is a map of key-value pairs that will be merged into the document when you use exec_map method.
 #[enum_dispatch(ProcessorKind)]
 pub trait Processor: std::fmt::Debug + Send + Sync + 'static {
-    /// Get the processor's fields
-    /// fields is just the same processor for multiple keys. It is not the case that a processor has multiple inputs
-    fn fields(&self) -> &Fields;
-
-    /// Get the processor's fields mutably
-    fn fields_mut(&mut self) -> &mut Fields;
-
     /// Get the processor's kind
     fn kind(&self) -> &str;
 
     /// Whether to ignore missing
     fn ignore_missing(&self) -> bool;
 
-    /// processor all output keys
-    /// if a processor has multiple output keys, it should return all of them
-    fn output_keys(&self) -> HashSet<&str>;
-
-    fn input_keys(&self) -> HashSet<&str>;
-    /// Execute the processor on a document
-    /// and return a map of key-value pairs
-    fn exec_field(&self, val: &Value, field: &Field) -> Result<Map, String>;
-
     /// Execute the processor on a vector which be preprocessed by the pipeline
     fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String>;
-
-    /// Execute the processor on a map
-    /// and merge the output into the original map
-    fn exec_map(&self, map: &mut Map) -> Result<(), String> {
-        for ff @ Field {
-            input_field: field_info,
-            ..
-        } in self.fields().iter()
-        {
-            match map.get(&field_info.name) {
-                Some(v) => {
-                    map.extend(self.exec_field(v, ff)?);
-                }
-                None if self.ignore_missing() => {}
-                None => {
-                    return Err(format!(
-                        "{} processor: field '{}' is required but missing in {map}",
-                        self.kind(),
-                        field_info.name,
-                    ))
-                }
-            }
-        }
-
-        Ok(())
-    }
 }
 
 #[derive(Debug)]

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -307,7 +307,7 @@ where
     })
 }
 
-pub(crate) fn yaml_new_fileds(v: &yaml_rust::Yaml, field: &str) -> Result<Fields, String> {
+pub(crate) fn yaml_new_fields(v: &yaml_rust::Yaml, field: &str) -> Result<Fields, String> {
     yaml_parse_strings(v, field).map(Fields::new)
 }
 

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -41,7 +41,7 @@ use urlencoding::{UrlEncodingProcessor, UrlEncodingProcessorBuilder};
 
 use super::field::{NewField, NewFields};
 use crate::etl::field::{Field, Fields};
-use crate::etl::value::{Map, Value};
+use crate::etl::value::Value;
 
 const FIELD_NAME: &str = "field";
 const FIELDS_NAME: &str = "fields";
@@ -50,6 +50,7 @@ const METHOD_NAME: &str = "method";
 const PATTERN_NAME: &str = "pattern";
 const PATTERNS_NAME: &str = "patterns";
 const SEPARATOR_NAME: &str = "separator";
+const TARGET_FIELDS_NAME: &str = "target_fields";
 
 // const IF_NAME: &str = "if";
 // const IGNORE_FAILURE_NAME: &str = "ignore_failure";
@@ -165,7 +166,7 @@ impl Processors {
     }
 }
 
-impl<'a> TryFrom<&Vec<yaml_rust::Yaml>> for ProcessorBuilderList {
+impl TryFrom<&Vec<yaml_rust::Yaml>> for ProcessorBuilderList {
     type Error = String;
 
     fn try_from(vec: &Vec<yaml_rust::Yaml>) -> Result<Self, Self::Error> {
@@ -313,7 +314,7 @@ pub(crate) fn yaml_fields(v: &yaml_rust::Yaml, field: &str) -> Result<Fields, St
 }
 
 pub(crate) fn yaml_new_fileds(v: &yaml_rust::Yaml, field: &str) -> Result<NewFields, String> {
-    yaml_parse_strings(v, field).map(|v| NewFields::new(v))
+    yaml_parse_strings(v, field).map(NewFields::new)
 }
 
 pub(crate) fn yaml_new_field(v: &yaml_rust::Yaml, field: &str) -> Result<NewField, String> {

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -319,18 +319,3 @@ pub(crate) fn yaml_new_fields(v: &yaml_rust::Yaml, field: &str) -> Result<Fields
 pub(crate) fn yaml_new_field(v: &yaml_rust::Yaml, field: &str) -> Result<Field, String> {
     yaml_parse_string(v, field)
 }
-
-pub(crate) fn generate_find_key_index_error_msg(kind: &str, key: &str) -> String {
-    format!("{} processor.{} not found in intermediate keys", kind, key)
-}
-
-pub(crate) fn find_key_index(
-    intermediate_keys: &[String],
-    key: &str,
-    kind: &str,
-) -> Result<usize, String> {
-    intermediate_keys
-        .iter()
-        .position(|k| k == key)
-        .ok_or(generate_find_key_index_error_msg(kind, key))
-}

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -93,7 +93,7 @@ pub enum ProcessorKind {
 pub trait ProcessorBuilder: std::fmt::Debug + Send + Sync + 'static {
     fn output_keys(&self) -> HashSet<&str>;
     fn input_keys(&self) -> HashSet<&str>;
-    fn build(self, intermediate_keys: &[String]) -> ProcessorKind;
+    fn build(self, intermediate_keys: &[String]) -> Result<ProcessorKind, String>;
 }
 
 #[derive(Debug)]
@@ -313,4 +313,19 @@ pub(crate) fn yaml_new_fields(v: &yaml_rust::Yaml, field: &str) -> Result<Fields
 
 pub(crate) fn yaml_new_field(v: &yaml_rust::Yaml, field: &str) -> Result<Field, String> {
     yaml_parse_string(v, field)
+}
+
+pub(crate) fn generate_find_key_index_error_msg(kind: &str, key: &str) -> String {
+    format!("{} processor.{} not found in intermediate keys", kind, key)
+}
+
+pub(crate) fn find_key_index(
+    intermediate_keys: &[String],
+    key: &str,
+    kind: &str,
+) -> Result<usize, String> {
+    intermediate_keys
+        .iter()
+        .position(|k| k == key)
+        .ok_or(generate_find_key_index_error_msg(kind, key))
 }

--- a/src/pipeline/src/etl/processor.rs
+++ b/src/pipeline/src/etl/processor.rs
@@ -39,8 +39,7 @@ use regex::{RegexProcessor, RegexProcessorBuilder};
 use timestamp::{TimestampProcessor, TimestampProcessorBuilder};
 use urlencoding::{UrlEncodingProcessor, UrlEncodingProcessorBuilder};
 
-use super::field::{NewField, NewFields};
-use crate::etl::field::{Field, Fields};
+use super::field::{Field, Fields};
 use crate::etl::value::Value;
 
 const FIELD_NAME: &str = "field";
@@ -308,27 +307,10 @@ where
     })
 }
 
-pub(crate) fn yaml_fields(v: &yaml_rust::Yaml, field: &str) -> Result<Fields, String> {
-    let v = yaml_parse_strings(v, field)?;
-    Fields::new(v)
+pub(crate) fn yaml_new_fileds(v: &yaml_rust::Yaml, field: &str) -> Result<Fields, String> {
+    yaml_parse_strings(v, field).map(Fields::new)
 }
 
-pub(crate) fn yaml_new_fileds(v: &yaml_rust::Yaml, field: &str) -> Result<NewFields, String> {
-    yaml_parse_strings(v, field).map(NewFields::new)
-}
-
-pub(crate) fn yaml_new_field(v: &yaml_rust::Yaml, field: &str) -> Result<NewField, String> {
+pub(crate) fn yaml_new_field(v: &yaml_rust::Yaml, field: &str) -> Result<Field, String> {
     yaml_parse_string(v, field)
-}
-
-pub(crate) fn yaml_field(v: &yaml_rust::Yaml, field: &str) -> Result<Field, String> {
-    yaml_parse_string(v, field)
-}
-
-pub(crate) fn update_one_one_output_keys(fields: &mut Fields) {
-    for field in fields.iter_mut() {
-        field
-            .output_fields_index_mapping
-            .insert(field.get_target_field().to_string(), 0_usize);
-    }
 }

--- a/src/pipeline/src/etl/processor/cmcd.rs
+++ b/src/pipeline/src/etl/processor/cmcd.rs
@@ -66,6 +66,8 @@ const CMCD_KEYS: [&str; 18] = [
     CMCD_KEY_V,
 ];
 
+/// CmcdProcessorBuilder is a builder for CmcdProcessor
+/// parse from raw yaml
 #[derive(Debug, Default)]
 pub struct CmcdProcessorBuilder {
     fields: Fields,
@@ -74,6 +76,8 @@ pub struct CmcdProcessorBuilder {
 }
 
 impl CmcdProcessorBuilder {
+    /// build_cmcd_outputs build cmcd output info
+    /// generate index and function for each output
     pub(super) fn build_cmcd_outputs(
         field: &Field,
         intermediate_keys: &[String],
@@ -113,6 +117,7 @@ impl CmcdProcessorBuilder {
         Ok((output_index, cmcd_field_outputs))
     }
 
+    /// build CmcdProcessor from CmcdProcessorBuilder
     pub fn build(self, intermediate_keys: &[String]) -> Result<CmcdProcessor, String> {
         let mut real_fields = vec![];
         let mut cmcd_outputs = Vec::with_capacity(CMCD_KEYS.len());
@@ -154,11 +159,16 @@ fn generate_key(prefix: &str, key: &str) -> String {
     format!("{}_{}", prefix, key)
 }
 
+/// CmcdOutputInfo is a struct to store output info
 #[derive(Debug)]
 pub(super) struct CmcdOutputInfo {
+    /// {input_field}_{cmcd_key}
     final_key: String,
+    /// cmcd key
     key: &'static str,
+    /// index in intermediate_keys
     index: usize,
+    /// function to resolve value
     f: fn(&str, &str, Option<&str>) -> Result<Value, String>,
 }
 

--- a/src/pipeline/src/etl/processor/cmcd.rs
+++ b/src/pipeline/src/etl/processor/cmcd.rs
@@ -18,9 +18,10 @@ use ahash::HashSet;
 use urlencoding::decode;
 
 use crate::etl::field::{Field, Fields, InputFieldInfo, OneInputMultiOutputField};
+use crate::etl::find_key_index;
 use crate::etl::processor::{
-    find_key_index, yaml_bool, yaml_new_field, yaml_new_fields, Processor, ProcessorBuilder,
-    ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, Processor, ProcessorBuilder, ProcessorKind,
+    FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
 

--- a/src/pipeline/src/etl/processor/cmcd.rs
+++ b/src/pipeline/src/etl/processor/cmcd.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+
 use ahash::HashSet;
 use urlencoding::decode;
 
 // use super::{yaml_new_field, yaml_new_fileds, Processor, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, NewFields, OneInputMultiOutputField};
+use crate::etl::field::{InputFieldInfo, NewField, NewFields, OneInputMultiOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fileds, Processor, ProcessorBuilder, ProcessorKind,
     FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
-use crate::etl::value::{Map, Value};
+use crate::etl::value::Value;
 
 pub(crate) const PROCESSOR_CMCD: &str = "cmcd";
 
@@ -68,22 +70,170 @@ const CMCD_KEYS: [&str; 18] = [
 #[derive(Debug, Default)]
 pub struct CmcdProcessorBuilder {
     fields: NewFields,
-
+    output_keys: HashSet<String>,
     ignore_missing: bool,
+}
+
+impl CmcdProcessorBuilder {
+    pub(super) fn build_cmcd_outputs(
+        field: &NewField,
+        intermediate_keys: &[String],
+    ) -> (BTreeMap<String, usize>, Vec<CmcdOutputInfo>) {
+        let mut output_index = BTreeMap::new();
+        let mut cmcd_field_outputs = Vec::with_capacity(CMCD_KEYS.len());
+        for cmcd in CMCD_KEYS {
+            let final_key = generate_key(field.target_or_input_field(), cmcd);
+            let index = intermediate_keys
+                .iter()
+                .position(|k| k == &final_key)
+                .unwrap();
+            output_index.insert(final_key.clone(), index);
+            match cmcd {
+                CMCD_KEY_BS | CMCD_KEY_SU => {
+                    let output_info = CmcdOutputInfo::new(final_key, cmcd, index, bs_su);
+                    cmcd_field_outputs.push(output_info);
+                }
+                CMCD_KEY_BR | CMCD_KEY_BL | CMCD_KEY_D | CMCD_KEY_DL | CMCD_KEY_MTP
+                | CMCD_KEY_RTP | CMCD_KEY_TB => {
+                    let output_info = CmcdOutputInfo::new(final_key, cmcd, index, br_tb);
+                    cmcd_field_outputs.push(output_info);
+                }
+                CMCD_KEY_CID | CMCD_KEY_NRR | CMCD_KEY_OT | CMCD_KEY_SF | CMCD_KEY_SID
+                | CMCD_KEY_ST | CMCD_KEY_V => {
+                    let output_info = CmcdOutputInfo::new(final_key, cmcd, index, cid_v);
+                    cmcd_field_outputs.push(output_info);
+                }
+                CMCD_KEY_NOR => {
+                    let output_info = CmcdOutputInfo::new(final_key, cmcd, index, nor);
+                    cmcd_field_outputs.push(output_info);
+                }
+                CMCD_KEY_PR => {
+                    let output_info = CmcdOutputInfo::new(final_key, cmcd, index, pr);
+                    cmcd_field_outputs.push(output_info);
+                }
+                _ => {}
+            }
+        }
+        (output_index, cmcd_field_outputs)
+    }
+
+    pub fn build(self, intermediate_keys: &[String]) -> CmcdProcessor {
+        let mut real_fields = vec![];
+        let mut cmcd_outputs = Vec::with_capacity(CMCD_KEYS.len());
+        for field in self.fields.into_iter() {
+            let input_index = intermediate_keys
+                .iter()
+                .position(|k| *k == field.input_field())
+                // TODO (qtang): handler error
+                .unwrap();
+
+            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
+
+            let (_, cmcd_field_outputs) = Self::build_cmcd_outputs(&field, intermediate_keys);
+
+            cmcd_outputs.push(cmcd_field_outputs);
+
+            let real_field = OneInputMultiOutputField::new(input_field_info, field.target_field);
+            real_fields.push(real_field);
+        }
+        CmcdProcessor {
+            real_fields,
+            cmcd_outputs,
+            ignore_missing: self.ignore_missing,
+        }
+    }
 }
 
 impl ProcessorBuilder for CmcdProcessorBuilder {
     fn output_keys(&self) -> HashSet<&str> {
-        todo!()
+        self.output_keys.iter().map(|s| s.as_str()).collect()
     }
 
     fn input_keys(&self) -> HashSet<&str> {
         self.fields.iter().map(|f| f.input_field()).collect()
     }
 
-    fn build(self, _intermediate_keys: &[String]) -> ProcessorKind {
-        todo!()
+    fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
+        ProcessorKind::Cmcd(self.build(intermediate_keys))
     }
+}
+
+fn generate_key(prefix: &str, key: &str) -> String {
+    format!("{}_{}", prefix, key)
+}
+
+#[derive(Debug)]
+pub(super) struct CmcdOutputInfo {
+    final_key: String,
+    key: &'static str,
+    index: usize,
+    f: fn(&str, &str, Option<&str>) -> Result<Value, String>,
+}
+
+impl CmcdOutputInfo {
+    fn new(
+        final_key: String,
+        key: &'static str,
+        index: usize,
+        f: fn(&str, &str, Option<&str>) -> Result<Value, String>,
+    ) -> Self {
+        Self {
+            final_key,
+            key,
+            index,
+            f,
+        }
+    }
+}
+
+impl Default for CmcdOutputInfo {
+    fn default() -> Self {
+        Self {
+            final_key: String::default(),
+            key: "",
+            index: 0,
+            f: |_, _, _| Ok(Value::Null),
+        }
+    }
+}
+
+/// function to resolve CMCD_KEY_BS | CMCD_KEY_SU
+fn bs_su(_: &str, _: &str, _: Option<&str>) -> Result<Value, String> {
+    Ok(Value::Boolean(true))
+}
+
+/// function to resolve CMCD_KEY_BR | CMCD_KEY_BL | CMCD_KEY_D | CMCD_KEY_DL | CMCD_KEY_MTP | CMCD_KEY_RTP | CMCD_KEY_TB
+fn br_tb(s: &str, k: &str, v: Option<&str>) -> Result<Value, String> {
+    let v = v.ok_or(format!("{k} missing value in {s}"))?;
+    let val: i64 = v
+        .parse()
+        .map_err(|_| format!("failed to parse {v} as i64"))?;
+    Ok(Value::Int64(val))
+}
+
+/// function to resolve CMCD_KEY_CID | CMCD_KEY_NRR | CMCD_KEY_OT | CMCD_KEY_SF | CMCD_KEY_SID | CMCD_KEY_V
+fn cid_v(s: &str, k: &str, v: Option<&str>) -> Result<Value, String> {
+    let v = v.ok_or(format!("{k} missing value in {s}"))?;
+    Ok(Value::String(v.to_string()))
+}
+
+/// function to resolve CMCD_KEY_NOR
+fn nor(s: &str, k: &str, v: Option<&str>) -> Result<Value, String> {
+    let v = v.ok_or(format!("{k} missing value in {s}"))?;
+    let val = match decode(v) {
+        Ok(val) => val.to_string(),
+        Err(_) => v.to_string(),
+    };
+    Ok(Value::String(val))
+}
+
+/// function to resolve CMCD_KEY_PR
+fn pr(s: &str, k: &str, v: Option<&str>) -> Result<Value, String> {
+    let v = v.ok_or(format!("{k} missing value in {s}"))?;
+    let val: f64 = v
+        .parse()
+        .map_err(|_| format!("failed to parse {v} as f64"))?;
+    Ok(Value::Float64(val))
 }
 
 /// Common Media Client Data Specification:
@@ -124,90 +274,33 @@ impl ProcessorBuilder for CmcdProcessorBuilder {
 #[derive(Debug, Default)]
 pub struct CmcdProcessor {
     real_fields: Vec<OneInputMultiOutputField>,
-    fields: Fields,
+    cmcd_outputs: Vec<Vec<CmcdOutputInfo>>,
 
     ignore_missing: bool,
 }
 
 impl CmcdProcessor {
-    fn with_fields(&mut self, mut fields: Fields) {
-        Self::update_output_keys(&mut fields);
-        self.fields = fields;
-    }
-
-    fn with_ignore_missing(&mut self, ignore_missing: bool) {
-        self.ignore_missing = ignore_missing;
-    }
-
     fn generate_key(prefix: &str, key: &str) -> String {
         format!("{}_{}", prefix, key)
     }
 
-    fn parse(prefix: &str, s: &str) -> Result<Map, String> {
-        let mut map = Map::default();
+    fn parse(&self, field_index: usize, s: &str) -> Result<Vec<(usize, Value)>, String> {
         let parts = s.split(',');
+        let mut result = Vec::new();
         for part in parts {
             let mut kv = part.split('=');
             let k = kv.next().ok_or(format!("{part} missing key in {s}"))?;
             let v = kv.next();
 
-            let key = Self::generate_key(prefix, k);
-            match k {
-                CMCD_KEY_BS | CMCD_KEY_SU => {
-                    map.insert(key, Value::Boolean(true));
+            for cmcd_key in self.cmcd_outputs[field_index].iter() {
+                if cmcd_key.key == k {
+                    let val = (cmcd_key.f)(s, k, v)?;
+                    result.push((cmcd_key.index, val));
                 }
-                CMCD_KEY_BR | CMCD_KEY_BL | CMCD_KEY_D | CMCD_KEY_DL | CMCD_KEY_MTP
-                | CMCD_KEY_RTP | CMCD_KEY_TB => {
-                    let v = v.ok_or(format!("{k} missing value in {s}"))?;
-                    let val: i64 = v
-                        .parse()
-                        .map_err(|_| format!("failed to parse {v} as i64"))?;
-                    map.insert(key, Value::Int64(val));
-                }
-                CMCD_KEY_CID | CMCD_KEY_NRR | CMCD_KEY_OT | CMCD_KEY_SF | CMCD_KEY_SID
-                | CMCD_KEY_ST | CMCD_KEY_V => {
-                    let v = v.ok_or(format!("{k} missing value in {s}"))?;
-                    map.insert(key, Value::String(v.to_string()));
-                }
-                CMCD_KEY_NOR => {
-                    let v = v.ok_or(format!("{k} missing value in {s}"))?;
-                    let val = match decode(v) {
-                        Ok(val) => val.to_string(),
-                        Err(_) => v.to_string(),
-                    };
-                    map.insert(key, Value::String(val));
-                }
-                CMCD_KEY_PR => {
-                    let v = v.ok_or(format!("{k} missing value in {s}"))?;
-                    let val: f64 = v
-                        .parse()
-                        .map_err(|_| format!("failed to parse {v} as f64"))?;
-                    map.insert(key, Value::Float64(val));
-                }
-                _ => match v {
-                    Some(v) => map.insert(key, Value::String(v.to_string())),
-                    None => map.insert(k, Value::Boolean(true)),
-                },
             }
         }
 
-        Ok(map)
-    }
-
-    fn process_field(&self, val: &str, field: &Field) -> Result<Map, String> {
-        let prefix = field.get_target_field();
-
-        Self::parse(prefix, val)
-    }
-
-    fn update_output_keys(fields: &mut Fields) {
-        for field in fields.iter_mut() {
-            for key in CMCD_KEYS.iter() {
-                field
-                    .output_fields_index_mapping
-                    .insert(Self::generate_key(field.get_target_field(), key), 0);
-            }
-        }
+        Ok(result)
     }
 }
 
@@ -238,8 +331,18 @@ impl TryFrom<&yaml_rust::yaml::Hash> for CmcdProcessorBuilder {
             }
         }
 
+        let output_keys = fields
+            .iter()
+            .flat_map(|f| {
+                CMCD_KEYS
+                    .iter()
+                    .map(|cmcd_key| generate_key(f.target_or_input_field(), cmcd_key))
+            })
+            .collect();
+
         let builder = CmcdProcessorBuilder {
             fields,
+            output_keys,
             ignore_missing,
         };
 
@@ -256,48 +359,14 @@ impl Processor for CmcdProcessor {
         self.ignore_missing
     }
 
-    //TODO (qtang): Implement this method.
-    // fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String> {
-    //     for field in self.real_fields.iter() {
-    //         match val.get(field.input().index) {
-    //             Some(Value::String(v)) => {
-    //                 let map = Self::p(v, field)?;
-    //                 for (k, v) in map.values.into_iter() {
-    //                     if let Some(index) = field.outputs().get(&k) {
-    //                         val[*index] = v;
-    //                     }
-    //                 }
-    //             }
-    //             Some(Value::Null) | None => {
-    //                 if !self.ignore_missing {
-    //                     return Err(format!(
-    //                         "{} processor: missing field: {}",
-    //                         self.kind(),
-    //                         field.input().name
-    //                     ));
-    //                 }
-    //             }
-    //             Some(v) => {
-    //                 return Err(format!(
-    //                     "{} processor: expect string value, but got {v:?}",
-    //                     self.kind()
-    //                 ));
-    //             }
-    //         }
-    //     }
-    //     Ok(())
-    // }
-
     fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String> {
-        for field in self.fields.iter() {
-            match val.get(field.input_field.index) {
+        for (field_index, field) in self.real_fields.iter().enumerate() {
+            let field_value_index = field.input_index();
+            match val.get(field_value_index) {
                 Some(Value::String(v)) => {
-                    // TODO(qtang): Let this method use the intermediate state collection directly.
-                    let map = self.process_field(v, field)?;
-                    for (k, v) in map.values.into_iter() {
-                        if let Some(index) = field.output_fields_index_mapping.get(&k) {
-                            val[*index] = v;
-                        }
+                    let result_list = self.parse(field_index, v)?;
+                    for (output_index, v) in result_list {
+                        val[output_index] = v;
                     }
                 }
                 Some(Value::Null) | None => {
@@ -305,7 +374,7 @@ impl Processor for CmcdProcessor {
                         return Err(format!(
                             "{} processor: missing field: {}",
                             self.kind(),
-                            field.get_field_name()
+                            field.input_name()
                         ));
                     }
                 }
@@ -326,7 +395,8 @@ mod tests {
     use ahash::HashMap;
     use urlencoding::decode;
 
-    use super::CmcdProcessor;
+    use super::{CmcdProcessorBuilder, CMCD_KEYS};
+    use crate::etl::field::{NewField, NewFields};
     use crate::etl::value::{Map, Value};
 
     #[test]
@@ -356,6 +426,7 @@ mod tests {
                 ],
             ),
             (
+                // we not resolve `b` key
                 "b%2Crtp%3D15000%2Csid%3D%226e2fb550-c457-11e9-bb97-0800200c9a66%22",
                 vec![
                     (
@@ -363,7 +434,6 @@ mod tests {
                         Value::String("\"6e2fb550-c457-11e9-bb97-0800200c9a66\"".into()),
                     ),
                     ("prefix_rtp", Value::Int64(15000)),
-                    ("b", Value::Boolean(true)),
                 ],
             ),
             (
@@ -374,16 +444,17 @@ mod tests {
                 ],
             ),
             (
+                // we not resolve custom key
                 "d%3D4004%2Ccom.example-myNumericKey%3D500%2Ccom.examplemyStringKey%3D%22myStringValue%22",
                 vec![
-                    (
-                        "prefix_com.example-myNumericKey",
-                        Value::String("500".into()),
-                    ),
-                    (
-                        "prefix_com.examplemyStringKey",
-                        Value::String("\"myStringValue\"".into()),
-                    ),
+                    // (
+                    //     "prefix_com.example-myNumericKey",
+                    //     Value::String("500".into()),
+                    // ),
+                    // (
+                    //     "prefix_com.examplemyStringKey",
+                    //     Value::String("\"myStringValue\"".into()),
+                    // ),
                     ("prefix_d", Value::Int64(4004)),
                 ],
             ),
@@ -458,6 +529,24 @@ mod tests {
             ),
         ];
 
+        let field = NewField::new("prefix", None);
+
+        let output_keys = CMCD_KEYS
+            .iter()
+            .map(|k| format!("prefix_{}", k))
+            .collect::<Vec<String>>();
+
+        let mut intermediate_keys = vec!["prefix".to_string()];
+        intermediate_keys.append(&mut (output_keys.clone()));
+
+        let builder = CmcdProcessorBuilder {
+            fields: NewFields::new(vec![field]),
+            output_keys: output_keys.iter().map(|s| s.to_string()).collect(),
+            ignore_missing: false,
+        };
+
+        let processor = builder.build(&intermediate_keys);
+
         for (s, vec) in ss.into_iter() {
             let decoded = decode(s).unwrap().to_string();
 
@@ -467,7 +556,12 @@ mod tests {
                 .collect::<HashMap<String, Value>>();
             let expected = Map { values };
 
-            let actual = CmcdProcessor::parse("prefix", &decoded).unwrap();
+            let actual = processor.parse(0, &decoded).unwrap();
+            let actual = actual
+                .into_iter()
+                .map(|(index, value)| (intermediate_keys[index].clone(), value))
+                .collect::<HashMap<String, Value>>();
+            let actual = Map { values: actual };
             assert_eq!(actual, expected);
         }
     }

--- a/src/pipeline/src/etl/processor/cmcd.rs
+++ b/src/pipeline/src/etl/processor/cmcd.rs
@@ -17,10 +17,9 @@ use std::collections::BTreeMap;
 use ahash::HashSet;
 use urlencoding::decode;
 
-// use super::{yaml_new_field, yaml_new_fileds, Processor, ProcessorBuilder, ProcessorKind};
 use crate::etl::field::{Field, Fields, InputFieldInfo, OneInputMultiOutputField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, Processor, ProcessorBuilder, ProcessorKind,
+    yaml_bool, yaml_new_field, yaml_new_fields, Processor, ProcessorBuilder, ProcessorKind,
     FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
@@ -320,7 +319,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for CmcdProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
 
                 IGNORE_MISSING_NAME => {

--- a/src/pipeline/src/etl/processor/csv.rs
+++ b/src/pipeline/src/etl/processor/csv.rs
@@ -21,7 +21,7 @@ use itertools::Itertools;
 
 use crate::etl::field::{InputFieldInfo, Fields, OneInputMultiOutputField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
@@ -169,7 +169,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for CsvProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 TARGET_FIELDS => {
                     target_fields = yaml_string(v, TARGET_FIELDS)?

--- a/src/pipeline/src/etl/processor/csv.rs
+++ b/src/pipeline/src/etl/processor/csv.rs
@@ -20,9 +20,10 @@ use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 
 use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
+use crate::etl::find_key_index;
 use crate::etl::processor::{
-    find_key_index, yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor,
-    ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
+    ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::Value;
 

--- a/src/pipeline/src/etl/processor/csv.rs
+++ b/src/pipeline/src/etl/processor/csv.rs
@@ -19,7 +19,7 @@ use csv::{ReaderBuilder, Trim};
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
 
-use crate::etl::field::{InputFieldInfo, Fields, OneInputMultiOutputField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,

--- a/src/pipeline/src/etl/processor/date.rs
+++ b/src/pipeline/src/etl/processor/date.rs
@@ -19,10 +19,9 @@ use chrono::{DateTime, NaiveDateTime};
 use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, yaml_strings, Processor,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings, Processor,
     ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::{Timestamp, Value};
@@ -160,7 +159,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DateProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
 
                 FORMATS_NAME => {

--- a/src/pipeline/src/etl/processor/date.rs
+++ b/src/pipeline/src/etl/processor/date.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, NaiveDateTime};
 use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings, Processor,
     ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
@@ -112,7 +112,7 @@ impl DateProcessorBuilder {
     pub fn build(self, intermediate_keys: &[String]) -> Result<DateProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "date",
                 intermediate_keys,
                 field.input_field(),
@@ -191,7 +191,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DateProcessorBuilder {
 /// Reserved for compatibility only
 #[derive(Debug, Default)]
 pub struct DateProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     formats: Formats,
     timezone: Option<Arc<String>>,
     locale: Option<Arc<String>>, // to support locale

--- a/src/pipeline/src/etl/processor/date.rs
+++ b/src/pipeline/src/etl/processor/date.rs
@@ -58,8 +58,14 @@ lazy_static! {
                 .collect();
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct Formats(Vec<Arc<String>>);
+
+impl Default for Formats {
+    fn default() -> Self {
+        Formats(DEFAULT_FORMATS.clone())
+    }
+}
 
 impl Formats {
     fn new(mut formats: Vec<Arc<String>>) -> Self {
@@ -209,38 +215,6 @@ pub struct DateProcessor {
 }
 
 impl DateProcessor {
-    // fn with_fields(&mut self, mut fields: Fields) {
-    //     todo!()
-    //     // update_one_one_output_keys(&mut fields);
-    //     // self.fields = fields
-    // }
-
-    // fn with_formats(&mut self, v: Option<Vec<Arc<String>>>) {
-    //     let v = match v {
-    //         Some(v) if !v.is_empty() => v,
-    //         _ => DEFAULT_FORMATS.clone(),
-    //     };
-
-    //     let formats = Formats::new(v);
-    //     self.formats = formats;
-    // }
-
-    // fn with_timezone(&mut self, timezone: String) {
-    //     if !timezone.is_empty() {
-    //         self.timezone = Some(Arc::new(timezone));
-    //     }
-    // }
-
-    // fn with_locale(&mut self, locale: String) {
-    //     if !locale.is_empty() {
-    //         self.locale = Some(Arc::new(locale));
-    //     }
-    // }
-
-    // fn with_ignore_missing(&mut self, ignore_missing: bool) {
-    //     self.ignore_missing = ignore_missing;
-    // }
-
     fn parse(&self, val: &str) -> Result<Timestamp, String> {
         let mut tz = Tz::UTC;
         if let Some(timezone) = &self.timezone {

--- a/src/pipeline/src/etl/processor/dissect.rs
+++ b/src/pipeline/src/etl/processor/dissect.rs
@@ -18,10 +18,9 @@ use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use common_telemetry::warn;
 use itertools::Itertools;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputMultiOutputField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_parse_string, yaml_parse_strings, yaml_string,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_parse_string, yaml_parse_strings, yaml_string,
     Processor, ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
     PATTERNS_NAME, PATTERN_NAME,
 };
@@ -766,7 +765,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DissectProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 PATTERN_NAME => {
                     let pattern: PatternInfo = yaml_parse_string(v, PATTERN_NAME)?;

--- a/src/pipeline/src/etl/processor/dissect.rs
+++ b/src/pipeline/src/etl/processor/dissect.rs
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
+use std::ops::Deref;
+use std::usize;
+
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use common_telemetry::warn;
 use itertools::Itertools;
 
-use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, NewFields, OneInputMultiOutputField};
+// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputMultiOutputField};
 use crate::etl::processor::{
-    yaml_bool, yaml_field, yaml_fields, yaml_parse_string, yaml_parse_strings, yaml_string,
-    Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERNS_NAME, PATTERN_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_parse_string, yaml_parse_strings, yaml_string,
+    Processor, ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
+    PATTERNS_NAME, PATTERN_NAME,
 };
 use crate::etl::value::{Map, Value};
 
@@ -60,13 +65,13 @@ impl std::fmt::Display for EndModifier {
 }
 
 #[derive(Debug, PartialEq, Default)]
-struct Name {
+struct NameInfo {
     name: String,
     start_modifier: Option<StartModifier>,
     end_modifier: Option<EndModifier>,
 }
 
-impl Name {
+impl NameInfo {
     fn is_name_empty(&self) -> bool {
         self.name.is_empty()
     }
@@ -126,18 +131,87 @@ impl Name {
     }
 }
 
+impl std::fmt::Display for NameInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
+
+impl From<&str> for NameInfo {
+    fn from(value: &str) -> Self {
+        NameInfo {
+            name: value.to_string(),
+            start_modifier: None,
+            end_modifier: None,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Default)]
+struct Name {
+    name: String,
+    index: usize,
+    start_modifier: Option<StartModifier>,
+    end_modifier: Option<EndModifier>,
+}
+
 impl std::fmt::Display for Name {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.name)
     }
 }
 
-impl From<&str> for Name {
-    fn from(value: &str) -> Self {
+impl From<NameInfo> for Name {
+    fn from(value: NameInfo) -> Self {
         Name {
-            name: value.to_string(),
-            start_modifier: None,
-            end_modifier: None,
+            name: value.name,
+            index: 0,
+            start_modifier: value.start_modifier,
+            end_modifier: value.end_modifier,
+        }
+    }
+}
+
+impl Name {
+    fn is_name_empty(&self) -> bool {
+        self.name.is_empty()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.name.is_empty() && self.start_modifier.is_none() && self.end_modifier.is_none()
+    }
+
+    fn is_end_modifier_set(&self) -> bool {
+        self.end_modifier.is_some()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum PartInfo {
+    Split(String),
+    Name(NameInfo),
+}
+
+impl PartInfo {
+    fn is_empty(&self) -> bool {
+        match self {
+            PartInfo::Split(v) => v.is_empty(),
+            PartInfo::Name(v) => v.is_empty(),
+        }
+    }
+
+    fn empty_split() -> Self {
+        PartInfo::Split(String::new())
+    }
+
+    fn empty_name() -> Self {
+        PartInfo::Name(NameInfo::default())
+    }
+
+    fn push(&mut self, ch: char) {
+        match self {
+            PartInfo::Split(v) => v.push(ch),
+            PartInfo::Name(v) => v.name.push(ch),
         }
     }
 }
@@ -163,11 +237,13 @@ impl Part {
     fn empty_name() -> Self {
         Part::Name(Name::default())
     }
+}
 
-    fn push(&mut self, ch: char) {
-        match self {
-            Part::Split(v) => v.push(ch),
-            Part::Name(v) => v.name.push(ch),
+impl From<PartInfo> for Part {
+    fn from(value: PartInfo) -> Self {
+        match value {
+            PartInfo::Split(v) => Part::Split(v),
+            PartInfo::Name(v) => Part::Name(v.into()),
         }
     }
 }
@@ -178,7 +254,7 @@ struct Pattern {
     parts: Vec<Part>,
 }
 
-impl std::ops::Deref for Pattern {
+impl Deref for Pattern {
     type Target = Vec<Part>;
 
     fn deref(&self) -> &Self::Target {
@@ -186,18 +262,42 @@ impl std::ops::Deref for Pattern {
     }
 }
 
-impl std::ops::DerefMut for Pattern {
+impl From<PatternInfo> for Pattern {
+    fn from(value: PatternInfo) -> Self {
+        let parts = value.parts.into_iter().map(|x| x.into()).collect();
+        Pattern {
+            origin: value.origin,
+            parts,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct PatternInfo {
+    origin: String,
+    parts: Vec<PartInfo>,
+}
+
+impl std::ops::Deref for PatternInfo {
+    type Target = Vec<PartInfo>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.parts
+    }
+}
+
+impl std::ops::DerefMut for PatternInfo {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.parts
     }
 }
 
-impl std::str::FromStr for Pattern {
+impl std::str::FromStr for PatternInfo {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut parts = vec![];
-        let mut cursor = Part::empty_split();
+        let mut cursor = PartInfo::empty_split();
 
         let origin = s.to_string();
         let chars: Vec<char> = origin.chars().collect();
@@ -207,27 +307,27 @@ impl std::str::FromStr for Pattern {
             let ch = chars[pos];
             match (ch, &mut cursor) {
                 // if cursor is Split part, and found %{, then ready to start a Name part
-                ('%', Part::Split(_)) if matches!(chars.get(pos + 1), Some('{')) => {
+                ('%', PartInfo::Split(_)) if matches!(chars.get(pos + 1), Some('{')) => {
                     if !cursor.is_empty() {
                         parts.push(cursor);
                     }
 
-                    cursor = Part::empty_name();
+                    cursor = PartInfo::empty_name();
                     pos += 1; // skip '{'
                 }
                 // if cursor is Split part, and not found % or {, then continue the Split part
-                (_, Part::Split(_)) => {
+                (_, PartInfo::Split(_)) => {
                     cursor.push(ch);
                 }
                 // if cursor is Name part, and found }, then end the Name part, start the next Split part
-                ('}', Part::Name(_)) => {
+                ('}', PartInfo::Name(_)) => {
                     parts.push(cursor);
-                    cursor = Part::empty_split();
+                    cursor = PartInfo::empty_split();
                 }
-                ('+', Part::Name(name)) if !name.is_start_modifier_set() => {
+                ('+', PartInfo::Name(name)) if !name.is_start_modifier_set() => {
                     name.try_start_modifier(StartModifier::Append(None))?;
                 }
-                ('/', Part::Name(name)) if name.is_append_modifier_set() => {
+                ('/', PartInfo::Name(name)) if name.is_append_modifier_set() => {
                     let mut order = 0;
                     let mut j = pos + 1;
                     while j < chars.len() {
@@ -249,16 +349,16 @@ impl std::str::FromStr for Pattern {
                     name.try_append_order(order)?;
                     pos = j - 1; // this will change the position to the last digit of the order
                 }
-                ('?', Part::Name(name)) if !name.is_start_modifier_set() => {
+                ('?', PartInfo::Name(name)) if !name.is_start_modifier_set() => {
                     name.try_start_modifier(StartModifier::NamedSkip)?;
                 }
-                ('*', Part::Name(name)) if !name.is_start_modifier_set() => {
+                ('*', PartInfo::Name(name)) if !name.is_start_modifier_set() => {
                     name.try_start_modifier(StartModifier::MapKey)?;
                 }
-                ('&', Part::Name(name)) if !name.is_start_modifier_set() => {
+                ('&', PartInfo::Name(name)) if !name.is_start_modifier_set() => {
                     name.try_start_modifier(StartModifier::MapVal)?;
                 }
-                ('-', Part::Name(name)) if !name.is_end_modifier_set() => {
+                ('-', PartInfo::Name(name)) if !name.is_end_modifier_set() => {
                     if let Some('>') = chars.get(pos + 1) {
                     } else {
                         return Err(format!(
@@ -274,7 +374,7 @@ impl std::str::FromStr for Pattern {
                     name.try_end_modifier()?;
                     pos += 1; // only skip '>', the next loop will skip '}'
                 }
-                (_, Part::Name(name)) if !is_valid_char(ch) => {
+                (_, PartInfo::Name(name)) if !is_valid_char(ch) => {
                     let tail: String = if name.is_name_empty() {
                         format!("Invalid '{ch}'")
                     } else {
@@ -282,7 +382,7 @@ impl std::str::FromStr for Pattern {
                     };
                     return Err(format!("Invalid Pattern: '{s}'. {tail}"));
                 }
-                (_, Part::Name(_)) => {
+                (_, PartInfo::Name(_)) => {
                     cursor.push(ch);
                 }
             }
@@ -291,8 +391,8 @@ impl std::str::FromStr for Pattern {
         }
 
         match cursor {
-            Part::Split(ref split) if !split.is_empty() => parts.push(cursor),
-            Part::Name(name) if !name.is_empty() => {
+            PartInfo::Split(ref split) if !split.is_empty() => parts.push(cursor),
+            PartInfo::Name(name) if !name.is_empty() => {
                 return Err(format!("Invalid Pattern: '{s}'. '{name}' is not closed"))
             }
             _ => {}
@@ -304,7 +404,7 @@ impl std::str::FromStr for Pattern {
     }
 }
 
-impl Pattern {
+impl PatternInfo {
     fn check(&self) -> Result<(), String> {
         if self.len() == 0 {
             return Err("Empty pattern is not allowed".to_string());
@@ -317,19 +417,19 @@ impl Pattern {
             let this_part = &self[i];
             let next_part = self.get(i + 1);
             match (this_part, next_part) {
-                (Part::Split(split), _) if split.is_empty() => {
+                (PartInfo::Split(split), _) if split.is_empty() => {
                     return Err(format!(
                         "Invalid Pattern: '{}'. Empty split is not allowed",
                         self.origin
                     ));
                 }
-                (Part::Name(name1), Some(Part::Name(name2))) => {
+                (PartInfo::Name(name1), Some(PartInfo::Name(name2))) => {
                     return Err(format!(
                         "Invalid Pattern: '{}'. consecutive names are not allowed: '{}' '{}'",
                         self.origin, name1, name2
                     ));
                 }
-                (Part::Name(name), _) if name.is_name_empty() => {
+                (PartInfo::Name(name), _) if name.is_name_empty() => {
                     if let Some(ref m) = name.start_modifier {
                         return Err(format!(
                             "Invalid Pattern: '{}'. only '{}' modifier is invalid",
@@ -337,7 +437,7 @@ impl Pattern {
                         ));
                     }
                 }
-                (Part::Name(name), _) => match name.start_modifier {
+                (PartInfo::Name(name), _) => match name.start_modifier {
                     Some(StartModifier::MapKey) => {
                         if map_keys.contains(&name.name) {
                             return Err(format!(
@@ -380,7 +480,7 @@ impl Pattern {
     }
 }
 
-impl std::fmt::Display for Pattern {
+impl std::fmt::Display for PatternInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.origin)
     }
@@ -389,28 +489,92 @@ impl std::fmt::Display for Pattern {
 #[derive(Debug, Default)]
 pub struct DissectProcessorBuilder {
     fields: NewFields,
-    patterns: Vec<Pattern>,
+    patterns: Vec<PatternInfo>,
     ignore_missing: bool,
     append_separator: Option<String>,
+    output_keys: HashSet<String>,
 }
 
 impl ProcessorBuilder for DissectProcessorBuilder {
     fn output_keys(&self) -> HashSet<&str> {
-        todo!()
+        self.output_keys.iter().map(|s| s.as_str()).collect()
     }
 
     fn input_keys(&self) -> HashSet<&str> {
-        todo!()
+        self.fields.iter().map(|f| f.input_field()).collect()
     }
 
     fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
-        todo!()
+        let mut real_fields = vec![];
+        let output_keys_index: BTreeMap<_, _> = self
+            .output_keys
+            .iter()
+            .map(|k| {
+                let index = intermediate_keys.iter().position(|x| x == k).unwrap();
+                (k.to_string(), index)
+            })
+            .collect();
+        for field in self.fields.into_iter() {
+            let input_index = intermediate_keys
+                .iter()
+                .position(|k| *k == field.input_field())
+                // TODO (qtang): handler error
+                .unwrap();
+
+            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
+
+            let real_field =
+                OneInputMultiOutputField::new(input_field_info, output_keys_index.clone());
+            real_fields.push(real_field);
+        }
+        let patterns = self
+            .patterns
+            .into_iter()
+            .map(|x| {
+                let original = x.origin;
+                let pattern1 = x
+                    .parts
+                    .into_iter()
+                    .map(|xx| match xx {
+                        PartInfo::Split(s) => Part::Split(s),
+                        PartInfo::Name(n) => match n.start_modifier {
+                            None | Some(StartModifier::Append(_)) => {
+                                let index =
+                                    intermediate_keys.iter().position(|x| x == &n.name).unwrap();
+                                Part::Name(Name {
+                                    name: n.name,
+                                    index,
+                                    start_modifier: n.start_modifier,
+                                    end_modifier: n.end_modifier,
+                                })
+                            }
+                            _ => Part::Name(Name {
+                                name: n.name,
+                                index: usize::MAX,
+                                start_modifier: n.start_modifier,
+                                end_modifier: n.end_modifier,
+                            }),
+                        },
+                    })
+                    .collect();
+                Pattern {
+                    origin: original,
+                    parts: pattern1,
+                }
+            })
+            .collect::<Vec<_>>();
+        let processor = DissectProcessor {
+            real_fields,
+            patterns,
+            ignore_missing: self.ignore_missing,
+            append_separator: self.append_separator,
+        };
+        ProcessorKind::Dissect(processor)
     }
 }
 
 #[derive(Debug, Default)]
 pub struct DissectProcessor {
-    fields: Fields,
     real_fields: Vec<OneInputMultiOutputField>,
     patterns: Vec<Pattern>,
     ignore_missing: bool,
@@ -420,28 +584,12 @@ pub struct DissectProcessor {
 }
 
 impl DissectProcessor {
-    fn with_fields(&mut self, fields: Fields) {
-        self.fields = fields;
-    }
-
-    fn with_ignore_missing(&mut self, ignore_missing: bool) {
-        self.ignore_missing = ignore_missing;
-    }
-
-    fn with_patterns(&mut self, patterns: Vec<Pattern>) {
-        self.patterns = patterns;
-    }
-
-    fn with_append_separator(&mut self, append_separator: String) {
-        self.append_separator = Some(append_separator);
-    }
-
-    fn process_pattern(&self, chs: &[char], pattern: &Pattern) -> Result<Map, String> {
+    fn process_pattern_map(&self, chs: &[char], pattern: &Pattern) -> Result<Map, String> {
         let mut map = Map::default();
         let mut pos = 0;
 
         let mut appends: HashMap<String, Vec<(String, u32)>> = HashMap::new();
-        let mut maps: HashMap<String, String> = HashMap::new();
+        // let mut maps: HashMap<usize, (String,String)> = HashMap::new();
 
         let mut process_name_value = |name: &Name, value: String| {
             let name_str = name.to_string();
@@ -455,24 +603,28 @@ impl DissectProcessor {
                         .or_default()
                         .push((value, order.unwrap_or_default()));
                 }
-                Some(StartModifier::MapKey) => match maps.get(&name_str) {
-                    Some(map_val) => {
-                        map.insert(value, Value::String(map_val.to_string()));
-                    }
-                    None => {
-                        maps.insert(name_str, value);
-                    }
-                },
-                Some(StartModifier::MapVal) => match maps.get(&name_str) {
-                    Some(map_key) => {
-                        map.insert(map_key, Value::String(value));
-                    }
-                    None => {
-                        maps.insert(name_str, value);
-                    }
-                },
+                // Some(StartModifier::MapKey) => match maps.get(&name_index) {
+                //     Some(map_val) => {
+                //         map.insert(value, Value::String(map_val.to_string()));
+                //     }
+                //     None => {
+                //         maps.insert(name_index, value);
+                //     }
+                // },
+                // Some(StartModifier::MapVal) => match maps.get(&name_index) {
+                //     Some(map_key) => {
+                //         map.insert(map_key, Value::String(value));
+                //     }
+                //     None => {
+                //         maps.insert(name_index, value);
+                //     }
+                // },
+                Some(_) => {
+                    // do nothing, ignore MapKey and MapVal
+                    // because transform can know the key name
+                }
                 None => {
-                    map.insert(name.to_string(), Value::String(value));
+                    map.insert(name_str, Value::String(value));
                 }
             }
         };
@@ -555,45 +707,146 @@ impl DissectProcessor {
         Ok(map)
     }
 
-    fn process(&self, val: &str) -> Result<Map, String> {
+    fn process_pattern(
+        &self,
+        chs: &[char],
+        pattern: &Pattern,
+    ) -> Result<Vec<(usize, Value)>, String> {
+        let mut map = Vec::new();
+        let mut pos = 0;
+
+        let mut appends: HashMap<usize, Vec<(String, u32)>> = HashMap::new();
+        // let mut maps: HashMap<usize, (String,String)> = HashMap::new();
+
+        let mut process_name_value = |name: &Name, value: String| {
+            let name_index = name.index;
+            match name.start_modifier {
+                Some(StartModifier::NamedSkip) => {
+                    // do nothing, ignore this match
+                }
+                Some(StartModifier::Append(order)) => {
+                    appends
+                        .entry(name_index)
+                        .or_default()
+                        .push((value, order.unwrap_or_default()));
+                }
+                // Some(StartModifier::MapKey) => match maps.get(&name_index) {
+                //     Some(map_val) => {
+                //         map.insert(value, Value::String(map_val.to_string()));
+                //     }
+                //     None => {
+                //         maps.insert(name_index, value);
+                //     }
+                // },
+                // Some(StartModifier::MapVal) => match maps.get(&name_index) {
+                //     Some(map_key) => {
+                //         map.insert(map_key, Value::String(value));
+                //     }
+                //     None => {
+                //         maps.insert(name_index, value);
+                //     }
+                // },
+                Some(_) => {
+                    // do nothing, ignore MapKey and MapVal
+                    // because transform can know the key name
+                }
+                None => {
+                    map.push((name_index, Value::String(value)));
+                }
+            }
+        };
+
+        for i in 0..pattern.len() {
+            let this_part = &pattern[i];
+            let next_part = pattern.get(i + 1);
+            match (this_part, next_part) {
+                // if Split part, and exactly matches, then move pos split.len() forward
+                (Part::Split(split), _) => {
+                    let split_chs = split.chars().collect::<Vec<char>>();
+                    let split_len = split_chs.len();
+                    if pos + split_len > chs.len() {
+                        return Err(format!("'{split}' exceeds the input",));
+                    }
+
+                    if &chs[pos..pos + split_len] != split_chs.as_slice() {
+                        return Err(format!(
+                            "'{split}' does not match the input '{}'",
+                            chs[pos..pos + split_len].iter().collect::<String>()
+                        ));
+                    }
+
+                    pos += split_len;
+                }
+
+                (Part::Name(name1), Some(Part::Name(name2))) => {
+                    return Err(format!(
+                        "consecutive names are not allowed: '{name1}' '{name2}'"
+                    ));
+                }
+
+                // if Name part is the last part, then the rest of the input is the value
+                (Part::Name(name), None) => {
+                    let value = chs[pos..].iter().collect::<String>();
+                    process_name_value(name, value);
+                }
+
+                // if Name part, and next part is Split, then find the matched value of the name
+                (Part::Name(name), Some(Part::Split(split))) => {
+                    let stop = split
+                        .chars()
+                        .next()
+                        .ok_or("Empty split is not allowed".to_string())?; // this won't happen
+                    let mut end = pos;
+                    while end < chs.len() && chs[end] != stop {
+                        end += 1;
+                    }
+
+                    if !name.is_name_empty() {
+                        let value = chs[pos..end].iter().collect::<String>();
+                        process_name_value(name, value);
+                    }
+
+                    if name.is_end_modifier_set() {
+                        while end < chs.len() && chs[end] == stop {
+                            end += 1;
+                        }
+                        end -= 1; // leave the last stop character to match the next split
+                    }
+
+                    pos = end;
+                }
+            }
+        }
+
+        if !appends.is_empty() {
+            let sep = match self.append_separator {
+                Some(ref sep) => sep,
+                None => " ",
+            };
+
+            for (name, mut values) in appends {
+                values.sort_by(|a, b| a.1.cmp(&b.1));
+                let value = values.into_iter().map(|(a, _)| a).join(sep);
+                map.push((name, Value::String(value)));
+            }
+        }
+
+        Ok(map)
+    }
+
+    fn process(&self, val: &str) -> Result<Vec<(usize, Value)>, String> {
         let chs = val.chars().collect::<Vec<char>>();
 
         for pattern in &self.patterns {
-            if let Ok(map) = self.process_pattern(&chs, pattern) {
-                return Ok(map);
+            match self.process_pattern(&chs, pattern) {
+                Ok(map) => return Ok(map),
+                Err(e) => {
+                    warn!("dissect processor: {}", e);
+                }
             }
         }
 
         Err("No matching pattern found".to_string())
-    }
-
-    /// Update the output keys for each field.
-    fn update_output_keys(&mut self) {
-        // every pattern had been checked, so we can get all the output keys
-        let output_keys = self
-            .patterns
-            .iter()
-            .flat_map(|pattern| pattern.iter())
-            .filter_map(|p| match p {
-                Part::Name(name) => {
-                    if !name.is_empty()
-                        && !name.start_modifier.as_ref().is_some_and(|x| {
-                            *x == StartModifier::NamedSkip || *x == StartModifier::MapVal
-                        })
-                    {
-                        Some(name)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        for field in self.fields.iter_mut() {
-            for k in &output_keys {
-                field.output_fields_index_mapping.insert(k.to_string(), 0);
-            }
-        }
     }
 }
 
@@ -619,7 +872,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DissectProcessorBuilder {
                     fields = yaml_new_fileds(v, FIELDS_NAME)?;
                 }
                 PATTERN_NAME => {
-                    let pattern: Pattern = yaml_parse_string(v, PATTERN_NAME)?;
+                    let pattern: PatternInfo = yaml_parse_string(v, PATTERN_NAME)?;
                     patterns = vec![pattern];
                 }
                 PATTERNS_NAME => {
@@ -634,11 +887,32 @@ impl TryFrom<&yaml_rust::yaml::Hash> for DissectProcessorBuilder {
                 _ => {}
             }
         }
+        let output_keys = patterns
+            .iter()
+            .flat_map(|pattern| pattern.iter())
+            .filter_map(|p| match p {
+                PartInfo::Name(name) => {
+                    if !name.is_empty()
+                        && (name.start_modifier.is_none()
+                            || name
+                                .start_modifier
+                                .as_ref()
+                                .is_some_and(|x| matches!(x, StartModifier::Append(_))))
+                    {
+                        Some(name.to_string())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect();
         let builder = DissectProcessorBuilder {
             fields,
             patterns,
             ignore_missing,
             append_separator,
+            output_keys,
         };
 
         Ok(builder)
@@ -654,73 +928,15 @@ impl Processor for DissectProcessor {
         self.ignore_missing
     }
 
-    fn fields(&self) -> &Fields {
-        &self.fields
-    }
-
-    fn fields_mut(&mut self) -> &mut Fields {
-        &mut self.fields
-    }
-
-    // fn output_keys(&self) -> HashSet<&str> {
-    //     let mut result = HashSet::with_capacity(30);
-    //     for pattern in &self.patterns {
-    //         for part in pattern.iter() {
-    //             if let Part::Name(name) = part {
-    //                 if !name.is_empty() {
-    //                     result.insert(name.to_string());
-    //                 }
-    //             }
-    //         }
-    //     }
-    //     result
-    // }
-
-    fn output_keys(&self) -> HashSet<&str> {
-        self.real_fields
-            .iter()
-            .flat_map(|f| f.outputs().into_keys().map(|k| k.as_str()))
-            .collect()
-    }
-
-    fn input_keys(&self) -> HashSet<&str> {
-        self.real_fields
-            .iter()
-            .map(|x| x.input().name.as_str())
-            .collect()
-    }
-
-    fn exec_field(&self, val: &Value, _field: &Field) -> Result<Map, String> {
-        match val {
-            Value::String(val) => match self.process(val) {
-                Ok(map) => Ok(map),
-                Err(e) => {
-                    warn!("dissect processor: {}", e);
-                    Ok(Map::default())
-                }
-            },
-            _ => Err(format!(
-                "{} processor: expect string value, but got {val:?}",
-                self.kind()
-            )),
-        }
-    }
-
     fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String> {
-        for field in self.fields.iter() {
-            let index = field.input_field.index;
+        for field in self.real_fields.iter() {
+            let index = field.input_index();
             match val.get(index) {
-                // TODO(qtang): Let this method use the intermediate state collection directly.
                 Some(Value::String(val_str)) => match self.process(val_str) {
-                    Ok(mut map) => {
-                        field
-                            .output_fields_index_mapping
-                            .iter()
-                            .for_each(|(k, output_index)| {
-                                if let Some(v) = map.remove(k) {
-                                    val[*output_index] = v
-                                }
-                            });
+                    Ok(r) => {
+                        for (k, v) in r {
+                            val[k] = v;
+                        }
                     }
                     Err(e) => {
                         warn!("dissect processor: {}", e);
@@ -731,7 +947,7 @@ impl Processor for DissectProcessor {
                         return Err(format!(
                             "{} processor: missing field: {}",
                             self.kind(),
-                            field.get_field_name()
+                            field.input_name()
                         ));
                     }
                 }
@@ -755,15 +971,16 @@ fn is_valid_char(ch: char) -> bool {
 mod tests {
     use ahash::HashMap;
 
-    use super::{DissectProcessor, EndModifier, Name, Part, Pattern, StartModifier};
+    use super::{DissectProcessor, EndModifier, NameInfo, PartInfo, PatternInfo, StartModifier};
     use crate::etl::value::{Map, Value};
 
     fn assert(pattern_str: &str, input: &str, expected: HashMap<String, Value>) {
         let chs = input.chars().collect::<Vec<char>>();
-        let pattern = pattern_str.parse().unwrap();
+        let pattern_info: PatternInfo = pattern_str.parse().unwrap();
+        let pattern = pattern_info.into();
 
         let processor = DissectProcessor::default();
-        let map = processor.process_pattern(&chs, &pattern).unwrap();
+        let map = processor.process_pattern_map(&chs, &pattern).unwrap();
 
         assert_eq!(map, Map::from(expected), "pattern: {}", pattern_str);
     }
@@ -773,236 +990,236 @@ mod tests {
         let cases = [(
             "%{clientip} %{ident} %{auth} [%{timestamp}] \"%{verb} %{request} HTTP/%{httpversion}\" %{status} %{size}",
             vec![
-                Part::Name("clientip".into()),
-                Part::Split(" ".into()),
-                Part::Name("ident".into()),
-                Part::Split(" ".into()),
-                Part::Name("auth".into()),
-                Part::Split(" [".into()),
-                Part::Name("timestamp".into()),
-                Part::Split("] \"".into()),
-                Part::Name("verb".into()),
-                Part::Split(" ".into()),
-                Part::Name("request".into()),
-                Part::Split(" HTTP/".into()),
-                Part::Name("httpversion".into()),
-                Part::Split("\" ".into()),
-                Part::Name("status".into()),
-                Part::Split(" ".into()),
-                Part::Name("size".into()),
+                PartInfo::Name("clientip".into()),
+                PartInfo::Split(" ".into()),
+                PartInfo::Name("ident".into()),
+                PartInfo::Split(" ".into()),
+                PartInfo::Name("auth".into()),
+                PartInfo::Split(" [".into()),
+                PartInfo::Name("timestamp".into()),
+                PartInfo::Split("] \"".into()),
+                PartInfo::Name("verb".into()),
+                PartInfo::Split(" ".into()),
+                PartInfo::Name("request".into()),
+                PartInfo::Split(" HTTP/".into()),
+                PartInfo::Name("httpversion".into()),
+                PartInfo::Split("\" ".into()),
+                PartInfo::Name("status".into()),
+                PartInfo::Split(" ".into()),
+                PartInfo::Name("size".into()),
             ],
         )];
 
         for (pattern, expected) in cases.into_iter() {
-            let p: Pattern = pattern.parse().unwrap();
+            let p: PatternInfo = pattern.parse().unwrap();
             assert_eq!(p.parts, expected);
         }
     }
 
-    #[test]
-    fn test_dissect_modifier_pattern() {
-        let cases = [
-            (
-                "%{} %{}",
-                vec![
-                    Part::Name(Name {
-                        name: "".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                ],
-            ),
-            (
-                "%{ts->} %{level}",
-                vec![
-                    Part::Name(Name {
-                        name: "ts".into(),
-                        start_modifier: None,
-                        end_modifier: Some(EndModifier),
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name("level".into()),
-                ],
-            ),
-            (
-                "[%{ts}]%{->}[%{level}]",
-                vec![
-                    Part::Split("[".into()),
-                    Part::Name(Name {
-                        name: "ts".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split("]".into()),
-                    Part::Name(Name {
-                        name: "".into(),
-                        start_modifier: None,
-                        end_modifier: Some(EndModifier),
-                    }),
-                    Part::Split("[".into()),
-                    Part::Name(Name {
-                        name: "level".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split("]".into()),
-                ],
-            ),
-            (
-                "%{+name} %{+name} %{+name} %{+name}",
-                vec![
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(None)),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(None)),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(None)),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(None)),
-                        end_modifier: None,
-                    }),
-                ],
-            ),
-            (
-                "%{+name/2} %{+name/4} %{+name/3} %{+name/1}",
-                vec![
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(Some(2))),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(Some(4))),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(Some(3))),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "name".into(),
-                        start_modifier: Some(StartModifier::Append(Some(1))),
-                        end_modifier: None,
-                    }),
-                ],
-            ),
-            (
-                "%{clientip} %{?ident} %{?auth} [%{timestamp}]",
-                vec![
-                    Part::Name(Name {
-                        name: "clientip".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "ident".into(),
-                        start_modifier: Some(StartModifier::NamedSkip),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "auth".into(),
-                        start_modifier: Some(StartModifier::NamedSkip),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" [".into()),
-                    Part::Name(Name {
-                        name: "timestamp".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split("]".into()),
-                ],
-            ),
-            (
-                "[%{ts}] [%{level}] %{*p1}:%{&p1} %{*p2}:%{&p2}",
-                vec![
-                    Part::Split("[".into()),
-                    Part::Name(Name {
-                        name: "ts".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split("] [".into()),
-                    Part::Name(Name {
-                        name: "level".into(),
-                        start_modifier: None,
-                        end_modifier: None,
-                    }),
-                    Part::Split("] ".into()),
-                    Part::Name(Name {
-                        name: "p1".into(),
-                        start_modifier: Some(StartModifier::MapKey),
-                        end_modifier: None,
-                    }),
-                    Part::Split(":".into()),
-                    Part::Name(Name {
-                        name: "p1".into(),
-                        start_modifier: Some(StartModifier::MapVal),
-                        end_modifier: None,
-                    }),
-                    Part::Split(" ".into()),
-                    Part::Name(Name {
-                        name: "p2".into(),
-                        start_modifier: Some(StartModifier::MapKey),
-                        end_modifier: None,
-                    }),
-                    Part::Split(":".into()),
-                    Part::Name(Name {
-                        name: "p2".into(),
-                        start_modifier: Some(StartModifier::MapVal),
-                        end_modifier: None,
-                    }),
-                ],
-            ),
-            (
-                "%{&p1}:%{*p1}",
-                vec![
-                    Part::Name(Name {
-                        name: "p1".into(),
-                        start_modifier: Some(StartModifier::MapVal),
-                        end_modifier: None,
-                    }),
-                    Part::Split(":".into()),
-                    Part::Name(Name {
-                        name: "p1".into(),
-                        start_modifier: Some(StartModifier::MapKey),
-                        end_modifier: None,
-                    }),
-                ],
-            ),
-        ];
+    // #[test]
+    // fn test_dissect_modifier_pattern() {
+    //     let cases = [
+    //         (
+    //             "%{} %{}",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //             ],
+    //         ),
+    //         (
+    //             "%{ts->} %{level}",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "ts".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: Some(EndModifier),
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name("level".into()),
+    //             ],
+    //         ),
+    //         (
+    //             "[%{ts}]%{->}[%{level}]",
+    //             vec![
+    //                 Part::Split("[".into()),
+    //                 Part::Name(Name {
+    //                     name: "ts".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split("]".into()),
+    //                 Part::Name(Name {
+    //                     name: "".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: Some(EndModifier),
+    //                 }),
+    //                 Part::Split("[".into()),
+    //                 Part::Name(Name {
+    //                     name: "level".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split("]".into()),
+    //             ],
+    //         ),
+    //         (
+    //             "%{+name} %{+name} %{+name} %{+name}",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(None)),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(None)),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(None)),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(None)),
+    //                     end_modifier: None,
+    //                 }),
+    //             ],
+    //         ),
+    //         (
+    //             "%{+name/2} %{+name/4} %{+name/3} %{+name/1}",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(Some(2))),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(Some(4))),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(Some(3))),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "name".into(),
+    //                     start_modifier: Some(StartModifier::Append(Some(1))),
+    //                     end_modifier: None,
+    //                 }),
+    //             ],
+    //         ),
+    //         (
+    //             "%{clientip} %{?ident} %{?auth} [%{timestamp}]",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "clientip".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "ident".into(),
+    //                     start_modifier: Some(StartModifier::NamedSkip),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "auth".into(),
+    //                     start_modifier: Some(StartModifier::NamedSkip),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" [".into()),
+    //                 Part::Name(Name {
+    //                     name: "timestamp".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split("]".into()),
+    //             ],
+    //         ),
+    //         (
+    //             "[%{ts}] [%{level}] %{*p1}:%{&p1} %{*p2}:%{&p2}",
+    //             vec![
+    //                 Part::Split("[".into()),
+    //                 Part::Name(Name {
+    //                     name: "ts".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split("] [".into()),
+    //                 Part::Name(Name {
+    //                     name: "level".into(),
+    //                     start_modifier: None,
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split("] ".into()),
+    //                 Part::Name(Name {
+    //                     name: "p1".into(),
+    //                     start_modifier: Some(StartModifier::MapKey),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(":".into()),
+    //                 Part::Name(Name {
+    //                     name: "p1".into(),
+    //                     start_modifier: Some(StartModifier::MapVal),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(" ".into()),
+    //                 Part::Name(Name {
+    //                     name: "p2".into(),
+    //                     start_modifier: Some(StartModifier::MapKey),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(":".into()),
+    //                 Part::Name(Name {
+    //                     name: "p2".into(),
+    //                     start_modifier: Some(StartModifier::MapVal),
+    //                     end_modifier: None,
+    //                 }),
+    //             ],
+    //         ),
+    //         (
+    //             "%{&p1}:%{*p1}",
+    //             vec![
+    //                 Part::Name(Name {
+    //                     name: "p1".into(),
+    //                     start_modifier: Some(StartModifier::MapVal),
+    //                     end_modifier: None,
+    //                 }),
+    //                 Part::Split(":".into()),
+    //                 Part::Name(Name {
+    //                     name: "p1".into(),
+    //                     start_modifier: Some(StartModifier::MapKey),
+    //                     end_modifier: None,
+    //                 }),
+    //             ],
+    //         ),
+    //     ];
 
-        for (pattern, expected) in cases.into_iter() {
-            let p: Pattern = pattern.parse().unwrap();
-            assert_eq!(p.parts, expected);
-        }
-    }
+    //     for (pattern, expected) in cases.into_iter() {
+    //         let p: Pattern = pattern.parse().unwrap();
+    //         assert_eq!(p.parts, expected);
+    //     }
+    // }
 
     #[test]
     fn test_dissect_invalid_pattern() {
@@ -1079,7 +1296,7 @@ mod tests {
         ];
 
         for (pattern, expected) in cases.into_iter() {
-            let err = pattern.parse::<Pattern>().unwrap_err();
+            let err = pattern.parse::<PatternInfo>().unwrap_err();
             assert_eq!(err, expected);
         }
     }
@@ -1215,44 +1432,45 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_dissect_reference_keys() {
-        let cases = [
-            (
-                "[%{ts}] [%{level}] %{*p1}:%{&p1} %{*p2}:%{&p2}",
-                "[2018-08-10T17:15:42,466] [ERR] ip:1.2.3.4 error:REFUSED",
-                [
-                    ("ts", "2018-08-10T17:15:42,466"),
-                    ("level", "ERR"),
-                    ("ip", "1.2.3.4"),
-                    ("error", "REFUSED"),
-                ],
-            ),
-            (
-                "[%{ts}] [%{level}] %{&p1}:%{*p1} %{*p2}:%{&p2}",
-                "[2018-08-10T17:15:42,466] [ERR] ip:1.2.3.4 error:REFUSED",
-                [
-                    ("ts", "2018-08-10T17:15:42,466"),
-                    ("level", "ERR"),
-                    ("1.2.3.4", "ip"),
-                    ("error", "REFUSED"),
-                ],
-            ),
-        ]
-        .into_iter()
-        .map(|(pattern, input, expected)| {
-            let map = expected
-                .into_iter()
-                .map(|(k, v)| (k.to_string(), Value::String(v.to_string())));
-            (pattern, input, map)
-        });
+    // no longer support
+    // #[test]
+    // fn test_dissect_reference_keys() {
+    //     let cases = [
+    //         (
+    //             "[%{ts}] [%{level}] %{*p1}:%{&p1} %{*p2}:%{&p2}",
+    //             "[2018-08-10T17:15:42,466] [ERR] ip:1.2.3.4 error:REFUSED",
+    //             [
+    //                 ("ts", "2018-08-10T17:15:42,466"),
+    //                 ("level", "ERR"),
+    //                 ("ip", "1.2.3.4"),
+    //                 ("error", "REFUSED"),
+    //             ],
+    //         ),
+    //         (
+    //             "[%{ts}] [%{level}] %{&p1}:%{*p1} %{*p2}:%{&p2}",
+    //             "[2018-08-10T17:15:42,466] [ERR] ip:1.2.3.4 error:REFUSED",
+    //             [
+    //                 ("ts", "2018-08-10T17:15:42,466"),
+    //                 ("level", "ERR"),
+    //                 ("1.2.3.4", "ip"),
+    //                 ("error", "REFUSED"),
+    //             ],
+    //         ),
+    //     ]
+    //     .into_iter()
+    //     .map(|(pattern, input, expected)| {
+    //         let map = expected
+    //             .into_iter()
+    //             .map(|(k, v)| (k.to_string(), Value::String(v.to_string())));
+    //         (pattern, input, map)
+    //     });
 
-        for (pattern_str, input, expected) in cases {
-            assert(
-                pattern_str,
-                input,
-                expected.collect::<HashMap<String, Value>>(),
-            );
-        }
-    }
+    //     for (pattern_str, input, expected) in cases {
+    //         assert(
+    //             pattern_str,
+    //             input,
+    //             expected.collect::<HashMap<String, Value>>(),
+    //         );
+    //     }
+    // }
 }

--- a/src/pipeline/src/etl/processor/dissect.rs
+++ b/src/pipeline/src/etl/processor/dissect.rs
@@ -19,10 +19,11 @@ use common_telemetry::warn;
 use itertools::Itertools;
 
 use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
+use crate::etl::find_key_index;
 use crate::etl::processor::{
-    find_key_index, yaml_bool, yaml_new_field, yaml_new_fields, yaml_parse_string,
-    yaml_parse_strings, yaml_string, Processor, ProcessorBuilder, ProcessorKind, FIELDS_NAME,
-    FIELD_NAME, IGNORE_MISSING_NAME, PATTERNS_NAME, PATTERN_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_parse_string, yaml_parse_strings, yaml_string,
+    Processor, ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
+    PATTERNS_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
 

--- a/src/pipeline/src/etl/processor/epoch.rs
+++ b/src/pipeline/src/etl/processor/epoch.rs
@@ -14,7 +14,7 @@
 
 use ahash::HashSet;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
@@ -80,7 +80,7 @@ impl EpochProcessorBuilder {
     pub fn build(self, intermediate_keys: &[String]) -> Result<EpochProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "epoch",
                 intermediate_keys,
                 field.input_field(),
@@ -101,7 +101,7 @@ impl EpochProcessorBuilder {
 /// Reserved for compatibility only
 #[derive(Debug, Default)]
 pub struct EpochProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     resolution: Resolution,
     ignore_missing: bool,
     // description

--- a/src/pipeline/src/etl/processor/epoch.rs
+++ b/src/pipeline/src/etl/processor/epoch.rs
@@ -14,7 +14,7 @@
 
 use ahash::HashSet;
 
-use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
@@ -71,37 +71,28 @@ impl ProcessorBuilder for EpochProcessorBuilder {
         self.fields.iter().map(|f| f.input_field()).collect()
     }
 
-    fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
-        let builder = Self::build(self, intermediate_keys);
-        ProcessorKind::Epoch(builder)
+    fn build(self, intermediate_keys: &[String]) -> Result<ProcessorKind, String> {
+        self.build(intermediate_keys).map(ProcessorKind::Epoch)
     }
 }
 
 impl EpochProcessorBuilder {
-    pub fn build(self, intermediate_keys: &[String]) -> EpochProcessor {
+    pub fn build(self, intermediate_keys: &[String]) -> Result<EpochProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input_index = intermediate_keys
-                .iter()
-                .position(|k| *k == field.input_field())
-                // TODO (qtang): handler error
-                .unwrap();
-            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
-            let output_index = intermediate_keys
-                .iter()
-                .position(|k| k == field.target_or_input_field())
-                .unwrap();
-            let input = OneInputOneOutPutField::new(
-                input_field_info,
-                (field.target_or_input_field().to_string(), output_index),
-            );
+            let input = OneInputOneOutPutField::build(
+                "epoch",
+                intermediate_keys,
+                field.input_field(),
+                field.target_or_input_field(),
+            )?;
             real_fields.push(input);
         }
-        EpochProcessor {
+        Ok(EpochProcessor {
             fields: real_fields,
             resolution: self.resolution,
             ignore_missing: self.ignore_missing,
-        }
+        })
     }
 }
 
@@ -223,7 +214,6 @@ impl Processor for EpochProcessor {
                     }
                 }
                 Some(v) => {
-                    // TODO(qtang): Let this method use the intermediate state collection directly.
                     let timestamp = self.parse(v)?;
                     let output_index = field.output_index();
                     val[output_index] = Value::Timestamp(timestamp);

--- a/src/pipeline/src/etl/processor/epoch.rs
+++ b/src/pipeline/src/etl/processor/epoch.rs
@@ -14,10 +14,9 @@
 
 use ahash::HashSet;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::time::{
@@ -178,7 +177,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for EpochProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 RESOLUTION_NAME => {
                     let s = yaml_string(v, RESOLUTION_NAME)?.as_str().try_into()?;

--- a/src/pipeline/src/etl/processor/epoch.rs
+++ b/src/pipeline/src/etl/processor/epoch.rs
@@ -15,17 +15,17 @@
 use ahash::HashSet;
 
 // use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
-    update_one_one_output_keys, yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor,
-    ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
 use crate::etl::value::time::{
     MICROSECOND_RESOLUTION, MICRO_RESOLUTION, MILLISECOND_RESOLUTION, MILLI_RESOLUTION,
     MS_RESOLUTION, NANOSECOND_RESOLUTION, NANO_RESOLUTION, NS_RESOLUTION, SECOND_RESOLUTION,
     SEC_RESOLUTION, S_RESOLUTION, US_RESOLUTION,
 };
-use crate::etl::value::{Map, Timestamp, Value};
+use crate::etl::value::{Timestamp, Value};
 
 pub(crate) const PROCESSOR_EPOCH: &str = "epoch";
 const RESOLUTION_NAME: &str = "resolution";
@@ -122,20 +122,6 @@ pub struct EpochProcessor {
 }
 
 impl EpochProcessor {
-    fn with_fields(&mut self, mut fields: Fields) {
-        todo!()
-        // update_one_one_output_keys(&mut fields);
-        // self.fields = fields
-    }
-
-    fn with_resolution(&mut self, resolution: Resolution) {
-        self.resolution = resolution;
-    }
-
-    fn with_ignore_missing(&mut self, ignore_missing: bool) {
-        self.ignore_missing = ignore_missing;
-    }
-
     fn parse(&self, val: &Value) -> Result<Timestamp, String> {
         let t: i64 = match val {
             Value::String(s) => s
@@ -171,12 +157,6 @@ impl EpochProcessor {
             Resolution::Micro => Ok(Timestamp::Microsecond(t)),
             Resolution::Nano => Ok(Timestamp::Nanosecond(t)),
         }
-    }
-
-    fn process_field(&self, val: &Value, field: &Field) -> Result<Map, String> {
-        let key = field.get_target_field();
-
-        Ok(Map::one(key, Value::Timestamp(self.parse(val)?)))
     }
 }
 
@@ -262,8 +242,10 @@ mod tests {
 
     #[test]
     fn test_parse_epoch() {
-        let mut processor = EpochProcessor::default();
-        processor.with_resolution(super::Resolution::Second);
+        let processor = EpochProcessor {
+            resolution: super::Resolution::Second,
+            ..Default::default()
+        };
 
         let values = [
             Value::String("1573840000".into()),

--- a/src/pipeline/src/etl/processor/gsub.rs
+++ b/src/pipeline/src/etl/processor/gsub.rs
@@ -15,7 +15,7 @@
 use ahash::HashSet;
 use regex::Regex;
 
-use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
@@ -46,9 +46,8 @@ impl ProcessorBuilder for GsubProcessorBuilder {
         self.fields.iter().map(|f| f.input_field()).collect()
     }
 
-    fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
-        let processor = Self::build(self, intermediate_keys);
-        ProcessorKind::Gsub(processor)
+    fn build(self, intermediate_keys: &[String]) -> Result<ProcessorKind, String> {
+        self.build(intermediate_keys).map(ProcessorKind::Gsub)
     }
 }
 
@@ -65,31 +64,23 @@ impl GsubProcessorBuilder {
         Ok(self)
     }
 
-    fn build(self, intermediate_keys: &[String]) -> GsubProcessor {
+    fn build(self, intermediate_keys: &[String]) -> Result<GsubProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input_index = intermediate_keys
-                .iter()
-                .position(|k| *k == field.input_field())
-                // TODO (qtang): handler error
-                .unwrap();
-            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
-            let output_index = intermediate_keys
-                .iter()
-                .position(|k| k == field.target_or_input_field())
-                .unwrap();
-            let input = OneInputOneOutPutField::new(
-                input_field_info,
-                (field.target_or_input_field().to_string(), output_index),
-            );
+            let input = OneInputOneOutPutField::build(
+                "gsub",
+                intermediate_keys,
+                field.input_field(),
+                field.target_or_input_field(),
+            )?;
             real_fields.push(input);
         }
-        GsubProcessor {
+        Ok(GsubProcessor {
             fields: real_fields,
             pattern: self.pattern,
             replacement: self.replacement,
             ignore_missing: self.ignore_missing,
-        }
+        })
     }
 }
 

--- a/src/pipeline/src/etl/processor/gsub.rs
+++ b/src/pipeline/src/etl/processor/gsub.rs
@@ -15,10 +15,9 @@
 use ahash::HashSet;
 use regex::Regex;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
@@ -158,7 +157,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for GsubProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 PATTERN_NAME => {
                     let pattern_str = yaml_string(v, PATTERN_NAME)?;

--- a/src/pipeline/src/etl/processor/gsub.rs
+++ b/src/pipeline/src/etl/processor/gsub.rs
@@ -15,13 +15,13 @@
 use ahash::HashSet;
 use regex::Regex;
 
-use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
+use crate::etl::field::{Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
-    update_one_one_output_keys, yaml_bool, yaml_field, yaml_fields, yaml_string, Processor,
-    FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
 };
-use crate::etl::value::{Array, Map, Value};
+use crate::etl::value::{Array, Value};
 
 pub(crate) const PROCESSOR_GSUB: &str = "gsub";
 
@@ -37,39 +37,18 @@ pub struct GsubProcessorBuilder {
 
 impl ProcessorBuilder for GsubProcessorBuilder {
     fn output_keys(&self) -> HashSet<&str> {
-        todo!()
+        self.fields
+            .iter()
+            .map(|f| f.target_or_input_field())
+            .collect()
     }
 
     fn input_keys(&self) -> HashSet<&str> {
-        todo!()
+        self.fields.iter().map(|f| f.input_field()).collect()
     }
 
     fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
-        let mut real_fields = vec![];
-        for field in self.fields.into_iter() {
-            let input_index = intermediate_keys
-                .iter()
-                .position(|k| *k == field.input_field())
-                // TODO (qtang): handler error
-                .unwrap();
-            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
-            let output_index = intermediate_keys
-                .iter()
-                .position(|k| *k == field.target_or_input_field())
-                .unwrap();
-            let input = OneInputOneOutPutField::new(
-                input_field_info,
-                (field.target_or_input_field().to_string(), output_index),
-            );
-            real_fields.push(input);
-        }
-        let processor = GsubProcessor {
-            fields: Fields::one(Field::new("test".to_string())),
-            real_fields,
-            pattern: self.pattern,
-            replacement: self.replacement,
-            ignore_missing: self.ignore_missing,
-        };
+        let processor = Self::build(self, intermediate_keys);
         ProcessorKind::Gsub(processor)
     }
 }
@@ -107,7 +86,6 @@ impl GsubProcessorBuilder {
             real_fields.push(input);
         }
         GsubProcessor {
-            fields: Fields::one(Field::new("test".to_string())),
             real_fields,
             pattern: self.pattern,
             replacement: self.replacement,
@@ -119,7 +97,6 @@ impl GsubProcessorBuilder {
 /// A processor to replace all matches of a pattern in string by a replacement, only support string value, and array string value
 #[derive(Debug, Default)]
 pub struct GsubProcessor {
-    fields: Fields,
     real_fields: Vec<OneInputOneOutPutField>,
     pattern: Option<Regex>,
     replacement: Option<String>,
@@ -127,24 +104,6 @@ pub struct GsubProcessor {
 }
 
 impl GsubProcessor {
-    fn with_fields(&mut self, mut fields: Fields) {
-        update_one_one_output_keys(&mut fields);
-        self.fields = fields;
-    }
-
-    fn with_ignore_missing(&mut self, ignore_missing: bool) {
-        self.ignore_missing = ignore_missing;
-    }
-
-    fn try_pattern(&mut self, pattern: &str) -> Result<(), String> {
-        self.pattern = Some(Regex::new(pattern).map_err(|e| e.to_string())?);
-        Ok(())
-    }
-
-    fn with_replacement(&mut self, replacement: impl Into<String>) {
-        self.replacement = Some(replacement.into());
-    }
-
     fn check(self) -> Result<Self, String> {
         if self.pattern.is_none() {
             return Err("pattern is required".to_string());
@@ -157,7 +116,7 @@ impl GsubProcessor {
         Ok(self)
     }
 
-    fn process_string_field(&self, val: &str, field: &Field) -> Result<Map, String> {
+    fn process_string(&self, val: &str) -> Result<Value, String> {
         let replacement = self.replacement.as_ref().unwrap();
         let new_val = self
             .pattern
@@ -167,14 +126,10 @@ impl GsubProcessor {
             .to_string();
         let val = Value::String(new_val);
 
-        let key = field.get_target_field();
-
-        Ok(Map::one(key, val))
+        Ok(val)
     }
 
-    fn process_array_field(&self, arr: &Array, field: &Field) -> Result<Map, String> {
-        let key = field.get_target_field();
-
+    fn process_array(&self, arr: &Array) -> Result<Value, String> {
         let re = self.pattern.as_ref().unwrap();
         let replacement = self.replacement.as_ref().unwrap();
 
@@ -194,7 +149,18 @@ impl GsubProcessor {
             }
         }
 
-        Ok(Map::one(key, Value::Array(result)))
+        Ok(Value::Array(result))
+    }
+
+    fn process(&self, val: &Value) -> Result<Value, String> {
+        match val {
+            Value::String(val) => self.process_string(val),
+            Value::Array(arr) => self.process_array(arr),
+            _ => Err(format!(
+                "{} processor: expect string or array string, but got {val:?}",
+                self.kind()
+            )),
+        }
     }
 }
 
@@ -255,63 +221,33 @@ impl crate::etl::processor::Processor for GsubProcessor {
         self.ignore_missing
     }
 
-    fn fields(&self) -> &Fields {
-        &self.fields
-    }
-
-    fn fields_mut(&mut self) -> &mut Fields {
-        &mut self.fields
-    }
-
-    fn output_keys(&self) -> HashSet<&str> {
-        self.real_fields
-            .iter()
-            .map(|f| f.output().0.as_str())
-            .collect()
-    }
-
-    fn input_keys(&self) -> HashSet<&str> {
-        self.real_fields
-            .iter()
-            .map(|f| f.input().name.as_str())
-            .collect()
-    }
-
-    fn exec_field(&self, val: &Value, field: &Field) -> Result<Map, String> {
-        match val {
-            Value::String(val) => self.process_string_field(val, field),
-            Value::Array(arr) => self.process_array_field(arr, field),
-            _ => Err(format!(
-                "{} processor: expect string or array string, but got {val:?}",
-                self.kind()
-            )),
-        }
-    }
-
     fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String> {
-        for field in self.fields.iter() {
-            let index = field.input_field.index;
+        for field in self.real_fields.iter() {
+            let index = field.input_index();
             match val.get(index) {
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {
                         return Err(format!(
                             "{} processor: missing field: {}",
                             self.kind(),
-                            field.get_field_name()
+                            field.input_name()
                         ));
                     }
                 }
                 Some(v) => {
                     // TODO(qtang): Let this method use the intermediate state collection directly.
-                    let mut map = self.exec_field(v, field)?;
-                    field
-                        .output_fields_index_mapping
-                        .iter()
-                        .for_each(|(k, output_index)| {
-                            if let Some(v) = map.remove(k) {
-                                val[*output_index] = v;
-                            }
-                        });
+                    let result = self.process(v)?;
+                    let output_index = field.output_index();
+                    val[output_index] = result;
+                    // let mut map = self.exec_field(v, field)?;
+                    // field
+                    //     .output_fields_index_mapping
+                    //     .iter()
+                    //     .for_each(|(k, output_index)| {
+                    //         if let Some(v) = map.remove(k) {
+                    //             val[*output_index] = v;
+                    //         }
+                    //     });
                 }
             }
         }
@@ -328,48 +264,49 @@ mod tests {
 
     #[test]
     fn test_string_value() {
-        let mut processor = GsubProcessor::default();
-        processor.try_pattern(r"\d+").unwrap();
-        processor.with_replacement("xxx");
+        // let mut processor = GsubProcessor::default();
+        // processor.try_pattern(r"\d+").unwrap();
+        // processor.with_replacement("xxx");
 
-        let field = Field::new("message");
-        let val = Value::String("123".to_string());
-        let result = processor.exec_field(&val, &field).unwrap();
+        // let field = Field::new("message");
+        // let val = Value::String("123".to_string());
+        // let result = processor.exec_field(&val, &field).unwrap();
 
-        assert_eq!(
-            result,
-            Map::one("message", Value::String("xxx".to_string()))
-        );
+        // assert_eq!(
+        //     result,
+        //     Map::one("message", Value::String("xxx".to_string()))
+        // );
     }
 
-    #[test]
-    fn test_array_string_value() {
-        let mut processor = GsubProcessor::default();
-        processor.try_pattern(r"\d+").unwrap();
-        processor.with_replacement("xxx");
+    // no longer support
+    // #[test]
+    // fn test_array_string_value() {
+    //     let mut processor = GsubProcessor::default();
+    //     processor.try_pattern(r"\d+").unwrap();
+    //     processor.with_replacement("xxx");
 
-        let field = Field::new("message");
-        let val = Value::Array(
-            vec![
-                Value::String("123".to_string()),
-                Value::String("456".to_string()),
-            ]
-            .into(),
-        );
-        let result = processor.exec_field(&val, &field).unwrap();
+    //     let field = Field::new("message");
+    //     let val = Value::Array(
+    //         vec![
+    //             Value::String("123".to_string()),
+    //             Value::String("456".to_string()),
+    //         ]
+    //         .into(),
+    //     );
+    //     let result = processor.exec_field(&val, &field).unwrap();
 
-        assert_eq!(
-            result,
-            Map::one(
-                "message",
-                Value::Array(
-                    vec![
-                        Value::String("xxx".to_string()),
-                        Value::String("xxx".to_string())
-                    ]
-                    .into()
-                )
-            )
-        );
-    }
+    //     assert_eq!(
+    //         result,
+    //         Map::one(
+    //             "message",
+    //             Value::Array(
+    //                 vec![
+    //                     Value::String("xxx".to_string()),
+    //                     Value::String("xxx".to_string())
+    //                 ]
+    //                 .into()
+    //             )
+    //         )
+    //     );
+    // }
 }

--- a/src/pipeline/src/etl/processor/gsub.rs
+++ b/src/pipeline/src/etl/processor/gsub.rs
@@ -15,7 +15,7 @@
 use ahash::HashSet;
 use regex::Regex;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
@@ -67,7 +67,7 @@ impl GsubProcessorBuilder {
     fn build(self, intermediate_keys: &[String]) -> Result<GsubProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "gsub",
                 intermediate_keys,
                 field.input_field(),
@@ -87,7 +87,7 @@ impl GsubProcessorBuilder {
 /// A processor to replace all matches of a pattern in string by a replacement, only support string value, and array string value
 #[derive(Debug, Default)]
 pub struct GsubProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     pattern: Option<Regex>,
     replacement: Option<String>,
     ignore_missing: bool,

--- a/src/pipeline/src/etl/processor/join.rs
+++ b/src/pipeline/src/etl/processor/join.rs
@@ -14,10 +14,9 @@
 
 use ahash::HashSet;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, SEPARATOR_NAME,
 };
 use crate::etl::value::{Array, Value};
@@ -132,7 +131,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for JoinProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 SEPARATOR_NAME => {
                     separator = Some(yaml_string(v, SEPARATOR_NAME)?);

--- a/src/pipeline/src/etl/processor/join.rs
+++ b/src/pipeline/src/etl/processor/join.rs
@@ -15,12 +15,12 @@
 use ahash::HashSet;
 
 // use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
-    update_one_one_output_keys, yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor,
-    ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, SEPARATOR_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, SEPARATOR_NAME,
 };
-use crate::etl::value::{Array, Map, Value};
+use crate::etl::value::{Array, Value};
 
 pub(crate) const PROCESSOR_JOIN: &str = "join";
 
@@ -167,18 +167,9 @@ impl Processor for JoinProcessor {
             let index = field.input_index();
             match val.get(index) {
                 Some(Value::Array(arr)) => {
-                    // TODO(qtang): Let this method use the intermediate state collection directly.
                     let result = self.process(arr)?;
                     let output_index = field.output_index();
                     val[output_index] = result;
-                    // field
-                    //     .output_fields_index_mapping
-                    //     .iter()
-                    //     .for_each(|(k, output_index)| {
-                    //         if let Some(v) = map.remove(k) {
-                    //             val[*output_index] = v;
-                    //         }
-                    //     });
                 }
                 Some(Value::Null) | None => {
                     if !self.ignore_missing {

--- a/src/pipeline/src/etl/processor/join.rs
+++ b/src/pipeline/src/etl/processor/join.rs
@@ -14,7 +14,7 @@
 
 use ahash::HashSet;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, SEPARATOR_NAME,
@@ -59,7 +59,7 @@ impl JoinProcessorBuilder {
     pub fn build(self, intermediate_keys: &[String]) -> Result<JoinProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "join",
                 intermediate_keys,
                 field.input_field(),
@@ -79,7 +79,7 @@ impl JoinProcessorBuilder {
 /// A processor to join each element of an array into a single string using a separator string between each element
 #[derive(Debug, Default)]
 pub struct JoinProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     separator: Option<String>,
     ignore_missing: bool,
 }

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -15,12 +15,12 @@
 use ahash::HashSet;
 
 // use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
 };
-use crate::etl::value::{Map, Value};
+use crate::etl::value::Value;
 
 pub(crate) const PROCESSOR_LETTER: &str = "letter";
 

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -15,7 +15,7 @@
 use ahash::HashSet;
 
 // use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
@@ -57,7 +57,7 @@ impl std::str::FromStr for Method {
 
 #[derive(Debug, Default)]
 pub struct LetterProcessorBuilder {
-    fields: NewFields,
+    fields: Fields,
     method: Method,
     ignore_missing: bool,
 }
@@ -95,7 +95,7 @@ impl ProcessorBuilder for LetterProcessorBuilder {
         }
 
         let processor = LetterProcessor {
-            real_fields,
+            fields: real_fields,
             method: self.method,
             ignore_missing: self.ignore_missing,
         };
@@ -125,7 +125,7 @@ impl LetterProcessorBuilder {
         }
 
         LetterProcessor {
-            real_fields,
+            fields: real_fields,
             method: self.method,
             ignore_missing: self.ignore_missing,
         }
@@ -135,7 +135,7 @@ impl LetterProcessorBuilder {
 /// only support string value
 #[derive(Debug, Default)]
 pub struct LetterProcessor {
-    real_fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutPutField>,
     method: Method,
     ignore_missing: bool,
 }
@@ -157,7 +157,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessorBuilder {
     type Error = String;
 
     fn try_from(value: &yaml_rust::yaml::Hash) -> Result<Self, Self::Error> {
-        let mut fields = NewFields::default();
+        let mut fields = Fields::default();
         let mut method = Method::Lower;
         let mut ignore_missing = false;
 
@@ -167,7 +167,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessorBuilder {
                 .ok_or(format!("key must be a string, but got {k:?}"))?;
             match key {
                 FIELD_NAME => {
-                    fields = NewFields::one(yaml_new_field(v, FIELD_NAME)?);
+                    fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
                     fields = yaml_new_fileds(v, FIELDS_NAME)?;
@@ -200,7 +200,7 @@ impl Processor for LetterProcessor {
     }
 
     fn exec_mut(&self, val: &mut Vec<Value>) -> Result<(), String> {
-        for field in self.real_fields.iter() {
+        for field in self.fields.iter() {
             let index = field.input_index();
             match val.get(index) {
                 Some(Value::String(s)) => {

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -14,7 +14,7 @@
 
 use ahash::HashSet;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
@@ -82,7 +82,7 @@ impl LetterProcessorBuilder {
     pub fn build(self, intermediate_keys: &[String]) -> Result<LetterProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "letter",
                 intermediate_keys,
                 field.input_field(),
@@ -102,7 +102,7 @@ impl LetterProcessorBuilder {
 /// only support string value
 #[derive(Debug, Default)]
 pub struct LetterProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     method: Method,
     ignore_missing: bool,
 }

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -14,10 +14,9 @@
 
 use ahash::HashSet;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, Processor, ProcessorBuilder,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, Processor, ProcessorBuilder,
     ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
 };
 use crate::etl::value::Value;
@@ -170,7 +169,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 METHOD_NAME => {
                     method = yaml_string(v, METHOD_NAME)?.parse()?;

--- a/src/pipeline/src/etl/processor/letter.rs
+++ b/src/pipeline/src/etl/processor/letter.rs
@@ -14,7 +14,8 @@
 
 use ahash::HashSet;
 
-use crate::etl::field::{Field, Fields};
+use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
+use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
     update_one_one_output_keys, yaml_bool, yaml_field, yaml_fields, yaml_string, Processor,
     FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
@@ -54,10 +55,99 @@ impl std::str::FromStr for Method {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct LetterProcessorBuilder {
+    fields: NewFields,
+    method: Method,
+    ignore_missing: bool,
+}
+
+impl ProcessorBuilder for LetterProcessorBuilder {
+    fn output_keys(&self) -> HashSet<&str> {
+        todo!()
+    }
+
+    fn input_keys(&self) -> HashSet<&str> {
+        todo!()
+    }
+
+    fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
+        let mut real_fields = vec![];
+        for field in self.fields.into_iter() {
+            let input_index = intermediate_keys
+                .iter()
+                .position(|k| *k == field.input_field())
+                // TODO (qtang): handler error
+                .unwrap();
+            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
+            let output_index = intermediate_keys
+                .iter()
+                .position(|k| *k == field.target_or_input_field())
+                .unwrap();
+            let input = OneInputOneOutPutField::new(
+                input_field_info,
+                (field.target_or_input_field().to_string(), output_index),
+            );
+            real_fields.push(input);
+        }
+
+        let processor = LetterProcessor {
+            fields: Fields::one(Field::new("test".to_string())),
+            real_fields,
+            method: self.method,
+            ignore_missing: self.ignore_missing,
+        };
+        ProcessorKind::Letter(processor)
+    }
+}
+
+impl LetterProcessorBuilder {
+    pub fn build(self, intermediate_keys: &[String]) -> LetterProcessor {
+        let mut real_fields = vec![];
+        for field in self.fields.into_iter() {
+            let input_index = intermediate_keys
+                .iter()
+                .position(|k| *k == field.input_field())
+                // TODO (qtang): handler error
+                .unwrap();
+            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
+            let output_index = intermediate_keys
+                .iter()
+                .position(|k| k == field.target_or_input_field())
+                .unwrap();
+            let input = OneInputOneOutPutField::new(
+                input_field_info,
+                (field.target_or_input_field().to_string(), output_index),
+            );
+            real_fields.push(input);
+        }
+
+        LetterProcessor {
+            fields: Fields::one(Field::new("test".to_string())),
+            real_fields,
+            method: self.method,
+            ignore_missing: self.ignore_missing,
+        }
+    }
+
+    pub fn with_fields(&mut self, fields: NewFields) {
+        self.fields = fields;
+    }
+
+    pub fn with_method(&mut self, method: Method) {
+        self.method = method;
+    }
+
+    pub fn with_ignore_missing(&mut self, ignore_missing: bool) {
+        self.ignore_missing = ignore_missing;
+    }
+}
+
 /// only support string value
 #[derive(Debug, Default)]
 pub struct LetterProcessor {
     fields: Fields,
+    real_fields: Vec<OneInputOneOutPutField>,
     method: Method,
     ignore_missing: bool,
 }
@@ -90,11 +180,13 @@ impl LetterProcessor {
     }
 }
 
-impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessor {
+impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessorBuilder {
     type Error = String;
 
     fn try_from(value: &yaml_rust::yaml::Hash) -> Result<Self, Self::Error> {
-        let mut processor = LetterProcessor::default();
+        let mut fields = NewFields::default();
+        let mut method = Method::Lower;
+        let mut ignore_missing = false;
 
         for (k, v) in value.iter() {
             let key = k
@@ -102,23 +194,26 @@ impl TryFrom<&yaml_rust::yaml::Hash> for LetterProcessor {
                 .ok_or(format!("key must be a string, but got {k:?}"))?;
             match key {
                 FIELD_NAME => {
-                    processor.with_fields(Fields::one(yaml_field(v, FIELD_NAME)?));
+                    fields = NewFields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    processor.with_fields(yaml_fields(v, FIELDS_NAME)?);
+                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
                 }
                 METHOD_NAME => {
-                    let method = yaml_string(v, METHOD_NAME)?;
-                    processor.with_method(method.parse()?);
+                    method = yaml_string(v, METHOD_NAME)?.parse()?;
                 }
                 IGNORE_MISSING_NAME => {
-                    processor.with_ignore_missing(yaml_bool(v, IGNORE_MISSING_NAME)?);
+                    ignore_missing = yaml_bool(v, IGNORE_MISSING_NAME)?;
                 }
                 _ => {}
             }
         }
 
-        Ok(processor)
+        Ok(LetterProcessorBuilder {
+            fields,
+            method,
+            ignore_missing,
+        })
     }
 }
 
@@ -139,10 +234,17 @@ impl Processor for LetterProcessor {
         &mut self.fields
     }
 
-    fn output_keys(&self) -> HashSet<String> {
-        self.fields
+    fn output_keys(&self) -> HashSet<&str> {
+        self.real_fields
             .iter()
-            .map(|f| f.get_target_field().to_string())
+            .map(|x| x.output().0.as_str())
+            .collect()
+    }
+
+    fn input_keys(&self) -> HashSet<&str> {
+        self.real_fields
+            .iter()
+            .map(|x| x.input().name.as_str())
             .collect()
     }
 

--- a/src/pipeline/src/etl/processor/regex.rs
+++ b/src/pipeline/src/etl/processor/regex.rs
@@ -23,10 +23,10 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
+use crate::etl::find_key_index;
 use crate::etl::processor::{
-    find_key_index, yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings,
-    Processor, ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
-    PATTERN_NAME,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings, Processor,
+    ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
 

--- a/src/pipeline/src/etl/processor/regex.rs
+++ b/src/pipeline/src/etl/processor/regex.rs
@@ -22,10 +22,9 @@ use ahash::{HashSet, HashSetExt};
 use lazy_static::lazy_static;
 use regex::Regex;
 
-// use super::{yaml_new_field, yaml_new_fileds, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputMultiOutputField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputMultiOutputField};
 use crate::etl::processor::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, yaml_strings, Processor,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings, Processor,
     ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, PATTERN_NAME,
 };
 use crate::etl::value::Value;
@@ -178,7 +177,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for RegexProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 PATTERN_NAME => {
                     let pattern = yaml_string(v, PATTERN_NAME)?;

--- a/src/pipeline/src/etl/processor/regex.rs
+++ b/src/pipeline/src/etl/processor/regex.rs
@@ -155,12 +155,12 @@ impl RegexProcessorBuilder {
         real_fields: &[OneInputMultiOutputField],
         patterns: &[GroupRegex],
         intermediate_keys: &[String],
-    ) -> Result<RegexPorcessorOutputInfo, String> {
+    ) -> Result<RegexProcessorOutputInfo, String> {
         let inner = real_fields
             .iter()
             .map(|om_field| Self::build_group_output_infos(patterns, om_field, intermediate_keys))
             .collect::<Result<Vec<_>, String>>();
-        inner.map(|inner| RegexPorcessorOutputInfo { inner })
+        inner.map(|inner| RegexProcessorOutputInfo { inner })
     }
 
     fn build(self, intermediate_keys: &[String]) -> Result<RegexProcessor, String> {
@@ -250,11 +250,11 @@ struct OutPutInfo {
 }
 
 #[derive(Debug, Default)]
-struct RegexPorcessorOutputInfo {
+struct RegexProcessorOutputInfo {
     pub inner: Vec<Vec<Vec<OutPutInfo>>>,
 }
 
-impl RegexPorcessorOutputInfo {
+impl RegexProcessorOutputInfo {
     fn get_output_index(
         &self,
         field_index: usize,
@@ -269,7 +269,7 @@ impl RegexPorcessorOutputInfo {
 #[derive(Debug, Default)]
 pub struct RegexProcessor {
     fields: Vec<OneInputMultiOutputField>,
-    output_info: RegexPorcessorOutputInfo,
+    output_info: RegexProcessorOutputInfo,
     patterns: Vec<GroupRegex>,
     ignore_missing: bool,
 }

--- a/src/pipeline/src/etl/processor/timestamp.rs
+++ b/src/pipeline/src/etl/processor/timestamp.rs
@@ -20,7 +20,7 @@ use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
 use super::{yaml_new_field, yaml_new_fileds, yaml_strings, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_string, Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };
@@ -29,7 +29,7 @@ use crate::etl::value::time::{
     MS_RESOLUTION, NANOSECOND_RESOLUTION, NANO_RESOLUTION, NS_RESOLUTION, SECOND_RESOLUTION,
     SEC_RESOLUTION, S_RESOLUTION, US_RESOLUTION,
 };
-use crate::etl::value::{Map, Timestamp, Value};
+use crate::etl::value::{Timestamp, Value};
 
 pub(crate) const PROCESSOR_TIMESTAMP: &str = "timestamp";
 const RESOLUTION_NAME: &str = "resolution";
@@ -147,7 +147,7 @@ impl ProcessorBuilder for TimestampProcessorBuilder {
             real_fields.push(input);
         }
         let processor = TimestampProcessor {
-            real_fields: real_fields,
+            real_fields,
             formats: self.formats,
             resolution: self.resolution,
             ignore_missing: self.ignore_missing,
@@ -177,7 +177,7 @@ impl TimestampProcessorBuilder {
             real_fields.push(input);
         }
         TimestampProcessor {
-            real_fields: real_fields,
+            real_fields,
             formats: self.formats,
             resolution: self.resolution,
             ignore_missing: self.ignore_missing,
@@ -265,12 +265,6 @@ impl TimestampProcessor {
             Resolution::Micro => Ok(Timestamp::Microsecond(t)),
             Resolution::Nano => Ok(Timestamp::Nanosecond(t)),
         }
-    }
-
-    fn process_field(&self, val: &Value, field: &Field) -> Result<Map, String> {
-        let key = field.get_target_field();
-
-        Ok(Map::one(key, Value::Timestamp(self.parse(val)?)))
     }
 }
 

--- a/src/pipeline/src/etl/processor/timestamp.rs
+++ b/src/pipeline/src/etl/processor/timestamp.rs
@@ -20,7 +20,7 @@ use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
 use super::{yaml_new_field, yaml_new_fields, yaml_strings, ProcessorBuilder, ProcessorKind};
-use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_string, Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
 };

--- a/src/pipeline/src/etl/processor/timestamp.rs
+++ b/src/pipeline/src/etl/processor/timestamp.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, NaiveDateTime};
 use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, yaml_strings, Processor,
     ProcessorBuilder, ProcessorKind, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
@@ -136,7 +136,7 @@ impl TimestampProcessorBuilder {
     pub fn build(self, intermediate_keys: &[String]) -> Result<TimestampProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "timestamp",
                 intermediate_keys,
                 field.input_field(),
@@ -156,7 +156,7 @@ impl TimestampProcessorBuilder {
 /// support string, integer, float, time, epoch
 #[derive(Debug, Default)]
 pub struct TimestampProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     formats: Formats,
     resolution: Resolution,
     ignore_missing: bool,

--- a/src/pipeline/src/etl/processor/timestamp.rs
+++ b/src/pipeline/src/etl/processor/timestamp.rs
@@ -19,7 +19,7 @@ use chrono::{DateTime, NaiveDateTime};
 use chrono_tz::Tz;
 use lazy_static::lazy_static;
 
-use super::{yaml_new_field, yaml_new_fileds, yaml_strings, ProcessorBuilder, ProcessorKind};
+use super::{yaml_new_field, yaml_new_fields, yaml_strings, ProcessorBuilder, ProcessorKind};
 use crate::etl::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
 use crate::etl::processor::{
     yaml_bool, yaml_string, Processor, FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME,
@@ -317,7 +317,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for TimestampProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
                 FORMATS_NAME => {
                     let formats_vec = parse_formats(v)?;

--- a/src/pipeline/src/etl/processor/urlencoding.rs
+++ b/src/pipeline/src/etl/processor/urlencoding.rs
@@ -16,7 +16,7 @@ use ahash::HashSet;
 use urlencoding::{decode, encode};
 
 use super::{
-    yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, ProcessorBuilder, ProcessorKind,
+    yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, ProcessorBuilder, ProcessorKind,
     FIELDS_NAME,
 };
 use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
@@ -141,7 +141,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for UrlEncodingProcessorBuilder {
                     fields = Fields::one(yaml_new_field(v, FIELD_NAME)?);
                 }
                 FIELDS_NAME => {
-                    fields = yaml_new_fileds(v, FIELDS_NAME)?;
+                    fields = yaml_new_fields(v, FIELDS_NAME)?;
                 }
 
                 IGNORE_MISSING_NAME => {

--- a/src/pipeline/src/etl/processor/urlencoding.rs
+++ b/src/pipeline/src/etl/processor/urlencoding.rs
@@ -15,12 +15,11 @@
 use ahash::HashSet;
 use urlencoding::{decode, encode};
 
-use super::{
+use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, ProcessorBuilder, ProcessorKind,
-    FIELDS_NAME,
+    FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
 };
-use crate::etl::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
-use crate::etl::processor::{FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME};
 use crate::etl::value::Value;
 
 pub(crate) const PROCESSOR_URL_ENCODING: &str = "urlencoding";
@@ -72,37 +71,29 @@ impl ProcessorBuilder for UrlEncodingProcessorBuilder {
         self.fields.iter().map(|f| f.input_field()).collect()
     }
 
-    fn build(self, intermediate_keys: &[String]) -> ProcessorKind {
-        let processor = Self::build(self, intermediate_keys);
-        ProcessorKind::UrlEncoding(processor)
+    fn build(self, intermediate_keys: &[String]) -> Result<ProcessorKind, String> {
+        self.build(intermediate_keys)
+            .map(ProcessorKind::UrlEncoding)
     }
 }
 
 impl UrlEncodingProcessorBuilder {
-    fn build(self, intermediate_keys: &[String]) -> UrlEncodingProcessor {
+    fn build(self, intermediate_keys: &[String]) -> Result<UrlEncodingProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input_index = intermediate_keys
-                .iter()
-                .position(|k| k == field.input_field())
-                // TODO (qtang): handler error
-                .unwrap();
-            let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
-            let output_index = intermediate_keys
-                .iter()
-                .position(|k| k == field.target_or_input_field())
-                .unwrap();
-            let input = OneInputOneOutPutField::new(
-                input_field_info,
-                (field.target_or_input_field().to_string(), output_index),
-            );
+            let input = OneInputOneOutPutField::build(
+                "urlencoding",
+                intermediate_keys,
+                field.input_field(),
+                field.target_or_input_field(),
+            )?;
             real_fields.push(input);
         }
-        UrlEncodingProcessor {
+        Ok(UrlEncodingProcessor {
             fields: real_fields,
             method: self.method,
             ignore_missing: self.ignore_missing,
-        }
+        })
     }
 }
 

--- a/src/pipeline/src/etl/processor/urlencoding.rs
+++ b/src/pipeline/src/etl/processor/urlencoding.rs
@@ -15,7 +15,7 @@
 use ahash::HashSet;
 use urlencoding::{decode, encode};
 
-use crate::etl::field::{Fields, OneInputOneOutPutField};
+use crate::etl::field::{Fields, OneInputOneOutputField};
 use crate::etl::processor::{
     yaml_bool, yaml_new_field, yaml_new_fields, yaml_string, ProcessorBuilder, ProcessorKind,
     FIELDS_NAME, FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME,
@@ -81,7 +81,7 @@ impl UrlEncodingProcessorBuilder {
     fn build(self, intermediate_keys: &[String]) -> Result<UrlEncodingProcessor, String> {
         let mut real_fields = vec![];
         for field in self.fields.into_iter() {
-            let input = OneInputOneOutPutField::build(
+            let input = OneInputOneOutputField::build(
                 "urlencoding",
                 intermediate_keys,
                 field.input_field(),
@@ -100,7 +100,7 @@ impl UrlEncodingProcessorBuilder {
 /// only support string value
 #[derive(Debug, Default)]
 pub struct UrlEncodingProcessor {
-    fields: Vec<OneInputOneOutPutField>,
+    fields: Vec<OneInputOneOutputField>,
     method: Method,
     ignore_missing: bool,
 }

--- a/src/pipeline/src/etl/processor/urlencoding.rs
+++ b/src/pipeline/src/etl/processor/urlencoding.rs
@@ -19,9 +19,9 @@ use super::{
     yaml_bool, yaml_new_field, yaml_new_fileds, yaml_string, ProcessorBuilder, ProcessorKind,
     FIELDS_NAME,
 };
-use crate::etl::field::{Field, Fields, InputFieldInfo, NewFields, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
 use crate::etl::processor::{FIELD_NAME, IGNORE_MISSING_NAME, METHOD_NAME};
-use crate::etl::value::{Map, Value};
+use crate::etl::value::Value;
 
 pub(crate) const PROCESSOR_URL_ENCODING: &str = "urlencoding";
 
@@ -121,19 +121,7 @@ impl UrlEncodingProcessor {
             Method::Decode => decode(val).map_err(|e| e.to_string())?.into_owned(),
         };
         Ok(Value::String(processed))
-
-        // let key = field.get_target_field();
-
-        // Ok(Map::one(key, val))
     }
-
-    // fn update_output_keys(fields: &mut Fields) {
-    //     for field in fields.iter_mut() {
-    //         field
-    //             .output_fields_index_mapping
-    //             .insert(field.get_target_field().to_string(), 0_usize);
-    //     }
-    // }
 }
 
 impl TryFrom<&yaml_rust::yaml::Hash> for UrlEncodingProcessorBuilder {

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -17,6 +17,7 @@ pub mod transformer;
 
 use itertools::Itertools;
 
+use crate::etl::find_key_index;
 use crate::etl::processor::yaml_string;
 use crate::etl::transform::index::Index;
 use crate::etl::value::Value;
@@ -31,7 +32,7 @@ const TRANSFORM_ON_FAILURE: &str = "on_failure";
 pub use transformer::greptime::GreptimeTransformer;
 
 use super::field::{Fields, InputFieldInfo, OneInputOneOutputField};
-use super::processor::{find_key_index, yaml_new_field, yaml_new_fields};
+use super::processor::{yaml_new_field, yaml_new_fields};
 
 pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {
     type Output;

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -266,40 +266,6 @@ impl Default for Transform {
 }
 
 impl Transform {
-    // fn with_fields(&mut self, mut fields: Fields) {
-    //     update_one_one_output_keys(&mut fields);
-    //     self.fields = fields;
-    // }
-
-    fn with_type(&mut self, type_: Value) {
-        self.type_ = type_;
-    }
-
-    // fn try_default(&mut self, default: Value) -> Result<(), String> {
-    //     match (&self.type_, &default) {
-    //         (Value::Null, _) => Err(format!(
-    //             "transform {} type MUST BE set before default {}",
-    //             self.fields, &default,
-    //         )),
-    //         (_, Value::Null) => Ok(()), // if default is not set, then it will be regarded as default null
-    //         (_, _) => {
-    //             let target = self
-    //                 .type_
-    //                 .parse_str_value(default.to_str_value().as_str())?;
-    //             self.default = Some(target);
-    //             Ok(())
-    //         }
-    //     }
-    // }
-
-    fn with_index(&mut self, index: Index) {
-        self.index = Some(index);
-    }
-
-    fn with_on_failure(&mut self, on_failure: OnFailure) {
-        self.on_failure = Some(on_failure);
-    }
-
     pub(crate) fn get_default(&self) -> Option<&Value> {
         self.default.as_ref()
     }

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -30,7 +30,7 @@ const TRANSFORM_ON_FAILURE: &str = "on_failure";
 
 pub use transformer::greptime::GreptimeTransformer;
 
-use super::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
+use super::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
 use super::processor::{yaml_new_field, yaml_new_fields};
 
 pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -41,7 +41,6 @@ pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {
     fn schemas(&self) -> &Vec<greptime_proto::v1::ColumnSchema>;
     fn transforms(&self) -> &Transforms;
     fn transforms_mut(&mut self) -> &mut Transforms;
-    fn transform(&self, val: Value) -> Result<Self::Output, String>;
     fn transform_mut(&self, val: &mut Vec<Value>) -> Result<Self::VecOutput, String>;
 }
 

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -30,7 +30,7 @@ const TRANSFORM_ON_FAILURE: &str = "on_failure";
 
 pub use transformer::greptime::GreptimeTransformer;
 
-use super::field::{InputFieldInfo, NewFields, OneInputOneOutPutField};
+use super::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
 use super::processor::{yaml_new_field, yaml_new_fileds};
 
 pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {
@@ -178,7 +178,7 @@ impl TryFrom<&Vec<yaml_rust::Yaml>> for TransformBuilders {
 
 #[derive(Debug, Clone)]
 pub struct TransformBuilder {
-    fields: NewFields,
+    fields: Fields,
     type_: Value,
     default: Option<Value>,
     index: Option<Index>,
@@ -315,7 +315,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for TransformBuilder {
     type Error = String;
 
     fn try_from(hash: &yaml_rust::yaml::Hash) -> Result<Self, Self::Error> {
-        let mut fields = NewFields::default();
+        let mut fields = Fields::default();
         let mut type_ = Value::Null;
         let mut default = None;
         let mut index = None;
@@ -325,7 +325,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for TransformBuilder {
             let key = k.as_str().ok_or("key must be a string")?;
             match key {
                 TRANSFORM_FIELD => {
-                    fields = NewFields::one(yaml_new_field(v, TRANSFORM_FIELD)?);
+                    fields = Fields::one(yaml_new_field(v, TRANSFORM_FIELD)?);
                 }
 
                 TRANSFORM_FIELDS => {

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -30,7 +30,7 @@ const TRANSFORM_ON_FAILURE: &str = "on_failure";
 
 pub use transformer::greptime::GreptimeTransformer;
 
-use super::field::{Fields, InputFieldInfo, OneInputOneOutPutField};
+use super::field::{Fields, InputFieldInfo, OneInputOneOutputField};
 use super::processor::{find_key_index, yaml_new_field, yaml_new_fields};
 
 pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {
@@ -197,7 +197,7 @@ impl TransformBuilder {
             let input_field_info = InputFieldInfo::new(field.input_field(), input_index);
             let output_index =
                 find_key_index(output_keys, field.target_or_input_field(), "transform")?;
-            let input = OneInputOneOutPutField::new(
+            let input = OneInputOneOutputField::new(
                 input_field_info,
                 (field.target_or_input_field().to_string(), output_index),
             );
@@ -216,7 +216,7 @@ impl TransformBuilder {
 /// only field is required
 #[derive(Debug, Clone)]
 pub struct Transform {
-    pub real_fields: Vec<OneInputOneOutPutField>,
+    pub real_fields: Vec<OneInputOneOutputField>,
 
     pub type_: Value,
 

--- a/src/pipeline/src/etl/transform.rs
+++ b/src/pipeline/src/etl/transform.rs
@@ -31,7 +31,7 @@ const TRANSFORM_ON_FAILURE: &str = "on_failure";
 pub use transformer::greptime::GreptimeTransformer;
 
 use super::field::{InputFieldInfo, Fields, OneInputOneOutPutField};
-use super::processor::{yaml_new_field, yaml_new_fileds};
+use super::processor::{yaml_new_field, yaml_new_fields};
 
 pub trait Transformer: std::fmt::Display + Sized + Send + Sync + 'static {
     type Output;
@@ -329,7 +329,7 @@ impl TryFrom<&yaml_rust::yaml::Hash> for TransformBuilder {
                 }
 
                 TRANSFORM_FIELDS => {
-                    fields = yaml_new_fileds(v, TRANSFORM_FIELDS)?;
+                    fields = yaml_new_fields(v, TRANSFORM_FIELDS)?;
                 }
 
                 TRANSFORM_TYPE => {

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -36,6 +36,7 @@ pub struct GreptimeTransformer {
 }
 
 impl GreptimeTransformer {
+    /// Add a default timestamp column to the transforms
     fn add_greptime_timestamp_column(transforms: &mut Transforms) {
         let ns = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
         let type_ = Value::Timestamp(Timestamp::Nanosecond(ns));
@@ -69,6 +70,7 @@ impl GreptimeTransformer {
         transforms.push(transform);
     }
 
+    /// Generate the schema for the GreptimeTransformer
     fn schemas(transforms: &Transforms) -> Result<Vec<ColumnSchema>, String> {
         let mut schema = vec![];
         for transform in transforms.iter() {

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -20,7 +20,7 @@ use coerce::{coerce_columns, coerce_value};
 use greptime_proto::v1::{ColumnSchema, Row, Rows, Value as GreptimeValue};
 use itertools::Itertools;
 
-use crate::etl::field::{InputFieldInfo, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, OneInputOneOutputField};
 use crate::etl::transform::index::Index;
 use crate::etl::transform::{Transform, Transformer, Transforms};
 use crate::etl::value::{Timestamp, Value};
@@ -43,7 +43,7 @@ impl GreptimeTransformer {
         let default = Some(type_.clone());
 
         let transform = Transform {
-            real_fields: vec![OneInputOneOutPutField::new(
+            real_fields: vec![OneInputOneOutputField::new(
                 InputFieldInfo {
                     name: DEFAULT_GREPTIME_TIMESTAMP_COLUMN.to_string(),
                     index: usize::MAX,

--- a/src/pipeline/src/etl/transform/transformer/greptime.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime.rs
@@ -15,16 +15,15 @@
 pub mod coerce;
 
 use std::collections::HashSet;
-use std::usize;
 
 use coerce::{coerce_columns, coerce_value};
 use greptime_proto::v1::{ColumnSchema, Row, Rows, Value as GreptimeValue};
 use itertools::Itertools;
 
-use crate::etl::field::{Field, Fields, InputFieldInfo, OneInputOneOutPutField};
+use crate::etl::field::{InputFieldInfo, OneInputOneOutPutField};
 use crate::etl::transform::index::Index;
 use crate::etl::transform::{Transform, Transformer, Transforms};
-use crate::etl::value::{Array, Map, Timestamp, Value};
+use crate::etl::value::{Timestamp, Value};
 
 const DEFAULT_GREPTIME_TIMESTAMP_COLUMN: &str = "greptime_timestamp";
 
@@ -76,55 +75,6 @@ impl GreptimeTransformer {
             schema.extend(coerce_columns(transform)?);
         }
         Ok(schema)
-    }
-
-    fn transform_map(&self, map: &Map) -> Result<Row, String> {
-        todo!()
-        // let mut values = vec![GreptimeValue { value_data: None }; self.schema.len()];
-        // for transform in self.transforms.iter() {
-        //     for field in transform.fields.iter() {
-        //         let value_data = match map.get(field.get_field_name()) {
-        //             Some(val) => coerce_value(val, transform)?,
-        //             None => {
-        //                 let default = transform.get_default();
-        //                 match default {
-        //                     Some(default) => coerce_value(default, transform)?,
-        //                     None => None,
-        //                 }
-        //             }
-        //         };
-        //         if let Some(i) = field
-        //             .output_fields_index_mapping
-        //             .iter()
-        //             .next()
-        //             .map(|kv| kv.1)
-        //         {
-        //             values[*i] = GreptimeValue { value_data }
-        //         } else {
-        //             return Err(format!(
-        //                 "field: {} output_fields is empty.",
-        //                 field.get_field_name()
-        //             ));
-        //         }
-        //     }
-        // }
-
-        // Ok(Row { values })
-    }
-
-    fn transform_array(&self, arr: &Array) -> Result<Vec<Row>, String> {
-        todo!()
-        // let mut rows = Vec::with_capacity(arr.len());
-        // for v in arr.iter() {
-        //     match v {
-        //         Value::Map(map) => {
-        //             let row = self.transform_map(map)?;
-        //             rows.push(row);
-        //         }
-        //         _ => return Err(format!("Expected map, found: {v:?}")),
-        //     }
-        // }
-        // Ok(rows)
     }
 }
 
@@ -198,27 +148,6 @@ impl Transformer for GreptimeTransformer {
                 )
             }
         }
-    }
-
-    fn transform(&self, value: Value) -> Result<Self::Output, String> {
-        todo!()
-        // match value {
-        //     Value::Map(map) => {
-        //         let rows = vec![self.transform_map(&map)?];
-        //         Ok(Rows {
-        //             schema: self.schema.clone(),
-        //             rows,
-        //         })
-        //     }
-        //     Value::Array(arr) => {
-        //         let rows = self.transform_array(&arr)?;
-        //         Ok(Rows {
-        //             schema: self.schema.clone(),
-        //             rows,
-        //         })
-        //     }
-        //     _ => Err(format!("Expected map or array, found: {}", value)),
-        // }
     }
 
     fn transform_mut(&self, val: &mut Vec<Value>) -> Result<Self::VecOutput, String> {

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -407,7 +407,6 @@ fn coerce_string_value(s: &String, transform: &Transform) -> Result<Option<Value
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::etl::field::Fields;
 
     #[test]
     fn test_coerce_string_without_on_failure() {

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -66,8 +66,8 @@ impl TryFrom<Value> for ValueData {
 pub(crate) fn coerce_columns(transform: &Transform) -> Result<Vec<ColumnSchema>, String> {
     let mut columns = Vec::new();
 
-    for field in transform.fields.iter() {
-        let column_name = field.get_target_field().to_string();
+    for field in transform.real_fields.iter() {
+        let column_name = field.output_name().to_string();
 
         let datatype = coerce_type(transform)? as i32;
 
@@ -134,7 +134,7 @@ fn coerce_type(transform: &Transform) -> Result<ColumnDataType, String> {
 
         Value::Null => Err(format!(
             "Null type not supported when to coerce '{}' type",
-            transform.fields
+            "123" // transform.fields
         )),
     }
 }
@@ -144,15 +144,18 @@ pub(crate) fn coerce_value(
     transform: &Transform,
 ) -> Result<Option<ValueData>, String> {
     match val {
-        Value::Null => match transform.on_failure {
-            Some(OnFailure::Ignore) => Ok(None),
-            Some(OnFailure::Default) => transform
-                .get_default()
-                .map(|default| coerce_value(default, transform))
-                .unwrap_or_else(|| {
-                    coerce_value(transform.get_type_matched_default_val(), transform)
-                }),
-            None => Ok(None),
+        Value::Null => match &transform.default {
+            Some(default) => coerce_value(default, transform),
+            None => match transform.on_failure {
+                Some(OnFailure::Ignore) => Ok(None),
+                Some(OnFailure::Default) => transform
+                    .get_default()
+                    .map(|default| coerce_value(default, transform))
+                    .unwrap_or_else(|| {
+                        coerce_value(transform.get_type_matched_default_val(), transform)
+                    }),
+                None => Ok(None),
+            },
         },
 
         Value::Int8(n) => coerce_i64_value(*n as i64, transform),
@@ -409,7 +412,6 @@ mod tests {
     #[test]
     fn test_coerce_string_without_on_failure() {
         let transform = Transform {
-            fields: Fields::default(),
             real_fields: vec![],
             type_: Value::Int32(0),
             default: None,
@@ -435,7 +437,6 @@ mod tests {
     #[test]
     fn test_coerce_string_with_on_failure_ignore() {
         let transform = Transform {
-            fields: Fields::default(),
             real_fields: vec![],
             type_: Value::Int32(0),
             default: None,
@@ -451,7 +452,6 @@ mod tests {
     #[test]
     fn test_coerce_string_with_on_failure_default() {
         let mut transform = Transform {
-            fields: Fields::default(),
             real_fields: vec![],
             type_: Value::Int32(0),
             default: None,

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -410,6 +410,7 @@ mod tests {
     fn test_coerce_string_without_on_failure() {
         let transform = Transform {
             fields: Fields::default(),
+            real_fields: vec![],
             type_: Value::Int32(0),
             default: None,
             index: None,
@@ -435,6 +436,7 @@ mod tests {
     fn test_coerce_string_with_on_failure_ignore() {
         let transform = Transform {
             fields: Fields::default(),
+            real_fields: vec![],
             type_: Value::Int32(0),
             default: None,
             index: None,
@@ -450,6 +452,7 @@ mod tests {
     fn test_coerce_string_with_on_failure_default() {
         let mut transform = Transform {
             fields: Fields::default(),
+            real_fields: vec![],
             type_: Value::Int32(0),
             default: None,
             index: None,

--- a/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
+++ b/src/pipeline/src/etl/transform/transformer/greptime/coerce.rs
@@ -134,7 +134,7 @@ fn coerce_type(transform: &Transform) -> Result<ColumnDataType, String> {
 
         Value::Null => Err(format!(
             "Null type not supported when to coerce '{}' type",
-            "123" // transform.fields
+            transform.type_.to_str_type()
         )),
     }
 }

--- a/src/pipeline/tests/common.rs
+++ b/src/pipeline/tests/common.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use greptime_proto::v1::{ColumnDataType, ColumnSchema, Rows, SemanticType};
-use pipeline::{parse, Content, GreptimeTransformer, Pipeline, Value};
+use pipeline::{parse, Content, GreptimeTransformer, Pipeline};
 
 /// test util function to parse and execute pipeline
 pub fn parse_and_exec(input_str: &str, pipeline_yaml: &str) -> Rows {

--- a/src/pipeline/tests/common.rs
+++ b/src/pipeline/tests/common.rs
@@ -17,16 +17,41 @@ use pipeline::{parse, Content, GreptimeTransformer, Pipeline, Value};
 
 /// test util function to parse and execute pipeline
 pub fn parse_and_exec(input_str: &str, pipeline_yaml: &str) -> Rows {
-    let input_value: Value = serde_json::from_str::<serde_json::Value>(input_str)
-        .expect("failed to parse into json")
-        .try_into()
-        .expect("failed to convert into value");
+    let input_value = serde_json::from_str::<serde_json::Value>(input_str).unwrap();
 
     let yaml_content = Content::Yaml(pipeline_yaml.into());
     let pipeline: Pipeline<GreptimeTransformer> =
         parse(&yaml_content).expect("failed to parse pipeline");
+    let mut result = pipeline.init_intermediate_state();
 
-    pipeline.exec(input_value).expect("failed to exec pipeline")
+    let schema = pipeline.schemas().clone();
+
+    let mut rows = Vec::new();
+
+    match input_value {
+        serde_json::Value::Array(array) => {
+            for value in array {
+                pipeline.prepare(value, &mut result).unwrap();
+                let row = pipeline
+                    .exec_mut(&mut result)
+                    .expect("failed to exec pipeline");
+                rows.push(row);
+                pipeline.reset_intermediate_state(&mut result);
+            }
+        }
+        serde_json::Value::Object(_) => {
+            pipeline.prepare(input_value, &mut result).unwrap();
+            let row = pipeline
+                .exec_mut(&mut result)
+                .expect("failed to exec pipeline");
+            rows.push(row);
+        }
+        _ => {
+            panic!("invalid input value");
+        }
+    }
+
+    Rows { schema, rows }
 }
 
 /// test util function to create column schema

--- a/src/pipeline/tests/dissect.rs
+++ b/src/pipeline/tests/dissect.rs
@@ -157,7 +157,7 @@ transform:
 fn test_modifier() {
     let empty_str = r#"
 {
-    "str": "key1 key2 key3 key4 key5       key6 key7 key8"
+    "str": "key1 key2 key3 key4 key5       key6"
 }"#;
 
     let pipeline_yaml = r#"
@@ -165,7 +165,7 @@ processors:
   - dissect:
       field: str
       patterns: 
-        - "%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6} %{*key_7} %{&key_7}"
+        - "%{key1} %{key2} %{+key3} %{+key3/2} %{key5->} %{?key6}"
 
 transform:
   - fields:
@@ -173,7 +173,6 @@ transform:
         - key2
         - key3
         - key5
-        - key7
     type: string
 "#;
 
@@ -184,7 +183,6 @@ transform:
         make_string_column_schema("key2".to_string()),
         make_string_column_schema("key3".to_string()),
         make_string_column_schema("key5".to_string()),
-        make_string_column_schema("key7".to_string()),
         common::make_column_schema(
             "greptime_timestamp".to_string(),
             ColumnDataType::TimestampNanosecond,
@@ -208,10 +206,6 @@ transform:
     assert_eq!(
         output.rows[0].values[3].value_data,
         Some(StringValue("key5".to_string()))
-    );
-    assert_eq!(
-        output.rows[0].values[4].value_data,
-        Some(StringValue("key8".to_string()))
     );
 }
 

--- a/src/pipeline/tests/pipeline.rs
+++ b/src/pipeline/tests/pipeline.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use api::v1::Rows;
 use common_telemetry::tracing::info;
 use greptime_proto::v1::value::ValueData::{
     BoolValue, F64Value, StringValue, TimestampNanosecondValue, TimestampSecondValue, U32Value,
     U64Value, U8Value,
 };
 use greptime_proto::v1::Value as GreptimeValue;
-use pipeline::{parse, Content, GreptimeTransformer, Pipeline, Value};
+use pipeline::{parse, Content, GreptimeTransformer, Pipeline};
 
 #[test]
 fn test_complex_data() {
     let input_value_str = r#"
-    [
       {
         "version": 1,
         "streamId": "12345",
@@ -73,12 +73,9 @@ fn test_complex_data() {
         "ewExecutionInfo": "c:4380:7:161:162:161:n:::12473:200|C:4380:3:0:4:0:n:::6967:200|R:4380:20:99:99:1:n:::35982:200",
         "customField": "any-custom-value"
       }
-    ]
 "#;
-    let input_value: Value = serde_json::from_str::<serde_json::Value>(input_value_str)
-        .expect("failed to parse input value")
-        .try_into()
-        .expect("failed to convert input value");
+    let input_value = serde_json::from_str::<serde_json::Value>(input_value_str)
+        .expect("failed to parse input value");
 
     let pipeline_yaml = r#"
 ---
@@ -422,7 +419,19 @@ transform:
     let yaml_content = Content::Yaml(pipeline_yaml.into());
     let pipeline: Pipeline<GreptimeTransformer> =
         parse(&yaml_content).expect("failed to parse pipeline");
-    let output = pipeline.exec(input_value).expect("failed to exec pipeline");
+    let mut stats = pipeline.init_intermediate_state();
+    pipeline
+        .prepare(input_value, &mut stats)
+        .expect("failed to prepare pipeline");
+
+    let row = pipeline
+        .exec_mut(&mut stats)
+        .expect("failed to exec pipeline");
+
+    let output = Rows {
+        schema: pipeline.schemas().clone(),
+        rows: vec![row],
+    };
 
     assert_eq!(output.rows.len(), 1);
     let values = output.rows.first().unwrap().values.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

* remove dissect reference keys. because the resulting key is uncertain, it can't be specified by transform; if it is certain, you can use name matching to get the specified key directly.
* make all processors modify the intermediate state of the vec format directly. optimizing performance
* use the builder to build all processors, making the processor build flow easier to understand.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [x] This PR requires documentation updates.
