### PR TITLE
fix: ref to auth err

### DIFF
--- a/src/auth/src/error.rs
+++ b/src/auth/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use common_error::ext::ErrorExt;
+use common_error::ext::{BoxedError, ErrorExt};
 use common_error::status_code::StatusCode;
 use common_macro::stack_trace_debug;
 use snafu::{Location, Snafu};
@@ -36,6 +36,14 @@ pub enum Error {
         error: std::io::Error,
         #[snafu(implicit)]
         location: Location,
+    },
+
+    #[snafu(display("Authentication source failure"))]
+    AuthBackend {
+        #[snafu(implicit)]
+        location: Location,
+        #[snafu(source)]
+        source: BoxedError,
     },
 
     #[snafu(display("User not found, username: {}", username))]
@@ -81,6 +89,7 @@ impl ErrorExt for Error {
             Error::FileWatch { .. } => StatusCode::InvalidArguments,
             Error::InternalState { .. } => StatusCode::Unexpected,
             Error::Io { .. } => StatusCode::StorageUnavailable,
+            Error::AuthBackend { .. } => StatusCode::Internal,
 
             Error::UserNotFound { .. } => StatusCode::UserNotFound,
             Error::UnsupportedPasswordType { .. } => StatusCode::UnsupportedPasswordType,

--- a/src/auth/src/tests.rs
+++ b/src/auth/src/tests.rs
@@ -52,7 +52,7 @@ impl MockUserProvider {
         info.username.clone_into(&mut self.username);
     }
 
-    // this is a delibrate function to ref AuthBackendSnafu
+    // this is a deliberate function to ref AuthBackendSnafu
     // so that it won't get deleted in the future
     pub fn ref_auth_backend_snafu(&self) -> Result<()> {
         let none_option = None;

--- a/src/auth/src/tests.rs
+++ b/src/auth/src/tests.rs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 use common_base::secrets::ExposeSecret;
+use common_error::ext::BoxedError;
+use snafu::{OptionExt, ResultExt};
 
 use crate::error::{
-    AccessDeniedSnafu, Result, UnsupportedPasswordTypeSnafu, UserNotFoundSnafu,
+    AccessDeniedSnafu, AuthBackendSnafu, Result, UnsupportedPasswordTypeSnafu, UserNotFoundSnafu,
     UserPasswordMismatchSnafu,
 };
 use crate::user_info::DefaultUserInfo;
@@ -48,6 +50,19 @@ impl MockUserProvider {
         info.catalog.clone_into(&mut self.catalog);
         info.schema.clone_into(&mut self.schema);
         info.username.clone_into(&mut self.username);
+    }
+
+    // this is a delibrate function to ref AuthBackendSnafu
+    // so that it won't get deleted in the future
+    pub fn ref_auth_backend_snafu(&self) -> Result<()> {
+        let none_option = None;
+
+        none_option
+            .context(UserNotFoundSnafu {
+                username: "no_user".to_string(),
+            })
+            .map_err(BoxedError::new)
+            .context(AuthBackendSnafu)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This pr mainly adds `AuthBackendSnafu` back and adds a test function ref to the error so it won't get deleted in the future.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
