### PR TITLE
chore: bump rust toolchain to 2024-06-06

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -13,7 +13,7 @@ on:
 name: Build API docs
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-07
+  RUST_TOOLCHAIN: nightly-2024-08-21
 
 jobs:
   apidoc:

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -13,7 +13,7 @@ on:
 name: Build API docs
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-21
+  RUST_TOOLCHAIN: nightly-2024-06-06
 
 jobs:
   apidoc:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-21
+  RUST_TOOLCHAIN: nightly-2024-06-06
 
 jobs:
   check-typos-and-docs:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-07
+  RUST_TOOLCHAIN: nightly-2024-08-21
 
 jobs:
   check-typos-and-docs:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-21
+  RUST_TOOLCHAIN: nightly-2024-06-06
 
 permissions:
   issues: write

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_TOOLCHAIN: nightly-2024-08-07
+  RUST_TOOLCHAIN: nightly-2024-08-21
 
 permissions:
   issues: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ on:
 # Use env variables to control all the release process.
 env:
   # The arguments of building greptime.
-  RUST_TOOLCHAIN: nightly-2024-08-21
+  RUST_TOOLCHAIN: nightly-2024-06-06
   CARGO_PROFILE: nightly
 
   # Controls whether to run tests, include unit-test, integration-test and sqlness.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ on:
 # Use env variables to control all the release process.
 env:
   # The arguments of building greptime.
-  RUST_TOOLCHAIN: nightly-2024-08-07
+  RUST_TOOLCHAIN: nightly-2024-08-21
   CARGO_PROFILE: nightly
 
   # Controls whether to run tests, include unit-test, integration-test and sqlness.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-07"
+channel = "nightly-2024-08-21"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-21"
+channel = "nightly-2024-06-06"
 

--- a/src/common/function/src/scalars/aggregate/scipy_stats_norm_pdf.rs
+++ b/src/common/function/src/scalars/aggregate/scipy_stats_norm_pdf.rs
@@ -245,7 +245,7 @@ mod test {
         ];
         scipy_stats_norm_pdf.update_batch(&v).unwrap();
         assert_eq!(
-            Value::from(0.17843340219081552),
+            Value::from(0.17843340219081558),
             scipy_stats_norm_pdf.evaluate().unwrap()
         );
 

--- a/src/meta-srv/src/lib.rs
+++ b/src/meta-srv/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(result_flattening)]
 #![feature(assert_matches)]
 #![feature(extract_if)]
+#![feature(option_take_if)]
 
 pub mod bootstrap;
 mod cache_invalidator;

--- a/src/metric-engine/src/error.rs
+++ b/src/metric-engine/src/error.rs
@@ -223,7 +223,7 @@ pub enum Error {
 
     #[snafu(display("Unsupported region request: {}", request))]
     UnsupportedRegionRequest {
-        request: RegionRequest,
+        request: Box<RegionRequest>,
         #[snafu(implicit)]
         location: Location,
     },


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?


previous 20240806 has an unexpected behavior which affects the result of float computation.

## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
