### PR TITLE
fix: disable field pruning in last non null mode

### DIFF
--- a/tests/cases/standalone/common/select/prune_field.result
+++ b/tests/cases/standalone/common/select/prune_field.result
@@ -23,6 +23,14 @@ insert into prune_field(ts, tag, a, b) values(0, 1, null, 1);
 
 Affected Rows: 1
 
+admin flush_table('prune_field');
+
++----------------------------------+
+| ADMIN flush_table('prune_field') |
++----------------------------------+
+| 0                                |
++----------------------------------+
+
 select * from prune_field where a = 1;
 
 +---------------------+-----+---+---+

--- a/tests/cases/standalone/common/select/prune_field.result
+++ b/tests/cases/standalone/common/select/prune_field.result
@@ -1,0 +1,61 @@
+CREATE TABLE IF NOT EXISTS prune_field (
+  ts TIMESTAMP TIME INDEX,
+  tag UInt16,
+  a UInt8,
+  b UInt8,
+PRIMARY KEY (tag)) ENGINE = mito WITH('merge_mode'='last_non_null');
+
+Affected Rows: 0
+
+insert into prune_field(ts, tag, a, b) values(0, 1, 1, null);
+
+Affected Rows: 1
+
+admin flush_table('prune_field');
+
++----------------------------------+
+| ADMIN flush_table('prune_field') |
++----------------------------------+
+| 0                                |
++----------------------------------+
+
+insert into prune_field(ts, tag, a, b) values(0, 1, null, 1);
+
+Affected Rows: 1
+
+select * from prune_field where a = 1;
+
++---------------------+-----+---+---+
+| ts                  | tag | a | b |
++---------------------+-----+---+---+
+| 1970-01-01T00:00:00 | 1   | 1 | 1 |
++---------------------+-----+---+---+
+
+select * from prune_field where b = 1;
+
++---------------------+-----+---+---+
+| ts                  | tag | a | b |
++---------------------+-----+---+---+
+| 1970-01-01T00:00:00 | 1   | 1 | 1 |
++---------------------+-----+---+---+
+
+select * from prune_field;
+
++---------------------+-----+---+---+
+| ts                  | tag | a | b |
++---------------------+-----+---+---+
+| 1970-01-01T00:00:00 | 1   | 1 | 1 |
++---------------------+-----+---+---+
+
+select * from prune_field where a = 1 and b = 1;
+
++---------------------+-----+---+---+
+| ts                  | tag | a | b |
++---------------------+-----+---+---+
+| 1970-01-01T00:00:00 | 1   | 1 | 1 |
++---------------------+-----+---+---+
+
+drop table prune_field;
+
+Affected Rows: 0
+

--- a/tests/cases/standalone/common/select/prune_field.sql
+++ b/tests/cases/standalone/common/select/prune_field.sql
@@ -11,6 +11,8 @@ admin flush_table('prune_field');
 
 insert into prune_field(ts, tag, a, b) values(0, 1, null, 1);
 
+admin flush_table('prune_field');
+
 select * from prune_field where a = 1;
 
 select * from prune_field where b = 1;

--- a/tests/cases/standalone/common/select/prune_field.sql
+++ b/tests/cases/standalone/common/select/prune_field.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS prune_field (
+  ts TIMESTAMP TIME INDEX,
+  tag UInt16,
+  a UInt8,
+  b UInt8,
+PRIMARY KEY (tag)) ENGINE = mito WITH('merge_mode'='last_non_null');
+
+insert into prune_field(ts, tag, a, b) values(0, 1, 1, null);
+
+admin flush_table('prune_field');
+
+insert into prune_field(ts, tag, a, b) values(0, 1, null, 1);
+
+select * from prune_field where a = 1;
+
+select * from prune_field where b = 1;
+
+select * from prune_field;
+
+select * from prune_field where a = 1 and b = 1;
+
+drop table prune_field;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
fixes https://github.com/GreptimeTeam/greptimedb/issues/4736

## What's changed and what's your intention?
This PR disables pruning SSTs by fields if the merge mode is `last_non_null`. Pruning rows by fields before the merge phase may remove some useful rows, like #4736

This may have a negative impact on query performance in `last_non_null` mode. We can alleviate this by checking whether SSTs and memtables have overlapping ranges and only remove field filters if they are overlapping. However, we need to refactor the scanner to postpone pruning.

I'll address this later.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
