### PR TITLE
refactor: reduce a object store "stat" call

### DIFF
--- a/src/mito2/src/worker/handle_manifest.rs
+++ b/src/mito2/src/worker/handle_manifest.rs
@@ -306,9 +306,10 @@ async fn edit_region(
 
             let index_key = IndexKey::new(region_id, file_meta.file_id, FileType::Parquet);
             let remote_path = location::sst_file_path(layer.region_dir(), file_meta.file_id);
+            let file_size = file_meta.file_size;
             common_runtime::spawn_global(async move {
                 if write_cache
-                    .download(index_key, &remote_path, layer.object_store())
+                    .download(index_key, &remote_path, layer.object_store(), file_size)
                     .await
                     .is_ok()
                 {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Since the file size is known, we don't need to call object store's "stat" on the file. Thx to this [comment](https://github.com/GreptimeTeam/greptimedb/pull/4636#discussion_r1736561254)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
