### PR TITLE
feat: remove sql in error desc

### DIFF
--- a/src/sql/src/error.rs
+++ b/src/sql/src/error.rs
@@ -38,21 +38,25 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[snafu(visibility(pub))]
 #[stack_trace_debug]
 pub enum Error {
-    #[snafu(display("SQL statement is not supported: {}, keyword: {}", sql, keyword))]
-    Unsupported { sql: String, keyword: String },
+    #[snafu(display("SQL statement is not supported, keyword: {}", keyword))]
+    Unsupported {
+        keyword: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display(
-        "Unexpected token while parsing SQL statement: {}, expected: '{}', found: {}",
-        sql,
+        "Unexpected token while parsing SQL statement, expected: '{}', found: {}",
         expected,
         actual,
     ))]
     Unexpected {
-        sql: String,
         expected: String,
         actual: String,
         #[snafu(source)]
         error: ParserError,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display(
@@ -60,7 +64,12 @@ pub enum Error {
         expr,
         column_name
     ))]
-    UnsupportedDefaultValue { column_name: String, expr: Expr },
+    UnsupportedDefaultValue {
+        column_name: String,
+        expr: Expr,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     // Syntax error from sql parser.
     #[snafu(display(""))]
@@ -84,31 +93,52 @@ pub enum Error {
     MissingTimeIndex {},
 
     #[snafu(display("Invalid time index: {}", msg))]
-    InvalidTimeIndex { msg: String },
+    InvalidTimeIndex {
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Invalid SQL, error: {}", msg))]
-    InvalidSql { msg: String },
+    InvalidSql {
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display(
-        "Unexpected token while parsing SQL statement: {}, expected: '{}', found: {}",
-        sql,
+        "Unexpected token while parsing SQL statement, expected: '{}', found: {}",
         expected,
         actual,
     ))]
     UnexpectedToken {
-        sql: String,
         expected: String,
         actual: String,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Invalid column option, column name: {}, error: {}", name, msg))]
-    InvalidColumnOption { name: String, msg: String },
+    InvalidColumnOption {
+        name: String,
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("SQL data type not supported yet: {:?}", t))]
-    SqlTypeNotSupported { t: crate::ast::DataType },
+    SqlTypeNotSupported {
+        t: crate::ast::DataType,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Failed to parse value: {}", msg))]
-    ParseSqlValue { msg: String },
+    ParseSqlValue {
+        msg: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display(
         "Column {} expect type: {:?}, actual: {:?}",
@@ -120,10 +150,16 @@ pub enum Error {
         column_name: String,
         expect: ConcreteDataType,
         actual: ConcreteDataType,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Invalid database name: {}", name))]
-    InvalidDatabaseName { name: String },
+    InvalidDatabaseName {
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Invalid interval provided: {}", reason))]
     InvalidInterval {
@@ -140,10 +176,18 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid table name: {}", name))]
-    InvalidTableName { name: String },
+    InvalidTableName {
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Invalid flow name: {}", name))]
-    InvalidFlowName { name: String },
+    InvalidFlowName {
+        name: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display("Invalid default constraint, column: {}", column))]
     InvalidDefault {
@@ -207,7 +251,11 @@ pub enum Error {
     },
 
     #[snafu(display("Invalid sql value: {}", value))]
-    InvalidSqlValue { value: String },
+    InvalidSqlValue {
+        value: String,
+        #[snafu(implicit)]
+        location: Location,
+    },
 
     #[snafu(display(
         "Converting timestamp {:?} to unit {:?} overflow",
@@ -217,6 +265,8 @@ pub enum Error {
     TimestampOverflow {
         timestamp: Timestamp,
         target_unit: TimeUnit,
+        #[snafu(implicit)]
+        location: Location,
     },
 
     #[snafu(display("Unable to convert statement {} to DataFusion statement", statement))]

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -100,7 +100,6 @@ impl<'a> ParserContext<'a> {
             self.parser
                 .parse_object_name(false)
                 .context(error::UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "a table name",
                     actual: self.parser.peek_token().to_string(),
                 })?;
@@ -171,7 +170,6 @@ impl<'a> ParserContext<'a> {
 
                         let database_name = self.parser.parse_identifier(false).context(
                             error::UnexpectedSnafu {
-                                sql: self.sql,
                                 expected: "a database name",
                                 actual: self.peek_token_as_string(),
                             },
@@ -213,11 +211,7 @@ impl<'a> ParserContext<'a> {
 
     /// Raises an "unsupported statement" error.
     pub fn unsupported<T>(&self, keyword: String) -> Result<T> {
-        error::UnsupportedSnafu {
-            sql: self.sql,
-            keyword,
-        }
-        .fail()
+        error::UnsupportedSnafu { keyword }.fail()
     }
 
     // Report unexpected token

--- a/src/sql/src/parsers/copy_parser.rs
+++ b/src/sql/src/parsers/copy_parser.rs
@@ -50,7 +50,6 @@ impl<'a> ParserContext<'a> {
         let database_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a database name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -98,7 +97,6 @@ impl<'a> ParserContext<'a> {
         let raw_table_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a table name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -133,7 +131,6 @@ impl<'a> ParserContext<'a> {
             self.parser
                 .parse_literal_string()
                 .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "a file name",
                     actual: self.peek_token_as_string(),
                 })?;
@@ -163,7 +160,6 @@ impl<'a> ParserContext<'a> {
                 self.parser
                     .parse_literal_uint()
                     .with_context(|_| error::UnexpectedSnafu {
-                        sql: self.sql,
                         expected: "the number of maximum rows",
                         actual: self.peek_token_as_string(),
                     })?,

--- a/src/sql/src/parsers/create_parser.rs
+++ b/src/sql/src/parsers/create_parser.rs
@@ -193,7 +193,6 @@ impl<'a> ParserContext<'a> {
         let _ = self.parser.next_token();
         let if_not_exists = self.parse_if_not_exist()?;
         let database_name = self.parse_object_name().context(error::UnexpectedSnafu {
-            sql: self.sql,
             expected: "a database name",
             actual: self.peek_token_as_string(),
         })?;
@@ -350,18 +349,13 @@ impl<'a> ParserContext<'a> {
                 .expect_keyword(Keyword::EXISTS)
                 .map(|_| true)
                 .context(UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "EXISTS",
                     actual: self.peek_token_as_string(),
                 });
         }
 
         if self.parser.parse_keywords(&[Keyword::IF, Keyword::EXISTS]) {
-            return UnsupportedSnafu {
-                sql: self.sql,
-                keyword: "EXISTS",
-            }
-            .fail();
+            return UnsupportedSnafu { keyword: "EXISTS" }.fail();
         }
 
         Ok(false)
@@ -394,7 +388,6 @@ impl<'a> ParserContext<'a> {
         self.parser
             .expect_keywords(&[Keyword::ON, Keyword::COLUMNS])
             .context(error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "ON, COLUMNS",
                 actual: self.peek_token_as_string(),
             })?;
@@ -425,7 +418,6 @@ impl<'a> ParserContext<'a> {
         self.parser
             .expect_token(&Token::LParen)
             .context(error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "(",
                 actual: self.peek_token_as_string(),
             })?;
@@ -441,7 +433,6 @@ impl<'a> ParserContext<'a> {
         self.parser
             .expect_token(&Token::RParen)
             .context(error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: ")",
                 actual: self.peek_token_as_string(),
             })?;
@@ -758,7 +749,6 @@ impl<'a> ParserContext<'a> {
                 self.parser
                     .expect_keyword(Keyword::KEY)
                     .context(error::UnexpectedSnafu {
-                        sql: self.sql,
                         expected: "KEY",
                         actual: self.peek_token_as_string(),
                     })?;
@@ -786,7 +776,6 @@ impl<'a> ParserContext<'a> {
                 self.parser
                     .expect_keyword(Keyword::INDEX)
                     .context(error::UnexpectedSnafu {
-                        sql: self.sql,
                         expected: "INDEX",
                         actual: self.peek_token_as_string(),
                     })?;
@@ -842,7 +831,6 @@ impl<'a> ParserContext<'a> {
         self.parser
             .expect_token(&Token::Eq)
             .context(error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "=",
                 actual: self.peek_token_as_string(),
             })?;

--- a/src/sql/src/parsers/delete_parser.rs
+++ b/src/sql/src/parsers/delete_parser.rs
@@ -31,7 +31,6 @@ impl<'a> ParserContext<'a> {
                 Ok(Statement::Delete(Box::new(Delete { inner: spstatement })))
             }
             unexp => error::UnsupportedSnafu {
-                sql: self.sql.to_string(),
                 keyword: unexp.to_string(),
             }
             .fail(),

--- a/src/sql/src/parsers/describe_parser.rs
+++ b/src/sql/src/parsers/describe_parser.rs
@@ -33,7 +33,6 @@ impl<'a> ParserContext<'a> {
         let raw_table_idents =
             self.parse_object_name()
                 .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "a table name",
                     actual: self.peek_token_as_string(),
                 })?;

--- a/src/sql/src/parsers/drop_parser.rs
+++ b/src/sql/src/parsers/drop_parser.rs
@@ -50,7 +50,6 @@ impl<'a> ParserContext<'a> {
         let raw_view_ident = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a view name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -75,7 +74,6 @@ impl<'a> ParserContext<'a> {
         let raw_flow_ident = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a flow name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -99,7 +97,6 @@ impl<'a> ParserContext<'a> {
             let raw_table_ident =
                 self.parse_object_name()
                     .with_context(|_| error::UnexpectedSnafu {
-                        sql: self.sql,
                         expected: "a table name",
                         actual: self.peek_token_as_string(),
                     })?;
@@ -126,7 +123,6 @@ impl<'a> ParserContext<'a> {
         let database_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a database name",
                 actual: self.peek_token_as_string(),
             })?;

--- a/src/sql/src/parsers/explain_parser.rs
+++ b/src/sql/src/parsers/explain_parser.rs
@@ -27,7 +27,6 @@ impl<'a> ParserContext<'a> {
             .parser
             .parse_explain(DescribeAlias::Explain)
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a query statement",
                 actual: self.peek_token_as_string(),
             })?;

--- a/src/sql/src/parsers/insert_parser.rs
+++ b/src/sql/src/parsers/insert_parser.rs
@@ -31,7 +31,6 @@ impl<'a> ParserContext<'a> {
                 Ok(Statement::Insert(Box::new(Insert { inner: spstatement })))
             }
             unexp => error::UnsupportedSnafu {
-                sql: self.sql.to_string(),
                 keyword: unexp.to_string(),
             }
             .fail(),

--- a/src/sql/src/parsers/set_var_parser.rs
+++ b/src/sql/src/parsers/set_var_parser.rs
@@ -43,7 +43,6 @@ impl<'a> ParserContext<'a> {
             })),
 
             unexp => error::UnsupportedSnafu {
-                sql: self.sql.to_string(),
                 keyword: unexp.to_string(),
             }
             .fail(),

--- a/src/sql/src/parsers/show_parser.rs
+++ b/src/sql/src/parsers/show_parser.rs
@@ -98,7 +98,6 @@ impl<'a> ParserContext<'a> {
             let variable = self
                 .parse_object_name()
                 .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "a variable name",
                     actual: self.peek_token_as_string(),
                 })?;
@@ -115,7 +114,6 @@ impl<'a> ParserContext<'a> {
         let raw_table_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a table name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -133,7 +131,6 @@ impl<'a> ParserContext<'a> {
         let raw_flow_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a flow name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -151,7 +148,6 @@ impl<'a> ParserContext<'a> {
         let raw_view_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a view name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -170,7 +166,6 @@ impl<'a> ParserContext<'a> {
         let table_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a table name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -193,7 +188,6 @@ impl<'a> ParserContext<'a> {
         let db_name = self
             .parse_object_name()
             .with_context(|_| error::UnexpectedSnafu {
-                sql: self.sql,
                 expected: "a database name",
                 actual: self.peek_token_as_string(),
             })?;
@@ -219,7 +213,6 @@ impl<'a> ParserContext<'a> {
             }
             _ => {
                 return error::UnexpectedTokenSnafu {
-                    sql: self.sql,
                     expected: "{FROM | IN} table",
                     actual: self.peek_token_as_string(),
                 }
@@ -264,7 +257,6 @@ impl<'a> ParserContext<'a> {
                     self.parser.next_token();
                     Ok(ShowKind::Like(self.parse_identifier().with_context(
                         |_| error::UnexpectedSnafu {
-                            sql: self.sql,
                             expected: "LIKE",
                             actual: self.peek_token_as_string(),
                         },
@@ -274,7 +266,6 @@ impl<'a> ParserContext<'a> {
                     self.parser.next_token();
                     Ok(ShowKind::Where(self.parser.parse_expr().with_context(
                         |_| error::UnexpectedSnafu {
-                            sql: self.sql,
                             expected: "some valid expression",
                             actual: self.peek_token_as_string(),
                         },
@@ -294,7 +285,6 @@ impl<'a> ParserContext<'a> {
             }
             _ => {
                 return error::UnexpectedTokenSnafu {
-                    sql: self.sql,
                     expected: "{FROM | IN} table",
                     actual: self.peek_token_as_string(),
                 }
@@ -328,7 +318,6 @@ impl<'a> ParserContext<'a> {
                     self.parser.next_token();
                     ShowKind::Where(self.parser.parse_expr().with_context(|_| {
                         error::UnexpectedSnafu {
-                            sql: self.sql,
                             expected: "some valid expression",
                             actual: self.peek_token_as_string(),
                         }
@@ -412,7 +401,6 @@ impl<'a> ParserContext<'a> {
                 Keyword::LIKE => Ok(Statement::ShowDatabases(ShowDatabases::new(
                     ShowKind::Like(self.parse_identifier().with_context(|_| {
                         error::UnexpectedSnafu {
-                            sql: self.sql,
                             expected: "LIKE",
                             actual: tok.to_string(),
                         }
@@ -422,7 +410,6 @@ impl<'a> ParserContext<'a> {
                 Keyword::WHERE => Ok(Statement::ShowDatabases(ShowDatabases::new(
                     ShowKind::Where(self.parser.parse_expr().with_context(|_| {
                         error::UnexpectedSnafu {
-                            sql: self.sql,
                             expected: "some valid expression",
                             actual: self.peek_token_as_string(),
                         }
@@ -766,7 +753,7 @@ mod tests {
         let result =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let error = result.unwrap_err();
-        assert_eq!("Unexpected token while parsing SQL statement: SHOW COLUMNS, expected: '{FROM | IN} table', found: EOF", error.to_string());
+        assert_eq!("Unexpected token while parsing SQL statement, expected: '{FROM | IN} table', found: EOF", error.to_string());
 
         let sql = "SHOW COLUMNS from test";
         let result =
@@ -826,7 +813,7 @@ mod tests {
         let result =
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let error = result.unwrap_err();
-        assert_eq!("Unexpected token while parsing SQL statement: SHOW INDEX, expected: '{FROM | IN} table', found: EOF", error.to_string());
+        assert_eq!("Unexpected token while parsing SQL statement, expected: '{FROM | IN} table', found: EOF", error.to_string());
 
         let sql = "SHOW INDEX from test";
         let result =
@@ -859,7 +846,7 @@ mod tests {
             ParserContext::create_with_dialect(sql, &GreptimeDbDialect {}, ParseOptions::default());
         let error = result.unwrap_err();
         assert_eq!(
-            "SQL statement is not supported: SHOW INDEX from test like 'disk%', keyword: like",
+            "SQL statement is not supported, keyword: like",
             error.to_string()
         );
 

--- a/src/sql/src/parsers/truncate_parser.rs
+++ b/src/sql/src/parsers/truncate_parser.rs
@@ -29,7 +29,6 @@ impl<'a> ParserContext<'a> {
         let raw_table_ident =
             self.parse_object_name()
                 .with_context(|_| error::UnexpectedSnafu {
-                    sql: self.sql,
                     expected: "a table name",
                     actual: self.peek_token_as_string(),
                 })?;

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -817,7 +817,7 @@ mod tests {
         assert!(v.is_err());
         assert!(
             format!("{v:?}").contains(
-                "Column a expect type: Float64(Float64Type), actual: Boolean(BooleanType))"
+                "Column a expect type: Float64(Float64Type), actual: Boolean(BooleanType)"
             ),
             "v is {v:?}",
         );

--- a/tests/cases/standalone/common/alter/alter_table_first_after.result
+++ b/tests/cases/standalone/common/alter/alter_table_first_after.result
@@ -168,7 +168,7 @@ SELECT * FROM t;
 
 ALTER TABLE t ADD COLUMN x int xxx;
 
-Error: 1001(Unsupported), SQL statement is not supported: ALTER TABLE t ADD COLUMN x int xxx;, keyword: xxx
+Error: 1001(Unsupported), SQL statement is not supported, keyword: xxx
 
 DROP TABLE t;
 

--- a/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
+++ b/tests/cases/standalone/common/copy/copy_from_fs_parquet.result
@@ -121,7 +121,7 @@ select count(*) from with_limit_rows_segment;
 
 Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT hello;
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: Copy with_limit_rows_segment FROM '/tmp/demo/export/parquet_files/' LIMIT hello;, expected: 'the number of maximum rows', found: ;: sql parser error: Expected literal int, found: hello at Line: 1, Column 75
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: 'the number of maximum rows', found: ;: sql parser error: Expected literal int, found: hello at Line: 1, Column 75
 
 drop table demo;
 

--- a/tests/cases/standalone/common/create/create_database.result
+++ b/tests/cases/standalone/common/create/create_database.result
@@ -4,7 +4,7 @@ Error: 1002(Unexpected), Unexpected, violated: Invalid database name: ㊙️data
 
 create database illegal-database;
 
-Error: 1001(Unsupported), SQL statement is not supported: create database illegal-database;, keyword: -
+Error: 1001(Unsupported), SQL statement is not supported, keyword: -
 
 create database 'illegal-database';
 

--- a/tests/cases/standalone/common/create/create_if_not_exists.result
+++ b/tests/cases/standalone/common/create/create_if_not_exists.result
@@ -1,14 +1,14 @@
 CREATE TABLE IF NOT EXIST t();
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: CREATE TABLE IF NOT EXIST t();, expected: 'EXISTS', found: EXIST: sql parser error: Expected EXISTS, found: EXIST at Line: 1, Column 21
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: 'EXISTS', found: EXIST: sql parser error: Expected EXISTS, found: EXIST at Line: 1, Column 21
 
 CREATE TABLE IF NOT t();
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: CREATE TABLE IF NOT t();, expected: 'EXISTS', found: t: sql parser error: Expected EXISTS, found: t at Line: 1, Column 21
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: 'EXISTS', found: t: sql parser error: Expected EXISTS, found: t at Line: 1, Column 21
 
 CREATE TABLE IF EXISTS t();
 
-Error: 1001(Unsupported), SQL statement is not supported: CREATE TABLE IF EXISTS t();, keyword: EXISTS
+Error: 1001(Unsupported), SQL statement is not supported, keyword: EXISTS
 
 CREATE TABLE IF NOT EXISTS t();
 

--- a/tests/cases/standalone/common/show/show_columns.result
+++ b/tests/cases/standalone/common/show/show_columns.result
@@ -13,7 +13,7 @@ Affected Rows: 0
 
 SHOW COLUMNS;
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: SHOW COLUMNS;, expected: '{FROM | IN} table', found: ;
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: '{FROM | IN} table', found: ;
 
 SHOW COLUMNS FROM system_metrics;
 

--- a/tests/cases/standalone/common/show/show_index.result
+++ b/tests/cases/standalone/common/show/show_index.result
@@ -24,7 +24,7 @@ Affected Rows: 0
 
 SHOW INDEX;
 
-Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement: SHOW INDEX;, expected: '{FROM | IN} table', found: ;
+Error: 2000(InvalidSyntax), Unexpected token while parsing SQL statement, expected: '{FROM | IN} table', found: ;
 
 SHOW INDEX FROM test;
 
@@ -58,7 +58,7 @@ SHOW INDEX FROM system_metrics in public;
 
 SHOW INDEX FROM system_metrics like '%util%';
 
-Error: 1001(Unsupported), SQL statement is not supported: SHOW INDEX FROM system_metrics like '%util%';, keyword: like
+Error: 1001(Unsupported), SQL statement is not supported, keyword: like
 
 SHOW INDEX FROM system_metrics WHERE Key_name = 'TIME INDEX';
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Don't repeat query SQL in error message.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
