### PR TITLE
feat: fine-grained page cache for row groups

### DIFF
--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -218,7 +218,7 @@ mod tests {
 
         // Cache 4 row groups.
         for i in 0..4 {
-            let page_key = PageKey {
+            let page_key = PageKey::Compressed {
                 region_id: metadata.region_id,
                 file_id: handle.file_id(),
                 row_group_idx: i,
@@ -226,7 +226,7 @@ mod tests {
             };
             assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
         }
-        let page_key = PageKey {
+        let page_key = PageKey::Compressed {
             region_id: metadata.region_id,
             file_id: handle.file_id(),
             row_group_idx: 5,

--- a/src/mito2/src/sst/parquet/page_reader.rs
+++ b/src/mito2/src/sst/parquet/page_reader.rs
@@ -133,31 +133,3 @@ impl Iterator for CachedPageReader {
         self.get_next_page().transpose()
     }
 }
-
-/// Get [PageMetadata] from `page`.
-///
-/// The conversion is based on [decode_page()](https://github.com/apache/arrow-rs/blob/1d6feeacebb8d0d659d493b783ba381940973745/parquet/src/file/serialized_reader.rs#L438-L481)
-/// and [PageMetadata](https://github.com/apache/arrow-rs/blob/65f7be856099d389b0d0eafa9be47fad25215ee6/parquet/src/column/page.rs#L279-L301).
-fn page_to_page_meta(page: &Page) -> PageMetadata {
-    match page {
-        Page::DataPage { num_values, .. } => PageMetadata {
-            num_rows: None,
-            num_levels: Some(*num_values as usize),
-            is_dict: false,
-        },
-        Page::DataPageV2 {
-            num_values,
-            num_rows,
-            ..
-        } => PageMetadata {
-            num_rows: Some(*num_rows as usize),
-            num_levels: Some(*num_values as usize),
-            is_dict: false,
-        },
-        Page::DictionaryPage { .. } => PageMetadata {
-            num_rows: None,
-            num_levels: None,
-            is_dict: true,
-        },
-    }
-}


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/2805

## What's changed and what's your intention?

This PR changes the page cache from row group level to page level:
- It also caches the compressed range as we need it to decompress pages in the row group
- It only caches uncompressed pages in a row group on demand

This can reduce memory consumption when a row group contains more than one page.

Limitation:
- It needs to cache the compressed page.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
