### PR TITLE
refactor: introduce `HeartbeatHandlerGroupBuilder`

### DIFF
--- a/src/meta-srv/src/metasrv.rs
+++ b/src/meta-srv/src/metasrv.rs
@@ -52,7 +52,7 @@ use crate::error::{
     StopProcedureManagerSnafu,
 };
 use crate::failure_detector::PhiAccrualFailureDetectorOptions;
-use crate::handler::HeartbeatHandlerGroup;
+use crate::handler::HeartbeatHandlerGroupRef;
 use crate::lease::lookup_datanode_peer;
 use crate::lock::DistLockRef;
 use crate::procedure::region_migration::manager::RegionMigrationManagerRef;
@@ -366,7 +366,7 @@ pub struct Metasrv {
     selector: SelectorRef,
     // The flow selector is used to select a target flownode.
     flow_selector: SelectorRef,
-    handler_group: HeartbeatHandlerGroup,
+    handler_group: HeartbeatHandlerGroupRef,
     election: Option<ElectionRef>,
     lock: DistLockRef,
     procedure_manager: ProcedureManagerRef,
@@ -562,7 +562,7 @@ impl Metasrv {
         &self.flow_selector
     }
 
-    pub fn handler_group(&self) -> &HeartbeatHandlerGroup {
+    pub fn handler_group(&self) -> &HeartbeatHandlerGroupRef {
         &self.handler_group
     }
 

--- a/src/meta-srv/src/service/heartbeat.rs
+++ b/src/meta-srv/src/service/heartbeat.rs
@@ -113,7 +113,7 @@ impl heartbeat_server::Heartbeat for Metasrv {
             );
 
             if let Some(key) = pusher_key {
-                let _ = handler_group.deregister(&key).await;
+                let _ = handler_group.deregister_push(&key).await;
             }
         });
 
@@ -177,7 +177,7 @@ async fn register_pusher(
     let node_id = get_node_id(header);
     let key = format!("{}-{}", role, node_id);
     let pusher = Pusher::new(sender, header);
-    handler_group.register(&key, pusher).await;
+    handler_group.register_pusher(&key, pusher).await;
     Some(key)
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://github.com/GreptimeTeam/.github/blob/main/CLA.md).

## Refer to a related PR or issue link (optional)

## What's changed and what's your intention?

Introduce the `HeartbeatHandlerGroupBuilder`, make it easier for upper layers to customize handler groups.

## Checklist

- [ ] I have written the necessary rustdoc comments.
- [ ] I have added the necessary unit tests and integration tests.
- [ ] This PR requires documentation updates.
