### PR TITLE
refactor(mito2): reduce duplicate IndexOutput struct

### DIFF
--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -52,9 +52,9 @@ pub struct IndexOutput {
     pub fulltext_index: FulltextIndexOutput,
 }
 
-/// Output of the inverted index creation.
+/// Base output of the index creation.
 #[derive(Debug, Clone, Default)]
-pub struct InvertedIndexOutput {
+pub struct IndexBaseOutput {
     /// Size of the index.
     pub index_size: ByteCount,
     /// Number of rows in the index.
@@ -63,28 +63,14 @@ pub struct InvertedIndexOutput {
     pub columns: Vec<ColumnId>,
 }
 
-/// Output of the fulltext index creation.
-#[derive(Debug, Clone, Default)]
-pub struct FulltextIndexOutput {
-    /// Size of the index.
-    pub index_size: ByteCount,
-    /// Number of rows in the index.
-    pub row_count: RowCount,
-    /// Available columns in the index.
-    pub columns: Vec<ColumnId>,
-}
-
-impl InvertedIndexOutput {
+impl IndexBaseOutput {
     pub fn is_available(&self) -> bool {
         self.index_size > 0
     }
 }
 
-impl FulltextIndexOutput {
-    pub fn is_available(&self) -> bool {
-        self.index_size > 0
-    }
-}
+pub type InvertedIndexOutput = IndexBaseOutput;
+pub type FulltextIndexOutput = IndexBaseOutput;
 
 /// The index creator that hides the error handling details.
 #[derive(Default)]

--- a/src/mito2/src/sst/index.rs
+++ b/src/mito2/src/sst/index.rs
@@ -69,7 +69,9 @@ impl IndexBaseOutput {
     }
 }
 
+/// Output of the inverted index creation.
 pub type InvertedIndexOutput = IndexBaseOutput;
+/// Output of the fulltext index creation.
 pub type FulltextIndexOutput = IndexBaseOutput;
 
 /// The index creator that hides the error handling details.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

https://github.com/GreptimeTeam/greptimedb/issues/4586

## What's changed and what's your intention?
- Reduce duplicate `IndexOutput` struct.
- Type `IndexBaseOutput` to `InvertedIndexOutput` and `FulltextIndexOutput`.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
