### PR TITLE
chore: optimize common_version build

### DIFF
--- a/src/common/version/build.rs
+++ b/src/common/version/build.rs
@@ -19,7 +19,11 @@ use build_data::{format_timestamp, get_source_time};
 use shadow_rs::{CARGO_METADATA, CARGO_TREE};
 
 fn main() -> shadow_rs::SdResult<()> {
-    println!("cargo:rerun-if-changed=../../../.git/refs/heads");
+    println!(
+        "cargo:rerun-if-changed={}/.git/refs/heads",
+        env!("CARGO_RUSTC_CURRENT_DIR")
+    );
+
     println!(
         "cargo:rustc-env=SOURCE_TIMESTAMP={}",
         if let Ok(t) = get_source_time() {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4605
https://github.com/GreptimeTeam/greptimedb/pull/4605#discussion_r1726820693

## What's changed and what's your intention?
If a project imports greptimedb as a submodule, [this approach](https://github.com/GreptimeTeam/greptimedb/pull/4605) will not work well, and each incremental build will also always compile the common version crate.

This PR mainly solves the above problem.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
