### PR TITLE
fix: determine region role by using is_readonly

### DIFF
--- a/src/mito2/src/engine.rs
+++ b/src/mito2/src/engine.rs
@@ -462,10 +462,10 @@ impl EngineInner {
 
     fn role(&self, region_id: RegionId) -> Option<RegionRole> {
         self.workers.get_region(region_id).map(|region| {
-            if region.is_writable() {
-                RegionRole::Leader
-            } else {
+            if region.is_readonly() {
                 RegionRole::Follower
+            } else {
+                RegionRole::Leader
             }
         })
     }

--- a/src/mito2/src/region.rs
+++ b/src/mito2/src/region.rs
@@ -174,6 +174,11 @@ impl MitoRegion {
         self.manifest_ctx.state.load() == RegionState::Writable
     }
 
+    /// Returns whether the region is readonly.
+    pub(crate) fn is_readonly(&self) -> bool {
+        self.manifest_ctx.state.load() == RegionState::ReadOnly
+    }
+
     /// Returns the state of the region.
     pub(crate) fn state(&self) -> RegionState {
         self.manifest_ctx.state.load()


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

determine region role by using `is_readonly`

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
