### PR TITLE
chore: bump version to v0.9.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "api"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "common-base",
  "common-decimal",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "auth"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "cache"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "catalog",
  "common-error",
@@ -1285,7 +1285,7 @@ dependencies = [
  "common-meta",
  "moka",
  "snafu 0.8.4",
- "substrait 0.9.1",
+ "substrait 0.9.2",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arrow",
@@ -1638,7 +1638,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1668,7 +1668,7 @@ dependencies = [
  "serde_json",
  "snafu 0.8.4",
  "substrait 0.37.3",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "auth",
@@ -1754,7 +1754,7 @@ dependencies = [
  "session",
  "snafu 0.8.4",
  "store-api",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "temp-env",
  "tempfile",
@@ -1800,7 +1800,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
 name = "common-base"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anymap",
  "bitvec",
@@ -1816,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "common-catalog"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "common-error",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "common-config"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "common-datasource"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "common-decimal"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bigdecimal",
  "common-error",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "common-error"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "snafu 0.8.4",
  "strum 0.25.0",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "common-frontend"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "common-function"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -1958,7 +1958,7 @@ dependencies = [
 
 [[package]]
 name = "common-greptimedb-telemetry"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "common-runtime",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "common-grpc-expr"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "common-base",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "common-macro"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "common-query",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "common-mem-prof"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "common-error",
  "common-macro",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "common-meta"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anymap2",
  "api",
@@ -2102,11 +2102,11 @@ dependencies = [
 
 [[package]]
 name = "common-plugins"
-version = "0.9.1"
+version = "0.9.2"
 
 [[package]]
 name = "common-procedure"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "common-procedure-test"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "common-procedure",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "common-query"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "common-recordbatch"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "common-error",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "common-runtime"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "common-error",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "common-telemetry"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "atty",
  "backtrace",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "common-test-util"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "client",
  "common-query",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "common-time"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "common-version"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "build-data",
  "const_format",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "common-wal"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "common-base",
  "common-error",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "datanode"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -3130,7 +3130,7 @@ dependencies = [
  "session",
  "snafu 0.8.4",
  "store-api",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "tokio",
  "toml 0.8.14",
@@ -3139,7 +3139,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "file-engine"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "flow"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
  "snafu 0.8.4",
  "store-api",
  "strum 0.25.0",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "tokio",
  "tonic 0.11.0",
@@ -3900,7 +3900,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frontend"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "index"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -5791,7 +5791,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "log-store"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6100,7 +6100,7 @@ dependencies = [
 
 [[package]]
 name = "meta-client"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6126,7 +6126,7 @@ dependencies = [
 
 [[package]]
 name = "meta-srv"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -6204,7 +6204,7 @@ dependencies = [
 
 [[package]]
 name = "metric-engine"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -6295,7 +6295,7 @@ dependencies = [
 
 [[package]]
 name = "mito2"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "object-store"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7189,7 +7189,7 @@ dependencies = [
 
 [[package]]
 name = "operator"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -7234,7 +7234,7 @@ dependencies = [
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",
  "store-api",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "tokio",
  "tokio-util",
@@ -7484,7 +7484,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -7773,7 +7773,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pipeline"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -7934,7 +7934,7 @@ dependencies = [
 
 [[package]]
 name = "plugins"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "auth",
  "common-base",
@@ -8203,7 +8203,7 @@ dependencies = [
 
 [[package]]
 name = "promql"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash 0.8.11",
  "async-trait",
@@ -8438,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-compression 0.4.11",
  "async-trait",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "query"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash 0.8.11",
  "api",
@@ -8623,7 +8623,7 @@ dependencies = [
  "stats-cli",
  "store-api",
  "streaming-stats",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "tokio",
  "tokio-stream",
@@ -9986,7 +9986,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "script"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -10280,7 +10280,7 @@ dependencies = [
 
 [[package]]
 name = "servers"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "aide",
  "api",
@@ -10386,7 +10386,7 @@ dependencies = [
 
 [[package]]
 name = "session"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arc-swap",
@@ -10687,7 +10687,7 @@ dependencies = [
 
 [[package]]
 name = "sql"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "chrono",
@@ -10747,7 +10747,7 @@ dependencies = [
 
 [[package]]
 name = "sqlness-runner"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "clap 4.5.7",
@@ -10964,7 +10964,7 @@ dependencies = [
 
 [[package]]
 name = "store-api"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "aquamarine",
@@ -11133,7 +11133,7 @@ dependencies = [
 
 [[package]]
 name = "substrait"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11334,7 +11334,7 @@ dependencies = [
 
 [[package]]
 name = "table"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "async-trait",
@@ -11599,7 +11599,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tests-fuzz"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arbitrary",
  "async-trait",
@@ -11641,7 +11641,7 @@ dependencies = [
 
 [[package]]
 name = "tests-integration"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "api",
  "arrow-flight",
@@ -11701,7 +11701,7 @@ dependencies = [
  "sql",
  "sqlx",
  "store-api",
- "substrait 0.9.1",
+ "substrait 0.9.2",
  "table",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4575 

## What's changed and what's your intention?

Prepare to release v0.9.2

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
