### PR TITLE
fix: use 'target' for 'actions-rust-lang/setup-rust-toolchain' to fix cross build failed

### DIFF
--- a/.github/actions/build-macos-artifacts/action.yml
+++ b/.github/actions/build-macos-artifacts/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Install rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        targets: ${{ inputs.arch }}
+        target: ${{ inputs.arch }}
 
     - name: Start etcd # For integration tests.
       if: ${{ inputs.disable-run-tests == 'false' }}

--- a/.github/actions/build-windows-artifacts/action.yml
+++ b/.github/actions/build-windows-artifacts/action.yml
@@ -27,7 +27,7 @@ runs:
     - name: Install rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
-        targets: ${{ inputs.arch }}
+        target: ${{ inputs.arch }}
         components: llvm-tools-preview
 
     - name: Rust Cache


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Since https://github.com/GreptimeTeam/greptimedb/commit/0b102ef846c9a907e95a9a5cb997e14ef88cfe1b changes the rust setup action from `dtolnay/rust-toolchain` to `actions-rust-lang/setup-rust-toolchain`, we need to resolve some arguments incompatible:

- `dtolnay/rust-toolchain` support both `target` and `targets`: https://github.com/dtolnay/rust-toolchain/blob/master/action.yml#L12-L17;

- `actions-rust-lang/setup-rust-toolchain` only support `target`: https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml#L18

Unfortunately, we use `targets` in the original release action.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
