### PR TITLE
fix(common_version): short_version with empty branch

### DIFF
--- a/src/cmd/src/lib.rs
+++ b/src/cmd/src/lib.rs
@@ -30,7 +30,7 @@ pub mod standalone;
 
 lazy_static::lazy_static! {
     static ref APP_VERSION: prometheus::IntGaugeVec =
-        prometheus::register_int_gauge_vec!("greptime_app_version", "app version", &["short_version", "version"]).unwrap();
+        prometheus::register_int_gauge_vec!("greptime_app_version", "app version", &["version", "short_version"]).unwrap();
 }
 
 #[async_trait]
@@ -74,16 +74,16 @@ pub trait App: Send {
 }
 
 /// Log the versions of the application, and the arguments passed to the cli.
-/// `version_string` should be the same as the output of cli "--version";
-/// and the `app_version` is the short version of the codes, often consist of git branch and commit.
-pub fn log_versions(version_string: &str, app_version: &str) {
+/// `version` should be the same as the output of cli "--version";
+/// and the `short_version` is the short version of the codes, often consist of git branch and commit.
+pub fn log_versions(version: &str, short_version: &str) {
     // Report app version as gauge.
     APP_VERSION
-        .with_label_values(&[env!("CARGO_PKG_VERSION"), app_version])
+        .with_label_values(&[env!("CARGO_PKG_VERSION"), short_version])
         .inc();
 
     // Log version and argument flags.
-    info!("GreptimeDB version: {}", version_string);
+    info!("GreptimeDB version: {}", version);
 
     log_env_flags();
 }

--- a/src/common/version/src/lib.rs
+++ b/src/common/version/src/lib.rs
@@ -125,5 +125,14 @@ pub const fn version() -> &'static str {
 }
 
 pub const fn short_version() -> &'static str {
-    const_format::formatcp!("{}-{}", BUILD_INFO.branch, BUILD_INFO.commit_short,)
+    const BRANCH: &str = BUILD_INFO.branch;
+    const COMMIT_ID: &str = BUILD_INFO.commit_short;
+
+    // When git checkout to a commit, the branch is empty.
+    #[allow(clippy::const_is_empty)]
+    if !BRANCH.is_empty() {
+        const_format::formatcp!("{}-{}", BRANCH, COMMIT_ID)
+    } else {
+        COMMIT_ID
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/issues/4533

## What's changed and what's your intention?

1. Fix `short_version` function to handle empty branch.
2. Fix incorrect assignment between variables `version` and `short_version`.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.