### PR TITLE
refactor: skip checking the existence of the SST files 

### DIFF
--- a/src/mito2/src/access_layer.rs
+++ b/src/mito2/src/access_layer.rs
@@ -175,14 +175,6 @@ impl AccessLayer {
 
         Ok(sst_info)
     }
-    /// Returns whether the file exists in the object store.
-    pub(crate) async fn is_exist(&self, file_meta: &FileMeta) -> Result<bool> {
-        let path = location::sst_file_path(&self.region_dir, file_meta.file_id);
-        self.object_store
-            .is_exist(&path)
-            .await
-            .context(OpenDalSnafu)
-    }
 }
 
 /// `OperationType` represents the origin of the `SstWriteRequest`.


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Mainly to lift out an expensive object store read when editing region directly.

By calling region edit from outside, greptimedb fully trust the caller. (Or put it in another way, the guarantee of the manifest correctness is not within the greptimedb itself.) An existence check of the SST files is **less important than** the latency of the interface.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
