### PR TITLE
feat: returning warning instead of error on unsupported `SET` statement

### DIFF
--- a/src/servers/src/postgres/types.rs
+++ b/src/servers/src/postgres/types.rs
@@ -37,7 +37,7 @@ use session::session_config::PGByteaOutputValue;
 
 use self::bytea::{EscapeOutputBytea, HexOutputBytea};
 use self::datetime::{StylingDate, StylingDateTime};
-pub use self::error::PgErrorCode;
+pub use self::error::{PgErrorCode, PgErrorSeverity};
 use self::interval::PgInterval;
 use crate::error::{self as server_error, Error, Result};
 use crate::SqlPlan;

--- a/src/servers/src/postgres/types/error.rs
+++ b/src/servers/src/postgres/types/error.rs
@@ -19,7 +19,7 @@ use strum::{AsRefStr, Display, EnumIter, EnumMessage};
 
 #[derive(Display, Debug, PartialEq)]
 #[allow(dead_code)]
-enum ErrorSeverity {
+pub enum PgErrorSeverity {
     #[strum(serialize = "INFO")]
     Info,
     #[strum(serialize = "DEBUG")]
@@ -335,23 +335,23 @@ pub enum PgErrorCode {
 }
 
 impl PgErrorCode {
-    fn severity(&self) -> ErrorSeverity {
+    fn severity(&self) -> PgErrorSeverity {
         match self {
-            PgErrorCode::Ec00000 => ErrorSeverity::Info,
-            PgErrorCode::Ec01000 => ErrorSeverity::Warning,
+            PgErrorCode::Ec00000 => PgErrorSeverity::Info,
+            PgErrorCode::Ec01000 => PgErrorSeverity::Warning,
 
             PgErrorCode::EcXX000 | PgErrorCode::Ec42P14 | PgErrorCode::Ec22023 => {
-                ErrorSeverity::Error
+                PgErrorSeverity::Error
             }
             PgErrorCode::Ec28000 | PgErrorCode::Ec28P01 | PgErrorCode::Ec3D000 => {
-                ErrorSeverity::Fatal
+                PgErrorSeverity::Fatal
             }
 
-            _ => ErrorSeverity::Error,
+            _ => PgErrorSeverity::Error,
         }
     }
 
-    fn code(&self) -> String {
+    pub(crate) fn code(&self) -> String {
         self.as_ref()[2..].to_string()
     }
 
@@ -428,19 +428,19 @@ mod tests {
     use common_error::status_code::StatusCode;
     use strum::{EnumMessage, IntoEnumIterator};
 
-    use super::{ErrorInfo, ErrorSeverity, PgErrorCode};
+    use super::{ErrorInfo, PgErrorCode, PgErrorSeverity};
 
     #[test]
     fn test_error_severity() {
         // test for ErrorSeverity enum
-        assert_eq!("INFO", ErrorSeverity::Info.to_string());
-        assert_eq!("DEBUG", ErrorSeverity::Debug.to_string());
-        assert_eq!("NOTICE", ErrorSeverity::Notice.to_string());
-        assert_eq!("WARNING", ErrorSeverity::Warning.to_string());
+        assert_eq!("INFO", PgErrorSeverity::Info.to_string());
+        assert_eq!("DEBUG", PgErrorSeverity::Debug.to_string());
+        assert_eq!("NOTICE", PgErrorSeverity::Notice.to_string());
+        assert_eq!("WARNING", PgErrorSeverity::Warning.to_string());
 
-        assert_eq!("ERROR", ErrorSeverity::Error.to_string());
-        assert_eq!("FATAL", ErrorSeverity::Fatal.to_string());
-        assert_eq!("PANIC", ErrorSeverity::Panic.to_string());
+        assert_eq!("ERROR", PgErrorSeverity::Error.to_string());
+        assert_eq!("FATAL", PgErrorSeverity::Fatal.to_string());
+        assert_eq!("PANIC", PgErrorSeverity::Panic.to_string());
 
         // test for severity method
         for code in PgErrorCode::iter() {
@@ -448,13 +448,13 @@ mod tests {
             assert_eq!("Ec", &name[0..2]);
 
             if name.starts_with("Ec00") {
-                assert_eq!(ErrorSeverity::Info, code.severity());
+                assert_eq!(PgErrorSeverity::Info, code.severity());
             } else if name.starts_with("Ec01") {
-                assert_eq!(ErrorSeverity::Warning, code.severity());
+                assert_eq!(PgErrorSeverity::Warning, code.severity());
             } else if name.starts_with("Ec28") || name.starts_with("Ec3D") {
-                assert_eq!(ErrorSeverity::Fatal, code.severity());
+                assert_eq!(PgErrorSeverity::Fatal, code.severity());
             } else {
-                assert_eq!(ErrorSeverity::Error, code.severity());
+                assert_eq!(PgErrorSeverity::Error, code.severity());
             }
         }
     }

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -257,6 +257,14 @@ impl QueryContext {
     pub fn set_channel(&mut self, channel: Channel) {
         self.channel = channel;
     }
+
+    pub fn warning(&self) -> Option<String> {
+        self.mutable_inner.read().unwrap().warning.clone()
+    }
+
+    pub fn set_warning(&self, msg: String) {
+        self.mutable_inner.write().unwrap().warning = Some(msg);
+    }
 }
 
 impl QueryContextBuilder {

--- a/src/session/src/context.rs
+++ b/src/session/src/context.rs
@@ -40,7 +40,9 @@ pub struct QueryContext {
     current_catalog: String,
     // we use Arc<RwLock>> for modifiable fields
     #[builder(default)]
-    mutable_inner: Arc<RwLock<MutableInner>>,
+    mutable_session_data: Arc<RwLock<MutableInner>>,
+    #[builder(default)]
+    mutable_query_context_data: Arc<RwLock<QueryContextMutableFields>>,
     sql_dialect: Arc<dyn Dialect + Send + Sync>,
     #[builder(default)]
     extensions: HashMap<String, String>,
@@ -50,6 +52,12 @@ pub struct QueryContext {
     // Track which protocol the query comes from.
     #[builder(default)]
     channel: Channel,
+}
+
+/// This fields hold data that is only valid to current query context
+#[derive(Debug, Builder, Clone, Default)]
+pub struct QueryContextMutableFields {
+    warning: Option<String>,
 }
 
 impl Display for QueryContext {
@@ -65,21 +73,26 @@ impl Display for QueryContext {
 
 impl QueryContextBuilder {
     pub fn current_schema(mut self, schema: String) -> Self {
-        if self.mutable_inner.is_none() {
-            self.mutable_inner = Some(Arc::new(RwLock::new(MutableInner::default())));
+        if self.mutable_session_data.is_none() {
+            self.mutable_session_data = Some(Arc::new(RwLock::new(MutableInner::default())));
         }
 
         // safe for unwrap because previous none check
-        self.mutable_inner.as_mut().unwrap().write().unwrap().schema = schema;
+        self.mutable_session_data
+            .as_mut()
+            .unwrap()
+            .write()
+            .unwrap()
+            .schema = schema;
         self
     }
 
     pub fn timezone(mut self, timezone: Timezone) -> Self {
-        if self.mutable_inner.is_none() {
-            self.mutable_inner = Some(Arc::new(RwLock::new(MutableInner::default())));
+        if self.mutable_session_data.is_none() {
+            self.mutable_session_data = Some(Arc::new(RwLock::new(MutableInner::default())));
         }
 
-        self.mutable_inner
+        self.mutable_session_data
             .as_mut()
             .unwrap()
             .write()
@@ -120,7 +133,7 @@ impl From<QueryContext> for api::v1::QueryContext {
     fn from(
         QueryContext {
             current_catalog,
-            mutable_inner,
+            mutable_session_data: mutable_inner,
             extensions,
             channel,
             ..
@@ -182,11 +195,11 @@ impl QueryContext {
     }
 
     pub fn current_schema(&self) -> String {
-        self.mutable_inner.read().unwrap().schema.clone()
+        self.mutable_session_data.read().unwrap().schema.clone()
     }
 
     pub fn set_current_schema(&self, new_schema: &str) {
-        self.mutable_inner.write().unwrap().schema = new_schema.to_string();
+        self.mutable_session_data.write().unwrap().schema = new_schema.to_string();
     }
 
     pub fn current_catalog(&self) -> &str {
@@ -208,19 +221,19 @@ impl QueryContext {
     }
 
     pub fn timezone(&self) -> Timezone {
-        self.mutable_inner.read().unwrap().timezone.clone()
+        self.mutable_session_data.read().unwrap().timezone.clone()
     }
 
     pub fn set_timezone(&self, timezone: Timezone) {
-        self.mutable_inner.write().unwrap().timezone = timezone;
+        self.mutable_session_data.write().unwrap().timezone = timezone;
     }
 
     pub fn current_user(&self) -> UserInfoRef {
-        self.mutable_inner.read().unwrap().user_info.clone()
+        self.mutable_session_data.read().unwrap().user_info.clone()
     }
 
     pub fn set_current_user(&self, user: UserInfoRef) {
-        self.mutable_inner.write().unwrap().user_info = user;
+        self.mutable_session_data.write().unwrap().user_info = user;
     }
 
     pub fn set_extension<S1: Into<String>, S2: Into<String>>(&mut self, key: S1, value: S2) {
@@ -259,11 +272,15 @@ impl QueryContext {
     }
 
     pub fn warning(&self) -> Option<String> {
-        self.mutable_inner.read().unwrap().warning.clone()
+        self.mutable_query_context_data
+            .read()
+            .unwrap()
+            .warning
+            .clone()
     }
 
     pub fn set_warning(&self, msg: String) {
-        self.mutable_inner.write().unwrap().warning = Some(msg);
+        self.mutable_query_context_data.write().unwrap().warning = Some(msg);
     }
 }
 
@@ -274,7 +291,8 @@ impl QueryContextBuilder {
             current_catalog: self
                 .current_catalog
                 .unwrap_or_else(|| DEFAULT_CATALOG_NAME.to_string()),
-            mutable_inner: self.mutable_inner.unwrap_or_default(),
+            mutable_session_data: self.mutable_session_data.unwrap_or_default(),
+            mutable_query_context_data: self.mutable_query_context_data.unwrap_or_default(),
             sql_dialect: self
                 .sql_dialect
                 .unwrap_or_else(|| Arc::new(GreptimeDbDialect {})),

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -45,7 +45,6 @@ pub(crate) struct MutableInner {
     schema: String,
     user_info: UserInfoRef,
     timezone: Timezone,
-    warning: Option<String>,
 }
 
 impl Default for MutableInner {
@@ -54,7 +53,6 @@ impl Default for MutableInner {
             schema: DEFAULT_SCHEMA_NAME.into(),
             user_info: auth::userinfo_by_name(None),
             timezone: get_timezone(None).clone(),
-            warning: None,
         }
     }
 }
@@ -78,7 +76,7 @@ impl Session {
             // catalog is not allowed for update in query context so we use
             // string here
             .current_catalog(self.catalog.read().unwrap().clone())
-            .mutable_inner(self.mutable_inner.clone())
+            .mutable_session_data(self.mutable_inner.clone())
             .sql_dialect(self.conn_info.channel.dialect())
             .configuration_parameter(self.configuration_variables.clone())
             .channel(self.conn_info.channel)

--- a/src/session/src/lib.rs
+++ b/src/session/src/lib.rs
@@ -45,6 +45,7 @@ pub(crate) struct MutableInner {
     schema: String,
     user_info: UserInfoRef,
     timezone: Timezone,
+    warning: Option<String>,
 }
 
 impl Default for MutableInner {
@@ -53,6 +54,7 @@ impl Default for MutableInner {
             schema: DEFAULT_SCHEMA_NAME.into(),
             user_info: auth::userinfo_by_name(None),
             timezone: get_timezone(None).clone(),
+            warning: None,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

In order to prevent those unsupported set statement from blocking connection establishment, here I return a warning message instead of hard error for postgres.

```
psql (16.3)
Type "help" for help.

public=> SET statement_timeout = 40000;
WARNING:  Unsupported set variable STATEMENT_TIMEOUT
OK 0
public=> SET statement_timeout to 40000;
WARNING:  Unsupported set variable STATEMENT_TIMEOUT
OK 0
```

## Checklist

- [x] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
