### PR TITLE
feat: unordered scanner scans data by time ranges

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -131,6 +131,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
     ) -> Result<BoxedBatchIterator>;
 
     /// Returns the ranges in the memtable.
+    /// The returned map contains the range id and the range after applying the predicate.
     fn ranges(
         &self,
         projection: Option<&[ColumnId]>,

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -14,6 +14,7 @@
 
 //! Memtables are write buffers for regions.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -134,7 +135,7 @@ pub trait Memtable: Send + Sync + fmt::Debug {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemtableRange>;
+    ) -> BTreeMap<usize, MemtableRange>;
 
     /// Returns true if the memtable is empty.
     fn is_empty(&self) -> bool;
@@ -339,7 +340,6 @@ impl MemtableRangeContext {
 pub struct MemtableRange {
     /// Shared context.
     context: MemtableRangeContextRef,
-    // TODO(yingwen): Id to identify the range in the memtable.
 }
 
 impl MemtableRange {

--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -71,6 +71,8 @@ pub struct MemtableStats {
     time_range: Option<(Timestamp, Timestamp)>,
     /// Total rows in memtable
     num_rows: usize,
+    /// Total number of ranges in the memtable.
+    num_ranges: usize,
 }
 
 impl MemtableStats {
@@ -94,6 +96,11 @@ impl MemtableStats {
     /// Returns the num of total rows in memtable.
     pub fn num_rows(&self) -> usize {
         self.num_rows
+    }
+
+    /// Returns the number of ranges in the memtable.
+    pub fn num_ranges(&self) -> usize {
+        self.num_ranges
     }
 }
 

--- a/src/mito2/src/memtable/bulk.rs
+++ b/src/mito2/src/memtable/bulk.rs
@@ -14,6 +14,7 @@
 
 //! Memtable implementation for bulk load
 
+use std::collections::BTreeMap;
 use std::sync::{Arc, RwLock};
 
 use store_api::metadata::RegionMetadataRef;
@@ -67,7 +68,7 @@ impl Memtable for BulkMemtable {
         &self,
         _projection: Option<&[ColumnId]>,
         _predicate: Option<Predicate>,
-    ) -> Vec<MemtableRange> {
+    ) -> BTreeMap<usize, MemtableRange> {
         todo!()
     }
 

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -24,6 +24,7 @@ mod shard;
 mod shard_builder;
 mod tree;
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -176,7 +177,7 @@ impl Memtable for PartitionTreeMemtable {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemtableRange> {
+    ) -> BTreeMap<usize, MemtableRange> {
         let projection = projection.map(|ids| ids.to_vec());
         let builder = Box::new(PartitionTreeIterBuilder {
             tree: self.tree.clone(),
@@ -185,7 +186,7 @@ impl Memtable for PartitionTreeMemtable {
         });
         let context = Arc::new(MemtableRangeContext::new(self.id, builder));
 
-        vec![MemtableRange::new(context)]
+        [(0, MemtableRange::new(context))].into()
     }
 
     fn is_empty(&self) -> bool {

--- a/src/mito2/src/memtable/partition_tree.rs
+++ b/src/mito2/src/memtable/partition_tree.rs
@@ -207,6 +207,7 @@ impl Memtable for PartitionTreeMemtable {
                 estimated_bytes,
                 time_range: None,
                 num_rows: 0,
+                num_ranges: 0,
             };
         }
 
@@ -225,6 +226,7 @@ impl Memtable for PartitionTreeMemtable {
             estimated_bytes,
             time_range: Some((min_timestamp, max_timestamp)),
             num_rows: self.num_rows.load(Ordering::Relaxed),
+            num_ranges: 1,
         }
     }
 

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -287,7 +287,7 @@ impl Memtable for TimeSeriesMemtable {
         &self,
         projection: Option<&[ColumnId]>,
         predicate: Option<Predicate>,
-    ) -> Vec<MemtableRange> {
+    ) -> BTreeMap<usize, MemtableRange> {
         let projection = if let Some(projection) = projection {
             projection.iter().copied().collect()
         } else {
@@ -305,7 +305,7 @@ impl Memtable for TimeSeriesMemtable {
         });
         let context = Arc::new(MemtableRangeContext::new(self.id, builder));
 
-        vec![MemtableRange::new(context)]
+        [(0, MemtableRange::new(context))].into()
     }
 
     fn is_empty(&self) -> bool {

--- a/src/mito2/src/memtable/time_series.rs
+++ b/src/mito2/src/memtable/time_series.rs
@@ -327,6 +327,7 @@ impl Memtable for TimeSeriesMemtable {
                 estimated_bytes,
                 time_range: None,
                 num_rows: 0,
+                num_ranges: 0,
             };
         }
         let ts_type = self
@@ -343,6 +344,7 @@ impl Memtable for TimeSeriesMemtable {
             estimated_bytes,
             time_range: Some((min_timestamp, max_timestamp)),
             num_rows: self.num_rows.load(Ordering::Relaxed),
+            num_ranges: 1,
         }
     }
 

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -20,6 +20,7 @@ pub mod last_row;
 pub mod merge;
 pub mod projection;
 pub(crate) mod prune;
+pub(crate) mod range;
 pub(crate) mod scan_region;
 pub(crate) mod seq_scan;
 pub(crate) mod unordered_scan;

--- a/src/mito2/src/read.rs
+++ b/src/mito2/src/read.rs
@@ -754,6 +754,10 @@ pub(crate) struct ScannerMetrics {
     num_batches: usize,
     /// Number of rows returned.
     num_rows: usize,
+    /// Number of mem ranges scanned.
+    num_mem_ranges: usize,
+    /// Number of file ranges scanned.
+    num_file_ranges: usize,
     /// Filter related metrics for readers.
     filter_metrics: ReaderFilterMetrics,
 }

--- a/src/mito2/src/read/dedup.rs
+++ b/src/mito2/src/read/dedup.rs
@@ -400,7 +400,6 @@ pub(crate) struct LastNonNull {
 
 impl LastNonNull {
     /// Creates a new strategy with the given `filter_deleted` flag.
-    #[allow(dead_code)]
     pub(crate) fn new(filter_deleted: bool) -> Self {
         Self {
             buffer: None,

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -23,11 +23,11 @@ use crate::sst::parquet::DEFAULT_ROW_GROUP_SIZE;
 
 /// Index to access a row group.
 #[derive(Clone)]
-struct RowGroupIndex {
+pub(crate) struct RowGroupIndex {
     /// Index to the file.
-    file_index: usize,
+    pub(crate) file_index: usize,
     /// Row group index in the file.
-    row_group_index: usize,
+    pub(crate) row_group_index: usize,
 }
 
 /// Meta data of a partition range.
@@ -113,6 +113,7 @@ impl RangeMeta {
         }
     }
 
+    // FIXME(yingwen): Replaces memtables by mem ranges.
     fn push_mem_ranges(memtables: &[MemtableRef], ranges: &mut Vec<RangeMeta>) {
         for (i, memtable) in memtables.iter().enumerate() {
             let stats = memtable.stats();

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -22,7 +22,7 @@ use crate::sst::file::{overlaps, FileHandle, FileTimeRange};
 use crate::sst::parquet::DEFAULT_ROW_GROUP_SIZE;
 
 /// Index to access a row group.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub(crate) struct RowGroupIndex {
     /// Index to the file.
     pub(crate) file_index: usize,
@@ -37,12 +37,12 @@ pub(crate) struct RangeMeta {
     /// The time range of the range.
     pub(crate) time_range: FileTimeRange,
     /// Indices to memtables.
-    mem_indices: SmallVec<[usize; 2]>,
+    pub(crate) mem_indices: SmallVec<[usize; 2]>,
     /// Indices to files. It contains the indices to all the files in `row_group_indices`.
     file_indices: SmallVec<[usize; 4]>,
     /// Indices to file row groups that this range scans.
     /// An empty vec indicates all row groups. (Some file metas don't have row group number).
-    row_group_indices: SmallVec<[RowGroupIndex; 2]>,
+    pub(crate) row_group_indices: SmallVec<[RowGroupIndex; 2]>,
     /// Estimated number of rows in the range. This can be 0 if the statistics are not available.
     pub(crate) num_rows: usize,
 }

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -1,0 +1,106 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Structs for partition ranges.
+
+use smallvec::SmallVec;
+
+use crate::sst::file::{overlaps, FileTimeRange};
+
+/// Index to access a row group.
+struct RowGroupIndex {
+    /// Index to the file.
+    file_index: usize,
+    /// Row group index in the file.
+    row_group_index: usize,
+}
+
+/// Meta data of a partition range.
+/// If the scanner is [UnorderedScan], each meta only has one row group or memtable.
+/// If the scanner is [SeqScan], each meta may have multiple row groups and memtables.
+pub(crate) struct RangeMeta {
+    /// The time range of the range.
+    pub(crate) time_range: FileTimeRange,
+    /// Indices to memtables.
+    mem_indices: SmallVec<[usize; 4]>,
+    /// Indices to files. It contains the indices to all the files in `row_group_indices`.
+    file_indices: SmallVec<[usize; 4]>,
+    /// Indices to file row groups that this range scans.
+    row_group_indices: SmallVec<[RowGroupIndex; 4]>,
+}
+
+impl RangeMeta {
+    /// Returns true if the time range of given `meta` overlaps with the time range of this meta.
+    pub(crate) fn overlaps(&self, meta: &RangeMeta) -> bool {
+        overlaps(&self.time_range, &meta.time_range)
+    }
+
+    /// Merges given `meta` to this meta.
+    /// It assumes that the time ranges overlap and they don't have the same file or memtable index.
+    pub(crate) fn merge(&mut self, mut other: RangeMeta) {
+        self.time_range = (
+            self.time_range.0.min(other.time_range.0),
+            self.time_range.1.max(other.time_range.1),
+        );
+        self.mem_indices.append(&mut other.mem_indices);
+        self.file_indices.append(&mut other.file_indices);
+        self.row_group_indices.append(&mut other.row_group_indices);
+    }
+
+    /// Returns true if we can split the range into multiple smaller ranges and
+    /// still preserve the order for [SeqScan].
+    pub(crate) fn can_split_preserve_order(&self) -> bool {
+        self.mem_indices.is_empty()
+            && self.file_indices.len() == 1
+            && self.row_group_indices.len() > 1
+    }
+}
+
+/// Groups ranges by time range.
+/// It assumes each input range only contains a file or a memtable.
+fn group_ranges_for_merge_mode(mut ranges: Vec<RangeMeta>) -> Vec<RangeMeta> {
+    if ranges.is_empty() {
+        return ranges;
+    }
+
+    // Sorts ranges by time range (start asc, end desc).
+    ranges.sort_unstable_by(|a, b| {
+        let l = a.time_range;
+        let r = b.time_range;
+        l.0.cmp(&r.0).then_with(|| r.1.cmp(&l.1))
+    });
+    let mut range_in_progress = None;
+    // Parts with exclusive time ranges.
+    let mut exclusive_ranges = Vec::with_capacity(ranges.len());
+    for range in ranges {
+        let Some(mut prev_range) = range_in_progress.take() else {
+            // This is the new range to process.
+            range_in_progress = Some(range);
+            continue;
+        };
+
+        if prev_range.overlaps(&range) {
+            prev_range.merge(range);
+            range_in_progress = Some(prev_range);
+        } else {
+            exclusive_ranges.push(prev_range);
+            range_in_progress = Some(range);
+        }
+    }
+    if let Some(range) = range_in_progress {
+        exclusive_ranges.push(range);
+    }
+
+    exclusive_ranges
+}

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -24,7 +24,7 @@ use crate::sst::parquet::DEFAULT_ROW_GROUP_SIZE;
 const ALL_ROW_GROUPS: i64 = -1;
 
 /// Index to access a row group.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub(crate) struct RowGroupIndex {
     /// Index to the memtable/file.
     pub(crate) index: usize,
@@ -75,6 +75,13 @@ impl RangeMeta {
     /// Merges given `meta` to this meta.
     /// It assumes that the time ranges overlap and they don't have the same file or memtable index.
     pub(crate) fn merge(&mut self, mut other: RangeMeta) {
+        debug_assert!(self.overlaps(&other));
+        debug_assert!(self.indices.iter().all(|idx| !other.indices.contains(idx)));
+        debug_assert!(self
+            .row_group_indices
+            .iter()
+            .all(|idx| !other.row_group_indices.contains(idx)));
+
         self.time_range = (
             self.time_range.0.min(other.time_range.0),
             self.time_range.1.max(other.time_range.1),

--- a/src/mito2/src/read/range.rs
+++ b/src/mito2/src/read/range.rs
@@ -248,7 +248,7 @@ fn group_ranges_for_seq_scan(mut ranges: Vec<RangeMeta>) -> Vec<RangeMeta> {
 }
 
 /// Splits the range into multiple smaller ranges.
-/// It assumes the input `ranges` list is created by [group_ranges_for_merge_mode()].
+/// It assumes the input `ranges` list is created by [group_ranges_for_seq_scan()].
 fn maybe_split_ranges_for_seq_scan(ranges: Vec<RangeMeta>) -> Vec<RangeMeta> {
     let mut new_ranges = Vec::with_capacity(ranges.len());
     for range in ranges {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -973,9 +973,10 @@ pub(crate) struct StreamContext {
     /// The mutex is used to ensure the parts are only built once.
     pub(crate) parts: Mutex<(ScanPartList, Duration)>,
     /// Metadata for partition ranges.
-    ranges: Vec<RangeMeta>,
+    pub(crate) ranges: Vec<RangeMeta>,
     /// Lists of range builders.
     range_builders: RangeBuilderList,
+    // FIXME(yingwen): Support mem range.
 
     // Metrics:
     /// The start time of the query.
@@ -1101,6 +1102,7 @@ impl RangeBuilderList {
     }
 }
 
+// FIXME(yingwen): Support range builder for mem.
 /// Builder to create file ranges.
 #[derive(Default)]
 struct RangeBuilder {

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -983,7 +983,6 @@ pub(crate) struct StreamContext {
     pub(crate) ranges: Vec<RangeMeta>,
     /// Lists of range builders.
     range_builders: RangeBuilderList,
-    // FIXME(yingwen): Support mem range.
 
     // Metrics:
     /// The start time of the query.
@@ -995,7 +994,6 @@ impl StreamContext {
     pub(crate) fn seq_scan_ctx(input: ScanInput) -> Self {
         let query_start = input.query_start.unwrap_or_else(Instant::now);
         let ranges = RangeMeta::seq_scan_ranges(&input);
-        // TODO(yingwen): Find a better place to put it.
         READ_SST_COUNT.observe(input.files.len() as f64);
         let range_builders = RangeBuilderList::new(input.memtables.len(), input.files.len());
 

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1089,11 +1089,11 @@ impl RangeBuilderList {
         index: RowGroupIndex,
         reader_metrics: &mut ReaderMetrics,
     ) -> Result<Option<FileRange>> {
-        let mut builder_opt = self.builders[index.file_index].lock().await;
+        let mut builder_opt = self.builders[index.index].lock().await;
         match &mut *builder_opt {
             Some(builder) => Ok(builder.build_reader(index.row_group_index)),
             None => {
-                let builder = input.prune_file(index.file_index, reader_metrics).await?;
+                let builder = input.prune_file(index.index, reader_metrics).await?;
                 let range = builder.build_reader(index.row_group_index);
                 *builder_opt = Some(builder);
                 Ok(range)

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -1034,6 +1034,7 @@ impl StreamContext {
         ranges: &mut Vec<FileRange>,
         reader_metrics: &mut ReaderMetrics,
     ) -> Result<()> {
+        ranges.clear();
         self.range_builders
             .build_file_ranges(&self.input, index, ranges, reader_metrics)
             .await
@@ -1041,6 +1042,7 @@ impl StreamContext {
 
     /// Creates memtable ranges to scan.
     pub(crate) fn build_mem_ranges(&self, index: RowGroupIndex, ranges: &mut Vec<MemtableRange>) {
+        ranges.clear();
         self.range_builders
             .build_mem_ranges(&self.input, index, ranges)
     }

--- a/src/mito2/src/read/scan_region.rs
+++ b/src/mito2/src/read/scan_region.rs
@@ -46,7 +46,7 @@ use crate::read::unordered_scan::UnorderedScan;
 use crate::read::{Batch, Source};
 use crate::region::options::MergeMode;
 use crate::region::version::VersionRef;
-use crate::sst::file::{overlaps, FileHandle, FileMeta, FileTimeRange};
+use crate::sst::file::{overlaps, FileHandle, FileMeta};
 use crate::sst::index::fulltext_index::applier::builder::FulltextIndexApplierBuilder;
 use crate::sst::index::fulltext_index::applier::FulltextIndexApplierRef;
 use crate::sst::index::inverted_index::applier::builder::InvertedIndexApplierBuilder;
@@ -954,55 +954,6 @@ impl ScanPartList {
                 .map(|ranges| ranges.len())
                 .sum()
         })
-    }
-}
-
-/// Index to access a row group.
-struct RowGroupIndex {
-    /// Index to the file.
-    file_index: usize,
-    /// Row group index in the file.
-    row_group_index: usize,
-}
-
-/// Meta data of a partition range.
-/// If the scanner is [UnorderedScan], each meta only has one row group or memtable.
-/// If the scanner is [SeqScan], each meta may have multiple row groups and memtables.
-pub(crate) struct RangeMeta {
-    /// The time range of the range.
-    pub(crate) time_range: FileTimeRange,
-    /// Indices to memtables.
-    mem_indices: SmallVec<[usize; 4]>,
-    /// Indices to files. It contains the indices to all the files in `row_group_indices`.
-    file_indices: SmallVec<[usize; 4]>,
-    /// Indices to file row groups that this range scans.
-    row_group_indices: SmallVec<[RowGroupIndex; 4]>,
-}
-
-impl RangeMeta {
-    /// Returns true if the time range of given `meta` overlaps with the time range of this meta.
-    pub(crate) fn overlaps(&self, meta: &RangeMeta) -> bool {
-        overlaps(&self.time_range, &meta.time_range)
-    }
-
-    /// Merges given `meta` to this meta.
-    /// It assumes that the time ranges overlap and they don't have the same file or memtable index.
-    pub(crate) fn merge(&mut self, mut other: RangeMeta) {
-        self.time_range = (
-            self.time_range.0.min(other.time_range.0),
-            self.time_range.1.max(other.time_range.1),
-        );
-        self.mem_indices.append(&mut other.mem_indices);
-        self.file_indices.append(&mut other.file_indices);
-        self.row_group_indices.append(&mut other.row_group_indices);
-    }
-
-    /// Returns true if we can split the range into multiple smaller ranges and
-    /// still preserve the order for [SeqScan].
-    pub(crate) fn can_split_preserve_order(&self) -> bool {
-        self.mem_indices.is_empty()
-            && self.file_indices.len() == 1
-            && self.row_group_indices.len() > 1
     }
 }
 

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -593,7 +593,7 @@ impl SeqDistributor {
                 continue;
             }
             let part = ScanPart {
-                memtable_ranges: mem_ranges,
+                memtable_ranges: mem_ranges.into_values().collect(),
                 file_ranges: smallvec![],
                 time_range: stats.time_range(),
             };

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -72,7 +72,7 @@ impl SeqScan {
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
         properties.partitions = vec![input.partition_ranges()];
-        let stream_ctx = Arc::new(StreamContext::new(input));
+        let stream_ctx = Arc::new(StreamContext::new(input, true));
 
         Self {
             properties,

--- a/src/mito2/src/read/seq_scan.rs
+++ b/src/mito2/src/read/seq_scan.rs
@@ -68,11 +68,10 @@ impl SeqScan {
     pub(crate) fn new(input: ScanInput) -> Self {
         let parallelism = input.parallelism.parallelism.max(1);
         let mut properties = ScannerProperties::default()
-            .with_parallelism(parallelism)
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
-        properties.partitions = vec![input.partition_ranges()];
-        let stream_ctx = Arc::new(StreamContext::new(input, true));
+        let stream_ctx = Arc::new(StreamContext::seq_scan_ctx(input));
+        properties.partitions = vec![stream_ctx.partition_ranges()];
 
         Self {
             properties,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -161,7 +161,7 @@ impl UnorderedScan {
             let cache = stream_ctx.input.cache_manager.as_deref();
             stream_ctx.build_mem_ranges(index, ranges);
             metrics.num_mem_ranges += ranges.len();
-            for range in &*ranges {
+            for range in ranges {
                 let build_reader_start = Instant::now();
                 let iter = range.build_iter().map_err(BoxedError::new).context(ExternalSnafu)?;
                 metrics.build_reader_cost = build_reader_start.elapsed();

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -64,7 +64,7 @@ impl UnorderedScan {
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
         properties.partitions = vec![input.partition_ranges()];
-        let stream_ctx = Arc::new(StreamContext::new(input));
+        let stream_ctx = Arc::new(StreamContext::new(input, false));
 
         Self {
             properties,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -58,13 +58,11 @@ pub struct UnorderedScan {
 impl UnorderedScan {
     /// Creates a new [UnorderedScan].
     pub(crate) fn new(input: ScanInput) -> Self {
-        let parallelism = input.parallelism.parallelism.max(1);
         let mut properties = ScannerProperties::default()
-            .with_parallelism(parallelism)
             .with_append_mode(input.append_mode)
             .with_total_rows(input.total_rows());
-        properties.partitions = vec![input.partition_ranges()];
-        let stream_ctx = Arc::new(StreamContext::new(input, false));
+        let stream_ctx = Arc::new(StreamContext::unordered_scan_ctx(input));
+        properties.partitions = vec![stream_ctx.partition_ranges()];
 
         Self {
             properties,

--- a/src/mito2/src/read/unordered_scan.rs
+++ b/src/mito2/src/read/unordered_scan.rs
@@ -175,7 +175,7 @@ impl UnorderedScan {
 
                 // Scans row groups.
                 let mut reader_metrics = ReaderMetrics::default();
-                for index in &range_meta.row_group_indices {
+                for index in &range_meta.file_row_group_indices {
                     let Some(file_range) = stream_ctx
                         .build_file_range(*index, &mut reader_metrics)
                         .await

--- a/src/mito2/src/sst/parquet.rs
+++ b/src/mito2/src/sst/parquet.rs
@@ -40,7 +40,7 @@ pub const PARQUET_METADATA_KEY: &str = "greptime:metadata";
 /// Default batch size to read parquet files.
 pub(crate) const DEFAULT_READ_BATCH_SIZE: usize = 1024;
 /// Default row group size for parquet files.
-const DEFAULT_ROW_GROUP_SIZE: usize = 100 * DEFAULT_READ_BATCH_SIZE;
+pub(crate) const DEFAULT_ROW_GROUP_SIZE: usize = 100 * DEFAULT_READ_BATCH_SIZE;
 
 /// Parquet write options.
 #[derive(Debug)]

--- a/src/mito2/src/sst/parquet/reader.rs
+++ b/src/mito2/src/sst/parquet/reader.rs
@@ -238,6 +238,7 @@ impl ParquetReaderBuilder {
             cache_manager: self.cache_manager.clone(),
         };
 
+        // TODO(yingwen): count the cost of the method.
         metrics.build_cost = start.elapsed();
 
         let mut filters = if let Some(predicate) = &self.predicate {

--- a/src/mito2/src/test_util/memtable_util.rs
+++ b/src/mito2/src/test_util/memtable_util.rs
@@ -14,6 +14,7 @@
 
 //! Memtable test utilities.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use api::helper::ColumnDataTypeWrapper;
@@ -92,8 +93,8 @@ impl Memtable for EmptyMemtable {
         &self,
         _projection: Option<&[ColumnId]>,
         _predicate: Option<Predicate>,
-    ) -> Vec<MemtableRange> {
-        vec![]
+    ) -> BTreeMap<usize, MemtableRange> {
+        BTreeMap::new()
     }
 
     fn is_empty(&self) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR adds the initial implementation for the unordered scanner to support reading rows from time ranges individually.

The scanner groups sources (files and memtables) into ranges and maintains a `RangeMeta` to store the metadata of that range. Each `PartitionRange` refers to a `RangeMeta` in the `StreamContext` so we can use the `PartitionRange::identifier` to locate the `RangeMeta`.

`SeqScan` and `UnorderedScan` have different grouping strategies:
- `SeqScan` merges all overlapping files and memtables to ensure output rows are sorted. So it puts overlapping files and memtables in the same range.
  - If the range only consists of one source, then it can further split row groups of the source into multiple ranges
- `UnorderedScan` can assign each row group to a dedicated range as it doesn't sort and merge duplication rows

The implementations of grouping strategies are similar to `SeqDistributor` and `UnorderedDistributor`.

It also refactors the `scan_partition()` method by wrapping some methods to scan memtables and files.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new module for managing partition ranges, enhancing data scanning capabilities.
  - Added methods to handle pruning of memtable and file ranges, improving efficiency during scans.

- **Improvements**
  - Updated return types for several methods to utilize `BTreeMap`, enhancing data organization and access.
  - Enhanced internal state management with the addition of `num_ranges` to track range counts.

- **Bug Fixes**
  - Removed unnecessary code attributes to streamline the codebase.

- **Documentation**
  - Added comments for future development tasks to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->