### PR TITLE
chore: replace anymap with anymap2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 name = "common-base"
 version = "0.9.3"
 dependencies = [
- "anymap",
+ "anymap2",
  "async-trait",
  "bitvec",
  "bytes",

--- a/src/common/base/Cargo.toml
+++ b/src/common/base/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-anymap = "1.0.0-beta.2"
+anymap2 = "0.13"
 async-trait.workspace = true
 bitvec = "1.0"
 bytes.workspace = true

--- a/src/common/base/src/plugins.rs
+++ b/src/common/base/src/plugins.rs
@@ -12,20 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::any::Any;
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-/// [`Plugins`] is a wrapper of [AnyMap](https://github.com/chris-morgan/anymap) and provides a thread-safe way to store and retrieve plugins.
+use anymap2::SendSyncAnyMap;
+
+/// [`Plugins`] is a wrapper of [anymap2](https://github.com/azriel91/anymap2) and provides a thread-safe way to store and retrieve plugins.
 /// Make it Cloneable and we can treat it like an Arc struct.
 #[derive(Default, Clone)]
 pub struct Plugins {
-    inner: Arc<RwLock<anymap::Map<dyn Any + Send + Sync>>>,
+    inner: Arc<RwLock<SendSyncAnyMap>>,
 }
 
 impl Plugins {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(anymap::Map::new())),
+            inner: Arc::new(RwLock::new(SendSyncAnyMap::new())),
         }
     }
 
@@ -61,11 +62,11 @@ impl Plugins {
         self.read().is_empty()
     }
 
-    fn read(&self) -> RwLockReadGuard<anymap::Map<dyn Any + Send + Sync>> {
+    fn read(&self) -> RwLockReadGuard<SendSyncAnyMap> {
         self.inner.read().unwrap()
     }
 
-    fn write(&self) -> RwLockWriteGuard<anymap::Map<dyn Any + Send + Sync>> {
+    fn write(&self) -> RwLockWriteGuard<SendSyncAnyMap> {
         self.inner.write().unwrap()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

This PR replaces the `anymap` dependency in plugin crate with `anymap2` in that the recent toolchain gives a warning:

```
>    --> /home/lei/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anymap-1.0.0-beta.2/src/any.rs:37:40
>     |
> 37  |                 unsafe { Box::from_raw(raw as *mut $t) }
>     |                                        ^^^^^^^^^^^^^^
> ...
> 144 | impl_clone!(dyn CloneAny + Send);
>     | -------------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #127323 <https://github.com/rust-lang/rust/issues/127323>
>     = note: this warning originates in the macro `impl_clone` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Related issues:  
- https://github.com/chris-morgan/anymap/issues/53
- https://github.com/rust-lang/rust/issues/127323

Looks like `anymap` is no longer under maintainence, we should switch to anymap2.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
