### PR TITLE
fix: set `selector_result_cache_size` in unit test

### DIFF
--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -218,6 +218,7 @@ fn test_load_standalone_example_config() {
                     sst_meta_cache_size: ReadableSize::mb(128),
                     vector_cache_size: ReadableSize::mb(512),
                     page_cache_size: ReadableSize::mb(512),
+                    selector_result_cache_size: ReadableSize::mb(512),
                     max_background_jobs: 4,
                     experimental_write_cache_ttl: Some(Duration::from_secs(60 * 60 * 8)),
                     ..Default::default()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
## What's changed and what's your intention?

fix https://github.com/GreptimeTeam/greptimedb/actions/runs/10580234514

set `selector_result_cache_size` in the unit test


## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
