### PR TITLE
fix: use `is_ascii_alphabetic`

### DIFF
--- a/src/sql/src/dialect.rs
+++ b/src/sql/src/dialect.rs
@@ -20,11 +20,11 @@ pub struct GreptimeDbDialect {}
 
 impl Dialect for GreptimeDbDialect {
     fn is_identifier_start(&self, ch: char) -> bool {
-        ch.is_alphabetic() || ch == '_' || ch == '#' || ch == '@'
+        ch.is_ascii_alphabetic() || ch == '_' || ch == '#' || ch == '@'
     }
 
     fn is_identifier_part(&self, ch: char) -> bool {
-        ch.is_alphabetic()
+        ch.is_ascii_alphabetic()
             || ch.is_ascii_digit()
             || ch == '@'
             || ch == '$'


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
[#4694](https://github.com/GreptimeTeam/greptimedb/issues/4696)
## What's changed and what's your intention?

use `is_ascii_alphabetic` instead of `is_alphabetic`  which checks for **Other** langauages' alphabet too(i.e: `assert!('京'.is_alphabetic());`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
