### PR TITLE
fix: return version string based on request protocol

### DIFF
--- a/src/common/function/src/system/version.rs
+++ b/src/common/function/src/system/version.rs
@@ -58,9 +58,7 @@ impl Function for VersionFunction {
             Channel::Postgres => {
                 format!("16.3-greptimedb-{}", env!("CARGO_PKG_VERSION"))
             }
-            _ => {
-                format!("{}", env!("CARGO_PKG_VERSION"))
-            }
+            _ => env!("CARGO_PKG_VERSION").to_string(),
         };
         let result = StringVector::from(vec![version]);
         Ok(Arc::new(result))

--- a/src/common/function/src/system/version.rs
+++ b/src/common/function/src/system/version.rs
@@ -19,6 +19,7 @@ use common_query::error::Result;
 use common_query::prelude::{Signature, Volatility};
 use datatypes::data_type::ConcreteDataType;
 use datatypes::vectors::{StringVector, VectorRef};
+use session::context::Channel;
 
 use crate::function::{Function, FunctionContext};
 
@@ -44,11 +45,24 @@ impl Function for VersionFunction {
         Signature::exact(vec![], Volatility::Immutable)
     }
 
-    fn eval(&self, _func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
-        let result = StringVector::from(vec![format!(
-            "5.7.20-greptimedb-{}",
-            env!("CARGO_PKG_VERSION")
-        )]);
+    fn eval(&self, func_ctx: FunctionContext, _columns: &[VectorRef]) -> Result<VectorRef> {
+        let version = match func_ctx.query_ctx.channel() {
+            Channel::Mysql => {
+                format!(
+                    "{}-greptimedb-{}",
+                    std::env::var("GREPTIMEDB_MYSQL_SERVER_VERSION")
+                        .unwrap_or_else(|_| "8.4.2".to_string()),
+                    env!("CARGO_PKG_VERSION")
+                )
+            }
+            Channel::Postgres => {
+                format!("16.3-greptimedb-{}", env!("CARGO_PKG_VERSION"))
+            }
+            _ => {
+                format!("{}", env!("CARGO_PKG_VERSION"))
+            }
+        };
+        let result = StringVector::from(vec![version]);
         Ok(Arc::new(result))
     }
 }

--- a/src/servers/src/postgres.rs
+++ b/src/servers/src/postgres.rs
@@ -48,7 +48,7 @@ pub(crate) struct GreptimeDBStartupParameters {
 impl GreptimeDBStartupParameters {
     fn new() -> GreptimeDBStartupParameters {
         GreptimeDBStartupParameters {
-            version: format!("16.3-greptime-{}", env!("CARGO_PKG_VERSION")),
+            version: format!("16.3-greptimedb-{}", env!("CARGO_PKG_VERSION")),
         }
     }
 }

--- a/tests/cases/standalone/common/function/system.result
+++ b/tests/cases/standalone/common/function/system.result
@@ -8,12 +8,12 @@ SELECT build();
 
 ++|build()|++|branch:BRANCH|commit:COMMIT|commit_short:COMMIT_SHORT|clean:CLEAN|version:VERSION++
 
--- SQLNESS REPLACE greptimedb-[\d\.]+ greptimedb-VERSION
+-- SQLNESS REPLACE [\d\.]+ VERSION
 SELECT version();
 
-+-------------------------+
-| version()               |
-+-------------------------+
-| 5.7.20-greptimedb-VERSION |
-+-------------------------+
++-----------+
+| version() |
++-----------+
+| VERSION     |
++-----------+
 

--- a/tests/cases/standalone/common/function/system.sql
+++ b/tests/cases/standalone/common/function/system.sql
@@ -6,5 +6,5 @@
 -- SQLNESS REPLACE [\s\-]+
 SELECT build();
 
--- SQLNESS REPLACE greptimedb-[\d\.]+ greptimedb-VERSION
+-- SQLNESS REPLACE [\d\.]+ VERSION
 SELECT version();


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch update `version` implementation to return version number according to the channel the client connects with.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
