### PR TITLE
feat: flush other workers if still need flush

### DIFF
--- a/src/mito2/src/worker.rs
+++ b/src/mito2/src/worker.rs
@@ -670,6 +670,11 @@ impl<S: LogStore> RegionWorkerLoop<S> {
                         // The channel is disconnected.
                         break;
                     } else {
+                        // Also flush this worker if other workers trigger flush as this worker may have
+                        // a large memtable to flush. We may not have chance to flush that memtable if we
+                        // never write to this worker. So only flushing other workers may not release enough
+                        // memory.
+                        self.maybe_flush_worker();
                         // A flush job is finished, handles stalled requests.
                         self.handle_stalled_requests().await;
                         continue;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?
This PR checks all workers to see if we need to flush them after a flush job is finished. An inactive worker may keep a large write buffer but never flush it. Then other workers may flush very frequently since the global write buffer size is still high.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
