### PR TITLE
refactor(tables): improve `tables` performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,6 +1377,7 @@ dependencies = [
  "store-api",
  "table",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2078,6 +2079,7 @@ dependencies = [
  "anymap2",
  "api",
  "async-recursion",
+ "async-stream",
  "async-trait",
  "base64 0.21.7",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "common-meta",
  "common-query",
  "common-recordbatch",
+ "common-runtime",
  "common-telemetry",
  "common-test-util",
  "common-time",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -24,6 +24,7 @@ common-macro.workspace = true
 common-meta.workspace = true
 common-query.workspace = true
 common-recordbatch.workspace = true
+common-runtime.workspace = true
 common-telemetry.workspace = true
 common-time.workspace = true
 common-version.workspace = true

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -48,6 +48,7 @@ sql.workspace = true
 store-api.workspace = true
 table.workspace = true
 tokio.workspace = true
+tokio-stream = "0.1"
 
 [dev-dependencies]
 cache.workspace = true

--- a/src/catalog/src/kvbackend/manager.rs
+++ b/src/catalog/src/kvbackend/manager.rs
@@ -180,7 +180,7 @@ impl CatalogManager for KvBackendCatalogManager {
         schema: &str,
         query_ctx: Option<&QueryContext>,
     ) -> Result<Vec<String>> {
-        let stream = self
+        let mut tables = self
             .table_metadata_manager
             .table_name_manager()
             .tables(catalog, schema)

--- a/src/catalog/src/kvbackend/manager.rs
+++ b/src/catalog/src/kvbackend/manager.rs
@@ -330,7 +330,7 @@ impl CatalogManager for KvBackendCatalogManager {
                     }) {
                     Ok(table_ids) => table_ids,
                     Err(e) => {
-                        let _ = tx.send(Err(e));
+                        let _ = tx.send(Err(e)).await;
                         return;
                     }
                 };

--- a/src/common/meta/Cargo.toml
+++ b/src/common/meta/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 anymap2 = "0.13.0"
 api.workspace = true
 async-recursion = "1.0"
+async-stream = "0.3"
 async-trait.workspace = true
 base64.workspace = true
 bytes.workspace = true

--- a/src/common/meta/src/key/catalog_name.rs
+++ b/src/common/meta/src/key/catalog_name.rs
@@ -147,7 +147,8 @@ impl CatalogManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(catalog_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/datanode_table.rs
+++ b/src/common/meta/src/key/datanode_table.rs
@@ -167,7 +167,8 @@ impl DatanodeTableManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(datanode_table_value_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/flow/flow_name.rs
+++ b/src/common/meta/src/key/flow/flow_name.rs
@@ -200,7 +200,8 @@ impl FlowNameManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(flow_name_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/flow/flow_route.rs
+++ b/src/common/meta/src/key/flow/flow_route.rs
@@ -180,7 +180,8 @@ impl FlowRouteManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(flow_route_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/flow/flownode_flow.rs
+++ b/src/common/meta/src/key/flow/flownode_flow.rs
@@ -180,7 +180,8 @@ impl FlownodeFlowManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(flownode_flow_key_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream.map_ok(|key| (key.flow_id(), key.partition_id())))
     }

--- a/src/common/meta/src/key/flow/table_flow.rs
+++ b/src/common/meta/src/key/flow/table_flow.rs
@@ -207,7 +207,8 @@ impl TableFlowManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(table_flow_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/schema_name.rs
+++ b/src/common/meta/src/key/schema_name.rs
@@ -230,7 +230,8 @@ impl SchemaManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(schema_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/key/table_name.rs
+++ b/src/common/meta/src/key/table_name.rs
@@ -259,7 +259,8 @@ impl TableNameManager {
             req,
             DEFAULT_PAGE_SIZE,
             Arc::new(table_decoder),
-        );
+        )
+        .into_stream();
 
         Box::pin(stream)
     }

--- a/src/common/meta/src/state_store.rs
+++ b/src/common/meta/src/state_store.rs
@@ -172,7 +172,8 @@ impl StateStore for KvStateStore {
             req,
             self.max_num_per_range_request.unwrap_or_default(),
             Arc::new(decode_kv),
-        );
+        )
+        .into_stream();
 
         let stream = stream.map(move |r| {
             let path = path.clone();

--- a/src/log-store/src/raft_engine/backend.rs
+++ b/src/log-store/src/raft_engine/backend.rs
@@ -264,9 +264,8 @@ impl KvBackend for RaftEngineBackend {
         let mut response = BatchGetResponse {
             kvs: Vec::with_capacity(req.keys.len()),
         };
-        let engine = self.engine.read().unwrap();
         for key in req.keys {
-            let Some(value) = engine.get(SYSTEM_NAMESPACE, &key) else {
+            let Some(value) = self.engine.read().unwrap().get(SYSTEM_NAMESPACE, &key) else {
                 continue;
             };
             response.kvs.push(KeyValue { key, value });

--- a/src/meta-srv/src/service/store/cached_kv.rs
+++ b/src/meta-srv/src/service/store/cached_kv.rs
@@ -103,9 +103,10 @@ impl LeaderCachedKvBackend {
                 RangeRequest::new().with_prefix(prefix.as_bytes()),
                 DEFAULT_PAGE_SIZE,
                 Arc::new(Ok),
-            );
+            )
+            .into_stream();
 
-            let kvs = stream.try_collect::<Vec<_>>().await?.into_iter().collect();
+            let kvs = stream.try_collect::<Vec<_>>().await?;
 
             self.cache
                 .batch_put(BatchPutRequest {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This patch tries to solve some user's complaint about the lag while switching database in mysql cli by enabling concurrent tables iteration in information_schema to accelerate table rehash.

It also introduces some refactor regarding reading table information in kvbackend.

For a database with 100k tables, it cuts `show tables` cost time from 430ms to 200ms.
```
# From
$ time mysql -h 127.0.0.1 -P 4002 -e "show tables" > /dev/null 2>&1
mysql -h 127.0.0.1 -P 4002 -e "show tables" > /dev/null 2>&1  0.01s user 0.00s system 7% cpu 0.432 total

# To
$ time mysql -h 127.0.0.1 -P 4002 -e "show tables" > /dev/null 2>&1
mysql -h 127.0.0.1 -P 4002 -e "show tables" > /dev/null 2>&1  0.01s user 0.00s system 7% cpu 0.201 total
```
## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
