### PR TITLE
fix: use gcc-10 in release dev build

### DIFF
--- a/docker/dev-builder/ubuntu/Dockerfile
+++ b/docker/dev-builder/ubuntu/Dockerfile
@@ -24,6 +24,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3.10 \
     python3.10-dev
 
+# https://github.com/GreptimeTeam/greptimedb/actions/runs/10935485852/job/30357457188#step:3:7106
+# `aws-lc-sys` require gcc >= 10.3.0 to work, hence alias to use gcc-10
+RUN alias gcc="gcc-10" && alias cc="gcc-10"
+
 # Remove Python 3.8 and install pip.
 RUN apt-get -y purge python3.8 && \
     apt-get -y autoremove && \


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

alias cc to gcc-10 in dev build dockerfile, so cc_builder wouldn't emit warning about c compiler errors

Please explain IN DETAIL what the changes are in this PR and why they are needed:
https://github.com/GreptimeTeam/greptimedb/actions/runs/10935485852/job/30357457188#step:3:7106
says `aws-lc-sys` need higher version of gcc(cc>=10.3.0 or clang) to build, so just alias cc to `gcc-10` which is 10.5.0


## Checklist

- [ ] wait for https://github.com/GreptimeTeam/greptimedb/actions/runs/10937322135 then rerun Release CI to success before merge
- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
