### PR TITLE
perf: add last insert schema hash cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7327,6 +7327,7 @@ dependencies = [
  "regex",
  "serde_json",
  "session",
+ "sha2",
  "snafu 0.8.4",
  "sql",
  "sqlparser 0.45.0 (git+https://github.com/GreptimeTeam/sqlparser-rs.git?rev=54a267ac89c09b11c0c88934690530807185d3e7)",

--- a/src/operator/Cargo.toml
+++ b/src/operator/Cargo.toml
@@ -48,6 +48,7 @@ query.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 session.workspace = true
+sha2 = "0.10.8"
 snafu.workspace = true
 sql.workspace = true
 sqlparser.workspace = true


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Add last insert schema hash cache

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
