### PR TITLE
chore: print downgraded region last_entry_id

### DIFF
--- a/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
+++ b/src/meta-srv/src/procedure/region_migration/downgrade_leader_region.rs
@@ -160,6 +160,11 @@ impl DowngradeLeaderRegion {
                         "Trying to downgrade the region {} on Datanode {}, but region doesn't exist!",
                         region_id, leader
                     );
+                } else {
+                    info!(
+                        "Region {} leader is downgraded, last_entry_id: {:?}",
+                        region_id, last_entry_id
+                    );
                 }
 
                 if let Some(last_entry_id) = last_entry_id {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Print downgraded region `last_entry_id`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
