### PR TITLE
feat: skip caching uncompressed pages if they are large

### DIFF
--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -156,7 +156,6 @@ impl CacheManager {
         }
     }
 
-    // TODO(yingwen): Rename pages to page.
     /// Gets pages for the row group.
     pub fn get_pages(&self, page_key: &PageKey) -> Option<Arc<PageValue>> {
         self.page_cache.as_ref().and_then(|page_cache| {

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -38,7 +38,9 @@ use crate::cache::cache_size::parquet_meta_size;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::index::{InvertedIndexCache, InvertedIndexCacheRef};
 use crate::cache::write_cache::WriteCacheRef;
-use crate::metrics::{CACHE_BYTES, CACHE_EVICTION, CACHE_HIT, CACHE_MISS};
+use crate::metrics::{
+    CACHE_BYTES, CACHE_EVICTION, CACHE_HIT, CACHE_MISS, GET_CACHE_ELAPSED, PUT_CACHE_ELAPSED,
+};
 use crate::read::Batch;
 use crate::sst::file::FileId;
 
@@ -158,6 +160,7 @@ impl CacheManager {
 
     /// Gets pages for the row group.
     pub fn get_pages(&self, page_key: &PageKey) -> Option<Arc<PageValue>> {
+        let _timer = GET_CACHE_ELAPSED.start_timer();
         self.page_cache.as_ref().and_then(|page_cache| {
             let value = page_cache.get(page_key);
             update_hit_miss(value, PAGE_TYPE)
@@ -166,6 +169,7 @@ impl CacheManager {
 
     /// Puts pages of the row group into the cache.
     pub fn put_pages(&self, page_key: PageKey, pages: Arc<PageValue>) {
+        let _timer = PUT_CACHE_ELAPSED.start_timer();
         if let Some(cache) = &self.page_cache {
             CACHE_BYTES
                 .with_label_values(&[PAGE_TYPE])

--- a/src/mito2/src/cache.rs
+++ b/src/mito2/src/cache.rs
@@ -38,9 +38,7 @@ use crate::cache::cache_size::parquet_meta_size;
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::index::{InvertedIndexCache, InvertedIndexCacheRef};
 use crate::cache::write_cache::WriteCacheRef;
-use crate::metrics::{
-    CACHE_BYTES, CACHE_EVICTION, CACHE_HIT, CACHE_MISS, GET_CACHE_ELAPSED, PUT_CACHE_ELAPSED,
-};
+use crate::metrics::{CACHE_BYTES, CACHE_EVICTION, CACHE_HIT, CACHE_MISS};
 use crate::read::Batch;
 use crate::sst::file::FileId;
 
@@ -160,7 +158,6 @@ impl CacheManager {
 
     /// Gets pages for the row group.
     pub fn get_pages(&self, page_key: &PageKey) -> Option<Arc<PageValue>> {
-        let _timer = GET_CACHE_ELAPSED.start_timer();
         self.page_cache.as_ref().and_then(|page_cache| {
             let value = page_cache.get(page_key);
             update_hit_miss(value, PAGE_TYPE)
@@ -169,7 +166,6 @@ impl CacheManager {
 
     /// Puts pages of the row group into the cache.
     pub fn put_pages(&self, page_key: PageKey, pages: Arc<PageValue>) {
-        let _timer = PUT_CACHE_ELAPSED.start_timer();
         if let Some(cache) = &self.page_cache {
             CACHE_BYTES
                 .with_label_values(&[PAGE_TYPE])

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -133,6 +133,7 @@ lazy_static! {
         vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
+    pub static ref READ_STAGE_FETCH_PAGES: Histogram = READ_STAGE_ELAPSED.with_label_values(&["fetch_pages"]);
     /// Counter of rows read from different source.
     pub static ref READ_ROWS_TOTAL: IntCounterVec =
         register_int_counter_vec!("greptime_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -133,6 +133,8 @@ lazy_static! {
         vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
+    pub static ref GET_CACHE_ELAPSED: Histogram = READ_STAGE_ELAPSED.with_label_values(&["get_cache"]);
+    pub static ref PUT_CACHE_ELAPSED: Histogram = READ_STAGE_ELAPSED.with_label_values(&["put_cache"]);
     /// Counter of rows read from different source.
     pub static ref READ_ROWS_TOTAL: IntCounterVec =
         register_int_counter_vec!("greptime_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();

--- a/src/mito2/src/metrics.rs
+++ b/src/mito2/src/metrics.rs
@@ -133,8 +133,6 @@ lazy_static! {
         vec![0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 60.0, 300.0]
     )
     .unwrap();
-    pub static ref GET_CACHE_ELAPSED: Histogram = READ_STAGE_ELAPSED.with_label_values(&["get_cache"]);
-    pub static ref PUT_CACHE_ELAPSED: Histogram = READ_STAGE_ELAPSED.with_label_values(&["put_cache"]);
     /// Counter of rows read from different source.
     pub static ref READ_ROWS_TOTAL: IntCounterVec =
         register_int_counter_vec!("greptime_mito_read_rows_total", "mito read rows total", &[TYPE_LABEL]).unwrap();

--- a/src/mito2/src/read/merge.rs
+++ b/src/mito2/src/read/merge.rs
@@ -89,6 +89,9 @@ impl Drop for MergeReader {
         READ_STAGE_ELAPSED
             .with_label_values(&["merge"])
             .observe(self.metrics.scan_cost.as_secs_f64());
+        READ_STAGE_ELAPSED
+            .with_label_values(&["merge_fetch"])
+            .observe(self.metrics.fetch_cost.as_secs_f64());
     }
 }
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -890,7 +890,12 @@ impl ScanPartList {
     /// Returns the number of file ranges.
     pub(crate) fn num_file_ranges(&self) -> usize {
         self.0.as_ref().map_or(0, |parts| {
-            parts.iter().map(|part| part.file_ranges.len()).sum()
+            parts
+                .iter()
+                .map(|part| part.file_ranges.iter())
+                .flatten()
+                .map(|ranges| ranges.len())
+                .sum()
         })
     }
 }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -887,6 +887,7 @@ impl ScanPartList {
         })
     }
 
+    // TODO(yingwen): Also add a method to return num files.
     /// Returns the number of file ranges.
     pub(crate) fn num_file_ranges(&self) -> usize {
         self.0.as_ref().map_or(0, |parts| {
@@ -936,6 +937,7 @@ impl StreamContext {
     ) -> fmt::Result {
         match self.parts.try_lock() {
             Ok(inner) => match t {
+                // TODO(yingwen): Print num files and ranges.
                 DisplayFormatType::Default => write!(
                     f,
                     "partition_count={} ({} memtable ranges, {} file ranges)",

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -907,8 +907,7 @@ impl ScanPartList {
         self.0.as_ref().map_or(0, |parts| {
             parts
                 .iter()
-                .map(|part| part.file_ranges.iter())
-                .flatten()
+                .flat_map(|part| part.file_ranges.iter())
                 .map(|ranges| ranges.len())
                 .sum()
         })

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -901,7 +901,13 @@ impl ScanPartList {
         })
     }
 
-    // TODO(yingwen): Also add a method to return num files.
+    /// Returns the number of files.
+    pub(crate) fn num_files(&self) -> usize {
+        self.0.as_ref().map_or(0, |parts| {
+            parts.iter().map(|part| part.file_ranges.len()).sum()
+        })
+    }
+
     /// Returns the number of file ranges.
     pub(crate) fn num_file_ranges(&self) -> usize {
         self.0.as_ref().map_or(0, |parts| {
@@ -950,12 +956,12 @@ impl StreamContext {
     ) -> fmt::Result {
         match self.parts.try_lock() {
             Ok(inner) => match t {
-                // TODO(yingwen): Print num files and ranges.
                 DisplayFormatType::Default => write!(
                     f,
-                    "partition_count={} ({} memtable ranges, {} file ranges)",
+                    "partition_count={} ({} memtable ranges, {} file {} ranges)",
                     inner.0.len(),
                     inner.0.num_mem_ranges(),
+                    inner.0.num_files(),
                     inner.0.num_file_ranges()
                 )?,
                 DisplayFormatType::Verbose => write!(f, "{:?}", inner.0)?,

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -166,8 +166,8 @@ impl SeqScan {
                     reader_metrics.merge_from(reader.metrics());
                 }
                 debug!(
-                    "Seq scan region {}, file {}, {} ranges finished, metrics: {:?}",
-                    region_id, file_id, range_num, reader_metrics
+                    "Seq scan region {}, file {}, {} ranges finished, metrics: {:?}, compaction: {}",
+                    region_id, file_id, range_num, reader_metrics, compaction
                 );
                 // Reports metrics.
                 reader_metrics.observe_rows(read_type);
@@ -238,11 +238,12 @@ impl SeqScan {
         let maybe_reader = Self::build_reader_from_sources(stream_ctx, sources, semaphore).await;
         let build_reader_cost = build_start.elapsed();
         metrics.build_reader_cost += build_reader_cost;
-        common_telemetry::debug!(
-            "Build reader region: {}, range_id: {}, from sources, build_reader_cost: {:?}",
+        debug!(
+            "Build reader region: {}, range_id: {}, from sources, build_reader_cost: {:?}, compaction: {}",
             stream_ctx.input.mapper.metadata().region_id,
             range_id,
-            build_reader_cost
+            build_reader_cost,
+            compaction,
         );
 
         maybe_reader
@@ -354,11 +355,12 @@ impl SeqScan {
                 metrics.observe_metrics_on_finish();
 
                 debug!(
-                    "Seq scan finished, region_id: {:?}, partition: {}, metrics: {:?}, first_poll: {:?}",
+                    "Seq scan finished, region_id: {:?}, partition: {}, metrics: {:?}, first_poll: {:?}, compaction: {}",
                     stream_ctx.input.mapper.metadata().region_id,
                     partition,
                     metrics,
                     first_poll,
+                    compaction,
                 );
             }
         };
@@ -450,13 +452,14 @@ impl SeqScan {
                 metrics.total_cost = stream_ctx.query_start.elapsed();
                 metrics.observe_metrics_on_finish();
 
-                common_telemetry::debug!(
-                    "Seq scan finished, region_id: {}, partition: {}, id: {}, metrics: {:?}, first_poll: {:?}",
+                debug!(
+                    "Seq scan finished, region_id: {}, partition: {}, id: {}, metrics: {:?}, first_poll: {:?}, compaction: {}",
                     stream_ctx.input.mapper.metadata().region_id,
                     partition,
                     id,
                     metrics,
                     first_poll,
+                    compaction,
                 );
             }
         };

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -218,7 +218,7 @@ mod tests {
 
         // Cache 4 row groups.
         for i in 0..4 {
-            let page_key = PageKey {
+            let page_key = PageKey::Compressed {
                 region_id: metadata.region_id,
                 file_id: handle.file_id(),
                 row_group_idx: i,
@@ -226,7 +226,7 @@ mod tests {
             };
             assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
         }
-        let page_key = PageKey {
+        let page_key = PageKey::Compressed {
             region_id: metadata.region_id,
             file_id: handle.file_id(),
             row_group_idx: 5,

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -217,30 +217,15 @@ mod tests {
         }
 
         // Doesn't have compressed page cached.
-        let page_key = PageKey::Compressed {
-            region_id: metadata.region_id,
-            file_id: handle.file_id(),
-            row_group_idx: 0,
-            column_idx: 0,
-        };
+        let page_key = PageKey::new_compressed(metadata.region_id, handle.file_id(), 0, 0);
         assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
 
         // Cache 4 row groups.
         for i in 0..4 {
-            let page_key = PageKey::RowGroup {
-                region_id: metadata.region_id,
-                file_id: handle.file_id(),
-                row_group_idx: i,
-                column_idx: 0,
-            };
+            let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), i, 0);
             assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
         }
-        let page_key = PageKey::RowGroup {
-            region_id: metadata.region_id,
-            file_id: handle.file_id(),
-            row_group_idx: 5,
-            column_idx: 0,
-        };
+        let page_key = PageKey::new_uncompressed(metadata.region_id, handle.file_id(), 5, 0);
         assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
     }
 

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -224,15 +224,6 @@ mod tests {
             column_idx: 0,
         };
         assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
-        // Doesn't have single page cached.
-        let page_key = PageKey::Single {
-            region_id: metadata.region_id,
-            file_id: handle.file_id(),
-            row_group_idx: 0,
-            column_idx: 0,
-            page_idx: 0,
-        };
-        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
 
         // Cache 4 row groups.
         for i in 0..4 {

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -216,9 +216,27 @@ mod tests {
             .await;
         }
 
+        // Doesn't have compressed page cached.
+        let page_key = PageKey::Compressed {
+            region_id: metadata.region_id,
+            file_id: handle.file_id(),
+            row_group_idx: 0,
+            column_idx: 0,
+        };
+        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+        // Doesn't have single page cached.
+        let page_key = PageKey::Single {
+            region_id: metadata.region_id,
+            file_id: handle.file_id(),
+            row_group_idx: 0,
+            column_idx: 0,
+            page_idx: 0,
+        };
+        assert!(cache.as_ref().unwrap().get_pages(&page_key).is_none());
+
         // Cache 4 row groups.
         for i in 0..4 {
-            let page_key = PageKey::Compressed {
+            let page_key = PageKey::RowGroup {
                 region_id: metadata.region_id,
                 file_id: handle.file_id(),
                 row_group_idx: i,
@@ -226,7 +244,7 @@ mod tests {
             };
             assert!(cache.as_ref().unwrap().get_pages(&page_key).is_some());
         }
-        let page_key = PageKey::Compressed {
+        let page_key = PageKey::RowGroup {
             region_id: metadata.region_id,
             file_id: handle.file_id(),
             row_group_idx: 5,

--- a/src/mito2/src/sst/parquet/page_reader.rs
+++ b/src/mito2/src/sst/parquet/page_reader.rs
@@ -69,7 +69,7 @@ impl PageReader for CachedPageReader {
         };
 
         // Tries to get it from the cache first.
-        let key = PageKey::Uncompressed {
+        let key = PageKey::Single {
             region_id: self.region_id,
             file_id: self.file_id,
             row_group_idx: self.row_group_idx,
@@ -82,8 +82,8 @@ impl PageReader for CachedPageReader {
             self.current_page_idx += 1;
             // The reader skips this page.
             reader.skip_next_page()?;
-            debug_assert!(page.uncompressed.is_some());
-            return Ok(page.uncompressed.clone());
+            debug_assert!(page.single.is_some());
+            return Ok(page.single.clone());
         }
 
         // Cache miss, load the page from the reader.
@@ -94,7 +94,7 @@ impl PageReader for CachedPageReader {
         };
         // Puts the page into the cache.
         self.cache
-            .put_pages(key, Arc::new(PageValue::new_uncompressed(page.clone())));
+            .put_pages(key, Arc::new(PageValue::new_single(page.clone())));
         // Bumps the page index.
         self.current_page_idx += 1;
 

--- a/src/mito2/src/sst/parquet/page_reader.rs
+++ b/src/mito2/src/sst/parquet/page_reader.rs
@@ -133,31 +133,3 @@ impl Iterator for CachedPageReader {
         self.get_next_page().transpose()
     }
 }
-
-/// Get [PageMetadata] from `page`.
-///
-/// The conversion is based on [decode_page()](https://github.com/apache/arrow-rs/blob/1d6feeacebb8d0d659d493b783ba381940973745/parquet/src/file/serialized_reader.rs#L438-L481)
-/// and [PageMetadata](https://github.com/apache/arrow-rs/blob/65f7be856099d389b0d0eafa9be47fad25215ee6/parquet/src/column/page.rs#L279-L301).
-fn page_to_page_meta(page: &Page) -> PageMetadata {
-    match page {
-        Page::DataPage { num_values, .. } => PageMetadata {
-            num_rows: None,
-            num_levels: Some(*num_values as usize),
-            is_dict: false,
-        },
-        Page::DataPageV2 {
-            num_values,
-            num_rows,
-            ..
-        } => PageMetadata {
-            num_rows: Some(*num_rows as usize),
-            num_levels: Some(*num_values as usize),
-            is_dict: false,
-        },
-        Page::DictionaryPage { .. } => PageMetadata {
-            num_rows: None,
-            num_levels: None,
-            is_dict: true,
-        },
-    }
-}

--- a/src/mito2/src/sst/parquet/page_reader.rs
+++ b/src/mito2/src/sst/parquet/page_reader.rs
@@ -26,7 +26,7 @@ pub(crate) struct RowGroupCachedReader {
 }
 
 impl RowGroupCachedReader {
-    /// Returns a new reader from a cache.
+    /// Returns a new reader from pages of a column in a row group.
     pub(crate) fn new(pages: &[Page]) -> Self {
         Self {
             pages: pages.iter().cloned().collect(),

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -165,7 +165,6 @@ impl<'a> InMemoryRowGroup<'a> {
                 .filter(|&(idx, chunk)| chunk.is_none() && projection.leaf_included(idx))
                 .map(|(idx, _chunk)| {
                     let column = self.metadata.column(idx);
-                    common_telemetry::info!("chunk meta of {idx} is {column:?}");
                     let (start, length) = column.byte_range();
                     start..(start + length)
                 })

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -104,7 +104,8 @@ impl<'a> InMemoryRowGroup<'a> {
                 .iter()
                 .zip(self.metadata.columns())
                 .enumerate()
-                .filter(|&(idx, (chunk, _chunk_meta))| {
+                .filter(|&(idx, (chunk, chunk_meta))| {
+                    common_telemetry::info!("chunk meta of {idx} is {chunk_meta:?}");
                     chunk.is_none() && projection.leaf_included(idx)
                 })
                 .flat_map(|(idx, (_chunk, chunk_meta))| {

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -104,8 +104,7 @@ impl<'a> InMemoryRowGroup<'a> {
                 .iter()
                 .zip(self.metadata.columns())
                 .enumerate()
-                .filter(|&(idx, (chunk, chunk_meta))| {
-                    common_telemetry::info!("chunk meta of {idx} is {chunk_meta:?}");
+                .filter(|&(idx, (chunk, _chunk_meta))| {
                     chunk.is_none() && projection.leaf_included(idx)
                 })
                 .flat_map(|(idx, (_chunk, chunk_meta))| {
@@ -166,6 +165,7 @@ impl<'a> InMemoryRowGroup<'a> {
                 .filter(|&(idx, chunk)| chunk.is_none() && projection.leaf_included(idx))
                 .map(|(idx, _chunk)| {
                     let column = self.metadata.column(idx);
+                    common_telemetry::info!("chunk meta of {idx} is {column:?}");
                     let (start, length) = column.byte_range();
                     start..(start + length)
                 })

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -202,8 +202,8 @@ impl<'a> InMemoryRowGroup<'a> {
                     continue;
                 };
 
+                let column = self.metadata.column(idx);
                 if let Some(cache) = &self.cache_manager {
-                    let column = self.metadata.column(idx);
                     // Put the page to the cache if we don't cache the whole row group.
                     if !cache_row_group_pages(column) {
                         let page_key = PageKey::Compressed {
@@ -218,7 +218,7 @@ impl<'a> InMemoryRowGroup<'a> {
                 }
 
                 *chunk = Some(Arc::new(ColumnChunkData::Dense {
-                    offset: self.metadata.column(idx).byte_range().0 as usize,
+                    offset: column.byte_range().0 as usize,
                     data,
                 }));
             }
@@ -260,7 +260,7 @@ impl<'a> InMemoryRowGroup<'a> {
 
                     *chunk = cache.get_pages(&page_key).map(|page_value| {
                         Arc::new(ColumnChunkData::Dense {
-                            offset: self.metadata.column(idx).byte_range().0 as usize,
+                            offset: column.byte_range().0 as usize,
                             data: page_value.compressed.clone(),
                         })
                     });

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -165,6 +165,8 @@ impl<'a> InMemoryRowGroup<'a> {
             // Now we only use cache in dense chunk data.
             self.fetch_pages_from_cache(projection);
 
+            // Release the CPU to avoid blocking the runtime. Since `fetch_pages_from_cache`
+            // is a synchronous, CPU-bound operation.
             yield_now().await;
 
             let fetch_ranges = self

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -32,7 +32,7 @@ use store_api::storage::RegionId;
 
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::{CacheManagerRef, PageKey, PageValue};
-use crate::metrics::READ_STAGE_ELAPSED;
+use crate::metrics::{READ_STAGE_ELAPSED, READ_STAGE_FETCH_PAGES};
 use crate::sst::file::FileId;
 use crate::sst::parquet::helper::fetch_byte_ranges;
 use crate::sst::parquet::page_reader::RowGroupCachedReader;
@@ -231,6 +231,7 @@ impl<'a> InMemoryRowGroup<'a> {
     /// Fetches pages for columns if cache is enabled.
     /// If the page is in the cache, sets the column chunk or `column_uncompressed_pages` for the column.
     fn fetch_pages_from_cache(&mut self, projection: &ProjectionMask) {
+        let _timer = READ_STAGE_FETCH_PAGES.start_timer();
         self.column_chunks
             .iter_mut()
             .enumerate()

--- a/src/mito2/src/sst/parquet/row_group.rs
+++ b/src/mito2/src/sst/parquet/row_group.rs
@@ -29,6 +29,7 @@ use parquet::file::reader::{ChunkReader, Length};
 use parquet::file::serialized_reader::SerializedPageReader;
 use parquet::format::PageLocation;
 use store_api::storage::RegionId;
+use tokio::task::yield_now;
 
 use crate::cache::file_cache::{FileType, IndexKey};
 use crate::cache::{CacheManagerRef, PageKey, PageValue};
@@ -163,6 +164,8 @@ impl<'a> InMemoryRowGroup<'a> {
         } else {
             // Now we only use cache in dense chunk data.
             self.fetch_pages_from_cache(projection);
+
+            yield_now().await;
 
             let fetch_ranges = self
                 .column_chunks

--- a/tests/cases/distributed/explain/analyze.result
+++ b/tests/cases/distributed/explain/analyze.result
@@ -36,7 +36,7 @@ explain analyze SELECT count(*) FROM system_metrics;
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[], aggr=[COUNT(system_REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+

--- a/tests/cases/standalone/common/aggregate/multi_regions.result
+++ b/tests/cases/standalone/common/aggregate/multi_regions.result
@@ -34,7 +34,7 @@ select sum(val) from t group by host;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[SUM(t.val)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 | 1_| 1_|_ProjectionExec: expr=[SUM(t.val)@1 as SUM(t.val)] REDACTED
 |_|_|_AggregateExec: mode=FinalPartitioned, gby=[host@0 as host], aggr=[SUM(t.val)] REDACTED
@@ -43,7 +43,7 @@ select sum(val) from t group by host;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[SUM(t.val)] REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+
@@ -66,9 +66,9 @@ select sum(val) from t;
 |_|_|_ProjectionExec: expr=[val@1 as val] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 1_|
 +-+-+-+
@@ -95,9 +95,9 @@ select sum(val) from t group by idc;
 |_|_|_ProjectionExec: expr=[val@1 as val, idc@3 as idc] REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
-| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file ranges) REDACTED
+| 1_| 1_|_SeqScan: region=REDACTED, partition_count=0 (0 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 0_|
 +-+-+-+

--- a/tests/cases/standalone/common/range/nest.result
+++ b/tests/cases/standalone/common/range/nest.result
@@ -77,7 +77,7 @@ EXPLAIN ANALYZE SELECT ts, host, min(val) RANGE '5s' FROM host ALIGN '5s';
 |_|_|_CoalescePartitionsExec REDACTED
 |_|_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 10_|
 +-+-+-+

--- a/tests/cases/standalone/common/select/prune.result
+++ b/tests/cases/standalone/common/select/prune.result
@@ -89,7 +89,7 @@ explain analyze select * from demo where idc='idc1';
 +-+-+-+
 | 0_| 0_|_MergeScanExec: REDACTED
 |_|_|_|
-| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+| 1_| 0_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 2_|
 +-+-+-+

--- a/tests/cases/standalone/common/tql-explain-analyze/analyze.result
+++ b/tests/cases/standalone/common/tql-explain-analyze/analyze.result
@@ -32,7 +32,7 @@ TQL ANALYZE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -63,7 +63,7 @@ TQL ANALYZE (0, 10, '1s', '2s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -2000 AND j@1 <= 12000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -93,7 +93,7 @@ TQL ANALYZE ('1970-01-01T00:00:00'::timestamp, '1970-01-01T00:00:00'::timestamp 
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+
@@ -125,7 +125,7 @@ TQL ANALYZE VERBOSE (0, 10, '5s') test;
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_FilterExec: j@1 >= -300000 AND j@1 <= 310000 REDACTED
 |_|_|_RepartitionExec: partitioning=REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges) REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges) REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+

--- a/tests/cases/standalone/optimizer/last_value.result
+++ b/tests/cases/standalone/optimizer/last_value.result
@@ -48,7 +48,7 @@ explain analyze
 |_|_|_CoalesceBatchesExec: target_batch_size=8192 REDACTED
 |_|_|_AggregateExec: mode=Partial, gby=[host@1 as host], aggr=[last_value(t.host) ORDER BY [t.ts ASC NULLS LAST], last_value(t.not_pk) ORDER BY [t.ts ASC NULLS LAST], last_value(t.val) ORDER BY [t.ts ASC NULLS LAST]] REDACTED
 |_|_|_RepartitionExec: REDACTED
-|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file ranges), selector=LastRow REDACTED
+|_|_|_SeqScan: region=REDACTED, partition_count=1 (1 memtable ranges, 0 file 0 ranges), selector=LastRow REDACTED
 |_|_|_|
 |_|_| Total rows: 4_|
 +-+-+-+


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR skips caching uncompressed pages for a column in a row group if it has multiple uncompressed pages. Since caching uncompressed pages for this column may be memory inefficient and decompressing all pages may be slower than only decompress pages on demand.

It also prints more information to logs and explain outputs.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new caching mechanism with enhanced clarity and usability through updated structures and methods.
	- Added a metric for tracking fetch time in the metrics module.
	- Implemented a method to calculate the total number of files in the `ScanPartList` struct.

- **Bug Fixes**
	- Improved logging for sequence scan operations to enhance traceability and observability.

- **Documentation**
	- Updated documentation comments for clarity on the purpose of various components.

- **Style**
	- Enhanced output formatting for execution plans to improve clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->