### PR TITLE
fix: expose missing options for initializing regions

### DIFF
--- a/config/config.md
+++ b/config/config.md
@@ -15,6 +15,8 @@
 | `mode` | String | `standalone` | The running mode of the datanode. It can be `standalone` or `distributed`. |
 | `enable_telemetry` | Bool | `true` | Enable telemetry to collect anonymous usage data. |
 | `default_timezone` | String | `None` | The default timezone of the server. |
+| `init_regions_in_background` | Bool | `false` | Initialize all regions in the background during the startup.<br/>By default, it provides services after all regions have been initialized. |
+| `init_regions_parallelism` | Integer | `16` | Parallelism of initializing regions. |
 | `runtime` | -- | -- | The runtime options. |
 | `runtime.global_rt_size` | Integer | `8` | The number of threads to execute the runtime for global read operations. |
 | `runtime.compact_rt_size` | Integer | `4` | The number of threads to execute the runtime for global write operations. |

--- a/config/standalone.example.toml
+++ b/config/standalone.example.toml
@@ -8,6 +8,13 @@ enable_telemetry = true
 ## +toml2docs:none-default
 default_timezone = "UTC"
 
+## Initialize all regions in the background during the startup.
+## By default, it provides services after all regions have been initialized.
+init_regions_in_background = false
+
+## Parallelism of initializing regions.
+init_regions_parallelism = 16
+
 ## The runtime options.
 [runtime]
 ## The number of threads to execute the runtime for global read operations.

--- a/src/cmd/src/standalone.rs
+++ b/src/cmd/src/standalone.rs
@@ -141,6 +141,8 @@ pub struct StandaloneOptions {
     pub region_engine: Vec<RegionEngineConfig>,
     pub export_metrics: ExportMetricsOption,
     pub tracing: TracingOptions,
+    pub init_regions_in_background: bool,
+    pub init_regions_parallelism: usize,
 }
 
 impl Default for StandaloneOptions {
@@ -168,6 +170,8 @@ impl Default for StandaloneOptions {
                 RegionEngineConfig::File(FileEngineConfig::default()),
             ],
             tracing: TracingOptions::default(),
+            init_regions_in_background: false,
+            init_regions_parallelism: 16,
         }
     }
 }
@@ -218,6 +222,9 @@ impl StandaloneOptions {
             storage: cloned_opts.storage,
             region_engine: cloned_opts.region_engine,
             grpc: cloned_opts.grpc,
+            init_regions_in_background: cloned_opts.init_regions_in_background,
+            init_regions_parallelism: cloned_opts.init_regions_parallelism,
+            mode: Mode::Standalone,
             ..Default::default()
         }
     }

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -746,6 +746,8 @@ pub async fn test_config_api(store_type: StorageType) {
         r#"
 mode = "standalone"
 enable_telemetry = true
+init_regions_in_background = false
+init_regions_parallelism = 16
 
 [http]
 addr = "127.0.0.1:4000"


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

expose `init_regions_in_background` and `init_regions_parallelism` opts

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
