### PR TITLE
fix: dead loop on detecting postgres ssl handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7765,9 +7765,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed4ca46dd335b3a030d977be54dfe121b1b9fe22aa8bbd69161ac2434524fc68"
+checksum = "4895c8e98cbe81496692ae3d2262a9fb0d26302af7c9ea483cf708000106aa0a"
 dependencies = [
  "async-trait",
  "bytes",

--- a/src/servers/Cargo.toml
+++ b/src/servers/Cargo.toml
@@ -71,7 +71,7 @@ openmetrics-parser = "0.4"
 opensrv-mysql = { git = "https://github.com/datafuselabs/opensrv", rev = "6bbc3b65e6b19212c4f7fc4f40c20daf6f452deb" }
 opentelemetry-proto.workspace = true
 parking_lot = "0.12"
-pgwire = { version = "0.24.2", default-features = false, features = ["server-api-ring"] }
+pgwire = { version = "0.24.3", default-features = false, features = ["server-api-ring"] }
 pin-project = "1.0"
 pipeline.workspace = true
 postgres-types = { version = "0.2", features = ["with-chrono-0_4", "with-serde_json-1"] }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Update pgwire to 0.24.3 which fixes the issue with disconnected clients. Upstream fix: https://github.com/sunng87/pgwire/pull/206

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
