### PR TITLE
fix: fallback to window size in manifest

### DIFF
--- a/src/mito2/src/region/opener.rs
+++ b/src/mito2/src/region/opener.rs
@@ -202,8 +202,8 @@ impl RegionOpener {
             options.need_dedup(),
             options.merge_mode(),
         );
-        // Initial memtable id is 0.
         let part_duration = options.compaction.time_window();
+        // Initial memtable id is 0.
         let mutable = Arc::new(TimePartitions::new(
             metadata.clone(),
             memtable_builder.clone(),
@@ -335,8 +335,13 @@ impl RegionOpener {
             region_options.need_dedup(),
             region_options.merge_mode(),
         );
+        // Use compaction time window in the manifest if region doesn't provide
+        // the time window option.
+        let part_duration = region_options
+            .compaction
+            .time_window()
+            .or(manifest.compaction_time_window);
         // Initial memtable id is 0.
-        let part_duration = region_options.compaction.time_window();
         let mutable = Arc::new(TimePartitions::new(
             metadata.clone(),
             memtable_builder.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR uses the compaction time window as the partition bucket if the region doesn't provide the time window in the compaction options.

Otherwise, the region may always infer the time bucket after re-opening the region.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
