### PR TITLE
feat: print frame ip in panic hook

### DIFF
--- a/src/common/telemetry/src/panic_hook.rs
+++ b/src/common/telemetry/src/panic_hook.rs
@@ -35,7 +35,8 @@ pub fn set_panic_hook() {
     let default_hook = panic::take_hook();
     panic::set_hook(Box::new(move |panic| {
         let backtrace = Backtrace::new();
-        let backtrace = format!("{backtrace:?}");
+        // Use alternative format to print the frame instruction pointer.
+        let backtrace = format!("{backtrace:#?}");
         if let Some(location) = panic.location() {
             tracing::error!(
                 message = %panic,


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

The default debug format of the backtrace doesn't print the instruction pointer.
https://github.com/rust-lang/backtrace-rs/blob/fd0aed536dd9d6ad1511a4ab3c350409f36ee52a/src/print.rs#L241-L243

https://github.com/rust-lang/backtrace-rs/blob/fd0aed536dd9d6ad1511a4ab3c350409f36ee52a/src/capture.rs#L481-L485

This PR uses the alternative format to print the backtrace so we can still get the address from the log when `strip = true`.

Before this PR:
```
assertion failed: region.region_id != self.region_id backtrace=   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <unknown>
  19: <unknown>
  20: start_thread
             at ./nptl/pthread_create.c:442:8
  21: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

After this PR:
```
assertion failed: region.region_id != self.region_id backtrace=   0:     0x557ca6aab07d - <unknown>
   1:     0x557ca71ce706 - <unknown>
   2:     0x557ca71ce47b - <unknown>
   3:     0x557ca71cd1d9 - <unknown>
   4:     0x557ca71ce1e7 - <unknown>
   5:     0x557c9f303623 - <unknown>
   6:     0x557c9f3036cc - <unknown>
   7:     0x557c9f57ca84 - <unknown>
   8:     0x557c9f585e77 - <unknown>
   9:     0x557c9f5c76af - <unknown>
  10:     0x557c9fa62931 - <unknown>
  11:     0x557ca70cc78a - <unknown>
  12:     0x557ca70cba5a - <unknown>
  13:     0x557ca70d8400 - <unknown>
  14:     0x557ca70caf28 - <unknown>
  15:     0x557ca70c319a - <unknown>
  16:     0x557ca70d45d2 - <unknown>
  17:     0x557ca70e1913 - <unknown>
  18:     0x557ca70c0ed2 - <unknown>
  19:     0x557ca71d566b - <unknown>
  20:     0x7f3d0afd7ac3 - start_thread
                               at ./nptl/pthread_create.c:442:8
  21:     0x7f3d0b069850 - __GI___clone3
                               at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
  22:                0x0 - <unknown>
```

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
