### PR TITLE
chore: add `stats` feature for jemalloc-ctl

### DIFF
--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -109,7 +109,7 @@ uuid.workspace = true
 zstd.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"] }
+tikv-jemalloc-ctl = { version = "0.6", features = ["use_std", "stats"] }
 
 [dev-dependencies]
 auth = { workspace = true, features = ["testing"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add `stats` feature for `jemalloc-ctl` in servers's toml, or else under certain features flag combination it will report error,
since in v0.6 of `jemalloc-ctl` the `stats` module is behind `stats` feature gate and we are using types in `stats` module

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
