### PR TITLE
fix: incremental compilation always compile the common-version crate 

### DIFF
--- a/src/common/version/build.rs
+++ b/src/common/version/build.rs
@@ -19,7 +19,7 @@ use build_data::{format_timestamp, get_source_time};
 use shadow_rs::{CARGO_METADATA, CARGO_TREE};
 
 fn main() -> shadow_rs::SdResult<()> {
-    println!("cargo:rerun-if-changed=.git/refs/heads");
+    println!("cargo:rerun-if-changed=../../../.git/refs/heads");
     println!(
         "cargo:rustc-env=SOURCE_TIMESTAMP={}",
         if let Ok(t) = get_source_time() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

I found a problem:
Each incremental build compiles the common-version crate and its dependent crates.

This causes each incremental build to take a very long time and puts pressure on my limited disk space.




## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
