### PR TITLE
feat: pre-download the ingested sst

### DIFF
--- a/src/mito2/src/cache/write_cache.rs
+++ b/src/mito2/src/cache/write_cache.rs
@@ -29,7 +29,7 @@ use crate::cache::file_cache::{FileCache, FileCacheRef, FileType, IndexKey, Inde
 use crate::error::{self, Result};
 use crate::metrics::{
     FLUSH_ELAPSED, UPLOAD_BYTES_TOTAL, WRITE_CACHE_DOWNLOAD_BYTES_TOTAL,
-    WRITE_CACHE_DOWNLOAD_ELAPSED_TOTAL,
+    WRITE_CACHE_DOWNLOAD_ELAPSED,
 };
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
@@ -181,7 +181,7 @@ impl WriteCache {
         const DOWNLOAD_READER_CHUNK_SIZE: ReadableSize = ReadableSize::mb(8);
 
         let file_type = index_key.file_type;
-        let timer = WRITE_CACHE_DOWNLOAD_ELAPSED_TOTAL
+        let timer = WRITE_CACHE_DOWNLOAD_ELAPSED
             .with_label_values(&[match file_type {
                 FileType::Parquet => "download_parquet",
                 FileType::Puffin => "download_puffin",

--- a/src/mito2/src/engine/listener.rs
+++ b/src/mito2/src/engine/listener.rs
@@ -22,6 +22,8 @@ use common_telemetry::info;
 use store_api::storage::RegionId;
 use tokio::sync::Notify;
 
+use crate::sst::file::FileId;
+
 /// Mito engine background event listener.
 #[async_trait]
 pub trait EventListener: Send + Sync {
@@ -61,6 +63,9 @@ pub trait EventListener: Send + Sync {
     fn on_recv_requests(&self, request_num: usize) {
         let _ = request_num;
     }
+
+    /// Notifies the listener that the file cache is filled when, for example, editing region.
+    fn on_file_cache_filled(&self, _file_id: FileId) {}
 }
 
 pub type EventListenerRef = Arc<dyn EventListener>;

--- a/src/mito2/src/error.rs
+++ b/src/mito2/src/error.rs
@@ -640,6 +640,22 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Failed to download file, region_id: {}, file_id: {}, file_type: {:?}",
+        region_id,
+        file_id,
+        file_type,
+    ))]
+    Download {
+        region_id: RegionId,
+        file_id: FileId,
+        file_type: FileType,
+        #[snafu(source)]
+        error: std::io::Error,
+        #[snafu(implicit)]
+        location: Location,
+    },
+
+    #[snafu(display(
         "Failed to upload file, region_id: {}, file_id: {}, file_type: {:?}",
         region_id,
         file_id,
@@ -965,7 +981,7 @@ impl ErrorExt for Error {
 
             FilterRecordBatch { source, .. } => source.status_code(),
 
-            Upload { .. } => StatusCode::StorageUnavailable,
+            Download { .. } | Upload { .. } => StatusCode::StorageUnavailable,
             ChecksumMismatch { .. } => StatusCode::Unexpected,
             RegionStopped { .. } => StatusCode::RegionNotReady,
             TimeRangePredicateOverflow { .. } => StatusCode::InvalidArguments,

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -189,6 +189,12 @@ lazy_static! {
         &[TYPE_LABEL]
     )
     .unwrap();
+    /// Download bytes counter.
+    pub static ref DOWNLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
+        "mito_download_bytes_total",
+        "mito download bytes total",
+    )
+    .unwrap();
     /// Upload bytes counter.
     pub static ref UPLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
         "mito_upload_bytes_total",

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -195,9 +195,9 @@ lazy_static! {
         "mito write cache download bytes total",
     ).unwrap();
     /// Timer of the downloading task in the write cache.
-    pub static ref WRITE_CACHE_DOWNLOAD_ELAPSED_TOTAL: HistogramVec = register_histogram_vec!(
-        "mito_write_cache_download_elapsed_total",
-        "mito write cache download elapsed total",
+    pub static ref WRITE_CACHE_DOWNLOAD_ELAPSED: HistogramVec = register_histogram_vec!(
+        "mito_write_cache_download_elapsed",
+        "mito write cache download elapsed",
         &[TYPE_LABEL],
     ).unwrap();
     /// Upload bytes counter.

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -189,12 +189,17 @@ lazy_static! {
         &[TYPE_LABEL]
     )
     .unwrap();
-    /// Download bytes counter.
-    pub static ref DOWNLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
-        "mito_download_bytes_total",
-        "mito download bytes total",
-    )
-    .unwrap();
+    /// Download bytes counter in the write cache.
+    pub static ref WRITE_CACHE_DOWNLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
+        "mito_write_cache_download_bytes_total",
+        "mito write cache download bytes total",
+    ).unwrap();
+    /// Timer of the downloading task in the write cache.
+    pub static ref WRITE_CACHE_DOWNLOAD_ELAPSED_TOTAL: HistogramVec = register_histogram_vec!(
+        "mito_write_cache_download_elapsed_total",
+        "mito write cache download elapsed total",
+        &[TYPE_LABEL],
+    ).unwrap();
     /// Upload bytes counter.
     pub static ref UPLOAD_BYTES_TOTAL: IntCounter = register_int_counter!(
         "mito_upload_bytes_total",

--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -57,6 +57,7 @@ use crate::request::{
     BackgroundNotify, DdlRequest, SenderDdlRequest, SenderWriteRequest, WorkerRequest,
 };
 use crate::schedule::scheduler::{LocalScheduler, SchedulerRef};
+use crate::sst::file::FileId;
 use crate::sst::index::intermediate::IntermediateManager;
 use crate::sst::index::puffin_manager::PuffinManagerFactory;
 use crate::time_provider::{StdTimeProvider, TimeProviderRef};
@@ -949,6 +950,13 @@ impl WorkerListener {
         }
         // Avoid compiler warning.
         let _ = request_num;
+    }
+
+    pub(crate) fn on_file_cache_filled(&self, _file_id: FileId) {
+        #[cfg(any(test, feature = "test"))]
+        if let Some(listener) = &self.listener {
+            listener.on_file_cache_filled(_file_id);
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Pre-download the ingested SST files from remote object store to fill the local file cache to accelerate following reads.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
