### PR TITLE
chore: make sure aws-lc-sys wouldn't be built

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -269,6 +269,9 @@ jobs:
       - name: Install cargo-gc-bin
         shell: bash
         run: cargo install cargo-gc-bin
+      - name: Check aws-lc-sys will not build
+        shell: bash
+        run: cargo tree -i aws-lc-sys -e features | grep aws-lc-sys && echo "Found aws-lc-sys, due to it having problem compiling on older gcc and etc. for now, please replace it with ring for now until it improve it's building experience" && exit 1
       - name: Build greptime bianry
         shell: bash
         # `cargo gc` will invoke `cargo build` with specified args

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -271,7 +271,7 @@ jobs:
         run: cargo install cargo-gc-bin
       - name: Check aws-lc-sys will not build
         shell: bash
-        run: cargo tree -i aws-lc-sys -e features | grep aws-lc-sys && echo "Found aws-lc-sys, due to it having problem compiling on older gcc and etc. for now, please replace it with ring for now until it improve it's building experience" && exit 1
+        run: cargo tree -i aws-lc-sys -e features | grep aws-lc-sys && echo "Found aws-lc-sys, due to it having problem compiling on older gcc and etc. for now, please replace it with ring for now until it improve it's building experience" && exit 1 || true
       - name: Build greptime bianry
         shell: bash
         # `cargo gc` will invoke `cargo build` with specified args

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -271,7 +271,11 @@ jobs:
         run: cargo install cargo-gc-bin
       - name: Check aws-lc-sys will not build
         shell: bash
-        run: cargo tree -i aws-lc-sys -e features | grep aws-lc-sys && echo "Found aws-lc-sys, due to it having problem compiling on older gcc and etc. for now, please replace it with ring for now until it improve it's building experience" && exit 1 || true
+        run: |
+             if cargo tree -i aws-lc-sys -e features | grep -q aws-lc-sys; then
+               echo "Found aws-lc-sys, which has compilation problems on older gcc versions. Please replace it with ring until its building experience improves."
+               exit 1
+             fi
       - name: Build greptime bianry
         shell: bash
         # `cargo gc` will invoke `cargo build` with specified args


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
https://github.com/GreptimeTeam/greptimedb/pull/4750
## What's changed and what's your intention?

Make sure `aws-lc-sys` wouldn't accidentially be built.

After update rustls to `0.23`, it switch it's crypto lib to `aws-lc`, however, it's wrapper crate `aws-lc-sys` have many building problems on different platform due to chore with gcc version and etc, and currently it will fail building on our CentOS image, and possibly on andorid, so add a check to avoid bring in `aws-lc-sys` depend before they solve most of the building problem. Have already test it locally by removing patches for `rustls`, `hyper-rustls` and `tokio-ruslts` and this check will detect `aws-lc-sys` dependency 

## Alternative
Switch back to `rustls` 0.22, however that might not be feasible, since some of our dependenices might have move to higher version of `rustls` without knowing this change of default on crypto library and it's building problems. 

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflow to check for successful builds of the `aws-lc-sys` crate.
	- Added informative output regarding potential compilation issues with `aws-lc-sys` on older GCC versions, suggesting alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->