### PR TITLE
fix: unconditional statistics

### DIFF
--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -709,6 +709,10 @@ impl ScanInput {
         rows_in_files + rows_in_memtables
     }
 
+    pub(crate) fn predicate(&self) -> Option<Predicate> {
+        self.predicate.clone()
+    }
+
     /// Retrieves [`PartitionRange`] from memtable and files
     pub(crate) fn partition_ranges(&self) -> Vec<PartitionRange> {
         let mut id = 0;

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -515,6 +515,11 @@ impl RegionScanner for SeqScan {
         self.properties.partitions = ranges;
         Ok(())
     }
+
+    fn has_predicate(&self) -> bool {
+        let predicate = self.stream_ctx.input.predicate();
+        predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
+    }
 }
 
 impl DisplayAs for SeqScan {

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -228,6 +228,11 @@ impl RegionScanner for UnorderedScan {
 
         Ok(stream)
     }
+
+    fn has_predicate(&self) -> bool {
+        let predicate = self.stream_ctx.input.predicate();
+        predicate.map(|p| !p.exprs().is_empty()).unwrap_or(false)
+    }
 }
 
 impl DisplayAs for UnorderedScan {

--- a/src/store-api/src/region_engine.rs
+++ b/src/store-api/src/region_engine.rs
@@ -233,6 +233,9 @@ pub trait RegionScanner: Debug + DisplayAs + Send {
     /// # Panics
     /// Panics if the `partition` is out of bound.
     fn scan_partition(&self, partition: usize) -> Result<SendableRecordBatchStream, BoxedError>;
+
+    /// Check if there is any predicate that may be executed in this scanner.
+    fn has_predicate(&self) -> bool;
 }
 
 pub type RegionScannerRef = Box<dyn RegionScanner>;
@@ -366,6 +369,10 @@ impl RegionScanner for SinglePartitionScanner {
                 StatusCode::Unexpected,
             ))
         })
+    }
+
+    fn has_predicate(&self) -> bool {
+        false
     }
 }
 

--- a/src/table/src/table/scan.rs
+++ b/src/table/src/table/scan.rs
@@ -180,7 +180,7 @@ impl ExecutionPlan for RegionScanExec {
     }
 
     fn statistics(&self) -> DfResult<Statistics> {
-        let statistics = if self.append_mode {
+        let statistics = if self.append_mode && !self.scanner.lock().unwrap().has_predicate() {
             let column_statistics = self
                 .arrow_schema
                 .fields

--- a/tests/cases/standalone/common/aggregate/count.result
+++ b/tests/cases/standalone/common/aggregate/count.result
@@ -81,3 +81,23 @@ select count(1) from count_where_bug where tag = 'b';
 | 2               |
 +-----------------+
 
+select count(1) from count_where_bug where ts > '2024-09-06T06:00:04Z';
+
++-----------------+
+| COUNT(Int64(1)) |
++-----------------+
+| 1               |
++-----------------+
+
+select count(1) from count_where_bug where num != 3;
+
++-----------------+
+| COUNT(Int64(1)) |
++-----------------+
+| 4               |
++-----------------+
+
+drop table count_where_bug;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/aggregate/count.result
+++ b/tests/cases/standalone/common/aggregate/count.result
@@ -54,3 +54,30 @@ drop table test;
 
 Affected Rows: 0
 
+-- Append table
+create table count_where_bug (
+    tag String,
+    ts TimestampMillisecond time index,
+    num Int64,
+    primary key (tag),
+) engine=mito with('append_mode'='true');
+
+Affected Rows: 0
+
+insert into count_where_bug (tag, ts, num)
+values  ('a', '2024-09-06T06:00:01Z', 1),
+        ('a', '2024-09-06T06:00:02Z', 2),
+        ('a', '2024-09-06T06:00:03Z', 3),
+        ('b', '2024-09-06T06:00:04Z', 4),
+        ('b', '2024-09-06T06:00:05Z', 5);
+
+Affected Rows: 5
+
+select count(1) from count_where_bug where tag = 'b';
+
++-----------------+
+| COUNT(Int64(1)) |
++-----------------+
+| 2               |
++-----------------+
+

--- a/tests/cases/standalone/common/aggregate/count.sql
+++ b/tests/cases/standalone/common/aggregate/count.sql
@@ -35,3 +35,9 @@ values  ('a', '2024-09-06T06:00:01Z', 1),
         ('b', '2024-09-06T06:00:05Z', 5);
 
 select count(1) from count_where_bug where tag = 'b';
+
+select count(1) from count_where_bug where ts > '2024-09-06T06:00:04Z';
+
+select count(1) from count_where_bug where num != 3;
+
+drop table count_where_bug;

--- a/tests/cases/standalone/common/aggregate/count.sql
+++ b/tests/cases/standalone/common/aggregate/count.sql
@@ -17,3 +17,21 @@ select count(*) from (select * from test cross join "HelloWorld");
 drop table "HelloWorld";
 
 drop table test;
+
+-- Append table
+
+create table count_where_bug (
+    tag String,
+    ts TimestampMillisecond time index,
+    num Int64,
+    primary key (tag),
+) engine=mito with('append_mode'='true');
+
+insert into count_where_bug (tag, ts, num)
+values  ('a', '2024-09-06T06:00:01Z', 1),
+        ('a', '2024-09-06T06:00:02Z', 2),
+        ('a', '2024-09-06T06:00:03Z', 3),
+        ('b', '2024-09-06T06:00:04Z', 4),
+        ('b', '2024-09-06T06:00:05Z', 5);
+
+select count(1) from count_where_bug where tag = 'b';


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

Closes #4692

## What's changed and what's your intention?

#4545 gives an incorrect impl of `statistics` method, which should consider both projection and filter of the underlying format reader when generating statistics.


## Checklist

- [x] I have written the necessary rustdoc comments.
- [x] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
