### PR TITLE
feat: initialize partition range from ScanInput

### DIFF
--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -713,6 +713,7 @@ impl ScanInput {
 
         for memtable in &self.memtables {
             let range = PartitionRange {
+                // TODO: filter out empty memtables in the future.
                 start: memtable.stats().time_range().unwrap().0,
                 end: memtable.stats().time_range().unwrap().1,
                 num_rows: memtable.stats().num_rows(),

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -713,7 +713,7 @@ impl ScanInput {
 
         for memtable in &self.memtables {
             let range = PartitionRange {
-                // TODO: filter out empty memtables in the future.
+                // TODO(ruihang): filter out empty memtables in the future.
                 start: memtable.stats().time_range().unwrap().0,
                 end: memtable.stats().time_range().unwrap().1,
                 num_rows: memtable.stats().num_rows(),

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -715,7 +715,7 @@ impl ScanInput {
             let range = PartitionRange {
                 start: memtable.stats().time_range().unwrap().0,
                 end: memtable.stats().time_range().unwrap().1,
-                estimated_size: memtable.stats().bytes_allocated(),
+                num_rows: memtable.stats().num_rows(),
                 identifier: id,
             };
             id += 1;
@@ -726,8 +726,7 @@ impl ScanInput {
             let range = PartitionRange {
                 start: file.meta_ref().time_range.0,
                 end: file.meta_ref().time_range.1,
-                // TODO(ruihang): maintain the size in file meta
-                estimated_size: 0,
+                num_rows: file.meta_ref().num_rows as usize,
                 identifier: id,
             };
             id += 1;

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -67,10 +67,11 @@ impl SeqScan {
     /// Creates a new [SeqScan].
     pub(crate) fn new(input: ScanInput) -> Self {
         let parallelism = input.parallelism.parallelism.max(1);
-        let properties = ScannerProperties::default()
+        let mut properties = ScannerProperties::default()
             .with_parallelism(parallelism)
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
+        properties.partitions = vec![input.partition_ranges()];
         let stream_ctx = Arc::new(StreamContext::new(input));
 
         Self {

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -59,10 +59,11 @@ impl UnorderedScan {
     /// Creates a new [UnorderedScan].
     pub(crate) fn new(input: ScanInput) -> Self {
         let parallelism = input.parallelism.parallelism.max(1);
-        let properties = ScannerProperties::default()
+        let mut properties = ScannerProperties::default()
             .with_parallelism(parallelism)
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
+        properties.partitions = vec![input.partition_ranges()];
         let stream_ctx = Arc::new(StreamContext::new(input));
 
         Self {

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -59,11 +59,10 @@ impl UnorderedScan {
     /// Creates a new [UnorderedScan].
     pub(crate) fn new(input: ScanInput) -> Self {
         let parallelism = input.parallelism.parallelism.max(1);
-        let mut properties = ScannerProperties::default()
+        let properties = ScannerProperties::default()
             .with_parallelism(parallelism)
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
-        properties.partitions = vec![input.partition_ranges()];
         let stream_ctx = Arc::new(StreamContext::new(input));
 
         Self {

--- a/src/mito2/src/test_util.rs
+++ b/src/mito2/src/test_util.rs
@@ -364,7 +364,7 @@ impl TestEnv {
                 .as_path()
                 .display()
                 .to_string();
-            let mut builder = Fs::default();
+            let builder = Fs::default();
             let object_store = ObjectStore::new(builder.root(&data_path)).unwrap().finish();
             object_store_manager.add(storage_name, object_store);
         }

--- a/src/query/src/optimizer/parallelize_scan.rs
+++ b/src/query/src/optimizer/parallelize_scan.rs
@@ -61,7 +61,6 @@ impl ParallelizeScan {
                     debug!(
                         "Assign {total_range_num} ranges to {expected_partition_num} partitions"
                     );
-
                     // update the partition ranges
                     let new_exec = region_scan_exec
                         .with_new_partitions(partition_ranges)

--- a/src/query/src/optimizer/parallelize_scan.rs
+++ b/src/query/src/optimizer/parallelize_scan.rs
@@ -113,25 +113,25 @@ mod test {
             PartitionRange {
                 start: Timestamp::new(0, TimeUnit::Second),
                 end: Timestamp::new(10, TimeUnit::Second),
-                estimated_size: 100,
+                num_rows: 100,
                 identifier: 1,
             },
             PartitionRange {
                 start: Timestamp::new(10, TimeUnit::Second),
                 end: Timestamp::new(20, TimeUnit::Second),
-                estimated_size: 200,
+                num_rows: 200,
                 identifier: 2,
             },
             PartitionRange {
                 start: Timestamp::new(20, TimeUnit::Second),
                 end: Timestamp::new(30, TimeUnit::Second),
-                estimated_size: 150,
+                num_rows: 150,
                 identifier: 3,
             },
             PartitionRange {
                 start: Timestamp::new(30, TimeUnit::Second),
                 end: Timestamp::new(40, TimeUnit::Second),
-                estimated_size: 250,
+                num_rows: 250,
                 identifier: 4,
             },
         ];
@@ -145,13 +145,13 @@ mod test {
                 PartitionRange {
                     start: Timestamp::new(0, TimeUnit::Second),
                     end: Timestamp::new(10, TimeUnit::Second),
-                    estimated_size: 100,
+                    num_rows: 100,
                     identifier: 1,
                 },
                 PartitionRange {
                     start: Timestamp::new(20, TimeUnit::Second),
                     end: Timestamp::new(30, TimeUnit::Second),
-                    estimated_size: 150,
+                    num_rows: 150,
                     identifier: 3,
                 },
             ],
@@ -159,13 +159,13 @@ mod test {
                 PartitionRange {
                     start: Timestamp::new(10, TimeUnit::Second),
                     end: Timestamp::new(20, TimeUnit::Second),
-                    estimated_size: 200,
+                    num_rows: 200,
                     identifier: 2,
                 },
                 PartitionRange {
                     start: Timestamp::new(30, TimeUnit::Second),
                     end: Timestamp::new(40, TimeUnit::Second),
-                    estimated_size: 250,
+                    num_rows: 250,
                     identifier: 4,
                 },
             ],
@@ -179,25 +179,25 @@ mod test {
             vec![PartitionRange {
                 start: Timestamp::new(0, TimeUnit::Second),
                 end: Timestamp::new(10, TimeUnit::Second),
-                estimated_size: 100,
+                num_rows: 100,
                 identifier: 1,
             }],
             vec![PartitionRange {
                 start: Timestamp::new(10, TimeUnit::Second),
                 end: Timestamp::new(20, TimeUnit::Second),
-                estimated_size: 200,
+                num_rows: 200,
                 identifier: 2,
             }],
             vec![PartitionRange {
                 start: Timestamp::new(20, TimeUnit::Second),
                 end: Timestamp::new(30, TimeUnit::Second),
-                estimated_size: 150,
+                num_rows: 150,
                 identifier: 3,
             }],
             vec![PartitionRange {
                 start: Timestamp::new(30, TimeUnit::Second),
                 end: Timestamp::new(40, TimeUnit::Second),
-                estimated_size: 250,
+                num_rows: 250,
                 identifier: 4,
             }],
         ];

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -149,9 +149,8 @@ pub struct PartitionRange {
     pub start: Timestamp,
     /// End time of time index column. Inclusive.
     pub end: Timestamp,
-    /// Estimate size of this range. Is used to balance ranges between partitions.
-    /// No base unit, just a number.
-    pub estimated_size: usize,
+    /// Number of rows in this range. Is used to balance ranges between partitions.
+    pub num_rows: usize,
     /// Identifier to this range. Assigned by storage engine.
     pub identifier: usize,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Initialize `PartitionRange`s from `ScanInput` for planner. It only contains a rough time range and number of rows at present.

The next step is to modify the corresponding logic about initializing `StreamContext`.

This patch also fixes the problem that `RegionScanExec` always generates only 1 partition.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
