### PR TITLE
fix(sqlness): redact all volatile text

### DIFF
--- a/tests/cases/distributed/explain/analyze_append_table_count.result
+++ b/tests/cases/distributed/explain/analyze_append_table_count.result
@@ -18,17 +18,21 @@ WITH(
 Affected Rows: 0
 
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT count(*) FROM test_table;
 
-+-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| stage | node | plan                                                                                                                                                                               |
-+-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 0     | 0    |  MergeScanExec: REDACTED
-|       |      |                                                                                                                                                                                    |
-| 1     | 0    |  ProjectionExec: expr=[0 as COUNT(test_table.timestamp)] REDACTED
-|       |      |   common_recordbatch::adapter::MetricCollector REDACTED
-|       |      |                                                                                                                                                                                    |
-|       |      | Total rows: 1                                                                                                                                                                      |
-+-------+------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-+-+-+
+| stage | node | plan_|
++-+-+-+
+| 0_| 0_|_MergeScanExec: REDACTED
+|_|_|_|
+| 1_| 0_|_ProjectionExec: expr=[0 as COUNT(test_table.timestamp)] REDACTED
+|_|_|_common_recordbatch::adapter::MetricCollector REDACTED
+|_|_|_|
+|_|_| Total rows: 1_|
++-+-+-+
 

--- a/tests/cases/distributed/explain/analyze_append_table_count.sql
+++ b/tests/cases/distributed/explain/analyze_append_table_count.sql
@@ -17,5 +17,9 @@ WITH(
 );
 
 -- SQLNESS REPLACE (metrics.*) REDACTED
+-- SQLNESS REPLACE (RoundRobinBatch.*) REDACTED
+-- SQLNESS REPLACE (-+) -
+-- SQLNESS REPLACE (\s\s+) _
 -- SQLNESS REPLACE (peers.*) REDACTED
+-- SQLNESS REPLACE region=\d+\(\d+,\s+\d+\) region=REDACTED
 EXPLAIN ANALYZE SELECT count(*) FROM test_table;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
- closes #4584

## What's changed and what's your intention?
Add SQLNESS replacements for RoundRobinBatch and region patterns etc.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
