### PR TITLE
feat(index): add explicit adapter between `RangeReader` and `AsyncRead`

### DIFF
--- a/src/index/src/inverted_index/format/reader/blob.rs
+++ b/src/index/src/inverted_index/format/reader/blob.rs
@@ -80,6 +80,7 @@ impl<R: RangeReader> InvertedIndexReader for InvertedIndexBlobReader<R> {
 #[cfg(test)]
 mod tests {
     use common_base::bit_vec::prelude::*;
+    use common_base::range_read::RangeReaderAdapter;
     use fst::MapBuilder;
     use futures::io::Cursor;
     use greptime_proto::v1::index::{InvertedIndexMeta, InvertedIndexMetas};
@@ -162,7 +163,8 @@ mod tests {
     #[tokio::test]
     async fn test_inverted_index_blob_reader_metadata() {
         let blob = create_inverted_index_blob();
-        let mut blob_reader = InvertedIndexBlobReader::new(Cursor::new(blob));
+        let cursor = RangeReaderAdapter(Cursor::new(blob));
+        let mut blob_reader = InvertedIndexBlobReader::new(cursor);
 
         let metas = blob_reader.metadata().await.unwrap();
         assert_eq!(metas.metas.len(), 2);
@@ -189,7 +191,8 @@ mod tests {
     #[tokio::test]
     async fn test_inverted_index_blob_reader_fst() {
         let blob = create_inverted_index_blob();
-        let mut blob_reader = InvertedIndexBlobReader::new(Cursor::new(blob));
+        let cursor = RangeReaderAdapter(Cursor::new(blob));
+        let mut blob_reader = InvertedIndexBlobReader::new(cursor);
 
         let metas = blob_reader.metadata().await.unwrap();
         let meta = metas.metas.get("tag0").unwrap();
@@ -221,7 +224,8 @@ mod tests {
     #[tokio::test]
     async fn test_inverted_index_blob_reader_bitmap() {
         let blob = create_inverted_index_blob();
-        let mut blob_reader = InvertedIndexBlobReader::new(Cursor::new(blob));
+        let cursor = RangeReaderAdapter(Cursor::new(blob));
+        let mut blob_reader = InvertedIndexBlobReader::new(cursor);
 
         let metas = blob_reader.metadata().await.unwrap();
         let meta = metas.metas.get("tag0").unwrap();

--- a/src/index/src/inverted_index/format/writer/blob.rs
+++ b/src/index/src/inverted_index/format/writer/blob.rs
@@ -99,6 +99,7 @@ impl<W: AsyncWrite + Send + Unpin> InvertedIndexBlobWriter<W> {
 
 #[cfg(test)]
 mod tests {
+    use common_base::range_read::RangeReaderAdapter;
     use futures::io::Cursor;
     use futures::stream;
 
@@ -119,7 +120,7 @@ mod tests {
             .await
             .unwrap();
 
-        let cursor = Cursor::new(blob);
+        let cursor = RangeReaderAdapter(Cursor::new(blob));
         let mut reader = InvertedIndexBlobReader::new(cursor);
         let metadata = reader.metadata().await.unwrap();
         assert_eq!(metadata.total_row_count, 8);
@@ -160,7 +161,7 @@ mod tests {
             .await
             .unwrap();
 
-        let cursor = Cursor::new(blob);
+        let cursor = RangeReaderAdapter(Cursor::new(blob));
         let mut reader = InvertedIndexBlobReader::new(cursor);
         let metadata = reader.metadata().await.unwrap();
         assert_eq!(metadata.total_row_count, 8);

--- a/src/mito2/src/sst/index/inverted_index/applier.rs
+++ b/src/mito2/src/sst/index/inverted_index/applier.rs
@@ -16,6 +16,7 @@ pub mod builder;
 
 use std::sync::Arc;
 
+use common_base::range_read::RangeReaderAdapter;
 use common_telemetry::warn;
 use index::inverted_index::format::reader::InvertedIndexBlobReader;
 use index::inverted_index::search::index_apply::{
@@ -108,6 +109,7 @@ impl InvertedIndexApplier {
                 self.remote_blob_reader(file_id).await?
             }
         };
+        let blob = RangeReaderAdapter(blob);
 
         if let Some(index_cache) = &self.inverted_index_cache {
             let mut index_reader = CachedInvertedIndexBlobReader::new(


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

#4717 

## What's changed and what's your intention?

* Add `RangeReaderAdapter`
* Simplify generic param on `InvertedIndeFooterReader`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
