### PR TITLE
fix: use information_schema returns Unknown database 

### DIFF
--- a/src/frontend/src/instance.rs
+++ b/src/frontend/src/instance.rs
@@ -359,7 +359,6 @@ impl SqlQueryHandler for Instance {
             .schema_exists(catalog, schema, None)
             .await
             .context(error::CatalogSnafu)
-            .map(|b| b && !self.catalog_manager.is_reserved_schema_name(schema))
     }
 }
 

--- a/tests/cases/standalone/common/system/information_schema.result
+++ b/tests/cases/standalone/common/system/information_schema.result
@@ -425,6 +425,10 @@ database my_db;
 
 Affected Rows: 1
 
+use information_schema;
+
+Affected Rows: 0
+
 use my_db;
 
 Affected Rows: 0

--- a/tests/cases/standalone/common/system/information_schema.sql
+++ b/tests/cases/standalone/common/system/information_schema.sql
@@ -14,6 +14,8 @@ select * from information_schema.columns order by table_schema, table_name, colu
 create
 database my_db;
 
+use information_schema;
+
 use my_db;
 
 create table foo


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)
#4773 

## What's changed and what's your intention?

 `is_reserved_schema_name` check should only be done when creating new database/schema.
Please explain IN DETAIL what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
