### PR TITLE
feat: change log level dynamically

### DIFF
--- a/src/common/telemetry/src/lib.rs
+++ b/src/common/telemetry/src/lib.rs
@@ -24,4 +24,4 @@ mod tracing_sampler;
 pub use logging::{init_default_ut_logging, init_global_logging};
 pub use metric::dump_metrics;
 pub use panic_hook::set_panic_hook;
-pub use {common_error, tracing};
+pub use {common_error, tracing, tracing_subscriber};

--- a/src/common/telemetry/src/lib.rs
+++ b/src/common/telemetry/src/lib.rs
@@ -21,7 +21,7 @@ mod panic_hook;
 pub mod tracing_context;
 mod tracing_sampler;
 
-pub use logging::{init_default_ut_logging, init_global_logging};
+pub use logging::{init_default_ut_logging, init_global_logging, RELOAD_HANDLE};
 pub use metric::dump_metrics;
 pub use panic_hook::set_panic_hook;
 pub use {common_error, tracing, tracing_subscriber};

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -710,7 +710,7 @@ impl HttpServer {
                     )),
             )
             .nest(
-                &format!("/{HTTP_API_VERSION}/admin"),
+                "/debug",
                 Router::new()
                     // handler for changing log level dynamically
                     .route(

--- a/src/servers/src/http.rs
+++ b/src/servers/src/http.rs
@@ -74,6 +74,7 @@ use crate::query_handler::{
 use crate::server::Server;
 
 pub mod authorize;
+pub mod dyn_log;
 pub mod event;
 pub mod handler;
 pub mod header;
@@ -707,6 +708,15 @@ impl HttpServer {
                         AuthState::new(self.user_provider.clone()),
                         authorize::check_http_auth,
                     )),
+            )
+            .nest(
+                &format!("/{HTTP_API_VERSION}/admin"),
+                Router::new()
+                    // handler for changing log level dynamically
+                    .route(
+                        "/log_level",
+                        routing::get(dyn_log::dyn_log_handler).post(dyn_log::dyn_log_handler),
+                    ),
             )
             // Handlers for debug, we don't expect a timeout.
             .nest(

--- a/src/servers/src/http/dyn_log.rs
+++ b/src/servers/src/http/dyn_log.rs
@@ -1,0 +1,59 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use common_telemetry::info;
+use common_telemetry::tracing_subscriber::filter::{self, Targets};
+use common_telemetry::tracing_subscriber::reload::Handle;
+use common_telemetry::tracing_subscriber::Registry;
+use once_cell::sync::OnceCell;
+use snafu::OptionExt;
+
+use crate::error::{InternalSnafu, InvalidParameterSnafu, Result};
+
+pub static RELOAD_HANDLE: OnceCell<Handle<Targets, Registry>> = OnceCell::new();
+
+#[axum_macros::debug_handler]
+pub async fn dyn_log_handler(level: String) -> Result<impl IntoResponse> {
+    let new_filter = level.parse::<filter::Targets>().map_err(|e| {
+        InvalidParameterSnafu {
+            reason: format!("Invalid filter: {e:?}"),
+        }
+        .build()
+    })?;
+    let mut old_filter = None;
+    RELOAD_HANDLE
+        .get()
+        .context(InternalSnafu {
+            err_msg: "Reload handler not initialized",
+        })?
+        .modify(|filter| {
+            old_filter = Some(filter.clone());
+            *filter = new_filter.clone()
+        })
+        .map_err(|e| {
+            InternalSnafu {
+                err_msg: format!("Fail to modify filter: {e:?}"),
+            }
+            .build()
+        })?;
+    let change_note = format!(
+        "Log Level changed from {:?} to {:?}",
+        old_filter.map(|f| f.to_string()),
+        new_filter.to_string()
+    );
+    info!("{}", change_note.clone());
+    Ok((StatusCode::OK, change_note))
+}

--- a/src/servers/src/http/dyn_log.rs
+++ b/src/servers/src/http/dyn_log.rs
@@ -45,9 +45,9 @@ pub async fn dyn_log_handler(level: String) -> Result<impl IntoResponse> {
             .build()
         })?;
     let change_note = format!(
-        "Log Level changed from {:?} to {:?}",
-        old_filter.map(|f| f.to_string()),
-        new_filter.to_string()
+        "Log Level changed from {} to {}",
+        old_filter.map(|f| f.to_string()).unwrap_or_default(),
+        new_filter
     );
     info!("{}", change_note.clone());
     Ok((StatusCode::OK, change_note))


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

add a http route to dynamic change log level, using the same syntax like `RUST_LOG`, i.e:
```bash
> curl --data "trace;flow=debug" 127.0.0.1:4000/debug/log_level;
Log Level changed from Some("info") to "trace"%
```
will change current log level to `trace;flow=debug` and appiled to logs came after this

Impl-wise, when init global logging, still will first check env `RUST_LOG` and etc, only difference are using `reload::Layer` to allow change log level dynamically.

perf-wise if not contended, logging with reloadable tracing layer is just fast path of acquire Read lock on a `RwLock` which is just one relaxed atomic operation and a few bit op

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
