### PR TITLE
fix: build in asahi linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[target.aarch64-unknown-linux-gnu]
-linker = "aarch64-linux-gnu-gcc"
-
 [alias]
 sqlness = "run --bin sqlness-runner --"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
I recently had some problems compiling greptimedb on an [asahi linux](https://asahilinux.org/) platform.

The error reported is as follows:
```
error: linker `aarch64-linux-gnu-gcc` not found
  |
  = note: No such file or directory (os error 2)
```

After investigation, found that linker was specified in [cargo's configuration]( https://github.com/GreptimeTeam/greptimedb/blob/main/.cargo/config.toml#L1-L2).

If not cross-compiling, it seems that we don't need to specify a linker.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
