### PR TITLE
fix: config test failed and use `similar_asserts::assert_eq` to replace `assert_eq` for long string compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+dependencies = [
+ "memchr",
+ "regex-automata 0.4.7",
+ "serde",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1772,7 @@ dependencies = [
  "serde_json",
  "servers",
  "session",
+ "similar-asserts",
  "snafu 0.8.4",
  "store-api",
  "substrait 0.9.3",
@@ -9655,7 +9667,7 @@ source = "git+https://github.com/discord9/RustPython?rev=9ed5137412#9ed51374125b
 dependencies = [
  "ascii",
  "bitflags 1.3.2",
- "bstr",
+ "bstr 0.2.17",
  "cfg-if",
  "hexf-parse",
  "itertools 0.10.5",
@@ -9690,7 +9702,7 @@ version = "0.2.0"
 source = "git+https://github.com/discord9/RustPython?rev=9ed5137412#9ed51374125b5f1a9e5cee5dd7e27023b8591f1e"
 dependencies = [
  "bitflags 1.3.2",
- "bstr",
+ "bstr 0.2.17",
  "itertools 0.10.5",
  "lz4_flex 0.9.5",
  "num-bigint",
@@ -9843,7 +9855,7 @@ dependencies = [
  "ascii",
  "atty",
  "bitflags 1.3.2",
- "bstr",
+ "bstr 0.2.17",
  "caseless",
  "cfg-if",
  "chrono",
@@ -10610,6 +10622,26 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+dependencies = [
+ "bstr 1.10.0",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+dependencies = [
+ "console",
+ "similar",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -11798,6 +11830,7 @@ dependencies = [
  "serde_json",
  "servers",
  "session",
+ "similar-asserts",
  "snafu 0.8.4",
  "sql",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,10 +165,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 serde_with = "3"
 shadow-rs = "0.31"
+similar-asserts = "1.6.0"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
 sysinfo = "0.30"
-similar-asserts = "1.6.0"
 # on branch v0.44.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "54a267ac89c09b11c0c88934690530807185d3e7", features = [
     "visitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,8 @@ shadow-rs = "0.31"
 smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
 sysinfo = "0.30"
-# on branch v0.44.x
 similar-asserts = "1.6.0"
+# on branch v0.44.x
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "54a267ac89c09b11c0c88934690530807185d3e7", features = [
     "visitor",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ smallvec = { version = "1", features = ["serde"] }
 snafu = "0.8"
 sysinfo = "0.30"
 # on branch v0.44.x
+similar-asserts = "1.6.0"
 sqlparser = { git = "https://github.com/GreptimeTeam/sqlparser-rs.git", rev = "54a267ac89c09b11c0c88934690530807185d3e7", features = [
     "visitor",
 ] }

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -70,6 +70,7 @@ serde.workspace = true
 serde_json.workspace = true
 servers.workspace = true
 session.workspace = true
+similar-asserts.workspace = true
 snafu.workspace = true
 store-api.workspace = true
 substrait.workspace = true

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::default::Default;
 use std::time::Duration;
 
 use cmd::options::GreptimeOptions;

--- a/src/cmd/tests/load_config_test.rs
+++ b/src/cmd/tests/load_config_test.rs
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::default::Default;
 use std::time::Duration;
 
 use cmd::options::GreptimeOptions;
 use cmd::standalone::StandaloneOptions;
-use common_base::readable_size::ReadableSize;
 use common_config::Configurable;
 use common_grpc::channel_manager::{
     DEFAULT_MAX_GRPC_RECV_MESSAGE_SIZE, DEFAULT_MAX_GRPC_SEND_MESSAGE_SIZE,
 };
-use common_runtime::global::RuntimeOptions;
 use common_telemetry::logging::{LoggingOptions, DEFAULT_OTLP_ENDPOINT};
 use common_wal::config::raft_engine::RaftEngineConfig;
 use common_wal::config::DatanodeWalConfig;
@@ -45,10 +44,6 @@ fn test_load_datanode_example_config() {
             .unwrap();
 
     let expected = GreptimeOptions::<DatanodeOptions> {
-        runtime: RuntimeOptions {
-            global_rt_size: 8,
-            compact_rt_size: 4,
-        },
         component: DatanodeOptions {
             node_id: Some(42),
             meta_client: Some(MetaClientOptions {
@@ -76,8 +71,6 @@ fn test_load_datanode_example_config() {
                 RegionEngineConfig::Mito(MitoConfig {
                     auto_flush_interval: Duration::from_secs(3600),
                     scan_parallelism: 0,
-                    global_write_buffer_reject_size: ReadableSize::gb(2),
-                    max_background_jobs: 4,
                     experimental_write_cache_ttl: Some(Duration::from_secs(60 * 60 * 8)),
                     ..Default::default()
                 }),
@@ -102,9 +95,10 @@ fn test_load_datanode_example_config() {
             rpc_max_send_message_size: Some(DEFAULT_MAX_GRPC_SEND_MESSAGE_SIZE),
             ..Default::default()
         },
+        ..Default::default()
     };
 
-    assert_eq!(options, expected);
+    similar_asserts::assert_eq!(options, expected);
 }
 
 #[test]
@@ -114,10 +108,6 @@ fn test_load_frontend_example_config() {
         GreptimeOptions::<FrontendOptions>::load_layered_options(example_config.to_str(), "")
             .unwrap();
     let expected = GreptimeOptions::<FrontendOptions> {
-        runtime: RuntimeOptions {
-            global_rt_size: 8,
-            compact_rt_size: 4,
-        },
         component: FrontendOptions {
             default_timezone: Some("UTC".to_string()),
             meta_client: Some(MetaClientOptions {
@@ -150,8 +140,9 @@ fn test_load_frontend_example_config() {
             },
             ..Default::default()
         },
+        ..Default::default()
     };
-    assert_eq!(options, expected);
+    similar_asserts::assert_eq!(options, expected);
 }
 
 #[test]
@@ -161,10 +152,6 @@ fn test_load_metasrv_example_config() {
         GreptimeOptions::<MetasrvOptions>::load_layered_options(example_config.to_str(), "")
             .unwrap();
     let expected = GreptimeOptions::<MetasrvOptions> {
-        runtime: RuntimeOptions {
-            global_rt_size: 8,
-            compact_rt_size: 4,
-        },
         component: MetasrvOptions {
             selector: SelectorType::default(),
             data_home: "/tmp/metasrv/".to_string(),
@@ -182,8 +169,9 @@ fn test_load_metasrv_example_config() {
             },
             ..Default::default()
         },
+        ..Default::default()
     };
-    assert_eq!(options, expected);
+    similar_asserts::assert_eq!(options, expected);
 }
 
 #[test]
@@ -193,10 +181,6 @@ fn test_load_standalone_example_config() {
         GreptimeOptions::<StandaloneOptions>::load_layered_options(example_config.to_str(), "")
             .unwrap();
     let expected = GreptimeOptions::<StandaloneOptions> {
-        runtime: RuntimeOptions {
-            global_rt_size: 8,
-            compact_rt_size: 4,
-        },
         component: StandaloneOptions {
             default_timezone: Some("UTC".to_string()),
             wal: DatanodeWalConfig::RaftEngine(RaftEngineConfig {
@@ -208,11 +192,8 @@ fn test_load_standalone_example_config() {
             region_engine: vec![
                 RegionEngineConfig::Mito(MitoConfig {
                     auto_flush_interval: Duration::from_secs(3600),
-                    scan_parallelism: 0,
-                    global_write_buffer_reject_size: ReadableSize::gb(2),
-                    sst_meta_cache_size: ReadableSize::mb(128),
-                    max_background_jobs: 4,
                     experimental_write_cache_ttl: Some(Duration::from_secs(60 * 60 * 8)),
+                    scan_parallelism: 0,
                     ..Default::default()
                 }),
                 RegionEngineConfig::File(EngineConfig {}),
@@ -234,6 +215,7 @@ fn test_load_standalone_example_config() {
             },
             ..Default::default()
         },
+        ..Default::default()
     };
-    assert_eq!(options, expected);
+    similar_asserts::assert_eq!(options, expected);
 }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -59,6 +59,7 @@ rstest_reuse.workspace = true
 serde_json.workspace = true
 servers = { workspace = true, features = ["testing"] }
 session.workspace = true
+similar-asserts.workspace = true
 snafu.workspace = true
 sql.workspace = true
 sqlx = { version = "0.6", features = [

--- a/tests-integration/tests/http.rs
+++ b/tests-integration/tests/http.rs
@@ -879,7 +879,7 @@ write_interval = "30s"
     .trim()
     .to_string();
     let body_text = drop_lines_with_inconsistent_results(res_get.text().await);
-    assert_eq!(body_text, expected_toml_str);
+    similar_asserts::assert_eq!(body_text, expected_toml_str);
 }
 
 fn drop_lines_with_inconsistent_results(input: String) -> String {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Resolve https://github.com/GreptimeTeam/greptimedb/issues/4722.

1. Fix config test failed in `cmd` crate by removing some auto configs;
2. Bring https://crates.io/crates/similar-asserts for config string compare;

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
